### PR TITLE
Hapi Model add accumulate gradients option

### DIFF
--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -298,10 +298,11 @@ class StaticGraphAdapter(object):
     def mode(self, value):
         self.model.mode = value
 
-    def train_batch(self, inputs, labels=None):
+    def train_batch(self, inputs, labels=None, update=True):
         assert self.model._optimizer, \
             "model not ready, please call `model.prepare()` first"
         self.mode = 'train'
+        assert update is True, "Model does not support `update == False` in static mode by now."
         return self._run(inputs, labels)
 
     def eval_batch(self, inputs, labels=None):

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -25,23 +25,18 @@ import warnings
 import time
 import socket
 import contextlib
-from collections import Iterable
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
 from paddle.fluid.framework import in_dygraph_mode
 from paddle.fluid.framework import Variable
-from paddle.fluid.framework import ParamBase
-from paddle.fluid.framework import _current_expected_place
 from paddle.fluid.framework import _get_paddle_place
 from paddle.fluid.framework import _current_expected_place as _get_device
 from paddle.fluid.executor import global_scope
 from paddle.fluid.io import is_belong_to_optimizer
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.dygraph.parallel import ParallelEnv
-from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator
-from paddle.fluid.dygraph.dygraph_to_static.program_translator import FunctionSpec
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX
 from paddle.fluid.dygraph.io import INFER_PARAMS_SUFFIX
 from paddle.fluid.layers.utils import flatten
@@ -50,9 +45,6 @@ from paddle.fluid.layers import collective
 from paddle.io import DataLoader
 from paddle.io import Dataset
 from paddle.io import DistributedBatchSampler
-from paddle.fluid.executor import scope_guard
-from paddle.fluid.executor import Executor
-from paddle.fluid.dygraph.layers import Layer
 from paddle.metric import Metric
 from paddle.static import InputSpec as Input
 import paddle.distributed as dist
@@ -1022,7 +1014,8 @@ class Model(object):
 
     def train_batch(self, inputs, labels=None, update=True):
         """
-        Run one training step on a batch of data.
+        Run one training step on one batch of data. And using `update` indicates
+        whether optimizer update gradients computing by this batch.
 
         Args:
             inputs (numpy.ndarray|Tensor|list): Batch of input data. It could 
@@ -1543,7 +1536,7 @@ class Model(object):
             shuffle=True,
             num_workers=0,
             callbacks=None,
-            accumulate=1, ):
+            accumulate_grad_batches=1, ):
         """
         Trains the model for a fixed number of epochs. If `eval_data` is set,
         evaluation will be done at the end of each epoch.
@@ -1586,8 +1579,8 @@ class Model(object):
             callbacks (Callback|None): A list of `Callback` instances to apply
                 during training. If None, `ProgBarLogger` and `ModelCheckpoint`
                 are automatically inserted. Default: None.
-            accumulate (int): The number of steps to accumulate gradident during 
-                training process before optimizer updates. It can mimic large batch
+            accumulate_grad_batches (int): The number of batches to accumulate gradident 
+                during training process before optimizer updates. It can mimic large batch
                 size. Default: 1.
             
         Returns:
@@ -1710,7 +1703,7 @@ class Model(object):
         do_eval = eval_loader is not None
         self._test_dataloader = eval_loader
 
