### PR TITLE
modify mkldnn default capacity

### DIFF
--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -699,7 +699,7 @@ struct PD_INFER_DECL AnalysisConfig {
   bool xpu_adaptive_seqlen_;
 
   // mkldnn related.
-  int mkldnn_cache_capacity_{0};
+  int mkldnn_cache_capacity_{10};
   bool use_mkldnn_quantizer_{false};
   std::shared_ptr<MkldnnQuantizerConfig> mkldnn_quantizer_config_;
   bool use_mkldnn_bfloat16_{false};

--- a/paddle/fluid/inference/goapi/go.mod
+++ b/paddle/fluid/inference/goapi/go.mod
@@ -1,3 +1,3 @@
-module github.com/jiweibo/paddle/paddle/fluid/inference/goapi
+module github.com/paddlepaddle/paddle/paddle/fluid/inference/goapi
 
 go 1.15


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. 修改mkldnn的默认capacity为10，针对10个shape做cache，不设置的话，变长shape输入会有内存泄露
2. 修复go.mod的错误路径