### PR TITLE
Fix gather_op to avoid cudaErrorLaunchFailure for solov2, test=develop

### DIFF
--- a/paddle/fluid/operators/gather.cu.h
+++ b/paddle/fluid/operators/gather.cu.h
@@ -30,20 +30,20 @@ using platform::DeviceContext;
 
 template <typename T, typename IndexT = int>
 __global__ void GatherCUDAKernel(const T* params, const IndexT* indices,
-                                 T* output, size_t input_size,
-                                 size_t index_size, size_t slice_size) {
+                                 T* output, size_t index_size,
+                                 size_t slice_size) {
   CUDA_KERNEL_LOOP(i, index_size * slice_size) {
     int indices_i = i / slice_size;
     int slice_i = i - indices_i * slice_size;  // offset inside the slice
     IndexT gather_i = indices[indices_i];
     IndexT params_i = gather_i * slice_size + slice_i;
-    PADDLE_ENFORCE(
-        gather_i >= 0 && gather_i < input_size,
-        "The index is out of bounds, "
-        "please check whether the dimensions of index and "
-        "input meet the requirements. It should "
-        "be less than [%d] and greater than or equal to 0, but received [%d]",
-        input_size, gather_i);
+    PADDLE_ENFORCE(gather_i >= 0,
+                   "The index is out of bounds, "
+                   "please check whether the dimensions of index and "
+                   "input meet the requirements. It should "
+                   "be less than the size of input and greater than or equal "
+                   "to 0, but received [%d]",
+                   gather_i);
     *(output + i) = *(params + params_i);
   }
 }
@@ -108,8 +108,6 @@ void GPUGather(const platform::DeviceContext& ctx, const Tensor& src,
   // slice size
   int slice_size = 1;
   for (int i = 1; i < src_dims.size(); ++i) slice_size *= src_dims[i];
-  // input size
-  int input_size = src_dims[0] * slice_size;
 
   const T* p_src = src.data<T>();
   const IndexT* p_index = index.data<IndexT>();
@@ -122,7 +120,7 @@ void GPUGather(const platform::DeviceContext& ctx, const Tensor& src,
   GatherCUDAKernel<T, IndexT><<<
       grid, block, 0,
       reinterpret_cast<const platform::CUDADeviceContext&>(ctx).stream()>>>(
-      p_src, p_index, p_output, input_size, index_size, slice_size);
+      p_src, p_index, p_output, index_size, slice_size);
 }
 
 template <typename DeviceContext, typename T, typename IndexT = int>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix gather_op to avoid cudaErrorLaunchFailure for solov2
icafe卡片：https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-32060/show
由于框架dev的改动，导致solov2模型评估/预测报错

经排查：在gather_op的cuda_kernel_loop对index做越界分析时，将index与上界input_size(the size of input)作比较时，报错信息如下：
![image](https://user-images.githubusercontent.com/86215757/125813233-07eb56d6-2f90-45b6-b315-7beef905db96.png)
目前未找到合适的解决方法，先取消上界越界分析，后续找到解决方法后再修复。

PR链接：https://github.com/PaddlePaddle/Paddle/pull/34096
