### PR TITLE
[hybrid parallel] Optimize pipeline memory

### DIFF
--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -548,6 +548,7 @@ class SectionWorker : public DeviceWorker {
   ~SectionWorker() override {}
 
   void Initialize(const TrainerDesc& desc) override;
+  void PrepareUnusedVar();
 
   void BindingDataFeedMemory() override {}
   void CreateDeviceResource(const ProgramDesc& main_prog) override{};
@@ -581,7 +582,8 @@ class SectionWorker : public DeviceWorker {
   void RunUpdate(
       std::unique_ptr<GarbageCollector>&,
       std::unordered_map<const OperatorBase*, std::vector<std::string>>&);
-  void PrepareUnusedVar();
+  void RunFThenB(std::unique_ptr<GarbageCollector>&);
+  void Run1F1B(std::unique_ptr<GarbageCollector>&);
 
  protected:
   int section_id_;
@@ -591,8 +593,12 @@ class SectionWorker : public DeviceWorker {
   int pipeline_stage_;
   int schedule_mode_;  // 0 for F-then-B and 1 for 1F1B
   std::vector<Scope*> microbatch_scopes_;
-  std::vector<std::string> skip_vars_;
   const Scope* minibatch_scope_;
+
+  // skip, forward&backward send vars only used in 1F1B
+  std::vector<std::string> skip_vars_;
+  std::vector<std::string> forward_send_vars_;
+  std::vector<std::string> backward_send_vars_;
 
   std::vector<std::unique_ptr<OperatorBase>> ops_;
   std::shared_ptr<framework::ProgramDesc> program_;

--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -595,7 +595,7 @@ class SectionWorker : public DeviceWorker {
   std::vector<Scope*> microbatch_scopes_;
   const Scope* minibatch_scope_;
 
-  // skip, forward&backward send vars only used in 1F1B
+  // skip&forward&backward vars are only used in 1F1B
   std::vector<std::string> skip_vars_;
   std::vector<std::string> forward_send_vars_;
   std::vector<std::string> backward_send_vars_;

--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -595,9 +595,8 @@ class SectionWorker : public DeviceWorker {
   std::vector<Scope*> microbatch_scopes_;
   const Scope* minibatch_scope_;
 
-  // skip&forward&backward vars are only used in 1F1B
+  // skip&backward vars are only used in 1F1B
   std::vector<std::string> skip_vars_;
-  std::vector<std::string> forward_send_vars_;
   std::vector<std::string> backward_send_vars_;
 
   std::vector<std::unique_ptr<OperatorBase>> ops_;

--- a/paddle/fluid/framework/executor_gc_helper.h
+++ b/paddle/fluid/framework/executor_gc_helper.h
@@ -36,6 +36,11 @@ GetUnusedVars(const BlockDesc &block,
               const std::vector<std::unique_ptr<OperatorBase>> &ops,
               const std::vector<std::string> &skip_vars);
 
+// Collect unused tensors
+void DeleteUnusedTensors(const Scope &scope,
+                         const std::vector<std::string> &delete_vars,
+                         GarbageCollector *gc);
+
 // Collect unused tensors after op runs
 void DeleteUnusedTensors(
     const Scope &scope, const OperatorBase *op,

--- a/paddle/fluid/framework/pipeline_trainer.cc
+++ b/paddle/fluid/framework/pipeline_trainer.cc
@@ -45,11 +45,11 @@ void PipelineTrainer::Initialize(const TrainerDesc& trainer_desc,
   auto this_worker =
       std::dynamic_pointer_cast<paddle::framework::SectionWorker>(worker_);
   this_worker->SetPlace(place_);
-  this_worker->Initialize(trainer_desc);
   this_worker->SetMicrobatchNum(num_microbatches_);
   this_worker->SetPipelineStageNum(num_pipeline_stages_);
   this_worker->SetPipelineStage(pipeline_stage_);
   this_worker->SetScheduleMode(schedule_mode_);
+  this_worker->Initialize(trainer_desc);
 }
 
 void PipelineTrainer::InitOtherEnv(const ProgramDesc& main_program) {

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -200,7 +200,6 @@ void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
 
     // delete forward send var at step<=(fw_step - 1)
     if (gc && !is_last_stage) {
-      // 0, 1, 2
       for (int i = reserve_fw_send_step; i < fw_step; ++i) {
         DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_,
                             gc.get());
@@ -223,7 +222,8 @@ void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
     // NOTE(wangxi): will only execute once
     // delete forward send var at step=(num_microbatches_ - 1)
     if (reserve_fw_send_step < num_microbatches_ && !is_last_stage) {
-      DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_, gc.get());
+      DeleteUnusedTensors(*microbatch_scopes_[reserve_fw_send_step],
+                          forward_send_vars_, gc.get());
       ++reserve_fw_send_step;
     }
   }

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -193,7 +193,7 @@ void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
     // delete backward send var at step=(bw_step - 2)
     if (gc && !is_first_stage && bw_step >= 2) {
       DeleteUnusedTensors(*microbatch_scopes_[bw_step - 2], backward_send_vars_,
-                          gc);
+                          gc.get());
     }
 
     RunBackward(bw_step, gc, unused_vars_);
@@ -202,7 +202,8 @@ void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
     if (gc && !is_last_stage) {
       // 0, 1, 2
       for (int i = reserve_fw_send_step; i < fw_step; ++i) {
-        DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_, gc);
+        DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_,
+                            gc.get());
       }
       // because assert(startup_steps < num_microbatches_), so will always
       // run 1F1B, reserve_fw_send_step will be update
@@ -222,7 +223,7 @@ void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
     // NOTE(wangxi): will only execute once
     // delete forward send var at step=(num_microbatches_ - 1)
     if (reserve_fw_send_step < num_microbatches_ && !is_last_stage) {
-      DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_, gc);
+      DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_, gc.get());
       ++reserve_fw_send_step;
     }
   }
@@ -233,7 +234,8 @@ void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
     // NOTE(wangxi): program must add sync backward send comm at update
     // delete backward send var
     for (int i = reserve_bw_send_step; i < num_microbatches_; ++i) {
-      DeleteUnusedTensors(*microbatch_scopes_[i], backward_send_vars_, gc);
+      DeleteUnusedTensors(*microbatch_scopes_[i], backward_send_vars_,
+                          gc.get());
     }
   }
 }

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -30,6 +30,52 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
   for (auto &op_desc : program_->Block(0).AllOps()) {
     ops_.push_back(OpRegistry::CreateOp(*op_desc));
   }
