### PR TITLE
fix some errors about pass enhance.

### DIFF
--- a/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add2_act_fuse_pass.cc
@@ -91,7 +91,8 @@ ConvElementwiseAdd2ActFusePass::ConvElementwiseAdd2ActFusePass() {
       .End()
       .AddAttr("axis")
       // the first elementwise_add-axis needs to be 1, the second has to be -1
-      .IsIntIn({1, -1})
+      // or 0
+      .IsIntIn({1, -1, 0})
       .End();
 
   AddOpCompat(OpCompat("relu"))

--- a/paddle/fluid/framework/ir/mkldnn/conv_bias_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_bias_mkldnn_fuse_pass.cc
@@ -70,7 +70,7 @@ ConvBiasFusePass::ConvBiasFusePass() {
       .IsTensor()
       .End()
       .AddAttr("axis")
-      .IsNumEQ(-1)
+      .IsIntIn({-1, 0})
       .End();
 }
 

--- a/paddle/fluid/framework/ir/squared_mat_sub_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/squared_mat_sub_fuse_pass.cc
@@ -436,7 +436,7 @@ SquaredMatSubFusePass::SquaredMatSubFusePass() {
       .IsTensor()
       .End()
       .AddAttr("axis")
-      .IsNumEQ(-1)
+      .IsIntIn({-1, 0})
       .End();
 
   AddOpCompat(OpCompat("elementwise_mul"))
@@ -450,7 +450,7 @@ SquaredMatSubFusePass::SquaredMatSubFusePass() {
       .IsTensor()
       .End()
       .AddAttr("axis")
-      .IsNumEQ(-1)
+      .IsIntIn({-1, 0})
       .End();
 
   AddOpCompat(OpCompat("fill_constant"))

--- a/paddle/fluid/operators/compat/batch_norm.pbtxt
+++ b/paddle/fluid/operators/compat/batch_norm.pbtxt
@@ -47,10 +47,6 @@ extra {
     type: BOOLEAN
   } 
   attrs {
-    name: "@ENABLE_CACHE_RUNTIME_CONTEXT@"
-    type: BOOLEAN
-  }
-  attrs {
     name: "is_test"
     type: BOOLEAN
   }

--- a/paddle/fluid/operators/compat/relu.pbtxt
+++ b/paddle/fluid/operators/compat/relu.pbtxt
@@ -13,6 +13,10 @@ extra {
     type: BOOLEAN
   }
   attrs {
+    name: "X0_threshold"
+    type: FLOAT
+  }
+  attrs {
     name: "out_threshold"
     type: FLOAT
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修正了一下pass中的前置条件书写不完善的情况，主要是针对 elementwise_* op的axis属性，当两个输入维度相等时，axis的取值条件应该是等于0或者-1，而不是直接等于-1。