### PR TITLE
Fix softmax on npu

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
@@ -13,10 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/softmax_with_cross_entropy_op.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "paddle/fluid/framework/op_version_registry.h"
 
 namespace paddle {
@@ -139,6 +141,12 @@ class SoftmaxWithCrossEntropyOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_EQ(
         ctx->HasOutput("Loss"), true,
         platform::errors::InvalidArgument("Output(Loss) should be not null."));
+
+#ifdef PADDLE_WITH_ASCEND_CL
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Backprop"), true,
+                      platform::errors::InvalidArgument(
+                          "Output(Backprop) should be not null."));
+#endif
 
     auto axis = ctx->Attrs().Get<int>("axis");
     auto logits_dims = ctx->GetInputDim("Logits");

--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
@@ -13,10 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/softmax_with_cross_entropy_op.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "paddle/fluid/framework/op_version_registry.h"
 
 namespace paddle {
@@ -133,12 +135,19 @@ class SoftmaxWithCrossEntropyOp : public framework::OperatorWithKernel {
         ctx->HasInput("Label"), true,
         platform::errors::InvalidArgument("Input(Label) should be not null."));
 
-    PADDLE_ENFORCE_EQ(ctx->HasOutput("Softmax"), true,
-                      platform::errors::InvalidArgument(
-                          "Output(Softmax) should be not null."));
+    PADDLE_ENFORCE_EQ(
+        ctx->HasOutput("Softmax"), true,
+        platform::errors::InvalidArgument(
+            "Output(Softmax) should be not null."));
     PADDLE_ENFORCE_EQ(
         ctx->HasOutput("Loss"), true,
         platform::errors::InvalidArgument("Output(Loss) should be not null."));
+
+#ifdef PADDLE_WITH_ASCEND_CL
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Backprop"), true,
+                      platform::errors::InvalidArgument(
+                          "Output(Backprop) should be not null."));
+#endif
 
     auto axis = ctx->Attrs().Get<int>("axis");
     auto logits_dims = ctx->GetInputDim("Logits");

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -100,7 +100,9 @@ std::map<std::string, std::set<std::string>> op_outs_map = {
     {"lamb",
      {"ParamOut", "Moment1Out", "Moment2Out", "Beta1PowOut", "Beta2PowOut"}},
     {"run_program", {"DOut"}},
+#ifdef PADDLE_WITH_ASCEND_CL
     {"softmax_with_cross_entropy", {"Softmax", "Backprop", "Loss"}},
+#endif
 };
 
 // NOTE(zhiqiu): Commonly, the outputs in auto-generated OP function are

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -100,6 +100,7 @@ std::map<std::string, std::set<std::string>> op_outs_map = {
     {"lamb",
      {"ParamOut", "Moment1Out", "Moment2Out", "Beta1PowOut", "Beta2PowOut"}},
     {"run_program", {"DOut"}},
+    {"softmax_with_cross_entropy", {"Softmax", "Backprop", "Loss"}},
 };
 
 // NOTE(zhiqiu): Commonly, the outputs in auto-generated OP function are

