### PR TITLE
[Cherry-Pick]Support finetuning the model saved on the MAC on the Linux 

### DIFF
--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -232,7 +232,9 @@ class MatMulGradKernel : public framework::OpKernel<T> {
     int head_number = 1;
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA) && \
     !defined(PADDLE_WITH_HIP)
-    head_number = context.Attr<int>("head_number");
+    if (context.HasAttr("head_number")) {
+      head_number = context.Attr<int>("head_number");
+    }
 #endif
 
     if (head_number <= 1 && a.dims().size() == 3 && b.dims().size() <= 2) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

![image](https://user-images.githubusercontent.com/22128369/124885671-157ef700-e006-11eb-949b-c234e25b7ac4.png)
修复《jit.save在Mac系统上保存的模型，在Linux平台上无法对模型进行重训练》的问题。
- 原因：如上图，在mac与linux 保存的program中matmul op描述不一致，左边Linux，右边mac，linux 的matmul op 多一个 head_number =1属性。由于在Linux加载这个Program时因为找不到head_number属性而报错。

- 可以修复的原因：在mac上保存的program没有head_number属性，在Linux上加载时，没有这个属性就默认head_number=1。

原始PR： https://github.com/PaddlePaddle/Paddle/pull/34027