### PR TITLE
Fix cast op that can not cast the arrays that  the size of arrays is beyond int32

### DIFF
--- a/paddle/fluid/operators/cast_op.cu
+++ b/paddle/fluid/operators/cast_op.cu
@@ -40,7 +40,8 @@ __global__ void VecCastCUDAKernel(const InT* in, const int64_t N, OutT* out) {
   int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
   using LoadT = AlignedVector<InT, VecSize>;
   using StoreT = AlignedVector<OutT, VecSize>;
-  for (int i = idx * VecSize; i < N; i += blockDim.x * gridDim.x * VecSize) {
+  for (int64_t i = idx * VecSize; i < N;
+       i += blockDim.x * gridDim.x * VecSize) {
     InT in_vec[VecSize];
     LoadT* in_value = reinterpret_cast<LoadT*>(&in_vec);
     *in_value = *reinterpret_cast<const LoadT*>(&in[i]);

--- a/paddle/fluid/platform/gpu_launch_config.h
+++ b/paddle/fluid/platform/gpu_launch_config.h
@@ -41,7 +41,7 @@ struct GpuLaunchConfig {
 };
 
 inline GpuLaunchConfig GetGpuLaunchConfig1D(
-    const platform::CUDADeviceContext& context, int element_count,
+    const platform::CUDADeviceContext& context, int64_t element_count,
 #ifdef PADDLE_WITH_HIP
     // HIP will throw GPU memory access fault if threads > 256
     int max_threads = 256) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix cast op that can not cast the arrays that  the size of arrays is beyond int32