### PR TITLE
Fix Bug of Used before Assignment

### DIFF
--- a/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
+++ b/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
@@ -194,8 +194,8 @@ class FSTestBase(unittest.TestCase):
         fs.touch(file2)
 
         fs.download(src_file, dst_file)
-        self.assertTrue(local.is_exist(dst_file))
         local = LocalFS()
+        self.assertTrue(local.is_exist(dst_file))
         local.delete(dst_file)
         fs.delete(src_file)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
In File: python/paddle/fluid/tests/unittests/test_basic_lstm_api.py, Line 197
Error: Using variable 'local' before assignment
Fix: move line 198 **local = LocalFS()** ahead of line 197
