### PR TITLE
[Cherry-Pick]Fix the bug that `ParamBase` lose attributes when `paddle.save(Layer)`

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5879,6 +5879,18 @@ class ParamBase(core.VarBase):
         new_param.copy_(self, True)
         return new_param
 
+    def __reduce__(self):
+        value = self.numpy()
+        state = (self.name, self.persistable, self.stop_gradient)
+        return ParamBase, (self.shape, self.dtype), (self.__dict__, value,
+                                                     state)
+
+    def __setstate__(self, state):
+        self.__dict__.update(state[0])
+        t = self.value().get_tensor()
+        t.set(state[1], _current_expected_place())
+        self.name, self.persistable, self.stop_gradient = state[2]
+
     __repr__ = __str__
 
 

--- a/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
@@ -869,21 +869,17 @@ class TestSaveLoadLayer(unittest.TestCase):
         layer2 = LinearNet()
         layer1.eval()
         layer2.eval()
+        origin_layer = (layer1, layer2)
         origin = (layer1(inps), layer2(inps))
         path = "test_save_load_layer_/layer.pdmodel"
-        paddle.save((layer1, layer2), path)
-
-        # static
-        paddle.enable_static()
-        with self.assertRaises(ValueError):
-            paddle.load(path)
-        # dygraph
-        paddle.disable_static()
+        paddle.save(origin_layer, path)
 
         loaded_layer = paddle.load(path)
         loaded_result = [l(inps) for l in loaded_layer]
         for i in range(len(origin)):
             self.assertTrue((origin[i] - loaded_result[i]).abs().max() < 1e-10)
+            for k, v in origin_layer[i]._linear.weight.__dict__.items():
+                self.assertTrue(v == loaded_layer[i]._linear.weight.__dict__[k])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
修复paddle.save(Layer)时参数属性丢失的问题:通过实现__reduce__的方式保存layer中的ParamBase的所有信息。

兼容性问题：
- paddle2.1 无法加载paddle2.1.1 保存的Layer对象。paddle2.1.1可以加载paddle2.1保存的Layer对象。
- 对于非Layer对象，如state_dict等，2.1与2.1.1完全兼容，2.1可以加载2.1.1保存的非Layer对象。可以脱离框架加载pickle格式的模型文件。

详情见原始PR：https://github.com/PaddlePaddle/Paddle/pull/33500