### PR TITLE
fix test_conv_nn_grad/test_norm_nn_grad/test_nn_grad unittest timeout

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -485,6 +485,9 @@ py_test_modules(test_imperative_static_runner_while MODULES test_imperative_stat
 set_tests_properties(test_conv2d_op PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_conv2d_op_depthwise_conv PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_conv2d_api PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
+set_tests_properties(test_conv_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
+set_tests_properties(test_norm_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
+set_tests_properties(test_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 if(WITH_DISTRIBUTE)
     # FIXME(typhoonzero): add these tests back
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_transformer")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix test_conv_nn_grad/test_norm_nn_grad/test_nn_grad unittest timeout
test_conv_nn_grad:
![image](https://user-images.githubusercontent.com/29245900/125398545-0b803e00-e3e2-11eb-8bff-d27fa5112091.png)
test_nn_grad:
![image](https://user-images.githubusercontent.com/29245900/125399077-abd66280-e3e2-11eb-91da-c658b83d1b63.png)

test_norm_nn_grad:
![image](https://user-images.githubusercontent.com/29245900/125399479-40d95b80-e3e3-11eb-9d26-085b2a0e4263.png)

if test_conv_nn_grad, test_nn_grad, test_norm_nn_grad  run at the same time, there will timeout, so add exclusive for test_conv_nn_grad, test_nn_grad, test_norm_nn_grad