### PR TITLE
Split op oneDNN AVX2 fix

### DIFF
--- a/paddle/fluid/operators/split_op.cc
+++ b/paddle/fluid/operators/split_op.cc
@@ -85,9 +85,9 @@ class SplitOp : public framework::OperatorWithKernel {
       // 8 or 16(depending on which blocking format is used) submemory cannot be
       // created, so in that scenario a fallback is needed
       auto tmp_md = dnnl::memory::desc(
-          framework::vectorize(ctx.Input<Tensor>("X")->dims()), dnnl::data_type
-          : f32, ctx.Input<Tensor>("X")->format());
-      if (tmp_md.inner_blks != 0)
+          framework::vectorize(ctx.Input<Tensor>("X")->dims()),
+          dnnl::memory::data_type::f32, ctx.Input<Tensor>("X")->format());
+      if (tmp_md.data.format_desc.blocking.inner_nblks == 0)
         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
                                        framework::DataLayout::kMKLDNN,
                                        framework::LibraryType::kMKLDNN);

--- a/paddle/fluid/operators/split_op.cc
+++ b/paddle/fluid/operators/split_op.cc
@@ -14,7 +14,6 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/split_op.h"
 #include <string>
-#include "paddle/fluid/platform/cpu_info.h"
 
 namespace paddle {
 namespace operators {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fixed bug that was occuring when AVX2 instruction set was used. In that scenario blocking format was chosen and split op doesn't support that. It is a fix for [#33918](https://github.com/PaddlePaddle/Paddle/issues/33918)