### PR TITLE
[CPU-PSLIB] Add clearer error log when sparse key name is not int type, test=release/1.8

### DIFF
--- a/paddle/fluid/framework/fleet/fleet_wrapper.cc
+++ b/paddle/fluid/framework/fleet/fleet_wrapper.cc
@@ -575,7 +575,15 @@ void FleetWrapper::PushSparseVarsWithLabelAsync(
     int64_t* ids = tensor->data<int64_t>();
     int slot = 0;
     if (dump_slot) {
-      slot = boost::lexical_cast<int>(sparse_key_names[i]);
+      try {
+        slot = boost::lexical_cast<int>(sparse_key_names[i]);
+      } catch (boost::bad_lexical_cast const& e) {
+        std::cout << "Error: " << e.what() << std::endl;
+        PADDLE_THROW(
+            "sparse var's name: %s, doesn't support non-integer type name when "
+            "dump_slot=True",
+            sparse_key_names[i]);
+      }
     }
     Variable* g_var = scope.FindVar(sparse_grad_names[i]);
     if (g_var == nullptr) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
问题复现：
   机器=0562
   代码路径=/home/zhangfan50/Demand/ctr_model_upgrd2fleet_210416/paddle_cloud
   说明：业务方需求，想在保存的sparse embedding中加上slot_name

关键配置:
config_fleet.py中config['dump_slot'] = True
network.py中sparse特征fluid.layers.data的name设置为非Int类型
dataset_generator.py中sparse特征的name设置为非Int类型

报错日志:
![image](https://user-images.githubusercontent.com/24829556/125724673-48d86efc-2b89-461b-8d77-85a6a78e4967.png)


修改说明：
上面报错十分不明显，使用者完全无法根据上面报错进行排查，更无法定位到是因为开启了dump_slot，且sparse特证名不为int导致的；因此，在该报错处增加更明显的报错信息，以方便使用者定位问题

修改后报错日志：
![image](https://user-images.githubusercontent.com/24829556/125724863-b68999fe-5b8a-4388-ae8b-fa7dd2690ad9.png)
