### PR TITLE
change strided_slice when step<0.

### DIFF
--- a/paddle/fluid/operators/strided_slice_op.h
+++ b/paddle/fluid/operators/strided_slice_op.h
@@ -141,8 +141,14 @@ static void StridedSliceFunctor(int64_t* starts, int64_t* ends,
       strides[axis_index] = -strides[axis_index];
       if (starts[axis_index] > ends[axis_index]) {
         // swap the reverse
-        starts[axis_index] = starts[axis_index] + 1;
-        ends[axis_index] = ends[axis_index] + 1;
+        auto end_dim = dims[axis_index] - 1 < starts[axis_index]
+                           ? dims[axis_index] - 1
+                           : starts[axis_index];
+        auto offset = (end_dim - ends[axis_index]) % strides[axis_index];
+        offset = offset == 0 ? strides[axis_index] : offset;
+
+        starts[axis_index] = starts[axis_index] + offset;
+        ends[axis_index] = ends[axis_index] + offset;
       }
       std::swap(starts[axis_index], ends[axis_index]);
     } else {

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
@@ -187,6 +187,7 @@ class TestPaddleStridedSlice(unittest.TestCase):
         stride1 = -2
         sl = paddle.strided_slice(
             pt, axes=[0, ], starts=[s1, ], ends=[e1, ], strides=[stride1, ])
+
         self.assertTrue(array[s1:e1:stride1], sl)
 
         array = np.arange(6 * 6).reshape((6, 6))
@@ -197,7 +198,9 @@ class TestPaddleStridedSlice(unittest.TestCase):
         sl = paddle.strided_slice(
             pt, axes=[0, 1], starts=s2, ends=e2, strides=stride2)
 
-        array[s2[0]:e2[0]:stride2[0], s2[1]:e2[1]:stride2[1]]
+        self.assertTrue(
+            np.array_equal(sl.numpy(), array[s2[0]:e2[0]:stride2[0], s2[1]:e2[
+                1]:stride2[1]]))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
@@ -176,5 +176,29 @@ class TestSetValueWithLayerAndSave(unittest.TestCase):
             output_spec=None)
 
 
+class TestPaddleStridedSlice(unittest.TestCase):
+    def test_compare_paddle_strided_slice_with_numpy(self):
+        paddle.disable_static()
+        array = np.arange(5)
+        pt = paddle.to_tensor(array)
+
+        s1 = 3
+        e1 = 1
+        stride1 = -2
+        sl = paddle.strided_slice(
+            pt, axes=[0, ], starts=[s1, ], ends=[e1, ], strides=[stride1, ])
+        self.assertTrue(array[s1:e1:stride1], sl)
+
+        array = np.arange(6 * 6).reshape((6, 6))
+        pt = paddle.to_tensor(array)
+        s2 = [8, -1]
+        e2 = [1, -5]
+        stride2 = [-2, -3]
+        sl = paddle.strided_slice(
+            pt, axes=[0, 1], starts=s2, ends=e2, strides=stride2)
+
+        array[s2[0]:e2[0]:stride2[0], s2[1]:e2[1]:stride2[1]]
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
strided_slice:当step<0时，没有与numpy对齐。

```python
import numpy as np
import paddle


array = np.arange(5)


pt = paddle.to_tensor(array)

sl = paddle.strided_slice(pt, axes=[0, ], starts=[3, ], ends=[1, ], strides=[-2, ])
print("array:", array)
print("numpy:", array[3:1:-2])
print("paddle:", sl)

# 输出
# array: [0 1 2 3 4]
# numpy: [3]
# paddle: Tensor(shape=[1], dtype=int64, place=CPUPlace, stop_gradient=True, [2])

```