### PR TITLE
Fix some Bugs of Undefined Variable

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/ascend/ascend_parser.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/ascend/ascend_parser.py
@@ -136,7 +136,7 @@ class AscendHelper(object):
 
     def dtype2np(self, index):
         assert index in self.dtype2np_map, "index[%d] is not supported %d" % (
-            dtype)
+            index)
         return self.dtype2np_map[index]
 
 

--- a/python/paddle/fluid/tests/unittests/asp/test_asp_pruning_2d_best.py
+++ b/python/paddle/fluid/tests/unittests/asp/test_asp_pruning_2d_best.py
@@ -16,6 +16,7 @@
 from __future__ import print_function
 
 import paddle
+import unittest
 from paddle.fluid.contrib import sparsity
 from paddle.fluid.tests.unittests.asp.asp_pruning_base import TestASPHelperPruningBase
 

--- a/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
@@ -27,6 +27,7 @@ from contextlib import closing
 import paddle.fluid as fluid
 import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
+from six import string_types
 
 
 class TestCollectiveRunnerBase(object):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe

1. In python/paddle/distributed/fleet/meta_optimizers/ascend/ascend_parser.py
   Error: Undefined variable 'dtype'
Fix:use **'index'** instead of **'dtype'**
2.  In python/paddle/fluid/tests/unittests/asp/test_asp_pruning_2d_best.py
Error: Undefined variable 'unittest'
Fix: **import unittest**

3. In python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
Error: Undefined variable 'string_types'
Fix: **from six import string_types**
