### PR TITLE
[NPU] add Wait after TensorCopy in uniform_random NPU OP

### DIFF
--- a/paddle/fluid/operators/uniform_random_op_npu.cc
+++ b/paddle/fluid/operators/uniform_random_op_npu.cc
@@ -56,10 +56,13 @@ class NPUUniformRandomKernel : public framework::OpKernel<T> {
           "unsupport type: %s.",
           framework::ToTypeName(out_var->Type())));
     }
-    T *data = tensor->mutable_data<T>(ctx.GetPlace());
-
+    tensor->mutable_data<T>(ctx.GetPlace());
     int64_t size = tensor->numel();
-    std::unique_ptr<T[]> data_cpu(new T[size]);
+
+    Tensor cpu_tensor(tensor->type());
+    cpu_tensor.Resize(tensor->dims());
+    T *data_cpu = cpu_tensor.mutable_data<T>(platform::CPUPlace());
+
     std::uniform_real_distribution<T> dist(
         static_cast<T>(ctx.Attr<float>("min")),
         static_cast<T>(ctx.Attr<float>("max")));
@@ -90,12 +93,10 @@ class NPUUniformRandomKernel : public framework::OpKernel<T> {
     }
 
     // copy to NPU
-    auto stream =
-        ctx.template device_context<paddle::platform::NPUDeviceContext>()
-            .stream();
-    memory::Copy(BOOST_GET_CONST(platform::NPUPlace, ctx.GetPlace()), data,
-                 platform::CPUPlace(), reinterpret_cast<void *>(data_cpu.get()),
-                 size * sizeof(T), stream);
+    framework::TensorCopy(
+        cpu_tensor, ctx.GetPlace(),
+        ctx.template device_context<platform::DeviceContext>(), tensor);
+    ctx.template device_context<paddle::platform::NPUDeviceContext>().Wait();
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
@@ -67,7 +67,7 @@ class TestNPUUniformRandomOp(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_customized(self.verify_output)
+        self.check_output_customized(self.verify_output, self.place)
 
     def verify_output(self, outs):
         hist, prob = self.output_hist(np.array(outs[0]))

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -1357,8 +1357,10 @@ class OpTest(unittest.TestCase):
             if self.op_type not in compile_vs_runtime_white_list.COMPILE_RUN_OP_WHITE_LIST:
                 self.check_compile_vs_runtime(fetch_list, outs)
 
-    def check_output_customized(self, checker):
+    def check_output_customized(self, checker, custom_place=None):
         places = self._get_places()
+        if custom_place:
+            places.append(custom_place)
         for place in places:
             outs = self.calc_output(place)
             outs = [np.array(out) for out in outs]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

CI单测有好多个挂了test_gelu_op_npu、test_matmulv2_op_npu、test_mul_op_npu、test_pow_op_npu、test_reduce_sum_op_npu、test_relu_op_npu、test_sgd_op_npu。
定位到是uniform random中数据拷贝错误导致的。

- CPU到NPU的数据拷贝后，加Wait，防止数据拷贝出错


uniform_random单测中使用`check_output_customized`检查，不支持传入NPUPlace，所以检查不了在NPU上执行的情况。
- 为`check_output_customized`添加传入place的参数。
<img width="653" alt="图片" src="https://user-images.githubusercontent.com/26408901/124726245-29f8bc00-df40-11eb-8e9b-1ee9ec278481.png">
