### PR TITLE
Fix Unexpected Keyword Arg

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_op.py
@@ -18,7 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 from paddle import fluid
-from paddle.fluid.layers import lstm, fill_constant
+from paddle.fluid.layers import lstm as LSTM
+from paddle.fluid.layers import fill_constant
 from paddle.fluid.framework import program_guard, Program
 
 SIGMOID_THRESHOLD_MIN = -40.0
@@ -156,21 +157,21 @@ class LstmUnitTestError(unittest.TestCase):
                 (num_layers, batch_size, hidden_size)).astype('float64')
 
             def test_input_Variable():
-                lstm(np_input, pre_hidden, pre_cell, \
+                LSTM(np_input, pre_hidden, pre_cell, \
                     seq_len, hidden_size, num_layers, \
                     dropout_prob=dropout_prob)
 
             self.assertRaises(TypeError, test_input_Variable)
 
             def test_pre_hidden_Variable():
-                lstm(np_input, np_pre_hidden, pre_cell, \
+                LSTM(np_input, np_pre_hidden, pre_cell, \
                     seq_len, hidden_size, num_layers, \
                     dropout_prob=dropout_prob)
 
             self.assertRaises(TypeError, test_pre_hidden_Variable)
 
             def test_pre_cell_Variable():
-                lstm(np_input, pre_hidden, np_pre_cell, \
+                LSTM(np_input, pre_hidden, np_pre_cell, \
                     seq_len, hidden_size, num_layers, \
                     dropout_prob=dropout_prob)
 
@@ -181,7 +182,7 @@ class LstmUnitTestError(unittest.TestCase):
                     name='error_input',
                     shape=[None, hidden_size * 3],
                     dtype='int32')
-                lstm(error_input, pre_hidden, pre_cell, \
+                LSTM(error_input, pre_hidden, pre_cell, \
                     seq_len, hidden_size, num_layers, \
                     dropout_prob=dropout_prob)
 
@@ -192,7 +193,7 @@ class LstmUnitTestError(unittest.TestCase):
                     name='error_pre_hidden',
                     shape=[None, hidden_size],
                     dtype='int32')
-                lstm(input, error_pre_hidden, pre_cell, \
+                LSTM(input, error_pre_hidden, pre_cell, \
                     seq_len, hidden_size, num_layers, \
                     dropout_prob=dropout_prob)
 
@@ -203,7 +204,7 @@ class LstmUnitTestError(unittest.TestCase):
                     name='error_pre_cell',
                     shape=[None, hidden_size],
                     dtype='int32')
-                lstm(input, pre_hidden, error_pre_cell, \
+                LSTM(input, pre_hidden, error_pre_cell, \
                     seq_len, hidden_size, num_layers, \
                     dropout_prob=dropout_prob)
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
In python/paddle/fluid/tests/unittests/test_lstm_op.py:
   Unexpected keyword argument 'dropout_prob' in function call
   **from paddle.fluid.layers import lstm as LSTM**
   **use 'LSTM' instead of 'lstm'**