### PR TITLE
[Cherry-pick] solve ANSI escape sequences print error in cmd and powershell (#33689)

### DIFF
--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -16,6 +16,7 @@ import inspect
 import numpy as np
 import warnings
 import weakref
+import sys
 
 import paddle
 from .. import framework
@@ -372,6 +373,9 @@ def monkey_patch_varbase():
         """
         msg = "tensor.grad will return the tensor value of the gradient."
         warning_msg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
+        # ensure ANSI escape sequences print correctly in cmd and powershell
+        if sys.platform.lower() == 'win32':
+            warning_msg = "\nWarning:\n%s " % (msg)
         warnings.warn(warning_msg)
         return self._grad_ivar()
 

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -18,6 +18,7 @@ decorator to deprecate a function or class
 import warnings
 import functools
 import paddle
+import sys
 
 __all__ = []
 
@@ -99,6 +100,10 @@ def deprecated(update_to="", since="", reason="", level=0):
                     func.__module__, func.__name__))
 
             warningmsg = "\033[93m\nWarning:\n%s \033[0m" % (msg)
+            # ensure ANSI escape sequences print correctly in cmd and powershell
+            if sys.platform.lower() == 'win32':
+                warningmsg = "\nWarning:\n%s " % (msg)
+
             v_current = [int(i) for i in paddle.__version__.split(".")]
             v_current += [0] * (4 - len(v_current))
             v_since = [int(i) for i in _since.split(".")]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
参考[how-to-print-colored-text-to-the-terminal](https://stackoverflow.com/questions/287871/how-to-print-colored-text-to-the-terminal)。

`\033[`开头为ANSI转义代码（`ANSI escape sequences`），在windows cmd和powershell上直接`print('\033[93m\nWarning:\n%s \033[0m' % ('Test'))`会乱码，因此`sys.platform.lower() == 'win32'`时直接不使用ANSI转义代码打印
```
import sys
if sys.platform.lower() == 'win32':
    warningmsg = "\nWarning:\n%s " % (msg)
```

> 若使用`os.system("")`会导致CI过不了，参考[#33656](https://github.com/PaddlePaddle/Paddle/pull/33656)。

<img width="860" alt="截屏2021-06-22 上午11 37 47" src="https://user-images.githubusercontent.com/31386411/122859520-be62fc00-d34e-11eb-96d4-4c99d8a6e327.png">
<img width="859" alt="截屏2021-06-22 上午11 38 12" src="https://user-images.githubusercontent.com/31386411/122859530-c02cbf80-d34e-11eb-9f76-e7d08ba29c9e.png">
<img width="858" alt="截屏2021-06-22 上午11 38 34" src="https://user-images.githubusercontent.com/31386411/122859535-c15dec80-d34e-11eb-918a-79ade7da5802.png">
