### PR TITLE
fix the quantization bug when the outchannel is 1

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -1148,7 +1148,7 @@ class QuantizationFreezePass(object):
                     ], "the dim of scale_v should be 1 or 2"
                     if scale_v.ndim == 2:
                         scale_v = scale_v[0]
-                    if scale_v.size == 1:
+                    if scale_v.size == 1 and self._weight_quantize_type == 'abs_max':
                         scale_v = scale_v[0]
                     else:
                         scale_v = scale_v.tolist()


### PR DESCRIPTION
修复了当outchannel为1时，channel_wise量化会报错的bug，具体报错见 https://github.com/PaddlePaddle/PaddleSlim/issues/767
