### PR TITLE
[AMP] add get() and set() for Grad_scaler

### DIFF
--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -145,3 +145,231 @@ class GradScaler(AmpScaler):
                 optimizer.clear_grad()
         """
         return super(GradScaler, self).minimize(optimizer, *args, **kwargs)
+
+    def get_enable(self):
+        """
+        Get the parameter of `_enable`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                enable = scaler.get_enable()
+        """
+        return super(GradScaler, self).get_enable()
+
+    def get_use_dynamic_loss_scaling(self):
+        """
+        Get the parameter of `_use_dynamic_loss_scaling`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                use_dynamic_loss_scaling = scaler.get_use_dynamic_loss_scaling()
+        """
+        return super(GradScaler, self).get_use_dynamic_loss_scaling()
+
+    def get_init_loss_scaling(self):
+        """
+        Get the parameter of `_init_loss_scaling`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                init_loss_scaling = scaler.get_init_loss_scaling()
+        """
+        return super(GradScaler, self).get_init_loss_scaling()
+
+    def set_init_loss_scaling(self, new_init_loss_scaling):
+        """
+        Set the parameter of `_init_loss_scaling` by `new_init_loss_scaling`.
+        Args:
+            new_init_loss_scaling(int):  The new_init_loss_scaling used to update _init_loss_scaling.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                new_init_loss_scaling = 1000
+                scaler.set_init_loss_scaling(new_init_loss_scaling)
+        """
+        super(GradScaler, self).set_init_loss_scaling(new_init_loss_scaling)
+
+    def get_incr_ratio(self):
+        """
+        Get the parameter of `_incr_ratio`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                incr_ratio = scaler.get_incr_ratio()
+        """
+        return super(GradScaler, self).get_incr_ratio()
+
+    def set_incr_ratio(self, new_incr_ratio):
+        """
+        Set the parameter of `_incr_ratio` by `new_incr_ratio`, `new_incr_ratio` should > 1.0.
+        Args:
+            new_incr_ratio(float):  The new_incr_ratio used to update _incr_ratio.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                new_incr_ratio = 3.0
+                scaler.set_incr_ratio(new_incr_ratio)
+        """
+        super(GradScaler, self).set_incr_ratio(new_incr_ratio)
+
+    def get_decr_ratio(self):
+        """
+        Get the parameter of `_decr_ratio`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                decr_ratio = scaler.get_decr_ratio()
+        """
+        return super(GradScaler, self).get_decr_ratio()
+
+    def set_decr_ratio(self, new_decr_ratio):
+        """
+        Set the parameter of `_decr_ratio` by `new_incr_ratio`, `new_decr_ratio` should < 1.0.
+        Args:
+            new_decr_ratio(float):  The new_decr_ratio used to update _decr_ratio.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                new_decr_ratio = 0.1
+                scaler.set_decr_ratio(new_decr_ratio)
+        """
+        super(GradScaler, self).set_decr_ratio(new_decr_ratio)
+
+    def get_incr_every_n_steps(self):
+        """
+        Get the parameter of `_incr_every_n_steps`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                incr_every_n_steps = scaler.get_incr_every_n_steps()
+        """
+        return super(GradScaler, self).get_incr_every_n_steps()
+
+    def set_incr_every_n_steps(self, new_incr_every_n_steps):
+        """
+        Set the parameter of `_incr_every_n_steps` by `new_incr_every_n_steps`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                new_incr_every_n_steps = 2000
+                scaler.set_incr_every_n_steps(new_incr_every_n_steps)
+        """
+        super(GradScaler, self).set_incr_every_n_steps(new_incr_every_n_steps)
+
+    def get_decr_every_n_nan_or_inf(self):
+        """
+        Get the parameter of `_decr_every_n_nan_or_inf`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                decr_every_n_nan_or_inf = scaler.get_decr_every_n_nan_or_inf()
+        """
+        return super(GradScaler, self).get_decr_every_n_nan_or_inf()
+
+    def set_decr_every_n_nan_or_inf(self, new_decr_every_n_nan_or_inf):
+        """
+        Set the parameter of `_decr_every_n_nan_or_inf` by `new_decr_every_n_nan_or_inf`.
+        
+        Examples:
+            .. code-block:: python
+                import paddle
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                new_decr_every_n_nan_or_inf = 3
+                scaler.set_decr_every_n_nan_or_inf(new_decr_every_n_nan_or_inf)
+        """
+        super(GradScaler,
+              self).set_decr_every_n_nan_or_inf(new_decr_every_n_nan_or_inf)

--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -146,9 +146,9 @@ class GradScaler(AmpScaler):
         """
         return super(GradScaler, self).minimize(optimizer, *args, **kwargs)
 