+
+  // if not 1F1B scheduler
+  if (schedule_mode_ != 1) return;
+
+  for (auto &op : ops_) {
+    if (!op->HasAttr("pipeline_send_var")) continue;
+
+    auto op_type = op->Type();
+    PADDLE_ENFORCE_EQ(op_type == "send_v2" || op_type == "partial_send", true,
+                      platform::errors::PreconditionNotMet(
+                          "The op which have `pipeline_send_var` must be "
+                          "send_v2 or partial_send op, but this op is %s",
+                          op_type));
+
+    auto var_name = op->Attr<std::string>("pipeline_send_var");
+    auto send_input_vars = op->InputVars();
+    PADDLE_ENFORCE_EQ(
+        var_name, send_input_vars[0],
+        platform::errors::NotFound("pipeline_send_var %s is not found in op %s",
+                                   var_name, op_type));
+
+    int op_role = op->Attr<int>("op_role");
+    int FORWARD = static_cast<int>(OpRole::kForward);
+    int BACKWARD = static_cast<int>(OpRole::kBackward);
+    PADDLE_ENFORCE_EQ(
+        op_role == FORWARD || op_role == BACKWARD, true,
+        platform::errors::PreconditionNotMet(
+            "%s op's op_role must be forward or backward", op_type));
+
+    bool is_last_stage = (pipeline_stage_ == num_pipeline_stages_ - 1);
+    bool is_first_stage = (pipeline_stage_ == 0);
+    if (op_role == FORWARD && !is_last_stage) {
+      // The last pipeline stage does not need to send forward var
+      forward_send_vars_.push_back(var_name);
+      skip_vars_.push_back(var_name);
+    } else if (op_role == BACKWARD && !is_first_stage) {
+      // The first pipeline stage does not need to send backward var
+      backward_send_vars_.push_back(var_name);
+      skip_vars_.push_back(var_name);
+    }
+  }
+}
+
+void SectionWorker::PrepareUnusedVar() {
+  VLOG(5) << "begin prepare the unsed vars";
+  unused_vars_ = GetUnusedVars(program_->Block(0), ops_, skip_vars_);
 }
 
 void SectionWorker::RunForward(
@@ -96,9 +142,100 @@ void SectionWorker::RunUpdate(
   }
 }
 
