### PR TITLE
Fix Bug of Used before Assignment

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_basic_lstm_api.py
+++ b/python/paddle/fluid/tests/unittests/test_basic_lstm_api.py
@@ -69,6 +69,7 @@ def lstm_np(input,
         return new_hidden, new_cell
 
     mask = None
+
     if batch_first:
         input = np.tranpose(input, [1, 0, 2])
         if mask is not None:

--- a/python/paddle/fluid/tests/unittests/test_basic_lstm_api.py
+++ b/python/paddle/fluid/tests/unittests/test_basic_lstm_api.py
@@ -68,13 +68,13 @@ def lstm_np(input,
 
         return new_hidden, new_cell
 
+    mask = None
     if batch_first:
         input = np.tranpose(input, [1, 0, 2])
         if mask is not None:
             mask = np.transpose(mask, [1, 0])
 
     batch_size = input.shape[1]
-    mask = None
     if sequence_length is not None:
         max_seq_len = input.shape[0]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
In File: python/paddle/fluid/tests/unittests/test_basic_lstm_api.py, Line 73
Error: Using variable 'mask' before assignment
Fix: move **"mask = None"** from Line 77 to Line 70
