### PR TITLE
jit.save/load support method with parameters.

### DIFF
--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -760,7 +760,7 @@ def save(layer, path, input_spec=None, **configs):
 
                 if static_function._class_instance is None:
                     warnings.warn(
-                        'Only when {} does not contain parameters, `jit.save` can succeed. If it contains parameters, please confirm that it is a member function of `paddle.nn.Layer` and these parameters are in `state_dict`, otherwise it cannot be saved with `jit.save`'.
+                        '`jit.save` will only save the `Program`, not the parameters. If you have to save the parameters, please make sure that {} is a member function of `paddle.nn.Layer` and the saved parameters are in `state_dict`'.
                         format(layer))
 
         dygraph_state_dict = None

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -35,7 +35,7 @@ from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTra
 from paddle.fluid.dygraph.io import TranslatedLayer, INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX, INFER_PARAMS_INFO_SUFFIX
 from paddle.fluid.dygraph.layers import Layer
 from paddle.fluid.executor import Executor, scope_guard
-from paddle.fluid.framework import Block, ParamBase, Program, Variable
+from paddle.fluid.framework import Block, ParamBase, Program, Variable, Parameter
 from paddle.fluid.framework import _current_expected_place, _dygraph_guard, _dygraph_tracer
 from paddle.fluid.framework import dygraph_only, in_dygraph_mode
 from paddle.fluid.wrapped_decorator import wrap_decorator
@@ -741,12 +741,33 @@ def save(layer, path, input_spec=None, **configs):
             else:
                 continue
 
+        else:
+            # When layer is a function
+            if isinstance(attr_func, StaticFunction):
+                concrete_program = attr_func.concrete_program_specify_input_spec(
+                    inner_input_spec)
+            else:
+                if inner_input_spec:
+                    inner_input_spec = pack_sequence_as(input_spec,
+                                                        inner_input_spec)
+                static_function = declarative(
+                    attr_func, input_spec=inner_input_spec)
+                concrete_program = static_function.concrete_program
+
+        dygraph_state_dict = None
+        if isinstance(inner_layer, Layer):
+            dygraph_state_dict = inner_layer.state_dict()
+        elif isinstance(attr_func, StaticFunction):
+            if attr_func._class_instance:
+                dygraph_state_dict = attr_func._class_instance.state_dict()
+
+        if dygraph_state_dict:
             # NOTE(chenweihang): we maintain the mapping of variable name to
             # structured name, the buffer variable (non-persistable)
             # saved to inference program may not need by dygraph Layer,
             # we only record the state_dict variable's structured name
             state_names_dict = dict()
-            for structured_name, var in six.iteritems(inner_layer.state_dict()):
+            for structured_name, var in six.iteritems(dygraph_state_dict):
                 state_names_dict[var.name] = structured_name
 
             # 3. share parameters from Layer to scope & record var info
@@ -767,18 +788,6 @@ def save(layer, path, input_spec=None, **configs):
                     if isinstance(param_or_buffer, ParamBase):
                         extra_info_dict['trainable'] = param_or_buffer.trainable
                     extra_var_info[param_or_buffer.name] = extra_info_dict
-        else:
-            # When layer is a function
-            if isinstance(attr_func, StaticFunction):
-                concrete_program = attr_func.concrete_program_specify_input_spec(
-                    inner_input_spec)
-            else:
-                if inner_input_spec:
-                    inner_input_spec = pack_sequence_as(input_spec,
-                                                        inner_input_spec)
-                static_function = declarative(
-                    attr_func, input_spec=inner_input_spec)
-                concrete_program = static_function.concrete_program
 
         # 4. build input & output of save_infernece_model
         # NOTE(chenweihang): [ Get input variables name ]
@@ -840,7 +849,14 @@ def save(layer, path, input_spec=None, **configs):
     # but we can save these information in `jit.save` without changing the original
     # storage to improve user experience. So we save extra information into
     # file `***.pdiparams.info`
-    if isinstance(layer, Layer) and extra_var_info:
+
+    # "layer" can only be Layer or function or StaticFunction.
+
+    contain_parameter = False
+    for var in concrete_program.main_program.list_vars():
+        contain_parameter |= isinstance(var, Parameter)
+
+    if (isinstance(layer, Layer) or contain_parameter) and extra_var_info:
         with scope_guard(scope):
             extra_var_info_path = path + INFER_PARAMS_INFO_SUFFIX
             with open(extra_var_info_path, 'wb') as f:

--- a/python/paddle/fluid/tests/unittests/test_jit_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_jit_save_load.py
@@ -1312,10 +1312,8 @@ class TestJitSaveLoadFunctionWithParamCase3(unittest.TestCase):
         inps = paddle.rand([3, 5])
         origin = layer.anothor_forward(inps)
 
-        func = paddle.jit.to_static(
-            layer.anothor_forward, [paddle.static.InputSpec(shape=[-1, 5])])
         path = 'test_jit_save_load_function_with_params_case3/func'
-        paddle.jit.save(func, path)
+        paddle.jit.save(layer.anothor_forward, path)
         load_func = paddle.jit.load(path)
 
         load_result = load_func(inps)

--- a/python/paddle/fluid/tests/unittests/test_jit_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_jit_save_load.py
@@ -1227,11 +1227,11 @@ class TestJitSaveLoadFunctionCase3(unittest.TestCase):
         self.assertTrue((load_result - origin).abs().max() < 1e-10)
 
 
