### PR TITLE
Fix Explicit return __init()__

### DIFF
--- a/python/paddle/autograd/py_layer.py
+++ b/python/paddle/autograd/py_layer.py
@@ -182,7 +182,7 @@ class PyLayerBackward(PyLayerContext):
 
 
 class LayerMeta(type):
-    def __init__(cls, name, bases, attrs):
+    def __new__(cls, name, bases, attrs):
         cls._backward_function = type(name + '_backward', (PyLayerBackward, ),
                                       {"_forward_cls": cls})
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. In FIle: python/paddle/autograd/py_layer.py:
    Error: Line185: Explicit return in __init__
    Fix: **use function name '\_\_new\_\_' instead of '\_\_init\_\_' in Line 185