### PR TITLE
[Dy2Stat] Ignore to convert paddle.no_grad

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/grad_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/grad_transformer.py
@@ -83,5 +83,6 @@ def is_grad_api_node(node):
     assert isinstance(node, gast.Call)
     api_name = utils.ast_to_source_code(node.func).strip()
     if utils.is_paddle_api(node):
-        return api_name.endswith("grad")
+        # NOTE: ignore paddle.no_grad
+        return api_name.endswith("grad") and 'no_' not in api_name
     return False

--- a/python/paddle/fluid/dygraph/dygraph_to_static/grad_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/grad_transformer.py
@@ -83,6 +83,10 @@ def is_grad_api_node(node):
     assert isinstance(node, gast.Call)
     api_name = utils.ast_to_source_code(node.func).strip()
     if utils.is_paddle_api(node):
-        # NOTE: ignore paddle.no_grad
-        return api_name.endswith("grad") and 'no_' not in api_name
+        if 'no_grad' in api_name:
+            warnings.warn(
+                "paddle.no_grad is only supported for inference model, and not supported for training under @to_static."
+            )
+            return False
+        return api_name.endswith("grad")
     return False

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_grad.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_grad.py
@@ -88,15 +88,16 @@ class TestGradLinear(TestGrad):
         self.func = GradLinearLayer()
         self.x = paddle.ones(shape=[10, 2, 5], dtype='float32')
         self.x.stop_gradient = False
+        self.infer_model_path = "double_grad_infer_model"
+        self.train_model_path = "double_grad_train_model"
 
     def test_save_infer_program(self):
-        path = "double_grad_infer_model"
         input_spec = [
             paddle.static.InputSpec(
                 shape=[10, 2, 5], dtype='float32')
         ]
-        paddle.jit.save(self.func, path, input_spec=input_spec)
-        load_func = paddle.jit.load(path)
+        paddle.jit.save(self.func, self.infer_model_path, input_spec=input_spec)
+        load_func = paddle.jit.load(self.infer_model_path)
 
         origin_res = self.func(self.x).numpy()
         load_res = load_func(self.x).numpy()
@@ -112,55 +113,24 @@ class TestGradLinear(TestGrad):
             avg_loss = paddle.mean(paddle.abs(out - 1))
             avg_loss.backward()
             optimizer.minimize(avg_loss)
+            print(self.x.grad.mean())
             self.func.clear_gradients()
 
-        path = "double_grad_train_model"
-        paddle.jit.save(self.func, path)
-        load_func = paddle.jit.load(path)
+        paddle.jit.save(self.func, self.train_model_path)
+        load_func = paddle.jit.load(self.train_model_path)
 
         origin_res = self.func(self.x).numpy()
         load_res = load_func(self.x).numpy()
         self.assertTrue(np.allclose(origin_res, load_res))
 
 
-class TestNoGradLinear(TestGrad):
+class TestNoGradLinear(TestGradLinear):
     def setUp(self):
         self.func = NoGradLinearLayer()
         self.x = paddle.ones(shape=[10, 2, 5], dtype='float32')
         self.x.stop_gradient = False
-
-    def test_save_infer_program(self):
-        path = "no_grad_infer_model"
-        input_spec = [
-            paddle.static.InputSpec(
-                shape=[10, 2, 5], dtype='float32')
-        ]
-        paddle.jit.save(self.func, path, input_spec=input_spec)
-        load_func = paddle.jit.load(path)
-
-        origin_res = self.func(self.x).numpy()
-        load_res = load_func(self.x).numpy()
-        self.assertTrue(np.allclose(origin_res, load_res))
-
-    def test_save_train_program(self):
-        grad_clip = paddle.nn.ClipGradByGlobalNorm(2.0)
-        optimizer = paddle.optimizer.SGD(learning_rate=0.01,
-                                         grad_clip=grad_clip,
-                                         parameters=self.func.parameters())
-        for i in range(10):
-            out = self.func(self.x)
-            avg_loss = paddle.mean(paddle.abs(out - 1))
-            avg_loss.backward()
-            optimizer.minimize(avg_loss)
-            self.func.clear_gradients()
-
-        path = "no_grad_train_model"
-        paddle.jit.save(self.func, path)
-        load_func = paddle.jit.load(path)
-
-        origin_res = self.func(self.x).numpy()
-        load_res = load_func(self.x).numpy()
-        self.assertTrue(np.allclose(origin_res, load_res))
+        self.infer_model_path = "no_grad_infer_model"
+        self.train_model_path = "no_grad_train_model"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

In https://github.com/PaddlePaddle/Paddle/pull/33110 , we support to convert `paddle.grad` into `paddle.static.gradients`. But it also convert `paddle.no_grad` by mistake. So in this PR, we fix it
