### PR TITLE
fix cuda_stream missing mkldnn dependence error

### DIFF
--- a/paddle/fluid/platform/stream/CMakeLists.txt
+++ b/paddle/fluid/platform/stream/CMakeLists.txt
@@ -1,5 +1,11 @@
+IF(WITH_MKLDNN)
+    set(MKLDNN_CTX_DEPS mkldnn)
+ELSE()
+    set(MKLDNN_CTX_DEPS)
+ENDIF()
+
 IF(WITH_GPU OR WITH_ROCM)
-cc_library(cuda_stream SRCS cuda_stream.cc DEPS enforce boost)
+cc_library(cuda_stream SRCS cuda_stream.cc DEPS enforce boost ${MKLDNN_CTX_DEPS})
 ENDIF()
 
 IF(WITH_ASCEND_CL)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix cuda_stream missing dependence of mkldnn error.
This error is included by https://github.com/PaddlePaddle/Paddle/pull/32460