### PR TITLE
fix function redefine

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_grid_sampler_op.py
+++ b/python/paddle/fluid/tests/unittests/test_grid_sampler_op.py
@@ -197,7 +197,7 @@ class Case1(TestGridSamplerOp):
         self.mode = "bilinear"
 
 
-class Case1(TestGridSamplerOp):
+class Case1_(TestGridSamplerOp):
     def initTestCase(self):
         self.x_shape = (2, 3, 5, 6)
         self.grid_shape = (2, 8, 9, 2)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
In File: python/paddle/fluid/tests/unittests/test_grid_sampler_op.py
Error: class already defined line 190
Fix: rename from **Case1** to **Case1_**
