### PR TITLE
Fix gather_op and gather_nd_op by rectifying use of 0UL, test=develop

### DIFF
--- a/paddle/fluid/operators/gather.h
+++ b/paddle/fluid/operators/gather.h
@@ -80,7 +80,7 @@ void CPUGather(const platform::DeviceContext& ctx, const Tensor& src,
                           "input dim size of axis which is %d, but received "
                           "index element which is %d in the %d index.",
                           input_size, p_index[i], i));
-    PADDLE_ENFORCE_GE(p_index[i], 0UL,
+    PADDLE_ENFORCE_GE(p_index[i], 0,
                       platform::errors::OutOfRange(
                           "The element of Index must be greater than or equal "
                           "to 0, but received index element which is %d in the "
@@ -128,7 +128,7 @@ void CPUGatherNd(const platform::DeviceContext& ctx, const Tensor& input,
           platform::errors::InvalidArgument(
               "Input(index[-1)] has wrong value, it is [%d]", index_value));
       PADDLE_ENFORCE_GE(
-          index_value, 0UL,
+          index_value, 0,
           platform::errors::InvalidArgument(
               "The value of Input(index) must be no less than 0"));
 
@@ -160,7 +160,7 @@ void GatherV2Function(const Tensor* input, const Tensor* index, int axis,
                           "input dim size of axis which is %d, but received "
                           "index element which is %d in the %d index.",
                           input_index_dim_size, index_data[i], i));
-    PADDLE_ENFORCE_GE(index_data[i], 0UL,
+    PADDLE_ENFORCE_GE(index_data[i], 0,
                       platform::errors::OutOfRange(
                           "The element of Index must be greater than or equal "
                           "to 0, but received index element which is %d in the "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix gather_op and gather_nd_op by rectifying use of 0UL, replaced with 0 or 0LL.

Testing codes : 
![image](https://user-images.githubusercontent.com/86215757/125553497-d2308a2f-632e-4af7-9cca-d005bfa59d7f.png)

Before fixing : (OutOfRangeCheck doesn't work.)
![image](https://user-images.githubusercontent.com/86215757/125553222-d7c3b4ee-413d-4a42-9210-e6b17c435fba.png)

After fixing : (OutOfRangeCheck works.)
![image](https://user-images.githubusercontent.com/86215757/125553440-a6b8b000-49ce-4215-a082-268045e0820e.png)
