### PR TITLE
Enhance error message when x or y is empty in elementwise_op

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -253,9 +253,9 @@ void CommonForwardBroadcastCPU(const framework::Tensor *x,
   const T *x_data = x->data<T>();
   const T *y_data = y->data<T>();
   PADDLE_ENFORCE_NOT_NULL(x_data, platform::errors::InvalidArgument(
-                     "The input X should not be empty.")); 
+                                      "The input X should not be empty."));
   PADDLE_ENFORCE_NOT_NULL(y_data, platform::errors::InvalidArgument(
-                         "The input Y should not be empty."));
+                                      "The input Y should not be empty."));
   OutType *out_data = z->mutable_data<OutType>(ctx.GetPlace());
 
   const int out_size = std::accumulate(out_dims_array, out_dims_array + max_dim,

--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -255,7 +255,7 @@ void CommonForwardBroadcastCPU(const framework::Tensor *x,
   PADDLE_ENFORCE_NOT_NULL(x_data, platform::errors::InvalidArgument(
                      "The input X should not be empty.")); 
   PADDLE_ENFORCE_NOT_NULL(y_data, platform::errors::InvalidArgument(
-                       "The input Y should not be empty."));
+                         "The input Y should not be empty."));
   OutType *out_data = z->mutable_data<OutType>(ctx.GetPlace());
 
   const int out_size = std::accumulate(out_dims_array, out_dims_array + max_dim,

--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -252,6 +252,10 @@ void CommonForwardBroadcastCPU(const framework::Tensor *x,
   std::vector<int> index_array(max_dim, 0);
   const T *x_data = x->data<T>();
   const T *y_data = y->data<T>();
+  PADDLE_ENFORCE_NOT_NULL(x_data, platform::errors::InvalidArgument(
+                     "The input X should not be empty.")); 
+  PADDLE_ENFORCE_NOT_NULL(y_data, platform::errors::InvalidArgument(
+                       "The input Y should not be empty."));
   OutType *out_data = z->mutable_data<OutType>(ctx.GetPlace());
 
   const int out_size = std::accumulate(out_dims_array, out_dims_array + max_dim,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

Enhance error message when x or y is empty in elementwise_op

```
import paddle
import numpy as np
paddle.set_device('cpu')

weight_arr = np.array([], dtype=np.float32)
weight = paddle.to_tensor(np.reshape(weight_arr, (1, 8, 0)))

x_arr = np.array([], dtype=np.float32)
x = paddle.to_tensor(np.reshape(x_arr, (0, 0, 0)))

y_arr = np.array([], dtype=np.float32)
y = paddle.to_tensor(np.reshape(y_arr, (0, 0, 0)))

bce_loss = paddle.nn.BCELoss(weight, 'none')
bce_loss(x, y)

# ValueError: (InvalidArgument) The input X should not be empty
```

