### PR TITLE
MemoryOptimizePass enhancement

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -124,7 +124,9 @@ void MemoryOptimizePass::CollectVarMemorySize(
     return true;
   };
 
-  // Collect unsafty tensors from graph.
+  // MemoryOptimizePass surppose input model is directed acyclic graph
+  // although it's not always the case. so black list is the best compromise
+  // between performance and underlying principle.
   std::unordered_set<std::string> black_list;
   for (auto* node : graph_->Nodes()) {
     if (node->IsVar() &&

--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -124,6 +124,7 @@ void MemoryOptimizePass::CollectVarMemorySize(
     return true;
   };
 
+  // Collect unsafty tensors from graph.
   std::unordered_set<std::string> black_list;
   for (auto* node : graph_->Nodes()) {
     if (node->IsVar() &&


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
MemoryOptimizePass的隐含前提是模型中不存在环，但是在实际使用时发现部分模型会出现重名节点。一个符合原则的修复方式是如果检测到重名那么就关闭这个pass，但是考虑到会影响推理的性能所以采用了记录节点名字的折中修复方式。

