### PR TITLE
[NPU] add dropout npu op

### DIFF
--- a/paddle/fluid/operators/dropout_op_npu.cc
+++ b/paddle/fluid/operators/dropout_op_npu.cc
@@ -1,0 +1,169 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the Licnse. */
+
+#include <memory>
+#include <string>
+
+#include "paddle/fluid/framework/ddim.h"
+#include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/fluid/operators/dropout_op.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+
+template <typename DeviceContext, typename T>
+class DropoutNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* x = ctx.Input<Tensor>("X");
+    auto* seed_tensor =
+        context.HasInput("Seed") ? ctx.Input<Tensor>("Seed") : nullptr;
+    auto* out = ctx.Output<Tensor>("Out");
+    auto* mask = ctx.Output<Tensor>("Mask");
+
+    auto dropout_prob = ctx.Attr<float>("dropout_prob");
+    auto is_test = ctx.Attr<bool>("is_test");
+
+    out->mutable_data<T>(ctx.GetPlace());
+    mask->mutable_data<uint8_t>(ctx.GetPlace());
+
+    if (dropout_prob == 1.) {
+      const auto& runner_zeros_out = NpuOpRunner("ZerosLike", {*out}, {*out});
+      runner_zeros_out.Run(stream);
+      const auto& runner_zeros_mask =
+          NpuOpRunner("ZerosLike", {*mask}, {*mask});
+      runner_zeros_mask.Run(stream);
+      return;
+    }
+
+    // only achive the default `upscale_in_train` method
+    if (!is_test) {
+      int seed = 0;
+      int seed2 = 0;
+      float keep_prob = 1. - dropout_prob;
+      if (seed_tensor) {
+        std::vector<int> seed_data;
+        TensorToVector(*seed_tensor, ctx, &seed_data);
+        seed = seed_data[0];
+      } else {
+        seed = ctx.Attr<bool>("fix_seed") ? ctx.Attr<int>("seed") : 0;
+      }
+
+      Tensor keep_prob_tensor(framework::proto::VarType::FP32);
+      keep_prob_tensor.mutable_data<float>({1}, ctx.GetPlace());
+      FillNpuTensorWithConstant<float>(&keep_prob_tensor,
+                                       static_cast<float>(keep_prob));
+
+      // mask used in `DropOutGenMask` NPU OP is different from
+      // the output `Mask`.
+      Tensor npu_mask(framework::proto::VarType::UINT8);
+      uint32_t length = (x->numel() + 128 - 1) / 128 * 128;
+      npu_mask.Resize(framework::make_ddim({length / 8}));
+      npu_mask.mutable_data<uint8_t>(ctx.GetPlace());
+
+      auto stream =
+          ctx.template device_context<paddle::platform::NPUDeviceContext>()
+              .stream();
+
+      // TODO(pangyoki): `keep_prob` used in `DropOutGenMask` NPU
+      // OP must be a scalar with shape[0]. At present, the shape
+      // of the `prob` Tensor of this OP is forced to be set to 0
+      // in `npu_op_runner.cc`, which needs to be optimized later.
+      NpuOpRunner runner_gen_mask;
+      runner_gen_mask.SetType("DropOutGenMask")
+          .AddInput(framework::vectorize(npu_mask.dims()))
+          .AddInput(keep_prob_tensor)
+          .AddOutput(npu_mask)
+          .AddAttr("seed", seed)
+          .AddAttr("seed2", seed2);
+      runner_gen_mask.Run(stream);
+
+      NpuOpRunner runner_dropout;
+      runner_dropout.SetType("DropOutDoMask")
+          .AddInput(*x)
+          .AddInput(npu_mask)
+          .AddInput(keep_prob_tensor)
+          .AddOutput(*out);
+      runner_dropout.Run(stream);
+
+      // cast `out` from float/float16 to bool
+      Tensor cast_mask(framework::proto::VarType::BOOL);
+      cast_mask.Resize(mask->dims());
+      cast_mask.mutable_data<bool>(ctx.GetPlace());
+      auto dst_dtype_bool = ConvertToNpuDtype(cast_mask.type());
+      const auto& runner_cast_mask_bool =
+          NpuOpRunner("Cast", {*out}, {cast_mask},
+                      {{"dst_type", static_cast<int>(dst_dtype_bool)}});
+      runner_cast_mask_bool.Run(stream);
+
+      // cast cast_mask from bool to uint8
+      auto dst_dtype_uint8 = ConvertToNpuDtype(mask->type());
+      const auto& runner_cast_mask_uint8 =
+          NpuOpRunner("Cast", {cast_mask}, {*mask},
+                      {{"dst_type", static_cast<int>(dst_dtype_uint8)}});
+      runner_cast_mask_uint8.Run(stream);
+    } else {
+      framework::TensorCopy(
+          *x, ctx.GetPlace(),
+          ctx.template device_context<platform::DeviceContext>(), out);
+    }
+  }
+};
+
+template <typename DeviceContext, typename T>
+class DropoutGradNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
+    auto* dout = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    auto* mask = ctx.Input<Tensor>("Mask");
+
+    auto dropout_prob = ctx.Attr<float>("dropout_prob");
+    auto is_test = ctx.Attr<bool>("is_test");
+
+    PADDLE_ENFORCE_EQ(is_test, false,
+                      platform::errors::PreconditionNotMet(
+                          "GradOp is only callable when is_test is false"));
+
+    dx->mutable_data<T>(ctx.GetPlace());
+
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+
+    const auto& runner =
+        NpuOpRunner("MaskedScale", {*dout, *mask}, {*dx},
+                    {{"value", static_cast<float>(1. / (1 - dropout_prob))}});
+    runner.Run(stream);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OP_NPU_KERNEL(
+    dropout, ops::DropoutNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::DropoutNPUKernel<paddle::platform::NPUDeviceContext,
+                          paddle::platform::float16>);
+
+REGISTER_OP_NPU_KERNEL(
+    dropout_grad,
+    ops::DropoutGradNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::DropoutGradNPUKernel<paddle::platform::NPUDeviceContext,
+                              paddle::platform::float16>);

