### PR TITLE
Fix Bug of Unexpected Key Word

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -62,7 +62,8 @@ class TestDistRunnerBase(object):
                   batch_size=DEFAULT_BATCH_SIZE,
                   lr=0.1,
                   single_device=False,
-                  use_dgc=False):
+                  use_dgc=False,
+                  dist_strategy=None):
         raise NotImplementedError(
             "get_model should be implemented by child classes.")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
File: In python/paddle/fluid/tests/unittests/test_dist_base.py, Line 127, 273
Error: Unexpected keyword argument 'dist_strategy' in method call
Fix: add parameter **dist_strategy=None** to function **get_model**
