### PR TITLE
[Paddle-TRT] Add noexcept on methods inherited from TensorRT

### DIFF
--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -39,6 +39,12 @@ namespace tensorrt {
   NV_TENSORRT_MAJOR * 1000 + NV_TENSORRT_MINOR * 100 + \
       NV_TENSORRT_PATCH * 10 + NV_TENSORRT_BUILD
 
+#if IS_TRT_VERSION_GE(8000)
+#define TRT_NOEXCEPT noexcept
+#else
+#define TRT_NOEXCEPT
+#endif
+
 namespace dy = paddle::platform::dynload;
 
 // TensorRT data type to size
@@ -72,7 +78,8 @@ static int GetInferLibVersion() {
 // A logger for create TensorRT infer builder.
 class NaiveLogger : public nvinfer1::ILogger {
  public:
-  void log(nvinfer1::ILogger::Severity severity, const char* msg) override {
+  void log(nvinfer1::ILogger::Severity severity,
+           const char* msg) TRT_NOEXCEPT override {
     switch (severity) {
       case Severity::kVERBOSE:
         VLOG(3) << msg;
@@ -105,7 +112,7 @@ class NaiveProfiler : public nvinfer1::IProfiler {
   typedef std::pair<std::string, float> Record;
   std::vector<Record> mProfile;
 
-  virtual void reportLayerTime(const char* layerName, float ms) {
+  virtual void reportLayerTime(const char* layerName, float ms) TRT_NOEXCEPT {
     auto record =
         std::find_if(mProfile.begin(), mProfile.end(),
                      [&](const Record& r) { return r.first == layerName; });

--- a/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.cu
@@ -110,16 +110,18 @@ AnchorGeneratorPlugin::AnchorGeneratorPlugin(const void* data, size_t length) {
   PrepareParamsOnDevice();
 }
 
-const char* AnchorGeneratorPlugin::getPluginType() const {
+const char* AnchorGeneratorPlugin::getPluginType() const TRT_NOEXCEPT {
   return "anchor_generator_plugin";
 }
 
-const char* AnchorGeneratorPlugin::getPluginVersion() const { return "1"; }
+const char* AnchorGeneratorPlugin::getPluginVersion() const TRT_NOEXCEPT {
+  return "1";
+}
 
-int AnchorGeneratorPlugin::getNbOutputs() const { return 2; }
+int AnchorGeneratorPlugin::getNbOutputs() const TRT_NOEXCEPT { return 2; }
 
 nvinfer1::Dims AnchorGeneratorPlugin::getOutputDimensions(
-    int index, const nvinfer1::Dims* inputs, int nb_input_dims) {
+    int index, const nvinfer1::Dims* inputs, int nb_input_dims) TRT_NOEXCEPT {
   nvinfer1::Dims dims{};
   dims.nbDims = 4;
   dims.d[0] = height_;
@@ -130,20 +132,21 @@ nvinfer1::Dims AnchorGeneratorPlugin::getOutputDimensions(
 }
 
 bool AnchorGeneratorPlugin::supportsFormat(
-    nvinfer1::DataType type, nvinfer1::TensorFormat format) const {
+    nvinfer1::DataType type, nvinfer1::TensorFormat format) const TRT_NOEXCEPT {
   // static shape plugin can't support different type between input/out
   // it may cause addition overhead in half mode
   return (type == data_type_ && format == nvinfer1::TensorFormat::kLINEAR);
 }
 
-size_t AnchorGeneratorPlugin::getWorkspaceSize(int max_batch_size) const {
+size_t AnchorGeneratorPlugin::getWorkspaceSize(int max_batch_size) const
+    TRT_NOEXCEPT {
   return 0;
 }
 
 template <typename T>
 int AnchorGeneratorPlugin::enqueue_impl(int batch_size,
                                         const void* const* inputs,
-                                        void** outputs, void* workspace,
+                                        void* const* outputs, void* workspace,
                                         cudaStream_t stream) {
   const int block = 512;
   const int gen_anchor_grid = (box_num_ + block - 1) / block;
@@ -169,15 +172,15 @@ int AnchorGeneratorPlugin::enqueue(int batch_size, const void* const* inputs,
 #else
                                    void* const* outputs, void* workspace,
 #endif
-                                   cudaStream_t stream) {
+                                   cudaStream_t stream) TRT_NOEXCEPT {
   return enqueue_impl<float>(batch_size, inputs, outputs, workspace, stream);
 }
 
-int AnchorGeneratorPlugin::initialize() { return 0; }
+int AnchorGeneratorPlugin::initialize() TRT_NOEXCEPT { return 0; }
 
-void AnchorGeneratorPlugin::terminate() {}
+void AnchorGeneratorPlugin::terminate() TRT_NOEXCEPT {}
 
-size_t AnchorGeneratorPlugin::getSerializationSize() const {
+size_t AnchorGeneratorPlugin::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(data_type_);
   serialize_size += SerializedSize(anchor_sizes_);
@@ -192,7 +195,7 @@ size_t AnchorGeneratorPlugin::getSerializationSize() const {
   return serialize_size;
 }
 
-void AnchorGeneratorPlugin::serialize(void* buffer) const {
+void AnchorGeneratorPlugin::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, data_type_);
   SerializeValue(&buffer, anchor_sizes_);
   SerializeValue(&buffer, aspect_ratios_);
@@ -205,28 +208,31 @@ void AnchorGeneratorPlugin::serialize(void* buffer) const {
   SerializeValue(&buffer, box_num_);
 }
 
-void AnchorGeneratorPlugin::destroy() {}
+void AnchorGeneratorPlugin::destroy() TRT_NOEXCEPT {}
 
-void AnchorGeneratorPlugin::setPluginNamespace(const char* lib_namespace) {
+void AnchorGeneratorPlugin::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* AnchorGeneratorPlugin::getPluginNamespace() const {
+const char* AnchorGeneratorPlugin::getPluginNamespace() const TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
 nvinfer1::DataType AnchorGeneratorPlugin::getOutputDataType(
-    int index, const nvinfer1::DataType* input_type, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_type,
+    int nb_inputs) const TRT_NOEXCEPT {
   return input_type[0];
 }
 
 bool AnchorGeneratorPlugin::isOutputBroadcastAcrossBatch(
-    int output_index, const bool* input_is_broadcast, int nb_inputs) const {
+    int output_index, const bool* input_is_broadcast,
+    int nb_inputs) const TRT_NOEXCEPT {
   return true;
 }
 
-bool AnchorGeneratorPlugin::canBroadcastInputAcrossBatch(
-    int input_index) const {
+bool AnchorGeneratorPlugin::canBroadcastInputAcrossBatch(int input_index) const
+    TRT_NOEXCEPT {
   return false;
 }
 
@@ -236,9 +242,9 @@ void AnchorGeneratorPlugin::configurePlugin(
     const nvinfer1::DataType* input_types,
     const nvinfer1::DataType* output_types, const bool* input_is_broadcast,
     const bool* output_is_broadcast, nvinfer1::PluginFormat float_format,
-    int max_batct_size) {}
+    int max_batct_size) TRT_NOEXCEPT {}
 
-nvinfer1::IPluginV2Ext* AnchorGeneratorPlugin::clone() const {
+nvinfer1::IPluginV2Ext* AnchorGeneratorPlugin::clone() const TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPlugin(
       data_type_, anchor_sizes_, aspect_ratios_, stride_, variances_, offset_,
       height_, width_, num_anchors_, box_num_);
@@ -246,30 +252,32 @@ nvinfer1::IPluginV2Ext* AnchorGeneratorPlugin::clone() const {
   return plugin;
 }
 
-void AnchorGeneratorPluginCreator::setPluginNamespace(
-    const char* lib_namespace) {
+void AnchorGeneratorPluginCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* AnchorGeneratorPluginCreator::getPluginNamespace() const {
+const char* AnchorGeneratorPluginCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
-const char* AnchorGeneratorPluginCreator::getPluginName() const {
+const char* AnchorGeneratorPluginCreator::getPluginName() const TRT_NOEXCEPT {
   return "anchor_generator_plugin";
 }
 
-const char* AnchorGeneratorPluginCreator::getPluginVersion() const {
+const char* AnchorGeneratorPluginCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
   return "1";
 }
 
 const nvinfer1::PluginFieldCollection*
-AnchorGeneratorPluginCreator::getFieldNames() {
+AnchorGeneratorPluginCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   const nvinfer1::PluginField* fields = fc->fields;
   int type_id = -1;
   std::vector<float> anchor_sizes, aspect_ratios, stride, variances;
@@ -315,7 +323,8 @@ nvinfer1::IPluginV2Ext* AnchorGeneratorPluginCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPlugin(serial_data, serial_length);
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;
@@ -374,7 +383,8 @@ AnchorGeneratorPluginDynamic::AnchorGeneratorPluginDynamic(void const* data,
   PrepareParamsOnDevice();
 }
 
-nvinfer1::IPluginV2DynamicExt* AnchorGeneratorPluginDynamic::clone() const {
+nvinfer1::IPluginV2DynamicExt* AnchorGeneratorPluginDynamic::clone() const
+    TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPluginDynamic(
       data_type_, anchor_sizes_, aspect_ratios_, stride_, variances_, offset_,
       num_anchors_);
@@ -384,7 +394,7 @@ nvinfer1::IPluginV2DynamicExt* AnchorGeneratorPluginDynamic::clone() const {
 
 nvinfer1::DimsExprs AnchorGeneratorPluginDynamic::getOutputDimensions(
     int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-    nvinfer1::IExprBuilder& exprBuilder) {
+    nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT {
   nvinfer1::DimsExprs ret{};
   ret.nbDims = 4;
   ret.d[0] = inputs[0].d[2];  // feature height
@@ -396,7 +406,7 @@ nvinfer1::DimsExprs AnchorGeneratorPluginDynamic::getOutputDimensions(
 
 bool AnchorGeneratorPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* inOut, int nbInputs,
-    int nbOutputs) {
+    int nbOutputs) TRT_NOEXCEPT {
   // input can be any, doesn't matter
   // anchor generator doesn't read input raw data, only need the shape info
   auto type = inOut[pos].type;
@@ -412,11 +422,12 @@ bool AnchorGeneratorPluginDynamic::supportsFormatCombination(
 
 void AnchorGeneratorPluginDynamic::configurePlugin(
     const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs,
-    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {}
+    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) TRT_NOEXCEPT {}
 
 size_t AnchorGeneratorPluginDynamic::getWorkspaceSize(
     const nvinfer1::PluginTensorDesc* inputs, int nbInputs,
-    const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
   return 0;
 }
 
@@ -449,7 +460,7 @@ int AnchorGeneratorPluginDynamic::enqueue_impl(
 int AnchorGeneratorPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc* inputDesc,
     const nvinfer1::PluginTensorDesc* outputDesc, const void* const* inputs,
-    void* const* outputs, void* workspace, cudaStream_t stream) {
+    void* const* outputs, void* workspace, cudaStream_t stream) TRT_NOEXCEPT {
   assert(outputDesc[0].type == nvinfer1::DataType::kFLOAT);
   assert(outputDesc[1].type == nvinfer1::DataType::kFLOAT);
   return enqueue_impl<float>(inputDesc, outputDesc, inputs, outputs, workspace,
@@ -457,21 +468,24 @@ int AnchorGeneratorPluginDynamic::enqueue(
 }
 
 nvinfer1::DataType AnchorGeneratorPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* inputTypes, int nbInputs) const {
+    int index, const nvinfer1::DataType* inputTypes,
+    int nbInputs) const TRT_NOEXCEPT {
   return inputTypes[0];
 }
 
-const char* AnchorGeneratorPluginDynamic::getPluginType() const {
+const char* AnchorGeneratorPluginDynamic::getPluginType() const TRT_NOEXCEPT {
   return "anchor_generator_plugin_dynamic";
 }
 
-int AnchorGeneratorPluginDynamic::getNbOutputs() const { return 2; }
+int AnchorGeneratorPluginDynamic::getNbOutputs() const TRT_NOEXCEPT {
+  return 2;
+}
 
-int AnchorGeneratorPluginDynamic::initialize() { return 0; }
+int AnchorGeneratorPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-void AnchorGeneratorPluginDynamic::terminate() {}
+void AnchorGeneratorPluginDynamic::terminate() TRT_NOEXCEPT {}
 
-size_t AnchorGeneratorPluginDynamic::getSerializationSize() const {
+size_t AnchorGeneratorPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(data_type_);
   serialize_size += SerializedSize(anchor_sizes_);
@@ -483,7 +497,7 @@ size_t AnchorGeneratorPluginDynamic::getSerializationSize() const {
   return serialize_size;
 }
 
-void AnchorGeneratorPluginDynamic::serialize(void* buffer) const {
+void AnchorGeneratorPluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, data_type_);
   SerializeValue(&buffer, anchor_sizes_);
   SerializeValue(&buffer, aspect_ratios_);
@@ -493,32 +507,35 @@ void AnchorGeneratorPluginDynamic::serialize(void* buffer) const {
   SerializeValue(&buffer, num_anchors_);
 }
 
-void AnchorGeneratorPluginDynamic::destroy() {}
+void AnchorGeneratorPluginDynamic::destroy() TRT_NOEXCEPT {}
 
 void AnchorGeneratorPluginDynamicCreator::setPluginNamespace(
-    const char* lib_namespace) {
+    const char* lib_namespace) TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* AnchorGeneratorPluginDynamicCreator::getPluginNamespace() const {
+const char* AnchorGeneratorPluginDynamicCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
-const char* AnchorGeneratorPluginDynamicCreator::getPluginName() const {
+const char* AnchorGeneratorPluginDynamicCreator::getPluginName() const
+    TRT_NOEXCEPT {
   return "anchor_generator_plugin_dynamic";
 }
 
-const char* AnchorGeneratorPluginDynamicCreator::getPluginVersion() const {
+const char* AnchorGeneratorPluginDynamicCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
   return "1";
 }
 
 const nvinfer1::PluginFieldCollection*
-AnchorGeneratorPluginDynamicCreator::getFieldNames() {
+AnchorGeneratorPluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginDynamicCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   const nvinfer1::PluginField* fields = fc->fields;
   int type_id = -1;
   std::vector<float> anchor_sizes, aspect_ratios, stride, variances;
@@ -555,7 +572,8 @@ nvinfer1::IPluginV2Ext* AnchorGeneratorPluginDynamicCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2Ext* AnchorGeneratorPluginDynamicCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new AnchorGeneratorPluginDynamic(serial_data, serial_length);
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;

--- a/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/anchor_generator_op_plugin.h
@@ -34,34 +34,35 @@ class AnchorGeneratorPlugin : public nvinfer1::IPluginV2Ext {
       const int width, const int num_anchors, const int box_num);
   AnchorGeneratorPlugin(const void* data, size_t length);
   ~AnchorGeneratorPlugin() override;
-  const char* getPluginType() const override;
-  const char* getPluginVersion() const override;
-  int getNbOutputs() const override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nb_input_dims) override;
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::TensorFormat format) const override;
-  size_t getWorkspaceSize(int max_batch_size) const override;
+                                     int nb_input_dims) TRT_NOEXCEPT override;
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::TensorFormat format)
+      const TRT_NOEXCEPT override;
+  size_t getWorkspaceSize(int max_batch_size) const TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_type,
-                                       int nb_inputs) const override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_type,
+      int nb_inputs) const TRT_NOEXCEPT override;
   bool isOutputBroadcastAcrossBatch(int output_index,
                                     const bool* input_is_broadcast,
-                                    int nb_inputs) const override;
-  bool canBroadcastInputAcrossBatch(int input_index) const override;
+                                    int nb_inputs) const TRT_NOEXCEPT override;
+  bool canBroadcastInputAcrossBatch(int input_index) const
+      TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::Dims* input_dims, int nb_inputs,
                        const nvinfer1::Dims* output_dims, int nb_outputs,
                        const nvinfer1::DataType* input_types,
@@ -69,13 +70,13 @@ class AnchorGeneratorPlugin : public nvinfer1::IPluginV2Ext {
                        const bool* input_is_broadcast,
                        const bool* output_is_broadcast,
                        nvinfer1::PluginFormat float_format,
-                       int max_batct_size) override;
-  nvinfer1::IPluginV2Ext* clone() const override;
+                       int max_batct_size) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* clone() const TRT_NOEXCEPT override;
 
  private:
   template <typename T>
-  int enqueue_impl(int batch_size, const void* const* inputs, void** outputs,
-                   void* workspace, cudaStream_t stream);
+  int enqueue_impl(int batch_size, const void* const* inputs,
+                   void* const* outputs, void* workspace, cudaStream_t stream);
   nvinfer1::DataType data_type_;
   std::vector<float> anchor_sizes_;
   std::vector<float> aspect_ratios_;
@@ -97,16 +98,17 @@ class AnchorGeneratorPluginCreator : public nvinfer1::IPluginCreator {
  public:
   AnchorGeneratorPluginCreator() = default;
   ~AnchorGeneratorPluginCreator() override = default;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
-                                            const void* serial_data,
-                                            size_t serial_length) override;
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
 
  private:
   std::string namespace_;
@@ -127,35 +129,36 @@ class AnchorGeneratorPluginDynamic : public DynamicPluginTensorRT {
                                         const int num_anchors);
   AnchorGeneratorPluginDynamic(void const* data, size_t length);
   ~AnchorGeneratorPluginDynamic();
-  nvinfer1::IPluginV2DynamicExt* clone() const override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override;
+                       int nbOutputs) TRT_NOEXCEPT override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override;
+                          int nbOutputs) const TRT_NOEXCEPT override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
-  const char* getPluginType() const override;
-  int getNbOutputs() const override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   template <typename T>
@@ -181,16 +184,17 @@ class AnchorGeneratorPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   AnchorGeneratorPluginDynamicCreator() = default;
   ~AnchorGeneratorPluginDynamicCreator() override = default;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
-                                            const void* serial_data,
-                                            size_t serial_length) override;
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
 
  private:
   std::string namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.cu
@@ -48,7 +48,7 @@ __global__ void elementwise_kernel(const size_t total, const T *x_data,
 }
 
 nvinfer1::Dims ElementWisePlugin::getOutputDimensions(
-    int index, const nvinfer1::Dims *input_dims, int num_inputs) {
+    int index, const nvinfer1::Dims *input_dims, int num_inputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "There is only one output in TRT elementwise "
                                   "op plugin, but got output index: %d.",
@@ -64,7 +64,7 @@ nvinfer1::Dims ElementWisePlugin::getOutputDimensions(
   return input_dims[0];
 }
 
-int ElementWisePlugin::initialize() {
+int ElementWisePlugin::initialize() TRT_NOEXCEPT {
   PADDLE_ENFORCE_GT(dims_y_.nbDims, 0,
                     platform::errors::InvalidArgument(
                         "The dimension of input Y of TRT elementwise op plugin "
@@ -120,7 +120,7 @@ int ElementWisePlugin::enqueue(int batch_size, const void *const *inputs,
 #else
                                void *const *outputs, void *workspace,
 #endif
-                               cudaStream_t stream) {
+                               cudaStream_t stream) TRT_NOEXCEPT {
   const float *x = reinterpret_cast<const float *>(inputs[0]);
   const float *y = reinterpret_cast<const float *>(inputs[1]);
   float *out = reinterpret_cast<float *>(outputs[0]);
@@ -147,26 +147,26 @@ int ElementWisePlugin::enqueue(int batch_size, const void *const *inputs,
 // Dynamic Plugin below.
 #if IS_TRT_VERSION_GE(6000)
 
-int ElementwisePluginDynamic::initialize() { return 0; }
+int ElementwisePluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t ElementwisePluginDynamic::getSerializationSize() const {
+size_t ElementwisePluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   return SerializedSize(type_.c_str()) + SerializedSize(axis_);
 }
 
-void ElementwisePluginDynamic::serialize(void *buffer) const {
+void ElementwisePluginDynamic::serialize(void *buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, type_.c_str());
   SerializeValue(&buffer, axis_);
 }
 
 nvinfer1::DimsExprs ElementwisePluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   return inputs[0];
 }
 
 bool ElementwisePluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -189,7 +189,8 @@ bool ElementwisePluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType ElementwisePluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0,
                     platform::errors::InvalidArgument(
                         "The Elementwise Plugin only has one input, so the "
@@ -201,7 +202,7 @@ nvinfer1::DataType ElementwisePluginDynamic::getOutputDataType(
 int ElementwisePluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto x_dims = input_desc[0].dims;
   auto y_dims = input_desc[1].dims;
   int axis = (axis_ == -1) ? x_dims.nbDims - y_dims.nbDims : axis_;

--- a/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/elementwise_op_plugin.h
@@ -48,33 +48,35 @@ class ElementWisePlugin : public PluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &post_size_);
   }
 
-  ElementWisePlugin* clone() const override {
+  ElementWisePlugin* clone() const TRT_NOEXCEPT override {
     return new ElementWisePlugin(type_, dims_x_, dims_y_, axis_);
   }
 
-  const char* getPluginType() const override { return "elementwise_plugin"; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "elementwise_plugin";
+  }
 
   nvinfer1::Dims getOutputDimensions(int index,
                                      const nvinfer1::Dims* input_dims,
-                                     int num_inputs) override;
+                                     int num_inputs) TRT_NOEXCEPT override;
 
-  int initialize() override;
+  int initialize() TRT_NOEXCEPT override;
 
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream);
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize() + SerializedSize(type_.c_str()) +
            SerializedSize(dims_x_) + SerializedSize(dims_y_) +
            SerializedSize(axis_) + SerializedSize(prev_size_) +
            SerializedSize(midd_size_) + SerializedSize(post_size_);
   }
 
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, type_.c_str());
     SerializeValue(&buffer, dims_x_);
@@ -97,13 +99,15 @@ class ElementWisePlugin : public PluginTensorRT {
 
 class ElementWisePluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "elementwise_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "elementwise_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new ElementWisePlugin(serial_data, serial_length);
   }
 };
@@ -120,48 +124,49 @@ class ElementwisePluginDynamic : public DynamicPluginTensorRT {
     type_ = std::string(elementwise_type);
     DeserializeValue(&serialData, &serialLength, &axis_);
   }
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new ElementwisePluginDynamic(type_, axis_);
   }
 
-  const char* getPluginType() const override {
+  const char* getPluginType() const TRT_NOEXCEPT override {
     return "elementwise_plugin_dynamic";
   }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   std::string type_;
@@ -171,33 +176,34 @@ class ElementwisePluginDynamic : public DynamicPluginTensorRT {
 class ElementwisePluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   ElementwisePluginDynamicCreator() {}
-  const char* getPluginName() const override {
+  const char* getPluginName() const TRT_NOEXCEPT override {
     return "elementwise_plugin_dynamic";
   }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new ElementwisePluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
@@ -128,7 +128,7 @@ template <typename T>
 int EmbEltwiseLayernormPluginDynamicImpl<T>::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto id_dims = input_desc[0].dims;
   int batch = id_dims.d[0];
   int seq_len = id_dims.d[1];
@@ -181,17 +181,19 @@ template class EmbEltwiseLayernormPluginDynamicImpl<float>;
 template class EmbEltwiseLayernormPluginDynamicImpl<half>;
 #endif
 
-int EmbEltwiseLayernormPluginDynamic::initialize() {
+int EmbEltwiseLayernormPluginDynamic::initialize() TRT_NOEXCEPT {
   impl_->initialize();
 
   return 0;
 }
 
-void EmbEltwiseLayernormPluginDynamic::terminate() { impl_->terminate(); }
+void EmbEltwiseLayernormPluginDynamic::terminate() TRT_NOEXCEPT {
+  impl_->terminate();
+}
 
 nvinfer1::DimsExprs EmbEltwiseLayernormPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {  // NOLINT
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {  // NOLINT
   PADDLE_ENFORCE_EQ(output_index, 0,
                     platform::errors::InvalidArgument(
                         "There is only one output of the EmbEltwiseLayernorm, "
@@ -208,7 +210,7 @@ nvinfer1::DimsExprs EmbEltwiseLayernormPluginDynamic::getOutputDimensions(
 
 bool EmbEltwiseLayernormPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -256,7 +258,8 @@ bool EmbEltwiseLayernormPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType EmbEltwiseLayernormPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(
       index, 0, platform::errors::InvalidArgument(
                     "The EmbEltwiseLayernorm Plugin only has one input, so the "
@@ -271,7 +274,7 @@ nvinfer1::DataType EmbEltwiseLayernormPluginDynamic::getOutputDataType(
 int EmbEltwiseLayernormPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   impl_->enqueue(input_desc, output_desc, inputs, outputs, workspace, stream);
   return cudaGetLastError() != cudaSuccess;
 }

--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
@@ -68,7 +68,7 @@ class EmbEltwiseLayernormPluginDynamicImpl
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream);
+              cudaStream_t stream) TRT_NOEXCEPT;
   void shareGPUData(const EmbEltwiseLayernormPluginDynamicImplBase* anthor);
 
  private:
@@ -189,7 +189,7 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
     }
   }
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     auto ptr = new EmbEltwiseLayernormPluginDynamic(
         embs_, bias_, scale_, emb_sizes_, bias_size_, scale_size_, hidden_size_,
         eps_, with_fp16_);
@@ -197,14 +197,14 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
     return ptr;
   }
 
-  const char* getPluginType() const override {
+  const char* getPluginType() const TRT_NOEXCEPT override {
     return "fused_embedding_eltwise_layernorm_plugin";
   }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
-  void terminate() override;
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     int sum_num = 0;
     sum_num += SerializedSize(emb_sizes_);
 
@@ -223,7 +223,7 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
     return sum_num;
   }
 
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, emb_sizes_);
     for (size_t i = 0; i < emb_sizes_.size(); i++) {
       auto size = emb_sizes_[i];
@@ -248,33 +248,34 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* input_desc,
               const nvinfer1::PluginTensorDesc* output_desc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override {
+  void destroy() TRT_NOEXCEPT override {
     if (own_host_buff_) {
       for (auto ptr : embs_) {
         delete[] ptr;
@@ -310,32 +311,33 @@ class EmbEltwiseLayernormPluginDynamicCreator
     : public nvinfer1::IPluginCreator {
  public:
   EmbEltwiseLayernormPluginDynamicCreator() {}
-  const char* getPluginName() const override {
+  const char* getPluginName() const TRT_NOEXCEPT override {
     return "fused_embedding_eltwise_layernorm_plugin";
   }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new EmbEltwiseLayernormPluginDynamic(serial_data, serial_length);
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.cu
@@ -58,19 +58,19 @@ __global__ void GatherNdCUDAKernel(const T* input, const int32_t* input_dims,
   }
 }
 
-int GatherNdPluginDynamic::initialize() { return 0; }
+int GatherNdPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t GatherNdPluginDynamic::getSerializationSize() const {
+size_t GatherNdPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   return SerializedSize(with_fp16_);
 }
 
-void GatherNdPluginDynamic::serialize(void* buffer) const {
+void GatherNdPluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, with_fp16_);
 }
 
 nvinfer1::DimsExprs GatherNdPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(
       nb_inputs, 2,
       platform::errors::InvalidArgument(
@@ -100,7 +100,7 @@ nvinfer1::DimsExprs GatherNdPluginDynamic::getOutputDimensions(
 
 bool GatherNdPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of gather_nd plugin should not be nullptr."));
@@ -134,14 +134,15 @@ bool GatherNdPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType GatherNdPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   return input_types[0];
 }
 
 int GatherNdPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc* input_desc,
     const nvinfer1::PluginTensorDesc* output_desc, const void* const* inputs,
-    void* const* outputs, void* workspace, cudaStream_t stream) {
+    void* const* outputs, void* workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   auto index_dims = input_desc[1].dims;
   auto input_dims_size = input_dims.nbDims;

--- a/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/gather_nd_op_plugin.h
@@ -35,46 +35,49 @@ class GatherNdPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &with_fp16_);
   }
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new GatherNdPluginDynamic(with_fp16_);
   }
 
-  const char* getPluginType() const override { return "gather_nd_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "gather_nd_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override {
+  void destroy() TRT_NOEXCEPT override {
     if (input_dims_data_) {
       cudaFree(input_dims_data_);
     }
@@ -88,31 +91,34 @@ class GatherNdPluginDynamic : public DynamicPluginTensorRT {
 class GatherNdPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   GatherNdPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "gather_nd_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "gather_nd_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new GatherNdPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.cu
@@ -30,8 +30,8 @@ static const float kAT = 0.5;
 static const float kBT = 0.7978845608028654;    // sqrt(2.0/M_PI)
 static const float kCT = 0.035677408136300125;  // 0.044715 * sqrt(2.0/M_PI)
 
-bool GeluPlugin::supportsFormat(nvinfer1::DataType type,
-                                nvinfer1::PluginFormat format) const {
+bool GeluPlugin::supportsFormat(
+    nvinfer1::DataType type, nvinfer1::PluginFormat format) const TRT_NOEXCEPT {
   if (with_fp16_) {
     return ((type == nvinfer1::DataType::kFLOAT ||
              type == nvinfer1::DataType::kHALF) &&
@@ -44,7 +44,7 @@ bool GeluPlugin::supportsFormat(nvinfer1::DataType type,
 
 nvinfer1::Dims GeluPlugin::getOutputDimensions(int index,
                                                const nvinfer1::Dims* in_dims,
-                                               int nb_inputs) {
+                                               int nb_inputs) TRT_NOEXCEPT {
   assert(nb_inputs == 1);
   assert(index < this->getNbOutputs());
   nvinfer1::Dims const& input_dims = in_dims[0];
@@ -96,7 +96,8 @@ int GeluPlugin::enqueue(int batch_size, const void* const* inputs,
 #if IS_TRT_VERSION_LT(8000)
                         void** outputs, void*, cudaStream_t stream) {
 #else
-                        void* const* outputs, void*, cudaStream_t stream) {
+                        void* const* outputs, void*,
+                        cudaStream_t stream) TRT_NOEXCEPT {
 #endif
   const auto& input_dims = this->getInputDims(0);
   int num = batch_size;
@@ -132,13 +133,13 @@ int GeluPlugin::enqueue(int batch_size, const void* const* inputs,
 
 nvinfer1::DimsExprs GeluPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   return inputs[0];
 }
 
 bool GeluPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -167,7 +168,8 @@ bool GeluPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType GeluPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The Gelu Plugin only has one input, so the "
                                   "index value should be 0, but get %d.",
@@ -178,7 +180,8 @@ nvinfer1::DataType GeluPluginDynamic::getOutputDataType(
 int GeluPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
                                const nvinfer1::PluginTensorDesc* output_desc,
                                const void* const* inputs, void* const* outputs,
-                               void* workspace, cudaStream_t stream) {
+                               void* workspace,
+                               cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   size_t num = ProductDim(input_dims);
   const int block_size = 256;

--- a/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/gelu_op_plugin.h
@@ -35,40 +35,48 @@ class GeluPlugin : public PluginTensorRT {
   }
 
   ~GeluPlugin() {}
-  GeluPlugin* clone() const override { return new GeluPlugin(with_fp16_); }
+  GeluPlugin* clone() const TRT_NOEXCEPT override {
+    return new GeluPlugin(with_fp16_);
+  }
 
-  const char* getPluginType() const override { return "gelu_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::PluginFormat format) const override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "gelu_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format)
+      const TRT_NOEXCEPT override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nb_input_dims) override;
+                                     int nb_input_dims) TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize();
   }
 
   // TRT will call this func  to serialize the configuration of TRT
   // It should not be called by users.
-  void serialize(void* buffer) const override { serializeBase(buffer); }
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
+    serializeBase(buffer);
+  }
 };
 
 class GeluPluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "gelu_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "gelu_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new GeluPlugin(serial_data, serial_length);
   }
 };
@@ -83,61 +91,66 @@ class GeluPluginDynamic : public DynamicPluginTensorRT {
   }
 
   ~GeluPluginDynamic() {}
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new GeluPluginDynamic(with_fp16_);
   }
 
-  const char* getPluginType() const override { return "gelu_plugin_dynamic"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "gelu_plugin_dynamic";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return SerializedSize(with_fp16_);
   }
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, with_fp16_);
   }
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* input_desc,
               const nvinfer1::PluginTensorDesc* output_desc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 };
 
 class GeluPluginDynamicCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "gelu_plugin_dynamic"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "gelu_plugin_dynamic";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new GeluPluginDynamic(serial_data, serial_length);
     return plugin;
   }

--- a/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.cu
@@ -22,7 +22,7 @@ namespace tensorrt {
 namespace plugin {
 
 nvinfer1::Dims HardSwishPlugin::getOutputDimensions(
-    int index, const nvinfer1::Dims* in_dims, int nb_inputs) {
+    int index, const nvinfer1::Dims* in_dims, int nb_inputs) TRT_NOEXCEPT {
   assert(nb_inputs == 1);
   assert(index < this->getNbOutputs());
   nvinfer1::Dims const& input_dims = in_dims[0];
@@ -54,7 +54,8 @@ int HardSwishPlugin::enqueue(int batch_size, const void* const* inputs,
 #if IS_TRT_VERSION_LT(8000)
                              void** outputs, void*, cudaStream_t stream) {
 #else
-                             void* const* outputs, void*, cudaStream_t stream) {
+                             void* const* outputs, void*,
+                             cudaStream_t stream) TRT_NOEXCEPT {
 #endif
   const auto& input_dims = this->getInputDims(0);
   int num = batch_size;

--- a/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/hard_swish_op_plugin.h
@@ -40,30 +40,32 @@ class HardSwishPlugin : public PluginTensorRT {
   }
 
   ~HardSwishPlugin() {}
-  HardSwishPlugin* clone() const override {
+  HardSwishPlugin* clone() const TRT_NOEXCEPT override {
     return new HardSwishPlugin(threshold_, scale_, offset_);
   }
 
-  const char* getPluginType() const override { return "hard_swish_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "hard_swish_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nbInputDims) override;
+                                     int nbInputDims) TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batchSize, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batchSize, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize() + SerializedSize(threshold_) +
            SerializedSize(scale_) + SerializedSize(offset_);
   }
 
   // TRT will call this func  to serialize the configuration of TRT
   // It should not be called by users.
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, threshold_);
     SerializeValue(&buffer, scale_);
@@ -78,13 +80,15 @@ class HardSwishPlugin : public PluginTensorRT {
 
 class HardSwishPluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "hard_swish_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "hard_swish_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new HardSwishPlugin(serial_data, serial_length);
   }
 };

--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.cu
@@ -39,10 +39,10 @@ cudnnStatus_t convert_trt2cudnn_dtype(nvinfer1::DataType trt_dtype,
   return CUDNN_STATUS_SUCCESS;
 }
 
-int InstanceNormPlugin::initialize() { return 0; }
+int InstanceNormPlugin::initialize() TRT_NOEXCEPT { return 0; }
 
 nvinfer1::Dims InstanceNormPlugin::getOutputDimensions(
-    int index, const nvinfer1::Dims *inputDims, int nbInputs) {
+    int index, const nvinfer1::Dims *inputDims, int nbInputs) TRT_NOEXCEPT {
   assert(nbInputs == 1);
   assert(index < this->getNbOutputs());
   nvinfer1::Dims const &input_dims = inputDims[0];
@@ -50,8 +50,8 @@ nvinfer1::Dims InstanceNormPlugin::getOutputDimensions(
   return output_dims;
 }
 
-bool InstanceNormPlugin::supportsFormat(nvinfer1::DataType type,
-                                        nvinfer1::PluginFormat format) const {
+bool InstanceNormPlugin::supportsFormat(
+    nvinfer1::DataType type, nvinfer1::PluginFormat format) const TRT_NOEXCEPT {
   return ((type == nvinfer1::DataType::kFLOAT ||
            type == nvinfer1::DataType::kHALF) &&
           (format == nvinfer1::PluginFormat::kLINEAR));
@@ -63,7 +63,7 @@ int InstanceNormPlugin::enqueue(int batch_size, const void *const *inputs,
 #else
                                 void *const *outputs, void *workspace,
 #endif
-                                cudaStream_t stream) {
+                                cudaStream_t stream) TRT_NOEXCEPT {
   const auto &input_dims = this->getInputDims(0);
 
   PADDLE_ENFORCE_EQ(input_dims.nbDims, 3,

--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
@@ -39,7 +39,7 @@ class InstanceNormPlugin : public PluginTensorRT {
   cudnnTensorDescriptor_t x_desc_, y_desc_, b_desc_;
 
  public:
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize() + SerializedSize(eps_) +
            SerializedSize(scale_) + SerializedSize(bias_);
   }
@@ -47,7 +47,7 @@ class InstanceNormPlugin : public PluginTensorRT {
   // TRT will call this func when we need to serialize the configuration of
   // tensorrt.
   // It should not be called by users.
-  void serialize(void *buffer) const override {
+  void serialize(void *buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, eps_);
     SerializeValue(&buffer, scale_);
@@ -89,37 +89,41 @@ class InstanceNormPlugin : public PluginTensorRT {
     platform::dynload::cudnnDestroyTensorDescriptor(b_desc_);
   }
 
-  int initialize() override;
+  int initialize() TRT_NOEXCEPT override;
 
-  InstanceNormPlugin *clone() const override {
+  InstanceNormPlugin *clone() const TRT_NOEXCEPT override {
     return new InstanceNormPlugin(eps_, scale_, bias_);
   }
 
-  const char *getPluginType() const override { return "instance_norm_plugin"; }
-  int getNbOutputs() const override { return 1; }
+  const char *getPluginType() const TRT_NOEXCEPT override {
+    return "instance_norm_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims *inputs,
-                                     int nbInputDims) override;
+                                     int nbInputDims) TRT_NOEXCEPT override;
 
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batchSize, const void *const *inputs, void **outputs,
 #else
   int enqueue(int batchSize, const void *const *inputs, void *const *outputs,
 #endif
-              void *workspace, cudaStream_t stream) override;
+              void *workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::PluginFormat format) const override;
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format)
+      const TRT_NOEXCEPT override;
 };
 
 class InstanceNormPluginCreator : public TensorRTPluginCreator {
  public:
-  const char *getPluginName() const override { return "instance_norm_plugin"; }
+  const char *getPluginName() const TRT_NOEXCEPT override {
+    return "instance_norm_plugin";
+  }
 
-  const char *getPluginVersion() const override { return "1"; }
+  const char *getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2 *deserializePlugin(const char *name,
-                                         const void *serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2 *deserializePlugin(
+      const char *name, const void *serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new InstanceNormPlugin(serial_data, serial_length);
   }
 };

--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
@@ -24,10 +24,10 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
-int LayerNormPlugin::initialize() { return 0; }
+int LayerNormPlugin::initialize() TRT_NOEXCEPT { return 0; }
 
 nvinfer1::Dims LayerNormPlugin::getOutputDimensions(
-    int index, const nvinfer1::Dims *inputDims, int nbInputs) {
+    int index, const nvinfer1::Dims *inputDims, int nbInputs) TRT_NOEXCEPT {
   assert(nbInputs == 1);
   assert(index < this->getNbOutputs());
   nvinfer1::Dims const &input_dims = inputDims[0];
@@ -41,10 +41,10 @@ int LayerNormPlugin::enqueue(int batch_size, const void *const *inputs,
 #else
                              void *const *outputs, void *workspace,
 #endif
-                             cudaStream_t stream) {
+                             cudaStream_t stream) TRT_NOEXCEPT {
   const auto &input_dims = this->getInputDims(0);
   const float *input = reinterpret_cast<const float *>(inputs[0]);
-  float *output = reinterpret_cast<float **>(outputs)[0];
+  float *output = reinterpret_cast<float *const *>(outputs)[0];
   int begin_norm_axis = begin_norm_axis_;
   float eps = eps_;
 
@@ -91,13 +91,13 @@ int LayerNormPlugin::enqueue(int batch_size, const void *const *inputs,
 
 nvinfer1::DimsExprs LayerNormPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputDims, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   return inputDims[0];
 }
 
 bool LayerNormPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of layernorm plugin shoule not be nullptr."));
@@ -118,7 +118,8 @@ bool LayerNormPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType LayerNormPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0,
                     platform::errors::InvalidArgument(
                         "The LayerNormPlugin only has one input, so the "
@@ -130,7 +131,7 @@ nvinfer1::DataType LayerNormPluginDynamic::getOutputDataType(
 int LayerNormPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   const auto &input_dims = input_desc[0].dims;
   int begin_norm_axis = begin_norm_axis_;
   float eps = eps_;

--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.h
@@ -40,7 +40,7 @@ class LayerNormPlugin : public PluginTensorRT {
   std::vector<int64_t> variance_shape_;
 
  public:
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize() + SerializedSize(bias_) +
            SerializedSize(scale_) + SerializedSize(begin_norm_axis_) +
            SerializedSize(eps_) + SerializedSize(mean_shape_) +
@@ -50,7 +50,7 @@ class LayerNormPlugin : public PluginTensorRT {
   // TRT will call this func when we need to serialize the configuration of
   // tensorrt.
   // It should not be called by users.
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, bias_);
     SerializeValue(&buffer, scale_);
@@ -86,35 +86,39 @@ class LayerNormPlugin : public PluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &variance_shape_);
   }
   ~LayerNormPlugin() {}
-  int initialize() override;
+  int initialize() TRT_NOEXCEPT override;
 
-  LayerNormPlugin* clone() const override {
+  LayerNormPlugin* clone() const TRT_NOEXCEPT override {
     return new LayerNormPlugin(bias_.data(), bias_.size(), scale_.data(),
                                scale_.size(), begin_norm_axis_, eps_,
                                mean_shape_, variance_shape_);
   }
 
-  const char* getPluginType() const override { return "layernorm_plugin"; }
-  int getNbOutputs() const override { return 1; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "layernorm_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nbInputDims) override;
+                                     int nbInputDims) TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batchSize, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batchSize, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 };
 
 class LayerNormPluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "layernorm_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "layernorm_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new LayerNormPlugin(serial_data, serial_length);
   }
 };
@@ -145,25 +149,25 @@ class LayerNormPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &mean_shape_);
     DeserializeValue(&serialData, &serialLength, &variance_shape_);
   }
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new LayerNormPluginDynamic(bias_.data(), bias_.size(), scale_.data(),
                                       scale_.size(), begin_norm_axis_, eps_,
                                       mean_shape_, variance_shape_);
   }
 
-  const char* getPluginType() const override {
+  const char* getPluginType() const TRT_NOEXCEPT override {
     return "layernorm_plugin_dynamic";
   }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return SerializedSize(bias_) + SerializedSize(scale_) +
            SerializedSize(begin_norm_axis_) + SerializedSize(eps_) +
            SerializedSize(mean_shape_) + SerializedSize(variance_shape_);
   }
 
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, bias_);
     SerializeValue(&buffer, scale_);
     SerializeValue(&buffer, begin_norm_axis_);
@@ -174,33 +178,34 @@ class LayerNormPluginDynamic : public DynamicPluginTensorRT {
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   std::vector<float> bias_;
@@ -217,15 +222,15 @@ class LayerNormPluginDynamic : public DynamicPluginTensorRT {
 
 class LayerNormPluginDynamicCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override {
+  const char* getPluginName() const TRT_NOEXCEPT override {
     return "layernorm_plugin_dynamic";
   }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new LayerNormPluginDynamic(serial_data, serial_length);
   }
 };

--- a/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.cu
@@ -22,7 +22,7 @@ namespace plugin {
 
 nvinfer1::Dims PoolPlugin::getOutputDimensions(int index,
                                                const nvinfer1::Dims *inputDims,
-                                               int nbInputs) {
+                                               int nbInputs) TRT_NOEXCEPT {
   assert(nbInputs == 1);
   assert(index == 0);
   assert(inputDims[0].nbDims == 3);
@@ -37,15 +37,16 @@ nvinfer1::Dims PoolPlugin::getOutputDimensions(int index,
 
 int PoolPlugin::enqueue(int batchSize, const void *const *inputs,
 #if IS_TRT_VERSION_LT(8000)
-                        void **outputs, void *workspace, cudaStream_t stream) {
+                        void **outputs, void *workspace,
+                        cudaStream_t stream) TRT_NOEXCEPT {
 #else
                         void *const *outputs, void *workspace,
-                        cudaStream_t stream) {
+                        cudaStream_t stream) TRT_NOEXCEPT {
 #endif
   auto const &input_dims = this->getInputDims(0);
   int input_size = 0;
   float const *idata = reinterpret_cast<float const *>(inputs[0]);
-  float **odatas = reinterpret_cast<float **>(outputs);
+  float *const *odatas = reinterpret_cast<float *const *>(outputs);
 
   std::vector<int> input_shape = input_shape_;
   std::vector<int> output_shape = output_shape_;
@@ -87,14 +88,14 @@ PoolPluginDynamic::PoolPluginDynamic(void const *serialData,
   DeserializeValue(&serialData, &serialLength, &is_global_);
 }
 
-size_t PoolPluginDynamic::getSerializationSize() const {
+size_t PoolPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   return SerializedSize(ceil_mode_) + SerializedSize(pool_type_.c_str()) +
          SerializedSize(adaptive_) + SerializedSize(ksize_) +
          SerializedSize(strides_) + SerializedSize(paddings_) +
          SerializedSize(is_global_);
 }
 
-void PoolPluginDynamic::serialize(void *buffer) const {
+void PoolPluginDynamic::serialize(void *buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, ceil_mode_);
   SerializeValue(&buffer, pool_type_.c_str());
   SerializeValue(&buffer, adaptive_);
@@ -106,7 +107,7 @@ void PoolPluginDynamic::serialize(void *buffer) const {
 
 nvinfer1::DimsExprs PoolPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(nb_inputs, 1,
                     platform::errors::InvalidArgument(
                         "The Split plugin should be only one input."));
@@ -181,7 +182,7 @@ nvinfer1::DimsExprs PoolPluginDynamic::getOutputDimensions(
 
 bool PoolPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -198,7 +199,8 @@ bool PoolPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType PoolPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The Pool Plugin only has one input, so the "
                                   "index value should be 0, but get %d.",
@@ -212,7 +214,8 @@ nvinfer1::DataType PoolPluginDynamic::getOutputDataType(
 int PoolPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc *input_desc,
                                const nvinfer1::PluginTensorDesc *output_desc,
                                const void *const *inputs, void *const *outputs,
-                               void *workspace, cudaStream_t stream) {
+                               void *workspace,
+                               cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   int n = input_dims.d[0];
   int c = input_dims.d[1];

--- a/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.h
@@ -57,7 +57,7 @@ static std::vector<int> CalcOutputSize(const std::vector<int>& input_shape,
 
 class PoolPlugin : public PluginTensorRT {
  public:
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize() + SerializedSize(ceil_mode_) +
            SerializedSize(pool_type_) + SerializedSize(adaptive_) +
            SerializedSize(ksize_) + SerializedSize(strides_) +
@@ -67,7 +67,7 @@ class PoolPlugin : public PluginTensorRT {
 
   // TRT will call this func when we need to serialize the configuration of
   // tensorrt.
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, ceil_mode_);
     SerializeValue(&buffer, pool_type_);
@@ -116,22 +116,24 @@ class PoolPlugin : public PluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &output_shape_);
   }
 
-  PoolPlugin* clone() const override {
+  PoolPlugin* clone() const TRT_NOEXCEPT override {
     return new PoolPlugin(ceil_mode_, pool_type_, adaptive_, ksize_, strides_,
                           paddings_, input_shape_);
   }
 
-  const char* getPluginType() const override { return "pool_plugin"; }
-  int getNbOutputs() const override { return 1; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "pool_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nbInputDims) override;
-  int initialize() override { return 0; }
+                                     int nbInputDims) TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override { return 0; }
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batchSize, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batchSize, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 
  private:
   bool ceil_mode_;
@@ -146,13 +148,15 @@ class PoolPlugin : public PluginTensorRT {
 
 class PoolPluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "pool_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "pool_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new PoolPlugin(serial_data, serial_length);
   }
 };
@@ -176,47 +180,50 @@ class PoolPluginDynamic : public DynamicPluginTensorRT {
 
   PoolPluginDynamic(void const* serialData, size_t serialLength);
   ~PoolPluginDynamic() {}
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new PoolPluginDynamic(ceil_mode_, pool_type_, adaptive_, ksize_,
                                  strides_, paddings_, is_global_);
   }
 
-  const char* getPluginType() const override { return "pool_plugin_dynamic"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "pool_plugin_dynamic";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   bool ceil_mode_;
@@ -230,13 +237,15 @@ class PoolPluginDynamic : public DynamicPluginTensorRT {
 
 class PoolPluginDynamicCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "pool_plugin_dynamic"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "pool_plugin_dynamic";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new PoolPluginDynamic(serial_data, serial_length);
   }
 };

--- a/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.h
@@ -34,7 +34,7 @@ class PReluPlugin : public PluginTensorRT {
   std::string mode_;
 
  public:
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize() + SerializedSize(mode_.c_str()) +
            SerializedSize(weight_);
   }
@@ -42,7 +42,7 @@ class PReluPlugin : public PluginTensorRT {
   // TRT will call this func when we need to serialize the configuration of
   // tensorrt.
   // It should not be called by users.
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, weight_);
     SerializeValue(&buffer, mode_.c_str());
@@ -65,36 +65,40 @@ class PReluPlugin : public PluginTensorRT {
     mode_ = std::string(prelu_mode);
   }
   ~PReluPlugin() {}
-  int initialize() override;
-  void terminate() override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
 
-  PReluPlugin* clone() const override {
+  PReluPlugin* clone() const TRT_NOEXCEPT override {
     auto* ptr = new PReluPlugin(weight_.data(), weight_.size(), mode_);
     ptr->p_gpu_weight_ = p_gpu_weight_;
     return ptr;
   }
 
-  const char* getPluginType() const override { return "prelu_plugin"; }
-  int getNbOutputs() const override { return 1; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "prelu_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nbInputDims) override;
+                                     int nbInputDims) TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batchSize, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batchSize, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 };
 
 class PReluPluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "prelu_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "prelu_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new PReluPlugin(serial_data, serial_length);
   }
 };
@@ -112,49 +116,52 @@ class PReluPluginDynamic : public DynamicPluginTensorRT {
 
   PReluPluginDynamic(void const* serialData, size_t serialLength);
   ~PReluPluginDynamic() {}
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     auto ptr = new PReluPluginDynamic(weight_.data(), weight_.size(), mode_);
     ptr->p_gpu_weight_ = p_gpu_weight_;
     return ptr;
   }
 
-  const char* getPluginType() const override { return "prelu_plugin_dynamic"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
-  void terminate() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "prelu_plugin_dynamic";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   std::vector<float> weight_;
@@ -165,13 +172,15 @@ class PReluPluginDynamic : public DynamicPluginTensorRT {
 
 class PReluPluginDynamicCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "prelu_plugin_dynamic"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "prelu_plugin_dynamic";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new PReluPluginDynamic(serial_data, serial_length);
   }
 };

--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
@@ -147,11 +147,11 @@ inline void TransposeQKV(const int batch, const int seq_len,
   }
 }
 
-int QkvToContextPluginDynamic::initialize() { return 0; }
+int QkvToContextPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
 nvinfer1::DimsExprs QkvToContextPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   // input[0], (B, S, 3 * N * H, 1, 1)
   // input[1], (B, head_num, seq_len, seq_len)
   // output, (B, seq_len, hidden)
@@ -177,7 +177,7 @@ nvinfer1::DimsExprs QkvToContextPluginDynamic::getOutputDimensions(
 
 bool QkvToContextPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -215,7 +215,8 @@ bool QkvToContextPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType QkvToContextPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(
       index, 0, platform::errors::InvalidArgument(
                     "The EmbEltwiseLayernorm Plugin only has one input, so the "
@@ -235,7 +236,7 @@ __global__ void apply_scale(T *data, T scale, int n) {
 int QkvToContextPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   int input_num = ProductDim(input_dims);
   // input[0], (B, S, 3 * N * H, 1, 1)

--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.h
@@ -59,21 +59,23 @@ class QkvToContextPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &scale_);
     DeserializeValue(&serial_data, &serial_length, &with_fp16_);
   }
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new QkvToContextPluginDynamic(hidden_, head_number_, head_size_,
                                          scale_, with_fp16_);
   }
 
-  const char* getPluginType() const override { return "qkv_to_context_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "qkv_to_context_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return SerializedSize(hidden_) + SerializedSize(head_number_) +
            SerializedSize(head_size_) + SerializedSize(scale_) +
            SerializedSize(with_fp16_);
   }
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, hidden_);
     SerializeValue(&buffer, head_number_);
     SerializeValue(&buffer, head_size_);
@@ -83,33 +85,34 @@ class QkvToContextPluginDynamic : public DynamicPluginTensorRT {
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   int hidden_;
@@ -121,31 +124,34 @@ class QkvToContextPluginDynamic : public DynamicPluginTensorRT {
 class QkvToContextPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   QkvToContextPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "qkv_to_context_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "qkv_to_context_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new QkvToContextPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.cu
@@ -200,7 +200,8 @@ RoiAlignPluginDynamic::RoiAlignPluginDynamic(void const* data, size_t length) {
   smem_per_block_ = smem_per_block;
 }
 
-nvinfer1::IPluginV2DynamicExt* RoiAlignPluginDynamic::clone() const {
+nvinfer1::IPluginV2DynamicExt* RoiAlignPluginDynamic::clone() const
+    TRT_NOEXCEPT {
   auto* plugin =
       new RoiAlignPluginDynamic(data_type_, pooled_height_, pooled_width_,
                                 spatial_scale_, sampling_ratio_);
@@ -210,7 +211,7 @@ nvinfer1::IPluginV2DynamicExt* RoiAlignPluginDynamic::clone() const {
 
 nvinfer1::DimsExprs RoiAlignPluginDynamic::getOutputDimensions(
     int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-    nvinfer1::IExprBuilder& exprBuilder) {
+    nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT {
   nvinfer1::DimsExprs ret{};
   ret.nbDims = 4;
   ret.d[0] = inputs[1].d[0];  // roi
@@ -222,7 +223,7 @@ nvinfer1::DimsExprs RoiAlignPluginDynamic::getOutputDimensions(
 
 bool RoiAlignPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* inOut, int nbInputs,
-    int nbOutputs) {
+    int nbOutputs) TRT_NOEXCEPT {
   if (inOut[pos].format != nvinfer1::TensorFormat::kLINEAR) {
     return false;
   }
@@ -234,11 +235,12 @@ bool RoiAlignPluginDynamic::supportsFormatCombination(
 
 void RoiAlignPluginDynamic::configurePlugin(
     const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs,
-    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {}
+    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) TRT_NOEXCEPT {}
 
 size_t RoiAlignPluginDynamic::getWorkspaceSize(
     const nvinfer1::PluginTensorDesc* inputs, int nbInputs,
-    const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
   return 0;
 }
 
@@ -287,7 +289,7 @@ int RoiAlignPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
                                    const nvinfer1::PluginTensorDesc* outputDesc,
                                    const void* const* inputs,
                                    void* const* outputs, void* workspace,
-                                   cudaStream_t stream) {
+                                   cudaStream_t stream) TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(outputDesc[0].type, data_type_,
                     platform::errors::InvalidArgument(
                         "TRT RoiAlignPluginDynamic expects outputDesc[0].type "
@@ -302,21 +304,22 @@ int RoiAlignPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
 }
 
 nvinfer1::DataType RoiAlignPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* inputTypes, int nbInputs) const {
+    int index, const nvinfer1::DataType* inputTypes,
+    int nbInputs) const TRT_NOEXCEPT {
   return inputTypes[0];
 }
 
-const char* RoiAlignPluginDynamic::getPluginType() const {
+const char* RoiAlignPluginDynamic::getPluginType() const TRT_NOEXCEPT {
   return "roi_align_plugin_dynamic";
 }
 
-int RoiAlignPluginDynamic::getNbOutputs() const { return 1; }
+int RoiAlignPluginDynamic::getNbOutputs() const TRT_NOEXCEPT { return 1; }
 
-int RoiAlignPluginDynamic::initialize() { return 0; }
+int RoiAlignPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-void RoiAlignPluginDynamic::terminate() {}
+void RoiAlignPluginDynamic::terminate() TRT_NOEXCEPT {}
 
-size_t RoiAlignPluginDynamic::getSerializationSize() const {
+size_t RoiAlignPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(data_type_);
   serialize_size += SerializedSize(pooled_height_);
@@ -326,7 +329,7 @@ size_t RoiAlignPluginDynamic::getSerializationSize() const {
   return serialize_size;
 }
 
-void RoiAlignPluginDynamic::serialize(void* buffer) const {
+void RoiAlignPluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, data_type_);
   SerializeValue(&buffer, pooled_height_);
   SerializeValue(&buffer, pooled_width_);
@@ -334,40 +337,43 @@ void RoiAlignPluginDynamic::serialize(void* buffer) const {
   SerializeValue(&buffer, sampling_ratio_);
 }
 
-void RoiAlignPluginDynamic::destroy() {}
+void RoiAlignPluginDynamic::destroy() TRT_NOEXCEPT {}
 
 RoiAlignPluginDynamicCreator::RoiAlignPluginDynamicCreator() {}
 
-void RoiAlignPluginDynamicCreator::setPluginNamespace(
-    const char* lib_namespace) {
+void RoiAlignPluginDynamicCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* RoiAlignPluginDynamicCreator::getPluginNamespace() const {
+const char* RoiAlignPluginDynamicCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
-const char* RoiAlignPluginDynamicCreator::getPluginName() const {
+const char* RoiAlignPluginDynamicCreator::getPluginName() const TRT_NOEXCEPT {
   return "roi_align_plugin_dynamic";
 }
 
-const char* RoiAlignPluginDynamicCreator::getPluginVersion() const {
+const char* RoiAlignPluginDynamicCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
   return "1";
 }
 
 const nvinfer1::PluginFieldCollection*
-RoiAlignPluginDynamicCreator::getFieldNames() {
+RoiAlignPluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2Ext* RoiAlignPluginDynamicCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   const nvinfer1::PluginField* fields = fc->fields;
   return nullptr;
 }
 
 nvinfer1::IPluginV2Ext* RoiAlignPluginDynamicCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new RoiAlignPluginDynamic(serial_data, serial_length);
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;

--- a/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/roi_align_op_plugin.h
@@ -34,37 +34,38 @@ class RoiAlignPluginDynamic : public DynamicPluginTensorRT {
                                  int sampling_ratio);
   RoiAlignPluginDynamic(void const* data, size_t length);
   ~RoiAlignPluginDynamic() = default;
-  nvinfer1::IPluginV2DynamicExt* clone() const override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override;
+                       int nbOutputs) TRT_NOEXCEPT override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override;
+                          int nbOutputs) const TRT_NOEXCEPT override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  const char* getPluginType() const override;
-  int getNbOutputs() const override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   template <typename T, typename OutT>
@@ -87,17 +88,18 @@ class RoiAlignPluginDynamicCreator : public nvinfer1::IPluginCreator {
   RoiAlignPluginDynamicCreator();
   ~RoiAlignPluginDynamicCreator() override = default;
 
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
 
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
-                                            const void* serial_data,
-                                            size_t serial_length) override;
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
 
  private:
   std::string namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
@@ -29,7 +29,7 @@ namespace plugin {
 // Dynamic Plugin below.
 #if IS_TRT_VERSION_GE(6000)
 
-int SkipLayerNormPluginDynamic::initialize() {
+int SkipLayerNormPluginDynamic::initialize() TRT_NOEXCEPT {
   cudaMalloc(&bias_gpu_, sizeof(float) * bias_size_);
   cudaMemcpy(bias_gpu_, bias_.data(), bias_size_ * sizeof(float),
              cudaMemcpyHostToDevice);
@@ -39,7 +39,7 @@ int SkipLayerNormPluginDynamic::initialize() {
   return 0;
 }
 
-void SkipLayerNormPluginDynamic::terminate() {
+void SkipLayerNormPluginDynamic::terminate() TRT_NOEXCEPT {
   if (bias_gpu_) {
     cudaFree(bias_gpu_);
     bias_gpu_ = nullptr;
@@ -52,13 +52,13 @@ void SkipLayerNormPluginDynamic::terminate() {
 
 nvinfer1::DimsExprs SkipLayerNormPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   return inputs[0];
 }
 
 bool SkipLayerNormPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -96,7 +96,8 @@ bool SkipLayerNormPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType SkipLayerNormPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0,
                     platform::errors::InvalidArgument(
                         "The SkipLayerNorm Plugin only has one input, so the "
@@ -112,7 +113,7 @@ nvinfer1::DataType SkipLayerNormPluginDynamic::getOutputDataType(
 int SkipLayerNormPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc, const void *const *inputs,
-    void *const *outputs, void *workspace, cudaStream_t stream) {
+    void *const *outputs, void *workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   size_t num = ProductDim(input_dims);
   int hidden = input_dims.d[2];

--- a/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.h
@@ -39,6 +39,7 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
     std::copy(bias, bias + bias_size, bias_.data());
     std::copy(scale, scale + scale_size, scale_.data());
   }
+
   SkipLayerNormPluginDynamic(void const* serial_data, size_t serial_length) {
     DeserializeValue(&serial_data, &serial_length, &bias_);
     DeserializeValue(&serial_data, &serial_length, &scale_);
@@ -48,7 +49,7 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &with_fp16_);
   }
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     auto ptr = new SkipLayerNormPluginDynamic(
         bias_.data(), scale_.data(), bias_size_, scale_size_, eps_, with_fp16_);
     ptr->bias_gpu_ = bias_gpu_;
@@ -56,17 +57,19 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
     return ptr;
   }
 
-  const char* getPluginType() const override { return "skip_layernorm_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "skip_layernorm_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     size_t ser_size = SerializedSize(bias_) + SerializedSize(scale_) +
                       SerializedSize(bias_size_) + SerializedSize(scale_size_) +
                       SerializedSize(eps_) + SerializedSize(with_fp16_);
     return ser_size;
   }
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     SerializeValue(&buffer, bias_);
     SerializeValue(&buffer, scale_);
     SerializeValue(&buffer, bias_size_);
@@ -77,34 +80,35 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* in_out,
-                                 int nb_inputs, int nb_outputs) override;
+                                 int nb_inputs,
+                                 int nb_outputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nb_inputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nb_outputs) override {}
+                       int nb_outputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* input_desc,
               const nvinfer1::PluginTensorDesc* output_desc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
-  void terminate() override;
+  void destroy() TRT_NOEXCEPT override { delete this; }
+  void terminate() TRT_NOEXCEPT override;
 
  private:
   std::vector<float> bias_;
@@ -122,31 +126,34 @@ class SkipLayerNormPluginDynamic : public DynamicPluginTensorRT {
 class SkipLayerNormPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SkipLayerNormPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "skip_layernorm_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "skip_layernorm_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new SkipLayerNormPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
@@ -75,12 +75,12 @@ SlicePlugin::~SlicePlugin() {
   cudaFree(offset_temp_data_);
 }
 
-SlicePlugin *SlicePlugin::clone() const {
+SlicePlugin *SlicePlugin::clone() const TRT_NOEXCEPT {
   return new SlicePlugin(starts_, ends_, axes_, with_fp16_);
 }
 
-bool SlicePlugin::supportsFormat(nvinfer1::DataType type,
-                                 nvinfer1::PluginFormat format) const {
+bool SlicePlugin::supportsFormat(
+    nvinfer1::DataType type, nvinfer1::PluginFormat format) const TRT_NOEXCEPT {
   if (with_fp16_) {
     return ((type == nvinfer1::DataType::kFLOAT ||
              type == nvinfer1::DataType::kHALF) &&
@@ -91,9 +91,8 @@ bool SlicePlugin::supportsFormat(nvinfer1::DataType type,
   }
 }
 
-nvinfer1::Dims SlicePlugin::getOutputDimensions(int index,
-                                                const nvinfer1::Dims *inputs,
-                                                int nb_input_dims) {
+nvinfer1::Dims SlicePlugin::getOutputDimensions(
+    int index, const nvinfer1::Dims *inputs, int nb_input_dims) TRT_NOEXCEPT {
   auto in_dims = inputs[0];
   nvinfer1::Dims out_dims = in_dims;
   for (size_t i = 0; i < axes_.size(); i++) {
@@ -109,7 +108,7 @@ int SlicePlugin::enqueue(int batch_size, const void *const *inputs,
                          void **outputs, void *workspace, cudaStream_t stream) {
 #else
                          void *const *outputs, void *workspace,
-                         cudaStream_t stream) {
+                         cudaStream_t stream) TRT_NOEXCEPT {
 #endif
   auto input_dims = getInputDims(0);
 
@@ -187,13 +186,13 @@ int SlicePlugin::enqueue(int batch_size, const void *const *inputs,
   return cudaGetLastError() != cudaSuccess;
 }
 
-size_t SlicePlugin::getSerializationSize() const {
+size_t SlicePlugin::getSerializationSize() const TRT_NOEXCEPT {
   return getBaseSerializationSize() + SerializedSize(getPluginType()) +
          SerializedSize(starts_) + SerializedSize(ends_) +
          SerializedSize(axes_);
 }
 
-void SlicePlugin::serialize(void *buffer) const {
+void SlicePlugin::serialize(void *buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, getPluginType());
   serializeBase(buffer);
   SerializeValue(&buffer, starts_);
@@ -222,23 +221,23 @@ SlicePluginDynamic::SlicePluginDynamic(void const *serialData,
   cudaStreamCreate(&copy_stream_);
 }
 
-void SlicePluginDynamic::destroy() {
+void SlicePluginDynamic::destroy() TRT_NOEXCEPT {
   cudaStreamDestroy(copy_stream_);
   cudaEventDestroy(copy_event_);
   cudaFree(offset_temp_data_);
   delete this;
 }
 
-int SlicePluginDynamic::initialize() { return 0; }
+int SlicePluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t SlicePluginDynamic::getSerializationSize() const {
+size_t SlicePluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t size = SerializedSize(starts_) + SerializedSize(ends_) +
                 SerializedSize(axes_) + SerializedSize(with_fp16_);
 
   return size;
 }
 
-void SlicePluginDynamic::serialize(void *buffer) const {
+void SlicePluginDynamic::serialize(void *buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, starts_);
   SerializeValue(&buffer, ends_);
   SerializeValue(&buffer, axes_);
@@ -247,7 +246,7 @@ void SlicePluginDynamic::serialize(void *buffer) const {
 
 nvinfer1::DimsExprs SlicePluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs *inputs, int nb_inputs,
-    nvinfer1::IExprBuilder &expr_builder) {
+    nvinfer1::IExprBuilder &expr_builder) TRT_NOEXCEPT {
   auto in_dims = inputs[0];
   nvinfer1::DimsExprs ret = in_dims;
   // start, ends should greater 0
@@ -261,7 +260,7 @@ nvinfer1::DimsExprs SlicePluginDynamic::getOutputDimensions(
 
 bool SlicePluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc *in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of swish plugin shoule not be nullptr."));
@@ -289,7 +288,8 @@ bool SlicePluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType SlicePluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType *input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType *input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The Slice Plugin only has one input, so the "
                                   "index value should be 0, but get %d.",
@@ -304,7 +304,8 @@ nvinfer1::DataType SlicePluginDynamic::getOutputDataType(
 int SlicePluginDynamic::enqueue(const nvinfer1::PluginTensorDesc *input_desc,
                                 const nvinfer1::PluginTensorDesc *output_desc,
                                 const void *const *inputs, void *const *outputs,
-                                void *workspace, cudaStream_t stream) {
+                                void *workspace,
+                                cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;
   auto out_dims = output_desc[0].dims;
   auto num_dims = input_dims.nbDims;

--- a/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.h
@@ -35,27 +35,29 @@ class SlicePlugin : public PluginTensorRT {
   // It should not be called by users.
   SlicePlugin(void const* serial_data, size_t serial_length);
   ~SlicePlugin();
-  SlicePlugin* clone() const override;
+  SlicePlugin* clone() const TRT_NOEXCEPT override;
 
-  const char* getPluginType() const override { return "slice_plugin"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override { return 0; }
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::PluginFormat format) const override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "slice_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format)
+      const TRT_NOEXCEPT override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nb_input_dims) override;
+                                     int nb_input_dims) TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
 
   // TRT will call this func  to serialize the configuration of TRT
   // It should not be called by users.
-  void serialize(void* buffer) const override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
  private:
   std::vector<int> starts_;
@@ -68,13 +70,15 @@ class SlicePlugin : public PluginTensorRT {
 
 class SlicePluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "slice_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "slice_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new SlicePlugin(serial_data, serial_length);
   }
 };
@@ -86,48 +90,51 @@ class SlicePluginDynamic : public DynamicPluginTensorRT {
   explicit SlicePluginDynamic(std::vector<int> starts, std::vector<int> ends,
                               std::vector<int> axes, bool with_fp16);
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new SlicePluginDynamic(starts_, ends_, axes_, with_fp16_);
   }
 
   SlicePluginDynamic(void const* serialData, size_t serialLength);
 
-  const char* getPluginType() const override { return "slice_plugin_dynamic"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "slice_plugin_dynamic";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   std::vector<int> starts_;
@@ -140,13 +147,15 @@ class SlicePluginDynamic : public DynamicPluginTensorRT {
 
 class SlicePluginDynamicCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "slice_plugin_dynamic"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "slice_plugin_dynamic";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serialData,
-                                         size_t serialLength) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serialData,
+      size_t serialLength) TRT_NOEXCEPT override {
     return new SlicePluginDynamic(serialData, serialLength);
   }
 };

--- a/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.cu
@@ -30,28 +30,29 @@ SpecialSlicePluginDynamic::SpecialSlicePluginDynamic(void const* serial_data,
 
 SpecialSlicePluginDynamic::~SpecialSlicePluginDynamic() {}
 
-nvinfer1::IPluginV2DynamicExt* SpecialSlicePluginDynamic::clone() const {
+nvinfer1::IPluginV2DynamicExt* SpecialSlicePluginDynamic::clone() const
+    TRT_NOEXCEPT {
   return new SpecialSlicePluginDynamic();
 }
 
-const char* SpecialSlicePluginDynamic::getPluginType() const {
+const char* SpecialSlicePluginDynamic::getPluginType() const TRT_NOEXCEPT {
   return "special_slice_plugin";
 }
 
-int SpecialSlicePluginDynamic::getNbOutputs() const { return 1; }
+int SpecialSlicePluginDynamic::getNbOutputs() const TRT_NOEXCEPT { return 1; }
 
-int SpecialSlicePluginDynamic::initialize() { return 0; }
+int SpecialSlicePluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t SpecialSlicePluginDynamic::getSerializationSize() const {
+size_t SpecialSlicePluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   return serialize_size;
 }
 
-void SpecialSlicePluginDynamic::serialize(void* buffer) const {}
+void SpecialSlicePluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {}
 
 nvinfer1::DimsExprs SpecialSlicePluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   nvinfer1::DimsExprs output(inputs[0]);
   output.nbDims++;
   for (int i = output.nbDims - 1; i > 1; i--) {
@@ -69,21 +70,22 @@ nvinfer1::DimsExprs SpecialSlicePluginDynamic::getOutputDimensions(
 
 void SpecialSlicePluginDynamic::configurePlugin(
     const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs,
-    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {}
+    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) TRT_NOEXCEPT {}
 
 size_t SpecialSlicePluginDynamic::getWorkspaceSize(
     const nvinfer1::PluginTensorDesc* inputs, int nbInputs,
-    const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
   return 0;
 }
 
-void SpecialSlicePluginDynamic::destroy() { delete this; }
+void SpecialSlicePluginDynamic::destroy() TRT_NOEXCEPT { delete this; }
 
-void SpecialSlicePluginDynamic::terminate() {}
+void SpecialSlicePluginDynamic::terminate() TRT_NOEXCEPT {}
 
 bool SpecialSlicePluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* desc, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   if (pos == 0)  // slice tensor
     return (desc[pos].type == nvinfer1::DataType::kHALF &&
             desc[pos].format ==
@@ -101,7 +103,8 @@ bool SpecialSlicePluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType SpecialSlicePluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The index should be equal to 0"));
   return input_types[0];
@@ -120,7 +123,7 @@ __global__ void SpecialSliceKernel(const T* slice_input,
 int SpecialSlicePluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc* input_desc,
     const nvinfer1::PluginTensorDesc* output_desc, const void* const* inputs,
-    void* const* outputs, void* workspace, cudaStream_t stream) {
+    void* const* outputs, void* workspace, cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;  // (sum(S), 768, 1, 1)
   auto out_dims = output_desc[0].dims;   // (batch, 768, 1, 1)
 
@@ -142,36 +145,40 @@ int SpecialSlicePluginDynamic::enqueue(
 
 SpecialSlicePluginDynamicCreator::SpecialSlicePluginDynamicCreator() {}
 
-const char* SpecialSlicePluginDynamicCreator::getPluginName() const {
+const char* SpecialSlicePluginDynamicCreator::getPluginName() const
+    TRT_NOEXCEPT {
   return "special_slice_plugin";
 }
 
-const char* SpecialSlicePluginDynamicCreator::getPluginVersion() const {
+const char* SpecialSlicePluginDynamicCreator::getPluginVersion() const
+    TRT_NOEXCEPT {
   return "1";
 }
 
 const nvinfer1::PluginFieldCollection*
-SpecialSlicePluginDynamicCreator::getFieldNames() {
+SpecialSlicePluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2* SpecialSlicePluginDynamicCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   return new SpecialSlicePluginDynamic();
 }
 
 nvinfer1::IPluginV2* SpecialSlicePluginDynamicCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new SpecialSlicePluginDynamic(serial_data, serial_length);
   return plugin;
 }
 
 void SpecialSlicePluginDynamicCreator::setPluginNamespace(
-    const char* lib_namespace) {
+    const char* lib_namespace) TRT_NOEXCEPT {
   plugin_namespace_ = lib_namespace;
 }
 
-const char* SpecialSlicePluginDynamicCreator::getPluginNamespace() const {
+const char* SpecialSlicePluginDynamicCreator::getPluginNamespace() const
+    TRT_NOEXCEPT {
   return plugin_namespace_.c_str();
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/special_slice_plugin.h
@@ -31,37 +31,38 @@ class SpecialSlicePluginDynamic : public DynamicPluginTensorRT {
   SpecialSlicePluginDynamic();
   SpecialSlicePluginDynamic(void const* serial_data, size_t serial_length);
   ~SpecialSlicePluginDynamic();
-  nvinfer1::IPluginV2DynamicExt* clone() const override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override;
+                       int nbOutputs) TRT_NOEXCEPT override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override;
+                          int nbOutputs) const TRT_NOEXCEPT override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  const char* getPluginType() const override;
-  int getNbOutputs() const override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   int axis_;
@@ -71,16 +72,17 @@ class SpecialSlicePluginDynamic : public DynamicPluginTensorRT {
 class SpecialSlicePluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SpecialSlicePluginDynamicCreator();
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
 
  private:
   std::string plugin_namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.h
@@ -39,43 +39,47 @@ class SplitPlugin : public PluginTensorRTV2Ext {
     DeserializeValue(&serial_data, &serial_length, &output_length_);
   }
 
-  nvinfer1::IPluginV2Ext* clone() const override {
+  nvinfer1::IPluginV2Ext* clone() const TRT_NOEXCEPT override {
     SplitPlugin* ptr = new SplitPlugin(axis_, output_length_, with_fp16_);
     ptr->setPluginNamespace(this->getPluginNamespace());
     ptr->shareData(this);
     return ptr;
   }
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_types,
-                                       int nb_inputs) const override {
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override {
     return input_types[0];
   }
 
-  const char* getPluginType() const override { return "split_plugin_v2ext"; }
-  int getNbOutputs() const override { return output_length_.size(); }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "split_plugin_v2ext";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override {
+    return output_length_.size();
+  }
   nvinfer1::Dims getOutputDimensions(int index,
                                      const nvinfer1::Dims* input_dims,
-                                     int num_inputs) override;
+                                     int num_inputs) TRT_NOEXCEPT override;
 
-  int initialize() override;
-  void terminate() override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  protected:
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return SerializedSize(axis_) + SerializedSize(output_length_) +
            getBaseSerializationSize();
   }
 
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, axis_);
     SerializeValue(&buffer, output_length_);
@@ -98,32 +102,35 @@ class SplitPlugin : public PluginTensorRTV2Ext {
 class SplitPluginCreator : public nvinfer1::IPluginCreator {
  public:
   SplitPluginCreator() {}
-  const char* getPluginName() const override { return "split_plugin_v2ext"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "split_plugin_v2ext";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     // not implemented
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new SplitPlugin(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 
@@ -151,46 +158,51 @@ class SplitPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serial_data, &serial_length, &with_fp16_);
   }
 
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new SplitPluginDynamic(axis_, output_length_, with_fp16_);
   }
 
-  const char* getPluginType() const override { return "split_plugin"; }
-  int getNbOutputs() const override { return output_length_.size(); }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "split_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override {
+    return output_length_.size();
+  }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   int axis_;
@@ -200,31 +212,34 @@ class SplitPluginDynamic : public DynamicPluginTensorRT {
 class SplitPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   SplitPluginDynamicCreator() {}
-  const char* getPluginName() const override { return "split_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "split_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override {
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
     return &field_collection_;
   }
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override {
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
     return nullptr;
   }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     auto plugin = new SplitPluginDynamic(serial_data, serial_length);
     return plugin;
   }
 
-  void setPluginNamespace(const char* lib_namespace) override {
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
     plugin_namespace_ = lib_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return plugin_namespace_.c_str();
   }
 

--- a/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.cu
@@ -37,17 +37,19 @@ StackPluginDynamic::StackPluginDynamic(void const* serial_data,
 
 StackPluginDynamic::~StackPluginDynamic() {}
 
-nvinfer1::IPluginV2DynamicExt* StackPluginDynamic::clone() const {
+nvinfer1::IPluginV2DynamicExt* StackPluginDynamic::clone() const TRT_NOEXCEPT {
   return new StackPluginDynamic(axis_, num_stack_, with_fp16_);
 }
 
-const char* StackPluginDynamic::getPluginType() const { return "stack_plugin"; }
+const char* StackPluginDynamic::getPluginType() const TRT_NOEXCEPT {
+  return "stack_plugin";
+}
 
-int StackPluginDynamic::getNbOutputs() const { return 1; }
+int StackPluginDynamic::getNbOutputs() const TRT_NOEXCEPT { return 1; }
 
-int StackPluginDynamic::initialize() { return 0; }
+int StackPluginDynamic::initialize() TRT_NOEXCEPT { return 0; }
 
-size_t StackPluginDynamic::getSerializationSize() const {
+size_t StackPluginDynamic::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(axis_);
   serialize_size += SerializedSize(num_stack_);
@@ -55,7 +57,7 @@ size_t StackPluginDynamic::getSerializationSize() const {
   return serialize_size;
 }
 
-void StackPluginDynamic::serialize(void* buffer) const {
+void StackPluginDynamic::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, axis_);
   SerializeValue(&buffer, num_stack_);
   SerializeValue(&buffer, with_fp16_);
@@ -63,7 +65,7 @@ void StackPluginDynamic::serialize(void* buffer) const {
 
 nvinfer1::DimsExprs StackPluginDynamic::getOutputDimensions(
     int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-    nvinfer1::IExprBuilder& expr_builder) {
+    nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT {
   nvinfer1::DimsExprs output(inputs[0]);
   output.nbDims = inputs[0].nbDims + 1;
 
@@ -76,21 +78,22 @@ nvinfer1::DimsExprs StackPluginDynamic::getOutputDimensions(
 
 void StackPluginDynamic::configurePlugin(
     const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs,
-    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {}
+    const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) TRT_NOEXCEPT {}
 
 size_t StackPluginDynamic::getWorkspaceSize(
     const nvinfer1::PluginTensorDesc* inputs, int nbInputs,
-    const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
+    const nvinfer1::PluginTensorDesc* outputs,
+    int nbOutputs) const TRT_NOEXCEPT {
   return num_stack_ * sizeof(uintptr_t);
 }
 
-void StackPluginDynamic::destroy() { delete this; }
+void StackPluginDynamic::destroy() TRT_NOEXCEPT { delete this; }
 
-void StackPluginDynamic::terminate() {}
+void StackPluginDynamic::terminate() TRT_NOEXCEPT {}
 
 bool StackPluginDynamic::supportsFormatCombination(
     int pos, const nvinfer1::PluginTensorDesc* in_out, int nb_inputs,
-    int nb_outputs) {
+    int nb_outputs) TRT_NOEXCEPT {
   PADDLE_ENFORCE_NOT_NULL(
       in_out, platform::errors::InvalidArgument(
                   "The input of stack plugin should not be nullptr."));
@@ -118,7 +121,8 @@ bool StackPluginDynamic::supportsFormatCombination(
 }
 
 nvinfer1::DataType StackPluginDynamic::getOutputDataType(
-    int index, const nvinfer1::DataType* input_types, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
   PADDLE_ENFORCE_EQ(index, 0, platform::errors::InvalidArgument(
                                   "The index should be equal to 0"));
   return input_types[0];
@@ -139,7 +143,8 @@ __global__ void StackKernel(const T* const* input, T* output, int num_stack,
 int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
                                 const nvinfer1::PluginTensorDesc* output_desc,
                                 const void* const* inputs, void* const* outputs,
-                                void* workspace, cudaStream_t stream) {
+                                void* workspace,
+                                cudaStream_t stream) TRT_NOEXCEPT {
   auto input_dims = input_desc[0].dims;  // (batch, seq, seq)
   auto out_dims = output_desc[0].dims;   // (batch, num_head, seq, seq)
   auto out_num_dims = out_dims.nbDims;
@@ -195,19 +200,21 @@ int StackPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* input_desc,
 
 StackPluginDynamicCreator::StackPluginDynamicCreator() {}
 
-const char* StackPluginDynamicCreator::getPluginName() const {
+const char* StackPluginDynamicCreator::getPluginName() const TRT_NOEXCEPT {
   return "stack_plugin";
 }
 
-const char* StackPluginDynamicCreator::getPluginVersion() const { return "1"; }
+const char* StackPluginDynamicCreator::getPluginVersion() const TRT_NOEXCEPT {
+  return "1";
+}
 
 const nvinfer1::PluginFieldCollection*
-StackPluginDynamicCreator::getFieldNames() {
+StackPluginDynamicCreator::getFieldNames() TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2* StackPluginDynamicCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   int axis = -1;
   int num_stack = -1;
   bool with_fp16 = false;
@@ -230,16 +237,18 @@ nvinfer1::IPluginV2* StackPluginDynamicCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2* StackPluginDynamicCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new StackPluginDynamic(serial_data, serial_length);
   return plugin;
 }
 
-void StackPluginDynamicCreator::setPluginNamespace(const char* lib_namespace) {
+void StackPluginDynamicCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   plugin_namespace_ = lib_namespace;
 }
 
-const char* StackPluginDynamicCreator::getPluginNamespace() const {
+const char* StackPluginDynamicCreator::getPluginNamespace() const TRT_NOEXCEPT {
   return plugin_namespace_.c_str();
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/stack_op_plugin.h
@@ -31,37 +31,36 @@ class StackPluginDynamic : public DynamicPluginTensorRT {
   explicit StackPluginDynamic(int axis, int num_stack, bool with_fp16);
   StackPluginDynamic(void const* serial_data, size_t serial_length);
   ~StackPluginDynamic();
-  nvinfer1::IPluginV2DynamicExt* clone() const override;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override;
   nvinfer1::DimsExprs getOutputDimensions(
       int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
-      nvinfer1::IExprBuilder& exprBuilder) override;
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override;
+                       int nbOutputs) TRT_NOEXCEPT override;
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override;
+                          int nbOutputs) const TRT_NOEXCEPT override;
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
-
-  const char* getPluginType() const override;
-  int getNbOutputs() const override;
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
 
  private:
   int axis_;
@@ -71,16 +70,17 @@ class StackPluginDynamic : public DynamicPluginTensorRT {
 class StackPluginDynamicCreator : public nvinfer1::IPluginCreator {
  public:
   StackPluginDynamicCreator();
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
 
  private:
   std::string plugin_namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/swish_op_plugin.h
@@ -31,11 +31,11 @@ class SwishPlugin : public PluginTensorRT {
   float beta_;
 
  public:
-  size_t getSerializationSize() const override {
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
     return getBaseSerializationSize() + SerializedSize(beta_);
   }
 
-  void serialize(void* buffer) const override {
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
     serializeBase(buffer);
     SerializeValue(&buffer, beta_);
   }
@@ -53,33 +53,37 @@ class SwishPlugin : public PluginTensorRT {
 
   ~SwishPlugin() {}
 
-  int initialize() override;
+  int initialize() TRT_NOEXCEPT override;
 
-  SwishPlugin* clone() const override {
+  SwishPlugin* clone() const TRT_NOEXCEPT override {
     return new SwishPlugin(beta_, with_fp16_);
   }
 
-  const char* getPluginType() const override { return "swish_plugin"; }
-  int getNbOutputs() const override { return 1; }
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "swish_plugin";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nbInputDims) override;
+                                     int nbInputDims) TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batchSize, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batchSize, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
 };
 
 class SwishPluginCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "swish_plugin"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "swish_plugin";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new SwishPlugin(serial_data, serial_length);
   }
 };
@@ -96,46 +100,49 @@ class SwishPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &beta_);
     DeserializeValue(&serialData, &serialLength, &with_fp16_);
   }
-  nvinfer1::IPluginV2DynamicExt* clone() const override {
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new SwishPluginDynamic(beta_, with_fp16_);
   }
 
-  const char* getPluginType() const override { return "swish_plugin_dynamic"; }
-  int getNbOutputs() const override { return 1; }
-  int initialize() override;
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "swish_plugin_dynamic";
+  }
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+  int initialize() TRT_NOEXCEPT override;
 
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
 
   nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) override;
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT override;
 
   bool supportsFormatCombination(int pos,
                                  const nvinfer1::PluginTensorDesc* inOut,
-                                 int nbInputs, int nbOutputs) override;
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
 
   void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                        int nbInputs,
                        const nvinfer1::DynamicPluginTensorDesc* out,
-                       int nbOutputs) override {}
+                       int nbOutputs) TRT_NOEXCEPT override {}
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nbInputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nbOutputs) const override {
+                          int nbOutputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
               const nvinfer1::PluginTensorDesc* outputDesc,
               const void* const* inputs, void* const* outputs, void* workspace,
-              cudaStream_t stream) override;
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* inputTypes,
-                                       int nbInputs) const override;
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
  private:
   float beta_;
@@ -143,13 +150,15 @@ class SwishPluginDynamic : public DynamicPluginTensorRT {
 
 class SwishPluginDynamicCreator : public TensorRTPluginCreator {
  public:
-  const char* getPluginName() const override { return "swish_plugin_dynamic"; }
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "swish_plugin_dynamic";
+  }
 
-  const char* getPluginVersion() const override { return "1"; }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
 
-  nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                         const void* serial_data,
-                                         size_t serial_length) override {
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
     return new SwishPluginDynamic(serial_data, serial_length);
   }
 };

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
@@ -85,7 +85,7 @@ void PluginTensorRTV2Ext::deserializeBase(void const*& serial_data,
           &with_fp16_);
 }
 
-size_t PluginTensorRTV2Ext::getBaseSerializationSize() const TRT_NOEXCEPT {
+size_t PluginTensorRTV2Ext::getBaseSerializationSize() const {
   return SeriaSize(input_dims_, data_type_, data_format_, with_fp16_);
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin.cc
@@ -60,8 +60,8 @@ size_t PluginTensorRT::getBaseSerializationSize() const {
   return SeriaSize(input_dims_, data_type_, data_format_, with_fp16_);
 }
 
-bool PluginTensorRT::supportsFormat(nvinfer1::DataType type,
-                                    nvinfer1::PluginFormat format) const {
+bool PluginTensorRT::supportsFormat(
+    nvinfer1::DataType type, nvinfer1::PluginFormat format) const TRT_NOEXCEPT {
   return ((type == nvinfer1::DataType::kFLOAT) &&
           (format == nvinfer1::PluginFormat::kLINEAR));
 }
@@ -69,7 +69,7 @@ bool PluginTensorRT::supportsFormat(nvinfer1::DataType type,
 void PluginTensorRT::configureWithFormat(
     const nvinfer1::Dims* input_dims, int num_inputs,
     const nvinfer1::Dims* output_dims, int num_outputs, nvinfer1::DataType type,
-    nvinfer1::PluginFormat format, int max_batch_size) {
+    nvinfer1::PluginFormat format, int max_batch_size) TRT_NOEXCEPT {
   data_type_ = type;
   data_format_ = format;
   input_dims_.assign(input_dims, input_dims + num_inputs);
@@ -85,7 +85,7 @@ void PluginTensorRTV2Ext::deserializeBase(void const*& serial_data,
           &with_fp16_);
 }
 
-size_t PluginTensorRTV2Ext::getBaseSerializationSize() const {
+size_t PluginTensorRTV2Ext::getBaseSerializationSize() const TRT_NOEXCEPT {
   return SeriaSize(input_dims_, data_type_, data_format_, with_fp16_);
 }
 
@@ -95,26 +95,28 @@ void PluginTensorRTV2Ext::configurePlugin(
     const nvinfer1::DataType* input_types,
     const nvinfer1::DataType* output_types, const bool* input_is_broadcast,
     const bool* output_is_broadcast, nvinfer1::PluginFormat float_format,
-    int32_t max_batch_size) {
+    int32_t max_batch_size) TRT_NOEXCEPT {
   input_dims_.assign(input_dims, input_dims + nb_inputs);
   data_format_ = float_format;
   data_type_ = input_types[0];
 }
 
-const nvinfer1::PluginFieldCollection* TensorRTPluginCreator::getFieldNames() {
+const nvinfer1::PluginFieldCollection* TensorRTPluginCreator::getFieldNames()
+    TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2* TensorRTPluginCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   return nullptr;
 }
 
-void TensorRTPluginCreator::setPluginNamespace(const char* lib_namespace) {
+void TensorRTPluginCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   plugin_namespace_ = lib_namespace;
 }
 
-const char* TensorRTPluginCreator::getPluginNamespace() const {
+const char* TensorRTPluginCreator::getPluginNamespace() const TRT_NOEXCEPT {
   return plugin_namespace_.c_str();
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/trt_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/trt_plugin.h
@@ -64,35 +64,35 @@ class PluginTensorRT : public nvinfer1::IPluginV2 {
   nvinfer1::PluginFormat getDataFormat() const { return data_format_; }
 
   // IPluginV2
-  virtual const char* getPluginType() const = 0;
+  virtual const char* getPluginType() const TRT_NOEXCEPT = 0;
 
-  virtual const char* getPluginVersion() const { return "1"; }
+  virtual const char* getPluginVersion() const TRT_NOEXCEPT { return "1"; }
 
-  int getNbOutputs() const { return 1; }
+  int getNbOutputs() const TRT_NOEXCEPT { return 1; }
 
   virtual nvinfer1::Dims getOutputDimensions(int index,
                                              const nvinfer1::Dims* input_dims,
-                                             int num_inputs) = 0;
+                                             int num_inputs) TRT_NOEXCEPT = 0;
 
   // Check format support. The default is FLOAT32 and kLINEAR.
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::PluginFormat format) const override;
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format)
+      const TRT_NOEXCEPT override;
 
   // Configure the layer
   void configureWithFormat(const nvinfer1::Dims* input_dims, int num_inputs,
                            const nvinfer1::Dims* output_dims, int num_outputs,
                            nvinfer1::DataType type,
                            nvinfer1::PluginFormat format,
-                           int max_batch_size) override;
+                           int max_batch_size) TRT_NOEXCEPT override;
 
   // Initialize the layer for execution.
-  int initialize() override { return 0; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
 
   // Shutdown the layer. This is called when the engine is destroyed
-  void terminate() override {}
+  void terminate() TRT_NOEXCEPT override {}
 
   // Find the workspace size required by the layer
-  size_t getWorkspaceSize(int) const override { return 0; }
+  size_t getWorkspaceSize(int) const TRT_NOEXCEPT override { return 0; }
 
 // Execute the layer
 #if IS_TRT_VERSION_LT(8000)
@@ -101,25 +101,27 @@ class PluginTensorRT : public nvinfer1::IPluginV2 {
   virtual int enqueue(int batch_size, const void* const* inputs,
                       void* const* outputs,
 #endif
-                      void* workspace, cudaStream_t stream) = 0;
+                      void* workspace, cudaStream_t stream) TRT_NOEXCEPT = 0;
 
   // Find the size of the serialization buffer required
-  virtual size_t getSerializationSize() const = 0;
+  virtual size_t getSerializationSize() const TRT_NOEXCEPT = 0;
 
   // Serialize the layer config to buffer.
   // TensorRT will call this func to serialize the configuration of TensorRT
   // engine. It should not be called by users.
-  virtual void serialize(void* buffer) const = 0;
+  virtual void serialize(void* buffer) const TRT_NOEXCEPT = 0;
 
-  void destroy() override { delete this; }
+  void destroy() TRT_NOEXCEPT override { delete this; }
 
-  virtual nvinfer1::IPluginV2* clone() const = 0;
+  virtual nvinfer1::IPluginV2* clone() const TRT_NOEXCEPT = 0;
 
-  void setPluginNamespace(const char* plugin_namespace) override {
+  void setPluginNamespace(const char* plugin_namespace) TRT_NOEXCEPT override {
     namespace_ = plugin_namespace;
   }
 
-  const char* getPluginNamespace() const override { return namespace_.c_str(); }
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
+    return namespace_.c_str();
+  }
 
  protected:
   // Deserialize input_dims, max_batch_size, data_type, data_format
@@ -155,15 +157,16 @@ class PluginTensorRTV2Ext : public nvinfer1::IPluginV2Ext {
   // The Func in IPluginV2Ext
   virtual nvinfer1::DataType getOutputDataType(
       int index, const nvinfer1::DataType* input_types,
-      int nb_inputs) const = 0;
+      int nb_inputs) const TRT_NOEXCEPT = 0;
 
-  virtual bool isOutputBroadcastAcrossBatch(int32_t output_index,
-                                            const bool* input_is_broadcasted,
-                                            int32_t nb_inputs) const {
+  virtual bool isOutputBroadcastAcrossBatch(
+      int32_t output_index, const bool* input_is_broadcasted,
+      int32_t nb_inputs) const TRT_NOEXCEPT {
     return false;
   }
 
-  virtual bool canBroadcastInputAcrossBatch(int32_t input_index) const {
+  virtual bool canBroadcastInputAcrossBatch(int32_t input_index) const
+      TRT_NOEXCEPT {
     return false;
   }
 
@@ -174,37 +177,37 @@ class PluginTensorRTV2Ext : public nvinfer1::IPluginV2Ext {
                        const bool* input_is_broadcast,
                        const bool* output_is_broadcast,
                        nvinfer1::PluginFormat float_format,
-                       int32_t max_batch_size) override;
+                       int32_t max_batch_size) TRT_NOEXCEPT override;
 
-  virtual IPluginV2Ext* clone() const = 0;
+  virtual IPluginV2Ext* clone() const TRT_NOEXCEPT = 0;
 
   void attachToContext(cudnnContext*, cublasContext*,
-                       nvinfer1::IGpuAllocator*) override {}
+                       nvinfer1::IGpuAllocator*) TRT_NOEXCEPT override {}
 
-  void detachFromContext() override {}
+  void detachFromContext() TRT_NOEXCEPT override {}
 
   // The Func in IPluginV2
-  virtual const char* getPluginType() const = 0;
-  const char* getPluginVersion() const override { return "1"; }
-  virtual int32_t getNbOutputs() const { return 1; }
+  virtual const char* getPluginType() const TRT_NOEXCEPT = 0;
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
+  virtual int32_t getNbOutputs() const TRT_NOEXCEPT { return 1; }
   virtual nvinfer1::Dims getOutputDimensions(int32_t index,
                                              const nvinfer1::Dims* inputs,
-                                             int32_t nb_input) = 0;
+                                             int32_t nb_input) TRT_NOEXCEPT = 0;
   // Check format support. The default is FLOAT32 and NCHW.
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::PluginFormat format) const override {
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format)
+      const TRT_NOEXCEPT override {
     return ((type == nvinfer1::DataType::kFLOAT) &&
             (format == nvinfer1::PluginFormat::kLINEAR));
   }
   // Initialize the layer for execution.
   // This is called when the engine is created.
-  int initialize() override { return 0; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
 
   // Shutdown the layer. This is called when the engine is destroyed
-  void terminate() override {}
+  void terminate() TRT_NOEXCEPT override {}
 
   // Find the workspace size required by the layer
-  size_t getWorkspaceSize(int) const override { return 0; }
+  size_t getWorkspaceSize(int) const TRT_NOEXCEPT override { return 0; }
 
 // Execute the layer
 #if IS_TRT_VERSION_LT(8000)
@@ -213,23 +216,23 @@ class PluginTensorRTV2Ext : public nvinfer1::IPluginV2Ext {
   virtual int enqueue(int batch_size, const void* const* inputs,
                       void* const* outputs,
 #endif
-                      void* workspace, cudaStream_t stream) = 0;
+                      void* workspace, cudaStream_t stream) TRT_NOEXCEPT = 0;
 
   // Find the size of the serialization buffer required
-  virtual size_t getSerializationSize() const = 0;
+  virtual size_t getSerializationSize() const TRT_NOEXCEPT = 0;
 
   // Serialize the layer config to buffer.
   // TensorRT will call this func to serialize the configuration of TensorRT
   // engine. It should not be called by users.
-  virtual void serialize(void* buffer) const = 0;
+  virtual void serialize(void* buffer) const TRT_NOEXCEPT = 0;
 
-  virtual void destroy() = 0;
+  virtual void destroy() TRT_NOEXCEPT = 0;
 
-  void setPluginNamespace(const char* plugin_namespace) override {
+  void setPluginNamespace(const char* plugin_namespace) TRT_NOEXCEPT override {
     name_space_ = plugin_namespace;
   }
 
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return name_space_.c_str();
   }
 
@@ -256,52 +259,52 @@ class DynamicPluginTensorRT : public nvinfer1::IPluginV2DynamicExt {
   DynamicPluginTensorRT(const void* serialized_data, size_t length) {}
 
   // The Func in IPluginExt or IpluginExtV2
-  virtual const char* getPluginVersion() const { return "1"; }
-  virtual const char* getPluginType() const = 0;
-  int getNbOutputs() const { return 1; }
-  int initialize() override { return 0; }
-  void terminate() override{};
+  virtual const char* getPluginVersion() const TRT_NOEXCEPT { return "1"; }
+  virtual const char* getPluginType() const TRT_NOEXCEPT = 0;
+  int getNbOutputs() const TRT_NOEXCEPT { return 1; }
+  int initialize() TRT_NOEXCEPT override { return 0; }
+  void terminate() TRT_NOEXCEPT override{};
 
-  virtual size_t getSerializationSize() const = 0;
-  virtual void serialize(void* buffer) const = 0;
+  virtual size_t getSerializationSize() const TRT_NOEXCEPT = 0;
+  virtual void serialize(void* buffer) const TRT_NOEXCEPT = 0;
 
   // The Func in IPluginV2
-  nvinfer1::IPluginV2DynamicExt* clone() const = 0;
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT = 0;
   virtual nvinfer1::DimsExprs getOutputDimensions(
       int output_index, const nvinfer1::DimsExprs* inputs, int nb_inputs,
-      nvinfer1::IExprBuilder& expr_builder) = 0;  // NOLINT
+      nvinfer1::IExprBuilder& expr_builder) TRT_NOEXCEPT = 0;  // NOLINT
 
   virtual bool supportsFormatCombination(
       int pos, const nvinfer1::PluginTensorDesc* in_out, int nb_inputs,
-      int nb_outputs) = 0;
+      int nb_outputs) TRT_NOEXCEPT = 0;
 
   virtual void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in,
                                int nb_inputs,
                                const nvinfer1::DynamicPluginTensorDesc* out,
-                               int nb_outputs) = 0;
+                               int nb_outputs) TRT_NOEXCEPT = 0;
 
   size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
                           int nb_inputs,
                           const nvinfer1::PluginTensorDesc* outputs,
-                          int nb_outputs) const override {
+                          int nb_outputs) const TRT_NOEXCEPT override {
     return 0;
   }
 
   virtual int enqueue(const nvinfer1::PluginTensorDesc* input_desc,
                       const nvinfer1::PluginTensorDesc* output_desc,
                       const void* const* inputs, void* const* outputs,
-                      void* workspace, cudaStream_t stream) = 0;
+                      void* workspace, cudaStream_t stream) TRT_NOEXCEPT = 0;
 
   virtual nvinfer1::DataType getOutputDataType(
       int index, const nvinfer1::DataType* input_types,
-      int nb_inputs) const = 0;
-  void setPluginNamespace(const char* plugin_namespace) override {
+      int nb_inputs) const TRT_NOEXCEPT = 0;
+  void setPluginNamespace(const char* plugin_namespace) TRT_NOEXCEPT override {
     name_space_ = plugin_namespace;
   }
-  const char* getPluginNamespace() const override {
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
     return name_space_.c_str();
   }
-  virtual void destroy() = 0;
+  virtual void destroy() TRT_NOEXCEPT = 0;
 
  protected:
   void deserializeBase(void const*& serial_data,  // NOLINT
@@ -320,22 +323,23 @@ class TensorRTPluginCreator : public nvinfer1::IPluginCreator {
  public:
   TensorRTPluginCreator() = default;
 
-  virtual const char* getPluginName() const = 0;
+  virtual const char* getPluginName() const TRT_NOEXCEPT = 0;
 
-  virtual const char* getPluginVersion() const = 0;
+  virtual const char* getPluginVersion() const TRT_NOEXCEPT = 0;
 
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
 
-  nvinfer1::IPluginV2* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override;
 
-  virtual nvinfer1::IPluginV2* deserializePlugin(const char* name,
-                                                 const void* serial_data,
-                                                 size_t serial_length) = 0;
+  virtual nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT = 0;
 
-  void setPluginNamespace(const char* lib_namespace) override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
 
-  const char* getPluginNamespace() const override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
 
  private:
   std::string plugin_namespace_;

--- a/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.cu
@@ -70,15 +70,16 @@ YoloBoxPlugin::~YoloBoxPlugin() {
   }
 }
 
-const char* YoloBoxPlugin::getPluginType() const { return "yolo_box_plugin"; }
+const char* YoloBoxPlugin::getPluginType() const TRT_NOEXCEPT {
+  return "yolo_box_plugin";
+}
 
-const char* YoloBoxPlugin::getPluginVersion() const { return "1"; }
+const char* YoloBoxPlugin::getPluginVersion() const TRT_NOEXCEPT { return "1"; }
 
-int YoloBoxPlugin::getNbOutputs() const { return 2; }
+int YoloBoxPlugin::getNbOutputs() const TRT_NOEXCEPT { return 2; }
 
-nvinfer1::Dims YoloBoxPlugin::getOutputDimensions(int index,
-                                                  const nvinfer1::Dims* inputs,
-                                                  int nb_input_dims) {
+nvinfer1::Dims YoloBoxPlugin::getOutputDimensions(
+    int index, const nvinfer1::Dims* inputs, int nb_input_dims) TRT_NOEXCEPT {
   const int anchor_num = anchors_.size() / 2;
   const int box_num = inputs[0].d[1] * inputs[0].d[2] * anchor_num;
 
@@ -90,13 +91,15 @@ nvinfer1::Dims YoloBoxPlugin::getOutputDimensions(int index,
   return nvinfer1::Dims2(box_num, class_num_);
 }
 
-bool YoloBoxPlugin::supportsFormat(nvinfer1::DataType type,
-                                   nvinfer1::TensorFormat format) const {
+bool YoloBoxPlugin::supportsFormat(
+    nvinfer1::DataType type, nvinfer1::TensorFormat format) const TRT_NOEXCEPT {
   return ((type == data_type_ || type == nvinfer1::DataType::kINT32) &&
           format == nvinfer1::TensorFormat::kLINEAR);
 }
 
-size_t YoloBoxPlugin::getWorkspaceSize(int max_batch_size) const { return 0; }
+size_t YoloBoxPlugin::getWorkspaceSize(int max_batch_size) const TRT_NOEXCEPT {
+  return 0;
+}
 
 template <typename T>
 __device__ inline T sigmoid(T x) {
@@ -219,7 +222,7 @@ __global__ void KeYoloBoxFw(const T* const input, const int* const imgsize,
 
 template <typename T>
 int YoloBoxPlugin::enqueue_impl(int batch_size, const void* const* inputs,
-                                void** outputs, void* workspace,
+                                void* const* outputs, void* workspace,
                                 cudaStream_t stream) {
   const int n = batch_size;
   const int h = input_h_;
@@ -247,7 +250,7 @@ int YoloBoxPlugin::enqueue(int batch_size, const void* const* inputs,
 #else
                            void* const* outputs, void* workspace,
 #endif
-                           cudaStream_t stream) {
+                           cudaStream_t stream) TRT_NOEXCEPT {
   if (data_type_ == nvinfer1::DataType::kFLOAT) {
     return enqueue_impl<float>(batch_size, inputs, outputs, workspace, stream);
   } else if (data_type_ == nvinfer1::DataType::kHALF) {
@@ -256,11 +259,11 @@ int YoloBoxPlugin::enqueue(int batch_size, const void* const* inputs,
   assert("unsupported type.");
 }
 
-int YoloBoxPlugin::initialize() { return 0; }
+int YoloBoxPlugin::initialize() TRT_NOEXCEPT { return 0; }
 
-void YoloBoxPlugin::terminate() {}
+void YoloBoxPlugin::terminate() TRT_NOEXCEPT {}
 
-size_t YoloBoxPlugin::getSerializationSize() const {
+size_t YoloBoxPlugin::getSerializationSize() const TRT_NOEXCEPT {
   size_t serialize_size = 0;
   serialize_size += SerializedSize(data_type_);
   serialize_size += SerializedSize(anchors_);
@@ -274,7 +277,7 @@ size_t YoloBoxPlugin::getSerializationSize() const {
   return serialize_size;
 }
 
-void YoloBoxPlugin::serialize(void* buffer) const {
+void YoloBoxPlugin::serialize(void* buffer) const TRT_NOEXCEPT {
   SerializeValue(&buffer, data_type_);
   SerializeValue(&buffer, anchors_);
   SerializeValue(&buffer, class_num_);
@@ -286,28 +289,30 @@ void YoloBoxPlugin::serialize(void* buffer) const {
   SerializeValue(&buffer, input_w_);
 }
 
-void YoloBoxPlugin::destroy() {}
+void YoloBoxPlugin::destroy() TRT_NOEXCEPT {}
 
-void YoloBoxPlugin::setPluginNamespace(const char* lib_namespace) {
+void YoloBoxPlugin::setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* YoloBoxPlugin::getPluginNamespace() const {
+const char* YoloBoxPlugin::getPluginNamespace() const TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
 nvinfer1::DataType YoloBoxPlugin::getOutputDataType(
-    int index, const nvinfer1::DataType* input_type, int nb_inputs) const {
+    int index, const nvinfer1::DataType* input_type,
+    int nb_inputs) const TRT_NOEXCEPT {
   return input_type[0];
 }
 
-bool YoloBoxPlugin::isOutputBroadcastAcrossBatch(int output_index,
-                                                 const bool* input_is_broadcast,
-                                                 int nb_inputs) const {
+bool YoloBoxPlugin::isOutputBroadcastAcrossBatch(
+    int output_index, const bool* input_is_broadcast,
+    int nb_inputs) const TRT_NOEXCEPT {
   return false;
 }
 
-bool YoloBoxPlugin::canBroadcastInputAcrossBatch(int input_index) const {
+bool YoloBoxPlugin::canBroadcastInputAcrossBatch(int input_index) const
+    TRT_NOEXCEPT {
   return false;
 }
 
@@ -317,9 +322,9 @@ void YoloBoxPlugin::configurePlugin(
     const nvinfer1::DataType* input_types,
     const nvinfer1::DataType* output_types, const bool* input_is_broadcast,
     const bool* output_is_broadcast, nvinfer1::PluginFormat float_format,
-    int max_batct_size) {}
+    int max_batct_size) TRT_NOEXCEPT {}
 
-nvinfer1::IPluginV2Ext* YoloBoxPlugin::clone() const {
+nvinfer1::IPluginV2Ext* YoloBoxPlugin::clone() const TRT_NOEXCEPT {
   return new YoloBoxPlugin(data_type_, anchors_, class_num_, conf_thresh_,
                            downsample_ratio_, clip_bbox_, scale_x_y_, input_h_,
                            input_w_);
@@ -327,26 +332,30 @@ nvinfer1::IPluginV2Ext* YoloBoxPlugin::clone() const {
 
 YoloBoxPluginCreator::YoloBoxPluginCreator() {}
 
-void YoloBoxPluginCreator::setPluginNamespace(const char* lib_namespace) {
+void YoloBoxPluginCreator::setPluginNamespace(const char* lib_namespace)
+    TRT_NOEXCEPT {
   namespace_ = std::string(lib_namespace);
 }
 
-const char* YoloBoxPluginCreator::getPluginNamespace() const {
+const char* YoloBoxPluginCreator::getPluginNamespace() const TRT_NOEXCEPT {
   return namespace_.c_str();
 }
 
-const char* YoloBoxPluginCreator::getPluginName() const {
+const char* YoloBoxPluginCreator::getPluginName() const TRT_NOEXCEPT {
   return "yolo_box_plugin";
 }
 
-const char* YoloBoxPluginCreator::getPluginVersion() const { return "1"; }
+const char* YoloBoxPluginCreator::getPluginVersion() const TRT_NOEXCEPT {
+  return "1";
+}
 
-const nvinfer1::PluginFieldCollection* YoloBoxPluginCreator::getFieldNames() {
+const nvinfer1::PluginFieldCollection* YoloBoxPluginCreator::getFieldNames()
+    TRT_NOEXCEPT {
   return &field_collection_;
 }
 
 nvinfer1::IPluginV2Ext* YoloBoxPluginCreator::createPlugin(
-    const char* name, const nvinfer1::PluginFieldCollection* fc) {
+    const char* name, const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT {
   const nvinfer1::PluginField* fields = fc->fields;
 
   int type_id = -1;
@@ -392,7 +401,8 @@ nvinfer1::IPluginV2Ext* YoloBoxPluginCreator::createPlugin(
 }
 
 nvinfer1::IPluginV2Ext* YoloBoxPluginCreator::deserializePlugin(
-    const char* name, const void* serial_data, size_t serial_length) {
+    const char* name, const void* serial_data,
+    size_t serial_length) TRT_NOEXCEPT {
   auto plugin = new YoloBoxPlugin(serial_data, serial_length);
   plugin->setPluginNamespace(namespace_.c_str());
   return plugin;

--- a/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/yolo_box_op_plugin.h
@@ -35,38 +35,39 @@ class YoloBoxPlugin : public nvinfer1::IPluginV2Ext {
   YoloBoxPlugin(const void* data, size_t length);
   ~YoloBoxPlugin() override;
 
-  const char* getPluginType() const override;
-  const char* getPluginVersion() const override;
-  int getNbOutputs() const override;
+  const char* getPluginType() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  int getNbOutputs() const TRT_NOEXCEPT override;
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims* inputs,
-                                     int nb_input_dims) override;
-  bool supportsFormat(nvinfer1::DataType type,
-                      nvinfer1::TensorFormat format) const override;
-  size_t getWorkspaceSize(int max_batch_size) const override;
+                                     int nb_input_dims) TRT_NOEXCEPT override;
+  bool supportsFormat(nvinfer1::DataType type, nvinfer1::TensorFormat format)
+      const TRT_NOEXCEPT override;
+  size_t getWorkspaceSize(int max_batch_size) const TRT_NOEXCEPT override;
 #if IS_TRT_VERSION_LT(8000)
   int enqueue(int batch_size, const void* const* inputs, void** outputs,
 #else
   int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
 #endif
-              void* workspace, cudaStream_t stream) override;
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
   template <typename T>
-  int enqueue_impl(int batch_size, const void* const* inputs, void** outputs,
-                   void* workspace, cudaStream_t stream);
-  int initialize() override;
-  void terminate() override;
-  size_t getSerializationSize() const override;
-  void serialize(void* buffer) const override;
-  void destroy() override;
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
+  int enqueue_impl(int batch_size, const void* const* inputs,
+                   void* const* outputs, void* workspace, cudaStream_t stream);
+  int initialize() TRT_NOEXCEPT override;
+  void terminate() TRT_NOEXCEPT override;
+  size_t getSerializationSize() const TRT_NOEXCEPT override;
+  void serialize(void* buffer) const TRT_NOEXCEPT override;
+  void destroy() TRT_NOEXCEPT override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
 
-  nvinfer1::DataType getOutputDataType(int index,
-                                       const nvinfer1::DataType* input_type,
-                                       int nb_inputs) const override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_type,
+      int nb_inputs) const TRT_NOEXCEPT override;
   bool isOutputBroadcastAcrossBatch(int output_index,
                                     const bool* input_is_broadcast,
-                                    int nb_inputs) const override;
-  bool canBroadcastInputAcrossBatch(int input_index) const override;
+                                    int nb_inputs) const TRT_NOEXCEPT override;
+  bool canBroadcastInputAcrossBatch(int input_index) const
+      TRT_NOEXCEPT override;
   void configurePlugin(const nvinfer1::Dims* input_dims, int nb_inputs,
                        const nvinfer1::Dims* output_dims, int nb_outputs,
                        const nvinfer1::DataType* input_types,
@@ -74,8 +75,8 @@ class YoloBoxPlugin : public nvinfer1::IPluginV2Ext {
                        const bool* input_is_broadcast,
                        const bool* output_is_broadcast,
                        nvinfer1::PluginFormat float_format,
-                       int max_batct_size) override;
-  nvinfer1::IPluginV2Ext* clone() const override;
+                       int max_batct_size) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* clone() const TRT_NOEXCEPT override;
 
  private:
   nvinfer1::DataType data_type_;
@@ -96,17 +97,18 @@ class YoloBoxPluginCreator : public nvinfer1::IPluginCreator {
   YoloBoxPluginCreator();
   ~YoloBoxPluginCreator() override = default;
 
-  void setPluginNamespace(const char* lib_namespace) override;
-  const char* getPluginNamespace() const override;
-  const char* getPluginName() const override;
-  const char* getPluginVersion() const override;
-  const nvinfer1::PluginFieldCollection* getFieldNames() override;
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override;
+  const char* getPluginNamespace() const TRT_NOEXCEPT override;
+  const char* getPluginName() const TRT_NOEXCEPT override;
+  const char* getPluginVersion() const TRT_NOEXCEPT override;
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override;
 
   nvinfer1::IPluginV2Ext* createPlugin(
-      const char* name, const nvinfer1::PluginFieldCollection* fc) override;
-  nvinfer1::IPluginV2Ext* deserializePlugin(const char* name,
-                                            const void* serial_data,
-                                            size_t serial_length) override;
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override;
+  nvinfer1::IPluginV2Ext* deserializePlugin(
+      const char* name, const void* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override;
 
  private:
   std::string namespace_;

--- a/paddle/fluid/inference/tensorrt/trt_int8_calibrator.cc
+++ b/paddle/fluid/inference/tensorrt/trt_int8_calibrator.cc
@@ -22,7 +22,7 @@ namespace inference {
 namespace tensorrt {
 
 // set the batch size before constructing the thread to execute engine
-int TRTInt8Calibrator::getBatchSize() const { return batch_size_; }
+int TRTInt8Calibrator::getBatchSize() const TRT_NOEXCEPT { return batch_size_; }
 
 TRTInt8Calibrator::TRTInt8Calibrator(
     const std::unordered_map<std::string, size_t>& buffers, int batch_size,
@@ -95,7 +95,7 @@ bool TRTInt8Calibrator::setBatch(
 }
 
 bool TRTInt8Calibrator::getBatch(void** bindings, const char** names,
-                                 int num_bindings) {
+                                 int num_bindings) TRT_NOEXCEPT {
   VLOG(4) << "get batch: " << engine_name_;
   std::unique_lock<std::mutex> lk(mut_);
   // The consumer has just finished processing a data.
@@ -131,14 +131,15 @@ void TRTInt8Calibrator::setDone() {
   cond_.notify_all();
 }
 
-const void* TRTInt8Calibrator::readCalibrationCache(size_t& length) {
+const void* TRTInt8Calibrator::readCalibrationCache(size_t& length)
+    TRT_NOEXCEPT {
   if (calibration_table_.empty()) return nullptr;
   length = calibration_table_.size();
   return calibration_table_.data();
 }
 
 void TRTInt8Calibrator::writeCalibrationCache(const void* ptr,
-                                              std::size_t length) {
+                                              std::size_t length) TRT_NOEXCEPT {
   calibration_table_ = std::string((const char*)ptr, length);
   VLOG(4) << "Got calibration data for " << engine_name_ << " " << ptr
           << " length=" << length;

--- a/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
+++ b/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
@@ -43,17 +43,18 @@ struct TRTInt8Calibrator : public nvinfer1::IInt8EntropyCalibrator2 {
   explicit TRTInt8Calibrator(const std::string& calibration_data);
   ~TRTInt8Calibrator();
 
-  int getBatchSize() const override;
+  int getBatchSize() const TRT_NOEXCEPT override;
 
   bool getBatch(void* bindings[], const char* names[],
-                int num_bindings) override;
+                int num_bindings) TRT_NOEXCEPT override;
 
   bool setBatch(const std::unordered_map<std::string, void*>& data);
   void setDone();
   void waitAndSetDone();
 
-  const void* readCalibrationCache(std::size_t& length) override;
-  void writeCalibrationCache(const void* ptr, std::size_t length) override;
+  const void* readCalibrationCache(std::size_t& length) TRT_NOEXCEPT override;
+  void writeCalibrationCache(const void* ptr,
+                             std::size_t length) TRT_NOEXCEPT override;
   const std::string& getCalibrationTableAsString() {
     return calibration_table_;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
TensorRT8 requires all class methods inherited from TensorRT should add noexcept keyword.
Paddle-TRT can support TensorRT8 after this PR.

[Reference](https://docs.nvidia.com/deeplearning/tensorrt/release-notes/tensorrt-8.html)
> TensorRT now declares API’s with the noexcept keyword to clarify that exceptions must not cross the library boundary. All TensorRT classes that an application inherits from (such as IGpuAllocator, IPluginV2, etc…) must guarantee that methods called by TensorRT do not throw uncaught exceptions, or the behavior is undefined.