-        self._accumulate = accumulate
+        self._accumulate = accumulate_grad_batches
 
         steps = self._len_data_loader(train_loader)
         cbks = config_callbacks(

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1032,7 +1032,8 @@ class Model(object):
                 a numpy array or paddle.Tensor, or a list of arrays or tensors 
                 (in case the model has multiple labels). If has no labels, 
                 set None. Default is None.
-            update (bool): Whether update parameters after loss.backward() computing. Using it to accumulate gradients. Default is True.
+            update (bool): Whether update parameters after loss.backward() computing.
+                Using it to accumulate gradients. Default is True.
 
         Returns:
             A list of scalar training loss if the model has no metrics,

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1585,7 +1585,9 @@ class Model(object):
             callbacks (Callback|None): A list of `Callback` instances to apply
                 during training. If None, `ProgBarLogger` and `ModelCheckpoint`
                 are automatically inserted. Default: None.
-            accumulate (int): The number of steps to accumulate gradident during training process before optimizer updates. It can mimic large batch size. Default: 1.
+            accumulate (int): The number of steps to accumulate gradident during 
+                training process before optimizer updates. It can mimic large batch
+                size. Default: 1.
             
         Returns:
             None
@@ -2045,7 +2047,8 @@ class Model(object):
 
                 _inputs = [data[:len(self._inputs)], data[len(self._inputs):]]
                 if mode == 'train':
-                    _inputs.append((step + 1) % self._accumulate == 0)
+                    _inputs.append((step + 1) % self._accumulate == 0 or
+                                   step + 1 == len(data_loader))
 
                 outs = getattr(self, mode + '_batch')(*_inputs)
 

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1031,6 +1031,7 @@ class Model(object):
                 a numpy array or paddle.Tensor, or a list of arrays or tensors 
                 (in case the model has multiple labels). If has no labels, 
                 set None. Default is None.
+            update (bool): Whether update parameters after loss.backward() computes. Using this to accumulate gradients. Default is True.
 
         Returns:
             A list of scalar training loss if the model has no metrics,
@@ -2046,9 +2047,6 @@ class Model(object):
                     _inputs.append((step + 1) % self._accumulate == 0)
 
                 outs = getattr(self, mode + '_batch')(*_inputs)
-
-                # outs = getattr(self, mode + '_batch')(data[:len(self._inputs)],
-                #                                       data[len(self._inputs):])
 
                 if self._metrics and self._loss:
                     metrics = [[l[0] for l in outs[0]]]

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -701,7 +701,7 @@ class DynamicGraphAdapter(object):
         self.model.mode = value
 
     # TODO multi device in dygraph mode not implemented at present time
-    def train_batch(self, inputs, labels=None):
+    def train_batch(self, inputs, labels=None, update=True):
         assert self.model._optimizer, \
             "model not ready, please call `model.prepare()` first"
         self.model.network.train()
@@ -729,13 +729,15 @@ class DynamicGraphAdapter(object):
         if self._amp_level != "O0":
             scaled = scaler.scale(final_loss)
             scaled.backward()
-            scaler.minimize(self.model._optimizer, scaled)
-            self.model.network.clear_gradients()
+            if update:
+                scaler.minimize(self.model._optimizer, scaled)
+                self.model.network.clear_gradients()
         else:
             final_loss.backward()
-            self.model._optimizer.minimize(final_loss)
-            self.model.network.clear_gradients()
-
+            if update:
+                self.model._optimizer.minimize(final_loss)
+                self.model.network.clear_gradients()
+            
         metrics = []
         for metric in self.model._metrics:
             metric_outs = metric.compute(*(to_list(outputs) + labels))
@@ -1017,7 +1019,7 @@ class Model(object):
         else:
             self._adapter = StaticGraphAdapter(self)
 
-    def train_batch(self, inputs, labels=None):
+    def train_batch(self, inputs, labels=None, update=True):
         """
         Run one training step on a batch of data.
 
@@ -1062,7 +1064,7 @@ class Model(object):
               loss = model.train_batch([data], [label])
               print(loss)
         """
-        loss = self._adapter.train_batch(inputs, labels)
+        loss = self._adapter.train_batch(inputs, labels, update)
         if fluid.in_dygraph_mode() and self._input_info is None:
             self._update_inputs()
         return loss
@@ -1537,7 +1539,8 @@ class Model(object):
             drop_last=False,
             shuffle=True,
             num_workers=0,
-            callbacks=None, ):
+            callbacks=None, 
+            accumulate=1, ):
         """
         Trains the model for a fixed number of epochs. If `eval_data` is set,
         evaluation will be done at the end of each epoch.
@@ -1580,7 +1583,8 @@ class Model(object):
             callbacks (Callback|None): A list of `Callback` instances to apply
                 during training. If None, `ProgBarLogger` and `ModelCheckpoint`
                 are automatically inserted. Default: None.
-
+            accumulate (int): The number of steps to accumulate gradident in training process before optimizer update. Using this to mimic large batch size. Default: 1.
+            
         Returns:
             None
 
@@ -1700,7 +1704,8 @@ class Model(object):
 
         do_eval = eval_loader is not None
         self._test_dataloader = eval_loader
-
+        self._accumulate = accumulate
+        
         steps = self._len_data_loader(train_loader)
         cbks = config_callbacks(
             callbacks,
@@ -1738,7 +1743,7 @@ class Model(object):
 
         cbks.on_end('train', logs)
         self._test_dataloader = None
-
+        
     def evaluate(
             self,
             eval_data,
@@ -2005,7 +2010,7 @@ class Model(object):
                 model_filename=model_filename,
                 params_filename=params_filename)
 
-    def _run_one_epoch(self, data_loader, callbacks, mode, logs={}):
+    def _run_one_epoch(self, data_loader, callbacks, mode, logs={},):
         outputs = []
         for step, data in enumerate(data_loader):
             # data might come from different types of data_loader and have
@@ -2029,8 +2034,16 @@ class Model(object):
             callbacks.on_batch_begin(mode, step, logs)
 
             if mode != 'predict':
-                outs = getattr(self, mode + '_batch')(data[:len(self._inputs)],
-                                                      data[len(self._inputs):])
+                
+                _inputs = [data[:len(self._inputs)], data[len(self._inputs):]]
+                if mode == 'train':
+                    _inputs.append((step + 1) % self._accumulate == 0)
+                    
+                outs = getattr(self, mode + '_batch')(*_inputs)
+                
+                # outs = getattr(self, mode + '_batch')(data[:len(self._inputs)],
+                #                                       data[len(self._inputs):])
+
                 if self._metrics and self._loss:
                     metrics = [[l[0] for l in outs[0]]]
                 elif self._loss:

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -737,7 +737,7 @@ class DynamicGraphAdapter(object):
             if update:
                 self.model._optimizer.minimize(final_loss)
                 self.model.network.clear_gradients()
-            
+
         metrics = []
         for metric in self.model._metrics:
             metric_outs = metric.compute(*(to_list(outputs) + labels))
@@ -1539,7 +1539,7 @@ class Model(object):
             drop_last=False,
             shuffle=True,
             num_workers=0,
-            callbacks=None, 
+            callbacks=None,
             accumulate=1, ):
         """
         Trains the model for a fixed number of epochs. If `eval_data` is set,
