### PR TITLE
[Paddle-TRT] Fix output data type selection

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
@@ -219,7 +219,7 @@ const char* AnchorGeneratorPlugin::getPluginNamespace() const {
 
 nvinfer1::DataType AnchorGeneratorPlugin::getOutputDataType(
     int index, const nvinfer1::DataType* input_type, int nb_inputs) const {
-  return data_type_;
+  return input_type[0];
 }
 
 bool AnchorGeneratorPlugin::isOutputBroadcastAcrossBatch(
@@ -460,7 +460,7 @@ int AnchorGeneratorPluginDynamic::enqueue(
 
 nvinfer1::DataType AnchorGeneratorPluginDynamic::getOutputDataType(
     int index, const nvinfer1::DataType* inputTypes, int nbInputs) const {
-  return data_type_;
+  return inputTypes[0];
 }
 
 const char* AnchorGeneratorPluginDynamic::getPluginType() const {

--- a/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
@@ -304,7 +304,7 @@ int RoiAlignPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
 
 nvinfer1::DataType RoiAlignPluginDynamic::getOutputDataType(
     int index, const nvinfer1::DataType* inputTypes, int nbInputs) const {
-  return data_type_;
+  return inputTypes[0];
 }
 
 const char* RoiAlignPluginDynamic::getPluginType() const {

--- a/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.cu
@@ -299,7 +299,7 @@ const char* YoloBoxPlugin::getPluginNamespace() const {
 
 nvinfer1::DataType YoloBoxPlugin::getOutputDataType(
     int index, const nvinfer1::DataType* input_type, int nb_inputs) const {
-  return data_type_;
+  return input_type[0];
 }
 
 bool YoloBoxPlugin::isOutputBroadcastAcrossBatch(int output_index,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

The output type in plugins should be same as input type instead of `data_type_`.
Or it will make trt fix the network output to `data_type_`.