### PR TITLE
Fix hapi fleet bug in static mode

### DIFF
--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -218,8 +218,6 @@ def prepare_distributed_context(place=None):
             fluid.disable_dygraph()
             _init_context()
             fluid.enable_dygraph(place)
-        else:
-            _init_context()
 
     else:
         assert ("Only support CUDAPlace for now.")

--- a/python/paddle/tests/dist_hapi_mnist_static.py
+++ b/python/paddle/tests/dist_hapi_mnist_static.py
@@ -59,6 +59,7 @@ def compute_accuracy(pred, gt):
                  'CPU testing is not supported')
 class TestDistTraning(unittest.TestCase):
     def test_static_multiple_gpus(self):
+        paddle.enable_static()
         device = set_device('gpu')
 
         im_shape = (-1, 1, 28, 28)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix hapi fleet bug in static mode,  remove ``_init_context `` when using fleet API