@@ -1704,8 +1704,9 @@ class Model(object):
 
         do_eval = eval_loader is not None
         self._test_dataloader = eval_loader
+
         self._accumulate = accumulate
-        
+
         steps = self._len_data_loader(train_loader)
         cbks = config_callbacks(
             callbacks,
@@ -1743,7 +1744,7 @@ class Model(object):
 
         cbks.on_end('train', logs)
         self._test_dataloader = None
-        
+
     def evaluate(
             self,
             eval_data,
@@ -2010,7 +2011,12 @@ class Model(object):
                 model_filename=model_filename,
                 params_filename=params_filename)
 
-    def _run_one_epoch(self, data_loader, callbacks, mode, logs={},):
+    def _run_one_epoch(
+            self,
+            data_loader,
+            callbacks,
+            mode,
+            logs={}, ):
         outputs = []
         for step, data in enumerate(data_loader):
             # data might come from different types of data_loader and have
@@ -2034,13 +2040,13 @@ class Model(object):
             callbacks.on_batch_begin(mode, step, logs)
 
             if mode != 'predict':
-                
+
                 _inputs = [data[:len(self._inputs)], data[len(self._inputs):]]
                 if mode == 'train':
                     _inputs.append((step + 1) % self._accumulate == 0)
-                    
+
                 outs = getattr(self, mode + '_batch')(*_inputs)
-                
+
                 # outs = getattr(self, mode + '_batch')(data[:len(self._inputs)],
                 #                                       data[len(self._inputs):])
 

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -302,7 +302,7 @@ class StaticGraphAdapter(object):
         assert self.model._optimizer, \
             "model not ready, please call `model.prepare()` first"
         self.mode = 'train'
-        assert update is True, "Model does not support `update == False` in static mode by now."
+        assert update is True, "Does not support `update == False` in static mode by now."
         return self._run(inputs, labels)
 
     def eval_batch(self, inputs, labels=None):
@@ -1032,7 +1032,7 @@ class Model(object):
                 a numpy array or paddle.Tensor, or a list of arrays or tensors 
                 (in case the model has multiple labels). If has no labels, 
                 set None. Default is None.
-            update (bool): Whether update parameters after loss.backward() computes. Using this to accumulate gradients. Default is True.
+            update (bool): Whether update parameters after loss.backward() computing. Using it to accumulate gradients. Default is True.
 
         Returns:
             A list of scalar training loss if the model has no metrics,
@@ -1585,7 +1585,7 @@ class Model(object):
             callbacks (Callback|None): A list of `Callback` instances to apply
                 during training. If None, `ProgBarLogger` and `ModelCheckpoint`
                 are automatically inserted. Default: None.
-            accumulate (int): The number of steps to accumulate gradident in training process before optimizer update. Using this to mimic large batch size. Default: 1.
+            accumulate (int): The number of steps to accumulate gradident during training process before optimizer updates. It can mimic large batch size. Default: 1.
             
         Returns:
             None

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -727,8 +727,16 @@ class TestModelFunction(unittest.TestCase):
                                     parameter_list=net.parameters())
         inputs = [InputSpec([None, dim], 'float32', 'x')]
         labels = [InputSpec([None, 1], 'int64', 'label')]
