### PR TITLE
fix no value for parameter

### DIFF
--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -126,7 +126,7 @@ class TestModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not fluid.is_compiled_with_cuda():
-            cls.skipTest('module not tested when ONLY_CPU compling')
+            cls().skipTest('module not tested when ONLY_CPU compling')
         cls.device = paddle.set_device('gpu')
         fluid.enable_dygraph(cls.device)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
In FIle: python/paddle/tests/test_model.py, Line 129
Error: No value for argument 'reason' in unbound method call
Fix: **cls.skipTest(...** --> **cls().skipTest(...**
