### PR TITLE
fix import paddle error in windows for python3.8 and python3.9

### DIFF
--- a/paddle/fluid/pybind/op_function.h
+++ b/paddle/fluid/pybind/op_function.h
@@ -984,12 +984,11 @@ void InitOpsAttrTypeMap() {
   }
 }
 
-PyObject* EOFExceptionException =
-    PyErr_NewException("paddle.EOFException", PyExc_Exception, NULL);
-PyObject* EnforceNotMetException =
-    PyErr_NewException("paddle.EnforceNotMet", PyExc_Exception, NULL);
-
 void ThrowExceptionToPython(std::exception_ptr p) {
+  static PyObject* EOFExceptionException =
+      PyErr_NewException("paddle.EOFException", PyExc_Exception, NULL);
+  static PyObject* EnforceNotMetException =
+      PyErr_NewException("paddle.EnforceNotMet", PyExc_Exception, NULL);
   try {
     if (p) std::rethrow_exception(p);
   } catch (const platform::EOFException& e) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
在PR https://github.com/PaddlePaddle/Paddle/pull/32524 合入后，集成测试发现Windows下，python3.8和python3.9 无法成功`import paddle`
本PR修复该问题