### PR TITLE
Use CBLAS for SelectedRows elementwise add operation.

### DIFF
--- a/paddle/fluid/operators/math/selected_rows_functor.cc
+++ b/paddle/fluid/operators/math/selected_rows_functor.cc
@@ -302,15 +302,15 @@ namespace scatter {
 
 #ifdef PADDLE_WITH_MKLDNN
 template <typename T>
-typename std::enable_if<std::is_same<T, float>::value ||
-                        std::is_same<T, platform::bfloat16>::value>::type
+typename std::enable_if<std::is_same<T, platform::bfloat16>::value>::type
 elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   onednn_handler_axpy(data_len, T(1.f), in, out);
 }
 
 template <typename T>
-typename std::enable_if<std::is_same<T, double>::value ||
+typename std::enable_if<std::is_same<T, float>::value ||
+                        std::is_same<T, double>::value ||
                         std::is_same<T, platform::complex<float>>::value ||
                         std::is_same<T, platform::complex<double>>::value>::type
 elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,

--- a/paddle/fluid/operators/math/selected_rows_functor.cc
+++ b/paddle/fluid/operators/math/selected_rows_functor.cc
@@ -300,12 +300,15 @@ template struct SelectedRowsAddToTensor<platform::CPUDeviceContext,
 // add or mul.
 namespace scatter {
 
-#ifdef PADDLE_WITH_MKLDNN
 template <typename T>
 typename std::enable_if<std::is_same<T, platform::bfloat16>::value>::type
 elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
+#ifdef PADDLE_WITH_MKLDNN
   onednn_handler_axpy(data_len, T(1.f), in, out);
+#else
+  blas->AXPY(data_len, T(1.f), in, out);
+#endif
 }
 
 template <typename T>
@@ -317,16 +320,6 @@ elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   blas->AXPY(data_len, T(1.f), in, out);
 }
-#else
-template <typename T>
-typename std::enable_if<std::is_floating_point<T>::value ||
-                        std::is_same<T, platform::complex<float>>::value ||
-                        std::is_same<T, platform::complex<double>>::value>::type
-elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
-                   const T* in, T* out) {
-  blas->AXPY(data_len, T(1.f), in, out);
-}
-#endif
 
 template <typename T>
 typename std::enable_if<std::is_integral<T>::value>::type elementwise_add_to(

--- a/paddle/fluid/operators/math/selected_rows_functor.cc
+++ b/paddle/fluid/operators/math/selected_rows_functor.cc
@@ -307,6 +307,7 @@ elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   onednn_handler_axpy(data_len, T(1.f), in, out);
 }
+#endif
 
 template <typename T>
 typename std::enable_if<std::is_same<T, float>::value ||
@@ -317,16 +318,6 @@ elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   blas->AXPY(data_len, T(1.f), in, out);
 }
-#else
-template <typename T>
-typename std::enable_if<std::is_floating_point<T>::value ||
-                        std::is_same<T, platform::complex<float>>::value ||
-                        std::is_same<T, platform::complex<double>>::value>::type
-elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
-                   const T* in, T* out) {
-  blas->AXPY(data_len, T(1.f), in, out);
-}
-#endif
 
 template <typename T>
 typename std::enable_if<std::is_integral<T>::value>::type elementwise_add_to(

--- a/paddle/fluid/operators/math/selected_rows_functor.cc
+++ b/paddle/fluid/operators/math/selected_rows_functor.cc
@@ -300,12 +300,14 @@ template struct SelectedRowsAddToTensor<platform::CPUDeviceContext,
 // add or mul.
 namespace scatter {
 
+#ifdef PADDLE_WITH_MKLDNN
 template <typename T>
 typename std::enable_if<std::is_same<T, platform::bfloat16>::value>::type
 elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   onednn_handler_axpy(data_len, T(1.f), in, out);
 }
+#endif
 
 template <typename T>
 typename std::enable_if<std::is_same<T, float>::value ||
@@ -559,8 +561,10 @@ template struct MergeAdd<platform::CPUDeviceContext,
                          paddle::platform::complex<float>>;
 template struct MergeAdd<platform::CPUDeviceContext,
                          paddle::platform::complex<double>>;
+#ifdef PADDLE_WITH_MKLDNN
 template struct MergeAdd<platform::CPUDeviceContext,
                          paddle::platform::bfloat16>;
+#endif
 
 template struct MergeAverage<platform::CPUDeviceContext, int>;
 template struct MergeAverage<platform::CPUDeviceContext, int64_t>;

--- a/paddle/fluid/operators/math/selected_rows_functor.cc
+++ b/paddle/fluid/operators/math/selected_rows_functor.cc
@@ -300,14 +300,12 @@ template struct SelectedRowsAddToTensor<platform::CPUDeviceContext,
 // add or mul.
 namespace scatter {
 
-#ifdef PADDLE_WITH_MKLDNN
 template <typename T>
 typename std::enable_if<std::is_same<T, platform::bfloat16>::value>::type
 elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   onednn_handler_axpy(data_len, T(1.f), in, out);
 }
-#endif
 
 template <typename T>
 typename std::enable_if<std::is_same<T, float>::value ||

--- a/paddle/fluid/operators/math/selected_rows_functor.cc
+++ b/paddle/fluid/operators/math/selected_rows_functor.cc
@@ -307,7 +307,6 @@ elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   onednn_handler_axpy(data_len, T(1.f), in, out);
 }
-#endif
 
 template <typename T>
 typename std::enable_if<std::is_same<T, float>::value ||
@@ -318,6 +317,16 @@ elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
                    const T* in, T* out) {
   blas->AXPY(data_len, T(1.f), in, out);
 }
+#else
+template <typename T>
+typename std::enable_if<std::is_floating_point<T>::value ||
+                        std::is_same<T, platform::complex<float>>::value ||
+                        std::is_same<T, platform::complex<double>>::value>::type
+elementwise_add_to(BlasT<platform::CPUDeviceContext, T>* blas, size_t data_len,
+                   const T* in, T* out) {
+  blas->AXPY(data_len, T(1.f), in, out);
+}
+#endif
 
 template <typename T>
 typename std::enable_if<std::is_integral<T>::value>::type elementwise_add_to(
@@ -561,10 +570,8 @@ template struct MergeAdd<platform::CPUDeviceContext,
                          paddle::platform::complex<float>>;
 template struct MergeAdd<platform::CPUDeviceContext,
                          paddle::platform::complex<double>>;
-#ifdef PADDLE_WITH_MKLDNN
 template struct MergeAdd<platform::CPUDeviceContext,
                          paddle::platform::bfloat16>;
-#endif
 
 template struct MergeAverage<platform::CPUDeviceContext, int>;
 template struct MergeAverage<platform::CPUDeviceContext, int64_t>;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR is taken from #33879. This PR gets back CBLAS library usage for float data type for SelectedRows tensors for elementwise add operation as it is faster.