### PR TITLE
change TensorCopy to ShareDataWith in matmul_grad op

### DIFF
--- a/paddle/fluid/operators/matmul_v2_op_npu.cc
+++ b/paddle/fluid/operators/matmul_v2_op_npu.cc
@@ -141,17 +141,13 @@ class MatMulV2GradNPUKernel : public framework::OpKernel<T> {
           if ((x->dims().size() == 3) && (dout->dims().size() == 3) &&
               (dy->dims().size() == 2)) {
             framework::Tensor dout_;
-            TensorCopy(*dout, ctx.GetPlace(), &dout_);
-            ctx.template device_context<paddle::platform::NPUDeviceContext>()
-                .Wait();
+            dout_.ShareDataWith(*dout);
             std::vector<int> vec_dim = framework::vectorize<int>(dout_.dims());
             std::vector<int> vec_dim_v{vec_dim[0] * vec_dim[1], vec_dim[2]};
             dout_.Resize(framework::make_ddim(vec_dim_v));
 
             framework::Tensor x_;
-            TensorCopy(*x, ctx.GetPlace(), &x_);
-            ctx.template device_context<paddle::platform::NPUDeviceContext>()
-                .Wait();
+            x_.ShareDataWith(*x);
             std::vector<int> vec_dim_x = framework::vectorize<int>(x_.dims());
             std::vector<int> vec_dim_x_v{vec_dim_x[0] * vec_dim_x[1],
                                          vec_dim_x[2]};


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

PR https://github.com/PaddlePaddle/Paddle/pull/33719 use `TensorCopy` to realize matmul_v2 grad op, this PR change it to `ShareDataWith`.

![图片](https://user-images.githubusercontent.com/26408901/123248158-303b7100-d51a-11eb-83ea-b3af188cfde0.png)
