### PR TITLE
[NPU] Refine npu unit tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/npu/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/npu/CMakeLists.txt
@@ -1,6 +1,8 @@
 file(GLOB TEST_OPS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
-foreach(TEST_OP ${TEST_OPS})
-    py_test_modules(${TEST_OP} MODULES ${TEST_OP})
-endforeach(TEST_OP)
+if (WITH_ASCEND_CL)
+    foreach(TEST_OP ${TEST_OPS})
+        py_test_modules(${TEST_OP} MODULES ${TEST_OP})
+    endforeach(TEST_OP)
+endif()

--- a/python/paddle/fluid/tests/unittests/npu/test_abs_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_abs_op_npu.py
@@ -25,8 +25,6 @@ import paddle.fluid as fluid
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUAbs(OpTest):
     def setUp(self):
         self.op_type = "abs"

--- a/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
@@ -58,7 +58,7 @@ class TestAccuracy(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestAccuracy2(TestAccuracy):

--- a/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAccuracy(OpTest):
     def setUp(self):
         self.op_type = "accuracy"

--- a/python/paddle/fluid/tests/unittests/npu/test_adam_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_adam_op_npu.py
@@ -25,8 +25,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAdam(OpTest):
     def setUp(self):
         self.set_npu()
@@ -78,8 +76,6 @@ class TestAdam(OpTest):
         self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAdamWithEpsilonTensor(OpTest):
     def setUp(self):
         self.set_npu()
@@ -134,8 +130,6 @@ class TestAdamWithEpsilonTensor(OpTest):
         self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAdamOpWithSkipUpdate(OpTest):
     def setUp(self):
         self.set_npu()
@@ -188,8 +182,6 @@ class TestAdamOpWithSkipUpdate(OpTest):
         self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAdamOpWithGlobalBetaPow(OpTest):
     def setUp(self):
         self.set_npu()
@@ -247,8 +239,6 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
         self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()
@@ -309,8 +299,6 @@ class TestNet(unittest.TestCase):
         self.assertTrue(np.allclose(npu_loss, cpu_loss, rtol=1e-3))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNetWithEpsilonTensor(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_adam_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_adam_op_npu.py
@@ -73,7 +73,7 @@ class TestAdam(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestAdamWithEpsilonTensor(OpTest):
@@ -127,7 +127,7 @@ class TestAdamWithEpsilonTensor(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestAdamOpWithSkipUpdate(OpTest):
@@ -179,7 +179,7 @@ class TestAdamOpWithSkipUpdate(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestAdamOpWithGlobalBetaPow(OpTest):
@@ -236,7 +236,7 @@ class TestAdamOpWithGlobalBetaPow(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-5, check_dygraph=False)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
@@ -25,8 +25,6 @@ from paddle.fluid.contrib.mixed_precision.amp_nn import check_finite_and_unscale
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestCheckFiniteAndUnscale(unittest.TestCase):
     def get_prog(self):
         paddle.enable_static()
@@ -95,8 +93,6 @@ class TestCheckFiniteAndUnscale(unittest.TestCase):
         self.assertFalse(found_inf[0])
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestCheckFiniteAndUnscaleClearFloatStatus(unittest.TestCase):
     def get_prog(self):
         paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
@@ -37,11 +37,11 @@ class TestCheckFiniteAndUnscale(unittest.TestCase):
                 name="status", shape=[8], dtype='float32')
             main_program.global_block().append_op(
                 type="alloc_float_status",
-                outputs={"FloatStatus": float_status}, )
+                outputs={"FloatStatus": float_status})
             main_program.global_block().append_op(
                 type="clear_float_status",
                 inputs={"FloatStatus": float_status},
-                outputs={"FloatStatusOut": float_status}, )
+                outputs={"FloatStatusOut": float_status})
             c = paddle.fluid.layers.elementwise_div(a, b)
             out, found_inf = check_finite_and_unscale(
                 [c], scale, float_status=float_status)
@@ -105,21 +105,21 @@ class TestCheckFiniteAndUnscaleClearFloatStatus(unittest.TestCase):
                 name="status", shape=[8], dtype='float32')
             main_program.global_block().append_op(
                 type="alloc_float_status",
-                outputs={"FloatStatus": float_status}, )
+                outputs={"FloatStatus": float_status})
             main_program.global_block().append_op(
                 type="clear_float_status",
                 inputs={"FloatStatus": float_status},
-                outputs={"FloatStatusOut": float_status}, )
+                outputs={"FloatStatusOut": float_status})
             c = paddle.fluid.layers.elementwise_div(a, b)
             out, found_inf = check_finite_and_unscale(
                 [c], scale, float_status=float_status)
             main_program.global_block().append_op(
                 type="alloc_float_status",
-                outputs={"FloatStatus": float_status}, )
+                outputs={"FloatStatus": float_status})
             main_program.global_block().append_op(
                 type="clear_float_status",
                 inputs={"FloatStatus": float_status},
-                outputs={"FloatStatusOut": float_status}, )
+                outputs={"FloatStatusOut": float_status})
             d = paddle.fluid.layers.elementwise_add(a, b)
             out, found_inf = check_finite_and_unscale(
                 [d], scale, float_status=float_status)

