### PR TITLE
fix undef var

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py
+++ b/python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import math
 import numpy as np
+from ....log_helper import get_logger
+
+_logger = get_logger(
+    name, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 __all__ = ['cal_kl_threshold']
 

--- a/python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py
+++ b/python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py
@@ -18,7 +18,7 @@ import numpy as np
 from ....log_helper import get_logger
 
 _logger = get_logger(
-    name, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
+    __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 __all__ = ['cal_kl_threshold']
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
File: python/paddle/fluid/contrib/slim/quantization/cal_kl_threshold.py, Line 62
Error: Undefined variable '_logger'
Fix: 
**import logging**
**from ....log_helper import get_logger**
**_logger = get_logger(\_\_name\_\_, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')**
