### PR TITLE
add '@deprecated' to static.save/load.

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -282,6 +282,7 @@ def _get_valid_program(main_program=None):
     return main_program
 
 
+@deprecated(since="2.1.0", update_to="paddle.save", level=1)
 @dygraph_not_support
 def save_vars(executor,
               dirname,
@@ -1836,6 +1837,7 @@ def _legacy_save(param_dict, model_path, protocol=2):
             pickle.dump(param_dict, f, protocol=protocol)
 
 
+@deprecated(since="2.1.0", update_to="paddle.save", level=1)
 @static_only
 def save(program, model_path, protocol=4, **configs):
     """
@@ -1944,6 +1946,7 @@ def _pickle_loads_mac(path, f):
     return load_result
 
 
+@deprecated(since="2.1.0", update_to="paddle.load", level=1)
 @static_only
 def load(program, model_path, executor=None, var_list=None):
     """

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -282,7 +282,7 @@ def _get_valid_program(main_program=None):
     return main_program
 
 
-@deprecated(since="2.1.0", update_to="paddle.save", level=1)
+@deprecated(since="2.1.2", update_to="paddle.save", level=1)
 @dygraph_not_support
 def save_vars(executor,
               dirname,
@@ -738,6 +738,7 @@ def save_persistables(executor, dirname, main_program=None, filename=None):
             filename=filename)
 
 
+@deprecated(since="2.1.2", update_to="paddle.load", level=1)
 def load_vars(executor,
               dirname,
               main_program=None,
@@ -1837,7 +1838,7 @@ def _legacy_save(param_dict, model_path, protocol=2):
             pickle.dump(param_dict, f, protocol=protocol)
 
 
-@deprecated(since="2.1.0", update_to="paddle.save", level=1)
+@deprecated(since="2.1.2", update_to="paddle.save", level=1)
 @static_only
 def save(program, model_path, protocol=4, **configs):
     """
@@ -1946,7 +1947,7 @@ def _pickle_loads_mac(path, f):
     return load_result
 
 
-@deprecated(since="2.1.0", update_to="paddle.load", level=1)
+@deprecated(since="2.1.2", update_to="paddle.load", level=1)
 @static_only
 def load(program, model_path, executor=None, var_list=None):
     """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
为static.save/load save/load_vars 添加`@deprecated` ，下面黄色字为警告。
![image](https://user-images.githubusercontent.com/22128369/126255874-b5dd20af-d0b9-4e61-ae90-c12a4c21ec7c.png)