-void SectionWorker::PrepareUnusedVar() {
-  VLOG(5) << "begin prepare the unsed vars";
-  unused_vars_ = GetUnusedVars(program_->Block(0), ops_, skip_vars_);
+void SectionWorker::RunFThenB(std::unique_ptr<GarbageCollector> &gc) {
+  // F-then-B scheduler which runs Forward phase for all microbatches,
+  // then runs Backward phase for all microbatches.
+  // step1: run forward
+  for (int i = 0; i < num_microbatches_; ++i) {
+    RunForward(i, gc, unused_vars_);
+  }
+  // step2: run backward
+  for (int i = 0; i < num_microbatches_; ++i) {
+    RunBackward(i, gc, unused_vars_);
+  }
+  // step3: run update
+  RunUpdate(gc, unused_vars_);
+}
+
+void SectionWorker::Run1F1B(std::unique_ptr<GarbageCollector> &gc) {
+  // 1F1B scheduler, which runs forward phase and backward phase altertively
+  // after startup phase. For a stage, the number of microbatches for
+  // startup is num_pipeline_stages_ - pipeline_stage_ - 1, where
+  // num_pipeline_stages_ is the total number of pipeline stages and
+  // pipeline_stage_ is the pipeline stage of the current device.
+  auto startup_steps = num_pipeline_stages_ - pipeline_stage_ - 1;
+  VLOG(3) << "startup_steps:" << startup_steps
+          << ", num_stages: " << num_pipeline_stages_
+          << ", stage:" << pipeline_stage_;
+  PADDLE_ENFORCE_GT(
+      num_microbatches_, startup_steps,
+      platform::errors::InvalidArgument(
+          "To use pipeline with 1F1B scheduler, please make sure number of "
+          "microbatches (%d) is than startup steps (%d).",
+          num_microbatches_, startup_steps));
+  int fw_step = 0;
+  int bw_step = 0;
+
+  bool is_last_stage = (pipeline_stage_ == num_pipeline_stages_ - 1);
+  bool is_first_stage = (pipeline_stage_ == 0);
+
+  int reserve_fw_send_step = 0;
+  // startup phase
+  while (fw_step < startup_steps) {
+    RunForward(fw_step, gc, unused_vars_);
+    fw_step += 1;
+  }
+
+  // 1f1b phase
+  while (fw_step < num_microbatches_) {
+    RunForward(fw_step, gc, unused_vars_);
+
+    // delete backward send var at step=(bw_step - 2)
+    if (gc && !is_first_stage && bw_step >= 2) {
+      DeleteUnusedTensors(*microbatch_scopes_[bw_step - 2], backward_send_vars_,
+                          gc);
+    }
+
+    RunBackward(bw_step, gc, unused_vars_);
+
+    // delete forward send var at step<=(fw_step - 1)
+    if (gc && !is_last_stage) {
+      // 0, 1, 2
+      for (int i = reserve_fw_send_step; i < fw_step; ++i) {
+        DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_, gc);
+      }
+      // because assert(startup_steps < num_microbatches_), so will always
+      // run 1F1B, reserve_fw_send_step will be update
+      reserve_fw_send_step = fw_step;
+    }
+
+    fw_step += 1;
+    bw_step += 1;
+  }
+
+  int reserve_bw_send_step = bw_step - 2;
+  // backward phase
+  while (bw_step < num_microbatches_) {
+    RunBackward(bw_step, gc, unused_vars_);
+    bw_step += 1;
+
+    // NOTE(wangxi): will only execute once
+    // delete forward send var at step=(num_microbatches_ - 1)
+    if (reserve_fw_send_step < num_microbatches_ && !is_last_stage) {
+      DeleteUnusedTensors(*microbatch_scopes_[i], forward_send_vars_, gc);
+      ++reserve_fw_send_step;
+    }
+  }
+
+  RunUpdate(gc, unused_vars_);
+
+  if (gc && !is_first_stage) {
+    // NOTE(wangxi): program must add sync backward send comm at update
+    // delete backward send var
+    for (int i = reserve_bw_send_step; i < num_microbatches_; ++i) {
+      DeleteUnusedTensors(*microbatch_scopes_[i], backward_send_vars_, gc);
+    }
+  }
 }
 
 void SectionWorker::TrainFiles() {
@@ -132,56 +269,11 @@ void SectionWorker::TrainFiles() {
   }  // max_memory_size >= 0
 
   if (schedule_mode_ == 0) {
-    // F-then-B scheduler which runs Forward phase for all microbatches,
-    // then runs Backward phase for all microbatches.
-    // step1: run forward
-    for (int i = 0; i < num_microbatches_; ++i) {
-      RunForward(i, gc, unused_vars_);
-    }
-    // step2: run backward
-    for (int i = 0; i < num_microbatches_; ++i) {
-      RunBackward(i, gc, unused_vars_);
-    }
-    // step3: run update
-    RunUpdate(gc, unused_vars_);
+    RunFThenB(gc);
   } else {
-    // 1F1B scheduler, which runs forward phase and backward phase altertively
-    // after startup phase. For a stage, the number of microbatches for
-    // startup is num_pipeline_stages_ - pipeline_stage_ - 1, where
-    // num_pipeline_stages_ is the total number of pipeline stages and
-    // pipeline_stage_ is the pipeline stage of the current device.
-    auto startup_steps = num_pipeline_stages_ - pipeline_stage_ - 1;
-    VLOG(3) << "startup_steps:" << startup_steps
-            << ", num_stages: " << num_pipeline_stages_
-            << ", stage:" << pipeline_stage_;
-    PADDLE_ENFORCE_GT(
-        num_microbatches_, startup_steps,
-        platform::errors::InvalidArgument(
-            "To use pipeline with 1F1B scheduler, please make sure number of "
-            "microbatches (%d) is than startup steps (%d).",
-            num_microbatches_, startup_steps));
-    int fw_step = 0;
-    int bw_step = 0;
-    // startup phase
-    while (fw_step < startup_steps) {
-      RunForward(fw_step, gc, unused_vars_);
-      fw_step += 1;
-    }
-
-    // 1f1b phase
-    while (fw_step < num_microbatches_) {
-      RunForward(fw_step, gc, unused_vars_);
-      fw_step += 1;
-      RunBackward(bw_step, gc, unused_vars_);
-      bw_step += 1;
-    }
-    // backward phase
-    while (bw_step < num_microbatches_) {
-      RunBackward(bw_step, gc, unused_vars_);
-      bw_step += 1;
-    }
-    RunUpdate(gc, unused_vars_);
+    Run1F1B(gc);
   }
+
   dev_ctx_->Wait();
   ++batch_id_;
 }

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -4877,7 +4877,7 @@ class PipelineOptimizer(object):
                                 self._op_role_key: op_role,
                             })
                         extra_index_info['index'] += 1
