### PR TITLE
ensure ANSI escape sequences print correctly in cmd and powershell

### DIFF
--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -16,6 +16,7 @@ import inspect
 import numpy as np
 import warnings
 import weakref
+import sys, os
 
 import paddle
 from .. import framework
@@ -370,6 +371,10 @@ def monkey_patch_varbase():
                 # Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False, [500.])
 
         """
+        # ensure ANSI escape sequences print correctly in cmd and powershell
+        if sys.platform.lower() == 'win32':
+            os.system('')
+
         msg = "tensor.grad will return the tensor value of the gradient."
         warning_msg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
         warnings.warn(warning_msg)

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -16,7 +16,7 @@ import inspect
 import numpy as np
 import warnings
 import weakref
-import sys, os
+import sys, subprocess
 
 import paddle
 from .. import framework
@@ -373,7 +373,7 @@ def monkey_patch_varbase():
         """
         # ensure ANSI escape sequences print correctly in cmd and powershell
         if sys.platform.lower() == 'win32':
-            os.system('')
+            subprocess.call('', shell=True)
 
         msg = "tensor.grad will return the tensor value of the gradient."
         warning_msg = "\033[93m\nWarning:\n%s \033[0m" % (msg)

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -371,12 +371,12 @@ def monkey_patch_varbase():
                 # Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False, [500.])
 
         """
-        # ensure ANSI escape sequences print correctly in cmd and powershell
-        if sys.platform.lower() == 'win32':
-            subprocess.call('', shell=True)
-
         msg = "tensor.grad will return the tensor value of the gradient."
         warning_msg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
+        # ensure ANSI escape sequences print correctly in cmd and powershell
+        if sys.platform.lower() == 'win32':
+            warning_msg = "\nWarning:\n%s " % (msg)
+
         warnings.warn(warning_msg)
         return self._grad_ivar()
 

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -16,7 +16,7 @@ import inspect
 import numpy as np
 import warnings
 import weakref
-import sys, subprocess
+import sys
 
 import paddle
 from .. import framework

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -99,11 +99,11 @@ def deprecated(update_to="", since="", reason="", level=0):
                 raise RuntimeError('API "{}.{}" has been deprecated.'.format(
                     func.__module__, func.__name__))
 
+            warningmsg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
             # ensure ANSI escape sequences print correctly in cmd and powershell
             if sys.platform.lower() == 'win32':
-                subprocess.call('', shell=True)
+                warningmsg = "\nWarning:\n%s " % (msg)
 
-            warningmsg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
             v_current = [int(i) for i in paddle.__version__.split(".")]
             v_current += [0] * (4 - len(v_current))
             v_since = [int(i) for i in _since.split(".")]

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -18,7 +18,7 @@ decorator to deprecate a function or class
 import warnings
 import functools
 import paddle
-import sys, os
+import sys, subprocess
 
 __all__ = []
 
@@ -101,7 +101,7 @@ def deprecated(update_to="", since="", reason="", level=0):
 
             # ensure ANSI escape sequences print correctly in cmd and powershell
             if sys.platform.lower() == 'win32':
-                os.system('')
+                subprocess.call('', shell=True)
 
             warningmsg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
             v_current = [int(i) for i in paddle.__version__.split(".")]

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -18,6 +18,7 @@ decorator to deprecate a function or class
 import warnings
 import functools
 import paddle
+import sys, os
 
 __all__ = []
 
@@ -97,6 +98,10 @@ def deprecated(update_to="", since="", reason="", level=0):
             if level == 2:
                 raise RuntimeError('API "{}.{}" has been deprecated.'.format(
                     func.__module__, func.__name__))
+
+            # ensure ANSI escape sequences print correctly in cmd and powershell
+            if sys.platform.lower() == 'win32':
+                os.system('')
 
             warningmsg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
             v_current = [int(i) for i in paddle.__version__.split(".")]

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -18,7 +18,7 @@ decorator to deprecate a function or class
 import warnings
 import functools
 import paddle
-import sys, subprocess
+import sys
 
 __all__ = []
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
# ` os.system('')`版本
参考[how-to-print-colored-text-to-the-terminal](https://stackoverflow.com/questions/287871/how-to-print-colored-text-to-the-terminal)。

`\033[`开头为ANSI转义代码（`ANSI escape sequences`），在windows cmd和powershell上直接`print('\033[93m\nWarning:\n%s \033[0m' % ('Test'))`会乱码，通过以下代码可解决该问题：
```
import sys, os
if sys.platform.lower() == 'win32':
    os.system('')
```

>  Q：why does `os.system("")` cause color codes to work?
>  A：It's not python's implementation, in C running `printf(fmt, ...);` with ASNI codes in windows after calling `system("");` (`include <stdlib.h>`) does prints the color text

![bj-4a8251c287aef586061d9dc5ca595cd9a81dafdf](https://user-images.githubusercontent.com/31386411/122532727-6927a180-d053-11eb-816f-03815e44391c.png)
![bj-72216ed6242790ae2208810f832f576a5fbfb6dc](https://user-images.githubusercontent.com/31386411/122532739-6b89fb80-d053-11eb-8d04-03204140aafc.png)
![bj-cd74edf9a85f4cfc47aabe8c16c75a5fc9f1c426](https://user-images.githubusercontent.com/31386411/122532746-6cbb2880-d053-11eb-9767-adde8a705ae9.png)

# `subprocess.call('', shell=True)`版本
 `os.system('')`版本下PR-CI-Window一直挂，原因是Timeout。查找时发现可能是因为[windows下在python中调用os.system()执行系统命令时的弹出框](https://blog.csdn.net/GYGuo95/article/details/80060328)，为解决该问题同时兼容python2和python3，使用`subprocess.call`替换`os.system('')`。

![0621anaconda](https://user-images.githubusercontent.com/31386411/122739839-f2d6a980-d2b5-11eb-9bef-acd6e9d6288e.png)
![0621cmd](https://user-images.githubusercontent.com/31386411/122739850-f5390380-d2b5-11eb-91e7-9df6c584a2b0.png)
![0621powershell](https://user-images.githubusercontent.com/31386411/122739853-f66a3080-d2b5-11eb-9d65-2d2c6a6254ff.png)

# win32下不显示颜色
`subprocess.call`版本在PR-CI-CPU-Py2下也直接挂，原因是`subprocess.call`调用将被废弃，但最新的`subprocess.run`只支持python3.5+版本，因此权衡之下干脆对于cmd和powershell不显示颜色。
