### PR TITLE
[NPU] remove duplicated stream sync in fetch op

### DIFF
--- a/paddle/fluid/operators/controlflow/fetch_op.cc
+++ b/paddle/fluid/operators/controlflow/fetch_op.cc
@@ -44,11 +44,6 @@ static void DataCopy(const framework::LoDTensor &src_item,
       TensorCopySync(src_item, platform::CPUPlace(), dst_item);
     }
 #else
-#ifdef PADDLE_WITH_ASCEND_CL
-    if (platform::is_npu_place(src_item.place())) {
-      platform::DeviceContextPool::Instance().Get(src_item.place())->Wait();
-    }
-#endif
     TensorCopySync(src_item, platform::CPUPlace(), dst_item);
 #endif
   } else {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
remove duplicated stream sync in fetch op, since `TensorCopySync` has `stream sync` Inside the function. 

- before 
![image](https://user-images.githubusercontent.com/6888866/123731125-23c46900-d8ca-11eb-86a0-40f8f37be4a7.png)

- after
![image](https://user-images.githubusercontent.com/6888866/123731040-fc6d9c00-d8c9-11eb-8c6f-99df125c741e.png)
