### PR TITLE
solve slice inplace illegal memory address bug

### DIFF
--- a/paddle/fluid/operators/slice_op.h
+++ b/paddle/fluid/operators/slice_op.h
@@ -391,17 +391,7 @@ class SliceGradKernel : public framework::OpKernel<T> {
         }
       }
 
-      if (need_pad_num == 0) {
-        // do not need padding, pass if data address same, else copy
-        if (d_input->mutable_data<T>(context.GetPlace()) == d_out->data<T>()) {
-          // inplace, do not any operator, pass
-        } else {
-          framework::TensorCopy(
-              *d_out, context.GetPlace(),
-              context.template device_context<platform::DeviceContext>(),
-              d_input);
-        }
-      } else if (need_pad_num == 1) {
+      if (need_pad_num == 1) {
         // only need padding one dimension, we can reduce dimension.
         // only the padding dimension is available for us.
         // How to reduce dimension(5 to 3 for example):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
# 问题
decoupledsegnet、hardnet单卡，batch_size=1训练报错，问题定位于[PR32266](https://github.com/PaddlePaddle/Paddle/commit/5161f71a27d90b074701c6d1cb64bd0932786205)。

![image](https://user-images.githubusercontent.com/31386411/126273126-14582fc9-06e7-48e3-8c03-afc97671443a.png)
![image](https://user-images.githubusercontent.com/31386411/126273148-45a69b03-4b4d-4dd1-9b61-e231c0c795ed.png)

# 原因
经`cuda-memcheck`排查发现在`ElemwiseGradBroadcast2CUDAKernel`处出现了非法内存访问导致出core。经分析原因在于Tensor实际分配大小与需求不一致，定位问题点在于`SliceGradKernel`的`need_pad_num == 0`判断有问题，直接跳过导致没有分配合适的空间，删去该判断逻辑后运行就正常了。

