### PR TITLE
[Paddle-TRT] kNCHW deprecation

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
@@ -42,10 +42,10 @@ bool GeluPlugin::supportsFormat(nvinfer1::DataType type,
   if (with_fp16_) {
     return ((type == nvinfer1::DataType::kFLOAT ||
              type == nvinfer1::DataType::kHALF) &&
-            (format == nvinfer1::PluginFormat::kNCHW));
+            (format == nvinfer1::PluginFormat::kLINEAR));
   } else {
     return ((type == nvinfer1::DataType::kFLOAT) &&
-            (format == nvinfer1::PluginFormat::kNCHW));
+            (format == nvinfer1::PluginFormat::kLINEAR));
   }
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
@@ -112,7 +112,7 @@ class InstanceNormPlugin : public PluginTensorRT {
                       nvinfer1::PluginFormat format) const override {
     return ((type == nvinfer1::DataType::kFLOAT ||
              type == nvinfer1::DataType::kHALF) &&
-            (format == nvinfer1::PluginFormat::kNCHW));
+            (format == nvinfer1::PluginFormat::kLINEAR));
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.cu
@@ -174,7 +174,7 @@ bool PoolPluginDynamic::supportsFormatCombination(
   (in_out && pos < (nb_inputs + nb_outputs));
 
   return ((in_out[pos].type == nvinfer1::DataType::kFLOAT) &&
-          in_out[pos].format == nvinfer1::PluginFormat::kNCHW);
+          in_out[pos].format == nvinfer1::PluginFormat::kLINEAR);
 }
 
 nvinfer1::DataType PoolPluginDynamic::getOutputDataType(

--- a/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.cu
@@ -129,7 +129,7 @@ bool PReluPluginDynamic::supportsFormatCombination(
   (in_out && pos < (nb_inputs + nb_outputs));
 
   return ((in_out[pos].type == nvinfer1::DataType::kFLOAT) &&
-          in_out[pos].format == nvinfer1::PluginFormat::kNCHW);
+          in_out[pos].format == nvinfer1::PluginFormat::kLINEAR);
 }
 
 nvinfer1::DataType PReluPluginDynamic::getOutputDataType(

--- a/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
@@ -90,10 +90,10 @@ bool SlicePlugin::supportsFormat(nvinfer1::DataType type,
   if (with_fp16_) {
     return ((type == nvinfer1::DataType::kFLOAT ||
              type == nvinfer1::DataType::kHALF) &&
-            (format == nvinfer1::PluginFormat::kNCHW));
+            (format == nvinfer1::PluginFormat::kLINEAR));
   } else {
     return ((type == nvinfer1::DataType::kFLOAT) &&
-            (format == nvinfer1::PluginFormat::kNCHW));
+            (format == nvinfer1::PluginFormat::kLINEAR));
   }
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/test_split_plugin.cc
+++ b/paddle/fluid/inference/tensorrt/plugin/test_split_plugin.cc
@@ -33,7 +33,7 @@ TEST(split_op_plugin, test_plugin) {
   input_dims.push_back(in_dims);
   sp_plugin.configurePlugin(input_dims.data(), 1, nullptr, 2,
                             input_types.data(), nullptr, nullptr, nullptr,
-                            nvinfer1::PluginFormat::kNCHW, 4);
+                            nvinfer1::PluginFormat::kLINEAR, 4);
   sp_plugin.initialize();
   sp_plugin.getPluginType();
   sp_plugin.canBroadcastInputAcrossBatch(0);

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
@@ -68,7 +68,7 @@ size_t PluginTensorRT::getBaseSerializationSize() {
 bool PluginTensorRT::supportsFormat(nvinfer1::DataType type,
                                     nvinfer1::PluginFormat format) const {
   return ((type == nvinfer1::DataType::kFLOAT) &&
-          (format == nvinfer1::PluginFormat::kNCHW));
+          (format == nvinfer1::PluginFormat::kLINEAR));
 }
 
 void PluginTensorRT::configureWithFormat(

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin.h
@@ -181,7 +181,7 @@ class PluginTensorRTV2Ext : public nvinfer1::IPluginV2Ext {
   bool supportsFormat(nvinfer1::DataType type,
                       nvinfer1::PluginFormat format) const override {
     return ((type == nvinfer1::DataType::kFLOAT) &&
-            (format == nvinfer1::PluginFormat::kNCHW));
+            (format == nvinfer1::PluginFormat::kLINEAR));
   }
   // Initialize the layer for execution.
   // This is called when the engine is created.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
``kNCHW`` is deprecated. In the new version, ``kLINEAR`` is used.
[reference](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-723/api/c_api/namespacenvinfer1.html#ac3e115b1a2b1e578e8221ef99d27cd45acaf70f83fa10041f93bb2ee89848d4b9)