### PR TITLE
[OP] fix histogram op when input tensor is empty, test=develop

### DIFF
--- a/paddle/fluid/operators/histogram_op.cu
+++ b/paddle/fluid/operators/histogram_op.cu
@@ -81,6 +81,13 @@ class HistogramCUDAKernel : public framework::OpKernel<T> {
     const T* input_data = input->data<T>();
     const int input_numel = input->numel();
 
+    int64_t* out_data = output->mutable_data<int64_t>(context.GetPlace());
+    math::SetConstant<platform::CUDADeviceContext, int64_t>()(
+        context.template device_context<platform::CUDADeviceContext>(), output,
+        static_cast<int64_t>(0));
+
+    if (input_data == nullptr) return;
+
     T output_min = static_cast<T>(minval);
     T output_max = static_cast<T>(maxval);
 
@@ -125,11 +132,6 @@ class HistogramCUDAKernel : public framework::OpKernel<T> {
             "the minimum and maximum values of the data are used. "
             "But received max is %d, min is %d",
             maxval, minval));
-
-    int64_t* out_data = output->mutable_data<int64_t>(context.GetPlace());
-    math::SetConstant<platform::CUDADeviceContext, int64_t>()(
-        context.template device_context<platform::CUDADeviceContext>(), output,
-        static_cast<int64_t>(0));
 
     auto stream =
         context.template device_context<platform::CUDADeviceContext>().stream();

--- a/paddle/fluid/operators/histogram_op.h
+++ b/paddle/fluid/operators/histogram_op.h
@@ -38,6 +38,13 @@ class HistogramKernel : public framework::OpKernel<T> {
     const T* input_data = input->data<T>();
     auto input_numel = input->numel();
 
+    int64_t* out_data = output->mutable_data<int64_t>(context.GetPlace());
+    math::SetConstant<DeviceContext, int64_t>()(
+        context.template device_context<DeviceContext>(), output,
+        static_cast<int64_t>(0));
+
+    if (input_data == nullptr) return;
+
     T output_min = static_cast<T>(minval);
     T output_max = static_cast<T>(maxval);
     if (output_min == output_max) {
@@ -62,11 +69,6 @@ class HistogramKernel : public framework::OpKernel<T> {
             "the minimum and maximum values of the data are used. "
             "But received max is %d, min is %d",
             maxval, minval));
-
-    int64_t* out_data = output->mutable_data<int64_t>(context.GetPlace());
-    math::SetConstant<DeviceContext, int64_t>()(
-        context.template device_context<DeviceContext>(), output,
-        static_cast<int64_t>(0));
 
     for (int64_t i = 0; i < input_numel; i++) {
       if (input_data[i] >= output_min && input_data[i] <= output_max) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

OPs

### Describe
<!-- Describe what this PR does -->

fix histogram op when input tensor is empty, keep the same behavior with torch.