### PR TITLE
[pass enhance] determine the scope of attribute compat check.

### DIFF
--- a/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
@@ -72,19 +72,29 @@ AttrCompat& AttrCompat::IsIntIn(const std::set<int>& candidates) {
 AttrCompat& AttrCompat::IsLeftDefault() {
   const std::string& op_name = op_compat_->Name();
   if (!OpInfoMap::Instance().Has(op_name)) {
-    LOG(WARNING) << "Op (" << op_name << ") is not registered!";
-    conditions_.emplace_back([](const Attribute& attr) { return false; });
+    conditions_.emplace_back([=](const Attribute& attr) {
+      LOG(WARNING) << "Op (" << op_name << ") is not find in op library!";
+      return false;
+    });
     return *this;
   }
   const OpInfo& op_info = OpInfoMap::Instance().Get(op_name);
   const AttributeMap attrs = op_info.Checker()->GetDefaultAttrsMap();
   if (attrs.find(attr_name_) == attrs.end()) {
-    LOG(WARNING) << "Op (" << op_name << ") has no default attr:" << attr_name_;
-    conditions_.emplace_back([](const Attribute& attr) { return false; });
+    conditions_.emplace_back([=](const Attribute& attr) {
+      LOG(WARNING) << "Op (" << op_name
+                   << ") has no default attr:" << attr_name_;
+      return false;
+    });
   } else {
     Attribute default_attr = attrs.at(attr_name_);
-    conditions_.emplace_back([default_attr](const Attribute& attr) -> bool {
-      return attr == default_attr;
+    conditions_.emplace_back([=](const Attribute& attr) -> bool {
+      if (attr == default_attr) {
+        return true;
+      }
+      LOG(WARNING) << "Attribute:(" << attr_name_ << ") of Op (" << op_name
+                   << ") not equal to default value!";
+      return false;
     });
   }
   return *this;
@@ -167,35 +177,39 @@ InputOrOutputCompat& OpCompat::AddOutput(const std::string& name) {
   return output_compats_.at(name);
 }
 
-bool OpCompat::Judge(const OpDesc& op_desc) {
+bool OpCompat::Judge(const OpDesc& op_desc, const std::string& pass_name) {
   if (is_first_judge_) {
     is_first_judge_ = false;
+    if (OpInfoMap::Instance().Has(op_name_)) {
+      auto& info = OpInfoMap::Instance().Get(op_name_);
+      if (info.proto_) {
+        for (const proto::OpProto::Attr& attr : info.proto_->attrs()) {
+          attrs_set_.emplace(attr.name());
+        }
+      }
+    }
     const proto::OpDef& op_def = GetOpDef(op_name_);
     if (op_def.has_extra()) {
       for (const proto::OpDef_AttrDef& attr : op_def.extra().attrs()) {
-        extra_attrs_.emplace(attr.name());
+        attrs_set_.erase(attr.name());
       }
     }
-  }
-
-  for (auto& attr_map : op_desc.GetAttrMap()) {
-    const std::string& name = attr_map.first;
-    if (name.size() >= 10u &&
-        0 == name.compare(name.size() - 10u, 10u, "_threshold")) {
-      continue;  // skip the attribute ends with "_threshold", it used for
-                 // quantization.
+    for (const std::string& attr : global_extra_attrs) {
+      attrs_set_.erase(attr);
     }
-    if (attr_compats_.find(attr_map.first) == attr_compats_.end()) {
-      if (global_extra_attrs.find(attr_map.first) != global_extra_attrs.end() ||
-          extra_attrs_.find(attr_map.first) != extra_attrs_.end()) {
-        continue;
+    for (const std::string& attr : attrs_set_) {
+      if (attr_compats_.find(attr) == attr_compats_.end()) {
+        attr_compats_.emplace(attr, AttrCompat(attr, this).IsLeftDefault());
       }
-      if (!AttrCompat(attr_map.first, this).IsLeftDefault()(op_desc)) {
-        LOG(WARNING)
-            << "The Attr(" << attr_map.first << ") of Op (" << op_name_
-            << ") not reigistered in OpCompat, not in extra attribute, not "
-               "equal to default value!";
-        return false;
+    }
+    for (auto& attr_compat : attr_compats_) {
+      if (attrs_set_.find(attr_compat.first) == attrs_set_.end()) {
+        LOG(WARNING) << " Attribute(" << attr_compat.first << ") of Op("
+                     << op_name_
+                     << ") is not defined in opProto or is in extra set!"
+                     << "The compatable check for this attribute is not use."
+                     << " Please remove it from the precondition of pass: "
+                     << pass_name.c_str();
       }
     }
   }
@@ -203,7 +217,8 @@ bool OpCompat::Judge(const OpDesc& op_desc) {
   for (auto& attr_compat : attr_compats_) {
     if (!attr_compat.second(op_desc)) {
       LOG(WARNING) << " Check the Attr(" << attr_compat.first << ") of Op("
-                   << op_name_ << ") failed!";
+                   << op_name_ << ") in pass(" << pass_name.c_str()
+                   << ") failed!";
       return false;
     }
   }
@@ -289,7 +304,7 @@ bool OpCompatSensiblePass::IsCompat(
       continue;
     }
     auto& judger = *op_compat_judgers_.at(op_type);
-    if (!judger.Judge(*(node_pair.second->Op()))) {
+    if (!judger.Judge(*(node_pair.second->Op()), Type())) {
       return false;
     }
   }

--- a/paddle/fluid/framework/ir/op_compat_sensible_pass.h
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass.h
@@ -138,7 +138,7 @@ class OpCompat {
   InputOrOutputCompat& AddOutput(const std::string& name);
 
   //! Judge whether an OpDesc match the defined Op compatibility.
-  bool Judge(const OpDesc& op_desc);
+  bool Judge(const OpDesc& op_desc, const std::string& pass_name);
   const std::string& Name() const { return op_name_; }
 
  private:
@@ -146,7 +146,7 @@ class OpCompat {
   std::unordered_map<std::string, AttrCompat> attr_compats_;
   std::unordered_map<std::string, InputOrOutputCompat> input_compats_;
   std::unordered_map<std::string, InputOrOutputCompat> output_compats_;
-  std::unordered_set<std::string> extra_attrs_;
+  std::unordered_set<std::string> attrs_set_;
   bool is_first_judge_ = true;
 };
 
@@ -206,7 +206,7 @@ class OpCompatSensiblePass : public Pass {
   //! Tell the op compatibility of a single Op.
   bool IsCompat(const OpDesc& op_desc) const {
     if (!op_compat_judgers_.count(op_desc.Type())) return false;
-    return op_compat_judgers_.at(op_desc.Type())->Judge(op_desc);
+    return op_compat_judgers_.at(op_desc.Type())->Judge(op_desc, Type());
   }
 
  private:

--- a/paddle/fluid/operators/compat/fc.pbtxt
+++ b/paddle/fluid/operators/compat/fc.pbtxt
@@ -23,10 +23,6 @@ def {
 }
 extra {
   attrs {
-    name: "use_mkldnn"
-    type: BOOLEAN
-  }
-  attrs {
     name: "padding_weights"
     type: BOOLEAN
   }
@@ -35,63 +31,19 @@ extra {
     type: BOOLEAN
   }
   attrs {
-    name: "use_quantizer"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "mkldnn_data_type"
-    type: STRING
-  }
-  attrs {
-    name: "weight_scale"
-    type: FLOATS
-  }
-  attrs {
-    name: "Input_scale"
+    name: "Scale_in"
     type: FLOAT
   }
   attrs {
-    name: "out_scale"
+    name: "Scale_weights"
     type: FLOAT
   }
   attrs {
-    name: "out_threshold"
+    name: "Scale_out"
     type: FLOAT
   }
   attrs {
     name: "force_fp32_output"
     type: BOOLEAN
-  }
-  attrs {
-    name: "enable_int8"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_fc_padding"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "use_gpu"
-    type: BOOLEAN
-  }
-  attrs {
-    name: "op_role"
-    type: INT
-  }
-  attrs {
-    name: "op_role_var"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_namescope"
-    type: STRING
-  }
-  attrs {
-    name: "op_callstack"
-    type: STRINGS
-  }
-  attrs {
-    name: "op_device"
-    type: STRING
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
限定pass针对op的属性兼容性检测范围
1. 在op marker中有定义
2. 不在@opname@.pbtxt的extra列表中。
3. 不在全局global_extra_attrs列表中。