### PR TITLE
Optimization batch_norm op with OpenMP

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cc
+++ b/paddle/fluid/operators/batch_norm_op.cc
@@ -743,7 +743,6 @@ class BatchNormGradKernel<platform::CPUDeviceContext, T>
 #pragma omp parallel for
 #endif
         for (int nc = 0; nc < N * C; ++nc) {
-          // int c = nc % C;
           dy_sum_arr(nc % C) += d_y_arr.col(nc).sum();
           dy_mul_x_sub_mean_mul_invstd_sum_arr(nc % C) +=
               ((x_arr.col(nc) - mean_arr(nc % C)) * inv_var_arr(nc % C) *
@@ -761,7 +760,6 @@ class BatchNormGradKernel<platform::CPUDeviceContext, T>
 #pragma omp parallel for
 #endif
           for (int nc = 0; nc < N * C; ++nc) {
-            // int c = nc % C;
             d_x_arr.col(nc) =
                 scale_inv_var_nhw(nc % C) *
                 (d_y_arr.col(nc) * N * sample_size - dy_sum_arr(nc % C) -
@@ -771,8 +769,7 @@ class BatchNormGradKernel<platform::CPUDeviceContext, T>
           }
         } else {
           for (int nc = 0; nc < N * C; ++nc) {
-            int c = nc % C;
-            d_x_arr.col(nc) = scale_inv_var_nhw(c) * d_y_arr.col(nc);
+            d_x_arr.col(nc) = scale_inv_var_nhw(nc % C) * d_y_arr.col(nc);
           }
         }
         break;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
Optimization batch_norm op with OpenMP, the optimized data is as follows when OMP is equal to 20:
![image](https://user-images.githubusercontent.com/62974595/123954227-bd7b3b80-d9da-11eb-9ef9-c939d31040f4.png)