-    def get_enable(self):
+    def is_use_loss_scaling(self):
         """
-        Get the parameter of `_enable`.
+        Enable loss scaling or not.
         
         Examples:
             .. code-block:: python
@@ -161,12 +161,13 @@ class GradScaler(AmpScaler):
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
                 enable = scaler.get_enable()
+                print(enable) # True
         """
-        return super(GradScaler, self).get_enable()
+        return super(GradScaler, self).is_use_loss_scaling()
 
-    def get_use_dynamic_loss_scaling(self):
+    def is_use_dynamic_loss_scaling(self):
         """
-        Get the parameter of `_use_dynamic_loss_scaling`.
+        Whether to use dynamic loss scaling.
         
         Examples:
             .. code-block:: python
@@ -179,12 +180,13 @@ class GradScaler(AmpScaler):
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
                 use_dynamic_loss_scaling = scaler.get_use_dynamic_loss_scaling()
+                print(use_dynamic_loss_scaling) # True
         """
-        return super(GradScaler, self).get_use_dynamic_loss_scaling()
+        return super(GradScaler, self).is_use_dynamic_loss_scaling()
 
     def get_init_loss_scaling(self):
         """
-        Get the parameter of `_init_loss_scaling`.
+        Return the initial loss scaling factor.
         
         Examples:
             .. code-block:: python
@@ -197,14 +199,16 @@ class GradScaler(AmpScaler):
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
                 init_loss_scaling = scaler.get_init_loss_scaling()
+                print(init_loss_scaling) # 1024
         """
         return super(GradScaler, self).get_init_loss_scaling()
 
     def set_init_loss_scaling(self, new_init_loss_scaling):
         """
-        Set the parameter of `_init_loss_scaling` by `new_init_loss_scaling`.
+        Set the initial loss scaling factor by `new_init_loss_scaling`.
+
         Args:
-            new_init_loss_scaling(int):  The new_init_loss_scaling used to update _init_loss_scaling.
+            new_init_loss_scaling(int):  The new_init_loss_scaling used to update initial loss scaling factor.
         
         Examples:
             .. code-block:: python
@@ -216,14 +220,16 @@ class GradScaler(AmpScaler):
                                                incr_every_n_steps=1000,
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
+                print(scaler.get_init_loss_scaling()) # 1024
                 new_init_loss_scaling = 1000
                 scaler.set_init_loss_scaling(new_init_loss_scaling)
+                print(scaler.get_init_loss_scaling()) # 1000
         """
         super(GradScaler, self).set_init_loss_scaling(new_init_loss_scaling)
 
     def get_incr_ratio(self):
         """
-        Get the parameter of `_incr_ratio`.
+        Return the multiplier to use when increasing the loss scaling.
         
         Examples:
             .. code-block:: python
@@ -236,14 +242,16 @@ class GradScaler(AmpScaler):
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
                 incr_ratio = scaler.get_incr_ratio()
+                print(incr_ratio) # 2.0
         """
         return super(GradScaler, self).get_incr_ratio()
 
     def set_incr_ratio(self, new_incr_ratio):
         """
-        Set the parameter of `_incr_ratio` by `new_incr_ratio`, `new_incr_ratio` should > 1.0.
+        Set the multiplier to use when increasing the loss scaling by `new_incr_ratio`, `new_incr_ratio` should > 1.0.
+
         Args:
-            new_incr_ratio(float):  The new_incr_ratio used to update _incr_ratio.
+            new_incr_ratio(float):  The new_incr_ratio used to update the multiplier to use when increasing the loss scaling.
         
         Examples:
             .. code-block:: python
@@ -255,14 +263,16 @@ class GradScaler(AmpScaler):
                                                incr_every_n_steps=1000,
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
+                print(scaler.get_incr_ratio()) # 2.0
                 new_incr_ratio = 3.0
                 scaler.set_incr_ratio(new_incr_ratio)
+                print(scaler.get_incr_ratio()) # 3.0
         """
         super(GradScaler, self).set_incr_ratio(new_incr_ratio)
 
     def get_decr_ratio(self):
         """
-        Get the parameter of `_decr_ratio`.
+        Get the less-than-one-multiplier to use when decreasing the loss scaling.
         
         Examples:
             .. code-block:: python
@@ -275,14 +285,16 @@ class GradScaler(AmpScaler):
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
                 decr_ratio = scaler.get_decr_ratio()
+                print(decr_ratio) # 0.5
         """
         return super(GradScaler, self).get_decr_ratio()
 
     def set_decr_ratio(self, new_decr_ratio):
         """
-        Set the parameter of `_decr_ratio` by `new_incr_ratio`, `new_decr_ratio` should < 1.0.
+        Set the less-than-one-multiplier to use when decreasing the loss scaling by `new_incr_ratio`, `new_decr_ratio` should < 1.0.
+
         Args:
-            new_decr_ratio(float):  The new_decr_ratio used to update _decr_ratio.
+            new_decr_ratio(float):  The new_decr_ratio used to update the less-than-one-multiplier to use when decreasing the loss scaling.
         
         Examples:
             .. code-block:: python
@@ -294,14 +306,16 @@ class GradScaler(AmpScaler):
                                                incr_every_n_steps=1000,
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
+                print(scaler.get_decr_ratio()) # 0.5
                 new_decr_ratio = 0.1
                 scaler.set_decr_ratio(new_decr_ratio)
+                print(scaler.get_decr_ratio()) # 0.1
         """
         super(GradScaler, self).set_decr_ratio(new_decr_ratio)
 
     def get_incr_every_n_steps(self):
         """
-        Get the parameter of `_incr_every_n_steps`.
+        Return the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
         
         Examples:
             .. code-block:: python
@@ -314,12 +328,16 @@ class GradScaler(AmpScaler):
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
                 incr_every_n_steps = scaler.get_incr_every_n_steps()
+                print(incr_every_n_steps) # 1000
         """
         return super(GradScaler, self).get_incr_every_n_steps()
 
     def set_incr_every_n_steps(self, new_incr_every_n_steps):
         """
-        Set the parameter of `_incr_every_n_steps` by `new_incr_every_n_steps`.
+        Set the num `n` by `new_incr_every_n_steps`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
+
+        Args:
+            new_incr_every_n_steps(int):  The new_incr_every_n_steps used to update the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
         
         Examples:
             .. code-block:: python
@@ -331,14 +349,16 @@ class GradScaler(AmpScaler):
                                                incr_every_n_steps=1000,
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
+                print(scaler.get_incr_every_n_steps()) # 1000
                 new_incr_every_n_steps = 2000
                 scaler.set_incr_every_n_steps(new_incr_every_n_steps)
+                print(scaler.get_incr_every_n_steps()) # 2000
         """
         super(GradScaler, self).set_incr_every_n_steps(new_incr_every_n_steps)
 
     def get_decr_every_n_nan_or_inf(self):
         """
-        Get the parameter of `_decr_every_n_nan_or_inf`.
+        Return the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
         
         Examples:
             .. code-block:: python
@@ -351,12 +371,16 @@ class GradScaler(AmpScaler):
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
                 decr_every_n_nan_or_inf = scaler.get_decr_every_n_nan_or_inf()
+                print(decr_every_n_nan_or_inf) # 2
         """
         return super(GradScaler, self).get_decr_every_n_nan_or_inf()
 
     def set_decr_every_n_nan_or_inf(self, new_decr_every_n_nan_or_inf):
         """
-        Set the parameter of `_decr_every_n_nan_or_inf` by `new_decr_every_n_nan_or_inf`.
+        Set the num `n` by `new_decr_every_n_nan_or_inf`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
+
+        Args:
+            new_decr_every_n_nan_or_inf(int):  The new_decr_every_n_nan_or_inf used to update the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
         
         Examples:
             .. code-block:: python
@@ -368,8 +392,10 @@ class GradScaler(AmpScaler):
                                                incr_every_n_steps=1000,
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
+                print(scaler.get_decr_every_n_nan_or_inf()) # 2
                 new_decr_every_n_nan_or_inf = 3
                 scaler.set_decr_every_n_nan_or_inf(new_decr_every_n_nan_or_inf)
+                print(scaler.get_decr_every_n_nan_or_inf()) # 3
         """
         super(GradScaler,
               self).set_decr_every_n_nan_or_inf(new_decr_every_n_nan_or_inf)

