### PR TITLE
[NPU] delete useless GELU in gelu grad npu op

### DIFF
--- a/paddle/fluid/operators/gelu_op_npu.cc
+++ b/paddle/fluid/operators/gelu_op_npu.cc
@@ -62,13 +62,11 @@ class GeluGradNPUKernel : public framework::OpKernel<T> {
             .stream();
 
     // NOTE(pangyoki): In the original implementation of GeluGrad op, the input
-    // is
-    // {*dout, *x, out}, where out = Gelu(x). However, we find that variable
-    // `out`
-    // was not actually used. In order to improve performance, the useless GELU
-    // operation was deleted.
-    // We directly use `*dout` as a placeholder to replace `out`, it will not be
-    // used in calculations.
+    // is {*dout, *x, out}, where out = Gelu(x). However, we find that variable
+    // `out` was not actually used. In order to improve performance, the
+    // useless GELU operation was deleted.
+    // We directly use `*dout` as a placeholder to replace `out`, it will not
+    // be used in calculations.
     const auto& runner_dx =
         NpuOpRunner("GeluGrad", {*dout, *x, *dout}, {*dx}, {});
     runner_dx.Run(stream);

--- a/paddle/fluid/operators/gelu_op_npu.cc
+++ b/paddle/fluid/operators/gelu_op_npu.cc
@@ -61,13 +61,7 @@ class GeluGradNPUKernel : public framework::OpKernel<T> {
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
-    Tensor out(x->type());
-    out.mutable_data<T>(x->dims(), place);
-    const auto& runner_out = NpuOpRunner("Gelu", {*x}, {out}, {});
-    runner_out.Run(stream);
-
-    const auto& runner_dx =
-        NpuOpRunner("GeluGrad", {*dout, *x, out}, {*dx}, {});
+    const auto& runner_dx = NpuOpRunner("GeluGrad", {*dout, *x, *x}, {*dx}, {});
     runner_dx.Run(stream);
   }
 };

--- a/python/paddle/fluid/tests/unittests/npu/test_gelu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gelu_op_npu.py
@@ -58,12 +58,9 @@ class TestGelu(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
 
-    # TODO(ascendrc): Add grad test
-    # def test_check_grad(self):
-    #     if self.dtype == np.float16:
-    #         return
-    #     self.check_grad(['X'], 'Out')
-    #
+    def test_check_grad(self):
+        self.check_grad_with_place(
+            self.place, ['X'], 'Out', check_dygraph=False)
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
@@ -115,10 +112,10 @@ class TestGeluNet(unittest.TestCase):
                 name="label", shape=[32, 1], dtype='int64')
 
             c = paddle.multiply(a, b)
-            d = fluid.layers.gelu(c)
 
-            fc_1 = fluid.layers.fc(input=d, size=128)
-            prediction = fluid.layers.fc(input=fc_1, size=2, act='softmax')
+            fc_1 = fluid.layers.fc(input=c, size=128)
+            fc_1_gelu = fluid.layers.gelu(fc_1)
+            prediction = fluid.layers.fc(input=fc_1_gelu, size=2, act='softmax')
 
             cost = fluid.layers.cross_entropy(input=prediction, label=label)
             loss = fluid.layers.reduce_mean(cost)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
In the original implementation of `gelu grad` op, `GELU` NPU OP is used to calculate an intermediate variable named `out`. However, we found that this variable was not actually used. In order to improve performance, the useless GELU operation was deleted. 

- unittest result
<img width="746" alt="图片" src="https://user-images.githubusercontent.com/26408901/124232871-cc7dfd00-db44-11eb-98f8-5ae5a911fc4c.png">
<img width="278" alt="图片" src="https://user-images.githubusercontent.com/26408901/124233297-47471800-db45-11eb-8ed9-5de0b23dc2ab.png">



- timeline of gelu grad op
Before:
![图片](https://user-images.githubusercontent.com/26408901/123963512-1ea80c80-d9e5-11eb-810c-dbd59788a760.png)
After:
![图片](https://user-images.githubusercontent.com/26408901/123963495-1a7bef00-d9e5-11eb-94f3-e94207fd666b.png)


- model performance
29491 tokens/s -> 30101 tokens/s, about 2.1% performance improvement.