### PR TITLE
remove the initialization of saved_mean and saved_variance for batch_norm op

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cu
+++ b/paddle/fluid/operators/batch_norm_op.cu
@@ -382,8 +382,8 @@ class BatchNormKernel<platform::CUDADeviceContext, T>
       }
 
       // Run training mode.
-      // obtain running mean and running inv var, and see if we need to
-      // initialize them.
+      // obtain running mean and running inv var, and there is no need
+      // to initialize them.
 
       auto *mean_out = ctx.Output<Tensor>("MeanOut");
       auto *variance_out = ctx.Output<Tensor>("VarianceOut");
@@ -394,10 +394,6 @@ class BatchNormKernel<platform::CUDADeviceContext, T>
       auto *saved_variance = ctx.Output<Tensor>("SavedVariance");
       saved_mean->mutable_data<BatchNormParamType<T>>(ctx.GetPlace());
       saved_variance->mutable_data<BatchNormParamType<T>>(ctx.GetPlace());
-      math::SetConstant<platform::CUDADeviceContext, BatchNormParamType<T>>
-          functor;
-      functor(dev_ctx, saved_mean, static_cast<BatchNormParamType<T>>(0));
-      functor(dev_ctx, saved_variance, static_cast<BatchNormParamType<T>>(0));
 
       if ((N * H * W * D) == 1) {
         // Only 1 element in normalization dimension,


### PR DESCRIPTION
### PR types
Performance optimization 

### PR changes
OPs

### Describe
remove the initialization of saved_mean and saved_variance for batch_norm op

ctest结果：

Test project /benchmark/bn-remove-eigenfill/Paddle/build

test 290
    Start 290: test_batch_norm_op
1/2 Test 290: test_batch_norm_op ...............   Passed    7.25 sec
test 291
    Start 291: test_batch_norm_op_v2
2/2 Test 291: test_batch_norm_op_v2 ............   Passed    7.14 sec

The following tests passed:
	test_batch_norm_op
	test_batch_norm_op_v2

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  14.50 sec

以fp32，NCHW格式为例，展示优化前后 batch_norm 算子的前向+反向的总时间情况。
benchmark 性能数据（单位：ms）如下：

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{background:#D9D9D9;
	mso-pattern:black none;}
.xl66
	{background:yellow;
	mso-pattern:black none;}
.xl67
	{border:.5pt solid windowtext;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#0563C1" vlink="#954F72">



Input   shape | Before   optimization | After   optimization | Speed
-- | -- | -- | --
[-1L, 256L] | 14.2568 | 11.6356 | 1.22527416
[-1L, 32768L] | 686.22 | 674.5369 | 1.01732018
[-1L, 1536L, 33L, 33L] | 903.8521 | 892.5328 | 1.01268222
[-1L, 256L, 1L, 1L] | 12.4789 | 11.6477 | 1.07136173
[-1L, 32L, 256L, 256L] | 2024.9894 | 2000.9023 | 1.01203812



</body>

</html>

