### PR TITLE
fix the attributes error in transpose.pbtxt.

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/matmul_transpose_reshape_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/matmul_transpose_reshape_fuse_pass.cc
@@ -34,10 +34,13 @@ MatmulTransposeReshapeMKLDNNPass::MatmulTransposeReshapeMKLDNNPass() {
       .IsTensor()
       .End()
       .AddAttr("alpha")  // unconstrained. can be any float value.
+      .IsType<float>()
       .End()
       .AddAttr("transpose_X")  // unconstrained. can be any bool value.
+      .IsType<bool>()
       .End()
       .AddAttr("transpose_Y")  // unconstrained. can be any bool value.
+      .IsType<bool>()
       .End();
 
   AddOpCompat(OpCompat("transpose2"))
@@ -51,9 +54,7 @@ MatmulTransposeReshapeMKLDNNPass::MatmulTransposeReshapeMKLDNNPass() {
       .IsTensor()
       .End()
       .AddAttr("axis")  // ints
-      .End()
-      .AddAttr("data_format")
-      .IsStringIn({"NHWC", "NCHW", "AnyLayout"})
+      .IsType<std::vector<int>>()
       .End();
 
   AddOpCompat(OpCompat("reshape2"))
@@ -75,6 +76,7 @@ MatmulTransposeReshapeMKLDNNPass::MatmulTransposeReshapeMKLDNNPass() {
       .IsTensor()
       .End()
       .AddAttr("shape")  // ints
+      .IsType<std::vector<int>>()
       .End();
 }
 void MatmulTransposeReshapeMKLDNNPass::ApplyImpl(ir::Graph *graph) const {

--- a/paddle/fluid/framework/ir/mkldnn/matmul_transpose_reshape_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/matmul_transpose_reshape_fuse_pass_tester.cc
@@ -28,7 +28,6 @@ void SetOp(ProgramDesc *prog, const std::string &type,
   op->SetOutput("Out", {outputs[0]});
   if (type == "transpose2") {
     op->SetAttr("axis", std::vector<int>({0, 2, 1, 3}));
-    op->SetAttr("data_format", std::string("NCHW"));
     op->SetOutput("XShape", {outputs[1]});
   }
   if (type == "reshape2") {

--- a/paddle/fluid/operators/compat/transpose.pbtxt
+++ b/paddle/fluid/operators/compat/transpose.pbtxt
@@ -10,12 +10,12 @@ def {
     name: "axis"
     type: INTS
   }
+}
+extra {
   attrs {
     name: "data_format"
     type: STRING
   }
-}
-extra {
   attrs {
     name: "use_mkldnn"
     type: BOOLEAN

--- a/paddle/fluid/operators/compat/transpose2.pbtxt
+++ b/paddle/fluid/operators/compat/transpose2.pbtxt
@@ -13,12 +13,12 @@ def {
     name: "axis"
     type: INTS
   }
+}
+extra {
   attrs {
     name: "data_format"
     type: STRING
   }
-}
-extra {
   attrs {
     name: "use_mkldnn"
     type: BOOLEAN


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
在transpose算子和transpose2算子中，data_format属性仅仅用来做kernel的选择，并不会影响该算子的数学输出，因此，data_format属性应该输入extra，之前将其分类到def是错误的。