### PR TITLE
Replace usage of elementwise cuda forward kernel in Compare_all_op

### DIFF
--- a/paddle/fluid/operators/controlflow/compare_all_op.cc
+++ b/paddle/fluid/operators/controlflow/compare_all_op.cc
@@ -30,29 +30,13 @@ class CompareReduceOpKernel
     auto* x = context.Input<Tensor>("X");
     auto* y = context.Input<Tensor>("Y");
     auto* z = context.Output<Tensor>("Out");
-    bool shape_same = true;
-
     Tensor tmp;
-    framework::DDim x_dims = x->dims();
-    framework::DDim y_dims = y->dims();
-
-    // judge the two inputs shape is same, if not same, just return false
-    if (x_dims.size() != y_dims.size()) {
-      shape_same = false;
-    } else {
-      for (auto i = 0; i < x_dims.size(); i++) {
-        if (x_dims[i] != y_dims[i]) {
-          shape_same = false;
-          break;
-        }
-      }
-    }
-
     bool* z_data = z->mutable_data<bool>(context.GetPlace());
-    if (!shape_same) {
+
+    if (x->dims() != y->dims()) {
       z_data[0] = false;
     } else {
-      tmp.mutable_data<bool>(x_dims, context.GetPlace());
+      tmp.mutable_data<bool>(x->dims(), context.GetPlace());
       if (x->numel() == 1 && y->numel() == 1) {
         bool* z_data = tmp.mutable_data<bool>(context.GetPlace());
         z_data[0] = Functor()(x->data<T>()[0], y->data<T>()[0]);

--- a/paddle/fluid/operators/controlflow/compare_all_op.cu
+++ b/paddle/fluid/operators/controlflow/compare_all_op.cu
@@ -80,7 +80,7 @@ class CompareReduceOpKernel
       std::vector<const framework::Tensor*> ins = {x, y};
       std::vector<framework::Tensor*> outs = {&tmp};
       LaunchSameDimsElementwiseCudaKernel<ElementwiseType::kBinary, T, bool>(
-                                  cuda_ctx, ins, &outs, Functor<T>();
+          cuda_ctx, ins, &outs, Functor());
 
       // Reduce by 'bitwise and' operator
       std::vector<int> reduce_dims;

--- a/paddle/fluid/operators/controlflow/compare_all_op.cu
+++ b/paddle/fluid/operators/controlflow/compare_all_op.cu
@@ -15,13 +15,17 @@ limitations under the License. */
 #include <thrust/fill.h>
 #include "paddle/fluid/operators/controlflow/compare_all_op.h"
 #include "paddle/fluid/operators/reduce_ops/cub_reduce.h"
+#include "paddle/fluid/operators/elementwise/elementwise_op_impl.cu.h"
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
 namespace paddle {
 namespace operators {
 
 template <typename T>
 struct IdentityFunctor {
   HOSTDEVICE explicit inline IdentityFunctor() {}
-
   HOSTDEVICE inline T operator()(const T& x) const { return x; }
 };
 
@@ -33,6 +37,24 @@ struct BitwiseAdd {
     return a & b;
   }
 };
+
+template <typename T, typename Enable = void>
+struct CudaEqualReduceFunctor {
+  using ELEM_TYPE = T;
+  HOSTDEVICE bool operator()(const T args[]) const {
+      return (args[0] == args[1]);
+  }
+};
+
+template <typename T>
+struct CudaEqualReduceFunctor<
+        T, typename std::enable_if<std::is_floating_point<T>::value>::type > {
+  using ELEM_TYPE = T;
+  HOSTDEVICE bool operator()(const T args[]) const { 
+      return fabs(static_cast<double>(args[0] - args[1])) < 1e-8;
+  }
+};
+
 template <typename DeviceContext, typename Functor>
 class CompareReduceOpKernel
     : public framework::OpKernel<typename Functor::ELEM_TYPE> {
@@ -44,32 +66,23 @@ class CompareReduceOpKernel
     auto* x = context.Input<Tensor>("X");
     auto* y = context.Input<Tensor>("Y");
     auto* z = context.Output<Tensor>("Out");
-    bool shape_same = true;
-
-    Tensor tmp;
-    framework::DDim x_dims = x->dims();
-    framework::DDim y_dims = y->dims();
-
-    if (x_dims.size() != y_dims.size()) {
-      shape_same = false;
-    } else {
-      for (auto i = 0; i < x_dims.size(); i++) {
-        if (x_dims[i] != y_dims[i]) {
-          shape_same = false;
-          break;
-        }
-      }
-    }
-
     bool* z_data = z->mutable_data<bool>(context.GetPlace());
-    if (!shape_same) {
+    Tensor tmp;
+
+    if (x->dims() != y->dims()) {
       thrust::device_ptr<bool> z_dev_ptr(z_data);
       thrust::fill(z_dev_ptr, z_dev_ptr + 1, false);
       return;
     } else {
-      tmp.mutable_data<bool>(x_dims, context.GetPlace());
-      ElementwiseComputeEx<Functor, DeviceContext, T, bool>(context, x, y, 0,
-                                                            Functor(), &tmp);
+      tmp.mutable_data<bool>(x->dims(), context.GetPlace());
+      auto functor = Functor();  
+      const auto& cuda_ctx =
+            context.template device_context<platform::CUDADeviceContext>();
+      std::vector<const framework::Tensor*> ins = {x, y};
+      std::vector<framework::Tensor*> outs = {&tmp};
+      LaunchSameDimsElementwiseCudaKernel<ElementwiseType::kBinary, T, bool>(
+                                  cuda_ctx, ins, &outs, functor);
+
       // Reduce by 'bitwise and' operator
       std::vector<int> reduce_dims;
       reduce_dims.resize(tmp.dims().size());
@@ -87,16 +100,12 @@ class CompareReduceOpKernel
 
 #define REGISTER_COMPARE_REDUCE_CUDA_KERNEL(op_type, functor)           \
   REGISTER_OP_CUDA_KERNEL(                                              \
-      op_type, paddle::operators::CompareReduceOpKernel<                \
-                   paddle::platform::CUDADeviceContext, functor<bool>>, \
-      paddle::operators::CompareReduceOpKernel<                         \
-          paddle::platform::CUDADeviceContext, functor<int>>,           \
-      paddle::operators::CompareReduceOpKernel<                         \
-          paddle::platform::CUDADeviceContext, functor<int64_t>>,       \
-      paddle::operators::CompareReduceOpKernel<                         \
-          paddle::platform::CUDADeviceContext, functor<float>>,         \
-      paddle::operators::CompareReduceOpKernel<                         \
-          paddle::platform::CUDADeviceContext, functor<double>>);
+      op_type,                                                          \
+      ops::CompareReduceOpKernel<plat::CUDADeviceContext, ops::functor<bool>>, \
+      ops::CompareReduceOpKernel<plat::CUDADeviceContext, ops::functor<int>>, \
+      ops::CompareReduceOpKernel<plat::CUDADeviceContext, ops::functor<int64_t>>,       \
+      ops::CompareReduceOpKernel<plat::CUDADeviceContext, ops::functor<float>>,         \
+      ops::CompareReduceOpKernel<plat::CUDADeviceContext, ops::functor<double>>);
 
-REGISTER_COMPARE_REDUCE_CUDA_KERNEL(equal_all,
-                                    paddle::operators::EqualReduceFunctor);
+REGISTER_COMPARE_REDUCE_CUDA_KERNEL(equal_all, CudaEqualReduceFunctor)
+#undef REGISTER_COMPARE_REDUCE_CUDA_KERNEL

--- a/paddle/fluid/operators/controlflow/compare_op.cu
+++ b/paddle/fluid/operators/controlflow/compare_op.cu
@@ -60,7 +60,6 @@ template <typename Functor, typename InverseFunctor>
 class CompareOpKernel<platform::CUDADeviceContext, Functor, InverseFunctor>
     : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
  public:
- public:
   using InT = typename Functor::ELEMENT_TYPE;
   using OutT = bool;
   void Compute(const framework::ExecutionContext& ctx) const override {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- To wholly replace the usage of old elementwise forward funcion with the new one in op level.