### PR TITLE
add persistent_workers

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -382,9 +382,9 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         while self._resume_worker_cnt > 0:
             time.sleep(0.5)
 
-        # 2. Resume blocking_queue, clear blocking_queue caches
-        # reset blocking_queue to clear cache
-        # self._blocking_queue.reset()
+        # 2. clear blocking_queue caches
+        # in order not to restart the thread, we just clear
+        # the blocking_queue cachees instead of recreating one
         while self._blocking_queue.size() >= len(self._places):
             if in_dygraph_mode():
                 self._reader.read_next_var_list()
@@ -394,9 +394,6 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                 data = self._reader.read_next()
 
         # 3. reset all states
-        # data get from _data_queue will be reordered by _rcvd_idx
-        # for data order keeping, data index not equal _rcvd_idx 
-        # will be cached in _task_infos
         self._send_idx = 0
         self._rcvd_idx = 0
         self._batches_outstanding = 0

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -383,9 +383,15 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
             time.sleep(0.5)
 
         # 2. Resume blocking_queue, clear blocking_queue caches
-        # reset blocking_queue and py_reader
+        # reset blocking_queue to clear cache
         # self._blocking_queue.reset()
-        # self._reader.reset()
+        while self._blocking_queue.size() >= len(self._places):
+            if in_dygraph_mode():
+                self._reader.read_next_var_list()
+            elif self._return_list:
+                self._reader.read_next_list()
+            else:
+                data = self._reader.read_next()
 
         # 3. reset all states
         # data get from _data_queue will be reordered by _rcvd_idx
@@ -522,9 +528,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                         # NOTE: _rcvd_idx and _send_idx only record batches among
                         #       workers, if batches among workers drained, there
                         #       may also be data in blocking queue
-                        if self._batches_outstanding < len(
-                                # self._places) and not self._persistent_workers:
-                                self._places):
+                        if self._batches_outstanding < len(self._places):
                             return None
                         continue
 

--- a/python/paddle/fluid/dataloader/worker.py
+++ b/python/paddle/fluid/dataloader/worker.py
@@ -297,7 +297,7 @@ def _worker_loop(dataset, dataset_kind, indices_queue, out_queue, done_event,
                 continue
 
             if isinstance(data, _ResumeIteration):
-                out_queue.put((data, None))
+                out_queue.put((data, None, None))
                 iterator_drained = False
                 fetcher = _DatasetKind.create_fetcher(
                     dataset_kind, dataset, auto_collate_batch, collate_fn, True)

--- a/python/paddle/fluid/dataloader/worker.py
+++ b/python/paddle/fluid/dataloader/worker.py
@@ -36,6 +36,10 @@ class _IterableDatasetStopIteration(object):
         self.worker_id = worker_id
 
 
+class _ResumeIteration(object):
+    pass
+
+
 class _DatasetKind(object):
     MAP = 0
     ITER = 1
@@ -290,6 +294,13 @@ def _worker_loop(dataset, dataset_kind, indices_queue, out_queue, done_event,
             try:
                 data = indices_queue.get(MP_STATUS_CHECK_INTERVAL)
             except queue.Empty:
+                continue
+
+            if isinstance(data, _ResumeIteration):
+                out_queue.put((data, None))
+                iterator_drained = False
+                fetcher = _DatasetKind.create_fetcher(
+                    dataset_kind, dataset, auto_collate_batch, collate_fn, True)
                 continue
 
             # None as poison piil, so worker event should be set

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -325,7 +325,8 @@ class DataLoader(object):
                  use_buffer_reader=True,
                  use_shared_memory=True,
                  timeout=0,
-                 worker_init_fn=None):
+                 worker_init_fn=None,
+                 persistent_workers=False):
         self.return_list = return_list
         self.collate_fn = collate_fn
         self.use_buffer_reader = use_buffer_reader
@@ -407,6 +408,9 @@ class DataLoader(object):
             self.pin_memory = True if use_pinned_memory(
             ) is None else use_pinned_memory()
 