--- a/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAssign(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
@@ -47,7 +47,7 @@ class TestAssign(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_bce_loss_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_bce_loss_npu.py
@@ -147,8 +147,6 @@ def calc_bceloss(input_np, label_np, reduction='mean', weight_np=None):
     return expected
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestBCELoss(unittest.TestCase):
     def test_BCELoss(self):
         input_np = np.random.uniform(0.1, 0.8, size=(20, 30)).astype(np.float32)
@@ -220,8 +218,6 @@ def bce_loss(input, label):
     return -1 * (label * np.log(input) + (1. - label) * np.log(1. - input))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestBceLossOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -248,15 +244,11 @@ class TestBceLossOp(OpTest):
         self.shape = [10, 10]
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestBceLossOpCase1(OpTest):
     def init_test_cast(self):
         self.shape = [2, 3, 4, 5]
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestBceLossOpCase2(OpTest):
     def init_test_cast(self):
         self.shape = [2, 3, 20]

--- a/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestCast1(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
@@ -46,7 +46,7 @@ class TestCast1(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestCast2(OpTest):
@@ -68,7 +68,7 @@ class TestCast2(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, atol=1e-3)
 
 
 class TestCast3(OpTest):
@@ -90,7 +90,7 @@ class TestCast3(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
@@ -80,8 +80,7 @@ class TestAllocContinuousSpace(OpTest):
         self.check_output_with_place(
             place=paddle.NPUPlace(0),
             no_check_set=["FusedOutput"],
-            atol=1e-5,
-            check_dygraph=False)
+            atol=1e-5, )
 
 
 class TestAllocContinuousSpace2(TestAllocContinuousSpace):
@@ -98,8 +97,7 @@ class TestAllocContinuousSpace2(TestAllocContinuousSpace):
         self.check_output_with_place(
             place=paddle.NPUPlace(0),
             no_check_set=["FusedOutput"],
-            atol=1e-5,
-            check_dygraph=False)
+            atol=1e-5, )
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
@@ -28,8 +28,6 @@ SEED = 2021
 alignment = 512
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAllocContinuousSpace(OpTest):
     def setUp(self):
         self.__class__.use_npu = True
@@ -86,8 +84,6 @@ class TestAllocContinuousSpace(OpTest):
             check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAllocContinuousSpace2(TestAllocContinuousSpace):
     def init_attr(self):
         return {

--- a/python/paddle/fluid/tests/unittests/npu/test_compare_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_compare_op_npu.py
@@ -51,7 +51,7 @@ class TestEqual(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestLessthan(OpTest):
@@ -79,7 +79,7 @@ class TestLessthan(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestEqual2(TestEqual):

--- a/python/paddle/fluid/tests/unittests/npu/test_compare_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_compare_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestEqual(OpTest):
     def setUp(self):
         self.set_npu()
@@ -56,8 +54,6 @@ class TestEqual(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLessthan(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_concat_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_concat_op_npu.py
@@ -54,7 +54,7 @@ class TestConcat(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def init_test_data(self):
         self.x0 = np.random.random((1, 4, 50)).astype(self.dtype)
@@ -63,12 +63,9 @@ class TestConcat(OpTest):
         self.axis = 0
 
     def test_check_grad(self):
-        self.check_grad_with_place(
-            self.place, ['x0', 'x2'], 'Out', check_dygraph=False)
-        self.check_grad_with_place(
-            self.place, ['x1'], 'Out', check_dygraph=False)
-        self.check_grad_with_place(
-            self.place, ['x2'], 'Out', check_dygraph=False)
+        self.check_grad_with_place(self.place, ['x0', 'x2'], 'Out')
+        self.check_grad_with_place(self.place, ['x1'], 'Out')
+        self.check_grad_with_place(self.place, ['x2'], 'Out')
 
 
 class TestConcatFP16(OpTest):
@@ -100,7 +97,7 @@ class TestConcatFP16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def init_test_data(self):
         self.x0 = np.random.random((1, 4, 50)).astype(self.dtype)

--- a/python/paddle/fluid/tests/unittests/npu/test_concat_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_concat_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestConcat(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
@@ -53,13 +53,12 @@ class TestDropoutOp(OpTest):
         self.place = paddle.NPUPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad_normal(self):
         if self.dtype == np.float16:
             return
-        self.check_grad_with_place(
-            self.place, ['X'], 'Out', check_dygraph=False)
+        self.check_grad_with_place(self.place, ['X'], 'Out')
 
 
 class TestDropoutOpInput1d(TestDropoutOp):
@@ -87,7 +86,7 @@ class TestDropoutOpInput1d(TestDropoutOp):
         self.op_type = "dropout"
         self.set_npu()
         self.init_dtype()
-        self.inputs = {'X': np.random.random((2000, )).astype(self.dtype)}
+        self.inputs = {'X': np.random.random((2000)).astype(self.dtype)}
         self.attrs = {
             'dropout_prob': 0.0,
             'fix_seed': True,
@@ -162,7 +161,7 @@ class TestDropoutOpInference(OpTest):
         self.place = paddle.NPUPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")

--- a/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
@@ -28,8 +28,6 @@ SEED = 2021
 EPOCH = 100
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutOp(OpTest):
     def setUp(self):
         self.op_type = "dropout"
@@ -64,8 +62,6 @@ class TestDropoutOp(OpTest):
             self.place, ['X'], 'Out', check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutOpInput1d(TestDropoutOp):
     # change input shape
     def setUp(self):
@@ -85,8 +81,6 @@ class TestDropoutOpInput1d(TestDropoutOp):
         }
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutOpInput1d(TestDropoutOp):
     # the input is 1-D
     def setUp(self):
@@ -106,8 +100,6 @@ class TestDropoutOpInput1d(TestDropoutOp):
         }
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutOp2(TestDropoutOp):
     # the dropout_prob is 1.0
     def setUp(self):
@@ -127,8 +119,6 @@ class TestDropoutOp2(TestDropoutOp):
         }
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutOp3(TestDropoutOp):
     # the input dim is 3
     def setUp(self):
@@ -148,8 +138,6 @@ class TestDropoutOp3(TestDropoutOp):
         }
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestDropoutOpInference(OpTest):
     # is_test = True
@@ -177,8 +165,6 @@ class TestDropoutOpInference(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 @skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestDropoutOpInference2(TestDropoutOpInference):
     def setUp(self):
@@ -194,8 +180,6 @@ class TestDropoutOpInference2(TestDropoutOpInference):
         self.outputs = {'Out': self.inputs['X']}
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutOpWithSeed(TestDropoutOp):
     # the seed is a Tensor
     def setUp(self):
@@ -218,8 +202,6 @@ class TestDropoutOpWithSeed(TestDropoutOp):
         }
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutOpFp16(TestDropoutOp):
     # float16
     def init_dtype(self):
@@ -231,8 +213,6 @@ class TestDropoutOpFp16(TestDropoutOp):
         self.place = paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestDropoutAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
@@ -60,30 +60,30 @@ class TestElementwiseAddOp(OpTest):
         self.axis = -1
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad_normal(self):
         self.check_grad_with_place(
-            self.place, ['X', 'Y'],
+            self.place,
+            ['X', 'Y'],
             'Out',
-            max_relative_error=0.006,
-            check_dygraph=False)
+            max_relative_error=0.006, )
 
     def test_check_grad_ingore_x(self):
         self.check_grad_with_place(
-            self.place, ['Y'],
+            self.place,
+            ['Y'],
             'Out',
             no_grad_set=set("X"),
-            max_relative_error=0.006,
-            check_dygraph=False)
+            max_relative_error=0.006, )
 
     def test_check_grad_ingore_y(self):
         self.check_grad_with_place(
-            self.place, ['X'],
+            self.place,
+            ['X'],
             'Out',
             no_grad_set=set("Y"),
-            max_relative_error=0.006,
-            check_dygraph=False)
+            max_relative_error=0.006, )
 
 
 class TestAddAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
@@ -25,8 +25,6 @@ import paddle.fluid as fluid
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseAddOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -88,8 +86,6 @@ class TestElementwiseAddOp(OpTest):
             check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAddAPI(unittest.TestCase):
     def test_name(self):
         with paddle.static.program_guard(paddle.static.Program()):
@@ -134,8 +130,6 @@ class TestAddAPI(unittest.TestCase):
                 msg="z_value = {}, but expected {}".format(z_value, z_expected))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAddError(unittest.TestCase):
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseDiv(OpTest):
     def setUp(self):
         self.set_npu()
@@ -76,8 +74,6 @@ class TestElementwiseDiv(OpTest):
             self.place, ['X'], 'Out', no_grad_set=set("Y"), check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseDivFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -108,8 +104,6 @@ class TestElementwiseDivFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseDivNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
@@ -52,26 +52,26 @@ class TestElementwiseDiv(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad_normal(self):
         self.check_grad_with_place(
-            self.place, ['X', 'Y'],
+            self.place,
+            ['X', 'Y'],
             'Out',
-            max_relative_error=0.007,
-            check_dygraph=False)
+            max_relative_error=0.007, )
 
     def test_check_grad_ingore_x(self):
         self.check_grad_with_place(
-            self.place, ['Y'],
+            self.place,
+            ['Y'],
             'Out',
             max_relative_error=0.007,
-            no_grad_set=set("X"),
-            check_dygraph=False)
+            no_grad_set=set("X"), )
 
     def test_check_grad_ingore_y(self):
         self.check_grad_with_place(
-            self.place, ['X'], 'Out', no_grad_set=set("Y"), check_dygraph=False)
+            self.place, ['X'], 'Out', no_grad_set=set("Y"))
 
 
 class TestElementwiseDivFp16(OpTest):
@@ -101,7 +101,7 @@ class TestElementwiseDivFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestElementwiseDivNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_floordiv_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_floordiv_op_npu.py
@@ -51,7 +51,7 @@ class TestElementwiseFloorDiv(OpTest):
         self.dtype = "int64"
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestElementwiseFloorDiv2(TestElementwiseFloorDiv):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_floordiv_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_floordiv_op_npu.py
@@ -24,8 +24,6 @@ import paddle
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseFloorDiv(OpTest):
     def setUp(self):
         self.op_type = "elementwise_floordiv"
@@ -56,8 +54,6 @@ class TestElementwiseFloorDiv(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseFloorDiv2(TestElementwiseFloorDiv):
     def init_dtype(self):
         self.dtype = "int32"

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_max_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMax(OpTest):
     def setUp(self):
         self.set_npu()
@@ -64,8 +62,6 @@ class TestElementwiseMax(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMaxFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -96,8 +92,6 @@ class TestElementwiseMaxFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMaxNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_max_op_npu.py
@@ -52,7 +52,7 @@ class TestElementwiseMax(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Max grad test
     # def test_check_grad(self):
@@ -89,7 +89,7 @@ class TestElementwiseMaxFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestElementwiseMaxNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMin(OpTest):
     def setUp(self):
         self.set_npu()
@@ -64,8 +62,6 @@ class TestElementwiseMin(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMinFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -96,8 +92,6 @@ class TestElementwiseMinFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMinNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
@@ -52,7 +52,7 @@ class TestElementwiseMin(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Min grad test
     # def test_check_grad(self):
@@ -89,7 +89,7 @@ class TestElementwiseMinFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestElementwiseMinNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMul(OpTest):
     def setUp(self):
         self.set_npu()
@@ -64,8 +62,6 @@ class TestElementwiseMul(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMulFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -96,8 +92,6 @@ class TestElementwiseMulFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseMulNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
@@ -52,7 +52,7 @@ class TestElementwiseMul(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Mul grad test
     # def test_check_grad(self):
@@ -89,7 +89,7 @@ class TestElementwiseMulFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestElementwiseMulNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_pow_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_pow_op_npu.py
@@ -52,7 +52,7 @@ class TestElementwisePow(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Pow grad test
     # def test_check_grad(self):
@@ -89,7 +89,7 @@ class TestElementwisePowFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestElementwisePowNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_pow_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_pow_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwisePow(OpTest):
     def setUp(self):
         self.set_npu()
@@ -64,8 +62,6 @@ class TestElementwisePow(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwisePowFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -96,8 +92,6 @@ class TestElementwisePowFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwisePowNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_sub_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_sub_op_npu.py
@@ -62,7 +62,7 @@ class TestElementwiseSubOp(OpTest):
         self.axis = 0
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): For grad tests, OpTest raises FatalError:Segmentation fault
     #  when call op.run, which may be caused by system environment exception
@@ -72,7 +72,7 @@ class TestElementwiseSubOp(OpTest):
     #         self.place, ['X', 'Y'],
     #         'Out',
     #         max_relative_error=0.006,
-    #         check_dygraph=False)
+    #         )
     #
     # def test_check_grad_ingore_x(self):
     #     self.check_grad_with_place(
@@ -80,14 +80,14 @@ class TestElementwiseSubOp(OpTest):
     #         'Out',
     #         no_grad_set=set("X"),
     #         max_relative_error=0.006,
-    #         check_dygraph=False)
+    #         )
     #
     # def test_check_grad_ingore_y(self):
     #     self.check_grad_with_place(
     #         self.place, ['X'],
     #         'Out',
     #         no_grad_set=set("Y"),
-    #         max_relative_error=0.006,check_dygraph=False)
+    #         max_relative_error=0.006,)
 
 
 class TestSubtractAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_sub_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_sub_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestElementwiseSubOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -92,8 +90,6 @@ class TestElementwiseSubOp(OpTest):
     #         max_relative_error=0.006,check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSubtractAPI(unittest.TestCase):
     def test_name(self):
         with paddle.static.program_guard(paddle.static.Program()):
@@ -138,8 +134,6 @@ class TestSubtractAPI(unittest.TestCase):
                 msg="z_value = {}, but expected {}".format(z_value, z_expected))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSubtractError(unittest.TestCase):
     def test_errors(self):
         with paddle.static.program_guard(paddle.static.Program()):
@@ -158,8 +152,6 @@ class TestSubtractError(unittest.TestCase):
             self.assertRaises(TypeError, paddle.subtract, x2, y2)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSubtractNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_expand_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_expand_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestExpand(OpTest):
     def setUp(self):
         self.set_npu()
@@ -60,8 +58,6 @@ class TestExpand(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestExpandV2(TestExpand):
     def setUp(self):
         self.set_npu()
@@ -82,8 +78,6 @@ class TestExpandV2(TestExpand):
         self.outputs = {'Out': out}
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestExpandFp16(TestExpand):
     no_need_check_grad = True
 
@@ -91,8 +85,6 @@ class TestExpandFp16(TestExpand):
         self.dtype = np.float16
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestExpandNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_expand_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_expand_op_npu.py
@@ -48,7 +48,7 @@ class TestExpand(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Add grad test
     # def test_check_grad(self):

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
@@ -45,7 +45,7 @@ class TestFillConstant(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestFillConstantInt(OpTest):
@@ -69,7 +69,7 @@ class TestFillConstantInt(OpTest):
         self.dtype = np.int32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestFillConstantFP16(OpTest):
@@ -93,7 +93,7 @@ class TestFillConstantFP16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestFillConstant(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
@@ -51,14 +51,14 @@ class TestGatherOp(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            self.place, ['X'],
+            self.place,
+            ['X'],
             'Out',
-            max_relative_error=0.006,
-            check_dygraph=False)
+            max_relative_error=0.006, )
 
     def config(self):
         """

--- a/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
@@ -34,8 +34,6 @@ def gather_numpy(x, index, axis):
     return gather
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestGatherOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -72,8 +70,6 @@ class TestGatherOp(OpTest):
         self.index_type = "int32"
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestCase1(TestGatherOp):
     def config(self):
         """
@@ -85,8 +81,6 @@ class TestCase1(TestGatherOp):
         self.index_type = "int32"
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class API_TestGather(unittest.TestCase):
     def test_out1(self):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
@@ -120,8 +114,6 @@ class API_TestGather(unittest.TestCase):
         self.assertTrue(np.allclose(result, expected_output))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestGatherGrad(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_gaussian_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gaussian_random_op_npu.py
@@ -26,8 +26,6 @@ from test_gaussian_random_op import TestGaussianRandomOp
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUGaussianRandomOp(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_gelu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gelu_op_npu.py
@@ -54,14 +54,11 @@ class TestGelu(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, atol=1e-3)
 
     def test_check_grad(self):
         self.check_grad_with_place(
-            self.place, ['X'],
-            'Out',
-            check_dygraph=False,
-            max_relative_error=0.007)
+            self.place, ['X'], 'Out', max_relative_error=0.007)
 
 
 class TestGeluFp16(OpTest):
@@ -87,7 +84,7 @@ class TestGeluFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, atol=1e-3)
 
 
 class TestGeluNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_gelu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gelu_op_npu.py
@@ -32,8 +32,6 @@ def np_gelu(x):
     return y
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestGelu(OpTest):
     def setUp(self):
         self.set_npu()
@@ -66,8 +64,6 @@ class TestGelu(OpTest):
             max_relative_error=0.007)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestGeluFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -94,8 +90,6 @@ class TestGeluFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestGeluNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
@@ -29,8 +29,6 @@ SEED = 2021
 NPUPlace = 0
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestIncrement(OpTest):
     def setUp(self):
         self.set_npu()
@@ -57,8 +55,6 @@ class TestIncrement(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestIncrementFP16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -85,8 +81,6 @@ class TestIncrementFP16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestIncrementInplace(unittest.TestCase):
     def test_npu(self):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
@@ -52,7 +52,7 @@ class TestIncrement(OpTest):
         self.dtype = np.int64
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestIncrementFP16(OpTest):
@@ -78,7 +78,7 @@ class TestIncrementFP16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestIncrementInplace(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_layer_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_layer_norm_op_npu.py
@@ -36,8 +36,6 @@ from op_test import _set_use_system_allocator
 _set_use_system_allocator(False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLayerNormOp(unittest.TestCase):
     def setUp(self):
         self.use_cudnn = True
@@ -191,8 +189,6 @@ class TestLayerNormOp(unittest.TestCase):
         self.check_forward_backward(shape=[2, 3, 4, 5], begin_norm_axis=3)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLayerNormOpFP16(TestLayerNormOp):
     def init_dtype(self):
         self.dtype = np.float16

--- a/python/paddle/fluid/tests/unittests/npu/test_log_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_log_op_npu.py
@@ -48,7 +48,7 @@ class TestLog(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Add grad test
     # def test_check_grad(self):
@@ -81,7 +81,7 @@ class TestLogFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestLogNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_log_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_log_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLog(OpTest):
     def setUp(self):
         self.set_npu()
@@ -60,8 +58,6 @@ class TestLog(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLogFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -88,8 +84,6 @@ class TestLogFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLogNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
@@ -220,8 +220,6 @@ def type_map_factory():
     } for x_type in x_type_list for y_type in y_type_list]
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestCPU(unittest.TestCase):
     def test(self):
         test(self)
@@ -235,8 +233,6 @@ class TestCPU(unittest.TestCase):
             test_type_error(self, False, type_map)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPU(unittest.TestCase):
     def test(self):
         test(self, True)

--- a/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLookupTableV2(OpTest):
     def setUp(self):
         self.set_npu()
@@ -76,8 +74,6 @@ class TestLookupTableV2(OpTest):
             self.place, ['W'], 'Out', check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLookupTableV2FP16(TestLookupTableV2):
     no_need_check_grad = True
 
@@ -89,16 +85,12 @@ class TestLookupTableV2FP16(TestLookupTableV2):
         self.__class__.no_need_check_grad = True
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLookupTableV2Dim32(TestLookupTableV2):
     def init_dim(self):
         # embedding_dim is multiple of 32
         self.dim = 64
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestLookupTableV2Dim32FP16(TestLookupTableV2):
     no_need_check_grad = True
 

--- a/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
@@ -65,13 +65,12 @@ class TestLookupTableV2(OpTest):
         self.dim = 20
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad_with_place(
-            self.place, ['W'], 'Out', check_dygraph=False)
+        self.check_grad_with_place(self.place, ['W'], 'Out')
 
 
 class TestLookupTableV2FP16(TestLookupTableV2):

--- a/python/paddle/fluid/tests/unittests/npu/test_matmulv2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_matmulv2_op_npu.py
@@ -32,7 +32,7 @@ def reference_matmul(X, Y, transpose_X=False, transpose_Y=False):
     # transpose X and Y appropriately.
     if transpose_X:
         if X.ndim == 1:
-            X = X.reshape((X.size, ))
+            X = X.reshape((X.size))
         elif X.ndim == 2:
             X = X.T
         else:
@@ -41,7 +41,7 @@ def reference_matmul(X, Y, transpose_X=False, transpose_Y=False):
             X = np.transpose(X, tuple(dim))
     if transpose_Y:
         if Y.ndim == 1:
-            Y = Y.reshape((Y.size, ))
+            Y = Y.reshape((Y.size))
         else:
             dim = [i for i in range(len(Y.shape))]
             dim[-1], dim[len(Y.shape) - 2] = dim[len(Y.shape) - 2], dim[-1]
@@ -51,7 +51,7 @@ def reference_matmul(X, Y, transpose_X=False, transpose_Y=False):
     if not Out.shape:
         # We do not support 0-dimensional Tensors (scalars). So where
         # np.matmul outputs a scalar, we must convert to a Tensor of
-        # shape (1, ) instead.
+        # shape (1) instead.
         # Everywhere else, we are compatible with np.matmul.
         Out = np.array([Out], dtype="float64")
     return Out
@@ -93,7 +93,7 @@ class TestMatMul(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
     # TODO(ascendrc): Add grad test

--- a/python/paddle/fluid/tests/unittests/npu/test_matmulv2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_matmulv2_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 def reference_matmul(X, Y, transpose_X=False, transpose_Y=False):
     """Reference forward implementation using np.matmul."""
     # np.matmul does not support the transpose flags, so we manually
@@ -137,8 +135,6 @@ class TestMatMul4(TestMatMul):
         self.trans_y = False
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMatMulNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()
@@ -207,8 +203,8 @@ class TestMatMulNet(unittest.TestCase):
 
 
 # The precision is aligned in NPU and GPU separately, which is only used for the usage method.
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+
+
 class TestMatMulNet3_2(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
@@ -48,11 +48,10 @@ class TestMean(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(
-            self.place, ['X'], 'Out', check_dygraph=False)
+        self.check_grad_with_place(self.place, ['X'], 'Out')
 
 
 class TestMeanFP16(OpTest):
@@ -77,7 +76,7 @@ class TestMeanFP16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMean(OpTest):
     def setUp(self):
         self.set_npu()
@@ -57,8 +55,6 @@ class TestMean(OpTest):
             self.place, ['X'], 'Out', check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMeanFP16(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
@@ -28,8 +28,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMemcpy_FillConstant(unittest.TestCase):
     def get_prog(self):
         paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
@@ -170,8 +170,6 @@ class TestMul3FP16(TestMul3):
         pass
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMulNet(unittest.TestCase):
     def init_dtype(self):
         self.dtype = np.float32
@@ -243,8 +241,6 @@ class TestMulNet(unittest.TestCase):
         self.assertTrue(np.allclose(npu_loss, cpu_loss))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMulNet3_2(unittest.TestCase):
     def init_dtype(self):
         self.dtype = np.float32
@@ -317,8 +313,6 @@ class TestMulNet3_2(unittest.TestCase):
         self.assertTrue(np.allclose(npu_loss, cpu_loss, atol=1e-5))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestMulNet3_2_xc2(unittest.TestCase):
     def init_dtype(self):
         self.dtype = np.float32

--- a/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mul_op_npu.py
@@ -52,30 +52,30 @@ class TestMul(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
     def test_check_grad_normal(self):
         self.check_grad_with_place(
-            self.place, ['X', 'Y'],
+            self.place,
+            ['X', 'Y'],
             'Out',
-            max_relative_error=0.0065,
-            check_dygraph=False)
+            max_relative_error=0.0065, )
 
     def test_check_grad_ingore_x(self):
         self.check_grad_with_place(
-            self.place, ['Y'],
+            self.place,
+            ['Y'],
             'Out',
             no_grad_set=set("X"),
-            max_relative_error=0.0065,
-            check_dygraph=False)
+            max_relative_error=0.0065, )
 
     def test_check_grad_ingore_y(self):
         self.check_grad_with_place(
-            self.place, ['X'],
+            self.place,
+            ['X'],
             'Out',
             no_grad_set=set("Y"),
-            max_relative_error=0.0065,
-            check_dygraph=False)
+            max_relative_error=0.0065, )
 
 
 @skip_check_grad_ci(

--- a/python/paddle/fluid/tests/unittests/npu/test_npu_place.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_npu_place.py
@@ -22,8 +22,6 @@ from paddle.fluid import core
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNpuPlace(unittest.TestCase):
     def test(self):
         p = core.Place()
@@ -33,8 +31,6 @@ class TestNpuPlace(unittest.TestCase):
         self.assertEqual(p.npu_device_id(), 0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNpuPlaceError(unittest.TestCase):
     def test_static(self):
         # NPU is not supported in ParallelExecutor

--- a/python/paddle/fluid/tests/unittests/npu/test_pow_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pow_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestPow(OpTest):
     def setUp(self):
         self.set_npu()
@@ -57,8 +55,6 @@ class TestPow(OpTest):
             self.place, ['X'], 'Out', check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestPowFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -85,8 +81,6 @@ class TestPowFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestPowNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_pow_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pow_op_npu.py
@@ -48,11 +48,10 @@ class TestPow(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad_with_place(
-            self.place, ['X'], 'Out', check_dygraph=False)
+        self.check_grad_with_place(self.place, ['X'], 'Out')
 
 
 class TestPowFp16(OpTest):
@@ -78,7 +77,7 @@ class TestPowFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestPowNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
@@ -28,8 +28,6 @@ from paddle.fluid.framework import convert_np_dtype_to_dtype_
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAny8DOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -49,8 +47,6 @@ class TestAny8DOp(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAnyOpWithDim(OpTest):
     def setUp(self):
         self.set_npu()
@@ -67,8 +63,6 @@ class TestAnyOpWithDim(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAny8DOpWithDim(OpTest):
     def setUp(self):
         self.set_npu()
@@ -88,8 +82,6 @@ class TestAny8DOpWithDim(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestAnyOpWithKeepDim(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
@@ -44,7 +44,7 @@ class TestAny8DOp(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestAnyOpWithDim(OpTest):
@@ -60,7 +60,7 @@ class TestAnyOpWithDim(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestAny8DOpWithDim(OpTest):
@@ -79,7 +79,7 @@ class TestAny8DOpWithDim(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestAnyOpWithKeepDim(OpTest):
@@ -88,7 +88,7 @@ class TestAnyOpWithKeepDim(OpTest):
         self.op_type = "reduce_any"
         self.place = paddle.NPUPlace(0)
         self.inputs = {'X': np.random.randint(0, 2, (5, 6, 10)).astype("bool")}
-        self.attrs = {'dim': (1, ), 'keep_dim': True}
+        self.attrs = {'dim': (1), 'keep_dim': True}
         self.outputs = {
             'Out': np.expand_dims(
                 self.inputs['X'].any(axis=self.attrs['dim']), axis=1)
@@ -98,7 +98,7 @@ class TestAnyOpWithKeepDim(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestAny8DOpWithKeepDim(OpTest):
@@ -110,7 +110,7 @@ class TestAny8DOpWithKeepDim(OpTest):
             'X': np.random.randint(0, 2,
                                    (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
         }
-        self.attrs = {'dim': (1, ), 'keep_dim': True}
+        self.attrs = {'dim': (1), 'keep_dim': True}
         self.outputs = {
             'Out': np.expand_dims(
                 self.inputs['X'].any(axis=self.attrs['dim']), axis=1)
@@ -120,7 +120,7 @@ class TestAny8DOpWithKeepDim(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_sum_op_npu.py
@@ -64,10 +64,10 @@ class TestReduceSum(OpTest):
 
     def initTestCase(self):
         self.shape = (5, 6)
-        self.axis = (0, )
+        self.axis = (0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Add grad test
     # def test_check_grad(self):

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_sum_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestReduceSum(OpTest):
     def setUp(self):
         np.random.seed(SEED)
@@ -84,8 +82,6 @@ class TestReduceSum2(OpTest):
         self.dtype = np.int32
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestReduceSumNet(unittest.TestCase):
     def set_reduce_sum_function(self, x):
         # keep_dim = False
@@ -151,16 +147,12 @@ class TestReduceSumNet(unittest.TestCase):
         self.assertTrue(np.allclose(npu_loss, cpu_loss))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestReduceSumNet2(TestReduceSumNet):
     def set_reduce_sum_function(self, x):
         # keep_dim = True
         return paddle.fluid.layers.reduce_sum(x, dim=-1, keep_dim=True)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestReduceSumNet3(TestReduceSumNet):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_relu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_relu_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestRelu(OpTest):
     def setUp(self):
         self.set_npu()
@@ -53,8 +51,6 @@ class TestRelu(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestReluFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -81,8 +77,6 @@ class TestReluFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestReluNeg(OpTest):
     def setUp(self):
         self.set_npu()
@@ -110,8 +104,8 @@ class TestReluNeg(OpTest):
 
 #
 #
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+
+
 class TestReluNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_relu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_relu_op_npu.py
@@ -48,7 +48,7 @@ class TestRelu(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestReluFp16(OpTest):
@@ -74,7 +74,7 @@ class TestReluFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestReluNeg(OpTest):
@@ -99,7 +99,7 @@ class TestReluNeg(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 #

--- a/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestReshape2(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
@@ -49,12 +49,10 @@ class TestReshape2(OpTest):
         self.infered_shape = (20, 10)
 
     def test_check_output(self):
-        self.check_output_with_place(
-            self.place, check_dygraph=False, no_check_set=['XShape'])
+        self.check_output_with_place(self.place, no_check_set=['XShape'])
 
     def test_check_grad_normal(self):
-        self.check_grad_with_place(
-            self.place, ['X'], 'Out', check_dygraph=False)
+        self.check_grad_with_place(self.place, ['X'], 'Out')
 
 
 class TestReshape2_case2(TestReshape2):

--- a/python/paddle/fluid/tests/unittests/npu/test_save_load_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_save_load_npu.py
@@ -36,56 +36,42 @@ from test_static_save_load import *
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUSaveLoadBase(TestSaveLoadBase):
     def set_place(self):
         return fluid.CPUPlace() if not core.is_compiled_with_npu(
         ) else paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUSaveLoadPartial(TestSaveLoadPartial):
     def set_place(self):
         return fluid.CPUPlace() if not core.is_compiled_with_npu(
         ) else paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUSaveLoadSetStateDict(TestSaveLoadSetStateDict):
     def set_place(self):
         return fluid.CPUPlace() if not core.is_compiled_with_npu(
         ) else paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUProgramStatePartial(TestProgramStatePartial):
     def set_place(self):
         return fluid.CPUPlace() if not core.is_compiled_with_npu(
         ) else paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPULoadFromOldInterface(TestLoadFromOldInterface):
     def set_place(self):
         return fluid.CPUPlace() if not core.is_compiled_with_npu(
         ) else paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPULoadFromOldInterfaceSingleFile(TestLoadFromOldInterfaceSingleFile):
     def set_place(self):
         return fluid.CPUPlace() if not core.is_compiled_with_npu(
         ) else paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUProgramStateOldSave(TestProgramStateOldSave):
     def setUp(self):
         self.test_dygraph = False
@@ -95,8 +81,6 @@ class TestNPUProgramStateOldSave(TestProgramStateOldSave):
         ) else paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUProgramStateOldSaveSingleModel(TestProgramStateOldSaveSingleModel):
     def set_place(self):
         return fluid.CPUPlace() if not core.is_compiled_with_npu(

--- a/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
@@ -49,7 +49,7 @@ class TestScale(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestFP16Scale(TestScale):
@@ -80,7 +80,7 @@ class TestBiasAfterScale(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestScale(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestCast1(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
@@ -47,7 +47,7 @@ class TestCast1(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestCast2(OpTest):
@@ -70,7 +70,7 @@ class TestCast2(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestCast3(OpTest):
@@ -93,7 +93,7 @@ class TestCast3(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestCast4(OpTest):
@@ -117,7 +117,7 @@ class TestCast4(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_seed_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_seed_op_npu.py
@@ -26,8 +26,6 @@ import paddle.fluid.core as core
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSeedOpFixSeed(OpTest):
     def setUp(self):
         self.set_npu()
@@ -43,8 +41,6 @@ class TestSeedOpFixSeed(OpTest):
         self.check_output_with_place(paddle.NPUPlace(0))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSeedOpDiffSeed(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_sgd_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sgd_op_npu.py
@@ -48,7 +48,7 @@ class TestSGD(OpTest):
         self.w = 15
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_sgd_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sgd_op_npu.py
@@ -24,8 +24,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSGD(OpTest):
     def setUp(self):
         self.set_npu()
@@ -53,8 +51,6 @@ class TestSGD(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
@@ -48,7 +48,7 @@ class TestShape(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestShape(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_slice_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_slice_op_npu.py
@@ -27,8 +27,6 @@ SEED = 2021
 EPOCH = 100
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSliceOp(OpTest):
     def setUp(self):
         self.op_type = "slice"
@@ -79,8 +77,6 @@ class TestSliceOp2(TestSliceOp):
         self.out = self.input[:, 0:1, :]
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSliceOpFp16(TestSliceOp):
     def init_dtype(self):
         self.dtype = np.float16
@@ -147,8 +143,6 @@ class TestSliceOpTensor2(TestSliceOpTensor):
         self.out = self.input[:, 0:1, :]
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSliceOpFp16Tensor(TestSliceOpTensor):
     def init_dtype(self):
         self.dtype = np.float16
@@ -237,8 +231,6 @@ class TestSliceOpTensorList2(TestSliceOpTensorList):
         self.out = self.input[:, 0:1, :]
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSliceOpFp16TensorList(TestSliceOpTensorList):
     def init_dtype(self):
         self.dtype = np.float16
@@ -249,8 +241,6 @@ class TestSliceOpFp16TensorList(TestSliceOpTensorList):
         self.place = paddle.NPUPlace(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSliceNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_slice_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_slice_op_npu.py
@@ -58,13 +58,12 @@ class TestSliceOp(OpTest):
         self.place = paddle.NPUPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad_normal(self):
         if self.dtype == np.float16:
             return
-        self.check_grad_with_place(
-            self.place, ['Input'], 'Out', check_dygraph=False)
+        self.check_grad_with_place(self.place, ['Input'], 'Out')
 
 
 class TestSliceOp2(TestSliceOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
@@ -49,7 +49,7 @@ class TestSoftmax(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestSoftmaxNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSoftmax(OpTest):
     def setUp(self):
         self.set_npu()
@@ -54,8 +52,6 @@ class TestSoftmax(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSoftmaxNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_softmax_with_cross_entropy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_softmax_with_cross_entropy_op_npu.py
@@ -84,7 +84,7 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
             self.attrs['axis'] = self.axis
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
@@ -93,7 +93,6 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         self.check_grad_with_place(
             self.place, ['Logits'],
             'Loss',
-            check_dygraph=False,
             numeric_grad_delta=0.001,
             max_relative_error=0.5)
 

--- a/python/paddle/fluid/tests/unittests/npu/test_softmax_with_cross_entropy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_softmax_with_cross_entropy_op_npu.py
@@ -28,8 +28,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSoftmaxWithCrossEntropyOp(OpTest):
     def set_npu(self):
         self.__class__.use_npu = True
@@ -100,8 +98,6 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
             max_relative_error=0.5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestPowNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_sqrt_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sqrt_op_npu.py
@@ -48,7 +48,7 @@ class TestSqrt(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Add grad test
     # def test_check_grad(self):
@@ -81,7 +81,7 @@ class TestSqrtFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestSqrtNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_sqrt_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sqrt_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSqrt(OpTest):
     def setUp(self):
         self.set_npu()
@@ -60,8 +58,6 @@ class TestSqrt(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSqrtFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -88,8 +84,6 @@ class TestSqrtFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSqrtNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_square_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_square_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSquare(OpTest):
     def setUp(self):
         self.set_npu()
@@ -60,8 +58,6 @@ class TestSquare(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSquareFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -88,8 +84,6 @@ class TestSquareFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSquareNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_square_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_square_op_npu.py
@@ -48,7 +48,7 @@ class TestSquare(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Add grad test
     # def test_check_grad(self):
@@ -81,7 +81,7 @@ class TestSquareFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-5)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestSquareNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_squeeze_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_squeeze_op_npu.py
@@ -26,10 +26,9 @@ from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 
-
 # Correct: General.
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+
+
 class TestSqueezeOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -58,8 +57,8 @@ class TestSqueezeOp(OpTest):
 
 
 # Correct: There is mins axis.
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+
+
 class TestSqueezeOp1(TestSqueezeOp):
     def init_test_case(self):
         self.ori_shape = (1, 3, 1, 40)
@@ -68,8 +67,8 @@ class TestSqueezeOp1(TestSqueezeOp):
 
 
 # Correct: No axes input.
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+
+
 class TestSqueezeOp2(TestSqueezeOp):
     def init_test_case(self):
         self.ori_shape = (1, 20, 1, 5)
@@ -78,8 +77,8 @@ class TestSqueezeOp2(TestSqueezeOp):
 
 
 # Correct: Just part of axes be squeezed. 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+
+
 class TestSqueezeOp3(TestSqueezeOp):
     def init_test_case(self):
         self.ori_shape = (6, 1, 5, 1, 4, 1)
@@ -88,8 +87,8 @@ class TestSqueezeOp3(TestSqueezeOp):
 
 
 # Correct: The demension of axis is not of size 1 remains unchanged.
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
+
+
 class TestSqueezeOp4(TestSqueezeOp):
     def init_test_case(self):
         self.ori_shape = (6, 1, 5, 1, 4, 1)

--- a/python/paddle/fluid/tests/unittests/npu/test_stack_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_stack_op_npu.py
@@ -26,8 +26,6 @@ import paddle.fluid.core as core
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOpBase(OpTest):
     def initDefaultParameters(self):
         self.num_inputs = 4
@@ -77,50 +75,36 @@ class TestStackOpBase(OpTest):
         self.check_grad_with_place(self.place, self.get_x_names(), 'Y')
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp1(TestStackOpBase):
     def initParameters(self):
         self.num_inputs = 16
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp2(TestStackOpBase):
     def initParameters(self):
         self.num_inputs = 20
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp3(TestStackOpBase):
     def initParameters(self):
         self.axis = -1
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp4(TestStackOpBase):
     def initParameters(self):
         self.axis = -4
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp5(TestStackOpBase):
     def initParameters(self):
         self.axis = 1
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp6(TestStackOpBase):
     def initParameters(self):
         self.axis = 3
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackAPIWithLoDTensorArray(unittest.TestCase):
     """
     Test stack api when the input(x) is a LoDTensorArray.
@@ -157,8 +141,6 @@ class TestStackAPIWithLoDTensorArray(unittest.TestCase):
                     [self.x] * self.iter_num, axis=self.axis)))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTensorStackAPIWithLoDTensorArray(unittest.TestCase):
     """
     Test stack api when the input(x) is a LoDTensorArray.
@@ -195,8 +177,6 @@ class TestTensorStackAPIWithLoDTensorArray(unittest.TestCase):
                     [self.x] * self.iter_num, axis=self.axis)))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class API_test(unittest.TestCase):
     def test_out(self):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
@@ -223,8 +203,6 @@ class API_test(unittest.TestCase):
             self.assertRaises(TypeError, paddle.stack, x)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class API_DygraphTest(unittest.TestCase):
     def test_out(self):
         data1 = np.array([[1.0, 2.0]])

--- a/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestSum1(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
@@ -50,7 +50,7 @@ class TestSum1(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestSum2(OpTest):
@@ -84,7 +84,7 @@ class TestSum2(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestSum3(OpTest):
@@ -109,7 +109,7 @@ class TestSum3(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_tanh_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tanh_op_npu.py
@@ -26,8 +26,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTanh(OpTest):
     def setUp(self):
         self.set_npu()
@@ -60,8 +58,6 @@ class TestTanh(OpTest):
     #
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTanhFp16(OpTest):
     def setUp(self):
         self.set_npu()
@@ -88,8 +84,6 @@ class TestTanhFp16(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTanhNet(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_tanh_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tanh_op_npu.py
@@ -48,7 +48,7 @@ class TestTanh(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
     # TODO(ascendrc): Add grad test
     # def test_check_grad(self):
@@ -81,7 +81,7 @@ class TestTanhFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, atol=1e-3)
 
 
 class TestTanhNet(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
@@ -27,8 +27,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTopk(OpTest):
     def setUp(self):
         self.set_npu()
@@ -59,8 +57,6 @@ class TestTopk(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTopkV2(OpTest):
     def setUp(self):
         self.set_npu()

--- a/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
@@ -54,7 +54,7 @@ class TestTopk(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestTopkV2(OpTest):
@@ -84,7 +84,7 @@ class TestTopkV2(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
@@ -25,8 +25,6 @@ import paddle.fluid as fluid
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTransposeOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -61,8 +59,6 @@ class TestTransposeOp(OpTest):
         self.check_output_with_place(self.place, check_dygraph=False)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTransposeOpFP16(TestTransposeOp):
     no_need_check_grad = True
 

--- a/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
@@ -56,7 +56,7 @@ class TestTransposeOp(OpTest):
         self.axis = -1
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestTransposeOpFP16(TestTransposeOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
@@ -29,8 +29,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestTruncatedNormal(unittest.TestCase):
     def _test(self, run_npu=True):
         main_prog = paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
@@ -39,8 +39,6 @@ def output_hist(out):
     return hist, prob
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUUniformRandomOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -76,8 +74,6 @@ class TestNPUUniformRandomOp(OpTest):
                 hist, prob, rtol=0, atol=0.01), "hist: " + str(hist))
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestNPUUniformRandomOpSelectedRows(unittest.TestCase):
     def get_places(self):
         places = [core.CPUPlace()]

--- a/python/paddle/fluid/tests/unittests/npu/test_unstack_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_unstack_op_npu.py
@@ -24,8 +24,6 @@ import paddle
 paddle.enable_static()
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestUnStackOpBase(OpTest):
     def initDefaultParameters(self):
         self.input_dim = (5, 6, 7)
@@ -75,29 +73,21 @@ class TestUnStackOpBase(OpTest):
         self.check_grad_with_place(self.place, ['X'], self.get_y_names())
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp3(TestUnStackOpBase):
     def initParameters(self):
         self.axis = -1
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp4(TestUnStackOpBase):
     def initParameters(self):
         self.axis = -3
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp5(TestUnStackOpBase):
     def initParameters(self):
         self.axis = 1
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestStackOp6(TestUnStackOpBase):
     def initParameters(self):
         self.axis = 2

--- a/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
@@ -69,7 +69,7 @@ class TestUpdateLossScalingOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        self.check_output_with_place(self.place)
 
 
 class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
@@ -25,8 +25,6 @@ paddle.enable_static()
 SEED = 2021
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestUpdateLossScalingOp(OpTest):
     def setUp(self):
         self.set_npu()
@@ -103,8 +101,6 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
         }
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
 class TestUpdateLossScalingLayer(unittest.TestCase):
     def loss_scaling_check(self, use_npu=True, scope=fluid.Scope()):
         a = fluid.data(name="a", shape=[1024, 1024], dtype='float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Refine npu unit tests
- using `@unittest.skip()` and `check_dygraph=False` needs approval
![image](https://user-images.githubusercontent.com/6888866/126144408-df47ac75-fe68-406c-8b4c-a1d14ff579ff.png)

However,
1. `@unittest.skip()` is not needed, since the unittests in `.../npu` will not be gererated if paddle is not compiled with NPU, so it is not needed.
2. Runing npu op in dygraph mode is supported now.

So, this PR removes all  `@unittest.skip()` and `check_dygraph=False` in npu tests.