--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -164,7 +164,7 @@ class GradScaler(AmpScaler):
                                                incr_every_n_steps=1000,
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
-                enable = scaler.get_enable()
+                enable = scaler.is_enable()
                 print(enable) # True
         """
         return super(GradScaler, self).is_enable()
@@ -178,6 +178,7 @@ class GradScaler(AmpScaler):
         
         Examples:
             .. code-block:: python
+            
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -186,7 +187,7 @@ class GradScaler(AmpScaler):
                                                incr_every_n_steps=1000,
                                                decr_every_n_nan_or_inf=2,
                                                use_dynamic_loss_scaling=True)
-                use_dynamic_loss_scaling = scaler.get_use_dynamic_loss_scaling()
+                use_dynamic_loss_scaling = scaler.is_use_dynamic_loss_scaling()
                 print(use_dynamic_loss_scaling) # True
         """
         return super(GradScaler, self).is_use_dynamic_loss_scaling()

--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -146,12 +146,16 @@ class GradScaler(AmpScaler):
         """
         return super(GradScaler, self).minimize(optimizer, *args, **kwargs)
 
-    def is_use_loss_scaling(self):
+    def is_enable(self):
         """
         Enable loss scaling or not.
+
+        Returns:
+            bool: enable loss scaling return True else return False.
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -163,11 +167,14 @@ class GradScaler(AmpScaler):
                 enable = scaler.get_enable()
                 print(enable) # True
         """
-        return super(GradScaler, self).is_use_loss_scaling()
+        return super(GradScaler, self).is_enable()
 
     def is_use_dynamic_loss_scaling(self):
         """
         Whether to use dynamic loss scaling.
