### PR TITLE
[hybrid performance] optimize grad_add device

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -474,11 +474,13 @@ def _addup_repetitive_outputs_(op_descs, block_idx):
                 continue
             if len(renamed_vars[var_name]) > 1:
                 if len(renamed_vars[var_name]) > _MAX_ADD_NUM_:
-                    _accumulate_gradients_by_sum_op_(
-                        var_name, renamed_vars, pending_sum_ops, idx, op_device)
+                    _accumulate_gradients_by_sum_op_(var_name, renamed_vars,
+                                                     pending_sum_ops, idx,
+                                                     var_device[var_name])
                 else:
-                    _accumulate_gradients_by_add_ops_(
-                        var_name, renamed_vars, pending_sum_ops, idx, op_device)
+                    _accumulate_gradients_by_add_ops_(var_name, renamed_vars,
+                                                      pending_sum_ops, idx,
+                                                      var_device[var_name])
 
         for param_idx, param_name in enumerate(op_desc.output_names()):
             arg_names = op_desc.output(param_name)
@@ -529,7 +531,7 @@ def _addup_repetitive_outputs_(op_descs, block_idx):
                     arg_names[arg_idx] = new_name
                     op_desc.set_output(param_name, arg_names)
                     renamed_vars[var_name].append(new_name)
-                    # record the latest device, for shared param
+                    # record the latest device
                     var_device[var_name] = op_device
 
     for var_name, inputs in six.iteritems(renamed_vars):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
优化grad_add op的device属性，从使用对应梯度op的device变为生成对应梯度op的device。
效果，在pipeline并行中：
1. 当前develop
grad_add op切分到使用对应梯度op的上，在pipeline send/recv时会发送多个子梯度
![image](https://user-images.githubusercontent.com/10208305/124351722-a03eab00-dc2e-11eb-9ad6-9441333fd4b1.png)
2. PR优化
grad_add op切分到生成对应梯度op的上，在pipeline send/recv时会发送最后累加的梯度
![image](https://user-images.githubusercontent.com/10208305/124352066-9fa71400-dc30-11eb-9ef7-a2c21779cb94.png)

V100 32G，gpt2-en模型测试
卡数 | 优化 | dtype | speed(tokens/s) （S） | 提升
-- | -- | -- | -- | -- |
4卡pp | baseline | fp32 | 16522 |  
|  |  | fp16 | 30215 |  
4卡pp | grad_add设备优化 | fp32 | 16748 | 1.37%
 | | fp16 | 31304 | 3.6%