### PR TITLE
[Paddle-TRT] TensorRT 8 Compatibility

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/anchor_generator_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/anchor_generator_op.cc
@@ -25,6 +25,7 @@ class AnchorGeneratorOpConverter : public OpConverter {
   void operator()(const paddle::framework::proto::OpDesc& op,
                   const paddle::framework::Scope& scope,
                   bool test_mode) override {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
     VLOG(3) << "convert a fluid anchor generator op to tensorrt plugin";
     framework::OpDesc op_desc(op, nullptr);
     std::string input_name = op_desc.Input("Input").front();
@@ -69,6 +70,7 @@ class AnchorGeneratorOpConverter : public OpConverter {
 
     RreplenishLayerAndOutput(anchor_generator_layer, "anchor_generator",
                              output_names, test_mode);
+#endif
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -249,6 +249,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
             "your TRT version is no less than 6.0"));
 #endif
       } else {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
         plugin::ElementWisePlugin* plugin =
             new plugin::ElementWisePlugin(op_type_, dims_x, dims_y, axis);
         plugin->AddInput(X);
@@ -258,6 +259,7 @@ class ElementwiseTensorOpConverter : public OpConverter {
             reinterpret_cast<plugin::PluginTensorRT*>(plugin));
 
         layer = plugin_layer;
+#endif
       }
     }
     common_func(layer);

