### PR TITLE
Fix some Bugs of Lack of Self Arg

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
@@ -79,7 +79,7 @@ class TestDeQuantizeOp(OpTest):
     def set_shift(self):
         pass
 
-    def set_data_type(OpTest):
+    def set_data_type(self):
         pass
 
     def set_input_size(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
@@ -100,7 +100,7 @@ class TestReQuantizeOp(OpTest):
     def set_shifts(self):
         pass
 
-    def set_input_data_type(OpTest):
+    def set_input_data_type(self):
         pass
 
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
   Line 82: Method should have "self" as first argument
   **rename 'OpTest' to 'self'**
5. python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
   Line 103: Method should have "self" as first argument
   **rename 'OpTest' to 'self'**