### PR TITLE
Enhance error message for interpolate_v2

### DIFF
--- a/paddle/fluid/operators/interpolate_v2_op.cc
+++ b/paddle/fluid/operators/interpolate_v2_op.cc
@@ -35,7 +35,12 @@ static void Interpolate1DInferShapeCheck(framework::InferShapeContext* ctx) {
                         interp_method));
   const DataLayout data_layout = framework::StringToDataLayout(
       ctx->Attrs().Get<std::string>("data_layout"));
-
+  for (int i = 0; i < dim_x.size(); ++i) {
+    PADDLE_ENFORCE_NE(dim_x[i], 0, platform::errors::InvalidArgument(
+                                       "The shape of input(x) should be larged "
+                                       "than 0, bug received shape[%d] is %d ",
+                                       i, dim_x[i]));
+  }
   if (ctx->HasInputs("SizeTensor")) {
     // top prority size
     auto inputs_name = ctx->Inputs("SizeTensor");
@@ -133,6 +138,13 @@ static void Interpolate2DInferShapeCheck(framework::InferShapeContext* ctx) {
           interp_method));
   const DataLayout data_layout = framework::StringToDataLayout(
       ctx->Attrs().Get<std::string>("data_layout"));
+
+  for (int i = 0; i < dim_x.size(); ++i) {
+    PADDLE_ENFORCE_NE(dim_x[i], 0, platform::errors::InvalidArgument(
+                                       "The shape of input(x) should be larged "
+                                       "than 0, bug received shape[%d] is %d ",
+                                       i, dim_x[i]));
+  }
 
   if (ctx->HasInputs("SizeTensor")) {
     // top prority size
@@ -245,6 +257,13 @@ static void Interpolate3DInferShapeCheck(framework::InferShapeContext* ctx) {
           interp_method));
   const DataLayout data_layout = framework::StringToDataLayout(
       ctx->Attrs().Get<std::string>("data_layout"));
+
+  for (int i = 0; i < dim_x.size(); ++i) {
+    PADDLE_ENFORCE_NE(dim_x[i], 0, platform::errors::InvalidArgument(
+                                       "The shape of input(x) should be larged "
+                                       "than 0, bug received shape[%d] is %d ",
+                                       i, dim_x[i]));
+  }
 
   if (ctx->HasInputs("SizeTensor")) {
     // top prority size

--- a/python/paddle/fluid/tests/unittests/test_bicubic_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bicubic_interp_v2_op.py
@@ -517,6 +517,11 @@ class TestBicubicOpError(unittest.TestCase):
                 out = interpolate(
                     x, size={2, 2}, mode='bicubic', align_corners=False)
 
+            def test_input_shape():
+                x = fluid.data(name="x", shape=[2, 1, 0, 0], dtype="float32")
+                out = interpolate(
+                    x, size=[3, 3], mode="bicubic", align_corners=False)
+
             self.assertRaises(ValueError, test_mode_type)
             self.assertRaises(ValueError, test_input_shape)
             self.assertRaises(TypeError, test_align_corcers)
@@ -534,6 +539,7 @@ class TestBicubicOpError(unittest.TestCase):
             self.assertRaises(ValueError, test_size_and_scale)
             self.assertRaises(ValueError, test_size_and_scale2)
             self.assertRaises(TypeError, test_size_type)
+            self.assertRaises(ValueError, test_input_shape)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_v2_op.py
@@ -21,6 +21,8 @@ import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.nn.functional import interpolate
 
+np.random.seed(123)
+
 
 def trilinear_interp_np(input,
                         out_d,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix interpolate for input_shape[i] == 0

```
import paddle
import paddle.nn as nn
import numpy as np

array = []
input_data = paddle.to_tensor(np.reshape(array, (17, 10, 0, 0)), dtype='float32')
upsample_out = paddle.nn.Upsample(size=[1, 1], align_corners=False, align_mode=0)
output = upsample_out(input_data)
# ValueError: (InvalidArgument) The shape of input(x) should be larged than 0, bug received shape[2] is 0 

```