### PR TITLE
[NPU] change ScatterAdd to EmbeddingDenseGrad in lookup_table NPU op

### DIFF
--- a/paddle/fluid/operators/lookup_table_v2_op_npu.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op_npu.cc
@@ -65,9 +65,11 @@ class LookupTableV2GradNPUKernel : public framework::OpKernel<T> {
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
-    int embedding_dim = table_grad_t->dims()[-1];
+    int embedding_dim = table_grad_t->dims()[1];
 
     if (embedding_dim % 32 == 0) {
+      // NOTE(pangyoki): The embedding_dim of Tensor used in
+      // EmbeddingDenseGrad must be an integer multiple of 32.
       int num_weights = table_grad_t->dims()[0];
       const auto &runner =
           NpuOpRunner("EmbeddingDenseGrad", {*output_grad_t, *ids_t},

--- a/paddle/fluid/operators/lookup_table_v2_op_npu.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op_npu.cc
@@ -65,13 +65,29 @@ class LookupTableV2GradNPUKernel : public framework::OpKernel<T> {
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
-    int num_words = table_grad_t->dims()[0];
-    const auto &runner_zeros =
-        NpuOpRunner("EmbeddingDenseGrad", {*output_grad_t, *ids_t},
-                    {*table_grad_t}, {{"num_weights", num_words},
-                                      {"padding_idx", -1},
-                                      {"scale_grad_by_freq", false}});
-    runner_zeros.Run(stream);
+    int embedding_dim = table_grad_t->dims()[-1];
+
+    if (embedding_dim % 32 == 0) {
+      int num_weights = table_grad_t->dims()[0];
+      const auto &runner =
+          NpuOpRunner("EmbeddingDenseGrad", {*output_grad_t, *ids_t},
+                      {*table_grad_t}, {{"num_weights", num_weights},
+                                        {"padding_idx", -1},
+                                        {"scale_grad_by_freq", false}});
+      runner.Run(stream);
+    } else {
+      const auto &runner_zeros =
+          NpuOpRunner("ZerosLike", {*table_grad_t}, {*table_grad_t});
+      runner_zeros.Run(stream);
+
+      // NOTE(zhiqiu): It seems in cann 20.1, the first input and output
+      // can be different tensor, but in cann 20.2+, it does inplace operation.
+      // Thus, the first input and output should be same tensor.
+      const auto &runner_scatter =
+          NpuOpRunner("ScatterAdd", {*table_grad_t, *ids_t, *output_grad_t},
+                      {*table_grad_t}, {{"use_locking", true}});
+      runner_scatter.Run(stream);
+    }
   }
 };
 }  // namespace operators

--- a/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
@@ -35,14 +35,14 @@ class TestLookupTableV2(OpTest):
         self.place = paddle.NPUPlace(0)
 
         self.init_dtype()
+        self.init_dim()
         np.random.seed(SEED)
         bsz = 6
         seqlen = 8
         vocab = 10
-        dim = 20
-        w = np.ones([vocab, dim]).astype(self.dtype)
+        w = np.ones([vocab, self.dim]).astype(self.dtype)
         x = np.random.randint(0, vocab, size=(bsz, seqlen)).astype(np.int32)
-        out = np.ones([bsz, seqlen, dim]).astype(self.dtype)
+        out = np.ones([bsz, seqlen, self.dim]).astype(self.dtype)
 
         self.inputs = {
             'W': OpTest.np_dtype_to_fluid_dtype(w),
@@ -62,6 +62,9 @@ class TestLookupTableV2(OpTest):
     def init_dtype(self):
         self.dtype = np.float32
 
+    def init_dim(self):
+        self.dim = 20
+
     def test_check_output(self):
         self.check_output_with_place(self.place, check_dygraph=False)
 
@@ -79,6 +82,29 @@ class TestLookupTableV2FP16(TestLookupTableV2):
 
     def init_dtype(self):
         self.dtype = np.float16
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.__class__.no_need_check_grad = True
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestLookupTableV2Dim32(TestLookupTableV2):
+    def init_dim(self):
+        self.dim = 32
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestLookupTableV2Dim32FP16(TestLookupTableV2):
+    no_need_check_grad = True
+
+    def init_dtype(self):
+        self.dtype = np.float16
+
+    def init_dim(self):
+        self.dim = 32
 
     def set_npu(self):
         self.__class__.use_npu = True

--- a/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
@@ -63,6 +63,7 @@ class TestLookupTableV2(OpTest):
         self.dtype = np.float32
 
     def init_dim(self):
+        # embedding_dim is not multiple of 32
         self.dim = 20
 
     def test_check_output(self):
@@ -92,7 +93,8 @@ class TestLookupTableV2FP16(TestLookupTableV2):
                  "core is not compiled with NPU")
 class TestLookupTableV2Dim32(TestLookupTableV2):
     def init_dim(self):
-        self.dim = 32
+        # embedding_dim is multiple of 32
+        self.dim = 64
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
@@ -104,7 +106,7 @@ class TestLookupTableV2Dim32FP16(TestLookupTableV2):
         self.dtype = np.float16
 
     def init_dim(self):
-        self.dim = 32
+        self.dim = 64
 
     def set_npu(self):
         self.__class__.use_npu = True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

将lookup_table_v2 npu op中的`ZerosLike + ScatterAdd`的实现改成了`EmbeddingDenseGrad`.

- 问题：
`EmbeddingDenseGrad`仅支持词向量维度为32的倍数的情况。
![图片](https://user-images.githubusercontent.com/26408901/124577246-aa0b1d00-de7f-11eb-897c-efeea33477f0.png)


测试 dim = 8 / 16 / 20 / 48 / 60 时，使用`EmbeddingDenseGrad`失败。
测试 dim = 32 / 64 时，使用`EmbeddingDenseGrad`成功。


因此，当词向量维度为32的倍数时，使用`EmbeddingDenseGrad`实现
![图片](https://user-images.githubusercontent.com/26408901/124754172-7d790300-df5c-11eb-8583-7c7c98892094.png)

当词向量维度不是32的倍数时，使用`ZerosLike + ScatterAdd`实现
![图片](https://user-images.githubusercontent.com/26408901/124754201-84a01100-df5c-11eb-9689-80bc18432720.png)


- 单测运行结果
<img width="317" alt="图片" src="https://user-images.githubusercontent.com/26408901/124754393-be711780-df5c-11eb-9956-65773f7f4955.png">