+
+        Returns:
+            bool: if fixed loss_scaling is used return False, if the loss scaling is updated dynamicly return true.
         
         Examples:
             .. code-block:: python
@@ -187,9 +194,13 @@ class GradScaler(AmpScaler):
     def get_init_loss_scaling(self):
         """
         Return the initial loss scaling factor.
+
+        Reurns:
+            float:  the initial loss scaling factor.
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -212,6 +223,7 @@ class GradScaler(AmpScaler):
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -230,9 +242,13 @@ class GradScaler(AmpScaler):
     def get_incr_ratio(self):
         """
         Return the multiplier to use when increasing the loss scaling.
+
+        Reurns:
+            float:  the multiplier to use when increasing the loss scaling.
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -255,6 +271,7 @@ class GradScaler(AmpScaler):
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -273,9 +290,13 @@ class GradScaler(AmpScaler):
     def get_decr_ratio(self):
         """
         Get the less-than-one-multiplier to use when decreasing the loss scaling.
+
+        Reurns:
+            float:  the less-than-one-multiplier to use when decreasing the loss scaling.
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -298,6 +319,7 @@ class GradScaler(AmpScaler):
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -316,9 +338,13 @@ class GradScaler(AmpScaler):
     def get_incr_every_n_steps(self):
         """
         Return the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
