### PR TITLE
add out_threshold for layernorm 

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -81,6 +81,7 @@ _out_scale_op_list = [
     "transpose",
     "pad2d",
     "reshape",
+    "layer_norm",
 ]
 
 # list op real input and output names, to avoid processing input such as AxisTensor.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
add out_threshold for layernorm, support trt int8 for ernie.