### PR TITLE
[NPU] optimize mul op, use BatchMatMul to realize

### DIFF
--- a/paddle/fluid/operators/mul_op_npu.cc
+++ b/paddle/fluid/operators/mul_op_npu.cc
@@ -46,11 +46,7 @@ class MulNPUKernel : public framework::OpKernel<T> {
         Tensor tmp_x(x->type());
         int64_t sec_dim = x->dims()[1] * x->dims()[2];
         int64_t first_dim = x->dims()[0];
-        tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
-        tmp_x.mutable_data<T>(ctx.GetPlace());
-        framework::TensorCopy(
-            *x, ctx.GetPlace(),
-            ctx.template device_context<platform::DeviceContext>(), &tmp_x);
+        tmp_x.ShareDataWith(*x);
         tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
         out->mutable_data<T>(ctx.GetPlace());
         // matmul
@@ -69,14 +65,40 @@ class MulNPUKernel : public framework::OpKernel<T> {
                         platform::errors::InvalidArgument(
                             "now only support x_num_col_dims == 2: but got %d",
                             x_num_col_dims));
+      if (x->type() == framework::proto::VarType::FP16 &&
+          y->type() == framework::proto::VarType::FP16) {
+        // NOTE: When the dim of the input and output shapes is inconsistent,
+        // (Boradcast) BatchMatMul NPU OP only support FP16.
+        out->mutable_data<T>(ctx.GetPlace());
+        const auto& runner =
+            NpuOpRunner("BatchMatMul", {*x, *y}, {*out},
+                        {{"adj_x1", false}, {"adj_x2", false}});
 
-      const auto& runner = NpuOpRunner("BatchMatMul", {*x, *y}, {*out},
-                                       {{"adj_x1", false}, {"adj_x2", false}});
+        auto stream =
+            ctx.template device_context<paddle::platform::NPUDeviceContext>()
+                .stream();
+        runner.Run(stream);
+      } else {
+        // flatten => x.shape=[6, 4]
+        Tensor tmp_x(x->type());
+        int64_t first_dim = x->dims()[0] * x->dims()[1];
+        int64_t sec_dim = x->dims()[2];
+        tmp_x.ShareDataWith(*x);
+        tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
 
-      auto stream =
-          ctx.template device_context<paddle::platform::NPUDeviceContext>()
-              .stream();
-      runner.Run(stream);
+        // matmul [6,4] , [4, 5] => [6, 5]
+        out->Resize(framework::make_ddim({first_dim, y->dims()[1]}));
+        out->mutable_data<T>(ctx.GetPlace());
+
+        const auto& runner_matmul =
+            NpuOpRunner("MatMul", {tmp_x, *y}, {*out},
+                        {{"transpose_x1", false}, {"transpose_x2", false}});
+        runner_matmul.Run(stream);
+
+        // reshape [6, 5] => [2, 3, 5]
+        out->Resize(
+            framework::make_ddim({x->dims()[0], x->dims()[1], y->dims()[1]}));
+      }
     }
   }
 };
