### PR TITLE
fix cuda Stream record_event bug

### DIFF
--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -164,8 +164,7 @@ void BindCudaStream(py::module *m_ptr) {
            [](paddle::platform::stream::CUDAStream &self,
               paddle::platform::CudaEvent *event) {
              if (event == nullptr) {
-               auto event_tmp = paddle::platform::CudaEvent();
-               event = &event_tmp;
+               event = new paddle::platform::CudaEvent();
              }
              event->Record(self);
              return event;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

当执行完如下示例代码， 程序退出时候，会报出重复释放的core错误。
问题原因:
当参数 event为None时，自动生成的 event 是在栈上分配的，为局部变量。函数调用完成后会被释放调，程序退出时返回的event再次释放会报错。

```python
import paddle
s = paddle.device.cuda.Stream(paddle.CUDAPlace(0), 1)
event = s.record_event()
```
修复方式：
修改event 为以new方式在堆上分配。