-class TestJitSaveLoadFunctionWithParam(unittest.TestCase):
+class TestJitSaveLoadFunctionWithParamCase1(unittest.TestCase):
     def setUp(self):
         paddle.disable_static()
 
-    def test_jit_save_load_function_function(self):
+    def test_jit_save_load_function(self):
         class LinearNet(paddle.nn.Layer):
             def __init__(self):
                 super(LinearNet, self).__init__()
@@ -1250,7 +1250,71 @@ class TestJitSaveLoadFunctionWithParam(unittest.TestCase):
 
         func = paddle.jit.to_static(
             layer.anothor_forward, [paddle.static.InputSpec(shape=[-1, 5])])
-        path = 'test_jit_save_load_function_with_params/func'
+        path = 'test_jit_save_load_function_with_params_case1/func'
+        paddle.jit.save(func, path)
+        load_func = paddle.jit.load(path)
+
+        load_result = load_func(inps)
+        self.assertTrue(np.array_equal(load_result.numpy(), origin.numpy()))
+
+
+class TestJitSaveLoadFunctionWithParamCase2(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_jit_save_load_function(self):
+        class LinearNet(paddle.nn.Layer):
+            def __init__(self):
+                super(LinearNet, self).__init__()
+                self._linear = paddle.nn.Linear(5, 6)
+
+            def forward(self, x):
+                return paddle.tanh(x)
+
+            @paddle.jit.to_static(input_spec=[InputSpec(shape=[-1, 5])])
+            def anothor_forward(self, x):
+                return self._linear(x)
+
+        layer = LinearNet()
+
+        inps = paddle.rand([3, 5])
+
+        path = 'test_jit_save_load_function_with_params_case2/func'
+        paddle.jit.save(layer.anothor_forward, path)
+        origin_result = layer.anothor_forward(inps)
+        load_func = paddle.jit.load(path)
+
+        load_result = load_func(inps)
+
+        self.assertTrue(
+            np.array_equal(origin_result.numpy(), load_result.numpy()))
+
+
+class TestJitSaveLoadFunctionWithParamCase3(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_jit_save_load_function(self):
+        class LinearNet(paddle.nn.Layer):
+            def __init__(self):
+                super(LinearNet, self).__init__()
+                self._linear = paddle.nn.Linear(5, 6)
+
+            def forward(self, x):
+                return paddle.tanh(x)
+
+            @paddle.jit.to_static
+            def anothor_forward(self, x):
+                return self._linear(x)
+
+        layer = LinearNet()
+
+        inps = paddle.rand([3, 5])
+        origin = layer.anothor_forward(inps)
+
+        func = paddle.jit.to_static(
+            layer.anothor_forward, [paddle.static.InputSpec(shape=[-1, 5])])
+        path = 'test_jit_save_load_function_with_params_case3/func'
         paddle.jit.save(func, path)
         load_func = paddle.jit.load(path)
 

--- a/python/paddle/fluid/tests/unittests/test_jit_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_jit_save_load.py
@@ -1227,6 +1227,37 @@ class TestJitSaveLoadFunctionCase3(unittest.TestCase):
         self.assertTrue((load_result - origin).abs().max() < 1e-10)
 
 
+class TestJitSaveLoadFunctionWithParam(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def test_jit_save_load_function_function(self):
+        class LinearNet(paddle.nn.Layer):
+            def __init__(self):
+                super(LinearNet, self).__init__()
+                self._linear = paddle.nn.Linear(5, 6)
+
+            def forward(self, x):
+                return paddle.tanh(x)
+
+            def anothor_forward(self, x):
+                return self._linear(x)
+
+        layer = LinearNet()
+
+        inps = paddle.rand([3, 5])
+        origin = layer.anothor_forward(inps)
+
+        func = paddle.jit.to_static(
+            layer.anothor_forward, [paddle.static.InputSpec(shape=[-1, 5])])
+        path = 'test_jit_save_load_function_with_params/func'
+        paddle.jit.save(func, path)
+        load_func = paddle.jit.load(path)
+
+        load_result = load_func(inps)
+        self.assertTrue(np.array_equal(load_result.numpy(), origin.numpy()))
+
+
 class TestJitSaveLoadDataParallel(unittest.TestCase):
     def verify_inference_correctness(self, layer, path):
         layer.eval()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

jit.save/load支持保存加载带有参数的成员函数。
根据jit.save的输入为function/StaticFunction 和layer分成了两种情况：
- 当输入为layer，规则与以前一致。
- 当输入为function/StaticFunction:
   - 是Layer类的成员函数**且**function的权重都在state_dict里面:按用户指定的名字保存模型，jit.load加载这个模型得到TranslatedLayer，加载的模型对映forward函数。
   - 否则，不能包含权重，因此只生成`*.pdmodel `一个文件


调用方式：
1. 下图这种写法仅支持保存function，如果保存layer（例如：`paddle.jit.save(layer, path)`）由于没有用`to_static`修饰forward会报错：`ValueError: No valid transformed program for function: forward(x), input_spec: None`
![image](https://user-images.githubusercontent.com/22128369/125385279-c998cd00-e3cc-11eb-89cf-29cc4ec91d27.png)


2.
![image](https://user-images.githubusercontent.com/22128369/125385236-b4bc3980-e3cc-11eb-83bc-09b63aa45424.png)

3.
![image](https://user-images.githubusercontent.com/22128369/125385433-0ebcff00-e3cd-11eb-802f-2a9287a9e122.png)
