### PR TITLE
fix new api ci check errors

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -92,6 +92,10 @@ from .dygraph.checkpoint import save_dygraph, load_dygraph
 from .dygraph.varbase_patch_methods import monkey_patch_varbase
 from . import generator
 from .core import _cuda_synchronize
+from .generator import Generator
+from .trainer_desc import TrainerDesc, DistMultiTrainer, PipelineTrainer, MultiTrainer, HeterXpuTrainer, HeterBoxTrainer
+from .transpiler import HashName, RoundRobin
+from .backward import append_backward
 
 Tensor = LoDTensor
 enable_imperative = enable_dygraph
@@ -116,7 +120,6 @@ __all__ = framework.__all__ + executor.__all__ + \
         'transpiler',
         'nets',
         'optimizer',
-        'learning_rate_decay',
         'backward',
         'regularizer',
         'LoDTensor',
@@ -137,7 +140,6 @@ __all__ = framework.__all__ + executor.__all__ + \
         'install_check',
         'save',
         'load',
-        'VarBase',
         '_cuda_synchronize'
     ]
 

--- a/python/paddle/fluid/contrib/__init__.py
+++ b/python/paddle/fluid/contrib/__init__.py
@@ -33,6 +33,7 @@ from .mixed_precision import *
 from . import layers
 from .layers import *
 from . import optimizer
+from .optimizer import *
 from . import sparsity
 from .sparsity import *
 

--- a/python/paddle/fluid/contrib/mixed_precision/__init__.py
+++ b/python/paddle/fluid/contrib/mixed_precision/__init__.py
@@ -20,7 +20,9 @@ from . import fp16_lists
 from .fp16_lists import *
 from . import fp16_utils
 from .fp16_utils import *
+from . import bf16
 
-__all__ = decorator.__all__
+__all__ = []
+__all__ += decorator.__all__
 __all__ += fp16_lists.__all__
 __all__ += fp16_utils.__all__

--- a/python/paddle/fluid/contrib/mixed_precision/bf16/__init__.py
+++ b/python/paddle/fluid/contrib/mixed_precision/bf16/__init__.py
@@ -21,6 +21,7 @@ from .amp_utils import *
 from . import decorator
 from .decorator import *
 
-__all__ = decorator.__all__
+__all__ = []
+__all__ += decorator.__all__
 __all__ += amp_lists.__all__
 __all__ += amp_utils.__all__


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add new api ci check tools file;
fix new api ci check errors

背景：
API相关CI检查的更新和完善
目前发现到的问题：
这样的代码也合入到了2.1版本中：https://github.com/PaddlePaddle/Paddle/blob/release/2.1/python/paddle/device.py#L28

为了防止带有错误字段的pr合入，更新ci递归遍历所有paddle下模块，依次检查每一项功能的可访问性，找出不具有可访问性的功能。

为了检查功能能够成功合入，本pr对检查出来的目前的存量错误进行了修复

新的检查机制能够发现的问题，例如：
__all__里少了逗号导致两个字符拼接到一起了。
或者仍然保留的无效的api接口