+
+        Reurns:
+            int:  the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -341,6 +367,7 @@ class GradScaler(AmpScaler):
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -359,9 +386,13 @@ class GradScaler(AmpScaler):
     def get_decr_every_n_nan_or_inf(self):
         """
         Return the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
+
+        Reurns:
+            int:  the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,
@@ -384,6 +415,7 @@ class GradScaler(AmpScaler):
         
         Examples:
             .. code-block:: python
+
                 import paddle
                 scaler = paddle.amp.GradScaler(enable=True,
                                                init_loss_scaling=1024,

--- a/python/paddle/fluid/dygraph/amp/loss_scaler.py
+++ b/python/paddle/fluid/dygraph/amp/loss_scaler.py
@@ -245,29 +245,30 @@ class AmpScaler(object):
 
         return
 
-    def get_enable(self):
+    def is_use_loss_scaling(self):
         """
-        Get the parameter of `_enable`.
+        Enable loss scaling or not.
         """
         return self._enable
 
-    def get_use_dynamic_loss_scaling(self):
+    def is_use_dynamic_loss_scaling(self):
         """
-        Get the parameter of `_use_dynamic_loss_scaling`.
+        Whether to use dynamic loss scaling.
         """
         return self._use_dynamic_loss_scaling
 
     def get_init_loss_scaling(self):
         """
-        Get the parameter of `_init_loss_scaling`.
+        Return the initial loss scaling factor.
         """
         return self._init_loss_scaling
 
     def set_init_loss_scaling(self, new_init_loss_scaling):
         """
-        Set the parameter of `_init_loss_scaling` by `new_init_loss_scaling`.
+        Set the initial loss scaling factor by `new_init_loss_scaling`.
+
         Args:
-            new_init_loss_scaling(int):  The new_init_loss_scaling used to update _init_loss_scaling.
+            new_init_loss_scaling(int):  The new_init_loss_scaling used to update initial loss scaling factor.s
         """
         self._init_loss_scaling = new_init_loss_scaling
         self._scale = to_variable(
@@ -275,58 +276,62 @@ class AmpScaler(object):
 
     def get_incr_ratio(self):
         """
-        Get the parameter of `_incr_ratio`.
+        Return the multiplier to use when increasing the loss scaling.
         """
         return self._incr_ratio
 
     def set_incr_ratio(self, new_incr_ratio):
         """
-        Set the parameter of `_incr_ratio` by `new_incr_ratio`, `new_incr_ratio` should > 1.0.
+        Set the multiplier to use when increasing the loss scaling by `new_incr_ratio`, `new_incr_ratio` should > 1.0.
+
         Args:
-            new_incr_ratio(float):  The new_incr_ratio used to update _incr_ratio.
+            new_incr_ratio(float):  The new_incr_ratio used to update the multiplier to use when increasing the loss scaling.
         """
         assert new_incr_ratio > 1.0, "The new_incr_ratio must be > 1.0."
         self._incr_ratio = new_incr_ratio
 
     def get_decr_ratio(self):
         """
-        Get the parameter of `_decr_ratio`.
+        Get the less-than-one-multiplier to use when decreasing the loss scaling.
         """
         return self._decr_ratio
 
     def set_decr_ratio(self, new_decr_ratio):
         """
-        Set the parameter of `_decr_ratio` by `new_incr_ratio`, `new_decr_ratio` should < 1.0.
+        Set the less-than-one-multiplier to use when decreasing the loss scaling by `new_incr_ratio`, `new_decr_ratio` should < 1.0.
+
         Args:
-            new_decr_ratio(float):  The new_decr_ratio used to update _decr_ratio.
+            new_decr_ratio(float):  The new_decr_ratio used to update the less-than-one-multiplier to use when decreasing the loss scaling.
         """
         assert new_decr_ratio < 1.0, "The new_decr_ratio must be < 1.0."
         self._decr_ratio = new_decr_ratio
 
     def get_incr_every_n_steps(self):
         """
-        Get the parameter of `_incr_every_n_steps`.
+        Return the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
         """
         return self._incr_every_n_steps
 
     def set_incr_every_n_steps(self, new_incr_every_n_steps):
         """
-        Set the parameter of `_incr_every_n_steps` by `new_incr_every_n_steps`.
+        Set the num `n` by `new_incr_every_n_steps`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
+
         Args:
