### PR TITLE
[pass_enhance] skip the atrribute check used for quantization.

### DIFF
--- a/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
@@ -179,6 +179,12 @@ bool OpCompat::Judge(const OpDesc& op_desc) {
   }
 
   for (auto& attr_map : op_desc.GetAttrMap()) {
+    const std::string& name = attr_map.first;
+    if (name.size() >= 10u &&
+        0 == name.compare(name.size() - 10u, 10u, "_threshold")) {
+      continue;  // skip the attribute ends with "_threshold", it used for
+                 // quantization.
+    }
     if (attr_compats_.find(attr_map.first) == attr_compats_.end()) {
       if (global_extra_attrs.find(attr_map.first) != global_extra_attrs.end() ||
           extra_attrs_.find(attr_map.first) != extra_attrs_.end()) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 APIs
### Describe
<!-- Describe what this PR does -->
量化涉及到的属性较多，但是同一以“_threshold”结尾，因为，统一跳过以_threshold结尾的属性检查。