-                        send_op = block._insert_op_without_sync(
+                        block._insert_op_without_sync(
                             index=index + extra_index_info['index'],
                             type='send_v2'
                             if self.mp_degree == 1 else 'partial_send',
@@ -4896,7 +4896,6 @@ class PipelineOptimizer(object):
                         insert_index = None
 
                         if int(op_role) == int(self._op_role.Backward):
-                            send_op._set_attr('pipeline_send_var', var.name)
                             insert_index = extra_index_info[
                                 'first_optimize_index']
                             new_op_role = self._op_role.Optimize

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -4877,7 +4877,7 @@ class PipelineOptimizer(object):
                                 self._op_role_key: op_role,
                             })
                         extra_index_info['index'] += 1
-                        block._insert_op_without_sync(
+                        send_op = block._insert_op_without_sync(
                             index=index + extra_index_info['index'],
                             type='send_v2'
                             if self.mp_degree == 1 else 'partial_send',
@@ -4892,6 +4892,7 @@ class PipelineOptimizer(object):
                                 'num': self.mp_degree,
                                 'id': self.mp_rank,
                             })
+                        send_op._set_attr('pipeline_send_var', var.name)
                         extra_index_info['index'] += 1
                         insert_index = None
 
@@ -4899,24 +4900,17 @@ class PipelineOptimizer(object):
                             insert_index = extra_index_info[
                                 'first_optimize_index']
                             new_op_role = self._op_role.Optimize
-                        else:
-                            insert_index = index
-                            new_op_role = self._op_role.Backward
 
