### PR TITLE
[ROCM] fix top_k_v2 with large shape

### DIFF
--- a/paddle/fluid/operators/top_k_v2_op.cu
+++ b/paddle/fluid/operators/top_k_v2_op.cu
@@ -99,6 +99,14 @@ class TopkV2OpCUDAKernel : public framework::OpKernel<T> {
       const int kMaxHeight = 2048;
       int gridx = input_height < kMaxHeight ? input_height : kMaxHeight;
       switch (GetDesiredBlockDim(input_width)) {
+#ifdef PADDLE_WITH_HIP
+        FIXED_BLOCK_DIM(
+            KeMatrixTopK<T, 20,
+                         kBlockDim><<<gridx, kBlockDim, 0, dev_ctx.stream()>>>(
+                output_data, k, indices_data, input_data, input_width,
+                input_width, static_cast<int>(k), gridx, input_height,
+                largest));
+#else
         FIXED_BLOCK_DIM(
             KeMatrixTopK<T, 5,
                          kBlockDim><<<gridx, kBlockDim, 0, dev_ctx.stream()>>>(
@@ -169,6 +177,14 @@ class TopkV2OpCUDAKernel : public framework::OpKernel<T> {
       const int kMaxHeight = 2048;
       int gridx = input_height < kMaxHeight ? input_height : kMaxHeight;
       switch (GetDesiredBlockDim(input_width)) {
+#ifdef PADDLE_WITH_HIP
+        FIXED_BLOCK_DIM(
+            KeMatrixTopK<T, 20,
+                         kBlockDim><<<gridx, kBlockDim, 0, dev_ctx.stream()>>>(
+                trans_out.data<T>(), k, trans_ind.data<int64_t>(),
+                trans_input.data<T>(), input_width, input_width,
+                static_cast<int>(k), gridx, input_height, largest));
+#else
         FIXED_BLOCK_DIM(
             KeMatrixTopK<T, 5,
                          kBlockDim><<<gridx, kBlockDim, 0, dev_ctx.stream()>>>(

--- a/paddle/fluid/operators/top_k_v2_op.cu
+++ b/paddle/fluid/operators/top_k_v2_op.cu
@@ -113,6 +113,7 @@ class TopkV2OpCUDAKernel : public framework::OpKernel<T> {
                 output_data, k, indices_data, input_data, input_width,
                 input_width, static_cast<int>(k), gridx, input_height,
                 largest));
+#endif
         default:
           PADDLE_THROW(platform::errors::Fatal(
               "the input data shape has error in the topk cuda kernel."));
@@ -191,6 +192,7 @@ class TopkV2OpCUDAKernel : public framework::OpKernel<T> {
                 trans_out.data<T>(), k, trans_ind.data<int64_t>(),
                 trans_input.data<T>(), input_width, input_width,
                 static_cast<int>(k), gridx, input_height, largest));
+#endif
         default:
           PADDLE_THROW(platform::errors::Fatal(
               "the input data shape has error in the topk cuda kernel."));

--- a/python/paddle/fluid/tests/unittests/test_top_k_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_top_k_v2_op.py
@@ -131,6 +131,24 @@ class TestTopkOp5(TestTopkOp):
         self.outputs = {'Out': output, 'Indices': indices}
 
 
+class TestTopkOp6(OpTest):
+    def init_args(self):
+        self.k = 100
+        self.axis = 1
+        self.largest = True
+
+    def setUp(self):
+        self.op_type = "top_k_v2"
+        self.dtype = np.float64
+        self.input_data = np.random.rand(80, 16384)
+        self.init_args()
+        self.inputs = {'X': self.input_data}
+        self.attrs = {'k': self.k, 'axis': self.axis, 'largest': self.largest}
+        output, indices = numpy_topk(
+            self.input_data, axis=self.axis, k=self.k, largest=self.largest)
+        self.outputs = {'Out': output, 'Indices': indices}
+
+
 class TestTopKAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(123)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
[ROCM] fix top_k_v2 op with large shape
![image](https://user-images.githubusercontent.com/70498791/123409729-1a44b380-d5e1-11eb-8ed1-207259bdc061.png)