--- a/paddle/fluid/operators/npu_op_runner.cc
+++ b/paddle/fluid/operators/npu_op_runner.cc
@@ -327,6 +327,10 @@ aclTensorDesc *NpuOpRunner::CreateTensorDesc(Tensor tensor,
   auto format = ConvertToNpuFormat(tensor.layout());
   auto dims = framework::vectorize(tensor.dims());
   int size = dims.size();
+  // TODO(pangyoki): `keep_prob` used in `DropOutGenMask` NPU
+  // OP must be a scalar with shape[0]. At present, the shape
+  // of the `prob` Tensor of this OP is forced to be set to 0
+  // in `npu_op_runner.cc`, which needs to be optimized later.
   if (op_type_ == "DropOutGenMask" && size == 1 && *(dims.data()) == 1) {
     size = 0;
   }

--- a/paddle/fluid/operators/npu_op_runner.cc
+++ b/paddle/fluid/operators/npu_op_runner.cc
@@ -32,6 +32,7 @@ namespace operators {
 static std::map<framework::proto::VarType::Type, aclDataType>
     DTYPE_2_ACL_DTYPE = {
         {framework::proto::VarType::BOOL, ACL_BOOL},
+        {framework::proto::VarType::UINT8, ACL_UINT8},
         {framework::proto::VarType::INT16, ACL_INT16},
         {framework::proto::VarType::INT32, ACL_INT32},
         {framework::proto::VarType::INT64, ACL_INT64},
@@ -325,17 +326,20 @@ aclTensorDesc *NpuOpRunner::CreateTensorDesc(Tensor tensor,
   auto dtype = ConvertToNpuDtype(tensor.type());
   auto format = ConvertToNpuFormat(tensor.layout());
   auto dims = framework::vectorize(tensor.dims());
+  int size = dims.size();
+  if (op_type_ == "DropOutGenMask" && size == 1 && *(dims.data()) == 1) {
+    size = 0;
+  }
 
   VLOG(4) << "NPU dtype:" << dtype << " "
           << "rank:" << dims.size() << " dims:" << tensor.dims()
           << " format:" << format;
 
-  auto *desc = aclCreateTensorDesc(dtype, dims.size(), dims.data(), format);
+  auto *desc = aclCreateTensorDesc(dtype, size, dims.data(), format);
   PADDLE_ENFORCE_NOT_NULL(
       desc, platform::errors::External("Call aclCreateTensorDesc failed."));
   PADDLE_ENFORCE_NPU_SUCCESS(aclSetTensorStorageFormat(desc, format));
-  PADDLE_ENFORCE_NPU_SUCCESS(
-      aclSetTensorStorageShape(desc, dims.size(), dims.data()));
+  PADDLE_ENFORCE_NPU_SUCCESS(aclSetTensorStorageShape(desc, size, dims.data()));
   if (mem_type == ACL_MEMTYPE_HOST) {
     PADDLE_ENFORCE_NPU_SUCCESS(aclSetTensorPlaceMent(desc, mem_type));
   }

--- a/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
@@ -66,6 +66,27 @@ class TestDropoutOp(OpTest):
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
                  "core is not compiled with NPU")
 class TestDropoutOpInput1d(TestDropoutOp):
+    # change input shape
+    def setUp(self):
+        self.op_type = "dropout"
+        self.set_npu()
+        self.init_dtype()
+        self.inputs = {'X': np.random.random((3, 62)).astype(self.dtype)}
+        self.attrs = {
+            'dropout_prob': 0.0,
+            'fix_seed': True,
+            'is_test': False,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {
+            'Out': self.inputs['X'],
+            'Mask': np.ones((3, 62)).astype('uint8')
+        }
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestDropoutOpInput1d(TestDropoutOp):
     # the input is 1-D
     def setUp(self):
         self.op_type = "dropout"
@@ -108,7 +129,7 @@ class TestDropoutOp2(TestDropoutOp):
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
                  "core is not compiled with NPU")
 class TestDropoutOp3(TestDropoutOp):
-    # the dropout_prob is 1.0
+    # the input dim is 3
     def setUp(self):
         self.op_type = "dropout"
         self.set_npu()
@@ -130,6 +151,7 @@ class TestDropoutOp3(TestDropoutOp):
                  "core is not compiled with NPU")
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestDropoutOpInference(OpTest):
+    # is_test = True
     def setUp(self):
         self.op_type = "dropout"
         self.set_npu()
@@ -174,7 +196,7 @@ class TestDropoutOpInference2(TestDropoutOpInference):
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
                  "core is not compiled with NPU")
 class TestDropoutOpWithSeed(TestDropoutOp):
-    # the input is 1-D
+    # the seed is a Tensor
     def setUp(self):
         self.op_type = "dropout"
         self.set_npu()
@@ -198,6 +220,7 @@ class TestDropoutOpWithSeed(TestDropoutOp):
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
                  "core is not compiled with NPU")
 class TestDropoutOpFp16(TestDropoutOp):