-                        sync_comm_op = block._insert_op_without_sync(
-                            index=insert_index + extra_index_info['index'],
-                            type='c_sync_comm_stream',
-                            inputs={'X': [var]},
-                            outputs={'Out': [var]},
-                            attrs={
-                                self._op_device_key: prev_dev,
-                                self._op_role_key: new_op_role,
-                                'ring_id': ring_id,
-                            })
-
-                        if int(op_role) == int(self._op_role.Forward):
-                            sync_comm_op._set_attr('pipeline_flag', '')
-                            extra_index_info['index'] += 1
+                            sync_comm_op = block._insert_op_without_sync(
+                                index=insert_index + extra_index_info['index'],
+                                type='c_sync_comm_stream',
+                                inputs={'X': [var]},
+                                outputs={'Out': [var]},
+                                attrs={
+                                    self._op_device_key: prev_dev,
+                                    self._op_role_key: new_op_role,
+                                    'ring_id': ring_id,
+                                })
 
                         var_shape = list(var.shape)
                         var_shape[0] = self.micro_batch_size if var_shape[

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -1258,7 +1258,7 @@ class TestDistBase(unittest.TestCase):
                 "fused_all_reduce_op_handle=10,all_reduce_op_handle=10,alloc_continuous_space_op=10,fuse_all_reduce_op_pass=10," \
                 "alloc_continuous_space_for_grad_pass=10,fast_threaded_ssa_graph_executor=10,executor=10,operator=10," \
                 "sparse_all_reduce_op_handle=10,gen_nccl_id_op=10,gen_nccl_id_op_help=10,nccl_helper=10,grpc_client=10," \
-                "grpc_server=10,request_handler_impl=10"
+                "grpc_server=10,request_handler_impl=10,section_worker=10"
             required_envs["GLOG_logtostderr"] = "1"
 
         required_envs.update(need_envs)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
优化流水线并行显存占用。
优化前显存会随着global batch size增大而增大，优化后显存不会随gbs增大而增大，**保持不变**。

原PR https://github.com/PaddlePaddle/Paddle/pull/34214 。原PR中存在一个bug，当反向过程使用到了前向send var时（如recompute)，由于存在提前gc情况，会导致反向使用这个var时出现 tensor为null的情况。
为解决这个问题，本PR采用最开始的 https://github.com/PaddlePaddle/Paddle/pull/34086 nop_op来hold住前向send var，通过gc管理用完即时释放就好。当然也可在c++端加入拓扑依赖判断，但工程实现上麻烦些。

最终Pipeline的send变量显存管理方式：
- Forward send var，通过nop_op，通过gc的机制，自动显存管理。
详见PR https://github.com/PaddlePaddle/Paddle/pull/34086
- Backward send var，通过section_worker执行器，根据分析的拓扑依赖，手工显存管理。
拓扑依赖如下图，当前stage的FB前向recv完成，那么前两个FB的反向send也一定完成了，这个时候可以将反向send的变量释放。(TODO：PR中为编码方便，将释放放到了Forward结束后，可优化为在Forward recv之后)
![image](https://user-images.githubusercontent.com/10208305/126116240-ffc0f120-7e4b-4ddb-95ee-5500521e8e90.png)


#### 测试
V100 32GB 单机8卡。
gpt2-medium-en 345MB模型，pipeline_stage=8， micro_batch=4,  

| gbs | 卡号 | develop(MB) | PR(MB) | 显存变化量(MB) |
| -- | -- | -- | -- | -- |
| 32 | 0 | 24402 | 24406 |  |
| | 1 | 21376  | 21380 |  |
| | 7 | 7830 | 7834 |  |
| 64 | 0 |  24660 | 24664  |  |
| | 1 | 21634  |  21380 | **-254** |
| | 7 |  7830 | 7834  |  |
| 256 | 0 | 24660 | 不变 |  |
| | 1 | 22408 | 不变  | **-1028** |
| | 7 | 8168 | 不变 | **-334** |
| 1024 | 0 | 24660 | 不变 | |
| | 1 | 25504  | 不变 | **-4124** |
| | 7 | 11770 | 不变 | **-3936** |
| 2048 | 0 | 24600 | 不变 | |
| | 1 | 29632 | 不变 | **-8252** |
| | 7 | 15710 | 不变 | **-7876** |
| 3072 | 0 | OOM | 不变 | |
| | 1 | OOM  | 不变 |  |
| | 7 | OOM | 不变 |  |

#### 测试结果
PR极大降低了显存，显存不随global batch size增大而增大，**理论可增大到无穷**。