--- a/paddle/fluid/inference/tensorrt/convert/gather_nd_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gather_nd_op.cc
@@ -23,6 +23,7 @@ class GatherNdOpConverter : public OpConverter {
  public:
   void operator()(const framework::proto::OpDesc& op,
                   const framework::Scope& scope, bool test_mode) override {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
     VLOG(4) << "convert a paddle gather_nd op to tensorrt gather_nd plugin";
     framework::OpDesc op_desc(op, nullptr);
 
@@ -48,6 +49,7 @@ class GatherNdOpConverter : public OpConverter {
       engine_->DeclareOutput(output_name);
     }
     layer->setName((layer_name + ")").c_str());
+#endif
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
@@ -63,10 +63,12 @@ class GeluOpConverter : public OpConverter {
           "your TRT version is no less than 6.0"));
 #endif
     } else {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
       bool with_fp16 =
           engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
       plugin::GeluPlugin* plugin = new plugin::GeluPlugin(with_fp16);
       layer = engine_->AddPlugin(&input, input_num, plugin);
+#endif
     }
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "gelu", {output_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/instance_norm_op.cc
@@ -36,6 +36,7 @@ class InstanceNormOpConverter : public OpConverter {
  public:
   void operator()(const framework::proto::OpDesc& op,
                   const framework::Scope& scope, bool test_mode) override {
+#if IS_TRT_VERSION_LT(8000)
     VLOG(4) << "convert fluid prelu op to tensorrt instance norm layer";
 
     framework::OpDesc op_desc(op, nullptr);
@@ -78,6 +79,7 @@ class InstanceNormOpConverter : public OpConverter {
 
     auto output_name = op_desc.Output("Y")[0];
     RreplenishLayerAndOutput(layer, "instance_norm", {output_name}, test_mode);
+#endif
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/layer_norm_op.cc
@@ -76,6 +76,7 @@ class LayerNormOpConverter : public OpConverter {
                                              variance_shape);
       layernorm_layer = engine_->AddDynamicPlugin(&X, 1, plugin);
     } else {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
       int input_num = 1;
       for (int i = begin_norm_axis - 1; i < X->getDimensions().nbDims; i++) {
         input_num *= X->getDimensions().d[i];
@@ -87,6 +88,7 @@ class LayerNormOpConverter : public OpConverter {
           begin_norm_axis, eps, mean_shape, variance_shape);
       layernorm_layer = engine_->AddPlugin(
           &X, 1, reinterpret_cast<plugin::PluginTensorRT*>(plugin));
+#endif
     }
 
     auto output_name = op_desc.Output("Y").front();

--- a/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
@@ -63,6 +63,7 @@ class Pool2dOpConverter : public OpConverter {
  public:
   void operator()(const framework::proto::OpDesc &op,
                   const framework::Scope &scope, bool test_mode) override {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
     VLOG(4)
         << "convert a fluid pool2d op to tensorrt pool2d layer without bias";
     framework::OpDesc op_desc(op, nullptr);
@@ -201,6 +202,7 @@ class Pool2dOpConverter : public OpConverter {
       pool_layer->setAverageCountExcludesPadding(exclusive);
       layer = pool_layer;
     } else {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
       // Average pooling needs to exclude the padding pixels from the average
       // mean.
       // It is not supported well by TRT, we use a plugin here.
@@ -217,9 +219,11 @@ class Pool2dOpConverter : public OpConverter {
           platform::errors::Fatal(
               "trt pool plugin layer in converter could not be created."));
       layer = pool_layer;
+#endif
     }
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "pool2d", {output_name}, test_mode);
+#endif
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/roi_align_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/roi_align_op.cc
@@ -36,6 +36,7 @@ class RoiAlignOpConverter : public OpConverter {
  public:
   void operator()(const framework::proto::OpDesc& op,
                   const framework::Scope& scope, bool test_mode) override {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
     VLOG(3) << "convert a fluid roi align op to tensorrt plugin";
 
     framework::OpDesc op_desc(op, nullptr);
@@ -70,6 +71,7 @@ class RoiAlignOpConverter : public OpConverter {
 
     std::vector<std::string> output_names{output_name};
     RreplenishLayerAndOutput(layer, "roi_align", output_names, test_mode);
+#endif
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
@@ -57,7 +57,7 @@ class ShuffleChannelOpConverter : public OpConverter {
     auto* output = layer->getOutput(0);
 
     auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
-    nvinfer1::DimsCHW reshape_dim2(c, h, w);
+    nvinfer1::Dims3 reshape_dim2(c, h, w);
     reshape_layer->setReshapeDimensions(reshape_dim2);
 
     auto output_name = op_desc.Output("Out")[0];

--- a/paddle/fluid/inference/tensorrt/convert/slice_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/slice_op.cc
@@ -98,11 +98,13 @@ class SliceOpConverter : public OpConverter {
           "your TRT version is no less than 6.0"));
 #endif
     } else {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
       bool with_fp16 =
           engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
       plugin::SlicePlugin* plugin =
           new plugin::SlicePlugin(starts, ends, axes, with_fp16);
       layer = engine_->AddPlugin(&input, 1, plugin);
+#endif
     }
 
     auto output_name = op_desc.Output("Out")[0];

--- a/paddle/fluid/inference/tensorrt/convert/swish_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/swish_op.cc
@@ -72,10 +72,12 @@ class SwishOpConverter : public OpConverter {
           "your TRT version is no less than 6.0"));
 #endif
     } else {
+#if IS_TRT_VERSION_LT(8000)  // TODO(trt8)
       bool with_fp16 =
           engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
       plugin::SwishPlugin* plugin = new plugin::SwishPlugin(beta, with_fp16);
       layer = engine_->AddPlugin(&input, input_num, plugin);
+#endif
     }
 
     auto output_name = op_desc.Output("Out")[0];

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -31,6 +31,10 @@ namespace tensorrt {
   ((NV_TENSORRT_MAJOR * 1000 + NV_TENSORRT_MINOR * 100 + \
     NV_TENSORRT_PATCH * 10 + NV_TENSORRT_BUILD) >= version)
 
+#define IS_TRT_VERSION_LT(version)                       \
+  ((NV_TENSORRT_MAJOR * 1000 + NV_TENSORRT_MINOR * 100 + \
+    NV_TENSORRT_PATCH * 10 + NV_TENSORRT_BUILD) < version)
+
 #define TRT_VERSION                                    \
   NV_TENSORRT_MAJOR * 1000 + NV_TENSORRT_MINOR * 100 + \
       NV_TENSORRT_PATCH * 10 + NV_TENSORRT_BUILD

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -35,6 +35,12 @@ namespace tensorrt {
   NV_TENSORRT_MAJOR * 1000 + NV_TENSORRT_MINOR * 100 + \
       NV_TENSORRT_PATCH * 10 + NV_TENSORRT_BUILD
 
+#if IS_TRT_VERSION_GE(8000)
+#define TRT_NOEXCEPT noexcept
+#else
+#define TRT_NOEXCEPT
+#endif
+
 namespace dy = paddle::platform::dynload;
 
 // TensorRT data type to size
@@ -68,7 +74,8 @@ static int GetInferLibVersion() {
 // A logger for create TensorRT infer builder.
 class NaiveLogger : public nvinfer1::ILogger {
  public:
-  void log(nvinfer1::ILogger::Severity severity, const char* msg) override {
+  void log(nvinfer1::ILogger::Severity severity,
+           const char* msg) TRT_NOEXCEPT override {
     switch (severity) {
       case Severity::kVERBOSE:
         VLOG(3) << msg;
@@ -101,7 +108,7 @@ class NaiveProfiler : public nvinfer1::IProfiler {
   typedef std::pair<std::string, float> Record;
   std::vector<Record> mProfile;
 
-  virtual void reportLayerTime(const char* layerName, float ms) {
+  virtual void reportLayerTime(const char* layerName, float ms) TRT_NOEXCEPT {
     auto record =
         std::find_if(mProfile.begin(), mProfile.end(),
                      [&](const Record& r) { return r.first == layerName; });

--- a/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
@@ -112,16 +112,18 @@ AnchorGeneratorPlugin::AnchorGeneratorPlugin(const void* data, size_t length) {
   PrepareParamsOnDevice();
 }
 
-const char* AnchorGeneratorPlugin::getPluginType() const {
+const char* AnchorGeneratorPlugin::getPluginType() const TRT_NOEXCEPT {
   return "anchor_generator_plugin";
 }
 
-const char* AnchorGeneratorPlugin::getPluginVersion() const { return "1"; }
+const char* AnchorGeneratorPlugin::getPluginVersion() const TRT_NOEXCEPT {
+  return "1";
+}
 
-int AnchorGeneratorPlugin::getNbOutputs() const { return 2; }
+int AnchorGeneratorPlugin::getNbOutputs() const TRT_NOEXCEPT { return 2; }
 
 nvinfer1::Dims AnchorGeneratorPlugin::getOutputDimensions(
-    int index, const nvinfer1::Dims* inputs, int nb_input_dims) {
+    int index, const nvinfer1::Dims* inputs, int nb_input_dims) TRT_NOEXCEPT {
   nvinfer1::Dims dims{};
   dims.nbDims = 4;
   dims.d[0] = height_;
@@ -132,20 +134,25 @@ nvinfer1::Dims AnchorGeneratorPlugin::getOutputDimensions(
 }
 
 bool AnchorGeneratorPlugin::supportsFormat(
-    nvinfer1::DataType type, nvinfer1::TensorFormat format) const {
+    nvinfer1::DataType type, nvinfer1::TensorFormat format) const TRT_NOEXCEPT {
   // static shape plugin can't support different type between input/out
   // it may cause addition overhead in half mode
   return (type == data_type_ && format == nvinfer1::TensorFormat::kLINEAR);
 }
 
-size_t AnchorGeneratorPlugin::getWorkspaceSize(int max_batch_size) const {
+size_t AnchorGeneratorPlugin::getWorkspaceSize(int max_batch_size) const
+    TRT_NOEXCEPT {
   return 0;
 }
 
 template <typename T>
 int AnchorGeneratorPlugin::enqueue_impl(int batch_size,
                                         const void* const* inputs,
+#if IS_TRT_VERSION_LT(8000)
                                         void** outputs, void* workspace,
+#else
+                                        void* const* outputs, void* workspace,
+#endif
                                         cudaStream_t stream) {
   const int block = 512;
   const int gen_anchor_grid = (box_num_ + block - 1) / block;
@@ -166,16 +173,20 @@ int AnchorGeneratorPlugin::enqueue_impl(int batch_size,
 }
 
 int AnchorGeneratorPlugin::enqueue(int batch_size, const void* const* inputs,
+#if IS_TRT_VERSION_LT(8000)
                                    void** outputs, void* workspace,
-                                   cudaStream_t stream) {
+#else
+                                   void* const* outputs, void* workspace,
+#endif
+                                   cudaStream_t stream) TRT_NOEXCEPT {
   return enqueue_impl<float>(batch_size, inputs, outputs, workspace, stream);
 }
 
-int AnchorGeneratorPlugin::initialize() { return 0; }
+int AnchorGeneratorPlugin::initialize() TRT_NOEXCEPT { return 0; }
 
-void AnchorGeneratorPlugin::terminate() {}
+void AnchorGeneratorPlugin::terminate() TRT_NOEXCEPT {}
 
-size_t AnchorGeneratorPlugin::getSerializationSize() const {
+size_t AnchorGeneratorPlugin::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(data_type_);
   serialize_size += SerializedSize(anchor_sizes_);
@@ -190,7 +201,7 @@ size_t AnchorGeneratorPlugin::getSerializationSize() const {
   return serialize_size;
 }
 
-void AnchorGeneratorPlugin::serialize(void* buffer) const {
+void AnchorGeneratorPlugin::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, data_type_);
   SerializeValue(&buffer, anchor_sizes_);
   SerializeValue(&buffer, aspect_ratios_);
@@ -203,28 +214,31 @@ void AnchorGeneratorPlugin::serialize(void* buffer) const {
   SerializeValue(&buffer, box_num_);
 }
 
-void AnchorGeneratorPlugin::destroy() {}
+void AnchorGeneratorPlugin::destroy() TRT_NOEXCEPT {}
 
-void AnchorGeneratorPlugin::setPluginNamespace(const char* lib_namespace) {
+void AnchorGeneratorPlugin::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* AnchorGeneratorPlugin::getPluginNamespace() const {
+const char* AnchorGeneratorPlugin::getPluginNamespace() const TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
 nvinfer1::DataType AnchorGeneratorPlugin::getOutputDataType(
-    int index, const nvinfer1::DataType* input_type, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_type,
+    int nb_inputs) const TRT_NOEXCEPT {
   return data_type_;
 }
 
 bool AnchorGeneratorPlugin::isOutputBroadcastAcrossBatch(
-    int output_index, const bool* input_is_broadcast, int nb_inputs) const {
+    int output_index, const bool* input_is_broadcast,
+    int nb_inputs) const TRT_NOEXCEPT {
   return true;
 }
 
-bool AnchorGeneratorPlugin::canBroadcastInputAcrossBatch(
-    int input_index) const {
+bool AnchorGeneratorPlugin::canBroadcastInputAcrossBatch(int input_index) const
+    TRT_NOEXCEPT {
   return false;
 }
 
@@ -234,9 +248,9 @@ void AnchorGeneratorPlugin::configurePlugin(
     const nvinfer1::DataType* input_types,
     const nvinfer1::DataType* output_types, const bool* input_is_broadcast,
     const bool* output_is_broadcast, nvinfer1::PluginFormat float_format,
-    int max_batct_size) {}
+    int max_batct_size) TRT_NOEXCEPT {}
 
-nvinfer1::IPluginV2Ext* AnchorGeneratorPlugin::clone() const {
+nvinfer1::IPluginV2Ext* AnchorGeneratorPlugin::clone() const TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPlugin(
       data_type_, anchor_sizes_, aspect_ratios_, stride_, variances_, offset_,
       height_, width_, num_anchors_, box_num_);
@@ -244,30 +258,32 @@ nvinfer1::IPluginV2Ext* AnchorGeneratorPlugin::clone() const {
   return plugin;
 }
 
-void AnchorGeneratorPluginCreator::setPluginNamespace(
-    const char* lib_namespace) {
+void AnchorGeneratorPluginCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* AnchorGeneratorPluginCreator::getPluginNamespace() const {
+const char* AnchorGeneratorPluginCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
-const char* AnchorGeneratorPluginCreator::getPluginName() const {
+const char* AnchorGeneratorPluginCreator::getPluginName() const TRT_NOEXCEPT {
   return "anchor_generator_plugin";
 }
 
-const char* AnchorGeneratorPluginCreator::getPluginVersion() const {
+const char* AnchorGeneratorPluginCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
   return "1";
 }
 
 const nvinfer1::PluginFieldCollection*
-AnchorGeneratorPluginCreator::getFieldNames() {
+AnchorGeneratorPluginCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   const nvinfer1::PluginField* fields = fc->fields;
   int type_id = -1;
   std::vector<float> anchor_sizes, aspect_ratios, stride, variances;
@@ -313,7 +329,8 @@ nvinfer1::IPluginV2Ext* AnchorGeneratorPluginCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPlugin(serial_data, serial_length);
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;
@@ -372,7 +389,8 @@ AnchorGeneratorPluginDynamic::AnchorGeneratorPluginDynamic(void const* data,
   PrepareParamsOnDevice();
 }
 
-nvinfer1::IPluginV2DynamicExt* AnchorGeneratorPluginDynamic::clone() const {
+nvinfer1::IPluginV2DynamicExt* AnchorGeneratorPluginDynamic::clone() const
+    TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPluginDynamic(
       data_type_, anchor_sizes_, aspect_ratios_, stride_, variances_, offset_,
       num_anchors_);
@@ -382,7 +400,7 @@ nvinfer1::IPluginV2DynamicExt* AnchorGeneratorPluginDynamic::clone() const {
 
 nvinfer1::DimsExprs AnchorGeneratorPluginDynamic::getOutputDimensions(
     int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-    nvinfer1::IExprBuilder& exprBuilder) {
+    nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT {
   nvinfer1::DimsExprs ret{};
   ret.nbDims = 4;
   ret.d[0] = inputs[0].d[2];  // feature height
@@ -394,7 +412,7 @@ nvinfer1::DimsExprs AnchorGeneratorPluginDynamic::getOutputDimensions(
 
 bool AnchorGeneratorPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* inOut, int nbInputs,
-    int nbOutputs) {
+    int nbOutputs) TRT_NOEXCEPT {
   // input can be any, doesn't matter
   // anchor generator doesn't read input raw data, only need the shape info
   auto type = inOut[pos].type;
@@ -410,11 +428,12 @@ bool AnchorGeneratorPluginDynamic::supportsFormatCombination(
 
 void AnchorGeneratorPluginDynamic::configurePlugin(
     const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs,
-    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {}
+    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) TRT_NOEXCEPT {}
 
 size_t AnchorGeneratorPluginDynamic::getWorkspaceSize(
     const nvinfer1::PluginTensorDesc* inputs, int nbInputs,
-    const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
   return 0;
 }
 
@@ -447,7 +466,7 @@ int AnchorGeneratorPluginDynamic::enqueue_impl(
 int AnchorGeneratorPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc* inputDesc,
     const nvinfer1::PluginTensorDesc* outputDesc, const void* const* inputs,
-    void* const* outputs, void* workspace, cudaStream_t stream) {
+    void* const* outputs, void* workspace, cudaStream_t stream) TRT_NOEXCEPT {
   assert(outputDesc[0].type == nvinfer1::DataType::kFLOAT);
   assert(outputDesc[1].type == nvinfer1::DataType::kFLOAT);
   return enqueue_impl<float>(inputDesc, outputDesc, inputs, outputs, workspace,
@@ -455,21 +474,24 @@ int AnchorGeneratorPluginDynamic::enqueue(
 }
 
 nvinfer1::DataType AnchorGeneratorPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* inputTypes, int nbInputs) const {
+    int index, const nvinfer1::DataType* inputTypes,
+    int nbInputs) const TRT_NOEXCEPT {
   return data_type_;
 }
 
-const char* AnchorGeneratorPluginDynamic::getPluginType() const {
+const char* AnchorGeneratorPluginDynamic::getPluginType() const TRT_NOEXCEPT {
   return "anchor_generator_plugin_dynamic";
 }
 
-int AnchorGeneratorPluginDynamic::getNbOutputs() const { return 2; }
+int AnchorGeneratorPluginDynamic::getNbOutputs() const TRT_NOEXCEPT {
+  return 2;
+}
 
-int AnchorGeneratorPluginDynamic::initialize() { return 0; }
+int AnchorGeneratorPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-void AnchorGeneratorPluginDynamic::terminate() {}
+void AnchorGeneratorPluginDynamic::terminate() TRT_NOEXCEPT {}
 
-size_t AnchorGeneratorPluginDynamic::getSerializationSize() const {
+size_t AnchorGeneratorPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(data_type_);
   serialize_size += SerializedSize(anchor_sizes_);
@@ -481,7 +503,7 @@ size_t AnchorGeneratorPluginDynamic::getSerializationSize() const {
   return serialize_size;
 }
 
-void AnchorGeneratorPluginDynamic::serialize(void* buffer) const {
+void AnchorGeneratorPluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, data_type_);
   SerializeValue(&buffer, anchor_sizes_);
   SerializeValue(&buffer, aspect_ratios_);
@@ -491,32 +513,35 @@ void AnchorGeneratorPluginDynamic::serialize(void* buffer) const {
   SerializeValue(&buffer, num_anchors_);
 }
 
-void AnchorGeneratorPluginDynamic::destroy() {}
+void AnchorGeneratorPluginDynamic::destroy() TRT_NOEXCEPT {}
 
 void AnchorGeneratorPluginDynamicCreator::setPluginNamespace(
-    const char* lib_namespace) {
+    const char* lib_namespace) TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* AnchorGeneratorPluginDynamicCreator::getPluginNamespace() const {
+const char* AnchorGeneratorPluginDynamicCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
-const char* AnchorGeneratorPluginDynamicCreator::getPluginName() const {
+const char* AnchorGeneratorPluginDynamicCreator::getPluginName() const
+    TRT_NOEXCEPT {
   return "anchor_generator_plugin_dynamic";
 }
 
-const char* AnchorGeneratorPluginDynamicCreator::getPluginVersion() const {
+const char* AnchorGeneratorPluginDynamicCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
   return "1";
 }
 
 const nvinfer1::PluginFieldCollection*
-AnchorGeneratorPluginDynamicCreator::getFieldNames() {
+AnchorGeneratorPluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginDynamicCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   const nvinfer1::PluginField* fields = fc->fields;
   int type_id = -1;
   std::vector<float> anchor_sizes, aspect_ratios, stride, variances;
@@ -553,7 +578,8 @@ nvinfer1::IPluginV2Ext* AnchorGeneratorPluginDynamicCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginDynamicCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPluginDynamic(serial_data, serial_length);
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;

--- a/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.h
@@ -25,7 +25,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
-class AnchorGeneratorPlugin : public nvinfer1::IPluginV2Ext {
+class AnchorGeneratorPlugin : public PluginTensorRTV2Ext {
  public:
   explicit AnchorGeneratorPlugin(
       const nvinfer1::DataType, const std::vector<float>& anchor_sizes,
@@ -34,30 +34,35 @@ class AnchorGeneratorPlugin : public nvinfer1::IPluginV2Ext {
       const int width, const int num_anchors, const int box_num);
   AnchorGeneratorPlugin(const void* data, size_t length);
   ~AnchorGeneratorPlugin() override;
-  const char* getPluginType() const override;
-  const char* getPluginVersion() const override;
-  int getNbOutputs() const override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nb_input_dims) override;
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::TensorFormat format) const override;
-  size_t getWorkspaceSize(int max_batch_size) const override;
+                                     int nb_input_dims) TRT_NOEXCEPT override;
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::TensorFormat format)
+      const TRT_NOEXCEPT override;
+  size_t getWorkspaceSize(int max_batch_size) const TRT_NOEXCEPT override;
+#if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
-              void* workspace, cudaStream_t stream) override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_type,
-                                       int nb_inputs) const override;
+#else
+  int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
+#endif
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_type,
+      int nb_inputs) const TRT_NOEXCEPT override;
   bool isOutputBroadcastAcrossBatch(int output_index,
                                     const bool* input_is_broadcast,
-                                    int nb_inputs) const override;
-  bool canBroadcastInputAcrossBatch(int input_index) const override;
+                                    int nb_inputs) const TRT_NOEXCEPT override;
+  bool canBroadcastInputAcrossBatch(int input_index) const
+      TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::Dims* input_dims, int nb_inputs,
                        const nvinfer1::Dims* output_dims, int nb_outputs,
                        const nvinfer1::DataType* input_types,
@@ -65,12 +70,17 @@ class AnchorGeneratorPlugin : public nvinfer1::IPluginV2Ext {
                        const bool* input_is_broadcast,
                        const bool* output_is_broadcast,
                        nvinfer1::PluginFormat float_format,
-                       int max_batct_size) override;
-  nvinfer1::IPluginV2Ext* clone() const override;
+                       int max_batct_size) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* clone() const TRT_NOEXCEPT override;
 
  private:
   template <typename T>
+#if IS_TRT_VERSION_LT(8000)
   int enqueue_impl(int batch_size, const void* const* inputs, void** outputs,
+#else
+  int enqueue_impl(int batch_size, const void* const* inputs,
+                   void* const* outputs,
+#endif
                    void* workspace, cudaStream_t stream);
   nvinfer1::DataType data_type_;
   std::vector<float> anchor_sizes_;
@@ -93,16 +103,17 @@ class AnchorGeneratorPluginCreator : public nvinfer1::IPluginCreator {
  public:
   AnchorGeneratorPluginCreator() = default;
   ~AnchorGeneratorPluginCreator() override = default;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
-                                            const void* serial_data,
-                                            size_t serial_length) override;
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
 
  private:
   std::string namespace_;
@@ -123,35 +134,36 @@ class AnchorGeneratorPluginDynamic : public DynamicPluginTensorRT {
                                         const int num_anchors);
   AnchorGeneratorPluginDynamic(void const* data, size_t length);
   ~AnchorGeneratorPluginDynamic();
-  nvinfer1::IPluginV2DynamicExt* clone() const override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override;
+                       int nbOutputs) TRT_NOEXCEPT override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override;
+                          int nbOutputs) const TRT_NOEXCEPT override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
-  const char* getPluginType() const override;
-  int getNbOutputs() const override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   template <typename T>
@@ -177,16 +189,17 @@ class AnchorGeneratorPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   AnchorGeneratorPluginDynamicCreator() = default;
   ~AnchorGeneratorPluginDynamicCreator() override = default;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
-                                            const void* serial_data,
-                                            size_t serial_length) override;
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
 
  private:
   std::string namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.h
@@ -25,7 +25,8 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
-class AnchorGeneratorPlugin : public PluginTensorRTV2Ext {
+#if IS_TRT_VERSION_LT(8000)
+class AnchorGeneratorPlugin : public nvinfer1::IPluginV2Ext {
  public:
   explicit AnchorGeneratorPlugin(
       const nvinfer1::DataType, const std::vector<float>& anchor_sizes,
@@ -34,35 +35,30 @@ class AnchorGeneratorPlugin : public PluginTensorRTV2Ext {
       const int width, const int num_anchors, const int box_num);
   AnchorGeneratorPlugin(const void* data, size_t length);
   ~AnchorGeneratorPlugin() override;
-  const char* getPluginType() const TRT_NOEXCEPT override;
-  const char* getPluginVersion() const TRT_NOEXCEPT override;
-  int getNbOutputs() const TRT_NOEXCEPT override;
+  const char* getPluginType() const override;
+  const char* getPluginVersion() const override;
+  int getNbOutputs() const override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nb_input_dims) TRT_NOEXCEPT override;
-  bool supportsFormat(nvinfer1::DataType type, nvinfer1::TensorFormat format)
-      const TRT_NOEXCEPT override;
-  size_t getWorkspaceSize(int max_batch_size) const TRT_NOEXCEPT override;
-#if IS_TRT_VERSION_LT(8000)
+                                     int nb_input_dims) override;
+  bool supportsFormat(nvinfer1::DataType type,
+                      nvinfer1::TensorFormat format) const override;
+  size_t getWorkspaceSize(int max_batch_size) const override;
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
-#else
-  int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
-#endif
-              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
-  int initialize() TRT_NOEXCEPT override;
-  void terminate() TRT_NOEXCEPT override;
-  size_t getSerializationSize() const TRT_NOEXCEPT override;
-  void serialize(void* buffer) const TRT_NOEXCEPT override;
-  void destroy() TRT_NOEXCEPT override;
-  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
-  const char* getPluginNamespace() const TRT_NOEXCEPT override;
-  nvinfer1::DataType getOutputDataType(
-      int index, const nvinfer1::DataType* input_type,
-      int nb_inputs) const TRT_NOEXCEPT override;
+              void* workspace, cudaStream_t stream) override;
+  int initialize() override;
+  void terminate() override;
+  size_t getSerializationSize() const override;
+  void serialize(void* buffer) const override;
+  void destroy() override;
+  void setPluginNamespace(const char* lib_namespace) override;
+  const char* getPluginNamespace() const override;
+  nvinfer1::DataType getOutputDataType(int index,
+                                       const nvinfer1::DataType* input_type,
+                                       int nb_inputs) const override;
   bool isOutputBroadcastAcrossBatch(int output_index,
                                     const bool* input_is_broadcast,
-                                    int nb_inputs) const TRT_NOEXCEPT override;
-  bool canBroadcastInputAcrossBatch(int input_index) const
-      TRT_NOEXCEPT override;
+                                    int nb_inputs) const override;
+  bool canBroadcastInputAcrossBatch(int input_index) const override;
   void configurePlugin(const nvinfer1::Dims* input_dims, int nb_inputs,
                        const nvinfer1::Dims* output_dims, int nb_outputs,
                        const nvinfer1::DataType* input_types,
@@ -70,17 +66,12 @@ class AnchorGeneratorPlugin : public PluginTensorRTV2Ext {
                        const bool* input_is_broadcast,
                        const bool* output_is_broadcast,
                        nvinfer1::PluginFormat float_format,
-                       int max_batct_size) TRT_NOEXCEPT override;
-  nvinfer1::IPluginV2Ext* clone() const TRT_NOEXCEPT override;
+                       int max_batct_size) override;
+  nvinfer1::IPluginV2Ext* clone() const override;
 
  private:
   template <typename T>
-#if IS_TRT_VERSION_LT(8000)
   int enqueue_impl(int batch_size, const void* const* inputs, void** outputs,
-#else
-  int enqueue_impl(int batch_size, const void* const* inputs,
-                   void* const* outputs,
-#endif
                    void* workspace, cudaStream_t stream);
   nvinfer1::DataType data_type_;
   std::vector<float> anchor_sizes_;
@@ -103,17 +94,16 @@ class AnchorGeneratorPluginCreator : public nvinfer1::IPluginCreator {
  public:
   AnchorGeneratorPluginCreator() = default;
   ~AnchorGeneratorPluginCreator() override = default;
-  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
-  const char* getPluginNamespace() const TRT_NOEXCEPT override;
-  const char* getPluginName() const TRT_NOEXCEPT override;
-  const char* getPluginVersion() const TRT_NOEXCEPT override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) override;
+  const char* getPluginNamespace() const override;
+  const char* getPluginName() const override;
+  const char* getPluginVersion() const override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() override;
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name,
-      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(
-      const char* name, const void* serial_data,
-      size_t serial_length) TRT_NOEXCEPT override;
+      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
+                                            const void* serial_data,
+                                            size_t serial_length) override;
 
  private:
   std::string namespace_;
@@ -134,36 +124,35 @@ class AnchorGeneratorPluginDynamic : public DynamicPluginTensorRT {
                                         const int num_anchors);
   AnchorGeneratorPluginDynamic(void const* data, size_t length);
   ~AnchorGeneratorPluginDynamic();
-  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2DynamicExt* clone() const override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
+      nvinfer1::IExprBuilder& exprBuilder) override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs,
-                                 int nbOutputs) TRT_NOEXCEPT override;
+                                 int nbInputs, int nbOutputs) override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) TRT_NOEXCEPT override;
+                       int nbOutputs) override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const TRT_NOEXCEPT override;
+                          int nbOutputs) const override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) TRT_NOEXCEPT override;
-  nvinfer1::DataType getOutputDataType(
-      int index, const nvinfer1::DataType* inputTypes,
-      int nbInputs) const TRT_NOEXCEPT override;
-  const char* getPluginType() const TRT_NOEXCEPT override;
-  int getNbOutputs() const TRT_NOEXCEPT override;
-  int initialize() TRT_NOEXCEPT override;
-  void terminate() TRT_NOEXCEPT override;
-  size_t getSerializationSize() const TRT_NOEXCEPT override;
-  void serialize(void* buffer) const TRT_NOEXCEPT override;
-  void destroy() TRT_NOEXCEPT override;
+              cudaStream_t stream) override;
+  nvinfer1::DataType getOutputDataType(int index,
+                                       const nvinfer1::DataType* inputTypes,
+                                       int nbInputs) const override;
+  const char* getPluginType() const override;
+  int getNbOutputs() const override;
+  int initialize() override;
+  void terminate() override;
+  size_t getSerializationSize() const override;
+  void serialize(void* buffer) const override;
+  void destroy() override;
 
  private:
   template <typename T>
@@ -189,23 +178,23 @@ class AnchorGeneratorPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   AnchorGeneratorPluginDynamicCreator() = default;
   ~AnchorGeneratorPluginDynamicCreator() override = default;
-  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
-  const char* getPluginNamespace() const TRT_NOEXCEPT override;
-  const char* getPluginName() const TRT_NOEXCEPT override;
-  const char* getPluginVersion() const TRT_NOEXCEPT override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) override;
+  const char* getPluginNamespace() const override;
+  const char* getPluginName() const override;
+  const char* getPluginVersion() const override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() override;
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name,
-      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(
-      const char* name, const void* serial_data,
-      size_t serial_length) TRT_NOEXCEPT override;
+      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
+                                            const void* serial_data,
+                                            size_t serial_length) override;
 
  private:
   std::string namespace_;
   nvinfer1::PluginFieldCollection field_collection_;
 };
 REGISTER_TRT_PLUGIN_V2(AnchorGeneratorPluginDynamicCreator);
+#endif
 #endif
 
 }  // namespace plugin

--- a/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.h
@@ -23,6 +23,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class ElementWisePlugin : public PluginTensorRT {
  public:
   ElementWisePlugin(std::string type, nvinfer1::Dims const& dims_x,
@@ -86,6 +87,7 @@ class ElementWisePlugin : public PluginTensorRT {
   int midd_size_;
   int post_size_;
 };
+#endif
 
 #if IS_TRT_VERSION_GE(6000)
 class ElementwisePluginDynamic : public DynamicPluginTensorRT {
@@ -98,46 +100,49 @@ class ElementwisePluginDynamic : public DynamicPluginTensorRT {
     type_ = std::string(elementwise_type);
     DeserializeValue(&serialData, &serialLength, &axis_);
   }
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new ElementwisePluginDynamic(type_, axis_);
   }
 
-  const char* getPluginType() const override { return "elementwise_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "elementwise_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   std::string type_;
@@ -147,31 +152,34 @@ class ElementwisePluginDynamic : public DynamicPluginTensorRT {
 class ElementwisePluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   ElementwisePluginDynamicCreator() {}
-  const char* getPluginName() const override { return "elementwise_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "elementwise_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new ElementwisePluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
@@ -182,17 +182,19 @@ template class EmbEltwiseLayernormPluginDynamicImpl<float>;
 template class EmbEltwiseLayernormPluginDynamicImpl<half>;
 #endif
 
-int EmbEltwiseLayernormPluginDynamic::initialize() {
+int EmbEltwiseLayernormPluginDynamic::initialize() TRT_NOEXCEPT {
   impl_->initialize();
 
   return 0;
 }
 
-void EmbEltwiseLayernormPluginDynamic::terminate() { impl_->terminate(); }
+void EmbEltwiseLayernormPluginDynamic::terminate() TRT_NOEXCEPT {
+  impl_->terminate();
+}
 
 nvinfer1::DimsExprs EmbEltwiseLayernormPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {  // NOLINT
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {  // NOLINT
   PADDLE_ENFORCE_EQ(output_index, 0,
                     platform::errors::InvalidArgument(
                         "There is only one output of the EmbEltwiseLayernorm, "
@@ -209,7 +211,7 @@ nvinfer1::DimsExprs EmbEltwiseLayernormPluginDynamic::getOutputDimensions(
 
 bool EmbEltwiseLayernormPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -257,7 +259,8 @@ bool EmbEltwiseLayernormPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType EmbEltwiseLayernormPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(
       index, 0, platform::errors::InvalidArgument(
                     "The EmbEltwiseLayernorm Plugin only has one input, so the "
@@ -272,7 +275,7 @@ nvinfer1::DataType EmbEltwiseLayernormPluginDynamic::getOutputDataType(
 int EmbEltwiseLayernormPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   impl_->enqueue(input_desc, output_desc, inputs, outputs, workspace, stream);
   return cudaGetLastError() != cudaSuccess;
 }

--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
@@ -189,7 +189,7 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
     }
   }
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     auto ptr = new EmbEltwiseLayernormPluginDynamic(
         embs_, bias_, scale_, emb_sizes_, bias_size_, scale_size_, hidden_size_,
         eps_, with_fp16_);
@@ -197,14 +197,14 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
     return ptr;
   }
 
-  const char* getPluginType() const override {
+  const char* getPluginType() const TRT_NOEXCEPT override {
     return "fused_embedding_eltwise_layernorm_plugin";
   }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
-  void terminate() override;
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     int sum_num = 0;
     sum_num += SerializedSize(emb_sizes_);
 
@@ -223,7 +223,7 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
     return sum_num;
   }
 
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, emb_sizes_);
     for (size_t i = 0; i < emb_sizes_.size(); i++) {
       auto size = emb_sizes_[i];
@@ -248,33 +248,34 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* input_desc,
               const nvinfer1::PluginTensorDesc* output_desc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override {
+  void destroy() TRT_NOEXCEPT override {
     if (own_host_buff_) {
       for (auto ptr : embs_) {
         delete[] ptr;
@@ -310,32 +311,33 @@ class EmbEltwiseLayernormPluginDynamicCreator
     : public nvinfer1::IPluginCreator {
  public:
   EmbEltwiseLayernormPluginDynamicCreator() {}
-  const char* getPluginName() const override {
+  const char* getPluginName() const TRT_NOEXCEPT override {
     return "fused_embedding_eltwise_layernorm_plugin";
   }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new EmbEltwiseLayernormPluginDynamic(serial_data, serial_length);
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.cu
@@ -30,6 +30,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 #if IS_TRT_VERSION_GE(6000)
 
 template <typename T, typename IndexT = int>
@@ -221,6 +222,7 @@ int GatherNdPluginDynamic::enqueue(
 
   return cudaGetLastError() != cudaSuccess;
 }
+#endif
 #endif
 
 }  // namespace plugin

--- a/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.h
@@ -26,6 +26,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 #if IS_TRT_VERSION_GE(6000)
 class GatherNdPluginDynamic : public DynamicPluginTensorRT {
  public:
@@ -124,6 +125,7 @@ class GatherNdPluginDynamicCreator : public nvinfer1::IPluginCreator {
 };
 
 REGISTER_TRT_PLUGIN_V2(GatherNdPluginDynamicCreator);
+#endif
 #endif
 
 }  // namespace plugin

--- a/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
@@ -31,6 +31,7 @@ static const float kAT = 0.5;
 static const float kBT = 0.7978845608028654;    // sqrt(2.0/M_PI)
 static const float kCT = 0.035677408136300125;  // 0.044715 * sqrt(2.0/M_PI)
 
+#if IS_TRT_VERSION_LT(8000)
 GeluPlugin* CreateGeluPluginDeserialize(const void* buffer, size_t length) {
   return new GeluPlugin(buffer, length);
 }
@@ -58,6 +59,7 @@ nvinfer1::Dims GeluPlugin::getOutputDimensions(int index,
   nvinfer1::Dims output_dims = input_dims;
   return output_dims;
 }
+#endif
 
 template <typename T, unsigned TPB>
 __global__ void gelu_kernel(const T a, int n, const T* input, T* output) {
@@ -99,6 +101,7 @@ __global__ void no_exact_gelu_kernel(const T a, const T b, const T c, int n,
 #endif
 }
 
+#if IS_TRT_VERSION_LT(8000)
 int GeluPlugin::enqueue(int batch_size, const void* const* inputs,
                         void** outputs, void*, cudaStream_t stream) {
   const auto& input_dims = this->getInputDims(0);
@@ -129,19 +132,20 @@ int GeluPlugin::enqueue(int batch_size, const void* const* inputs,
   }
   return cudaGetLastError() != cudaSuccess;
 }
+#endif
 
 // Dynamic Plugin below.
 #if IS_TRT_VERSION_GE(6000)
 
 nvinfer1::DimsExprs GeluPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   return inputs[0];
 }
 
 bool GeluPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -170,7 +174,8 @@ bool GeluPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType GeluPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The Gelu Plugin only has one input, so the "
                                   "index value should be 0, but get %d.",
@@ -181,7 +186,8 @@ nvinfer1::DataType GeluPluginDynamic::getOutputDataType(
 int GeluPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
                                const nvinfer1::PluginTensorDesc* output_desc,
                                const void* const* inputs, void* const* outputs,
-                               void* workspace, cudaStream_t stream) {
+                               void* workspace,
+                               cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   size_t num = ProductDim(input_dims);
   const int block_size = 256;

--- a/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.h
@@ -24,6 +24,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class GeluPlugin : public PluginTensorRT {
  public:
   explicit GeluPlugin(const bool with_fp16) { with_fp16_ = with_fp16; }
@@ -39,7 +40,7 @@ class GeluPlugin : public PluginTensorRT {
 
   const char* getPluginType() const override { return "gelu_plugin"; }
   int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
   bool supportsFormat(nvinfer1::DataType type,
                       nvinfer1::PluginFormat format) const override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
@@ -59,6 +60,7 @@ class GeluPlugin : public PluginTensorRT {
     serializeBase(buffer);
   }
 };
+#endif
 
 #if IS_TRT_VERSION_GE(6000)
 class GeluPluginDynamic : public DynamicPluginTensorRT {
@@ -69,80 +71,86 @@ class GeluPluginDynamic : public DynamicPluginTensorRT {
   }
 
   ~GeluPluginDynamic() {}
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new GeluPluginDynamic(with_fp16_);
   }
 
-  const char* getPluginType() const override { return "gelu_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "gelu_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return SerializedSize(with_fp16_);
   }
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, with_fp16_);
   }
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* input_desc,
               const nvinfer1::PluginTensorDesc* output_desc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 };
 
 class GeluPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   GeluPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "gelu_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "gelu_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new GeluPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.cu
@@ -22,6 +22,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 HardSwishPlugin* CreateHardSwishPluginDeserialize(const void* buffer,
                                                   size_t length) {
   return new HardSwishPlugin(buffer, length);
@@ -79,6 +80,7 @@ int HardSwishPlugin::enqueue(int batch_size, const void* const* inputs,
 
   return cudaGetLastError() != cudaSuccess;
 }
+#endif
 
 }  // namespace plugin
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.h
@@ -25,6 +25,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class HardSwishPlugin : public PluginTensorRT {
  public:
   HardSwishPlugin(const float threshold, const float scale, const float offset)
@@ -73,6 +74,7 @@ class HardSwishPlugin : public PluginTensorRT {
     SerializeValue(&buffer, offset_);
   }
 };
+#endif
 
 }  // namespace plugin
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.cu
@@ -40,6 +40,7 @@ cudnnStatus_t convert_trt2cudnn_dtype(nvinfer1::DataType trt_dtype,
   return CUDNN_STATUS_SUCCESS;
 }
 
+#if IS_TRT_VERSION_LT(8000)
 InstanceNormPlugin *CreateInstanceNormPluginDeserialize(const void *buffer,
                                                         size_t length) {
   return new InstanceNormPlugin(buffer, length);
@@ -107,6 +108,7 @@ int InstanceNormPlugin::enqueue(int batch_size, const void *const *inputs,
       eps_, nullptr, nullptr);
   return cudaGetLastError() != cudaSuccess;
 }
+#endif
 
 }  // namespace plugin
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
@@ -27,6 +27,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class InstanceNormPlugin : public PluginTensorRT {
  private:
   float eps_;
@@ -111,6 +112,7 @@ class InstanceNormPlugin : public PluginTensorRT {
             (format == nvinfer1::PluginFormat::kNCHW));
   }
 };
+#endif
 
 }  // namespace plugin
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
@@ -25,6 +25,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 LayerNormPlugin *CreateLayerNormPluginDeserialize(const void *buffer,
                                                   size_t length) {
   return new LayerNormPlugin(buffer, length);
@@ -97,10 +98,11 @@ nvinfer1::DimsExprs LayerNormPluginDynamic::getOutputDimensions(
     nvinfer1::IExprBuilder &expr_builder) {
   return inputDims[0];
 }
+#endif
 
 bool LayerNormPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of layernorm plugin shoule not be nullptr."));
@@ -121,7 +123,8 @@ bool LayerNormPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType LayerNormPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0,
                     platform::errors::InvalidArgument(
                         "The LayerNormPlugin only has one input, so the "
@@ -133,7 +136,7 @@ nvinfer1::DataType LayerNormPluginDynamic::getOutputDataType(
 int LayerNormPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   const auto &input_dims = input_desc[0].dims;
   int begin_norm_axis = begin_norm_axis_;
   float eps = eps_;

--- a/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.h
@@ -55,6 +55,7 @@ static std::vector<int> CalcOutputSize(const std::vector<int>& input_shape,
   return output_shape;
 }
 
+#if IS_TRT_VERSION_LT(8000)
 class PoolPlugin : public PluginTensorRT {
  protected:
   size_t getSerializationSize() override {
@@ -141,6 +142,7 @@ class PoolPlugin : public PluginTensorRT {
   std::vector<int> input_shape_;
   std::vector<int> output_shape_;
 };
+#endif
 
 #if IS_TRT_VERSION_GE(6000)
 class PoolPluginDynamic : public DynamicPluginTensorRT {
@@ -171,47 +173,50 @@ class PoolPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &is_global_);
   }
   ~PoolPluginDynamic() {}
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new PoolPluginDynamic(ceil_mode_, pool_type_, adaptive_, ksize_,
                                  strides_, paddings_, is_global_);
   }
 
-  const char* getPluginType() const override { return "pool_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "pool_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   bool ceil_mode_;

--- a/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.h
@@ -28,6 +28,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class PReluPlugin : public PluginTensorRT {
   std::vector<float> weight_;
   float* p_gpu_weight_;
@@ -83,6 +84,7 @@ class PReluPlugin : public PluginTensorRT {
   int enqueue(int batchSize, const void* const* inputs, void** outputs,
               void* workspace, cudaStream_t stream) override;
 };
+#endif
 
 #if IS_TRT_VERSION_GE(6000)
 class PReluPluginDynamic : public DynamicPluginTensorRT {
@@ -104,49 +106,52 @@ class PReluPluginDynamic : public DynamicPluginTensorRT {
     mode_ = std::string(prelu_mode);
   }
   ~PReluPluginDynamic() {}
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     auto ptr = new PReluPluginDynamic(weight_.data(), weight_.size(), mode_);
     ptr->p_gpu_weight_ = p_gpu_weight_;
     return ptr;
   }
 
-  const char* getPluginType() const override { return "prelu_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
-  void terminate() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "prelu_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   std::vector<float> weight_;

--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
@@ -148,11 +148,11 @@ inline void TransposeQKV(const int batch, const int seq_len,
   }
 }
 
-int QkvToContextPluginDynamic::initialize() { return 0; }
+int QkvToContextPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
 nvinfer1::DimsExprs QkvToContextPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   // input[0], (B, S, 3 * N * H, 1, 1)
   // input[1], (B, head_num, seq_len, seq_len)
   // output, (B, seq_len, hidden)
@@ -178,7 +178,7 @@ nvinfer1::DimsExprs QkvToContextPluginDynamic::getOutputDimensions(
 
 bool QkvToContextPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -216,7 +216,8 @@ bool QkvToContextPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType QkvToContextPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(
       index, 0, platform::errors::InvalidArgument(
                     "The EmbEltwiseLayernorm Plugin only has one input, so the "
@@ -236,7 +237,7 @@ __global__ void apply_scale(T *data, T scale, int n) {
 int QkvToContextPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   int input_num = ProductDim(input_dims);
   // input[0], (B, S, 3 * N * H, 1, 1)

--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.h
@@ -59,21 +59,23 @@ class QkvToContextPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &scale_);
     DeserializeValue(&serial_data, &serial_length, &with_fp16_);
   }
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new QkvToContextPluginDynamic(hidden_, head_number_, head_size_,
                                          scale_, with_fp16_);
   }
 
-  const char* getPluginType() const override { return "qkv_to_context_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "qkv_to_context_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return SerializedSize(hidden_) + SerializedSize(head_number_) +
            SerializedSize(head_size_) + SerializedSize(scale_) +
            SerializedSize(with_fp16_);
   }
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, hidden_);
     SerializeValue(&buffer, head_number_);
     SerializeValue(&buffer, head_size_);
@@ -83,33 +85,34 @@ class QkvToContextPluginDynamic : public DynamicPluginTensorRT {
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   int hidden_;
@@ -121,31 +124,34 @@ class QkvToContextPluginDynamic : public DynamicPluginTensorRT {
 class QkvToContextPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   QkvToContextPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "qkv_to_context_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "qkv_to_context_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new QkvToContextPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
@@ -24,6 +24,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 template <class T>
 __inline__ __device__ T BilinearInterpolate(const T* input_data,
                                             const int height, const int width,
@@ -373,6 +374,7 @@ nvinfer1::IPluginV2Ext* RoiAlignPluginDynamicCreator::deserializePlugin(
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;
 }
+#endif
 #endif
 
 }  // namespace plugin

--- a/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.h
@@ -25,6 +25,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 #if IS_TRT_VERSION_GE(6000)
 class RoiAlignPluginDynamic : public DynamicPluginTensorRT {
  public:
@@ -104,6 +105,7 @@ class RoiAlignPluginDynamicCreator : public nvinfer1::IPluginCreator {
   nvinfer1::PluginFieldCollection field_collection_;
 };
 REGISTER_TRT_PLUGIN_V2(RoiAlignPluginDynamicCreator);
+#endif
 #endif
 
 }  // namespace plugin

--- a/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
@@ -30,7 +30,7 @@ namespace plugin {
 // Dynamic Plugin below.
 #if IS_TRT_VERSION_GE(6000)
 
-int SkipLayerNormPluginDynamic::initialize() {
+int SkipLayerNormPluginDynamic::initialize() TRT_NOEXCEPT {
   cudaMalloc(&bias_gpu_, sizeof(float) * bias_size_);
   cudaMemcpy(bias_gpu_, bias_.data(), bias_size_ * sizeof(float),
              cudaMemcpyHostToDevice);
@@ -40,7 +40,7 @@ int SkipLayerNormPluginDynamic::initialize() {
   return 0;
 }
 
-void SkipLayerNormPluginDynamic::terminate() {
+void SkipLayerNormPluginDynamic::terminate() TRT_NOEXCEPT {
   if (bias_gpu_) {
     cudaFree(bias_gpu_);
     bias_gpu_ = nullptr;
@@ -53,13 +53,13 @@ void SkipLayerNormPluginDynamic::terminate() {
 
 nvinfer1::DimsExprs SkipLayerNormPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   return inputs[0];
 }
 
 bool SkipLayerNormPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -97,7 +97,8 @@ bool SkipLayerNormPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType SkipLayerNormPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0,
                     platform::errors::InvalidArgument(
                         "The SkipLayerNorm Plugin only has one input, so the "
@@ -113,7 +114,7 @@ nvinfer1::DataType SkipLayerNormPluginDynamic::getOutputDataType(
 int SkipLayerNormPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   size_t num = ProductDim(input_dims);
   int hidden = input_dims.d[2];

--- a/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.h
@@ -48,7 +48,7 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &with_fp16_);
   }
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     auto ptr = new SkipLayerNormPluginDynamic(
         bias_.data(), scale_.data(), bias_size_, scale_size_, eps_, with_fp16_);
     ptr->bias_gpu_ = bias_gpu_;
@@ -56,17 +56,19 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
     return ptr;
   }
 
-  const char* getPluginType() const override { return "skip_layernorm_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "skip_layernorm_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     size_t ser_size = SerializedSize(bias_) + SerializedSize(scale_) +
                       SerializedSize(bias_size_) + SerializedSize(scale_size_) +
                       SerializedSize(eps_) + SerializedSize(with_fp16_);
     return ser_size;
   }
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, bias_);
     SerializeValue(&buffer, scale_);
     SerializeValue(&buffer, bias_size_);
@@ -77,34 +79,35 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* input_desc,
               const nvinfer1::PluginTensorDesc* output_desc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
-  void terminate() override;
+  void destroy() TRT_NOEXCEPT override { delete this; }
+  void terminate() TRT_NOEXCEPT override;
 
  private:
   std::vector<float> bias_;
@@ -122,31 +125,34 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
 class SkipLayerNormPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SkipLayerNormPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "skip_layernorm_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "skip_layernorm_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new SkipLayerNormPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
@@ -26,10 +26,12 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 SlicePlugin *CreateSlicePluginDeserialize(const void *buffer, size_t length) {
   return new SlicePlugin(buffer, length);
 }
 REGISTER_TRT_PLUGIN("slice_plugin", CreateSlicePluginDeserialize);
+#endif
 
 template <typename T>
 __global__ void SliceKernel(int num, int dims, const T *input,
@@ -58,6 +60,7 @@ __global__ void SliceKernel(int num, int dims, const T *input,
   }
 }
 
+#if IS_TRT_VERSION_LT(8000)
 SlicePlugin::SlicePlugin(std::vector<int> starts, std::vector<int> ends,
                          std::vector<int> axes, bool with_fp16)
     : starts_(starts), ends_(ends), axes_(axes) {
@@ -201,6 +204,7 @@ void SlicePlugin::serialize(void *buffer) {
   SerializeValue(&buffer, ends_);
   SerializeValue(&buffer, axes_);
 }
+#endif
 
 // Dynamic Plugin below.
 #if IS_TRT_VERSION_GE(6000)
@@ -223,23 +227,23 @@ SlicePluginDynamic::SlicePluginDynamic(void const *serialData,
   cudaStreamCreate(&copy_stream_);
 }
 
-void SlicePluginDynamic::destroy() {
+void SlicePluginDynamic::destroy() TRT_NOEXCEPT {
   cudaStreamDestroy(copy_stream_);
   cudaEventDestroy(copy_event_);
   cudaFree(offset_temp_data_);
   delete this;
 }
 
-int SlicePluginDynamic::initialize() { return 0; }
+int SlicePluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t SlicePluginDynamic::getSerializationSize() const {
+size_t SlicePluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t size = SerializedSize(starts_) + SerializedSize(ends_) +
                 SerializedSize(axes_) + SerializedSize(with_fp16_);
 
   return size;
 }
 
-void SlicePluginDynamic::serialize(void *buffer) const {
+void SlicePluginDynamic::serialize(void *buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, starts_);
   SerializeValue(&buffer, ends_);
   SerializeValue(&buffer, axes_);
@@ -248,7 +252,7 @@ void SlicePluginDynamic::serialize(void *buffer) const {
 
 nvinfer1::DimsExprs SlicePluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   auto in_dims = inputs[0];
   nvinfer1::DimsExprs ret = in_dims;
   // start, ends should greater 0
@@ -262,7 +266,7 @@ nvinfer1::DimsExprs SlicePluginDynamic::getOutputDimensions(
 
 bool SlicePluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -290,7 +294,8 @@ bool SlicePluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType SlicePluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The Slice Plugin only has one input, so the "
                                   "index value should be 0, but get %d.",
@@ -305,7 +310,8 @@ nvinfer1::DataType SlicePluginDynamic::getOutputDataType(
 int SlicePluginDynamic::enqueue(const nvinfer1::PluginTensorDesc *input_desc,
                                 const nvinfer1::PluginTensorDesc *output_desc,
                                 const void *const *inputs, void *const *outputs,
-                                void *workspace, cudaStream_t stream) {
+                                void *workspace,
+                                cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   auto out_dims = output_desc[0].dims;
   auto num_dims = input_dims.nbDims;

--- a/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.h
@@ -26,6 +26,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class SlicePlugin : public PluginTensorRT {
  public:
   explicit SlicePlugin(std::vector<int> starts, std::vector<int> ends,
@@ -62,6 +63,7 @@ class SlicePlugin : public PluginTensorRT {
   cudaEvent_t copy_event_;
   cudaStream_t copy_stream_;
 };
+#endif
 
 #if IS_TRT_VERSION_GE(6000)
 class SlicePluginDynamic : public DynamicPluginTensorRT {
@@ -69,48 +71,51 @@ class SlicePluginDynamic : public DynamicPluginTensorRT {
   explicit SlicePluginDynamic(std::vector<int> starts, std::vector<int> ends,
                               std::vector<int> axes, bool with_fp16);
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new SlicePluginDynamic(starts_, ends_, axes_, with_fp16_);
   }
 
   SlicePluginDynamic(void const* serialData, size_t serialLength);
 
-  const char* getPluginType() const override { return "slice_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "slice_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   std::vector<int> starts_;
@@ -124,31 +129,36 @@ class SlicePluginDynamic : public DynamicPluginTensorRT {
 class SlicePluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SlicePluginDynamicCreator() {}
-  const char* getPluginName() const override { return "slice_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "slice_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serialData,
-                                         size_t serialLength) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serialData,
+      size_t serialLength) TRT_NOEXCEPT override {
     auto plugin = new SlicePluginDynamic(serialData, serialLength);
     return plugin;
   }
 
-  void setPluginNamespace(const char* libNamespace) override {
+  void setPluginNamespace(const char* libNamespace) TRT_NOEXCEPT override {
     namespace_ = libNamespace;
   }
 
-  const char* getPluginNamespace() const override { return namespace_.c_str(); }
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
+    return namespace_.c_str();
+  }
 
  private:
   std::string namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.cu
@@ -31,28 +31,29 @@ SpecialSlicePluginDynamic::SpecialSlicePluginDynamic(void const* serial_data,
 
 SpecialSlicePluginDynamic::~SpecialSlicePluginDynamic() {}
 
-nvinfer1::IPluginV2DynamicExt* SpecialSlicePluginDynamic::clone() const {
+nvinfer1::IPluginV2DynamicExt* SpecialSlicePluginDynamic::clone() const
+    TRT_NOEXCEPT {
   return new SpecialSlicePluginDynamic();
 }
 
-const char* SpecialSlicePluginDynamic::getPluginType() const {
+const char* SpecialSlicePluginDynamic::getPluginType() const TRT_NOEXCEPT {
   return "special_slice_plugin";
 }
 
-int SpecialSlicePluginDynamic::getNbOutputs() const { return 1; }
+int SpecialSlicePluginDynamic::getNbOutputs() const TRT_NOEXCEPT { return 1; }
 
-int SpecialSlicePluginDynamic::initialize() { return 0; }
+int SpecialSlicePluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t SpecialSlicePluginDynamic::getSerializationSize() const {
+size_t SpecialSlicePluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   return serialize_size;
 }
 
-void SpecialSlicePluginDynamic::serialize(void* buffer) const {}
+void SpecialSlicePluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {}
 
 nvinfer1::DimsExprs SpecialSlicePluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   nvinfer1::DimsExprs output(inputs[0]);
   output.nbDims++;
   for (int i = output.nbDims - 1; i > 1; i--) {
@@ -70,21 +71,22 @@ nvinfer1::DimsExprs SpecialSlicePluginDynamic::getOutputDimensions(
 
 void SpecialSlicePluginDynamic::configurePlugin(
     const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs,
-    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {}
+    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) TRT_NOEXCEPT {}
 
 size_t SpecialSlicePluginDynamic::getWorkspaceSize(
     const nvinfer1::PluginTensorDesc* inputs, int nbInputs,
-    const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
   return 0;
 }
 
-void SpecialSlicePluginDynamic::destroy() { delete this; }
+void SpecialSlicePluginDynamic::destroy() TRT_NOEXCEPT { delete this; }
 
-void SpecialSlicePluginDynamic::terminate() {}
+void SpecialSlicePluginDynamic::terminate() TRT_NOEXCEPT {}
 
 bool SpecialSlicePluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* desc, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   if (pos == 0)  // slice tensor
     return (desc[pos].type == nvinfer1::DataType::kHALF &&
             desc[pos].format ==
@@ -102,7 +104,8 @@ bool SpecialSlicePluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType SpecialSlicePluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The index should be equal to 0"));
   return input_types[0];
@@ -121,7 +124,7 @@ __global__ void SpecialSliceKernel(const T* slice_input,
 int SpecialSlicePluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc* input_desc,
     const nvinfer1::PluginTensorDesc* output_desc, const void* const* inputs,
-    void* const* outputs, void* workspace, cudaStream_t stream) {
+    void* const* outputs, void* workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;  // (sum(S), 768, 1, 1)
   auto out_dims = output_desc[0].dims;   // (batch, 768, 1, 1)
 
@@ -143,36 +146,40 @@ int SpecialSlicePluginDynamic::enqueue(
 
 SpecialSlicePluginDynamicCreator::SpecialSlicePluginDynamicCreator() {}
 
-const char* SpecialSlicePluginDynamicCreator::getPluginName() const {
+const char* SpecialSlicePluginDynamicCreator::getPluginName() const
+    TRT_NOEXCEPT {
   return "special_slice_plugin";
 }
 
-const char* SpecialSlicePluginDynamicCreator::getPluginVersion() const {
+const char* SpecialSlicePluginDynamicCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
   return "1";
 }
 
 const nvinfer1::PluginFieldCollection*
-SpecialSlicePluginDynamicCreator::getFieldNames() {
+SpecialSlicePluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2* SpecialSlicePluginDynamicCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   return new SpecialSlicePluginDynamic();
 }
 
 nvinfer1::IPluginV2* SpecialSlicePluginDynamicCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new SpecialSlicePluginDynamic(serial_data, serial_length);
   return plugin;
 }
 
 void SpecialSlicePluginDynamicCreator::setPluginNamespace(
-    const char* lib_namespace) {
+    const char* lib_namespace) TRT_NOEXCEPT {
   plugin_namespace_ = lib_namespace;
 }
 
-const char* SpecialSlicePluginDynamicCreator::getPluginNamespace() const {
+const char* SpecialSlicePluginDynamicCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
   return plugin_namespace_.c_str();
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.h
@@ -31,37 +31,38 @@ class SpecialSlicePluginDynamic : public DynamicPluginTensorRT {
   SpecialSlicePluginDynamic();
   SpecialSlicePluginDynamic(void const* serial_data, size_t serial_length);
   ~SpecialSlicePluginDynamic();
-  nvinfer1::IPluginV2DynamicExt* clone() const override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override;
+                       int nbOutputs) TRT_NOEXCEPT override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override;
+                          int nbOutputs) const TRT_NOEXCEPT override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  const char* getPluginType() const override;
-  int getNbOutputs() const override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   int axis_;
@@ -71,16 +72,17 @@ class SpecialSlicePluginDynamic : public DynamicPluginTensorRT {
 class SpecialSlicePluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SpecialSlicePluginDynamicCreator();
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
 
  private:
   std::string plugin_namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.cu
@@ -39,7 +39,7 @@ __device__ int upper_bound(T const* vals, int n, T const& key) {
 }
 
 nvinfer1::Dims SplitPlugin::getOutputDimensions(
-    int index, const nvinfer1::Dims* input_dims, int num_inputs) {
+    int index, const nvinfer1::Dims* input_dims, int num_inputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(num_inputs, 1,
                     platform::errors::InvalidArgument(
                         "Invalid number of inputs of split TRT plugin. "
@@ -67,7 +67,7 @@ void SplitPlugin::shareData(const SplitPlugin* another) {
   d_output_ptrs_.resize(another->d_output_ptrs_.size(), nullptr);
 }
 
-int SplitPlugin::initialize() {
+int SplitPlugin::initialize() TRT_NOEXCEPT {
   PADDLE_ENFORCE_LE(axis_, nvinfer1::Dims::MAX_DIMS,
                     platform::errors::InvalidArgument(
                         "Axis dimension exceeds max dimension in TensorRT. "
@@ -99,7 +99,7 @@ int SplitPlugin::initialize() {
 }
 
 // nothing to release according to initialize
-void SplitPlugin::terminate() {}
+void SplitPlugin::terminate() TRT_NOEXCEPT {}
 
 // The following part of the code refers to onnx-tensorrt
 // https://github.com/onnx/onnx-tensorrt/blob/master/Split.cu
@@ -125,8 +125,14 @@ __global__ void split_kernel(int nsegment,
   }
 }
 
+#if IS_TRT_VERSION_LT(8000)
 int SplitPlugin::enqueue(int batchSize, const void* const* inputs,
-                         void** outputs, void* workspace, cudaStream_t stream) {
+                         void** outputs,
+#else
+int SplitPlugin::enqueue(int batchSize, const void* const* inputs,
+                         void* const* outputs,
+#endif
+                         void* workspace, cudaStream_t stream) TRT_NOEXCEPT {
   const int* d_segment_offsets_ptr =
       thrust::raw_pointer_cast(&d_segment_offsets_[0]);
   float const* input_ptr = reinterpret_cast<float const*>(inputs[0]);
@@ -151,14 +157,14 @@ int SplitPlugin::enqueue(int batchSize, const void* const* inputs,
 
 // Dynamic Plugin below.
 #if IS_TRT_VERSION_GE(6000)
-int SplitPluginDynamic::initialize() { return 0; }
+int SplitPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t SplitPluginDynamic::getSerializationSize() const {
+size_t SplitPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   return SerializedSize(axis_) + SerializedSize(output_length_) +
          SerializedSize(with_fp16_);
 }
 
-void SplitPluginDynamic::serialize(void* buffer) const {
+void SplitPluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, axis_);
   SerializeValue(&buffer, output_length_);
   SerializeValue(&buffer, with_fp16_);
@@ -166,7 +172,7 @@ void SplitPluginDynamic::serialize(void* buffer) const {
 
 nvinfer1::DimsExprs SplitPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nb_inputs, 1,
                     platform::errors::InvalidArgument(
                         "The Split plugin should be only one input."));
@@ -184,7 +190,7 @@ nvinfer1::DimsExprs SplitPluginDynamic::getOutputDimensions(
 
 bool SplitPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of split plugin should not be nullptr."));
@@ -213,14 +219,16 @@ bool SplitPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType SplitPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   return input_types[0];
 }
 
 int SplitPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
                                 const nvinfer1::PluginTensorDesc* output_desc,
                                 const void* const* inputs, void* const* outputs,
-                                void* workspace, cudaStream_t stream) {
+                                void* workspace,
+                                cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   int outer_rows = 1;
   int inner_cols = 1;

--- a/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.h
@@ -39,39 +39,47 @@ class SplitPlugin : public PluginTensorRTV2Ext {
     DeserializeValue(&serial_data, &serial_length, &output_length_);
   }
 
-  nvinfer1::IPluginV2Ext* clone() const override {
+  nvinfer1::IPluginV2Ext* clone() const TRT_NOEXCEPT override {
     SplitPlugin* ptr = new SplitPlugin(axis_, output_length_, with_fp16_);
     ptr->setPluginNamespace(this->getPluginNamespace());
     ptr->shareData(this);
     return ptr;
   }
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override {
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override {
     return input_types[0];
   }
 
-  const char* getPluginType() const override { return "split_plugin_v2ext"; }
-  int getNbOutputs() const override { return output_length_.size(); }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "split_plugin_v2ext";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override {
+    return output_length_.size();
+  }
   nvinfer1::Dims getOutputDimensions(int index,
                                      const nvinfer1::Dims* input_dims,
-                                     int num_inputs) override;
+                                     int num_inputs) TRT_NOEXCEPT override;
 
-  int initialize() override;
-  void terminate() override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+#if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
-              void* workspace, cudaStream_t stream) override;
+#else
+  int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
+#endif
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  protected:
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return SerializedSize(axis_) + SerializedSize(output_length_) +
            getBaseSerializationSize();
   }
 
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, axis_);
     SerializeValue(&buffer, output_length_);
@@ -94,32 +102,35 @@ class SplitPlugin : public PluginTensorRTV2Ext {
 class SplitPluginCreator : public nvinfer1::IPluginCreator {
  public:
   SplitPluginCreator() {}
-  const char* getPluginName() const override { return "split_plugin_v2ext"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "split_plugin_v2ext";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     // not implemented
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new SplitPlugin(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 
@@ -147,46 +158,51 @@ class SplitPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &with_fp16_);
   }
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new SplitPluginDynamic(axis_, output_length_, with_fp16_);
   }
 
-  const char* getPluginType() const override { return "split_plugin"; }
-  int getNbOutputs() const override { return output_length_.size(); }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "split_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override {
+    return output_length_.size();
+  }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   int axis_;
@@ -196,31 +212,34 @@ class SplitPluginDynamic : public DynamicPluginTensorRT {
 class SplitPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SplitPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "split_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "split_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new SplitPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.cu
@@ -38,17 +38,19 @@ StackPluginDynamic::StackPluginDynamic(void const* serial_data,
 
 StackPluginDynamic::~StackPluginDynamic() {}
 
-nvinfer1::IPluginV2DynamicExt* StackPluginDynamic::clone() const {
+nvinfer1::IPluginV2DynamicExt* StackPluginDynamic::clone() const TRT_NOEXCEPT {
   return new StackPluginDynamic(axis_, num_stack_, with_fp16_);
 }
 
-const char* StackPluginDynamic::getPluginType() const { return "stack_plugin"; }
+const char* StackPluginDynamic::getPluginType() const TRT_NOEXCEPT {
+  return "stack_plugin";
+}
 
-int StackPluginDynamic::getNbOutputs() const { return 1; }
+int StackPluginDynamic::getNbOutputs() const TRT_NOEXCEPT { return 1; }
 
-int StackPluginDynamic::initialize() { return 0; }
+int StackPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t StackPluginDynamic::getSerializationSize() const {
+size_t StackPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(axis_);
   serialize_size += SerializedSize(num_stack_);
@@ -56,7 +58,7 @@ size_t StackPluginDynamic::getSerializationSize() const {
   return serialize_size;
 }
 
-void StackPluginDynamic::serialize(void* buffer) const {
+void StackPluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, axis_);
   SerializeValue(&buffer, num_stack_);
   SerializeValue(&buffer, with_fp16_);
@@ -64,7 +66,7 @@ void StackPluginDynamic::serialize(void* buffer) const {
 
 nvinfer1::DimsExprs StackPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   nvinfer1::DimsExprs output(inputs[0]);
   output.nbDims = inputs[0].nbDims + 1;
 
@@ -77,21 +79,22 @@ nvinfer1::DimsExprs StackPluginDynamic::getOutputDimensions(
 
 void StackPluginDynamic::configurePlugin(
     const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs,
-    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {}
+    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) TRT_NOEXCEPT {}
 
 size_t StackPluginDynamic::getWorkspaceSize(
     const nvinfer1::PluginTensorDesc* inputs, int nbInputs,
-    const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
   return num_stack_ * sizeof(uintptr_t);
 }
 
-void StackPluginDynamic::destroy() { delete this; }
+void StackPluginDynamic::destroy() TRT_NOEXCEPT { delete this; }
 
-void StackPluginDynamic::terminate() {}
+void StackPluginDynamic::terminate() TRT_NOEXCEPT {}
 
 bool StackPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of stack plugin should not be nullptr."));
@@ -119,7 +122,8 @@ bool StackPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType StackPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The index should be equal to 0"));
   return input_types[0];
@@ -140,7 +144,8 @@ __global__ void StackKernel(const T* const* input, T* output, int num_stack,
 int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
                                 const nvinfer1::PluginTensorDesc* output_desc,
                                 const void* const* inputs, void* const* outputs,
-                                void* workspace, cudaStream_t stream) {
+                                void* workspace,
+                                cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;  // (batch, seq, seq)
   auto out_dims = output_desc[0].dims;   // (batch, num_head, seq, seq)
   auto out_num_dims = out_dims.nbDims;
@@ -196,19 +201,21 @@ int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
 
 StackPluginDynamicCreator::StackPluginDynamicCreator() {}
 
-const char* StackPluginDynamicCreator::getPluginName() const {
+const char* StackPluginDynamicCreator::getPluginName() const TRT_NOEXCEPT {
   return "stack_plugin";
 }
 
-const char* StackPluginDynamicCreator::getPluginVersion() const { return "1"; }
+const char* StackPluginDynamicCreator::getPluginVersion() const TRT_NOEXCEPT {
+  return "1";
+}
 
 const nvinfer1::PluginFieldCollection*
-StackPluginDynamicCreator::getFieldNames() {
+StackPluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2* StackPluginDynamicCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   int axis = -1;
   int num_stack = -1;
   bool with_fp16 = false;
@@ -231,16 +238,18 @@ nvinfer1::IPluginV2* StackPluginDynamicCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2* StackPluginDynamicCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new StackPluginDynamic(serial_data, serial_length);
   return plugin;
 }
 
-void StackPluginDynamicCreator::setPluginNamespace(const char* lib_namespace) {
+void StackPluginDynamicCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   plugin_namespace_ = lib_namespace;
 }
 
-const char* StackPluginDynamicCreator::getPluginNamespace() const {
+const char* StackPluginDynamicCreator::getPluginNamespace() const TRT_NOEXCEPT {
   return plugin_namespace_.c_str();
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.h
@@ -31,37 +31,38 @@ class StackPluginDynamic : public DynamicPluginTensorRT {
   explicit StackPluginDynamic(int axis, int num_stack, bool with_fp16);
   StackPluginDynamic(void const* serial_data, size_t serial_length);
   ~StackPluginDynamic();
-  nvinfer1::IPluginV2DynamicExt* clone() const override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override;
+                       int nbOutputs) TRT_NOEXCEPT override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override;
+                          int nbOutputs) const TRT_NOEXCEPT override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  const char* getPluginType() const override;
-  int getNbOutputs() const override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   int axis_;
@@ -71,16 +72,17 @@ class StackPluginDynamic : public DynamicPluginTensorRT {
 class StackPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   StackPluginDynamicCreator();
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
 
  private:
   std::string plugin_namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.h
@@ -26,6 +26,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class SwishPlugin : public PluginTensorRT {
  private:
   float beta_;
@@ -70,6 +71,7 @@ class SwishPlugin : public PluginTensorRT {
   int enqueue(int batchSize, const void* const* inputs, void** outputs,
               void* workspace, cudaStream_t stream) override;
 };
+#endif
 
 #if IS_TRT_VERSION_GE(6000)
 class SwishPluginDynamic : public DynamicPluginTensorRT {
@@ -82,46 +84,49 @@ class SwishPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &beta_);
     DeserializeValue(&serialData, &serialLength, &with_fp16_);
   }
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new SwishPluginDynamic(beta_, with_fp16_);
   }
 
-  const char* getPluginType() const override { return "swish_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "swish_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   float beta_;
@@ -130,31 +135,34 @@ class SwishPluginDynamic : public DynamicPluginTensorRT {
 class SwishPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SwishPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "swish_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "swish_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new SwishPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
@@ -49,6 +49,7 @@ inline size_t SeriaSize(const std::vector<nvinfer1::Dims>& input_dims,
           SerializedSize(with_fp16));
 }
 
+#if IS_TRT_VERSION_LT(8000)
 void PluginTensorRT::serializeBase(void*& buffer) {
   Seria(buffer, input_dims_, max_batch_size_, data_type_, data_format_,
         with_fp16_);
@@ -80,6 +81,7 @@ void PluginTensorRT::configureWithFormat(
   input_dims_.assign(input_dims, input_dims + num_inputs);
   max_batch_size_ = max_batch_size;
 }
+#endif
 
 void PluginTensorRTV2Ext::serializeBase(void*& buffer) const {
   Seria(buffer, input_dims_, max_batch_size_, data_type_, data_format_,
@@ -103,7 +105,7 @@ void PluginTensorRTV2Ext::configurePlugin(
     const nvinfer1::DataType* input_types,
     const nvinfer1::DataType* output_types, const bool* input_is_broadcast,
     const bool* output_is_broadcast, nvinfer1::PluginFormat float_format,
-    int32_t max_batch_size) {
+    int32_t max_batch_size) TRT_NOEXCEPT {
   input_dims_.assign(input_dims, input_dims + nb_inputs);
   max_batch_size_ = max_batch_size;
   data_format_ = float_format;

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin.h
@@ -122,8 +122,6 @@ class PluginTensorRT : public nvinfer1::IPluginExt {
 };
 #endif
 
-// TensorRT introduced IPluginV2Ext after 5.1, Paddle no longer supports
-// versions before 5.1
 class PluginTensorRTV2Ext : public nvinfer1::IPluginV2Ext {
  public:
   PluginTensorRTV2Ext() : with_fp16_(false) {}
@@ -191,8 +189,13 @@ class PluginTensorRTV2Ext : public nvinfer1::IPluginV2Ext {
   // Find the workspace size required by the layer
   size_t getWorkspaceSize(int) const TRT_NOEXCEPT override { return 0; }
 
-  // Execute the layer
+// Execute the layer
+#if IS_TRT_VERSION_LT(8000)
   virtual int enqueue(int batch_size, const void* const* inputs, void** outputs,
+#else
+  virtual int enqueue(int batch_size, const void* const* inputs,
+                      void* const* outputs,
+#endif
                       void* workspace, cudaStream_t stream) TRT_NOEXCEPT = 0;
 
   // Find the size of the serialization buffer required

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin_factory.cc
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin_factory.cc
@@ -21,6 +21,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 PluginTensorRT* PluginFactoryTensorRT::createPlugin(const char* layer_name,
                                                     const void* serial_data,
                                                     size_t serial_length) {
@@ -45,6 +46,7 @@ bool PluginFactoryTensorRT::RegisterPlugin(
 }
 
 void PluginFactoryTensorRT::DestroyPlugins() { owned_plugins_.clear(); }
+#endif
 
 }  // namespace plugin
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin_factory.h
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin_factory.h
@@ -33,6 +33,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
+#if IS_TRT_VERSION_LT(8000)
 class PluginFactoryTensorRT : public nvinfer1::IPluginFactory,
                               public DeleteHelper {
  public:
@@ -72,6 +73,7 @@ class TrtPluginRegistrar {
       trt_plugin_registrar##ctr UNUSED =                           \
           paddle::inference::tensorrt::plugin::TrtPluginRegistrar( \
               name, deserialize_func)
+#endif
 
 }  // namespace plugin
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.cu
@@ -71,15 +71,16 @@ YoloBoxPlugin::~YoloBoxPlugin() {
   }
 }
 
-const char* YoloBoxPlugin::getPluginType() const { return "yolo_box_plugin"; }
+const char* YoloBoxPlugin::getPluginType() const TRT_NOEXCEPT {
+  return "yolo_box_plugin";
+}
 
-const char* YoloBoxPlugin::getPluginVersion() const { return "1"; }
+const char* YoloBoxPlugin::getPluginVersion() const TRT_NOEXCEPT { return "1"; }
 
-int YoloBoxPlugin::getNbOutputs() const { return 2; }
+int YoloBoxPlugin::getNbOutputs() const TRT_NOEXCEPT { return 2; }
 
-nvinfer1::Dims YoloBoxPlugin::getOutputDimensions(int index,
-                                                  const nvinfer1::Dims* inputs,
-                                                  int nb_input_dims) {
+nvinfer1::Dims YoloBoxPlugin::getOutputDimensions(
+    int index, const nvinfer1::Dims* inputs, int nb_input_dims) TRT_NOEXCEPT {
   const int anchor_num = anchors_.size() / 2;
   const int box_num = inputs[0].d[1] * inputs[0].d[2] * anchor_num;
 
@@ -91,13 +92,15 @@ nvinfer1::Dims YoloBoxPlugin::getOutputDimensions(int index,
   return nvinfer1::Dims2(box_num, class_num_);
 }
 
-bool YoloBoxPlugin::supportsFormat(nvinfer1::DataType type,
-                                   nvinfer1::TensorFormat format) const {
+bool YoloBoxPlugin::supportsFormat(
+    nvinfer1::DataType type, nvinfer1::TensorFormat format) const TRT_NOEXCEPT {
   return ((type == data_type_ || type == nvinfer1::DataType::kINT32) &&
           format == nvinfer1::TensorFormat::kLINEAR);
 }
 
-size_t YoloBoxPlugin::getWorkspaceSize(int max_batch_size) const { return 0; }
+size_t YoloBoxPlugin::getWorkspaceSize(int max_batch_size) const TRT_NOEXCEPT {
+  return 0;
+}
 
 template <typename T>
 __device__ inline T sigmoid(T x) {
@@ -220,7 +223,11 @@ __global__ void KeYoloBoxFw(const T* const input, const int* const imgsize,
 
 template <typename T>
 int YoloBoxPlugin::enqueue_impl(int batch_size, const void* const* inputs,
+#if IS_TRT_VERSION_LT(8000)
                                 void** outputs, void* workspace,
+#else
+                                void* const* outputs, void* workspace,
+#endif
                                 cudaStream_t stream) {
   const int n = batch_size;
   const int h = input_h_;
@@ -243,8 +250,12 @@ int YoloBoxPlugin::enqueue_impl(int batch_size, const void* const* inputs,
 }
 
 int YoloBoxPlugin::enqueue(int batch_size, const void* const* inputs,
+#if IS_TRT_VERSION_LT(8000)
                            void** outputs, void* workspace,
-                           cudaStream_t stream) {
+#else
+                           void* const* outputs, void* workspace,
+#endif
+                           cudaStream_t stream) TRT_NOEXCEPT {
   if (data_type_ == nvinfer1::DataType::kFLOAT) {
     return enqueue_impl<float>(batch_size, inputs, outputs, workspace, stream);
   } else if (data_type_ == nvinfer1::DataType::kHALF) {
@@ -253,11 +264,11 @@ int YoloBoxPlugin::enqueue(int batch_size, const void* const* inputs,
   assert("unsupported type.");
 }
 
-int YoloBoxPlugin::initialize() { return 0; }
+int YoloBoxPlugin::initialize() TRT_NOEXCEPT { return 0; }
 
-void YoloBoxPlugin::terminate() {}
+void YoloBoxPlugin::terminate() TRT_NOEXCEPT {}
 
-size_t YoloBoxPlugin::getSerializationSize() const {
+size_t YoloBoxPlugin::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(data_type_);
   serialize_size += SerializedSize(anchors_);
@@ -271,7 +282,7 @@ size_t YoloBoxPlugin::getSerializationSize() const {
   return serialize_size;
 }
 
-void YoloBoxPlugin::serialize(void* buffer) const {
+void YoloBoxPlugin::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, data_type_);
   SerializeValue(&buffer, anchors_);
   SerializeValue(&buffer, class_num_);
@@ -283,28 +294,30 @@ void YoloBoxPlugin::serialize(void* buffer) const {
   SerializeValue(&buffer, input_w_);
 }
 
-void YoloBoxPlugin::destroy() {}
+void YoloBoxPlugin::destroy() TRT_NOEXCEPT {}
 
-void YoloBoxPlugin::setPluginNamespace(const char* lib_namespace) {
+void YoloBoxPlugin::setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* YoloBoxPlugin::getPluginNamespace() const {
+const char* YoloBoxPlugin::getPluginNamespace() const TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
 nvinfer1::DataType YoloBoxPlugin::getOutputDataType(
-    int index, const nvinfer1::DataType* input_type, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_type,
+    int nb_inputs) const TRT_NOEXCEPT {
   return data_type_;
 }
 
-bool YoloBoxPlugin::isOutputBroadcastAcrossBatch(int output_index,
-                                                 const bool* input_is_broadcast,
-                                                 int nb_inputs) const {
+bool YoloBoxPlugin::isOutputBroadcastAcrossBatch(
+    int output_index, const bool* input_is_broadcast,
+    int nb_inputs) const TRT_NOEXCEPT {
   return false;
 }
 
-bool YoloBoxPlugin::canBroadcastInputAcrossBatch(int input_index) const {
+bool YoloBoxPlugin::canBroadcastInputAcrossBatch(int input_index) const
+    TRT_NOEXCEPT {
   return false;
 }
 
@@ -314,9 +327,9 @@ void YoloBoxPlugin::configurePlugin(
     const nvinfer1::DataType* input_types,
     const nvinfer1::DataType* output_types, const bool* input_is_broadcast,
     const bool* output_is_broadcast, nvinfer1::PluginFormat float_format,
-    int max_batct_size) {}
+    int max_batct_size) TRT_NOEXCEPT {}
 
-nvinfer1::IPluginV2Ext* YoloBoxPlugin::clone() const {
+nvinfer1::IPluginV2Ext* YoloBoxPlugin::clone() const TRT_NOEXCEPT {
   return new YoloBoxPlugin(data_type_, anchors_, class_num_, conf_thresh_,
                            downsample_ratio_, clip_bbox_, scale_x_y_, input_h_,
                            input_w_);
@@ -324,26 +337,30 @@ nvinfer1::IPluginV2Ext* YoloBoxPlugin::clone() const {
 
 YoloBoxPluginCreator::YoloBoxPluginCreator() {}
 
-void YoloBoxPluginCreator::setPluginNamespace(const char* lib_namespace) {
+void YoloBoxPluginCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* YoloBoxPluginCreator::getPluginNamespace() const {
+const char* YoloBoxPluginCreator::getPluginNamespace() const TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
-const char* YoloBoxPluginCreator::getPluginName() const {
+const char* YoloBoxPluginCreator::getPluginName() const TRT_NOEXCEPT {
   return "yolo_box_plugin";
 }
 
-const char* YoloBoxPluginCreator::getPluginVersion() const { return "1"; }
+const char* YoloBoxPluginCreator::getPluginVersion() const TRT_NOEXCEPT {
+  return "1";
+}
 
-const nvinfer1::PluginFieldCollection* YoloBoxPluginCreator::getFieldNames() {
+const nvinfer1::PluginFieldCollection* YoloBoxPluginCreator::getFieldNames()
+    TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2Ext* YoloBoxPluginCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   const nvinfer1::PluginField* fields = fc->fields;
 
   int type_id = -1;
@@ -389,7 +406,8 @@ nvinfer1::IPluginV2Ext* YoloBoxPluginCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2Ext* YoloBoxPluginCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new YoloBoxPlugin(serial_data, serial_length);
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;

--- a/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.h
@@ -25,7 +25,7 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
-class YoloBoxPlugin : public nvinfer1::IPluginV2Ext {
+class YoloBoxPlugin : public PluginTensorRTV2Ext {
  public:
   explicit YoloBoxPlugin(const nvinfer1::DataType data_type,
                          const std::vector<int>& anchors, const int class_num,
@@ -35,34 +35,44 @@ class YoloBoxPlugin : public nvinfer1::IPluginV2Ext {
   YoloBoxPlugin(const void* data, size_t length);
   ~YoloBoxPlugin() override;
 
-  const char* getPluginType() const override;
-  const char* getPluginVersion() const override;
-  int getNbOutputs() const override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nb_input_dims) override;
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::TensorFormat format) const override;
-  size_t getWorkspaceSize(int max_batch_size) const override;
+                                     int nb_input_dims) TRT_NOEXCEPT override;
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::TensorFormat format)
+      const TRT_NOEXCEPT override;
+  size_t getWorkspaceSize(int max_batch_size) const TRT_NOEXCEPT override;
+#if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
-              void* workspace, cudaStream_t stream) override;
+#else
+  int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
+#endif
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
   template <typename T>
+#if IS_TRT_VERSION_LT(8000)
   int enqueue_impl(int batch_size, const void* const* inputs, void** outputs,
+#else
+  int enqueue_impl(int batch_size, const void* const* inputs,
+                   void* const* outputs,
+#endif
                    void* workspace, cudaStream_t stream);
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_type,
-                                       int nb_inputs) const override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_type,
+      int nb_inputs) const TRT_NOEXCEPT override;
   bool isOutputBroadcastAcrossBatch(int output_index,
                                     const bool* input_is_broadcast,
-                                    int nb_inputs) const override;
-  bool canBroadcastInputAcrossBatch(int input_index) const override;
+                                    int nb_inputs) const TRT_NOEXCEPT override;
+  bool canBroadcastInputAcrossBatch(int input_index) const
+      TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::Dims* input_dims, int nb_inputs,
                        const nvinfer1::Dims* output_dims, int nb_outputs,
                        const nvinfer1::DataType* input_types,
@@ -70,8 +80,8 @@ class YoloBoxPlugin : public nvinfer1::IPluginV2Ext {
                        const bool* input_is_broadcast,
                        const bool* output_is_broadcast,
                        nvinfer1::PluginFormat float_format,
-                       int max_batct_size) override;
-  nvinfer1::IPluginV2Ext* clone() const override;
+                       int max_batct_size) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* clone() const TRT_NOEXCEPT override;
 
  private:
   nvinfer1::DataType data_type_;
@@ -92,17 +102,18 @@ class YoloBoxPluginCreator : public nvinfer1::IPluginCreator {
   YoloBoxPluginCreator();
   ~YoloBoxPluginCreator() override = default;
 
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
 
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
-                                            const void* serial_data,
-                                            size_t serial_length) override;
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
 
  private:
   std::string namespace_;

--- a/paddle/fluid/inference/tensorrt/trt_int8_calibrator.cc
+++ b/paddle/fluid/inference/tensorrt/trt_int8_calibrator.cc
@@ -22,7 +22,7 @@ namespace inference {
 namespace tensorrt {
 
 // set the batch size before constructing the thread to execute engine
-int TRTInt8Calibrator::getBatchSize() const { return batch_size_; }
+int TRTInt8Calibrator::getBatchSize() const TRT_NOEXCEPT { return batch_size_; }
 
 TRTInt8Calibrator::TRTInt8Calibrator(
     const std::unordered_map<std::string, size_t>& buffers, int batch_size,
@@ -95,7 +95,7 @@ bool TRTInt8Calibrator::setBatch(
 }
 
 bool TRTInt8Calibrator::getBatch(void** bindings, const char** names,
-                                 int num_bindings) {
+                                 int num_bindings) TRT_NOEXCEPT {
   VLOG(4) << "get batch: " << engine_name_;
   std::unique_lock<std::mutex> lk(mut_);
   // The consumer has just finished processing a data.
@@ -131,14 +131,15 @@ void TRTInt8Calibrator::setDone() {
   cond_.notify_all();
 }
 
-const void* TRTInt8Calibrator::readCalibrationCache(size_t& length) {
+const void* TRTInt8Calibrator::readCalibrationCache(size_t& length)
+    TRT_NOEXCEPT {
   if (calibration_table_.empty()) return nullptr;
   length = calibration_table_.size();
   return calibration_table_.data();
 }
 
 void TRTInt8Calibrator::writeCalibrationCache(const void* ptr,
-                                              std::size_t length) {
+                                              std::size_t length) TRT_NOEXCEPT {
   calibration_table_ = std::string((const char*)ptr, length);
   VLOG(4) << "Got calibration data for " << engine_name_ << " " << ptr
           << " length=" << length;

--- a/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
+++ b/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
@@ -43,17 +43,18 @@ struct TRTInt8Calibrator : public nvinfer1::IInt8EntropyCalibrator2 {
   explicit TRTInt8Calibrator(const std::string& calibration_data);
   ~TRTInt8Calibrator();
 
-  int getBatchSize() const override;
+  int getBatchSize() const TRT_NOEXCEPT override;
 
   bool getBatch(void* bindings[], const char* names[],
-                int num_bindings) override;
+                int num_bindings) TRT_NOEXCEPT override;
 
   bool setBatch(const std::unordered_map<std::string, void*>& data);
   void setDone();
   void waitAndSetDone();
 
-  const void* readCalibrationCache(std::size_t& length) override;
-  void writeCalibrationCache(const void* ptr, std::size_t length) override;
+  const void* readCalibrationCache(std::size_t& length) TRT_NOEXCEPT override;
+  void writeCalibrationCache(const void* ptr,
+                             std::size_t length) TRT_NOEXCEPT override;
   const std::string& getCalibrationTableAsString() {
     return calibration_table_;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
TensorRT 8 Compatibility
1. Add TRT_NOEXCEPT definition for version compatibility, because trt functions use noexcept after trt 8.0,
2. Disable ``anchor_generator``, ``yolo_box``, ``roi_align``, ``gather_nd``  plugins in trt8 due to PR lines limit, I will add them back in the following PR.
3. Disable all plugins which inherit ``PluginTensorRT`` and corresponding converter in TRT8. Because ``nvinfer1::IPluginExt`` is deprecated after trt5, and it has been removed from trt8.