### PR TITLE
TestSaveLoadLargeParameters use cpu place.

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
@@ -95,6 +95,7 @@ class TestSaveLoadLargeParameters(unittest.TestCase):
     def test_large_parameters_paddle_save(self):
         # enable dygraph mode
         paddle.disable_static()
+        paddle.set_device("cpu")
         # create network
         layer = LayerWithLargeParameters()
         save_dict = layer.state_dict()
@@ -103,7 +104,7 @@ class TestSaveLoadLargeParameters(unittest.TestCase):
                             "layer.pdparams")
         protocol = 4
         paddle.save(save_dict, path, protocol=protocol)
-        dict_load = paddle.load(path)
+        dict_load = paddle.load(path, return_numpy=True)
         # compare results before and after saving
         for key, value in save_dict.items():
             self.assertTrue(

--- a/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
@@ -107,8 +107,7 @@ class TestSaveLoadLargeParameters(unittest.TestCase):
         dict_load = paddle.load(path, return_numpy=True)
         # compare results before and after saving
         for key, value in save_dict.items():
-            self.assertTrue(
-                np.array_equal(dict_load[key].numpy(), value.numpy()))
+            self.assertTrue(np.array_equal(dict_load[key], value.numpy()))
 
 
 class TestSaveLoadPickle(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
paddle_test_save_load单测申请了大块显存，在windows上有超出显存的风险。将TestSaveLoadLargeParameters改为cpu模式。

![image](https://user-images.githubusercontent.com/22128369/123199411-6c9eab00-d4e1-11eb-91c0-2149bc9676e0.png)
