### PR TITLE
[CPU-PSLIB] Add consistency insepection of op's embedding name and sparse table name in config_fleet.py

### DIFF
--- a/python/paddle/fluid/incubate/fleet/parameter_server/pslib/optimizer_factory.py
+++ b/python/paddle/fluid/incubate/fleet/parameter_server/pslib/optimizer_factory.py
@@ -22,6 +22,7 @@ from google.protobuf import text_format
 from collections import OrderedDict
 from .node import DownpourWorker, DownpourServer
 from . import ps_pb2 as pslib
+import logging
 
 # this dict is for store info about pull/push sparse ops.
 FLEET_GLOBAL_DICT = {
@@ -36,6 +37,10 @@ FLEET_GLOBAL_DICT = {
     "click_name": "",
     "scale_sparse_grad": None,
 }
+
+logging.basicConfig(
+    format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 class DistributedOptimizerImplBase(object):
@@ -167,6 +172,74 @@ class DistributedAdam(DistributedOptimizerImplBase):
             ret_list.append(x[0])
         return ret_list
 
+    def _gen_distributed_emb_to_size_dict(self, program):
+        d_size = dict()
+        local_vars = program.current_block().vars
+
+        for op in program.global_block().ops:
+            if op.type in self.supported_embedding_types:
+                if op.attr('is_distributed') is True:
+                    table_name = op.input("W")[0]
+                    emb_size = local_vars[table_name].shape[1]
+                    if d_size.get(table_name) is None:
+                        d_size[table_name] = emb_size
+                    elif d_size[table_name] != emb_size:
+                        raise ValueError("embedding size error: %s vs %s" %
+                                         (emb_size, d_size[table_name]))
+
+        return d_size
+
+    def _check_config_fleet_with_program_op(self, strategy, table_name,
+                                            emb_to_size):
+        if strategy.get(table_name) is None:
+            strategy[table_name] = dict()
+        st = strategy[table_name]
+
+        accessor = None
+        if st.get("sparse_accessor_class") is not None:
+            accessor = st["sparse_accessor_class"]
+
+        if accessor is None:
+            accessor = "DownpourCtrAccessor"
+
+        # set sparse_embedx_dim in strategy,
+        # user do not have to set it in config_fleet
+        if accessor == "DownpourFeatureValueAccessor" \
+                or accessor == "DownpourCtrAccessor" \
+                or accessor == "DownpourDoubleUnitAccessor" \
+                or accessor == "DownpourUnitAccessor":
+            if st.get("sparse_embedx_dim") is not None \
+                    and st["sparse_embedx_dim"] != emb_to_size[table_name] - 3:
+                raise ValueError("fleet config sparse_embedx_dim=%s not"
+                                 " equal to embedding size - 3 = %s" %
+                                 (st["sparse_embedx_dim"],
+                                  emb_to_size[table_name] - 3))
+            if st.get("sparse_embedx_dim") is None:
+                logger.warning(
+                    "sparse embedding size for table name '{}' is: {}, while sparse_embedx_dim "
+                    "with same sparse table name is not set in config_fleet.py. "
+                    "Hence automatically set sparse_embedx_dim = {} - 3.".
+                    format(table_name, emb_to_size[table_name], emb_to_size[
+                        table_name]))
+                st["sparse_embedx_dim"] = emb_to_size[table_name] - 3
+        elif accessor == "DownpourSparseValueAccessor":
+            if st.get("sparse_embedx_dim") is not None \
+                    and st["sparse_embedx_dim"] != emb_to_size[table_name]:
+                raise ValueError("fleet config sparse_embedx_dim=%s not"
+                                 " equal to embedding size = %s" %
+                                 (st["sparse_embedx_dim"],
+                                  emb_to_size[table_name]))
+            if st.get("sparse_embedx_dim") is None:
+                logger.warning(
+                    "sparse embedding size for table name '{}' is: {}, while sparse_embedx_dim "
+                    "with same sparse table name is not set in config_fleet.py. "
+                    "Hence automatically set sparse_embedx_dim = {}.".format(
+                        table_name, emb_to_size[table_name], emb_to_size[
+                            table_name]))
+                st["sparse_embedx_dim"] = emb_to_size[table_name]
+
+        return strategy
+
     def _minimize(self,
                   losses,
                   startup_program=None,
@@ -225,6 +298,10 @@ class DistributedAdam(DistributedOptimizerImplBase):
                     if sparse_table_to_index.get(tn) is None:
                         sparse_table_to_index[tn] = sparse_table_index
                         sparse_table_index += 1
+
+                # get {table_name: emb_size} dict from program ops
+                emb_to_size = self._gen_distributed_emb_to_size_dict(
+                    loss.block.program)
 
                 # get inputs_dict
                 inputs_dict = self._find_distributed_lookup_table_inputs(
@@ -340,8 +417,10 @@ class DistributedAdam(DistributedOptimizerImplBase):
         # ServerParameter add all sparse tables
         for tn in sparse_table_to_index:
             sparse_table_index = sparse_table_to_index[tn]
-            if strategy.get(tn) is not None:
-                server.add_sparse_table(sparse_table_index, strategy[tn])
+            st = self._check_config_fleet_with_program_op(strategy, tn,
+                                                          emb_to_size)
+            if st.get(tn) is not None:
+                server.add_sparse_table(sparse_table_index, st[tn])
             else:
                 server.add_sparse_table(sparse_table_index, None)
 


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
Others

### Describe
**问题描述：**
1) 现在没有对fluid.layers.embedding的name与config_fleet.py中的sparse table name的一致性检查，导致用户遇到报错无法直接定位
2) 之前的做法：当fluid.layers.embedding的name不在config_fleet.py中时，会对该embedding设置为默认的11维，如果用户设置的embedding的emb_size不是11维，会进行间接性报错(见下图)，用户不清楚为什么


**之前的报错日志：**
1) 报错1：sequence_conv_pool，fluid.layer.embedding传入的emb_size与默认配置的11维不符(由于name不在config_fleet.py里，所以默认配置)
![image](https://user-images.githubusercontent.com/24829556/126168072-f5096b29-21ed-4458-a480-b8fa2f01ef0b.png)
2) 报错2: layers.fc,  fc层传入的input是根据实际的emb_size获取的(11维)，但fc层的参数shape是根据fluid.layer.embedding的shape获得的，因此mul时不一致而报错
![image](https://user-images.githubusercontent.com/24829556/126168119-992a862a-5d98-47bc-a471-697bd40391af.png)

**改动说明：**
增加训练前的检查机制：1) 如果配置的fluid.layers.embedding的name不在config_fleet.py的config词典的key中，则进行warning提示，同时根据fluid.layers.embedding中的size配置生成一张新的sparse_table (原来是直接用默认值生成新的sparse_table，但这样会导致fluid.layers.embedding中的emb_size和实际的不符而报错) 2) 如果配置的fluid.layers.embedding的name在config_fleet.py的config词典的key中，但config_fleet.py中的sparse_embdex_dim + 3 != fluid.layers.embedding中的fea_dim，则直接进行报错

**修改后报错日志:** 
![image](https://user-images.githubusercontent.com/24829556/126168878-1532b578-6dc1-4147-b3fa-12aa9f451632.png)
![image](https://user-images.githubusercontent.com/24829556/126266879-f24209ee-4bbb-47dd-b97a-7f1e486918af.png)
