### PR TITLE
[pass_enhance] add global extra attributes for op def.

### DIFF
--- a/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
@@ -19,6 +19,15 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_def_api.h"
 #include "paddle/fluid/framework/op_info.h"
 
+namespace {
+std::unordered_set<std::string> global_extra_attrs = {
+    "op_role",       "op_role_var",      "op_namescope",
+    "op_callstack",  "op_device",        "@ENABLE_CACHE_RUNTIME_CONTEXT@",
+    "is_test",       "use_mkldnn",       "mkldnn_data_type",
+    "use_quantizer", "mkldnn_data_type", "use_cudnn",
+    "name"};
+}
+
 namespace paddle {
 namespace framework {
 namespace ir {
@@ -171,7 +180,8 @@ bool OpCompat::Judge(const OpDesc& op_desc) {
 
   for (auto& attr_map : op_desc.GetAttrMap()) {
     if (attr_compats_.find(attr_map.first) == attr_compats_.end()) {
-      if (extra_attrs_.find(attr_map.first) != extra_attrs_.end()) {
+      if (global_extra_attrs.find(attr_map.first) != global_extra_attrs.end() ||
+          extra_attrs_.find(attr_map.first) != extra_attrs_.end()) {
         continue;
       }
       if (!AttrCompat(attr_map.first, this).IsLeftDefault()(op_desc)) {

--- a/paddle/fluid/operators/compat/affine_channel.pbtxt
+++ b/paddle/fluid/operators/compat/affine_channel.pbtxt
@@ -17,25 +17,3 @@ def {
     name: "Out"
   }
 }
-extra {
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
-  }
-}

--- a/paddle/fluid/operators/compat/batch_norm.pbtxt
+++ b/paddle/fluid/operators/compat/batch_norm.pbtxt
@@ -15,6 +15,9 @@ def {
   inputs {
     name: "Variance"
   }
+  inputs {
+    name: "MomentumTensor"
+  }
   outputs {
     name: "Y"
   }
@@ -39,28 +42,17 @@ def {
   }
 }
 extra {
-  inputs {
-    name: "MomentumTensor"
-  }
-   attrs {
-    name: "@ENABLE_CACHE_RUNTIME_CONTEXT@"
-    type: BOOLEAN
-  } 
-  attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
   attrs {
     name: "momentum"
     type: FLOAT
   }
   attrs {
-    name: "data_layout"
-    type: STRING
+    name: "Y0_threshold"
+    type: FLOAT
   }
   attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
+    name: "data_layout"
+    type: STRING
   }
   attrs {
     name: "fuse_with_relu"
@@ -73,26 +65,6 @@ extra {
   attrs {
     name: "trainable_statistics"
     type: BOOLEAN
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
 }
 

--- a/paddle/fluid/operators/compat/concat.pbtxt
+++ b/paddle/fluid/operators/compat/concat.pbtxt
@@ -14,37 +14,3 @@ def {
     type: INT
   }
 }
-extra {
-  attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
-    type: STRING
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
-  }
-}

--- a/paddle/fluid/operators/compat/conv2d.pbtxt
+++ b/paddle/fluid/operators/compat/conv2d.pbtxt
@@ -46,6 +46,14 @@ extra {
     type: FLOAT
   }
   attrs {
+    name: "Input0_threshold"
+    type: FLOAT
+  }
+  attrs {
+    name: "weight_scale"
+    type: FLOAT
+  }
+  attrs {
     name: "quantization_type"
     type: STRING
   } 
@@ -58,40 +66,12 @@ extra {
     type: FLOAT
   }
   attrs {
-    name: "@ENABLE_CACHE_RUNTIME_CONTEXT@"
-    type: BOOLEAN
-  } 
-  attrs {
     name: "skip_quant"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "name"
-    type: STRING
-  }
-  attrs {
-    name: "use_cudnn"
     type: BOOLEAN
   }
   attrs {
     name: "fuse_relu_before_depthwise_conv"
     type: BOOLEAN
-  }
-  attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
-    type: STRING
   }
   attrs {
     name: "fuse_relu"
@@ -152,26 +132,6 @@ extra {
   attrs {
     name: "exhaustive_search"
     type: BOOLEAN
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
 }
 

--- a/paddle/fluid/operators/compat/conv2d_transpose.pbtxt
+++ b/paddle/fluid/operators/compat/conv2d_transpose.pbtxt
@@ -47,24 +47,8 @@ def {
 }
 extra {
   attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_cudnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
     name: "force_fp32_output"
     type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
-    type: STRING
   }
   attrs {
     name: "fuse_relu"
@@ -85,26 +69,6 @@ extra {
   attrs {
     name: "workspace_size_MB"
     type: INT
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
 }
 

--- a/paddle/fluid/operators/compat/conv3d.pbtxt
+++ b/paddle/fluid/operators/compat/conv3d.pbtxt
@@ -6,6 +6,9 @@ def {
   inputs {
     name: "Filter"
   }
+  inputs {
+    name: "ResidualData"
+  }
   outputs {
     name: "Output"
   }
@@ -35,32 +38,9 @@ def {
   }
 }
 extra {
-  inputs {
-    name: "ResidualData"
-  }
-  attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_cudnn"
-    type: BOOLEAN
-  }
   attrs {
     name: "fuse_relu_before_depthwise_conv"
     type: BOOLEAN
-  }
-  attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
-    type: STRING
   }
   attrs {
     name: "fuse_relu"

--- a/paddle/fluid/operators/compat/cvm.pbtxt
+++ b/paddle/fluid/operators/compat/cvm.pbtxt
@@ -14,26 +14,4 @@ def {
     type: BOOLEAN
   }
 }
-extra {
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
-  }
-}
 

--- a/paddle/fluid/operators/compat/depthwise_conv2d.pbtxt
+++ b/paddle/fluid/operators/compat/depthwise_conv2d.pbtxt
@@ -58,40 +58,12 @@ extra {
     type: FLOAT
   }
   attrs {
-    name: "@ENABLE_CACHE_RUNTIME_CONTEXT@"
-    type: BOOLEAN
-  } 
-  attrs {
     name: "skip_quant"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "name"
-    type: STRING
-  }
-  attrs {
-    name: "use_cudnn"
     type: BOOLEAN
   }
   attrs {
     name: "fuse_relu_before_depthwise_conv"
     type: BOOLEAN
-  }
-  attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
-    type: STRING
   }
   attrs {
     name: "fuse_relu"
@@ -152,26 +124,6 @@ extra {
   attrs {
     name: "exhaustive_search"
     type: BOOLEAN
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
 }
 

--- a/paddle/fluid/operators/compat/elementwise_add.pbtxt
+++ b/paddle/fluid/operators/compat/elementwise_add.pbtxt
@@ -16,10 +16,6 @@ def {
 }
 extra {
   attrs {
-    name: "@ENABLE_CACHE_RUNTIME_CONTEXT@"
-    type: BOOLEAN
-  }
-  attrs {
     name: "out_threshold"
     type: FLOAT
   }
@@ -38,19 +34,6 @@ extra {
     # no longer to use
   }
   attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-    # no longer to use, Use 'mkldnn_data_type' instead.
-  }
-  attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
-    type: STRING
-  }
-  attrs {
     name: "Scale_x"
     type: FLOAT
   }
@@ -61,25 +44,5 @@ extra {
   attrs {
     name: "Scale_out"
     type: FLOAT
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
 }

--- a/paddle/fluid/operators/compat/elementwise_div.pbtxt
+++ b/paddle/fluid/operators/compat/elementwise_div.pbtxt
@@ -16,23 +16,11 @@ def {
 }
 extra {
   attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
     name: "x_data_format"
     type: STRING
   }
   attrs {
     name: "y_data_format"
-    type: STRING
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
     type: STRING
   }
   attrs {
@@ -46,26 +34,6 @@ extra {
   attrs {
     name: "Scale_out"
     type: FLOAT
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
   attrs {
     name: "act"

--- a/paddle/fluid/operators/compat/elementwise_mul.pbtxt
+++ b/paddle/fluid/operators/compat/elementwise_mul.pbtxt
@@ -15,24 +15,12 @@ def {
   }
 }
 extra {
- attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
   attrs {
     name: "x_data_format"
     type: STRING
   }
   attrs {
     name: "y_data_format"
-    type: STRING
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
     type: STRING
   }
   attrs {
@@ -46,25 +34,5 @@ extra {
   attrs {
     name: "Scale_out"
     type: FLOAT
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
 }

--- a/paddle/fluid/operators/compat/elementwise_pow.pbtxt
+++ b/paddle/fluid/operators/compat/elementwise_pow.pbtxt
@@ -16,23 +16,11 @@ def {
 }
 extra {
   attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
     name: "x_data_format"
     type: STRING
   }
   attrs {
     name: "y_data_format"
-    type: STRING
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
     type: STRING
   }
   attrs {
@@ -46,26 +34,6 @@ extra {
   attrs {
     name: "Scale_out"
     type: FLOAT
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
   attrs {
     name: "act"

--- a/paddle/fluid/operators/compat/elementwise_sub.pbtxt
+++ b/paddle/fluid/operators/compat/elementwise_sub.pbtxt
@@ -16,23 +16,11 @@ def {
 }
 extra {
   attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
     name: "x_data_format"
     type: STRING
   }
   attrs {
     name: "y_data_format"
-    type: STRING
-  }
-  attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
     type: STRING
   }
   attrs {
@@ -46,26 +34,6 @@ extra {
   attrs {
     name: "Scale_out"
     type: FLOAT
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
   attrs {
     name: "act"

--- a/paddle/fluid/operators/compat/fake_channel_wise_dequantize_max_abs.pbtxt
+++ b/paddle/fluid/operators/compat/fake_channel_wise_dequantize_max_abs.pbtxt
@@ -18,30 +18,3 @@ def {
     type: INT
   }
 }
-extra {
-  attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
-  }
-}
-

--- a/paddle/fluid/operators/compat/fake_channel_wise_quantize_abs_max.pbtxt
+++ b/paddle/fluid/operators/compat/fake_channel_wise_quantize_abs_max.pbtxt
@@ -18,29 +18,3 @@ def {
     type: INT
   }
 }
-extra {
-  attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
-  }
-}

--- a/paddle/fluid/operators/compat/relu.pbtxt
+++ b/paddle/fluid/operators/compat/relu.pbtxt
@@ -8,9 +8,9 @@ def {
   }
 }
 extra {
-    attrs {
-    name: "@ENABLE_CACHE_RUNTIME_CONTEXT@"
-    type: BOOLEAN
+  attrs {
+    name: "X0_threshold"
+    type: FLOAT
   }
   attrs {
     name: "X0_threshold"
@@ -23,41 +23,5 @@ extra {
   attrs {
     name: "Out0_threshold"
     type: FLOAT
-  }
-  attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_cudnn"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
-  }
-  attrs {
-    name: "is_test"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "name"
-    type: STRINGS
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
pass专项相关：
考虑到op def里面的extra 属性存在大面积的重复，因此，提炼出一个 全局的extra 属性。表示在所有op里面，该属性都是extra的。
全局extra属性主要包括opmarker的基类里面添加的一些类似 "op_callback" 的用以调试的属性，以及部分奇特的pass会给所有op都添加的类似 “is_test”、“use_mkldnn”之类的环境属性。