### PR TITLE
[NPU] add NPU ops of stack and unstack, test=develop

### DIFF
--- a/paddle/fluid/operators/stack_op_npu.cc
+++ b/paddle/fluid/operators/stack_op_npu.cc
@@ -12,15 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#ifdef PADDLE_WITH_ASCEND_CL
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "paddle/fluid/operators/activation_op.h"
-#include "paddle/fluid/operators/npu_op_runner.h"
 #include "paddle/fluid/operators/stack_op.h"
-#include "paddle/fluid/operators/unsqueeze_op.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
 
 namespace paddle {
 namespace operators {
@@ -32,64 +25,56 @@ class StackNPUKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto x = ctx.MultiInput<Tensor>("X");
-    int32_t N = x.size();
-
-    PADDLE_ENFORCE_GT(
-        N, 0, platform::errors::InvalidArgument("number of input Tensor <= 0"));
-
-    std::vector<paddle::framework::Tensor> x_list;
-    for (int i = 0; i < N; i++) {
-      x_list.push_back(*x[i]);
-    }
-
+    auto* y = ctx.Output<Tensor>("Y");
     int axis = ctx.Attr<int>("axis");
+    if (axis < 0) axis += (x[0]->dims().size() + 1);
+    int num = static_cast<int>(x.size());
 
-    if (axis < 0) {
-      axis = axis + x_list[0].dims().size() + 1;
-    }
-    auto* out = ctx.Output<Tensor>("Y");
-
-    auto place = ctx.GetPlace();
+    PADDLE_ENFORCE_GT(num, 0, platform::errors::InvalidArgument(
+                                  "number of input Tensor <= 0"));
 
     auto stream =
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
-    out->mutable_data<T>(place);
-
-    if (axis != 0) {
-      auto x_dim = x_list[0].dims();
-      std::vector<int> vec_dim_tmp;
-      vec_dim_tmp.push_back(N);
-      for (auto i = 0; i < x_dim.size(); ++i) {
-        vec_dim_tmp.push_back(x_dim[i]);
-      }
-
-      Tensor tmp_stack(out->type());
-      tmp_stack.Resize(framework::make_ddim(vec_dim_tmp));
-      tmp_stack.mutable_data<T>(ctx.GetPlace());
-
-      const auto& runner =
-          NpuOpRunner("Pack", {x_list}, {tmp_stack}, {{"axis", 0}, {"N", N}});
-      runner.Run(stream);
-
-      std::vector<int64_t> vec_trans;
-      for (auto i = 1; i <= x_dim.size(); ++i) {
-        vec_trans.push_back(i);
-        if (i == axis) {
-          vec_trans.push_back(0);
-        }
-      }
-
-      const auto& runner_trans_final =
-          NpuOpRunner("TransposeD", {tmp_stack}, {*out}, {{"perm", vec_trans}});
-      runner_trans_final.Run(stream);
-
-    } else {
-      const auto& runner =
-          NpuOpRunner("Pack", {x_list}, {*out}, {{"axis", axis}, {"N", N}});
-      runner.Run(stream);
+    std::vector<paddle::framework::Tensor> x_list;
+    for (int i = 0; i < num; i++) {
+      x_list.push_back(*x[i]);
     }
+    y->mutable_data<T>(ctx.GetPlace());
+
+    const auto& runner =
+        NpuOpRunner("Pack", {x_list}, {*y}, {{"axis", axis}, {"N", num}});
+    runner.Run(stream);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class StackGradNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* dy = ctx.Input<Tensor>(framework::GradVarName("Y"));
+    auto dx = ctx.MultiOutput<Tensor>(framework::GradVarName("X"));
+    int axis = ctx.Attr<int>("axis");
+    if (axis < 0) axis += dy->dims().size();
+    int num = dy->dims()[axis];
+
+    PADDLE_ENFORCE_GT(num, 0, platform::errors::InvalidArgument(
+                                  "number of input Tensor <= 0"));
+
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+
+    std::vector<paddle::framework::Tensor> dx_list;
+    for (int i = 0; i < num; i++) {
+      dx[i]->mutable_data<T>(ctx.GetPlace());
+      dx_list.push_back(*dx[i]);
+    }
+
+    const auto& runner =
+        NpuOpRunner("Unpack", {*dy}, {dx_list}, {{"axis", axis}, {"num", num}});
+    runner.Run(stream);
   }
 };
 
@@ -103,4 +88,8 @@ REGISTER_OP_NPU_KERNEL(
     ops::StackNPUKernel<paddle::platform::NPUDeviceContext,
                         paddle::platform::float16>);
 
-#endif
+REGISTER_OP_NPU_KERNEL(
+    stack_grad,
+    ops::StackGradNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::StackGradNPUKernel<paddle::platform::NPUDeviceContext,
+                            paddle::platform::float16>);

--- a/paddle/fluid/operators/unstack_op_npu.cc
+++ b/paddle/fluid/operators/unstack_op_npu.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/unstack_op.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename DeviceContext, typename T>
+class UnStackNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    auto *dy = ctx.Input<Tensor>("X");
+    auto dx = ctx.MultiOutput<Tensor>("Y");
+    int axis = ctx.Attr<int>("axis");
+    if (axis < 0) axis += dy->dims().size();
+    int num = dy->dims()[axis];
+
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+
+    std::vector<paddle::framework::Tensor> dx_list;
+    for (int i = 0; i < num; i++) {
+      dx[i]->mutable_data<T>(ctx.GetPlace());
+      dx_list.push_back(*dx[i]);
+    }
+
+    const auto &runner =
+        NpuOpRunner("Unpack", {*dy}, {dx_list}, {{"axis", axis}, {"num", num}});
+    runner.Run(stream);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class UnStackGradNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    auto x = ctx.MultiInput<Tensor>(framework::GradVarName("Y"));
+    auto *y = ctx.Output<Tensor>(framework::GradVarName("X"));
+    int axis = ctx.Attr<int>("axis");
+    if (axis < 0) axis += (x[0]->dims().size() + 1);
+    int num = static_cast<int>(x.size());
+
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+
+    std::vector<paddle::framework::Tensor> x_list;
+    for (int i = 0; i < num; i++) {
+      x_list.push_back(*x[i]);
+    }
+    y->mutable_data<T>(ctx.GetPlace());
+
+    const auto &runner =
+        NpuOpRunner("Pack", {x_list}, {*y}, {{"axis", axis}, {"N", num}});
+    runner.Run(stream);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace plat = paddle::platform;
+namespace ops = paddle::operators;
+
+REGISTER_OP_NPU_KERNEL(
+    unstack, ops::UnStackNPUKernel<plat::NPUDeviceContext, float>,
+    ops::UnStackNPUKernel<plat::NPUDeviceContext, plat::float16>);
+
+REGISTER_OP_NPU_KERNEL(
+    unstack_grad, ops::UnStackGradNPUKernel<plat::NPUDeviceContext, float>,
+    ops::UnStackGradNPUKernel<plat::NPUDeviceContext, plat::float16>);

--- a/python/paddle/fluid/tests/unittests/npu/test_unstack_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_unstack_op_npu.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import sys
+sys.path.append("..")
+from op_test import OpTest
+import unittest
+import paddle
+
+paddle.enable_static()
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestUnStackOpBase(OpTest):
+    def initDefaultParameters(self):
+        self.input_dim = (5, 6, 7)
+        self.axis = 0
+
+    def initParameters(self):
+        pass
+
+    def get_y_names(self):
+        y_names = []
+        for i in range(self.input_dim[self.axis]):
+            y_names.append('y{}'.format(i))
+        return y_names
+
+    def setUp(self):
+        self.initDefaultParameters()
+        self.initParameters()
+        self.op_type = 'unstack'
+        self.set_npu()
+        self.init_dtype()
+
+        self.x = np.random.random(size=self.input_dim).astype(self.dtype)
+
+        outs = np.split(self.x, self.input_dim[self.axis], self.axis)
+        new_shape = list(self.input_dim)
+        del new_shape[self.axis]
+        y_names = self.get_y_names()
+        tmp = []
+        for i in range(self.input_dim[self.axis]):
+            tmp.append((y_names[i], np.reshape(outs[i], new_shape)))
+
+        self.inputs = {'X': self.x}
+        self.outputs = {'Y': tmp}
+        self.attrs = {'axis': self.axis, 'num': self.input_dim[self.axis]}
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.place = paddle.NPUPlace(0)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def test_check_grad(self):
+        self.check_grad_with_place(self.place, ['X'], self.get_y_names())
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestStackOp3(TestUnStackOpBase):
+    def initParameters(self):
+        self.axis = -1
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestStackOp4(TestUnStackOpBase):
+    def initParameters(self):
+        self.axis = -3
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestStackOp5(TestUnStackOpBase):
+    def initParameters(self):
+        self.axis = 1
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestStackOp6(TestUnStackOpBase):
+    def initParameters(self):
+        self.axis = 2
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

OPs

### Describe
<!-- Describe what this PR does -->

(1) 新增了unstack, unstack_grad 和 stack_grad 三个 NPU OP Kernel，以及 test_unstack_op_npu.py 的单测
(2) 改动了 stack 的 NPU  OP Kernel, 在 axis != 0 的情况下可以直接调用Pack, 不需要先Pack再Transpose，(原PR  https://github.com/PaddlePaddle/Paddle/pull/31711)
(3) 增加了test_stack_op_npu.py里面的单测内容，保持单测与 test_stack_op.py一致，且单测通过
(4) PR 里面没有提，但是手动测试增加stack和unstack的C++单测，位于
    - https://github.com/qili93/Paddle/blob/test_npu_stack/paddle/fluid/operators/stack_op_npu_test.cc
    - https://github.com/qili93/Paddle/blob/test_npu_stack/paddle/fluid/operators/unstack_op_npu_test.cc