+
         model = Model(net, inputs, labels)
         model.prepare(optim, loss=CrossEntropyLoss(reduction="sum"))
+        loss1, = model.train_batch([data], [label], update=False)
+        loss2, = model.train_batch([data], [label], update=True)
+        np.testing.assert_almost_equal(loss1, loss2, decimal=4)
+
+        model = Model(net, inputs, labels)
+        model.prepare(
+            optim, loss=CrossEntropyLoss(reduction="sum"), amp_configs='O1')
         loss1, = model.train_batch([data], [label], update=False)
         loss2, = model.train_batch([data], [label], update=True)
         np.testing.assert_almost_equal(loss1, loss2, decimal=4)

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -729,8 +729,9 @@ class TestModelFunction(unittest.TestCase):
         labels = [InputSpec([None, 1], 'int64', 'label')]
         model = Model(net, inputs, labels)
         model.prepare(optim, loss=CrossEntropyLoss(reduction="sum"))
-        loss1, = model.train_batch([data], [label], update=True)
-        loss2, = model.train_batch([data], [label], update=False)
+        loss1, = model.train_batch([data], [label], update=False)
+        loss2, = model.train_batch([data], [label], update=True)
+        np.testing.assert_almost_equal(loss1, loss2, decimal=4)
 
 
 class TestModelWithLRScheduler(unittest.TestCase):

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -718,6 +718,20 @@ class TestModelFunction(unittest.TestCase):
         model.save(save_dir, training=False)
         shutil.rmtree(save_dir)
 
+    def test_accumulate(self, ):
+        dim = 20
+        data = np.random.random(size=(4, dim)).astype(np.float32)
+        label = np.random.randint(0, 10, size=(4, 1)).astype(np.int64)
+        net = MyModel()
+        optim = fluid.optimizer.SGD(learning_rate=0.001,
+                                    parameter_list=net.parameters())
+        inputs = [InputSpec([None, dim], 'float32', 'x')]
+        labels = [InputSpec([None, 1], 'int64', 'label')]
+        model = Model(net, inputs, labels)
+        model.prepare(optim, loss=CrossEntropyLoss(reduction="sum"))
+        loss1, = model.train_batch([data], [label], update=True)
+        loss2, = model.train_batch([data], [label], update=False)
+
 
 class TestModelWithLRScheduler(unittest.TestCase):
     def test_fit_by_step(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- add `accumulate` option in `Model.fit`
  - the number of steps of accumulating gradients, used to mimic large batch size
  - **only support dygraph**

- usage
```python
import paddle
import paddle.nn as nn
import paddle.vision.transforms as T

device = paddle.set_device('cpu') # or 'gpu'

net = nn.Sequential(nn.Flatten(1), nn.Linear(784, 200), nn.Tanh(), nn.Linear(200, 10))

model = paddle.Model(net)
optim = paddle.optimizer.SGD(learning_rate=1e-3, parameters=model.parameters())
model.prepare(optim, paddle.nn.CrossEntropyLoss(), paddle.metric.Accuracy())

transform = T.Compose([ T.Transpose(), T.Normalize([127.5], [127.5])])
data = paddle.vision.datasets.MNIST(mode='train', transform=transform)

model.fit(data, epochs=5, batch_size=4, verbose=1, accumulate=4)

```