### PR TITLE
fix the opt path create error in windows.

### DIFF
--- a/paddle/fluid/inference/analysis/helper.h
+++ b/paddle/fluid/inference/analysis/helper.h
@@ -182,15 +182,16 @@ static bool PathExists(const std::string &path) {
 }
 
 static std::string GetDirRoot(const std::string &path) {
-  char sep = '/';
+  char sep_1 = '/', sep_2 = '\\';
 
-#ifdef _WIN32
-  sep = '\\';
-#endif
-
-  size_t i = path.rfind(sep, path.length());
-  if (i != std::string::npos) {
-    return (path.substr(0, i));
+  size_t i_1 = path.rfind(sep_1, path.length());
+  size_t i_2 = path.rfind(sep_2, path.length());
+  if (i_1 != std::string::npos && i_2 != std::string::npos) {
+    return path.substr(0, std::max(i_1, i_2));
+  } else if (i_1 != std::string::npos) {
+    return path.substr(0, i_1);
+  } else if (i_2 != std::string::npos) {
+    return path.substr(0, i_2);
   }
   return path;
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Windows环境预测，trt 序列化和int8 校准，生成opt路径，会在__model__ 文件下创建目录，然后报错没有创建权限.
经检查，发现是因为在获取模型所在文件夹时，只去查找了模型文件路径的最后一个'\\'字符，如果路径使用左斜杠进行分割的，就会出现此错误，