### PR TITLE
Fix Bug of Undefine Variable

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py
+++ b/python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ....log_helper import get_logger
 import math
 import numpy as np
 
 __all__ = ['cal_kl_threshold']
+
+_logger = get_logger(
+    __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 
 def expand_quantized_bins(quantized_bins, reference_bins):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
File: python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py, Line 62
Error: Undefined variable '_logger'
Fix: **from ....log_helper import get_logger**
**_logger = get_logger(__name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')**
