### PR TITLE
Dynamic amp support sync_batch_norm op (#32770)

### DIFF
--- a/paddle/fluid/imperative/amp_auto_cast.cc
+++ b/paddle/fluid/imperative/amp_auto_cast.cc
@@ -160,7 +160,8 @@ NameVarBaseMap AutoCastInputs(const std::string& op_type,
   if (AmpOperators::Instance().GetMutableAllowOps()->count(op_type)) {
     for (auto& pair : new_ins) {
       // NOTE(zhiqiu): batch_norm and layer_norm support only input x is fp16.
-      if ((op_type == "batch_norm" || op_type == "layer_norm") &&
+      if ((op_type == "batch_norm" || op_type == "layer_norm" ||
+           op_type == "sync_batch_norm") &&
           pair.first != "X") {
         continue;
       }
@@ -191,7 +192,8 @@ NameVarBaseMap AutoCastInputs(const std::string& op_type,
     }
     for (auto& pair : new_ins) {
       // NOTE(zhiqiu): batch_norm and layer_norm support only input x is fp16.
-      if ((op_type == "batch_norm" || op_type == "layer_norm") &&
+      if ((op_type == "batch_norm" || op_type == "layer_norm" ||
+           op_type == "sync_batch_norm") &&
           pair.first == "X" && dst_type == framework::proto::VarType::FP32) {
         continue;
       }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types  
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes  
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
cherry-pick from #32770
amp_auto_cast 支持SyncBN  
amp模式下DeepLabV3P(bs=4)性能提升：  
|版本| 单卡速度 |多卡速度 |8卡加速比|
|:-----:|:-----:|:-----:|:-----:|
|develop| 15.6 ips | 80.6 ips | 5.1 |
|当前PR | 15.7 ips | 96 ips | 6.1 |

<!-- Describe what this PR does -->
