### PR TITLE
replace spatial with per_activation mode for bn op when input is NCHW and H==1 and W==1 to improve perf

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cu
+++ b/paddle/fluid/operators/batch_norm_op.cu
@@ -225,11 +225,17 @@ class BatchNormKernel<platform::CUDADeviceContext, T>
 #elif CUDNN_VERSION_MIN(7, 0, 1)
     if (FLAGS_cudnn_batchnorm_spatial_persistent) {
       mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
+    } else if (H == 1 && W == 1) {
+      mode_ = CUDNN_BATCHNORM_PER_ACTIVATION;
     } else {
       mode_ = CUDNN_BATCHNORM_SPATIAL;
     }
 #else
-    mode_ = CUDNN_BATCHNORM_SPATIAL;
+    if (H == 1 && W == 1) {
+      mode_ = CUDNN_BATCHNORM_PER_ACTIVATION;
+    } else {
+      mode_ = CUDNN_BATCHNORM_SPATIAL;
+    }
 #endif  // CUDNN_VERSION_MIN(7, 0, 1)
 
     VLOG(3) << "Setting descriptors.";
@@ -989,11 +995,17 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
 #elif CUDNN_VERSION_MIN(7, 0, 1)
       if (FLAGS_cudnn_batchnorm_spatial_persistent) {
         mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
+      } else if (H == 1 && W == 1) {
+        mode_ = CUDNN_BATCHNORM_PER_ACTIVATION;
       } else {
         mode_ = CUDNN_BATCHNORM_SPATIAL;
       }
 #else
-      mode_ = CUDNN_BATCHNORM_SPATIAL;
+      if (H == 1 && W == 1) {
+        mode_ = CUDNN_BATCHNORM_PER_ACTIVATION;
+      } else {
+        mode_ = CUDNN_BATCHNORM_SPATIAL;
+      }
 #endif  // CUDNN_VERSION_MIN(7, 0, 1)
 
 #ifdef PADDLE_WITH_HIP


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
OPs

### Describe
1 Motivation：
When input is NCHW format and H==1, W==1, Paddle calls cuDNN bn with spatial mode, 
leading to worse performance than PyTorch.

2 ctest结果：

Test project /Paddle/build

test 290
    Start 290: test_batch_norm_op
1/2 Test 290: test_batch_norm_op ...............   Passed    8.76 sec
test 291
    Start 291: test_batch_norm_op_v2
2/2 Test 291: test_batch_norm_op_v2 ............   Passed    7.45 sec

The following tests passed:
	test_batch_norm_op
	test_batch_norm_op_v2

100% tests passed, 0 tests failed out of 2

Total Test time (real) =  16.31 sec

3 统计了op-benchmark batch_norm 的性能情况，性能数据如下：
测试配置：fp32，NCHW格式
统计量：运行1000次，前向+反向总 gpu time (单位：ms)

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{border:.5pt solid windowtext;}
.xl66
	{border:.5pt solid windowtext;
	background:#D9D9D9;
	mso-pattern:black none;}
.xl67
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;}
.xl68
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;}
.xl69
	{color:red;
	border:.5pt solid windowtext;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#0563C1" vlink="#954F72">



Input   shape | Pytorch | Paddle before   optimization | Paddle after   optimization | Before/After | Pytorch/Paddle
-- | -- | -- | -- | -- | --
[-1L, 256L] | 8.61 | 11.64 | 9.27 | 1.26 | 0.93
[-1L, 32768L] | 23.95 | 674.54 | 26.68 | 25.28 | 0.90
[-1L, 1536L,   33L, 33L] | 1293.62 | 1284.35 | 1286.04 | 1.00 | 1.01
[-1L, 256L,   1L, 1L] | 12.45 | 11.65 | 9.34 | 1.25 | 1.33
[-1L, 32L,   256L, 256L] | 2266.70 | 2187.63 | 2187.73 | 1.00 | 1.04



</body>

</html>



由性能数据可得：
(a) 对于 H==1&&W==1 的 case，该优化带来了 1.2x 和 25x 的加速；
(b) Paddle bn 的性能基本打平或超越 PyTorch。

