### PR TITLE
Fix some Bugs of Undefined Variables

### DIFF
--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -29,6 +29,7 @@ import struct
 
 import paddle
 import paddle.fluid as fluid
+from distutils.util import strtobool
 logger = logging.getLogger("root")
 logger.propagate = False
 
@@ -349,7 +350,7 @@ def add_arguments(argname, type, default, help, argparser, **kwargs):
         add_argument("name", str, "Jonh", "User name.", parser)
         args = parser.parse_args()
     """
-    type = distutils.util.strtobool if type == bool else type
+    type = strtobool if type == bool else type
     argparser.add_argument(
         "--" + argname,
         default=default,
@@ -685,7 +686,7 @@ def get_device_proc_info(args):
         gpus = get_gpus(args.gpus)
         if args.nproc_per_node is not None:
             assert (len(gpus) % int(args.nproc_per_node)) ==0, \
-                "gpus' number:{} mod args.nproc_per_node:{} must == 0".format(len(gpus), arg.nproc_per_node)
+                "gpus' number:{} mod args.nproc_per_node:{} must == 0".format(len(gpus), args.nproc_per_node)
 
             n = int(len(gpus) / int(args.nproc_per_node))
             devices_per_proc = [
@@ -699,7 +700,7 @@ def get_device_proc_info(args):
         xpus = get_xpus(args.xpus)
         if args.nproc_per_node is not None:
             assert (len(xpus) % int(args.nproc_per_node)) == 0, \
-                "xpus' number:{} mod args.nproc_per_node:{} must == 0".format(len(xpus), arg.nproc_per_node)
+                "xpus' number:{} mod args.nproc_per_node:{} must == 0".format(len(xpus), args.nproc_per_node)
 
             n = int(len(xpus) / int(args.nproc_per_node))
             devices_per_proc = [

--- a/python/paddle/fluid/tests/unittests/asp/test_asp_pruning_1d.py
+++ b/python/paddle/fluid/tests/unittests/asp/test_asp_pruning_1d.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 
+import unittest
 import paddle
 from paddle.fluid.contrib import sparsity
 from paddle.fluid.tests.unittests.asp.asp_pruning_base import TestASPHelperPruningBase

--- a/python/paddle/fluid/tests/unittests/asp/test_asp_pruning_2d_greedy.py
+++ b/python/paddle/fluid/tests/unittests/asp/test_asp_pruning_2d_greedy.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function
 
+import unittest
 import paddle
 from paddle.fluid.contrib import sparsity
 from paddle.fluid.tests.unittests.asp.asp_pruning_base import TestASPHelperPruningBase

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_transformer.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_transformer.py
@@ -20,6 +20,7 @@ import six
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph import Embedding, LayerNorm, Linear, to_variable, Layer
+from paddle.optimizer.lr import NoamDecay
 
 from test_dist_base import runtime_main, TestParallelDyGraphRunnerBase
 """

--- a/python/paddle/fluid/tests/unittests/xpu/test_batch_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_batch_norm_op_xpu.py
@@ -141,7 +141,7 @@ class TestXPUBatchNormOp(unittest.TestCase):
         else:
             raise ValueError(
                 "Unsupported data layout! Only NCHW and NHWC is supported, but received "
-                + data_layout)
+                + self.data_layout)
         np.random.seed(1024)
         self.x_np = np.random.random_sample(self.shape).astype(self.dtype)
         self.scale_np = np.random.random_sample(

--- a/tools/CrossStackProfiler/NetFileReader.py
+++ b/tools/CrossStackProfiler/NetFileReader.py
@@ -17,6 +17,7 @@ import json
 import glob
 import logging
 import pandas as pd
+import multiprocessing
 
 from multiprocessing import Process
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. In python/paddle/fluid/tests/unittests/asp/test_asp_pruning_1d.py:
   Line 36: Undefined variable 'unittest'
   **import unittest**
2. In python/paddle/distributed/fleet/launch_utils.py:
   Line 702: Undefined variable 'arg'
   **use 'args' instead of 'arg'**
   Line 352: Undefined variable 'distutils'
   **from distutils.util import strtobool**
   Line 688: Undefined variable 'arg'
   **use 'args' instead of 'arg'**
3. In python/paddle/fluid/tests/unittests/asp/test_asp_pruning_2d_greedy.py:
   Line 36: Undefined variable 'unittest'
   **import unittest**
4. In python/paddle/fluid/tests/unittests/xpu/test_batch_norm_op_xpu.py:
   Line 144: Undefined variable 'data_layout'
   **use 'self.data_layout' instead of 'data_layout'**
5. In tools/CrossStackProfiler/NetFileReader.py:
   Line 83: Undefined variable 'multiprocessing'
   **import multiprocessing**
6. In python/paddle/fluid/tests/unittests/parallel_dygraph_transformer.py:
   Line 915: Undefined variable 'NoamDecay'
   **from paddle.optimizer.lr import NoamDecay**