### PR TITLE
Fix the bug in paddle.distributed.split demo. The paddle.distributed.split op just can be used in static mode.

### DIFF
--- a/python/paddle/distributed/collective.py
+++ b/python/paddle/distributed/collective.py
@@ -1341,7 +1341,7 @@ def split(x,
 
     Examples:
         .. code-block:: python
-
+            # required: distributed
             import paddle
             import paddle.distributed.fleet as fleet
 

--- a/python/paddle/distributed/collective.py
+++ b/python/paddle/distributed/collective.py
@@ -1343,18 +1343,18 @@ def split(x,
         .. code-block:: python
 
             import paddle
-            from paddle.distributed import init_parallel_env
+            import paddle.distributed.fleet as fleet
 
-            # required: gpu
-
+            paddle.enable_static()
             paddle.set_device('gpu:%d'%paddle.distributed.ParallelEnv().dev_id)
-            init_parallel_env()
+            fleet.init(is_collective=True)
             data = paddle.randint(0, 8, shape=[10,4])
             emb_out = paddle.distributed.split(
                 data,
                 (8, 8),
                 operation="embedding",
                 num_partitions=2)
+
     """
     assert isinstance(size, (list, tuple)), (
         "The type of size for "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
Fix the bug in paddle.distributed.split demo. The paddle.distributed.split op just can be used in static mode.