-            new_incr_every_n_steps(float):  The new_incr_every_n_steps used to update _incr_every_n_steps.
+            new_incr_every_n_steps(int):  The new_incr_every_n_steps used to update the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
         """
         self._incr_every_n_steps = new_incr_every_n_steps
 
     def get_decr_every_n_nan_or_inf(self):
         """
-        Get the parameter of `_decr_every_n_nan_or_inf`.
+        Return the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
         """
         return self._decr_every_n_nan_or_inf
 
     def set_decr_every_n_nan_or_inf(self, new_decr_every_n_nan_or_inf):
         """
-        Set the parameter of `_decr_every_n_nan_or_inf` by `new_decr_every_n_nan_or_inf`.
+        Set the num `n` by `new_decr_every_n_nan_or_inf`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
+
         Args:
-            new_decr_every_n_nan_or_inf(float):  The new_decr_every_n_nan_or_inf used to update _decr_every_n_nan_or_inf.
+            new_decr_every_n_nan_or_inf(int):  The new_decr_every_n_nan_or_inf used to update the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
         """
         self._decr_every_n_nan_or_inf = new_decr_every_n_nan_or_inf

--- a/python/paddle/fluid/dygraph/amp/loss_scaler.py
+++ b/python/paddle/fluid/dygraph/amp/loss_scaler.py
@@ -244,3 +244,89 @@ class AmpScaler(object):
                 self._incr_count = 0
 
         return
+
+    def get_enable(self):
+        """
+        Get the parameter of `_enable`.
+        """
+        return self._enable
+
+    def get_use_dynamic_loss_scaling(self):
+        """
+        Get the parameter of `_use_dynamic_loss_scaling`.
+        """
+        return self._use_dynamic_loss_scaling
+
+    def get_init_loss_scaling(self):
+        """
+        Get the parameter of `_init_loss_scaling`.
+        """
+        return self._init_loss_scaling
+
+    def set_init_loss_scaling(self, new_init_loss_scaling):
+        """
+        Set the parameter of `_init_loss_scaling` by `new_init_loss_scaling`.
+        Args:
+            new_init_loss_scaling(int):  The new_init_loss_scaling used to update _init_loss_scaling.
+        """
+        self._init_loss_scaling = new_init_loss_scaling
+        self._scale = to_variable(
+            np.array([self._init_loss_scaling]).astype(np.float32))
+
+    def get_incr_ratio(self):
+        """
+        Get the parameter of `_incr_ratio`.
+        """
+        return self._incr_ratio
+
+    def set_incr_ratio(self, new_incr_ratio):
+        """
+        Set the parameter of `_incr_ratio` by `new_incr_ratio`, `new_incr_ratio` should > 1.0.
+        Args:
+            new_incr_ratio(float):  The new_incr_ratio used to update _incr_ratio.
+        """
+        assert new_incr_ratio > 1.0, "The new_incr_ratio must be > 1.0."
+        self._incr_ratio = new_incr_ratio
+
+    def get_decr_ratio(self):
+        """
+        Get the parameter of `_decr_ratio`.
+        """
+        return self._decr_ratio
+
+    def set_decr_ratio(self, new_decr_ratio):
+        """
+        Set the parameter of `_decr_ratio` by `new_incr_ratio`, `new_decr_ratio` should < 1.0.
+        Args:
+            new_decr_ratio(float):  The new_decr_ratio used to update _decr_ratio.
+        """
+        assert new_decr_ratio < 1.0, "The new_decr_ratio must be < 1.0."
+        self._decr_ratio = new_decr_ratio
+
+    def get_incr_every_n_steps(self):
+        """
+        Get the parameter of `_incr_every_n_steps`.
+        """
+        return self._incr_every_n_steps
+
+    def set_incr_every_n_steps(self, new_incr_every_n_steps):
+        """
+        Set the parameter of `_incr_every_n_steps` by `new_incr_every_n_steps`.
+        Args:
+            new_incr_every_n_steps(float):  The new_incr_every_n_steps used to update _incr_every_n_steps.
+        """
+        self._incr_every_n_steps = new_incr_every_n_steps
+
+    def get_decr_every_n_nan_or_inf(self):
+        """
+        Get the parameter of `_decr_every_n_nan_or_inf`.
+        """
+        return self._decr_every_n_nan_or_inf
+
+    def set_decr_every_n_nan_or_inf(self, new_decr_every_n_nan_or_inf):
+        """
+        Set the parameter of `_decr_every_n_nan_or_inf` by `new_decr_every_n_nan_or_inf`.
+        Args:
+            new_decr_every_n_nan_or_inf(float):  The new_decr_every_n_nan_or_inf used to update _decr_every_n_nan_or_inf.
+        """
+        self._decr_every_n_nan_or_inf = new_decr_every_n_nan_or_inf

--- a/python/paddle/fluid/dygraph/amp/loss_scaler.py
+++ b/python/paddle/fluid/dygraph/amp/loss_scaler.py
@@ -245,21 +245,30 @@ class AmpScaler(object):
 
         return
 
-    def is_use_loss_scaling(self):
+    def is_enable(self):
         """
         Enable loss scaling or not.
