### PR TITLE
fix bug when the cuda kernel config exceeds dims max

### DIFF
--- a/paddle/fluid/operators/layer_norm_op.cu
+++ b/paddle/fluid/operators/layer_norm_op.cu
@@ -398,9 +398,9 @@ __global__ void LayerNormBackwardComputeGradInput(
     const U *__restrict__ mean, const U *__restrict__ var, const float epsilon,
     const U *gamma, T *grad_input) {
 #ifdef __HIPCC__
-  for (auto i1 = hipBlockIdx_y; i1 < n1; i1 += hipGridDim_y) {
+  for (auto i1 = hipBlockIdx_x; i1 < n1; i1 += hipGridDim_x) {
 #else
-  for (auto i1 = blockIdx.y; i1 < n1; i1 += gridDim.y) {
+  for (auto i1 = blockIdx.x; i1 < n1; i1 += gridDim.x) {
 #endif
     U sum_loss1 = U(0);
     U sum_loss2 = U(0);
@@ -864,9 +864,8 @@ static void LayerNormBackward(const T *x, const T *d_y, const U *scale,
       constexpr int BDIMX1 = 32;
       constexpr int BDIMY1 = 4;
       dim3 threads1(BDIMX1, BDIMY1, 1);
-      const dim3 blocks1(1, batch_size, 1);
       LayerNormBackwardComputeGradInput<
-          T, U, BDIMX1, BDIMY1><<<blocks1, threads1, 0, stream>>>(
+          T, U, BDIMX1, BDIMY1><<<batch_size, threads1, 0, stream>>>(
           d_y, x, batch_size, feature_size, mean, var, epsilon, scale, d_x);
       break;
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix bug when the cuda kernel config exceeds dims max
close https://github.com/PaddlePaddle/PaddleClas/pull/685, #33107

When use 3D dim3 config for the blocks of cuda kernel, the limit of each dim is (1024, 1024, 64). For example
```
dim3 num_blocks(x,y,z), num_threads(32, 8, 1);
kernel<<<num_blocks, num_threads>>>(param)
```
The condition shouble be: x <=1024, y <=1024, z <=64, otherwise, "cudaErrorInvalidConfiguration" will be raised.

In layer_norm_grad, it uses 3D dim3 (1, batch_size, 1) as blocks config. While, batch_size may > 1024.
This PR change `3D dim3 (1, batch_size, 1)` to `1D dim3 (batch_size)` to solve the problem.

