### PR TITLE
exclude lr scheduler's state from accumulators_holder

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -286,7 +286,10 @@ class Optimizer(object):
         if isinstance(self._learning_rate, LRScheduler):
             self._learning_rate.set_state_dict(state_dict["LR_Scheduler"])
 
-        state_dict.pop("LR_Scheduler")
+        # NOTE: exclude learning rate scheduler's state from 
+        # _accumulators_holder.
+        if "LR_Scheduler" in state_dict:
+            state_dict.pop("LR_Scheduler")
         self._accumulators_holder = state_dict
         for k, v in self._accumulators.items():
             for para_name, var_tmp in v.items():

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -286,6 +286,7 @@ class Optimizer(object):
         if isinstance(self._learning_rate, LRScheduler):
             self._learning_rate.set_state_dict(state_dict["LR_Scheduler"])
 
+        state_dict.pop("LR_Scheduler")
         self._accumulators_holder = state_dict
         for k, v in self._accumulators.items():
             for para_name, var_tmp in v.items():

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -288,6 +288,7 @@ class Optimizer(object):
 
         # NOTE: exclude learning rate scheduler's state from 
         # _accumulators_holder.
+        state_dict = state_dict.copy()
         if "LR_Scheduler" in state_dict:
             state_dict.pop("LR_Scheduler")
         self._accumulators_holder = state_dict


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

Fix the bug that "an optimizer that has a learning rate scheduler who has called `set_state_dict()` before any update would cause an error in `step()` afterwards."