+
+        Returns:
+            bool: enable loss scaling return True else return False.
         """
         return self._enable
 
     def is_use_dynamic_loss_scaling(self):
         """
         Whether to use dynamic loss scaling.
+
+        Returns:
+            bool: if fixed loss_scaling is used return False, if the loss scaling is updated dynamicly return true.
         """
         return self._use_dynamic_loss_scaling
 
     def get_init_loss_scaling(self):
         """
         Return the initial loss scaling factor.
+
+        Reurns:
+            float:  the initial loss scaling factor.
         """
         return self._init_loss_scaling
 
@@ -277,6 +286,9 @@ class AmpScaler(object):
     def get_incr_ratio(self):
         """
         Return the multiplier to use when increasing the loss scaling.
+
+        Reurns:
+            float:  the multiplier to use when increasing the loss scaling.
         """
         return self._incr_ratio
 
@@ -293,6 +305,9 @@ class AmpScaler(object):
     def get_decr_ratio(self):
         """
         Get the less-than-one-multiplier to use when decreasing the loss scaling.
+
+        Reurns:
+            float:  the less-than-one-multiplier to use when decreasing the loss scaling.
         """
         return self._decr_ratio
 
@@ -309,6 +324,9 @@ class AmpScaler(object):
     def get_incr_every_n_steps(self):
         """
         Return the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
+
+        Reurns:
+            int:  the num `n`, `n` represent increases loss scaling every `n` consecutive steps with finite gradients.
         """
         return self._incr_every_n_steps
 
@@ -324,6 +342,9 @@ class AmpScaler(object):
     def get_decr_every_n_nan_or_inf(self):
         """
         Return the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
