### PR TITLE
[Dy2Stat]Add NoNeedBufferVarsInferer to reduce memory usage

### DIFF
--- a/paddle/fluid/framework/executor_cache.cc
+++ b/paddle/fluid/framework/executor_cache.cc
@@ -77,6 +77,7 @@ void ParseSafeEagerDeletionSkipVars(
     const std::vector<std::string> &output_var_names,
     std::vector<std::string> *skip_eager_delete_vars) {
   auto all_ops = program.Block(0).AllOps();
+  auto &op_info_map = OpInfoMap::Instance();
   // NOTE: skip `shape` and `fill_constant` op created by
   // fluid.backward.gradients, one forward output will generate one `shape`
   // and `fill_constant`.
@@ -86,11 +87,29 @@ void ParseSafeEagerDeletionSkipVars(
   // step 2: parse the necessary variable of backward op
   std::unordered_set<std::string> op_outputs;
   std::unordered_set<std::string> op_inputs;
+  std::unordered_set<std::string> no_need_buffer_ins;
+
   for (auto i = backward_op_start_index; i < all_ops.size(); ++i) {
     framework::OpDesc *op = all_ops[i];
-    for (const std::string &in_arg_name : op->InputArgumentNames()) {
-      op_inputs.emplace(in_arg_name);
+    // NOTE: skip NoNeedBufferVars of grad_op and GC its memory in advance.
+    auto &op_info = op_info_map.Get(op->Type());
+    auto &inferer = op_info.NoNeedBufferVarsInferer();
+    no_need_buffer_ins.clear();
+    if (inferer != nullptr) {
+      no_need_buffer_ins =
+          inferer(op->Inputs(), op->Outputs(), op->GetAttrMap());
     }
+    for (auto &in_names : op->Inputs()) {
+      if (no_need_buffer_ins.count(in_names.first) == 0) {
+        for (auto &in_name : in_names.second) {
+          op_inputs.emplace(in_name);
+        }
+      } else {
+        VLOG(2) << op->Type() << " has no_need_buffer_in: " << in_names.first
+                << " , skip it.";
+      }
+    }
+    
     for (const std::string &out_arg_name : op->OutputArgumentNames()) {
       op_outputs.emplace(out_arg_name);
     }

--- a/paddle/fluid/framework/executor_cache.cc
+++ b/paddle/fluid/framework/executor_cache.cc
@@ -109,12 +109,11 @@ void ParseSafeEagerDeletionSkipVars(
                 << " , skip it.";
       }
     }
-    
+
     for (const std::string &out_arg_name : op->OutputArgumentNames()) {
       op_outputs.emplace(out_arg_name);
     }
   }
-
   // For the grad op input variables, if it is not output of grad_op, it may
   // be output of forward op and we should set the variables as skip_var to
   // prevent it being deleted when grad op is called multiple times.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add NoNeedBufferVarsInferer to reduce memory usage

|显存占用（M） | 静态图 | 动态图 | to_static（优化前） | 优化后 | 减少比例
|:---:|:---:|:---:|:---:|:---:|:---:|
|ResNet50_bs32 | 5115   | 4608 | 5626 | 4770 |  -15.2% |
|ResNet50_bs128 | 15087   | 13329 | 15157  | 14050 | -7.3% |
|MobileNetV1_bs128 |  - | 7481 | 8025 |7063 | -11.9% |
|MobileNetV2_bs128 |  - | 9345 | 10419  |9287| -10.8% |
| Bert Base | 8531| 7085| 7523 |7167| -4.7% |