+    # float16
     def init_dtype(self):
         self.dtype = np.float16
 

--- a/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
@@ -1,0 +1,124 @@
+#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+sys.path.append("..")
+from op_test import OpTest
+import paddle
+
+paddle.enable_static()
+
+SEED = 2021
+EPOCH = 100
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestDropoutOp(OpTest):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.set_npu()
+        self.init_dtype()
+        self.config()
+        self.inputs = {'X': self.x, 'Seed': self.seed}
+        self.outputs = {
+            'Out': self.out,
+            'Mask': np.ones((32, 64)).astype('uint8')
+        }
+        self.attrs = {
+            'dropout_prob': self.dropout_prob,
+            'fix_seed': True,
+            'is_test': self.is_test
+        }
+
+    def config(self):
+        self.x = np.random.random((32, 64)).astype(self.dtype)
+        self.seed = np.asarray([125], dtype="int32")
+        self.dropout_prob = 0.0
+        self.is_test = False
+        self.out = self.x
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.place = paddle.NPUPlace(0)
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place, check_dygraph=False)
+
+    def test_check_grad_normal(self):
+        if self.dtype == np.float16:
+            return
+        self.check_grad_with_place(
+            self.place, ['X'], 'Out', check_dygraph=False)
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestDropoutOp4(TestDropoutOp):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.set_npu()
+        self.init_dtype()
+        self.config()
+        self.inputs = {'X': self.x, 'Seed': self.seed}
+        self.outputs = {'Out': self.out}
+        self.attrs = {
+            'dropout_prob': self.dropout_prob,
+            'fix_seed': True,
+            'is_test': self.is_test
+        }
+
+    def config(self):
+        self.x = np.random.random((32, 64)).astype(self.dtype)
+        self.seed = np.asarray([125], dtype="int32")
+        self.dropout_prob = 0.35
+        self.is_test = True
+        self.out = self.x * (1.0 - self.dropout_prob)
+
+    def test_check_grad_normal(self):
+        pass
+
+
+"""
+class TestSliceOp2(TestSliceOp):
+    def config(self):
+        self.input = np.random.random([10, 5, 6]).astype(self.dtype)
+        self.starts = [0]
+        self.ends = [1]
+        self.axes = [1]
+        self.infer_flags = [1]
+        self.out = self.input[:, 0:1, :]
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestSliceOpFp16(TestSliceOp):
+    def init_dtype(self):
+        self.dtype = np.float16
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.__class__.no_need_check_grad = True
+        self.place = paddle.NPUPlace(0)
+"""
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

实现的是upscale_in_train方式的dropout：
<img width="780" alt="图片" src="https://user-images.githubusercontent.com/26408901/125195419-1626c000-e288-11eb-99ee-1b0ac0afc39b.png">

使用`DropOutGenMask`+`DropOutDoMask`实现Dropout NPU OP。

因为随机性，单测中只测试了dropout_prob = 0 和 dropout_prob = 1的情况。
手动测试了下dropout_prob = 0.3的输出结果，看scale的比例确实是1.428倍 ( 1 / (1-0.3) = 1.428)：
<img width="704" alt="图片" src="https://user-images.githubusercontent.com/26408901/125193970-cd6c0880-e281-11eb-8bb8-451565a4cfe2.png">


注意：
- `DropOutGenMask`中需要使用Tensor `prob`，在NPU执行时其shape必须为0，这里在runner中做了特殊处理，后面需要优化实现。
- 添加了对uint8数据类型的支持。


单测结果：
<img width="768" alt="图片" src="https://user-images.githubusercontent.com/26408901/125193922-8b42c700-e281-11eb-9c7b-45e5f365fe54.png">

log:
<img width="1440" alt="图片" src="https://user-images.githubusercontent.com/26408901/125194181-d4dfe180-e282-11eb-80b5-3565356ac49c.png">
![图片](https://user-images.githubusercontent.com/26408901/125194205-de694980-e282-11eb-8cbc-4d8c4925b605.png)