+
+        Reurns:
+            int:  the num `n`, `n` represent decreases loss scaling every `n` accumulated steps with nan or inf gradients.
         """
         return self._decr_every_n_nan_or_inf
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
@@ -219,14 +219,13 @@ class TestAmpScaler(unittest.TestCase):
                 incr_every_n_steps=1000,
                 decr_every_n_nan_or_inf=2,
                 use_dynamic_loss_scaling=True)
-            self.assertEqual(scaler.get_enable() == True, True)
+            self.assertEqual(scaler.is_use_loss_scaling() == True, True)
             self.assertEqual(scaler.get_init_loss_scaling() == 1024, True)
             self.assertEqual(scaler.get_incr_ratio() == 2.0, True)
             self.assertEqual(scaler.get_decr_ratio() == 0.5, True)
             self.assertEqual(scaler.get_incr_every_n_steps() == 1000, True)
             self.assertEqual(scaler.get_decr_every_n_nan_or_inf() == 2, True)
-            self.assertEqual(scaler.get_use_dynamic_loss_scaling() == True,
-                             True)
+            self.assertEqual(scaler.is_use_dynamic_loss_scaling() == True, True)
             scaler.set_decr_every_n_nan_or_inf(4)
             self.assertEqual(scaler.get_decr_every_n_nan_or_inf() == 4, True)
             scaler.set_decr_ratio(0.1)

--- a/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
@@ -209,6 +209,35 @@ class TestAmpScaler(unittest.TestCase):
                 self.assertTrue(
                     np.array_equal(param.numpy(), params_init[param.name]))
 
+    def test_get_and_set(self):
+        with fluid.dygraph.guard():
+            scaler = paddle.amp.GradScaler(
+                enable=True,
+                init_loss_scaling=1024,
+                incr_ratio=2.0,
+                decr_ratio=0.5,
+                incr_every_n_steps=1000,
+                decr_every_n_nan_or_inf=2,
+                use_dynamic_loss_scaling=True)
+            self.assertEqual(scaler.get_enable() == True, True)
+            self.assertEqual(scaler.get_init_loss_scaling() == 1024, True)
+            self.assertEqual(scaler.get_incr_ratio() == 2.0, True)
+            self.assertEqual(scaler.get_decr_ratio() == 0.5, True)
+            self.assertEqual(scaler.get_incr_every_n_steps() == 1000, True)
+            self.assertEqual(scaler.get_decr_every_n_nan_or_inf() == 2, True)
+            self.assertEqual(scaler.get_use_dynamic_loss_scaling() == True,
+                             True)
+            scaler.set_decr_every_n_nan_or_inf(4)
+            self.assertEqual(scaler.get_decr_every_n_nan_or_inf() == 4, True)
+            scaler.set_decr_ratio(0.1)
+            self.assertEqual(scaler.get_decr_ratio() == 0.1, True)
+            scaler.set_incr_every_n_steps(200)
+            self.assertEqual(scaler.get_incr_every_n_steps() == 200, True)
+            scaler.set_incr_ratio(3.0)
+            self.assertEqual(scaler.get_incr_ratio() == 3.0, True)
+            scaler.set_init_loss_scaling(100)
+            self.assertEqual(scaler.get_init_loss_scaling() == 100, True)
+
 
 def reader_decorator(reader):
     def __reader__():

--- a/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
@@ -219,7 +219,7 @@ class TestAmpScaler(unittest.TestCase):
                 incr_every_n_steps=1000,
                 decr_every_n_nan_or_inf=2,
                 use_dynamic_loss_scaling=True)
-            self.assertEqual(scaler.is_use_loss_scaling() == True, True)
+            self.assertEqual(scaler.is_enable() == True, True)
             self.assertEqual(scaler.get_init_loss_scaling() == 1024, True)
             self.assertEqual(scaler.get_incr_ratio() == 2.0, True)
             self.assertEqual(scaler.get_decr_ratio() == 0.5, True)


### PR DESCRIPTION
### PR types
New features

### PR changes
APIs

### Describe
Add get() and set() function for amp properties：

```
scaler = paddle.amp.GradScaler(init_loss_scaling=1024)
print("get_enable=",scaler.get_enable())
print("get_decr_every_n_nan_or_inf=",scaler.get_decr_every_n_nan_or_inf())
print("get_decr_ratio=",scaler.get_decr_ratio())
print("get_incr_every_n_steps=",scaler.get_incr_every_n_steps())
print("get_incr_ratio=",scaler.get_incr_ratio())
print("get_init_loss_scaling=",scaler.get_init_loss_scaling())
print("get_use_dynamic_loss_scaling=",scaler.get_use_dynamic_loss_scaling())

scaler.set_decr_every_n_nan_or_inf(2)
print("get_decr_every_n_nan_or_inf=",scaler.get_decr_every_n_nan_or_inf())
scaler.set_decr_ratio(0.1)
print("get_decr_ratio=",scaler.get_decr_ratio())
scaler.set_incr_every_n_steps(200)
print("get_incr_every_n_steps=",scaler.get_incr_every_n_steps())
scaler.set_incr_ratio(3)
print("get_incr_ratio=",scaler.get_incr_ratio())
scaler.set_init_loss_scaling(100)
print("get_init_loss_scaling=",scaler.get_init_loss_scaling())

```
