### PR TITLE
1.8

### DIFF
--- a/paddle/fluid/framework/fleet/fleet_wrapper.cc
+++ b/paddle/fluid/framework/fleet/fleet_wrapper.cc
@@ -578,7 +578,6 @@ void FleetWrapper::PushSparseVarsWithLabelAsync(
       try {
         slot = boost::lexical_cast<int>(sparse_key_names[i]);
       } catch (boost::bad_lexical_cast const& e) {
-        std::cout << "Error: " << e.what() << std::endl;
         PADDLE_THROW(
             "sparse var's name: %s, doesn't support non-integer type name when "
             "dump_slot=True",

--- a/paddle/fluid/framework/fleet/fleet_wrapper.cc
+++ b/paddle/fluid/framework/fleet/fleet_wrapper.cc
@@ -575,7 +575,14 @@ void FleetWrapper::PushSparseVarsWithLabelAsync(
     int64_t* ids = tensor->data<int64_t>();
     int slot = 0;
     if (dump_slot) {
-      slot = boost::lexical_cast<int>(sparse_key_names[i]);
+      try {
+        slot = boost::lexical_cast<int>(sparse_key_names[i]);
+      } catch (boost::bad_lexical_cast const& e) {
+        PADDLE_THROW(platform::errors::PreconditionNotMet(
+            "sparse var's name: %s, doesn't support non-integer type name when "
+            "dump_slot=True",
+            sparse_key_names[i]));
+      }
     }
     Variable* g_var = scope.FindVar(sparse_grad_names[i]);
     if (g_var == nullptr) {

--- a/paddle/fluid/framework/fleet/fleet_wrapper.cc
+++ b/paddle/fluid/framework/fleet/fleet_wrapper.cc
@@ -575,7 +575,15 @@ void FleetWrapper::PushSparseVarsWithLabelAsync(
     int64_t* ids = tensor->data<int64_t>();
     int slot = 0;
     if (dump_slot) {
-      slot = boost::lexical_cast<int>(sparse_key_names[i]);
+      try {
+        slot = boost::lexical_cast<int>(sparse_key_names[i]);
+      } catch (boost::bad_lexical_cast const& e) {
+        std::cout << "Error: " << e.what() << std::endl;
+        PADDLE_THROW(
+            "sparse var's name: %s, doesn't support non-integer type name when "
+            "dump_slot=True",
+            sparse_key_names[i]);
+      }
     }
     Variable* g_var = scope.FindVar(sparse_grad_names[i]);
     if (g_var == nullptr) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
问题描述：
想在保存的sparse embedding中加上slot_name

关键配置:
config_fleet.py中config['dump_slot'] = True
network.py中sparse特征fluid.layers.data的name设置为非Int类型
dataset_generator.py中sparse特征的name设置为非Int类型

报错信息:
![image](https://user-images.githubusercontent.com/24829556/125731972-46c8f06f-de5f-4fc3-8e19-d692a0de84a1.png)

修改说明：
上面报错十分不明显，使用者完全无法根据上面报错进行排查，更无法定位到是因为开启了dump_slot，且sparse特证名不为int导致的；因此，在该报错处增加更明显的报错信息，以方便使用者定位问题

修改后报错日志:
![image](https://user-images.githubusercontent.com/24829556/125732002-36e0766a-d962-4eac-aa7c-37154310add0.png)

