### PR TITLE
fix bug for num_iters in fit/evaluate

### DIFF
--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1709,7 +1709,8 @@ class Model(object):
 
         steps = self._len_data_loader(train_loader)
         self.num_iters = num_iters
-        if num_iters is not None and isinstance(num_iters, int):
+        if num_iters is not None and isinstance(num_iters, int) and isinstance(
+                steps, int):
             assert num_iters > 0, "num_iters must be greater than 0!"
             epochs = (num_iters // steps) + 1
             steps = min(num_iters, steps)
@@ -1744,8 +1745,8 @@ class Model(object):
                 eval_logs = self._run_one_epoch(eval_loader, cbks, 'eval')
 
                 cbks.on_end('eval', eval_logs)
-                if self.stop_training:
-                    break
+            if self.stop_training:
+                break
 
         cbks.on_end('train', logs)
         self._test_dataloader = None
@@ -1832,7 +1833,8 @@ class Model(object):
 
         eval_steps = self._len_data_loader(eval_loader)
         self.num_iters = num_iters
-        if num_iters is not None and isinstance(num_iters, int):
+        if num_iters is not None and isinstance(num_iters, int) and isinstance(
+                eval_steps, int):
             assert num_iters > 0, "num_iters must be greater than 0!"
             eval_steps = min(num_iters, eval_steps)
             self.num_iters = eval_steps
@@ -2094,7 +2096,9 @@ class Model(object):
             callbacks.on_batch_end(mode, step, logs)
             if hasattr(self, 'num_iters') and self.num_iters is not None:
                 self.num_iters -= 1
-                if self.num_iters == 0:
+                if self.num_iters <= 0:
+                    self.stop_training = True
+                    del self.num_iters
                     break
         self._reset_metrics()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix bug in .fit() and .evaluate() when dataset is iterable, the steps is None.