+        self._persistent_workers = persistent_workers
+        self._iterator = None
+
     def __len__(self):
         if self.dataset_kind == _DatasetKind.ITER:
             raise ValueError("length of IterableDataset not supported")
@@ -419,6 +423,12 @@ class DataLoader(object):
     def __iter__(self):
         if self.num_workers == 0:
             return _DataLoaderIterSingleProcess(self)
+        elif self._persistent_workers:
+            if self._iterator is None:
+                self._iterator = _DataLoaderIterMultiProcess(self)
+            else:
+                self._iterator._reset()
+            return self._iterator
         else:
             return _DataLoaderIterMultiProcess(self)
 

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
@@ -114,7 +114,8 @@ class TestDygraphDataLoader(unittest.TestCase):
             for persistent_workers in [False, True]:
                 results = []
                 for num_workers in [0, 2]:
-                    print(self.__class__.__name__, p, num_workers)
+                    print(self.__class__.__name__, p, num_workers,
+                          persistent_workers)
                     sys.stdout.flush()
                     ret = self.run_main(
                         num_workers=num_workers,

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
@@ -66,7 +66,7 @@ class SimpleFCNet(fluid.dygraph.Layer):
 
 
 class TestDygraphDataLoader(unittest.TestCase):
-    def run_main(self, num_workers, places):
+    def run_main(self, num_workers, places, persistent_workers):
         fluid.default_startup_program().random_seed = 1
         fluid.default_main_program().random_seed = 1
         with fluid.dygraph.guard(places[0]):
@@ -78,7 +78,8 @@ class TestDygraphDataLoader(unittest.TestCase):
                 dataset,
                 num_workers=num_workers,
                 batch_size=BATCH_SIZE,
-                drop_last=True)
+                drop_last=True,
+                persistent_workers=persistent_workers)
             assert len(dataloader) == int(SAMPLE_NUM / BATCH_SIZE)
 
             step_list = []
@@ -110,20 +111,24 @@ class TestDygraphDataLoader(unittest.TestCase):
     def test_main(self):
         # dynamic graph do not run with_data_parallel
         for p in prepare_places(False):
-            results = []
-            for num_workers in [0, 2]:
-                print(self.__class__.__name__, p, num_workers)
-                sys.stdout.flush()
-                ret = self.run_main(num_workers=num_workers, places=p)
-                results.append(ret)
-            diff = np.max(
-                np.abs(results[0]['loss'] - results[1]['loss']) /
-                np.abs(results[0]['loss']))
-            self.assertLess(diff, 1e-2)
+            for persistent_workers in [False, True]:
+                results = []
+                for num_workers in [0, 2]:
+                    print(self.__class__.__name__, p, num_workers)
+                    sys.stdout.flush()
+                    ret = self.run_main(
+                        num_workers=num_workers,
+                        places=p,
+                        persistent_workers=persistent_workers)
+                    results.append(ret)
+                diff = np.max(
+                    np.abs(results[0]['loss'] - results[1]['loss']) /
+                    np.abs(results[0]['loss']))
+                self.assertLess(diff, 1e-2)
 
 
 class TestDygraphDataLoaderWithBatchedDataset(TestDygraphDataLoader):
-    def run_main(self, num_workers, places):
+    def run_main(self, num_workers, places, persistent_workers):
         fluid.default_startup_program().random_seed = 1
         fluid.default_main_program().random_seed = 1
         with fluid.dygraph.guard(places[0]):
@@ -135,7 +140,8 @@ class TestDygraphDataLoaderWithBatchedDataset(TestDygraphDataLoader):
                 dataset,
                 num_workers=num_workers,
                 batch_size=None,
-                drop_last=True)
+                drop_last=True,
+                persistent_workers=persistent_workers)
             assert len(dataloader) == int(SAMPLE_NUM / BATCH_SIZE)
 
             step_list = []

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
@@ -66,7 +66,7 @@ class SimpleFCNet(fluid.dygraph.Layer):
 
 
 class TestDygraphDataLoader(unittest.TestCase):
