### PR TITLE
multi profiles support

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -318,6 +318,7 @@ class TensorRTEngine {
             "on the same GPU architecture;\n2. The Paddle Inference version of "
             "generating serialization file and doing inference are "
             "consistent."));
+    binding_num_ = infer_engine_->getNbBindings();
   }
 
   void SetRuntimeBatch(size_t batch_size);

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -285,7 +285,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
     nvinfer1::IExecutionContext *trt_context = nullptr;
     if (engine->with_dynamic_shape()) {
       // Initilize context and get offset by profile index
-      auto *trt_context = engine->context();
+      trt_context = engine->context();
       binding_offset = engine->GetBindingsOffset();
     }
     // This method returns the total over all profiles.

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -282,6 +282,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
         Attr<std::vector<std::string>>("output_name_mapping");
 
     int binding_offset = 0;
+    nvinfer1::IExecutionContext *trt_context = nullptr;
     if (engine->with_dynamic_shape()) {
       // Initilize context and get offset by profile index
       auto *trt_context = engine->context();
@@ -340,7 +341,6 @@ class TensorRTEngineOp : public framework::OperatorBase {
         auto x_max_input_shape = max_input_shape[x];
         RuntimeDynamicShapeCheck(x, t_shape, x_min_input_shape,
                                  x_max_input_shape);
-        auto *trt_context = engine->context();
         trt_context->setBindingDimensions(
             bind_index, inference::tensorrt::Vec2TRT_Dims(t_shape, x, true));
 #endif
@@ -378,7 +378,6 @@ class TensorRTEngineOp : public framework::OperatorBase {
         }
       } else {
 #if IS_TRT_VERSION_GE(6000)
-        auto *trt_context = engine->context();
         auto dims = trt_context->getBindingDimensions(bind_index);
         int nb_dims = dims.nbDims;
         for (; nb_dims > 0; nb_dims--) {

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -291,6 +291,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
     // This method returns the total over all profiles.
     const int num_bindings = engine->GetNbBindings();
     std::vector<void *> buffers(num_bindings, nullptr);
+
     // Bind input tensor to TRT.
     for (const auto &x : Inputs("Xs")) {
       if (param_names_.count(x)) continue;

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -288,7 +288,6 @@ class TensorRTEngineOp : public framework::OperatorBase {
       auto *trt_context = engine->context();
       binding_offset = engine->GetBindingsOffset();
     }
-
     // This method returns the total over all profiles.
     const int num_bindings = engine->GetNbBindings();
     std::vector<void *> buffers(num_bindings, nullptr);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
变长多线程切换支持。对于每一个context都需要设置一个profile，如果没有会core。
遗留问题：
1.profile数目需要在engine创建时确定，此后不能修改。代码中强制定义max_profile_num为2。

2.调用createExecutionContext时trt必然会先尝试使用profile 0所以会出警告信息：
E0713 05:49:52.728997 53494 helper.h:88] Profile 0 has been chosen by another IExecutionContext. Use another profileIndex or destroy the IExecutionContext that use this profile.
W0713 05:49:52.729036 53494 helper.h:84] Could not set default profile 0 for execution context. Profile index must be set explicitly.

3.在没有调用IOptimizationProfile::setExtraMemoryTarget接口的情况下显存随max_profile_num数目显著增长(运行时只有一个线程的情况下)：
1 1965MiB
2 3131MiB
8 7863MiB

4.随着max_profile_num数目增加predictor初始化时间也显著增加。
