### PR TITLE
fix bn grad compute when x.stop_gradient=True

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cc
+++ b/paddle/fluid/operators/batch_norm_op.cc
@@ -634,7 +634,9 @@ class BatchNormGradKernel<platform::CPUDeviceContext, T>
     const int sample_size = x->numel() / N / C;
 
     // init output
-    d_x->mutable_data<T>(ctx.GetPlace());
+    if (d_x) {
+      d_x->mutable_data<T>(ctx.GetPlace());
+    }
 
     const T *mean_data = saved_mean->data<T>();
     const T *inv_var_data = saved_inv_variance->data<T>();

--- a/paddle/fluid/operators/batch_norm_op.cu
+++ b/paddle/fluid/operators/batch_norm_op.cu
@@ -831,18 +831,22 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
     // by inverse operation of batch_norm on Y
     const Tensor *x;
     bool is_inplace;
-    if (ctx.HasInput("Y")) {
-      x = ctx.Input<Tensor>("Y");
-      is_inplace = true;
-      PADDLE_ENFORCE_EQ(d_x, d_y,
-                        platform::errors::InvalidArgument(
-                            "X@GRAD and Y@GRAD not inplace in inplace mode"));
+    if (d_x) {
+      if (ctx.HasInput("Y")) {
+        x = ctx.Input<Tensor>("Y");
+        is_inplace = true;
+        PADDLE_ENFORCE_EQ(d_x, d_y,
+                          platform::errors::InvalidArgument(
+                              "X@GRAD and Y@GRAD not inplace in inplace mode"));
+      } else {
+        x = ctx.Input<Tensor>("X");
+        is_inplace = false;
+        PADDLE_ENFORCE_NE(d_x, d_y,
+                          platform::errors::InvalidArgument(
+                              "X@GRAD and Y@GRAD inplaced in non-inplace mode"));
+      }
     } else {
-      x = ctx.Input<Tensor>("X");
       is_inplace = false;
-      PADDLE_ENFORCE_NE(d_x, d_y,
-                        platform::errors::InvalidArgument(
-                            "X@GRAD and Y@GRAD inplaced in non-inplace mode"));
     }
 
     const bool is_test = ctx.Attr<bool>("is_test");
@@ -861,7 +865,7 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
     ExtractNCWHD(x_dims, data_layout, &N, &C, &H, &W, &D);
 
     // init output
-    d_x->mutable_data<T>(ctx.GetPlace());
+    if (d_x) {d_x->mutable_data<T>(ctx.GetPlace());}
 
     if (d_scale && d_bias) {
       d_scale->mutable_data<BatchNormParamType<T>>(ctx.GetPlace());
@@ -902,7 +906,7 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
 
     Tensor transformed_x(x->type());
     Tensor transformed_d_y(d_y->type());
-    Tensor transformed_d_x(d_x->type());
+    Tensor transformed_d_x;
     if (data_layout == DataLayout::kNHWC &&
         compute_format == DataLayout::kNCHW) {
       VLOG(3) << "Transform input tensor from NHWC to NCHW.";
@@ -914,12 +918,14 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
                                                            &transformed_d_y);
       TransToChannelFirst<platform::CUDADeviceContext, T>(ctx, d_y,
                                                           &transformed_d_y);
-      ResizeToChannelFirst<platform::CUDADeviceContext, T>(ctx, d_x,
+      if (d_x) { 
+        ResizeToChannelFirst<platform::CUDADeviceContext, T>(ctx, d_x,
                                                            &transformed_d_x);
+      }
     } else {
       transformed_x.ShareDataWith(*x);
       transformed_d_y.ShareDataWith(*d_y);
-      transformed_d_x.ShareDataWith(*d_x);
+      if (d_x) { transformed_d_x.ShareDataWith(*d_x); }
     }
 
     std::vector<int> dims;
@@ -948,7 +954,7 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
 
     if (!use_global_stats) {
       if ((N * H * W * D) == 1) {
-        framework::TensorCopy(*d_y, ctx.GetPlace(), d_x);
+        if (d_x) { framework::TensorCopy(*d_y, ctx.GetPlace(), d_x); }
         math::SetConstant<platform::CUDADeviceContext, BatchNormParamType<T>>
             functor;
         functor(dev_ctx, d_scale, static_cast<BatchNormParamType<T>>(0));
@@ -1030,7 +1036,7 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
       }
 
       // This branch calls CUDNN APIs
-      if (d_scale && d_bias) {
+      if (d_x && d_scale && d_bias) {
         bool called = false;
 #if CUDNN_VERSION_MIN(7, 4, 1)
         called = true;
@@ -1175,6 +1181,14 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
                 saved_mean_data, x->data<T>(), saved_var_data, C, N, H * W * D,
                 d_x->data<T>());
           }
+          if (d_scale && d_bias) {
+            KeBNBackwardScaleBias<
+                T, block,
+                framework::DataLayout::kNCHW><<<grid2, block, 0, stream>>>(
+                d_y->data<T>(), x->data<T>(), saved_mean_data, saved_var_data,
+                epsilon, N, C, H * W * D, d_scale->data<BatchNormParamType<T>>(),
+                d_bias->data<BatchNormParamType<T>>());
+          }
         } else {
           if (d_x) {
             BNBackwardData<T, block, framework::DataLayout::kNHWC><<<
@@ -1182,6 +1196,14 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
                 d_y->data<T>(), scale->data<BatchNormParamType<T>>(),
                 saved_mean_data, x->data<T>(), saved_var_data, C, N, H * W * D,
                 d_x->data<T>());
+          }
+          if (d_scale && d_bias) {
+            KeBNBackwardScaleBias<
+                T, block,
+                framework::DataLayout::kNHWC><<<grid2, block, 0, stream>>>(
+                d_y->data<T>(), x->data<T>(), saved_mean_data, saved_var_data,
+                epsilon, N, C, H * W * D, d_scale->data<BatchNormParamType<T>>(),
+                d_bias->data<BatchNormParamType<T>>());
           }
         }
       }

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
@@ -515,6 +515,13 @@ class TestBatchNormOpTrainingCase2(TestBatchNormOpTraining):
         os.environ['FLAGS_cudnn_batchnorm_spatial_persistent'] = "1"
 
 
+class TestBatchNormOpTrainingCase3(TestBatchNormOpTraining):
+    def init_test_case(self):
+        self.use_global_stats = False
+        self.no_grad_set = set(['x@GRAD'])
+        self.fetch_list = ['y', 'mean', 'variance', 'scale@GRAD', 'bias@GRAD']
+
+
 class TestBatchNormOpTrainingMomentumVariable(TestBatchNormOpTraining):
     def init_test_case(self):
         self.use_momentum_variable = True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
fix bn grad compute when x.stop_gradient=True
```python
import paddle
paddle.enable_static()

x = paddle.static.data(shape=[4,3, 10, 10], dtype='float32', name='x')
x.stop_gradient = True

bn = paddle.nn.BatchNorm2D(3)
y = bn(x)

avg_cost = paddle.mean(y)
sgd_optimizer = paddle.optimizer.SGD(learning_rate=0.001)
sgd_optimizer.minimize(avg_cost)
print(paddle.static.default_main_program())```