### PR TITLE
fix build error of gtest dependency, test=develop

### DIFF
--- a/paddle/fluid/inference/analysis/passes/CMakeLists.txt
+++ b/paddle/fluid/inference/analysis/passes/CMakeLists.txt
@@ -5,7 +5,11 @@ cc_library(ir_params_sync_among_devices_pass SRCS ir_params_sync_among_devices_p
 cc_library(ir_graph_to_program_pass SRCS ir_graph_to_program_pass.cc DEPS analysis_pass graph_to_program_pass)
 cc_library(adjust_cudnn_workspace_size_pass SRCS adjust_cudnn_workspace_size_pass.cc DEPS analysis_pass graph_to_program_pass)
 cc_library(inference_op_replace_pass SRCS inference_op_replace_pass.cc DEPS analysis_pass graph_to_program_pass)
-cc_library(ir_graph_clean_pass SRCS ir_graph_clean_pass.cc DEPS analysis_pass gtest)
+IF(WITH_TESTING)
+  cc_library(ir_graph_clean_pass SRCS ir_graph_clean_pass.cc DEPS analysis_pass gtest)
+ELSE()
+  cc_library(ir_graph_clean_pass SRCS ir_graph_clean_pass.cc DEPS analysis_pass)
+ENDIF()
 
 cc_library(analysis_passes SRCS passes.cc DEPS
   ir_graph_build_pass

--- a/paddle/fluid/inference/analysis/passes/CMakeLists.txt
+++ b/paddle/fluid/inference/analysis/passes/CMakeLists.txt
@@ -5,7 +5,7 @@ cc_library(ir_params_sync_among_devices_pass SRCS ir_params_sync_among_devices_p
 cc_library(ir_graph_to_program_pass SRCS ir_graph_to_program_pass.cc DEPS analysis_pass graph_to_program_pass)
 cc_library(adjust_cudnn_workspace_size_pass SRCS adjust_cudnn_workspace_size_pass.cc DEPS analysis_pass graph_to_program_pass)
 cc_library(inference_op_replace_pass SRCS inference_op_replace_pass.cc DEPS analysis_pass graph_to_program_pass)
-cc_library(ir_graph_clean_pass SRCS ir_graph_clean_pass.cc DEPS analysis_pass)
+cc_library(ir_graph_clean_pass SRCS ir_graph_clean_pass.cc DEPS analysis_pass gtest)
 
 cc_library(analysis_passes SRCS passes.cc DEPS
   ir_graph_build_pass


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

根据这个CI结果，当并发数较大时，在日志3095行抛出如下错误
2021-07-23 16:30:50 In file included from /paddle/paddle/fluid/inference/analysis/passes/ir_graph_clean_pass.cc:18:
2021-07-23 16:30:50 /paddle/paddle/fluid/framework/ir/graph_pattern_detector.h:18:10: fatal error: gtest/gtest_prod.h: No such file or directory

而日志的3372行才对extern_gtest配置和编译完成，因此无法找到"gtest/gtest_prod.h"
2021-07-23 16:31:00 [ 25%] Performing install step for 'extern_gtest'
2021-07-23 16:31:00 -- extern_gtest install command succeeded.  See also /paddle/build/third_party/gtest/src/extern_gtest-stamp/extern_gtest-install-*.log
2021-07-23 16:31:00 [ 25%] Completed 'extern_gtest'
2021-07-23 16:31:00 [ 25%] Built target extern_gtest

这个PR修改了ir_graph_clean_pass.cc需依赖于gtest，因此避免这个编译错误。

