### PR TITLE
Fix some Bugs of Undefined Variables

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/localsgd_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/localsgd_optimizer.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import paddle
 from paddle.fluid import program_guard, layers, default_main_program
+from paddle.fluid import default_startup_program
 from .meta_optimizer_base import MetaOptimizerBase
 from .common import OpRole, OP_ROLE_KEY, CollectiveHelper, is_update_op
 

--- a/python/paddle/fluid/dataloader/flat.py
+++ b/python/paddle/fluid/dataloader/flat.py
@@ -120,7 +120,7 @@ def _restore_batch(flat_batch, structure):
                 elif isinstance(field, (Sequence, Mapping)):
                     field_idx = _restore(structure[k], field_idx)
         else:
-            raise TypeError("wrong flat data type: {}".format(type(batch)))
+            raise TypeError("wrong flat data type: {}".format(type(structure)))
 
         return field_idx
 

--- a/python/paddle/fluid/distributed/fleet.py
+++ b/python/paddle/fluid/distributed/fleet.py
@@ -13,6 +13,7 @@
 import sys
 from .. import core
 from . import ps_instance
+from google.protobuf import text_format
 
 __all__ = ['Fleet']
 

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -46,7 +46,7 @@ class TestGroupNormOpError(unittest.TestCase):
 
             def test_x_type():
                 input = np.random.random(2, 100, 3, 5).astype('float32')
-                goups = 2
+                groups = 2
                 fluid.layers.group_norm(input, groups)
 
             self.assertRaises(TypeError, test_x_type)

--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 from .optimizer import Optimizer
 from ..fluid import core
 from ..fluid import framework


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. In python/paddle/fluid/distributed/fleet.py:
   Line 39, 56: Undefined variable 'text_format'
   **from google.protobuf import text_format**
2. In python/paddle/fluid/tests/unittests/test_group_norm_op.py:
   Line 50: Undefined variable 'groups'
   **use 'groups' instead of 'goups' in Line 49**
3. In python/paddle/distributed/fleet/meta_optimizers/localsgd_optimizer.py:
   Line 99, 298: Undefined variable 'default_startup_program'
   **from paddle.fluid import default_startup_program**
4. In python/paddle/fluid/dataloader/flat.py:
   Line 123: Undefined variable 'batch'
   **use 'structure' instead of 'batch'**
5. In python/paddle/optimizer/momentum.py
   Line 249: Undefined variable 'warnings'
   **import warnings**