### PR TITLE
Fix some Bugs of Undefined Variables

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
@@ -16,6 +16,10 @@ import math
 import numpy as np
 
 import paddle
+from paddle.fluid.log_helper import get_logger
+
+_logger = get_logger(
+    __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 from . import quant_nn
 

--- a/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
@@ -27,6 +27,7 @@ from contextlib import closing
 import paddle.fluid as fluid
 import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
+from six import string_types
 
 
 class TestCollectiveRunnerBase(object):


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. In File: python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
   Error: Line 38: Undefined variable 'string_types'
   Fix: **from six import string_types**
2. In File: python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
   Error: Line 183: Undefined variable '_logger'
   Fix: **from paddle.fluid.log_helper import get_logger
        _logger = get_logger(
           __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')**