-    def run_main(self, num_workers, places):
+    def run_main(self, num_workers, places, persistent_workers):
         fluid.default_startup_program().random_seed = 1
         fluid.default_main_program().random_seed = 1
         with fluid.dygraph.guard(places[0]):
@@ -78,7 +78,8 @@ class TestDygraphDataLoader(unittest.TestCase):
                 dataset,
                 num_workers=num_workers,
                 batch_size=BATCH_SIZE,
-                drop_last=True)
+                drop_last=True,
+                persistent_workers=persistent_workers)
 
             step_list = []
             loss_list = []
@@ -109,18 +110,22 @@ class TestDygraphDataLoader(unittest.TestCase):
     def test_main(self):
         # dynamic graph do not run with_data_parallel
         for p in prepare_places(False):
-            results = []
-            for num_workers in [0, 2]:
-                print(self.__class__.__name__, p, num_workers)
-                sys.stdout.flush()
-                ret = self.run_main(num_workers=num_workers, places=p)
-                results.append(ret)
-            assert results[0]['loss'].shape[0] * 2 == results[1]['loss'].shape[
-                0]
+            for persistent_workers in [False, True]:
+                results = []
+                for num_workers in [0, 2]:
+                    print(self.__class__.__name__, p, num_workers)
+                    sys.stdout.flush()
+                    ret = self.run_main(
+                        num_workers=num_workers,
+                        places=p,
+                        persistent_workers=persistent_workers)
+                    results.append(ret)
+                assert results[0]['loss'].shape[0] * 2 == results[1][
+                    'loss'].shape[0]
 
 
 class TestDygraphDataLoaderWithBatchedDataset(TestDygraphDataLoader):
-    def run_main(self, num_workers, places):
+    def run_main(self, num_workers, places, persistent_workers):
         fluid.default_startup_program().random_seed = 1
         fluid.default_main_program().random_seed = 1
         with fluid.dygraph.guard(places[0]):
@@ -132,7 +137,8 @@ class TestDygraphDataLoaderWithBatchedDataset(TestDygraphDataLoader):
                 dataset,
                 num_workers=num_workers,
                 batch_size=None,
-                drop_last=True)
+                drop_last=True,
+                persistent_workers=persistent_workers)
 
             step_list = []
             loss_list = []

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
@@ -113,7 +113,8 @@ class TestDygraphDataLoader(unittest.TestCase):
             for persistent_workers in [False, True]:
                 results = []
                 for num_workers in [0, 2]:
