### PR TITLE
add slice in ext_tensor

### DIFF
--- a/paddle/fluid/extension/include/ext_tensor.h
+++ b/paddle/fluid/extension/include/ext_tensor.h
@@ -62,6 +62,9 @@ class PD_DLL_DECL Tensor {
   /// \param shape The shape to set.
   void reshape(const std::vector<int64_t>& shape);
 
+  /// \brief Return a sub-tensor of the given tensor.
+  Tensor Tensor::slice(int64_t begin_idx, int64_t end_idx) const;
+
   /// \brief Get the memory pointer in CPU or GPU with
   /// specific data type.
   /// Please Reshape the tensor first before call this.

--- a/paddle/fluid/extension/src/ext_tensor.cc
+++ b/paddle/fluid/extension/src/ext_tensor.cc
@@ -105,6 +105,13 @@ void Tensor::reshape(const std::vector<int64_t> &shape) {
   tensor->Resize(new_dim);
 }
 
+Tensor Tensor::slice(int64_t begin_idx, int64_t end_idx) const {
+  GET_CASTED_TENSOR
+  tensor = tensor->Slice(begin_idx, end_idx);
+  auto *target = static_cast<paddle::Tensor *>(tensor.get());
+  return target
+}
+
 Tensor::Tensor(const PlaceType &place)
     : tensor_(std::make_shared<framework::LoDTensor>()),
       place_(place),

--- a/paddle/fluid/framework/custom_tensor_test.cc
+++ b/paddle/fluid/framework/custom_tensor_test.cc
@@ -235,6 +235,21 @@ void TestInitilized() {
   }
 }
 
+void TestSlice() {
+  auto t1 = InitCPUTensorForTest<float>();
+  float* t1_ptr = t1.mutable_data<float>(paddle::PlaceType::kCPU);
+  for (int64_t i = 0; i < 5; i++) {
+    t1_ptr[i] = 0.5;
+  }
+  t2 = t1.slice(0, 1);
+  CHECK_EQ(t2.shape()[0], 1);
+  CHECK_EQ(t2.shape()[1], 5);
+  float* tensor_data = t2.data<float>();
+  for (int64_t i = 0; i < 5; i++) {
+    CHECK_EQ(tensor_data[i], 0.5);
+  }
+}
+
 TEST(CustomTensor, copyTest) {
   VLOG(2) << "TestCopy";
   GroupTestCopy();
@@ -250,4 +265,6 @@ TEST(CustomTensor, copyTest) {
   GroupTestDtypeConvert();
   VLOG(2) << "TestInitilized";
   TestInitilized();
+  VLOG(2) << "TestSlice";
+  TestSlice();
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
This PR add slice API into paddle::Tensor to support user slice tensor.