### PR TITLE
make fleet API PushDenseVarsAsync's parameter name more suitable 

### DIFF
--- a/paddle/fluid/distributed/fleet.cc
+++ b/paddle/fluid/distributed/fleet.cc
@@ -368,7 +368,7 @@ void FleetWrapper::PushDenseVarsSync(
 void FleetWrapper::PushDenseVarsAsync(
     const Scope& scope, const uint64_t table_id,
     const std::vector<std::string>& var_names,
-    std::vector<std::future<int32_t>>* push_sparse_status, float scale_datanorm,
+    std::vector<std::future<int32_t>>* push_dense_status, float scale_datanorm,
     int batch_size) {
   auto* communicator = Communicator::GetInstance();
   PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/distributed/fleet.h
+++ b/paddle/fluid/distributed/fleet.h
@@ -124,7 +124,7 @@ class FleetWrapper {
 
   void PushDenseVarsAsync(const Scope& scope, const uint64_t table_id,
                           const std::vector<std::string>& var_names,
-                          std::vector<std::future<int32_t>>* push_sparse_status,
+                          std::vector<std::future<int32_t>>* push_dense_status,
                           float scale_datanorm, int batch_size);
 
   // push dense variables to server in sync mode


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types 
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe 
<!-- Describe what this PR does -->
make fleet API PushDenseVarsAsync's parameter name more suitable 
