### PR TITLE
[Dy2Stat] Refine PartialProgramLayer logic

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
@@ -103,8 +103,11 @@ class FunctionSpec(object):
         for idx, input_var in enumerate(flatten(args)):
             if isinstance(input_var, np.ndarray):
                 input_var = paddle.static.InputSpec.from_numpy(input_var)
+                _set_spec_stop_gradient(input_var, True)
             elif isinstance(input_var, core.VarBase):
+                stop_gradient = input_var.stop_gradient
                 input_var = paddle.static.InputSpec.from_tensor(input_var)
+                _set_spec_stop_gradient(input_var, stop_gradient)
 
             args_with_spec.append(input_var)
 
@@ -172,13 +175,15 @@ class FunctionSpec(object):
         block = main_program.global_block()
         for i, var_spec in enumerate(flat_input_spec):
             if isinstance(var_spec, paddle.static.InputSpec):
+                stop_gradient = getattr(var_spec, 'stop_gradient', False)
                 feed_layer = block.create_var(
                     # TODO(Aurelius84): consider a more elegant way to name this
                     name=var_spec.name or "feed_%s" % i,
                     shape=var_spec.shape,
                     dtype=var_spec.dtype,
                     is_data=True,
-                    need_check_feed=False)
+                    need_check_feed=False,
+                    stop_gradient=stop_gradient)
             else:
                 feed_layer = var_spec
             inputs.append(feed_layer)
@@ -302,7 +307,7 @@ def convert_to_input_spec(inputs, input_spec):
                 if isinstance(rest_input, (core.VarBase, np.ndarray)):
                     logging_utils.warn(
                         "The inputs constain `{}` without specificing InputSpec, its shape and dtype will be treated immutable. "
-                        "Please specific InputSpec information in `@declarative` if you expect them as mutable inputs.".
+                        "Please specific InputSpec information in `@to_static` if you expect them as mutable inputs.".
                         format(type_name(rest_input)))
         input_with_spec.extend(inputs[len(input_spec):])
 
@@ -318,6 +323,7 @@ def convert_to_input_spec(inputs, input_spec):
                 input_with_spec[name] = input
         return input_with_spec
     elif isinstance(input_spec, paddle.static.InputSpec):
+        _set_spec_stop_gradient(input_spec, inputs.stop_gradient)
         return input_spec
     else:
         # NOTE(Aurelius84): Support non-Tensor type as input spec info
@@ -380,3 +386,12 @@ def _replace_spec_name(name, input_spec):
         return processed_specs
     else:
         return input_spec
+
+
+def _set_spec_stop_gradient(spec, stop_gradient):
+    """
+    Set new attribute ``stop_gradient`` for InputSpec to avoid generating redundant grad_op
+    while append_backward.
+    """
+    assert isinstance(spec, paddle.static.InputSpec)
+    spec.stop_gradient = stop_gradient

--- a/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
@@ -323,7 +323,6 @@ def convert_to_input_spec(inputs, input_spec):
                 input_with_spec[name] = input
         return input_with_spec
     elif isinstance(input_spec, paddle.static.InputSpec):
-        _set_spec_stop_gradient(input_spec, inputs.stop_gradient)
         return input_spec
     else:
         # NOTE(Aurelius84): Support non-Tensor type as input spec info

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -419,12 +419,9 @@ class PartialProgramLayer:
 
 def _create_fake_var():
     """
-    Create a fake_var to handle empty input or output
+    Create a fake_var (force on CPU) to handle empty input or output
     """
-    fake_var = paddle.to_tensor([0], 'float32', paddle.CPUPlace(), True)
-    # NOTE: keep consistent with run_program_op
-    fake_var.name = "Fake_var"
-    return [fake_var]
+    return [core.VarBase(value=[1], name='Fake_var', place=paddle.CPUPlace())]
 
 
 def partial_program_from(concrete_program):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### PR 内容

1. 优化了 valid_vars 的Fake_vars逻辑，强制为empty的force_cpu tensor，避免引入额外 cuda memcpysyc（会阻塞kernel拉起）
2. 新增入口函数Tensor的stop_gradient判断，减少grad_op的计算量（如conv2d_grad_op）
2. 优化了temp_scope_var的创建逻辑，放在__init__，仅创建一次，减少foward的开销
3. 优化了grad_var的valid_vars逻辑
4. 移除对nn.Layer的继承，改为__call__直接调用


### 性能收益

| 模型 | 优化前  | 优化后 | 提升
|:---:|:---:|:---:|:---:|
|ResNet50_bs32 | 302 | 312 | 3.3% |
|ResNet50_bs128| 340 | 345 | 1.4% | 
|ResNet152_bs32| 136 | 138 | 1.4%|