### PR TITLE
optimize perf of reduce_any

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_op.cu.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.cu.h
@@ -407,9 +407,6 @@ struct ReduceConfig {
     grid_dim->x = grid_num;
     grid_dim->y = std::max(std::min(input_split_num_1, input_split_num_3),
                            input_split_num_2);
-
-    blocking_size = detail::AlignUp(reduce_num_per_thread, grid_dim->y);
-
     // if grid.y > 1, we need launch reduce kernel again.
     if (grid_dim->y > 1) {
       should_reduce_again = true;
@@ -621,7 +618,7 @@ __device__ void ReduceHigherDim(const Tx* x, Ty* y, ReduceOp reducer,
 template <typename Tx, typename Ty, typename ReduceOp, typename TransformOp>
 __device__ void ReduceAny(const Tx* x, Ty* y, ReduceOp reducer,
                           TransformOp transformer, Ty init, int reduce_num,
-                          int left_num, int block_size, bool reduce_lastdim,
+                          int left_num, bool reduce_lastdim,
                           const IndexCalculator& reduce_index_calculator,
                           const IndexCalculator& left_index_calculator) {
   int input_idx, left_idx, stride;
@@ -721,8 +718,8 @@ __device__ void ReduceModule(const Tx* x, Ty* y, ReduceOp reducer,
     // reduce_rank >= 2
   } else {
     ReduceAny<Tx, Ty, ReduceOp, TransformOp>(
-        x, y, reducer, transformer, init, reduce_num, left_num, blocking_size,
-        reduce_lastdim, reduce_index_calculator, left_index_calculator);
+        x, y, reducer, transformer, init, reduce_num, left_num, reduce_lastdim,
+        reduce_index_calculator, left_index_calculator);
   }
 }
 

--- a/paddle/fluid/platform/fast_divmod.h
+++ b/paddle/fluid/platform/fast_divmod.h
@@ -54,7 +54,7 @@ struct FastDivMod {
     return (t + n) >> shift_val;
   }
 
-  __device__ __forceinline__ DivModT Divmod(uint32_t n) {
+  __device__ __forceinline__ DivModT Divmod(uint32_t n) const {
     uint32_t q = Div(n);
     DivModT result = {q, n - q * divisor};
     return result;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
优化任意维度 reduce 的性能
| case             | axis   | Pytorch | 优化前  | 优化后  | 加速比(old/new) | diff with pytorch |
| ------------------ | ------ | ------- | ------- | ------- | --------------- | ------------------- |
| [32, 12, 128, 128] | [0, 3] | 0.04004 | 0.05693 | 0.03473 | 1.64            |  优于 (13.26%)|
| [16, 32, 32, 32]   | [1, 3] | 0.00792 | 0.00882 | 0.00443 | 1.99            |    优于 (44.07%)            |
| [16, 64, 512, 64]  | [1, 3] | 0.16585 | 0.28347 | 0.15995  | 1.77            |      打平 (3.56%)          |
| [16, 2048, 32, 32] | [1, 3] | 0.16437 | 0.28301 | 0.17622 | 1.61             |      差于 (7.21%)          |
| [16, 32, 2048, 32] | [1, 3] | 0.16290  | 0.36183 | 0.16178  | 2.24            |        打平 (0.69%)        |
| [16, 2048, 32, 32] | [0, 2] | 0.16285 | 0.8464  | 0.16668 | 5.08            |       打平 (2.35%)         |
| [16, 32, 2048, 32] | [0, 2] | 0.16657 | 1.92995 | 0.16499 | 11.70           |       打平 (0.95%)         |
| [16, 2048, 33, 33] | [0, 2] | 0.17842 | 0.90048 | 0.18290 | 4.92            |       打平 (2.51%)         |
| [16, 33, 2048, 33] | [0, 2] | 0.26361 | 2.05965 | 0.23080 | 8.92            |优于 (12.45%)|