### PR TITLE
Add ext_tensor.slice() API

### DIFF
--- a/paddle/fluid/extension/include/ext_tensor.h
+++ b/paddle/fluid/extension/include/ext_tensor.h
@@ -92,8 +92,8 @@ class PD_DLL_DECL Tensor {
   Tensor copy_to(const PlaceType& place) const;
 
   /// \brief Return a sub-tensor of the given tensor.
-  /// It is usually used to extract a sub-tensor (which supports 
-  /// modifying the data of the original tensor) to perform further 
+  /// It is usually used to extract a sub-tensor (which supports
+  /// modifying the data of the original tensor) to perform further
   /// operations.
   /// \param begin_idx The index of the start row (inclusive) to slice.
   ///                  The index number begins from 0.

--- a/paddle/fluid/extension/include/ext_tensor.h
+++ b/paddle/fluid/extension/include/ext_tensor.h
@@ -92,8 +92,9 @@ class PD_DLL_DECL Tensor {
   Tensor copy_to(const PlaceType& place) const;
 
   /// \brief Return a sub-tensor of the given tensor.
-  /// It's usually used to extract a read-only sub-tensor for
-  /// further operations.
+  /// It is usually used to extract a sub-tensor (which supports 
+  /// modifying the data of the original tensor) to perform further 
+  /// operations.
   /// \param begin_idx The index of the start row (inclusive) to slice.
   ///                  The index number begins from 0.
   /// \param end_idx  The index of the end row (exclusive) to slice.

--- a/paddle/fluid/extension/include/ext_tensor.h
+++ b/paddle/fluid/extension/include/ext_tensor.h
@@ -88,9 +88,18 @@ class PD_DLL_DECL Tensor {
   /// It's usually used to set the input tensor data.
   /// \param PlaceType of target place, of which
   /// the tensor will copy to.
-
   template <typename T>
   Tensor copy_to(const PlaceType& place) const;
+
+  /// \brief Return a sub-tensor of the given tensor.
+  /// It's usually used to extract a read-only sub-tensor for
+  /// further operations.
+  /// \param begin_idx The index of the start row (inclusive) to slice.
+  ///                  The index number begins from 0.
+  /// \param end_idx  The index of the end row (exclusive) to slice.
+  ///                 The index number begins from begin_idx + 1.
+  /// \return The sliced tensor.
+  Tensor slice(const int64_t begin_idx, const int64_t end_idx) const;
 
   /// \brief Return the shape of the Tensor.
   std::vector<int64_t> shape() const;

--- a/paddle/fluid/extension/src/ext_tensor.cc
+++ b/paddle/fluid/extension/src/ext_tensor.cc
@@ -112,7 +112,7 @@ void GpuCopy(T *src, T *dst, PlaceType src_plc, PlaceType dst_plc,
       PADDLE_THROW(platform::errors::Unavailable(     \
           "Custom operator unsupported place id(%d)", \
           static_cast<int>(place_)));                 \
-  }                                                   \
+  }
 
 void Tensor::reshape(const std::vector<int64_t> &shape) {
   GET_CASTED_TENSOR

--- a/paddle/fluid/extension/src/ext_tensor.cc
+++ b/paddle/fluid/extension/src/ext_tensor.cc
@@ -228,6 +228,48 @@ Tensor Tensor::slice(const int64_t begin_idx, const int64_t end_idx) const {
       framework::vectorize<int64_t>(tensor->dims());
   shape_vec[0] = end_idx - begin_idx;
   Tensor target = Tensor(place_, shape_vec);
+  auto dtype = tensor->type();
+  switch (dtype) {
+    case framework::proto::VarType::FP32:
+      target.mutable_data<float>();
+      break;
+    case framework::proto::VarType::FP64:
+      target.mutable_data<double>();
+      break;
+    case framework::proto::VarType::INT64:
+      target.mutable_data<int64_t>();
+      break;
+    case framework::proto::VarType::INT32:
+      target.mutable_data<int32_t>();
+      break;
+    case framework::proto::VarType::INT16:
+      target.mutable_data<int16_t>();
+      break;
+    case framework::proto::VarType::INT8:
+      target.mutable_data<int8_t>();
+      break;
+    case framework::proto::VarType::UINT8:
+      target.mutable_data<uint8_t>();
+      break;
+    case framework::proto::VarType::BOOL:
+      target.mutable_data<bool>();
+      break;
+    case framework::proto::VarType::COMPLEX64:
+      target.mutable_data<complex64>();
+      break;
+    case framework::proto::VarType::COMPLEX128:
+      target.mutable_data<complex128>();
+      break;
+    case framework::proto::VarType::FP16:
+      target.mutable_data<float16>();
+      break;
+    // TODO(JiabinYang) support more data types if needed.
+    default:
+      PADDLE_THROW(platform::errors::Unavailable(
+        "Not supported VarType(%s) for slicing.",
+        ToString(framework::CustomTensorUtils::ConvertInnerDTypeToEnumDType(dtype))));
+      break;
+  }
   auto *target_tensor =
       static_cast<framework::LoDTensor *>(target.tensor_.get());
   target_tensor->ShareDataWith(intermediate);

--- a/paddle/fluid/extension/src/ext_tensor.cc
+++ b/paddle/fluid/extension/src/ext_tensor.cc
@@ -284,8 +284,8 @@ Tensor Tensor::slice(const int64_t begin_idx, const int64_t end_idx) const {
     // TODO(JiabinYang) support more data types if needed.
     default:
       PADDLE_THROW(platform::errors::Unavailable(
-        "Not supported VarType(%s) for slicing.",
-        ToString(framework::CustomTensorUtils::ConvertInnerDTypeToEnumDType(dtype))));
+          "Not supported VarType(%s) for slicing.",
+          ToString(framework::CustomTensorUtils::ConvertInnerDTypeToEnumDType(dtype))));
       break;
   }
   target_tensor->ShareDataWith(intermediate);

--- a/paddle/fluid/extension/src/ext_tensor.cc
+++ b/paddle/fluid/extension/src/ext_tensor.cc
@@ -240,56 +240,9 @@ Tensor Tensor::slice(const int64_t begin_idx, const int64_t end_idx) const {
   GET_CASTED_TENSOR
   GET_INNER_PLACE
   framework::Tensor intermediate = tensor->Slice(begin_idx, end_idx);
-  std::vector<int64_t> shape_vec =
-      framework::vectorize<int64_t>(tensor->dims());
-  shape_vec[0] = end_idx - begin_idx;
-  Tensor target = Tensor(place_, shape_vec);
-  auto *target_tensor =
-      static_cast<framework::LoDTensor *>(target.tensor_.get());
-  auto dtype = tensor->type();
-  switch (dtype) {
-    case framework::proto::VarType::FP32:
-      target_tensor->mutable_data<float>(place);
-      break;
-    case framework::proto::VarType::FP64:
-      target_tensor->mutable_data<double>(place);
-      break;
-    case framework::proto::VarType::INT64:
-      target_tensor->mutable_data<int64_t>(place);
-      break;
-    case framework::proto::VarType::INT32:
-      target_tensor->mutable_data<int32_t>(place);
-      break;
-    case framework::proto::VarType::INT16:
-      target_tensor->mutable_data<int16_t>(place);
-      break;
-    case framework::proto::VarType::INT8:
-      target_tensor->mutable_data<int8_t>(place);
-      break;
-    case framework::proto::VarType::UINT8:
-      target_tensor->mutable_data<uint8_t>(place);
-      break;
-    case framework::proto::VarType::BOOL:
-      target_tensor->mutable_data<bool>(place);
-      break;
-    case framework::proto::VarType::COMPLEX64:
-      target_tensor->mutable_data<complex64>(place);
-      break;
-    case framework::proto::VarType::COMPLEX128:
-      target_tensor->mutable_data<complex128>(place);
-      break;
-    case framework::proto::VarType::FP16:
-      target_tensor->mutable_data<float16>(place);
-      break;
-    // TODO(JiabinYang) support more data types if needed.
-    default:
-      PADDLE_THROW(platform::errors::Unavailable(
-          "Not supported VarType(%s) for slicing.",
-          ToString(framework::CustomTensorUtils::ConvertInnerDTypeToEnumDType(
-              dtype))));
-      break;
-  }
-  target_tensor->ShareDataWith(intermediate);
+  Tensor target = Tensor(place_);
+  framework::CustomTensorUtils::ShareDataFrom(
+      static_cast<const void *>(&intermediate), target);
   return target;
 }
 

--- a/paddle/fluid/extension/src/ext_tensor.cc
+++ b/paddle/fluid/extension/src/ext_tensor.cc
@@ -221,6 +221,19 @@ Tensor Tensor::copy_to(const PlaceType &target_place) const {
   return target;
 }
 
+Tensor Tensor::slice(const int64_t begin_idx, const int64_t end_idx) const {
+  GET_CASTED_TENSOR
+  framework::Tensor intermediate = tensor->Slice(begin_idx, end_idx);
+  std::vector<int64_t> shape_vec =
+      framework::vectorize<int64_t>(tensor->dims());
+  shape_vec[0] = end_idx - begin_idx;
+  Tensor target = Tensor(place_, shape_vec);
+  auto *target_tensor =
+      static_cast<framework::LoDTensor *>(target.tensor_.get());
+  target_tensor->ShareDataWith(intermediate);
+  return target;
+}
+
 template PD_DLL_DECL Tensor
 Tensor::copy_to<float>(const PlaceType &target_place) const;
 template PD_DLL_DECL Tensor

--- a/paddle/fluid/extension/src/ext_tensor.cc
+++ b/paddle/fluid/extension/src/ext_tensor.cc
@@ -99,20 +99,20 @@ void GpuCopy(T *src, T *dst, PlaceType src_plc, PlaceType dst_plc,
   }                                                     \
   auto *tensor = static_cast<framework::LoDTensor *>(tensor_.get());
 
-#define GET_INNER_PLACE                                 \
-  platform::Place place;                                \
-  switch (place_) {                                     \
-    case PlaceType::kCPU:                               \
-      place = platform::CPUPlace();                     \
-      break;                                            \
-    case PlaceType::kGPU:                               \
-      place = platform::CUDAPlace();                    \
-      break;                                            \
-    default:                                            \
-      PADDLE_THROW(platform::errors::Unavailable(       \
-          "Custom operator unsupported place id(%d)",   \
-          static_cast<int>(place_)));                   \
-  }                                                     \
+#define GET_INNER_PLACE                               \
+  platform::Place place;                              \
+  switch (place_) {                                   \
+    case PlaceType::kCPU:                             \
+      place = platform::CPUPlace();                   \
+      break;                                          \
+    case PlaceType::kGPU:                             \
+      place = platform::CUDAPlace();                  \
+      break;                                          \
+    default:                                          \
+      PADDLE_THROW(platform::errors::Unavailable(     \
+          "Custom operator unsupported place id(%d)", \
+          static_cast<int>(place_)));                 \
+  }                                                   \
 
 void Tensor::reshape(const std::vector<int64_t> &shape) {
   GET_CASTED_TENSOR
@@ -285,7 +285,8 @@ Tensor Tensor::slice(const int64_t begin_idx, const int64_t end_idx) const {
     default:
       PADDLE_THROW(platform::errors::Unavailable(
           "Not supported VarType(%s) for slicing.",
-          ToString(framework::CustomTensorUtils::ConvertInnerDTypeToEnumDType(dtype))));
+          ToString(framework::CustomTensorUtils::ConvertInnerDTypeToEnumDType(
+              dtype))));
       break;
   }
   target_tensor->ShareDataWith(intermediate);

--- a/paddle/fluid/framework/custom_tensor_test.cc
+++ b/paddle/fluid/framework/custom_tensor_test.cc
@@ -80,12 +80,14 @@ void TestAPISlice() {
   std::vector<int64_t> tensor_shape_sub1 = {3, 5};
   std::vector<int64_t> tensor_shape_sub2 = {1, 5};
 #ifdef PADDLE_WITH_CUDA
-  auto t1 = paddle::Tensor(paddle::PlaceType::kGPU);
+  auto t1 = paddle::Tensor(paddle::PlaceType::kGPU, tensor_shape_origin);
+  t1.mutable_data<float>();
   CHECK(t1.slice(0, 5).shape() == tensor_shape_origin);
   CHECK(t1.slice(0, 3).shape() == tensor_shape_sub1);
   CHECK(t1.slice(4, 5).shape() == tensor_shape_sub2);
 #endif
-  auto t2 = paddle::Tensor(paddle::PlaceType::kCPU);
+  auto t2 = paddle::Tensor(paddle::PlaceType::kCPU, tensor_shape_origin);
+  t2.mutable_data<float>();
   CHECK(t2.slice(0, 5).shape() == tensor_shape_origin);
   CHECK(t2.slice(0, 3).shape() == tensor_shape_sub1);
   CHECK(t2.slice(4, 5).shape() == tensor_shape_sub2);

--- a/paddle/fluid/framework/custom_tensor_test.cc
+++ b/paddle/fluid/framework/custom_tensor_test.cc
@@ -75,6 +75,22 @@ void TestAPISizeAndShape() {
   CHECK(t1.shape() == tensor_shape);
 }
 
+void TestAPISlice() {
+  std::vector<int64_t> tensor_shape_origin = {5, 5};
+  std::vector<int64_t> tensor_shape_sub1 = {3, 5};
+  std::vector<int64_t> tensor_shape_sub2 = {1, 5};
+#ifdef PADDLE_WITH_CUDA
+  auto t1 = paddle::Tensor(paddle::PlaceType::kGPU);
+  CHECK(t1.slice(0, 5).shape() == tensor_shape_origin);
+  CHECK(t1.slice(0, 3).shape() == tensor_shape_sub1);
+  CHECK(t1.slice(4, 5).shape() == tensor_shape_sub2);
+#endif
+  auto t2 = paddle::Tensor(paddle::PlaceType::kCPU);
+  CHECK(t2.slice(0, 5).shape() == tensor_shape_origin);
+  CHECK(t2.slice(0, 3).shape() == tensor_shape_sub1);
+  CHECK(t2.slice(4, 5).shape() == tensor_shape_sub2);
+}
+
 template <typename T>
 paddle::DataType TestDtype() {
   std::vector<int64_t> tensor_shape = {5, 5};
@@ -244,6 +260,8 @@ TEST(CustomTensor, copyTest) {
   TestAPISizeAndShape();
   VLOG(2) << "TestPlace";
   TestAPIPlace();
+  VLOG(2) << "TestSlice";
+  TestAPISlice();
   VLOG(2) << "TestCast";
   GroupTestCast();
   VLOG(2) << "TestDtypeConvert";

--- a/paddle/fluid/framework/custom_tensor_test.cc
+++ b/paddle/fluid/framework/custom_tensor_test.cc
@@ -89,6 +89,18 @@ void TestAPISlice() {
   CHECK(t2.slice(0, 5).shape() == tensor_shape_origin);
   CHECK(t2.slice(0, 3).shape() == tensor_shape_sub1);
   CHECK(t2.slice(4, 5).shape() == tensor_shape_sub2);
+
+  // Test writing function for sliced tensor
+  auto t = InitCPUTensorForTest<float>();
+  auto t_sliced = t.slice(0, 1);
+  auto* t_sliced_data_ptr = t_sliced.mutable_data<float>();
+  for (int64_t i = 0; i < t_sliced.size(); i++) {
+    t_sliced_data_ptr[i] += float(5);
+  }
+  auto* t_data_ptr = t.mutable_data<float>();
+  for (int64_t i = 0; i < t_sliced.size(); i++) {
+    CHECK_EQ(t_data_ptr[i], float(10));
+  }
 }
 
 template <typename T>

--- a/paddle/fluid/framework/custom_tensor_test.cc
+++ b/paddle/fluid/framework/custom_tensor_test.cc
@@ -76,32 +76,37 @@ void TestAPISizeAndShape() {
 }
 
 void TestAPISlice() {
-  std::vector<int64_t> tensor_shape_origin = {5, 5};
+  std::vector<int64_t> tensor_shape_origin1 = {5, 5};
   std::vector<int64_t> tensor_shape_sub1 = {3, 5};
-  std::vector<int64_t> tensor_shape_sub2 = {1, 5};
+  std::vector<int64_t> tensor_shape_origin2 = {5, 5, 5};
+  std::vector<int64_t> tensor_shape_sub2 = {1, 5, 5};
 #ifdef PADDLE_WITH_CUDA
-  auto t1 = paddle::Tensor(paddle::PlaceType::kGPU, tensor_shape_origin);
+  auto t1 = paddle::Tensor(paddle::PlaceType::kGPU, tensor_shape_origin1);
   t1.mutable_data<float>();
-  CHECK(t1.slice(0, 5).shape() == tensor_shape_origin);
+  CHECK(t1.slice(0, 5).shape() == tensor_shape_origin1);
   CHECK(t1.slice(0, 3).shape() == tensor_shape_sub1);
-  CHECK(t1.slice(4, 5).shape() == tensor_shape_sub2);
-#endif
-  auto t2 = paddle::Tensor(paddle::PlaceType::kCPU, tensor_shape_origin);
+  auto t2 = paddle::Tensor(paddle::PlaceType::kGPU, tensor_shape_origin2);
   t2.mutable_data<float>();
-  CHECK(t2.slice(0, 5).shape() == tensor_shape_origin);
-  CHECK(t2.slice(0, 3).shape() == tensor_shape_sub1);
   CHECK(t2.slice(4, 5).shape() == tensor_shape_sub2);
+#endif
+  auto t3 = paddle::Tensor(paddle::PlaceType::kCPU, tensor_shape_origin1);
+  t3.mutable_data<float>();
+  CHECK(t3.slice(0, 5).shape() == tensor_shape_origin1);
+  CHECK(t3.slice(0, 3).shape() == tensor_shape_sub1);
+  auto t4 = paddle::Tensor(paddle::PlaceType::kCPU, tensor_shape_origin2);
+  t4.mutable_data<float>();
+  CHECK(t4.slice(4, 5).shape() == tensor_shape_sub2);
 
   // Test writing function for sliced tensor
   auto t = InitCPUTensorForTest<float>();
   auto t_sliced = t.slice(0, 1);
   auto* t_sliced_data_ptr = t_sliced.mutable_data<float>();
   for (int64_t i = 0; i < t_sliced.size(); i++) {
-    t_sliced_data_ptr[i] += float(5);
+    t_sliced_data_ptr[i] += static_cast<float>(5);
   }
   auto* t_data_ptr = t.mutable_data<float>();
   for (int64_t i = 0; i < t_sliced.size(); i++) {
-    CHECK_EQ(t_data_ptr[i], float(10));
+    CHECK_EQ(t_data_ptr[i], static_cast<float>(10));
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
Add `Tensor slice(const int64_t begin_idx, const int64_t end_idx) const;` for ext_tensor, which introduces tensor slicing feature for custom external operators.

A detailed doc PR in Chinese is now available at [docs PR3824](https://github.com/PaddlePaddle/docs/pull/3824).