### PR TITLE
fix bug about deallocating None

### DIFF
--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -275,8 +275,7 @@ static PyObject * %s(PyObject *self, PyObject *args, PyObject *kwargs)
       PyEval_RestoreThread(tstate);
     }
     ThrowExceptionToPython(std::current_exception());
-    Py_INCREF(Py_None);
-    return Py_None;
+    return nullptr;
   }
 })";
 

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -268,14 +268,15 @@ static PyObject * %s(PyObject *self, PyObject *args, PyObject *kwargs)
     imperative::GetCurrentTracer()->TraceOp("%s", ins, outs, attrs, {%s});
     PyEval_RestoreThread(tstate);
     tstate = nullptr;
-    return %s;
+    %s
   }
   catch(...) {
     if (tstate) {
       PyEval_RestoreThread(tstate);
     }
     ThrowExceptionToPython(std::current_exception());
-    return nullptr;
+    Py_INCREF(Py_None);
+    return Py_None;
   }
 })";
 
@@ -488,13 +489,13 @@ std::string GenerateOpFunctionsBody(
         viwe_input_name, viwe_output_name);
   }
   if (outs_num == 0) {
-    return_str = "Py_None";
+    return_str = "Py_INCREF(Py_None);\n    return Py_None;";
   } else if (outs_num == 1) {
-    return_str = "MakeReturnPyObject(" + return_str + ")";
+    return_str = "return MakeReturnPyObject(" + return_str + ");";
   } else {
-    return_str = "MakeReturnPyObject(" +
+    return_str = "return MakeReturnPyObject(" +
                  paddle::string::Sprintf(RETURN_TUPLE_TEMPLATE, return_str) +
-                 ")";
+                 ");";
   }
   std::string function_args = "";
   if (input_args == "") {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
PR https://github.com/PaddlePaddle/Paddle/pull/32524 merge后导致分布式CE崩溃。并报如下错误：
`Fatal Python error: deallocating None`
经分析，应该在`return Py_None;`前加`Py_INCREF(Py_None);`。否则导致Py_None的引用计数错误。