### PR TITLE
fix no iter return

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -91,7 +91,7 @@ class _DataLoaderIterBase(object):
         self._thread_done_event = threading.Event()
 
     def __iter__(self):
-        return self
+        return self._sampler_iter
 
     def __len__(self):
         return len(self._batch_sampler)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
In python/paddle/fluid/dataloader/dataloader_iter.py:
   __iter__ returns non-iterator
   **return self._sampler_iter**