@@ -135,11 +157,7 @@ class MulGradNPUKernel : public framework::OpKernel<T> {
           Tensor tmp_x(x->type());
           int64_t sec_dim = x->dims()[1] * x->dims()[2];
           int64_t first_dim = x->dims()[0];
-          tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
-          tmp_x.mutable_data<T>(ctx.GetPlace());
-          framework::TensorCopy(
-              *x, ctx.GetPlace(),
-              ctx.template device_context<platform::DeviceContext>(), &tmp_x);
+          tmp_x.ShareDataWith(*x);
           tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
           dy->mutable_data<T>(ctx.GetPlace());
           const auto& runner_dy =
@@ -159,35 +177,42 @@ class MulGradNPUKernel : public framework::OpKernel<T> {
       Tensor tmp_dout(x->type());
       int64_t dout_first_dim = dout->dims()[0] * dout->dims()[1];
       int64_t dout_sec_dim = dout->dims()[2];
-      tmp_dout.Resize(framework::make_ddim({dout_first_dim, dout_sec_dim}));
-      tmp_dout.mutable_data<T>(ctx.GetPlace());
-      framework::TensorCopy(
-          *dout, ctx.GetPlace(),
-          ctx.template device_context<platform::DeviceContext>(), &tmp_dout);
+      tmp_dout.ShareDataWith(*dout);
       tmp_dout.Resize(framework::make_ddim({dout_first_dim, dout_sec_dim}));
 
       if (dx) {
         // tmp_dout * y [2, 3, 5] * [4,5] => [2, 3, 4]
-        dx->mutable_data<T>(ctx.GetPlace());
+        if (dout->type() == framework::proto::VarType::FP16 &&
+            y->type() == framework::proto::VarType::FP16) {
+          // NOTE: When the dim of the input and output shapes is inconsistent,
+          // (Boradcast) BatchMatMul NPU OP only support FP16.
+          dx->mutable_data<T>(ctx.GetPlace());
+          const auto& runner =
+              NpuOpRunner("BatchMatMul", {*dout, *y}, {*dx},
+                          {{"adj_x1", false}, {"adj_x2", true}});
 
-        const auto& runner = NpuOpRunner("BatchMatMul", {*dout, *y}, {*dx},
-                                         {{"adj_x1", false}, {"adj_x2", true}});
-
-        auto stream =
-            ctx.template device_context<paddle::platform::NPUDeviceContext>()
-                .stream();
-        runner.Run(stream);
+          auto stream =
+              ctx.template device_context<paddle::platform::NPUDeviceContext>()
+                  .stream();
+          runner.Run(stream);
+        } else {
+          dx->mutable_data<T>(ctx.GetPlace());
+          auto dx_dims = dx->dims();
+          dx->Resize(framework::make_ddim({dout_first_dim, y->dims()[0]}));
+          const auto& runner_matmul =
+              NpuOpRunner("MatMul", {tmp_dout, *y}, {*dx},
+                          {{"transpose_x1", false}, {"transpose_x2", true}});
+          runner_matmul.Run(stream);
+          // reshape [2, 12] => [2, 3, 4]
+          dx->Resize(dx_dims);
+        }
       }
       if (dy) {
         // flatten x.shape [2,3,4] => [6, 4]
         Tensor tmp_x(x->type());
         int64_t first_dim = x->dims()[0] * x->dims()[1];
         int64_t sec_dim = x->dims()[2];
-        tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
-        tmp_x.mutable_data<T>(ctx.GetPlace());
-        framework::TensorCopy(
-            *x, ctx.GetPlace(),
-            ctx.template device_context<platform::DeviceContext>(), &tmp_x);
+        tmp_x.ShareDataWith(*x);
         tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
         // mamtul [6,4] [6,5] =>[4,5]
         dy->mutable_data<T>(ctx.GetPlace());

--- a/paddle/fluid/operators/mul_op_npu.cc
+++ b/paddle/fluid/operators/mul_op_npu.cc
@@ -87,17 +87,16 @@ class MulNPUKernel : public framework::OpKernel<T> {
         tmp_x.Resize(framework::make_ddim({first_dim, sec_dim}));
 
         // matmul [6,4] , [4, 5] => [6, 5]
-        out->Resize(framework::make_ddim({first_dim, y->dims()[1]}));
         out->mutable_data<T>(ctx.GetPlace());
 
+        Tensor tmp_out(x->type());
+        tmp_out.ShareDataWith(*out);
+        tmp_out.Resize(framework::make_ddim({first_dim, y->dims()[1]}));
+
         const auto& runner_matmul =
-            NpuOpRunner("MatMul", {tmp_x, *y}, {*out},
+            NpuOpRunner("MatMul", {tmp_x, *y}, {tmp_out},
                         {{"transpose_x1", false}, {"transpose_x2", false}});
         runner_matmul.Run(stream);
-
-        // reshape [6, 5] => [2, 3, 5]
-        out->Resize(
-            framework::make_ddim({x->dims()[0], x->dims()[1], y->dims()[1]}));
       }
     }
   }
@@ -142,14 +141,14 @@ class MulGradNPUKernel : public framework::OpKernel<T> {
         if (dx) {
           // matmul [2, 5] * [12, 5] => [2, 12]
           dx->mutable_data<T>(ctx.GetPlace());
-          auto dx_dims = dx->dims();
-          dx->Resize(framework::make_ddim({dout->dims()[0], y->dims()[0]}));
+          Tensor tmp_dx(x->type());
+          tmp_dx.ShareDataWith(*dx);
+          tmp_dx.Resize(framework::make_ddim({dout->dims()[0], y->dims()[0]}));
+
           const auto& runner_matmul =
-              NpuOpRunner("MatMul", {*dout, *y}, {*dx},
+              NpuOpRunner("MatMul", {*dout, *y}, {tmp_dx},
                           {{"transpose_x1", false}, {"transpose_x2", true}});
           runner_matmul.Run(stream);
-          // reshape [2, 12] => [2, 3, 4]
-          dx->Resize(dx_dims);
         }
 
         if (dy) {
@@ -197,14 +196,14 @@ class MulGradNPUKernel : public framework::OpKernel<T> {
           runner.Run(stream);
         } else {
           dx->mutable_data<T>(ctx.GetPlace());
-          auto dx_dims = dx->dims();
-          dx->Resize(framework::make_ddim({dout_first_dim, y->dims()[0]}));
+          Tensor tmp_dx(x->type());
+          tmp_dx.ShareDataWith(*dx);
+          tmp_dx.Resize(framework::make_ddim({dout_first_dim, y->dims()[0]}));
+
           const auto& runner_matmul =
-              NpuOpRunner("MatMul", {tmp_dout, *y}, {*dx},
+              NpuOpRunner("MatMul", {tmp_dout, *y}, {tmp_dx},
                           {{"transpose_x1", false}, {"transpose_x2", true}});
           runner_matmul.Run(stream);
-          // reshape [2, 12] => [2, 3, 4]
-          dx->Resize(dx_dims);
         }
       }
       if (dy) {

--- a/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
@@ -55,10 +55,17 @@ class TestMul(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
+    def test_check_grad(self):
+        self.check_grad_with_place(
+            self.place, ['X', 'Y'], ['Out'], check_dygraph=False)
+
 
 class TestMulFP16(TestMul):
     def init_dtype(self):
         self.dtype = np.float16
+
+    def test_check_grad(self):
+        pass
 
 
 class TestMul2(TestMul):
@@ -87,6 +94,9 @@ class TestMul2FP16(TestMul2):
     def init_dtype(self):
         self.dtype = np.float16
 
+    def test_check_grad(self):
+        pass
+
 
 class TestMul3(TestMul):
     # case 3: (2, 3, 4) * (4, 5) -> (2, 3, 5), x_num_col_dims = 2
@@ -113,6 +123,9 @@ class TestMul3(TestMul):
 class TestMul3FP16(TestMul3):
     def init_dtype(self):
         self.dtype = np.float16
+
+    def test_check_grad(self):
+        pass
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),

--- a/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
@@ -190,13 +190,6 @@ class TestMulNet(unittest.TestCase):
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
                  "core is not compiled with NPU")
-class TestMulNet_FP16(TestMulNet):
-    def init_dtype(self):
-        self.dtype = np.float16
-
-
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMulNet3_2(unittest.TestCase):
     def init_dtype(self):
         self.dtype = np.float32
@@ -271,13 +264,6 @@ class TestMulNet3_2(unittest.TestCase):
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
                  "core is not compiled with NPU")
-class TestMulNet3_2_FP16(TestMulNet3_2):
-    def init_dtype(self):
-        self.dtype = np.float16
-
-
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMulNet3_2_xc2(unittest.TestCase):
     def init_dtype(self):
         self.dtype = np.float32
@@ -348,13 +334,6 @@ class TestMulNet3_2_xc2(unittest.TestCase):
 
         self.assertTrue(np.allclose(npu_pred, cpu_pred))
         self.assertTrue(np.allclose(npu_loss, cpu_loss))
-
-
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
-class TestMulNet3_2_xc2_FP16(TestMulNet3_2_xc2):
-    def init_dtype(self):
-        self.dtype = np.float16
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

- use `BatchMatMul` to replace `reshape + MatMul + reshape`
- use `ShareDatawith` to replace `TensorCopy`

- 单测运行结果
<img width="303" alt="图片" src="https://user-images.githubusercontent.com/26408901/122366246-f6a0be00-cf8d-11eb-93b6-cf60b4859293.png">


- 性能

<img width="731" alt="图片" src="https://user-images.githubusercontent.com/26408901/122367457-066cd200-cf8f-11eb-9a22-e45da8667d13.png">

20684 tokens/s -> 22079 tokens/s
提升约 6.7%
