### PR TITLE
【No Merge】python端开启`FLAG_convert_all_blocks`用于多Block下Graph与Program互转

### DIFF
--- a/paddle/fluid/framework/ir/graph.cc
+++ b/paddle/fluid/framework/ir/graph.cc
@@ -21,6 +21,12 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
+bool GetGflagConvertAllBlocks() { return FLAGS_convert_all_blocks; }
+
+void SetGflagConvertAllBlocks(bool convert_all_blocks) {
+  FLAGS_convert_all_blocks = convert_all_blocks;
+}
+
 Graph::Graph(const ProgramDesc &program) : program_(program) {
   auto var_nodes = InitFromProgram(program_);
   ResolveHazard(var_nodes);

--- a/paddle/fluid/framework/ir/graph.h
+++ b/paddle/fluid/framework/ir/graph.h
@@ -43,7 +43,8 @@ constexpr char kStaleProgramOpDescs[] = "stale_program_op_descs";
 }  //  namespace details
 
 namespace ir {
-
+bool GetGflagConvertAllBlocks();
+void SetGflagConvertAllBlocks(bool convert_all_blocks);
 /*
  * The graph is a Directed Acyclic Single Static Assignment Graph.
  *

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -485,6 +485,8 @@ PYBIND11_MODULE(core_noavx, m) {
   BindException(&m);
 
   m.def("set_num_threads", &platform::SetNumThreads);
+  m.def("convert_all_blocks", &ir::GetGflagConvertAllBlocks);
+  m.def("set_convert_all_blocks", &ir::SetGflagConvertAllBlocks);
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   m.def("cudnn_version", &platform::CudnnVersion);

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2597,7 +2597,7 @@ class Block(object):
             type(skip_op_callstack))
         block_str = "{ // block "
         block_str += "{}\n".format(self.idx)
-        for var in list(self.vars.values()):
+        for var in sorted(list(self.vars.values()), key=lambda v: v.name):
             block_str += "    {}\n".format(var._to_readable_code())
         block_str += "\n"
         for op in self.ops:
@@ -2626,7 +2626,7 @@ class Block(object):
             re_add_indent = re.compile(r"\n(.)")
             res_str = "blocks {\n  idx: %d\n  parent_idx: %d" % (
                 self.idx, self.parent_idx)
-            for var in list(self.vars.values()):
+            for var in sorted(list(self.vars.values()), key=lambda v: v.name):
                 res_str += "\n  vars {\n    %s  }" % re_add_indent.sub(
                     r"\n    \1", var.to_string(throw_on_error, with_details))
             for op in self.ops:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
通过pybind将C++端的gtest Flag `FLAGS_convert_all_blocks`暴露到python端。

```
fluid.core.set_convert_all_blocks(True) # 开启`FLAGS_convert_all_blocks`
flag = fluid.core.convert_all_blocks() # 获取当前状态
```