--- a/python/paddle/fluid/tests/unittests/npu/test_cross_entropy_dynamic_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cross_entropy_dynamic_npu.py
@@ -1,0 +1,104 @@
+#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+sys.path.append("..")
+import paddle
+import paddle.fluid as fluid
+import paddle.nn.functional as F
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestForwardNetDynamic(unittest.TestCase):
+    def _test(self, run_npu=True):
+        if not paddle.in_dynamic_mode():
+            paddle.disable_static()
+        if run_npu:
+            paddle.set_device('npu:0')
+        else:
+            paddle.set_device('cpu')
+
+        np.random.seed(2021)
+        paddle.seed(2021)
+
+        b_np = np.random.random(size=(32, 32)).astype('float32')
+        label_np = np.random.randint(2, size=(32, 1)).astype('int64')
+
+        class MLP(paddle.nn.Layer):
+            def __init__(self):
+                super(MLP, self).__init__()
+                self.linear1 = paddle.nn.Linear(in_features=32, out_features=2)
+
+            def forward(self, x):
+                x = paddle.flatten(x, start_axis=1, stop_axis=-1)
+                x = self.linear1(x)
+                return x
+
+        def train(model):
+            model.train()
+            epochs = 20
+            optim = paddle.optimizer.Adam(
+                learning_rate=0.001, parameters=model.parameters())
+            for epoch in range(epochs):
+                x_data = paddle.to_tensor(b_np)
+                y_data = paddle.to_tensor(label_np)
+                predicts = model(x_data)
+                loss = F.cross_entropy(predicts, y_data)
+                acc = paddle.metric.accuracy(predicts, y_data)
+                loss.backward()
+                print("epoch: {}, loss is: {}, acc is: {}".format(
+                    epoch, loss.numpy(), acc.numpy()))
+                optim.step()
+                optim.clear_grad()
+
+        model = MLP()
+        train(model)
+
+        def test(model):
+            model.eval()
+            acc_set = []
+            avg_loss_set = []
+            x_data = paddle.to_tensor(b_np)
+            y_data = paddle.to_tensor(label_np)
+            predicts = model(x_data)
+            loss = F.cross_entropy(predicts, y_data)
+            avg_loss = paddle.mean(loss)
+            avg_loss_set.append(float(avg_loss.numpy()))
+            acc = paddle.metric.accuracy(predicts, y_data)
+            acc_set.append(float(acc.numpy()))
+            acc_val_mean = np.array(acc_set).mean()
+            avg_loss_val_mean = np.array(avg_loss_set).mean()
+            print('loss={}, acc={}'.format(avg_loss_val_mean, acc_val_mean))
+            return predicts, avg_loss_val_mean, acc_val_mean
+
+        predicts, loss, acc = test(model)
+        return predicts, loss, acc
+
+    def test_npu(self):
+        cpu_pred, cpu_loss, cpu_acc = self._test(False)
+        npu_pred, npu_loss, npu_acc = self._test(True)
+
+        # relax the rtol=1e-05 to 5e-5
+        self.assertTrue(np.allclose(npu_pred, cpu_pred, rtol=5e-5))
+        self.assertTrue(np.allclose(npu_loss, cpu_loss))
+        self.assertTrue(np.allclose(npu_acc, cpu_acc))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/npu/test_cross_entropy_dynamic_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cross_entropy_dynamic_npu.py
@@ -1,0 +1,104 @@
+#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+sys.path.append("..")
+import paddle
+import paddle.fluid as fluid
+import paddle.nn.functional as F
+
+
+@unittest.skipIf(not paddle.is_compiled_with_npu(),
+                 "core is not compiled with NPU")
+class TestForwardNetDynamic(unittest.TestCase):
+    def _test(self, run_npu=True):
+        if not paddle.in_dynamic_mode():
+            paddle.disable_static()
+        if run_npu:
+            paddle.set_device('npu:0')
+        else:
+            paddle.set_device('cpu')
+
+        np.random.seed(2021)
+        paddle.seed(2021)
+
+        b_np = np.random.random(size=(32, 32)).astype('float32')
+        label_np = np.random.randint(2, size=(32, 1)).astype('int64')
+
+        class MLP(paddle.nn.Layer):
+            def __init__(self):
+                super(MLP, self).__init__()
+                self.linear1 = paddle.nn.Linear(in_features=32, out_features=2)
+
+            def forward(self, x):
+                x = paddle.flatten(x, start_axis=1, stop_axis=-1)
+                x = self.linear1(x)
+                return x
+
+        def train(model):
+            model.train()
+            epochs = 20
+            optim = paddle.optimizer.Adam(
+                learning_rate=0.001, parameters=model.parameters())
+            for epoch in range(epochs):
+                x_data = paddle.to_tensor(b_np)
+                y_data = paddle.to_tensor(label_np)
+                predicts = model(x_data)
+                loss = F.cross_entropy(predicts, y_data)
+                acc = paddle.metric.accuracy(predicts, y_data)
+                loss.backward()
+                print("epoch: {}, loss is: {}, acc is: {}".format(
+                    epoch, loss.numpy(), acc.numpy()))
+                optim.step()
+                optim.clear_grad()
+
+        model = MLP()
+        train(model)
+
+        def test(model):
+            model.eval()
+            acc_set = []
+            avg_loss_set = []
+            x_data = paddle.to_tensor(b_np)
+            y_data = paddle.to_tensor(label_np)
+            predicts = model(x_data)
+            loss = F.cross_entropy(predicts, y_data)
+            avg_loss = paddle.mean(loss)
+            avg_loss_set.append(float(avg_loss.numpy()))
+            acc = paddle.metric.accuracy(predicts, y_data)
+            acc_set.append(float(acc.numpy()))
+            acc_val_mean = np.array(acc_set).mean()
+            avg_loss_val_mean = np.array(avg_loss_set).mean()
+            print('loss={}, acc={}'.format(avg_loss_val_mean, acc_val_mean))
+            return predicts, loss, acc
+
+        predicts, loss, acc = test(model)
+        return predicts, loss, acc
+
+    def test_npu(self):
+        cpu_pred, cpu_loss, cpu_acc = self._test(False)
+        npu_pred, npu_loss, npu_acc = self._test(True)
+
+        # relax the rtol=1e-05 to 5e-5
+        self.assertTrue(np.allclose(npu_pred, cpu_pred, rtol=5e-5))
+        self.assertTrue(np.allclose(npu_loss, cpu_loss))
+        self.assertTrue(np.allclose(npu_acc, cpu_acc))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1386,10 +1386,16 @@ def cross_entropy(input,
     if input_dims - 1 == label_dims:
         label = paddle.unsqueeze(label, axis=axis)
     if in_dygraph_mode():
-        _, out = core.ops.softmax_with_cross_entropy(
-            input, label, 'soft_label', soft_label, 'ignore_index',
-            ignore_index, 'numeric_stable_mode', True, 'axis', axis,
-            'use_softmax', use_softmax)
+        if core.is_compiled_with_npu():
+            _, backprop, out = core.ops.softmax_with_cross_entropy(
+                input, label, 'soft_label', soft_label, 'ignore_index',
+                ignore_index, 'numeric_stable_mode', True, 'axis', axis,
+                'use_softmax', use_softmax)
+        else:
+            _, out = core.ops.softmax_with_cross_entropy(
+                input, label, 'soft_label', soft_label, 'ignore_index',
+                ignore_index, 'numeric_stable_mode', True, 'axis', axis,
+                'use_softmax', use_softmax)
 
         if weight is not None:
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
在NPU环境下使用softmax的时候，多出来的Backprop是dispensable的，需要被op_function_generator.cc处理一下。否则的话会在softmax_with_cross_entropy的infer shape阶段，报NotFoundError: can not find [Backprop] in output。
此外增加了一个检查，先判断有没有这个output，而不用等到后面需要setOutputDim的时候再踩上。
此外修改了loss.py，这样使用cross_entropy的时候也不会报错了。

改了上述问题之后，NPU环境下可以用动态图模式跑起来一个简单的MNIST数据集加MLP网络的训练了。（参考单测。单测中用的是固定数据以及单层网络。）