### PR TITLE
[Dygraph QAT] Save all scales to target ops and Move quant layers to paddle.nn.quant

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/__init__.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/__init__.py
@@ -14,9 +14,6 @@
 
 from __future__ import print_function
 
-from . import quant_nn
-from .quant_nn import *
-
 from . import qat
 from .qat import *
 
@@ -33,7 +30,6 @@ from . import ptq_registry
 from .ptq_registry import *
 
 __all__ = []
-__all__ += quant_nn.__all__
 __all__ += qat.__all__
 __all__ += ptq.__all__
 __all__ += ptq_config.__all__

--- a/python/paddle/fluid/contrib/slim/quantization/imperative/qat.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/qat.py
@@ -516,7 +516,7 @@ class ImperativeQuantizeOutputs(object):
                 out_scale = utils.load_variable_data(scope, out_scale_name)
                 out_scale = utils.fp_numpy_to_naive(out_scale)
 
-                if previous_op is not None:
+                if previous_op.type != "feed":
                     argname, index = utils._get_output_name_index(previous_op,
                                                                   in_var_name)
                     previous_op._set_attr(argname + str(index) + "_threshold",

--- a/python/paddle/fluid/contrib/slim/quantization/imperative/quant_nn.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/quant_nn.py
@@ -64,7 +64,7 @@ class FakeQuantMovingAverageAbsMax(layers.Layer):
             name) if name else 'quant_dequant.scale'
         scale_attr = ParamAttr(
             name=unique_name.generate(scale_prefix),
-            initializer=Constant(0.001),
+            initializer=Constant(0.),
             trainable=False)
         self._scale = self.create_parameter(
             shape=[1], attr=scale_attr, dtype=dtype)
@@ -74,7 +74,7 @@ class FakeQuantMovingAverageAbsMax(layers.Layer):
             name) if name else 'quant_dequant.state'
         state_attr = ParamAttr(
             name=unique_name.generate(state_prefix),
-            initializer=Constant(1),
+            initializer=Constant(0),
             trainable=False)
         self._state = self.create_parameter(
             shape=[1], attr=state_attr, dtype=dtype)
@@ -84,7 +84,7 @@ class FakeQuantMovingAverageAbsMax(layers.Layer):
             name) if name else 'quant_dequant.accum'
         accum_attr = ParamAttr(
             name=unique_name.generate(accum_prefix),
-            initializer=Constant(1),
+            initializer=Constant(0),
             trainable=False)
         self._accum = self.create_parameter(
             shape=[1], attr=accum_attr, dtype=dtype)
@@ -527,7 +527,7 @@ class MovingAverageAbsMaxScale(layers.Layer):
         scale_prefix = '{}.scale'.format(name) if name else 'outscale.scale'
         scale_name = unique_name.generate(scale_prefix)
         scale_attr = ParamAttr(
-            name=scale_name, initializer=Constant(1), trainable=False)
+            name=scale_name, initializer=Constant(0), trainable=False)
         self._scale = self.create_parameter(
             shape=[1], attr=scale_attr, dtype=dtype)
         self._scale.stop_gradient = True
@@ -535,7 +535,7 @@ class MovingAverageAbsMaxScale(layers.Layer):
         state_prefix = "{}.state".format(name) if name else 'outscale.state'
         state_attr = ParamAttr(
             name=unique_name.generate(state_prefix),
-            initializer=Constant(1),
+            initializer=Constant(0),
             trainable=False)
         self._state = self.create_parameter(
             shape=[1], attr=state_attr, dtype=dtype)
@@ -544,7 +544,7 @@ class MovingAverageAbsMaxScale(layers.Layer):
         accum_prefix = "{}.accum".format(name) if name else 'outscale.accum'
         accum_attr = ParamAttr(
             name=unique_name.generate(accum_prefix),
-            initializer=Constant(1),
+            initializer=Constant(0),
             trainable=False)
         self._accum = self.create_parameter(
             shape=[1], attr=accum_attr, dtype=dtype)
