### PR TITLE
Refine QuantizeTranspilerV2 to support distributed training

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/test_quantize_transpiler_v2.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quantize_transpiler_v2.py
@@ -96,11 +96,9 @@ class TestQuantizeProgramPass(unittest.TestCase):
         qt = QuantizeTranspilerV2(
             activation_quantize_type=activation_quant_type,
             weight_quantize_type=weight_quant_type,
-            quantizable_op_type=[
-                'conv2d', 'depthwise_conv2d', 'mul', 'pool2d'
-            ])
-        qt.apply(train_program, startup_program)
-        qt.apply(test_program, startup_program)
+            quantizable_op_type=['conv2d', 'depthwise_conv2d', 'mul'])
+        qt.apply(train_program, startup_program, False)
+        qt.apply(test_program, startup_program, True)
 
         place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
         exe = fluid.Executor(place)
@@ -120,20 +118,22 @@ class TestQuantizeProgramPass(unittest.TestCase):
         build_strategy.fuse_all_reduce_ops = False
         binary = fluid.CompiledProgram(train_program).with_data_parallel(
             loss_name=loss.name, build_strategy=build_strategy)
-        iters = 2
+        iters = 5
         batch_size = 8
 
         train_reader = paddle.batch(
             paddle.dataset.mnist.train(), batch_size=batch_size)
         feeder = fluid.DataFeeder(feed_list=feeds, place=place)
         with fluid.scope_guard(scope):
-            for _ in range(iters):
+            for idx in range(iters):
                 data = next(train_reader())
                 loss_v = exe.run(binary,
                                  feed=feeder.feed(data),
                                  fetch_list=[loss])
-                if not for_ci:
-                    print('{}: {}'.format('loss', loss_v))
+                if not for_ci and idx % 20 == 0:
+                    print('{}: {}'.format('loss', np.mean(loss_v)))
+
+        print('{}: {}'.format('loss', np.mean(loss_v)))
 
         if not for_ci:
             with fluid.scope_guard(scope):
@@ -141,7 +141,7 @@ class TestQuantizeProgramPass(unittest.TestCase):
                                               ['image', 'label'], [loss], exe,
                                               test_program)
 
-    def test_quantize_program_gpu(self):
+    def test_gpu_1(self):
         if fluid.core.is_compiled_with_cuda():
             self.quantize_program(
                 use_cuda=True,
@@ -150,12 +150,29 @@ class TestQuantizeProgramPass(unittest.TestCase):
                 weight_quant_type='abs_max',
                 for_ci=True)
 
-    def test_quantize_program_cpu(self):
+    def test_gpu_2(self):
+        if fluid.core.is_compiled_with_cuda():
+            self.quantize_program(
+                use_cuda=True,
+                seed=1,
+                activation_quant_type='moving_average_abs_max',
+                weight_quant_type='channel_wise_abs_max',
+                for_ci=True)
+
+    def test_cpu_1(self):
         self.quantize_program(
             use_cuda=False,
             seed=2,
             activation_quant_type='abs_max',
             weight_quant_type='abs_max',
+            for_ci=True)
+
+    def test_cpu_2(self):
+        self.quantize_program(
+            use_cuda=False,
+            seed=2,
+            activation_quant_type='moving_average_abs_max',
+            weight_quant_type='channel_wise_abs_max',
             for_ci=True)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
QuantizeTranspilerV2 supports moving_average_abs_max and per_channel_abs_max