### PR TITLE
修正batch_norm.pbtxt中的属性分类错误

### DIFF
--- a/paddle/fluid/operators/compat/batch_norm.pbtxt
+++ b/paddle/fluid/operators/compat/batch_norm.pbtxt
@@ -18,6 +18,21 @@ def {
   outputs {
     name: "Y"
   }
+  outputs {
+    name: "MeanOut"
+  }
+  outputs {
+    name: "VarianceOut"
+  }
+  outputs {
+    name: "SavedMean"
+  }
+  outputs {
+    name: "SavedVariance"
+  }
+  outputs {
+    name: "ReserveSpace"
+  }
   attrs {
     name: "epsilon"
     type: FLOAT
@@ -54,21 +69,6 @@ extra {
   attrs {
     name: "trainable_statistics"
     type: BOOLEAN
-  }
-  outputs {
-    name: "MeanOut"
-  }
-  outputs {
-    name: "VarianceOut"
-  }
-  outputs {
-    name: "SavedMean"
-  }
-  outputs {
-    name: "SavedVariance"
-  }
-  outputs {
-    name: "ReserveSpace"
   }
   attrs {
     name: "op_role"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
之前将    "MeanOut"、 "VarianceOut"、 "SavedMean"、"SavedVariance"、"ReserveSpace"这5个输出错误的划分到了extra里面，予以改正。