@@ -598,8 +598,8 @@ class MovingAverageAbsMaxScale(layers.Layer):
 
 class MAOutputScaleLayer(layers.Layer):
     """
-    Calculate the scale (moving average abs max) for the output of the input layer.
     Add MovingAverageMaxScale layer to the behind of the input layer.
+    Calculate the scale (moving average abs max) for the output of the input layer.
     """
 
     def __init__(self, layer=None, moving_rate=0.9, name=None, dtype='float32'):
@@ -623,6 +623,10 @@ class MAOutputScaleLayer(layers.Layer):
 
 
 class FakeQuantMAOutputScaleLayer(layers.Layer):
+    """
+    Add FakeQuantMovingAverageAbsMax layer to the behind of the input layer.
+    """
+
     def __init__(self,
                  layer,
                  weight_bits=8,

--- a/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
@@ -16,8 +16,8 @@ import math
 import numpy as np
 
 import paddle
+import paddle.nn.quant.quant_layers as quant_layers
 
-from . import quant_nn
 from ..quantization_pass import _get_op_input_var_names
 from ..quantization_pass import _get_op_output_var_names
 from ..quantization_pass import _get_output_name_index
@@ -58,13 +58,15 @@ fake_quant_output_layers = [
 ]
 
 fake_quant_leaf_layers = [
-    quant_nn.FakeQuantAbsMax,
-    quant_nn.FakeQuantChannelWiseAbsMax,
-    quant_nn.FakeQuantMovingAverageAbsMax,
-    quant_nn.MovingAverageAbsMaxScale,
+    quant_layers.FakeQuantAbsMax,
+    quant_layers.FakeQuantChannelWiseAbsMax,
+    quant_layers.FakeQuantMovingAverageAbsMax,
+    quant_layers.MovingAverageAbsMaxScale,
 ]
 
-fake_quant_wrap_layers = [quant_nn.QuantizedConv2D, quant_nn.QuantizedLinear]
+fake_quant_wrap_layers = [
+    quant_layers.QuantizedConv2D, quant_layers.QuantizedLinear
+]
 
 # The weight format of these layers is Cin * Cout * H * W 
 spec_channel_axis_layers = [paddle.nn.Conv2D, paddle.nn.Conv2DTranspose]

--- a/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
@@ -18,6 +18,10 @@ import numpy as np
 import paddle
 
 from . import quant_nn
+from ..quantization_pass import _get_op_input_var_names
+from ..quantization_pass import _get_op_output_var_names
+from ..quantization_pass import _get_output_name_index
+from ..quantization_pass import _get_input_name_index
 
 layer_name_map = {
     'Conv2D': paddle.nn.Conv2D,
@@ -94,6 +98,7 @@ def find_previous_op(block, var_name):
     for op in block.ops:
         if var_name in op.output_arg_names:
             return op
+    return None
 
 
 def find_next_ops(block, var_name):
@@ -244,3 +249,10 @@ def cal_kl_scaling_factor(hist, abs_max, bits):
                 break
         min_kl_index = starting_iter
     return (min_kl_index + 0.5) * bin_width
+
+
+def fp_numpy_to_naive(x_np):
+    if x_np.size == 1:
+        return float(x_np)
+    else:
+        return x_np.tolist()

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -141,12 +141,21 @@ _channelwise_quant_axis1_ops = ['conv2d_transpose', 'mul']
 
 
 def _get_op_input_var_names(op):
-    """ """
+    """
+    Get the input var names of the op.
+    Args:
+        op(IrNode, Operator): the input op.
+    Returns:
+        input_var_names or None.
+    """
     assert isinstance(op, (IrNode, Operator)), \
         "The input op should be IrNode or Operator."
     var_names = []
     op_name = op.name() if isinstance(op, IrNode) \
         else op.type
+    if op_name not in _op_real_in_out_name:
+        return []
+
     name_list = _op_real_in_out_name[op_name][0]
     for name in name_list:
         var_name = op.input(name)
@@ -163,6 +172,9 @@ def _get_input_name_index(op, input_var_name):
         "The input op should be IrNode or Operator."
     op_name = op.name() if isinstance(op, IrNode) \
         else op.type
+    if op_name not in _op_real_in_out_name:
+        return None
+
     res = None
     for argname in _op_real_in_out_name[op_name][0]:
         var_names = op.input(argname)
@@ -179,6 +191,9 @@ def _get_op_output_var_names(op):
     var_names = []
     op_name = op.name() if isinstance(op, IrNode) \
         else op.type
+    if op_name not in _op_real_in_out_name:
+        return []
+
     name_list = _op_real_in_out_name[op_name][1]
     for name in name_list:
         var_name = op.output(name)
@@ -195,6 +210,9 @@ def _get_output_name_index(op, output_var_name):
         "The input op should be IrNode or Operator."
     op_name = op.name() if isinstance(op, IrNode) \
         else op.type
+    if op_name not in _op_real_in_out_name:
+        return None
+
     name_list = _op_real_in_out_name[op_name][1]
     res = None
     for name in name_list:

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat.py
@@ -31,7 +31,7 @@ from paddle.fluid.dygraph.container import Sequential
 from paddle.nn import Linear, Conv2D, Softmax
 from paddle.fluid.log_helper import get_logger
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
-from paddle.fluid.contrib.slim.quantization.imperative.quant_nn import QuantizedConv2D
+from paddle.nn.quant.quant_layers import QuantizedConv2D
 
 from imperative_test_utils import fix_model_dict, ImperativeLenet
 

--- a/python/paddle/fluid/contrib/slim/tests/test_moving_average_abs_max_scale_op.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_moving_average_abs_max_scale_op.py
@@ -20,7 +20,7 @@ import paddle
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
-from paddle.fluid.contrib.slim.quantization.imperative import quant_nn
+import paddle.nn.quant.quant_layers as quant_layers
 
 paddle.enable_static()
 
@@ -45,7 +45,7 @@ class TestMovingAverageAbsMaxScaleOp(unittest.TestCase):
                 name='image', shape=[784], dtype='float32')
             label = fluid.layers.data(name='label', shape=[1], dtype='int64')
             fc_tmp = fluid.layers.fc(image, size=10, act='softmax')
-            out_scale = quant_nn.MovingAverageAbsMaxScale(
+            out_scale = quant_layers.MovingAverageAbsMaxScale(
                 name=fc_tmp.name, dtype=fc_tmp.dtype)
             fc_tmp_1 = out_scale(fc_tmp)
             cross_entropy = fluid.layers.softmax_with_cross_entropy(fc_tmp,

--- a/python/paddle/nn/quant/__init__.py
+++ b/python/paddle/nn/quant/__init__.py
@@ -21,5 +21,6 @@ from .functional_layers import reshape  # noqa: F401
 from .functional_layers import transpose  # noqa: F401
 from .functional_layers import concat  # noqa: F401
 from .functional_layers import flatten  # noqa: F401
+from .quant_layers import QuantStub  # noqa: F401
 
 __all__ = []

--- a/python/paddle/nn/quant/quant_layers.py
+++ b/python/paddle/nn/quant/quant_layers.py
@@ -26,19 +26,101 @@ import logging
 from paddle.fluid.log_helper import get_logger
 
 __all__ = [
-    'FakeQuantMovingAverageAbsMax',
     'FakeQuantAbsMax',
+    'FakeQuantMovingAverageAbsMax',
     'FakeQuantChannelWiseAbsMax',
     'QuantizedConv2D',
     'QuantizedLinear',
-    'QuantizedNoweightLayer',
     'MovingAverageAbsMaxScale',
     'MAOutputScaleLayer',
     'FakeQuantMAOutputScaleLayer',
+    'QuantStub',
 ]
 
 _logger = get_logger(
     __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
+
+
+class FakeQuantAbsMax(layers.Layer):
+    r"""
+    FakeQuantAbsMax layer does the abs_max quant and then dequant.
+    Its computational formula is described as below:
+
+    :math:`scale = max(abs(X))`
+    :math:`range = 2^{bit\_length - 1} - 1`
+    :math:`Out = round(X / scale * range) * scale / range`
+    """
+
+    def __init__(self,
+                 name=None,
+                 quant_bits=8,
+                 dtype='float32',
+                 quant_on_weight=False):
+        super(FakeQuantAbsMax, self).__init__()
+        self._quant_bits = quant_bits
+        self._name = name
+        scale_prefix = "{}.scale".format(
+            name) if name else 'quant_dequant.scale'
+        self._scale_name = unique_name.generate(scale_prefix)
+        if quant_on_weight:
+            scale_attr = ParamAttr(
+                name=self._scale_name,
+                initializer=Constant(0.0),
+                trainable=False)
+            self._scale = self.create_parameter(
+                shape=[1], attr=scale_attr, dtype=self._dtype)
+            self._scale.stop_gradient = True
+        else:
+            self._scale = None
+
+    def forward(self, input):
+        if in_dygraph_mode():
+            attrs = ('bit_length', self._quant_bits)
+            quant_out = _varbase_creator(
+                type=input.type,
+                name="{}.quantized.dequantized".format(input.name),
+                shape=input.shape,
+                dtype=input.dtype,
+                persistable=False)
+            out_scale = self._scale
+            if not out_scale:
+                out_scale = _varbase_creator(
+                    type=core.VarDesc.VarType.LOD_TENSOR,
+                    name=self._scale_name,
+                    shape=[1],
+                    dtype=self._dtype,
+                    persistable=False)
+                out_scale.stop_gradient = True
+            out, _, = core.ops.fake_quantize_dequantize_abs_max(
+                input, quant_out, out_scale, *attrs)
+            return out
+
+        check_variable_and_dtype(input, 'input', ['float32'], "FakeQuantAbsMax")
+        attrs = {'bit_length': self._quant_bits}
+        inputs = {"X": [input]}
+        quant_out = self._helper.create_variable(
+            name="{}.quantized.dequantized".format(input.name),
+            dtype=input.dtype,
+            type=core.VarDesc.VarType.LOD_TENSOR,
+            persistable=False,
+            stop_gradient=False)
+        out_scale = self._scale
+        if not out_scale:
+            out_scale = self._helper.create_variable(
+                name=self._scale_name,
+                dtype=self._dtype,
+                type=core.VarDesc.VarType.LOD_TENSOR,
+                persistable=False,
+                stop_gradient=True)
+        outputs = {"Out": [quant_out], "OutScale": [out_scale]}
+
+        self._helper.append_op(
+            type="fake_quantize_dequantize_abs_max",
+            inputs=inputs,
+            outputs=outputs,
+            attrs=attrs)
+
+        return quant_out
 
 
 class FakeQuantMovingAverageAbsMax(layers.Layer):
@@ -139,88 +221,6 @@ class FakeQuantMovingAverageAbsMax(layers.Layer):
         return quant_out
 
 
-class FakeQuantAbsMax(layers.Layer):
-    r"""
-    FakeQuantAbsMax layer does the abs_max quant and then dequant.
-    Its computational formula is described as below:
-
-    :math:`scale = max(abs(X))`
-    :math:`range = 2^{bit\_length - 1} - 1`
-    :math:`Out = round(X / scale * range) * scale / range`
-    """
-
-    def __init__(self,
-                 name=None,
-                 quant_bits=8,
-                 dtype='float32',
-                 quant_on_weight=False):
-        super(FakeQuantAbsMax, self).__init__()
-        self._quant_bits = quant_bits
-        self._name = name
-        scale_prefix = "{}.scale".format(
-            name) if name else 'quant_dequant.scale'
-        self._scale_name = unique_name.generate(scale_prefix)
-        if quant_on_weight:
-            scale_attr = ParamAttr(
-                name=self._scale_name,
-                initializer=Constant(0.0),
-                trainable=False)
-            self._scale = self.create_parameter(
-                shape=[1], attr=scale_attr, dtype=self._dtype)
-            self._scale.stop_gradient = True
-        else:
-            self._scale = None
-
-    def forward(self, input):
-        if in_dygraph_mode():
-            attrs = ('bit_length', self._quant_bits)
-            quant_out = _varbase_creator(
-                type=input.type,
-                name="{}.quantized.dequantized".format(input.name),
-                shape=input.shape,
-                dtype=input.dtype,
-                persistable=False)
-            out_scale = self._scale
-            if not out_scale:
-                out_scale = _varbase_creator(
-                    type=core.VarDesc.VarType.LOD_TENSOR,
-                    name=self._scale_name,
-                    shape=[1],
-                    dtype=self._dtype,
-                    persistable=False)
-                out_scale.stop_gradient = True
-            out, _, = core.ops.fake_quantize_dequantize_abs_max(
-                input, quant_out, out_scale, *attrs)
-            return out
-
-        check_variable_and_dtype(input, 'input', ['float32'], "FakeQuantAbsMax")
-        attrs = {'bit_length': self._quant_bits}
-        inputs = {"X": [input]}
-        quant_out = self._helper.create_variable(
-            name="{}.quantized.dequantized".format(input.name),
-            dtype=input.dtype,
-            type=core.VarDesc.VarType.LOD_TENSOR,
-            persistable=False,
-            stop_gradient=False)
-        out_scale = self._scale
-        if not out_scale:
-            out_scale = self._helper.create_variable(
-                name=self._scale_name,
-                dtype=self._dtype,
-                type=core.VarDesc.VarType.LOD_TENSOR,
-                persistable=False,
-                stop_gradient=True)
-        outputs = {"Out": [quant_out], "OutScale": [out_scale]}
-
-        self._helper.append_op(
-            type="fake_quantize_dequantize_abs_max",
-            inputs=inputs,
-            outputs=outputs,
-            attrs=attrs)
-
-        return quant_out
-
-
 class FakeQuantChannelWiseAbsMax(layers.Layer):
     def __init__(self,
                  name=None,
@@ -304,31 +304,91 @@ class FakeQuantChannelWiseAbsMax(layers.Layer):
         return quant_out
 
 
-def _get_fake_quant_type(quant_type, **kwargs):
-    call_args = {
-        "name": kwargs.get("name", None),
-        "quant_bits": kwargs.get("quant_bits", 8),
-        "dtype": kwargs.get("dtype", "float32")
-    }
+class MovingAverageAbsMaxScale(layers.Layer):
+    def __init__(self, name=None, moving_rate=0.9, dtype='float32'):
+        r"""
+        MovingAverageMaxScale layer is used to calculating the output quantization
+        scale of Layer. Its computational formula is described as below:
 
-    if quant_type == 'abs_max':
-        call_args["quant_on_weight"] = kwargs.get("quant_on_weight", False)
-    elif quant_type == 'moving_average_abs_max':
-        call_args["moving_rate"] = kwargs.get("moving_rate", 0.9)
-    elif quant_type == 'channel_wise_abs_max':
-        call_args["quant_on_weight"] = kwargs.get("quant_on_weight", False)
-        call_args["channel_num"] = kwargs.get("channel_num", None)
-        call_args["quant_axis"] = kwargs.get("quant_axis", 0)
-        assert call_args["channel_num"] is not None, (
-            "You need to input channel_num"
-            "when you use channel_wise_abs_max strategy.")
-    fake_quant_map = {
-        'abs_max': FakeQuantAbsMax,
-        'moving_average_abs_max': FakeQuantMovingAverageAbsMax,
-        'channel_wise_abs_max': FakeQuantChannelWiseAbsMax
-    }
+        :math:`scale = (moving\_rate*accum+max(abs(x)))/(moving\_rate*state+1)`
+        :math:`Out = X`
+        """
+        super(MovingAverageAbsMaxScale, self).__init__()
+        self._moving_rate = moving_rate
 
-    return fake_quant_map[quant_type](**call_args)
+        scale_prefix = '{}.scale'.format(name) if name else 'outscale.scale'
+        scale_name = unique_name.generate(scale_prefix)
+        scale_attr = ParamAttr(
+            name=scale_name, initializer=Constant(0), trainable=False)
+        self._scale = self.create_parameter(
+            shape=[1], attr=scale_attr, dtype=dtype)
+        self._scale.stop_gradient = True
+
+        state_prefix = "{}.state".format(name) if name else 'outscale.state'
+        state_attr = ParamAttr(
+            name=unique_name.generate(state_prefix),
+            initializer=Constant(0),
+            trainable=False)
+        self._state = self.create_parameter(
+            shape=[1], attr=state_attr, dtype=dtype)
+        self._state.stop_gradient = True
+
+        accum_prefix = "{}.accum".format(name) if name else 'outscale.accum'
+        accum_attr = ParamAttr(
+            name=unique_name.generate(accum_prefix),
+            initializer=Constant(0),
+            trainable=False)
+        self._accum = self.create_parameter(
+            shape=[1], attr=accum_attr, dtype=dtype)
+        self._accum.stop_gradient = True
+
+    def forward(self, input):
+        if in_dygraph_mode():
+            attrs = ('moving_rate', self._moving_rate, 'is_test',
+                     not self.training)
+            state = self._state if self.training else None
+            accum = self._accum if self.training else None
+            quant_out = _varbase_creator(
+                type=input.type,
+                name="{}.tmp".format(input.name),
+                shape=input.shape,
+                dtype=input.dtype,
+                persistable=False)
+
+            out, _, _, _ = core.ops.moving_average_abs_max_scale(
+                input, accum, state, quant_out, self._scale, state, accum,
+                *attrs)
+            return out
+
+        check_variable_and_dtype(input, 'input', ['float32', 'float64'],
+                                 'MovingAverageAbsMaxScale')
+
+        attrs = {'moving_rate': self._moving_rate, 'is_test': not self.training}
+        inputs = {"X": [input]}
+        quant_out = self._helper.create_variable(
+            name="{}.tmp".format(input.name),
+            dtype=input.dtype,
+            type=core.VarDesc.VarType.LOD_TENSOR,
+            persistable=False,
+            stop_gradient=False)
+        outputs = {"Out": [quant_out], "OutScale": [self._scale]}
+
+        if self.training:
+            inputs['InState'] = [self._state]
+            inputs['InAccum'] = [self._accum]
+            outputs['OutState'] = [self._state]
+            outputs['OutAccum'] = [self._accum]
+
+        self._helper.append_op(
+            type="moving_average_abs_max_scale",
+            inputs=inputs,
+            outputs=outputs,
+            attrs=attrs)
+
+        return quant_out
+
+
+QuantStub = MovingAverageAbsMaxScale
 
 
 class QuantizedConv2D(layers.Layer):
@@ -489,113 +549,6 @@ class QuantizedLinear(layers.Layer):
         return out
 
 
-class QuantizedNoweightLayer(layers.Layer):
-    def __init__(self,
-                 layer,
-                 weight_bits=8,
-                 activation_bits=8,
-                 moving_rate=0.9,
-                 *args,
-                 **kwargs):
-
-        super(QuantizedNoweightLayer, self).__init__()
-        self._layer = layer
-        self._fake_quant_input = _get_fake_quant_type(
-            'moving_average_abs_max',
-            name=layer.full_name(),
-            moving_rate=moving_rate,
-            quant_bits=activation_bits,
-            dtype=self._dtype,
-            quant_on_weight=False)
-
-    def forward(self, input):
-        return self._layer.forward(self._fake_quant_input(input))
-
-
-class MovingAverageAbsMaxScale(layers.Layer):
-    def __init__(self, name=None, moving_rate=0.9, dtype='float32'):
-        r"""
-        MovingAverageMaxScale layer is used to calculating the output quantization
-        scale of Layer. Its computational formula is described as below:
-
-        :math:`scale = (moving\_rate*accum+max(abs(x)))/(moving\_rate*state+1)`
-        :math:`Out = X`
-        """
-        super(MovingAverageAbsMaxScale, self).__init__()
-        self._moving_rate = moving_rate
-
-        scale_prefix = '{}.scale'.format(name) if name else 'outscale.scale'
-        scale_name = unique_name.generate(scale_prefix)
-        scale_attr = ParamAttr(
-            name=scale_name, initializer=Constant(0), trainable=False)
-        self._scale = self.create_parameter(
-            shape=[1], attr=scale_attr, dtype=dtype)
-        self._scale.stop_gradient = True
-
-        state_prefix = "{}.state".format(name) if name else 'outscale.state'
-        state_attr = ParamAttr(
-            name=unique_name.generate(state_prefix),
-            initializer=Constant(0),
-            trainable=False)
-        self._state = self.create_parameter(
-            shape=[1], attr=state_attr, dtype=dtype)
-        self._state.stop_gradient = True
-
-        accum_prefix = "{}.accum".format(name) if name else 'outscale.accum'
-        accum_attr = ParamAttr(
-            name=unique_name.generate(accum_prefix),
-            initializer=Constant(0),
-            trainable=False)
-        self._accum = self.create_parameter(
-            shape=[1], attr=accum_attr, dtype=dtype)
-        self._accum.stop_gradient = True
-
-    def forward(self, input):
-        if in_dygraph_mode():
-            attrs = ('moving_rate', self._moving_rate, 'is_test',
-                     not self.training)
-            state = self._state if self.training else None
-            accum = self._accum if self.training else None
-            quant_out = _varbase_creator(
-                type=input.type,
-                name="{}.tmp".format(input.name),
-                shape=input.shape,
-                dtype=input.dtype,
-                persistable=False)
-
-            out, _, _, _ = core.ops.moving_average_abs_max_scale(
-                input, accum, state, quant_out, self._scale, state, accum,
-                *attrs)
-            return out
-
-        check_variable_and_dtype(input, 'input', ['float32', 'float64'],
-                                 'MovingAverageAbsMaxScale')
-
-        attrs = {'moving_rate': self._moving_rate, 'is_test': not self.training}
-        inputs = {"X": [input]}
-        quant_out = self._helper.create_variable(
-            name="{}.tmp".format(input.name),
-            dtype=input.dtype,
-            type=core.VarDesc.VarType.LOD_TENSOR,
-            persistable=False,
-            stop_gradient=False)
-        outputs = {"Out": [quant_out], "OutScale": [self._scale]}
-
-        if self.training:
-            inputs['InState'] = [self._state]
-            inputs['InAccum'] = [self._accum]
-            outputs['OutState'] = [self._state]
-            outputs['OutAccum'] = [self._accum]
-
-        self._helper.append_op(
-            type="moving_average_abs_max_scale",
-            inputs=inputs,
-            outputs=outputs,
-            attrs=attrs)
-
-        return quant_out
-
-
 class MAOutputScaleLayer(layers.Layer):
     """
     Add MovingAverageMaxScale layer to the behind of the input layer.
@@ -653,3 +606,30 @@ class FakeQuantMAOutputScaleLayer(layers.Layer):
             return out
         else:
             return self._fake_quant_output(out)
+
+
+def _get_fake_quant_type(quant_type, **kwargs):
+    call_args = {
+        "name": kwargs.get("name", None),
+        "quant_bits": kwargs.get("quant_bits", 8),
+        "dtype": kwargs.get("dtype", "float32")
+    }
+
+    if quant_type == 'abs_max':
+        call_args["quant_on_weight"] = kwargs.get("quant_on_weight", False)
+    elif quant_type == 'moving_average_abs_max':
+        call_args["moving_rate"] = kwargs.get("moving_rate", 0.9)
+    elif quant_type == 'channel_wise_abs_max':
+        call_args["quant_on_weight"] = kwargs.get("quant_on_weight", False)
+        call_args["channel_num"] = kwargs.get("channel_num", None)
+        call_args["quant_axis"] = kwargs.get("quant_axis", 0)
+        assert call_args["channel_num"] is not None, (
+            "You need to input channel_num"
+            "when you use channel_wise_abs_max strategy.")
+    fake_quant_map = {
+        'abs_max': FakeQuantAbsMax,
+        'moving_average_abs_max': FakeQuantMovingAverageAbsMax,
+        'channel_wise_abs_max': FakeQuantChannelWiseAbsMax
+    }
+
+    return fake_quant_map[quant_type](**call_args)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
* Save all scales to target ops
* Move quant layers to paddle.nn.quant