### PR TITLE
Change dtype of flops and params used in flops calculation to prevent integer overflow (from int32 -> int64)

### DIFF
--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -211,8 +211,8 @@ def dynamic_flops(model, inputs, custom_ops=None, print_detail=False):
     def add_hooks(m):
         if len(list(m.children())) > 0:
             return
-        m.register_buffer('total_ops', paddle.zeros([1], dtype='int32'))
-        m.register_buffer('total_params', paddle.zeros([1], dtype='int32'))
+        m.register_buffer('total_ops', paddle.zeros([1], dtype='int64'))
+        m.register_buffer('total_params', paddle.zeros([1], dtype='int64'))
         m_type = type(m)
 
         flops_fn = None


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
#33481 