### PR TITLE
fix unittest can't get cuda error message correctly

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -253,15 +253,17 @@ if(WITH_GPU)
     set(URL  "https://paddlepaddledeps.bj.bcebos.com/externalErrorMsg.tar.gz" CACHE STRING "" FORCE)
     file_download_and_uncompress(${URL} "externalError" MD5 c0749523ebb536eb7382487d645d9cd4)   # download file externalErrorMsg.tar.gz
     if(WITH_TESTING)
-        # copy externalErrorMsg.pb for unittest 'enforce_test'
+        # copy externalErrorMsg.pb, just for unittest can get error message correctly.
         set(SRC_DIR ${THIRD_PARTY_PATH}/externalError/data)
         if(WIN32 AND (NOT "${CMAKE_GENERATOR}" STREQUAL "Ninja"))
-            set(DST_DIR ${CMAKE_BINARY_DIR}/paddle/fluid/third_party/externalError/data)
+            set(DST_DIR1 ${CMAKE_BINARY_DIR}/paddle/fluid/third_party/externalError/data)
         else()
-            set(DST_DIR ${CMAKE_BINARY_DIR}/paddle/third_party/externalError/data)
+            set(DST_DIR1 ${CMAKE_BINARY_DIR}/paddle/third_party/externalError/data)
         endif()
+        set(DST_DIR2 ${CMAKE_BINARY_DIR}/python/paddle/include/third_party/externalError/data)
         add_custom_command(TARGET download_externalError POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_directory ${SRC_DIR} ${DST_DIR}
+            COMMAND ${CMAKE_COMMAND} -E copy_directory ${SRC_DIR} ${DST_DIR1}
+            COMMAND ${CMAKE_COMMAND} -E copy_directory ${SRC_DIR} ${DST_DIR2}
             COMMENT "copy_directory from ${SRC_DIR} to ${DST_DIR}")
     endif()
 endif(WITH_GPU)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

目前所有单测无法正确的CUDA报错，是由于单测运行时，使用的paddle为build目录下的paddle，而不是site-package下的paddle，但externalErrorMsg.pb只会打包到site-package下的paddle，因此用户报错信息正常，但是单测报错信息会不正常。

该PR修复了这个问题。