### PR TITLE
enhance the attribute constraint for pass,test=develop

### DIFF
--- a/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
@@ -75,9 +75,6 @@ AttrCompat& AttrCompat::IsLeftDefault() {
 }
 
 bool AttrCompat::operator()(const OpDesc& op_desc) {
-  if (conditions_.empty()) {
-    return true;
-  }
   if (!op_desc.HasAttr(attr_name_)) {
     if (!optional_) {
       LOG(WARNING) << "The non-optional Attr(" << attr_name_ << ") of Op ("


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
之前的pass前置条件判断为： 如果一个属性的前置条件为空，兼容性判定直接返回true.
修改为：
如果一个属性的前置条件为空，如果该属性不是optional的话，相应的opdesc必须得存在该属性，否则返回false.