### PR TITLE
Gpu samplecode test On PR-CPU-Py2

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2158,7 +2158,6 @@ function main() {
         ;;
       build_and_check)
         set +e
-        export WITH_GPU=ON
         check_style_info=$(check_style)
         check_style_code=$?
         generate_upstream_develop_api_spec ${PYTHON_ABI:-""} ${parallel_number}
@@ -2166,8 +2165,12 @@ function main() {
         check_sequence_op_unittest
         generate_api_spec ${PYTHON_ABI:-""} "PR"
         set +e
-        example_info_gpu=$(exec_samplecode_test gpu)
-        example_code_gpu=$?
+        example_info_gpu=""
+        example_code_gpu=0
+        if [ "${WITH_GPU}" == "ON" ] ; then
+            example_info_gpu=$(exec_samplecode_test gpu)
+            example_code_gpu=$?
+        fi
         example_info=$(exec_samplecode_test cpu)
         example_code=$?
         summary_check_problems $check_style_code $[${example_code_gpu} + ${example_code}] "$check_style_info" "${example_info_gpu}\n${example_info}"

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2051,7 +2051,7 @@ function exec_samplecode_test() {
     if [ "$1" = "cpu" ] ; then
         python sampcd_processor.py cpu; example_error=$?
     elif [ "$1" = "gpu" ] ; then
-        python sampcd_processor.py --threads=16 --full-test gpu; example_error=$?
+        python sampcd_processor.py --threads=16 gpu; example_error=$?
     fi
     if [ "$example_error" != "0" ];then
       echo "Code instance execution failed" >&2
@@ -2170,7 +2170,7 @@ function main() {
         example_code_gpu=$?
         example_info=$(exec_samplecode_test cpu)
         example_code=$?
-        summary_check_problems $check_style_code $example_code "$check_style_info" "$example_info"
+        summary_check_problems $check_style_code $[${example_code_gpu} + ${example_code}] "$check_style_info" "${example_info_gpu}\n${example_info}"
         assert_api_spec_approvals
         ;;
       build)

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2158,6 +2158,7 @@ function main() {
         ;;
       build_and_check)
         set +e
+        export WITH_GPU=ON
         check_style_info=$(check_style)
         check_style_code=$?
         generate_upstream_develop_api_spec ${PYTHON_ABI:-""} ${parallel_number}
@@ -2165,6 +2166,8 @@ function main() {
         check_sequence_op_unittest
         generate_api_spec ${PYTHON_ABI:-""} "PR"
         set +e
+        example_info_gpu=$(exec_samplecode_test gpu)
+        example_code_gpu=$?
         example_info=$(exec_samplecode_test cpu)
         example_code=$?
         summary_check_problems $check_style_code $example_code "$check_style_info" "$example_info"

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -831,12 +831,6 @@ function generate_api_spec() {
 
     awk -F '(' '{print $NF}' $spec_path >${spec_path}.doc
     awk -F '(' '{$NF="";print $0}' $spec_path >${spec_path}.api
-    # delete it. Py2 version is no longer maintained.
-    # if [ "$1" == "cp35-cp35m" ] || [ "$1" == "cp36-cp36m" ] || [ "$1" == "cp37-cp37m" ] || [ "$1" == "cp38-cp38" ] || [ "$1" == "cp39-cp39" ]; then
-    #     # Use sed to make python2 and python3 sepc keeps the same
-    #     sed -i 's/arg0: str/arg0: unicode/g' $spec_path
-    #     sed -i "s/\(.*Transpiler.*\).__init__ (ArgSpec(args=\['self'].*/\1.__init__ /g" $spec_path
-    # fi   
     
     python ${PADDLE_ROOT}/tools/diff_use_default_grad_op_maker.py \
         ${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_maker_${spec_kind}.spec

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -829,14 +829,14 @@ function generate_api_spec() {
     api_source_md5_path=${PADDLE_ROOT}/paddle/fluid/API_${spec_kind}.source.md5
     python ${PADDLE_ROOT}/tools/count_api_without_core_ops.py -p paddle > $api_source_md5_path
 
-    # TODO: delete it. Py2 version is no longer maintained.
     awk -F '(' '{print $NF}' $spec_path >${spec_path}.doc
     awk -F '(' '{$NF="";print $0}' $spec_path >${spec_path}.api
-    if [ "$1" == "cp35-cp35m" ] || [ "$1" == "cp36-cp36m" ] || [ "$1" == "cp37-cp37m" ] || [ "$1" == "cp38-cp38" ] || [ "$1" == "cp39-cp39" ]; then
-        # Use sed to make python2 and python3 sepc keeps the same
-        sed -i 's/arg0: str/arg0: unicode/g' $spec_path
-        sed -i "s/\(.*Transpiler.*\).__init__ (ArgSpec(args=\['self'].*/\1.__init__ /g" $spec_path
-    fi   
+    # delete it. Py2 version is no longer maintained.
+    # if [ "$1" == "cp35-cp35m" ] || [ "$1" == "cp36-cp36m" ] || [ "$1" == "cp37-cp37m" ] || [ "$1" == "cp38-cp38" ] || [ "$1" == "cp39-cp39" ]; then
+    #     # Use sed to make python2 and python3 sepc keeps the same
+    #     sed -i 's/arg0: str/arg0: unicode/g' $spec_path
+    #     sed -i "s/\(.*Transpiler.*\).__init__ (ArgSpec(args=\['self'].*/\1.__init__ /g" $spec_path
+    # fi   
     
     python ${PADDLE_ROOT}/tools/diff_use_default_grad_op_maker.py \
         ${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_maker_${spec_kind}.spec

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -829,6 +829,7 @@ function generate_api_spec() {
     api_source_md5_path=${PADDLE_ROOT}/paddle/fluid/API_${spec_kind}.source.md5
     python ${PADDLE_ROOT}/tools/count_api_without_core_ops.py -p paddle > $api_source_md5_path
 
+    # TODO: delete it. Py2 version is no longer maintained.
     awk -F '(' '{print $NF}' $spec_path >${spec_path}.doc
     awk -F '(' '{$NF="";print $0}' $spec_path >${spec_path}.api
     if [ "$1" == "cp35-cp35m" ] || [ "$1" == "cp36-cp36m" ] || [ "$1" == "cp37-cp37m" ] || [ "$1" == "cp38-cp38" ] || [ "$1" == "cp39-cp39" ]; then

--- a/python/paddle/fluid/layers/ops.py
+++ b/python/paddle/fluid/layers/ops.py
@@ -87,26 +87,26 @@ for _OP in set(__activations_noattr__):
     _new_OP = _OP
     if _OP in __deprecated_func_name__:
         _new_OP = __deprecated_func_name__[_OP]
-    func = generate_activation_fn(_OP)
-    func = deprecated(
-        since="2.0.0", update_to="paddle.nn.functional.%s" % (_new_OP))(func)
-    globals()[_OP] = func
+    _func = generate_activation_fn(_OP)
+    _func = deprecated(
+        since="2.0.0", update_to="paddle.nn.functional.%s" % (_new_OP))(_func)
+    globals()[_OP] = _func
 
 for _OP in set(__unary_func__):
     _new_OP = _OP
     if _OP in __deprecated_func_name__:
         _new_OP = __deprecated_func_name__[_OP]
-    func = generate_activation_fn(_OP)
-    func = deprecated(since="2.0.0", update_to="paddle.%s" % (_new_OP))(func)
-    globals()[_OP] = func
+    _func = generate_activation_fn(_OP)
+    _func = deprecated(since="2.0.0", update_to="paddle.%s" % (_new_OP))(_func)
+    globals()[_OP] = _func
 
 for _OP in set(__inplace_unary_func__):
     _new_OP = _OP
     if _OP in __deprecated_func_name__:
         _new_OP = __deprecated_func_name__[_OP]
-    func = generate_inplace_fn(_OP)
-    func = deprecated(since="2.0.0", update_to="paddle.%s" % (_new_OP))(func)
-    globals()[_OP] = func
+    _func = generate_inplace_fn(_OP)
+    _func = deprecated(since="2.0.0", update_to="paddle.%s" % (_new_OP))(_func)
+    globals()[_OP] = _func
 
 add_sample_code(globals()["sigmoid"], r"""
 Examples:

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -86,6 +86,7 @@ if [ -n "${echo_list}" ];then
   echo "****************"
 fi
 
+# 为什么这里会再次执行？ 前面L48 L62已执行过了啊
 python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec
 python ${PADDLE_ROOT}/tools/check_op_register_type.py ${PADDLE_ROOT}/paddle/fluid/OP_TYPE_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_TYPE_PR.spec
 if [ -n "${echo_list}" ]; then

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -38,7 +38,11 @@ function add_failed(){
 
 
 api_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.api  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.api` 
-if [ "$api_spec_diff" != "" ]; then
+ops_func_in_diff=$(echo ${api_spec_diff} | grep '\bpaddle\.fluid\.layers\.ops\.func\b')
+linenum=$(echo ${api_spec_diff} | wc -l | sed 's/[[:space:]]//g')
+if [ "${linenum}" = "3" -a "${ops_func_in_diff}" != "" ] ; then
+    echo "skip paddle.fluid.layers.ops.func"
+elif [ "$api_spec_diff" != "" ]; then
     echo_line="You must have one RD (XiaoguangHu01 or lanxianghit) and one TPM (saxon-zh or jzhang533 or dingjiaweiww or Heeenrrry or TCChenlong) approval for the api change for the management reason of API interface.\n"
     check_approval 1 46782768 47554610
     echo_line=""
@@ -46,7 +50,10 @@ if [ "$api_spec_diff" != "" ]; then
 fi
 
 api_doc_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.doc  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.doc` 
-if [ "$api_doc_spec_diff" != "" ]; then
+linenum=$(echo ${api_doc_spec_diff} | wc -l | sed 's/[[:space:]]//g')
+if [ "${linenum}" = "3" -a "${ops_func_in_diff}" != "" ] ; then
+    echo "skip paddle.fluid.layers.ops.func for doc diff"
+elif [ "$api_doc_spec_diff" != "" ]; then
     echo_line="You must have one TPM (saxon-zh or jzhang533 or dingjiaweiww or Heeenrrry or TCChenlong) approval for the api change for the management reason of API document.\n"
     check_approval 1 2870059 29231 23093488 28379894 11935832
 fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -85,5 +85,10 @@ if [ -n "${echo_list}" ];then
   echo "There are ${failed_num} approved errors."
   echo "****************"
 
+  # L40 L48 L62 has fetch the result out.
+  echo "api_spec_diff: ${api_spec_diff}"
+  echo "api_doc_spec_diff: ${api_doc_spec_diff}"
+  echo "op_type_spec_diff: ${op_type_spec_diff}"
+ 
   exit 6
 fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -84,8 +84,6 @@ if [ -n "${echo_list}" ];then
   echo -e "${echo_list[@]}"
   echo "There are ${failed_num} approved errors."
   echo "****************"
-fi
 
-if [ -n "${echo_list}" ]; then
   exit 6
 fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -51,9 +51,9 @@ if [ "$api_doc_spec_diff" != "" ]; then
     check_approval 1 2870059 29231 23093488 28379894 11935832
 fi
 
-api_spec_diff=`python ${PADDLE_ROOT}/tools/check_api_source_without_core_ops.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.source.md5  ${PADDLE_ROOT}/paddle/fluid/API_PR.source.md5` 
-if [ "$api_spec_diff" != "" ]; then
-    echo_line="APIs without core.ops: \n${api_spec_diff}\n"
+api_src_spec_diff=`python ${PADDLE_ROOT}/tools/check_api_source_without_core_ops.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.source.md5  ${PADDLE_ROOT}/paddle/fluid/API_PR.source.md5` 
+if [ "$api_src_spec_diff" != "" ]; then
+    echo_line="APIs without core.ops: \n${api_src_spec_diff}\n"
     echo_line="${echo_line}You must have one RD (zhiqiu (Recommend) or phlrain) approval for the api change for the opreator-related api without 'core.ops'.\n"
     echo_line="${echo_line}For more details, please click [https://github.com/PaddlePaddle/Paddle/wiki/paddle_api_development_manual.md]\n"
     check_approval 1 6888866 43953930
@@ -86,9 +86,14 @@ if [ -n "${echo_list}" ];then
   echo "****************"
 
   # L40 L48 L62 has fetch the result out.
-  echo "api_spec_diff: ${api_spec_diff}"
-  echo "api_doc_spec_diff: ${api_doc_spec_diff}"
-  echo "op_type_spec_diff: ${op_type_spec_diff}"
- 
+  if [ "${api_spec_diff}" != "" ] ; then
+    echo "api_spec_diff: ${api_spec_diff}"
+  fi
+  if [ "${api_doc_spec_diff}" != "" ] ; then
+    echo "api_doc_spec_diff: ${api_doc_spec_diff}"
+  fi
+  if [ "${op_type_spec_diff}" != "" ] ; then
+    echo "op_type_spec_diff: ${op_type_spec_diff}"
+  fi 
   exit 6
 fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -86,9 +86,6 @@ if [ -n "${echo_list}" ];then
   echo "****************"
 fi
 
-# 为什么这里会再次执行？ 前面L48 L62已执行过了啊
-python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec
-python ${PADDLE_ROOT}/tools/check_op_register_type.py ${PADDLE_ROOT}/paddle/fluid/OP_TYPE_DEV.spec  ${PADDLE_ROOT}/paddle/fluid/OP_TYPE_PR.spec
 if [ -n "${echo_list}" ]; then
   exit 6
 fi

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -29,6 +29,7 @@ import platform
 import functools
 import pkgutil
 import logging
+import argparse
 import paddle
 
 member_dict = collections.OrderedDict()
@@ -157,7 +158,8 @@ def get_all_api(root_path='paddle', attr="__all__"):
     logger.info('%s: collected %d apis, %d distinct apis.', attr, api_counter,
                 len(api_info_dict))
 
-    return [api_info['all_names'][0] for api_info in api_info_dict.values()]
+    return [(list(api_info['all_names'])[0], md5(api_info['docstring']))
+            for api_info in api_info_dict.values()]
 
 
 def insert_api_into_dict(full_name, gen_doc_anno=None):
@@ -185,6 +187,7 @@ def insert_api_into_dict(full_name, gen_doc_anno=None):
                 "id": fc_id,
                 "object": obj,
                 "type": type(obj).__name__,
+                "docstring": '',
             }
             docstr = inspect.getdoc(obj)
             if docstr:
@@ -229,15 +232,49 @@ def get_all_api_from_modulelist():
     return member_dict
 
 
-if __name__ == '__main__':
-    get_all_api_from_modulelist()
+def parse_args():
+    """
+    Parse input arguments
+    """
+    parser = argparse.ArgumentParser(description='Print Apis Signatures')
+    parser.add_argument('--debug', dest='debug', action="store_true")
+    parser.add_argument(
+        '--method',
+        dest='method',
+        type=str,
+        default='from_modulelist',
+        help="using get_all_api or from_modulelist")
+    parser.add_argument(
+        'module', type=str, help='module', default='paddle')  # not used
 
-    for name in member_dict:
-        print(name, member_dict[name])
+    if len(sys.argv) == 1:
+        args = parser.parse_args(['paddle'])
+        return args
+    #    parser.print_help()
+    #    sys.exit(1)
+
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    if args.method == 'from_modulelist':
+        get_all_api_from_modulelist()
+        for name in member_dict:
+            print(name, member_dict[name])
+    elif args.method == 'get_all_api':
+        api_signs = get_all_api()
+        for api_sign in api_signs:
+            print("{0} ({0}, ('document', '{1}'))".format(api_sign[0], api_sign[
+                1]))
+
     if len(ErrorSet) == 0:
         sys.exit(0)
-    for erroritem in ErrorSet:
-        print(
-            "Error, new function {} is unreachable".format(erroritem),
-            file=sys.stderr)
-    sys.exit(1)
+    else:
+        for erroritem in ErrorSet:
+            print(
+                "Error, new function {} is unreachable".format(erroritem),
+                file=sys.stderr)
+        sys.exit(1)

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -81,7 +81,9 @@ def is_primitive(instance):
 ErrorSet = set()
 IdSet = set()
 skiplist = [
-    'paddle.vision.datasets.DatasetFolderImageFolder', 'paddle.truncdigamma'
+    'paddle.vision.datasets.DatasetFolderImageFolder',
+    'paddle.truncdigamma',
+    'paddle.fluid.layers.ops.func',
 ]
 
 

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -158,7 +158,7 @@ def get_all_api(root_path='paddle', attr="__all__"):
     logger.info('%s: collected %d apis, %d distinct apis.', attr, api_counter,
                 len(api_info_dict))
 
-    return [(list(api_info['all_names'])[0], md5(api_info['docstring']))
+    return [(sorted(list(api_info['all_names']))[0], md5(api_info['docstring']))
             for api_info in api_info_dict.values()]
 
 

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -103,9 +103,11 @@ def visit_all_module(mod):
     if hasattr(mod, "__all__"):
         member_names += mod.__all__
     for member_name in member_names:
-        if member_name.startswith('__'):
+        if member_name.startswith('_'):
             continue
         cur_name = mod_name + '.' + member_name
+        if cur_name in skiplist:
+            continue
         try:
             instance = getattr(mod, member_name)
             if inspect.ismodule(instance):

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -443,7 +443,7 @@ def get_filenames(full_test=False):
     import paddle
     whl_error = []
     if full_test:
-        get_full_api()
+        get_full_api_from_pr_spec()
     else:
         get_incrementapi()
     all_sample_code_filenames = {}
@@ -514,6 +514,19 @@ def get_full_api_by_walk():
     apilist = get_all_api()
     with open(API_DIFF_SPEC_FN, 'w') as f:
         f.write("\n".join([ai[0] for ai in apilist]))
+
+
+def get_full_api_from_pr_spec():
+    """
+    get all the apis
+    """
+    global API_PR_SPEC_FN, API_DIFF_SPEC_FN  ## readonly
+    pr_api = get_api_md5(API_PR_SPEC_FN)
+    if len(pr_api):
+        with open(API_DIFF_SPEC_FN, 'w') as f:
+            f.write("\n".join(pr_api.keys()))
+    else:
+        get_full_api_by_walk()
 
 
 def get_incrementapi():

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -513,7 +513,7 @@ def get_full_api_by_walk():
     from print_signatures import get_all_api
     apilist = get_all_api()
     with open(API_DIFF_SPEC_FN, 'w') as f:
-        f.write("\n".join(apilist))
+        f.write("\n".join([ai[0] for ai in apilist]))
 
 
 def get_incrementapi():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
在PR-CPU-Py2流水线执行GPU示例代码测试，把流水线的版本改为GPU版本。
// 对啊，第一个怎么办
see http://agroup.baidu.com/paddlepaddle-org-cn/md/article/4036225#0618
已测三次，第一次运行时间5小时；第二次运行时间2.5小时，第三次运行时间接近3小时。
因为编译cache的有益影响，第二次编译非常快就完成了。但是整体增加时间确实太长了。等于将py2流水线增加了约两个小时。

而若在已有的py3流水线上执行个全量测试，增加时间也就10分钟左右（单卡P4上测得）。

06-21：经过多次运行之后，编译缓存也见效显著。编译代码未做变更时，编译时长仅为17分钟左右。与CPU的9分钟相比增加8分钟。
代码少量变更的[roll optimize by SunNy820828449 · Pull Request #32880 · PaddlePaddle/Paddle](https://github.com/PaddlePaddle/Paddle/pull/32880)任务时长为28分钟。可以接受。与之前的9-15分钟相比，增长<20分钟。

但有更改主体代码的仅此一例。需要合入此PR代码后继续观察。且此逻辑由`WITH_GPU`直接影响，仅需修改PRC-CI-CPU-Py2的执行脚本内的环境变量即可控制本逻辑。

0622
补充修改：http://agroup.baidu.com/paddlepaddle-org-cn/md/article/4036225
关于ops.py 中的`func`变量，改为私有`_func`。因为func是个临时变量。 昨天的一个修改把这个导出 print signatures 打印出来了。这个临时变量 可能因为顺序每次不一样，然后每次就都与另一个不同的op的md5相同， 也有可能顺序正好一致 就通过了CI， 顺序不一致就通不过。 