-                    print(self.__class__.__name__, p, num_workers)
+                    print(self.__class__.__name__, p, num_workers,
+                          persistent_workers)
                     sys.stdout.flush()
                     ret = self.run_main(
                         num_workers=num_workers,

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_static.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_static.py
@@ -93,7 +93,7 @@ def prepare_places(with_data_parallel, with_cpu=False, with_gpu=True):
     if with_gpu and fluid.core.is_compiled_with_cuda():
         tmp = fluid.cuda_places()[:2]
         assert len(tmp) > 0, "no gpu detected"
-        if with_data_parallel:
+        if with_data_parallel and len(tmp) > 1:
             places.append(tmp)
         places.append([tmp[0]])
     return places
@@ -162,7 +162,8 @@ class TestStaticDataLoader(unittest.TestCase):
             for persistent_workers in [False, True]:
                 results = []
                 for num_workers in [0, 2]:
-                    print(self.__class__.__name__, p, num_workers)
+                    print(self.__class__.__name__, p, num_workers,
+                          persistent_workers)
                     sys.stdout.flush()
                     ret = self.run_main(
                         num_workers=num_workers,

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
@@ -94,7 +94,7 @@ def prepare_places(with_data_parallel, with_cpu=False, with_gpu=True):
     if with_gpu and fluid.core.is_compiled_with_cuda():
         tmp = fluid.cuda_places()[:2]
         assert len(tmp) > 0, "no gpu detected"
-        if with_data_parallel:
+        if with_data_parallel and len(tmp) > 1:
             places.append(tmp)
         places.append([tmp[0]])
     return places
@@ -166,7 +166,8 @@ class TestStaticDataLoader(unittest.TestCase):
             for persistent_workers in [True, False]:
                 results = []
                 for num_workers in [0, 2]:
-                    print(self.__class__.__name__, p, num_workers)
+                    print(self.__class__.__name__, p, num_workers,
+                          persistent_workers)
                     sys.stdout.flush()
                     ret = self.run_main(
                         num_workers=num_workers,

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
@@ -101,7 +101,7 @@ def prepare_places(with_data_parallel, with_cpu=False, with_gpu=True):
 
 
 class TestStaticDataLoader(unittest.TestCase):
-    def run_main(self, num_workers, places, use_pe=True):
+    def run_main(self, num_workers, places, persistent_workers, use_pe=True):
         scope = fluid.Scope()
         with fluid.scope_guard(scope):
             startup_prog, main_prog, image, label, loss = simple_fc_net_static()
@@ -114,7 +114,8 @@ class TestStaticDataLoader(unittest.TestCase):
                 num_workers=num_workers,
                 batch_size=BATCH_SIZE,
                 return_list=False,
-                drop_last=True)
+                drop_last=True,
+                persistent_workers=persistent_workers)
             assert len(dataloader) == int(SAMPLE_NUM / BATCH_SIZE)
 
             exe = fluid.Executor(place=places[0])
@@ -162,16 +163,20 @@ class TestStaticDataLoader(unittest.TestCase):
 
     def test_main(self):
         for p in prepare_places(True):
-            results = []
-            for num_workers in [0, 2]:
-                print(self.__class__.__name__, p, num_workers)
-                sys.stdout.flush()
-                ret = self.run_main(num_workers=num_workers, places=p)
-                results.append(ret)
-            diff = np.max(
-                np.abs(results[0]['loss'] - results[1]['loss']) /
-                np.abs(results[0]['loss']))
-            self.assertLess(diff, 1e-2)
+            for persistent_workers in [True, False]:
+                results = []
+                for num_workers in [0, 2]:
+                    print(self.__class__.__name__, p, num_workers)
+                    sys.stdout.flush()
+                    ret = self.run_main(
+                        num_workers=num_workers,
+                        places=p,
+                        persistent_workers=persistent_workers)
+                    results.append(ret)
+                diff = np.max(
+                    np.abs(results[0]['loss'] - results[1]['loss']) /
+                    np.abs(results[0]['loss']))
+                self.assertLess(diff, 1e-2)
 
 
 class TestStaticDataLoaderReturnList(unittest.TestCase):
@@ -241,7 +246,7 @@ class RandomBatchedDataset(Dataset):
 
 
 class TestStaticDataLoaderWithBatchedDataset(TestStaticDataLoader):
-    def run_main(self, num_workers, places):
+    def run_main(self, num_workers, places, persistent_workers):
         scope = fluid.Scope()
         with fluid.scope_guard(scope):
             startup_prog, main_prog, image, label, loss = simple_fc_net_static()
@@ -254,7 +259,8 @@ class TestStaticDataLoaderWithBatchedDataset(TestStaticDataLoader):
                 num_workers=num_workers,
                 batch_size=None,
                 return_list=False,
-                drop_last=True)
+                drop_last=True,
+                persistent_workers=persistent_workers)
             assert len(dataloader) == int(SAMPLE_NUM / BATCH_SIZE)
 
             exe = fluid.Executor(place=places[0])


### PR DESCRIPTION
### PR types
New features 

### PR changes
APIs

### Describe

**Add persistent_workers argument for DataLoader**
- when `persistent_workers=True`，in `persistent_workers`, worker processes will be resued among epoches, which mean DataLoader only start workers in DataLoader `__init__` and stop workers when program end, workers remain alive cross epoches
