### PR TITLE
Fix split on empty tensor

### DIFF
--- a/paddle/fluid/operators/math/concat_and_split.cc
+++ b/paddle/fluid/operators/math/concat_and_split.cc
@@ -83,6 +83,12 @@ class SplitFunctor<platform::CPUDeviceContext, T> {
                   const framework::Tensor& input,
                   const std::vector<const framework::Tensor*>& ref_inputs,
                   const int axis, std::vector<framework::Tensor*>* outputs) {
+    // NOTE(zhiqiu): split a tensor of shape [0,3,4] at axis=1, result in 3
+    // tensors of shape [0,1,4]
+    if (input.numel() == 0) {
+      return;
+    }
+
     // TODO(zcd): Add input data validity checking
     size_t num = outputs->size();
 

--- a/paddle/fluid/operators/math/concat_and_split.cu
+++ b/paddle/fluid/operators/math/concat_and_split.cu
@@ -352,6 +352,12 @@ class SplitFunctor<platform::CUDADeviceContext, T> {
                   const framework::Tensor& input,
                   const std::vector<const framework::Tensor*>& ref_inputs,
                   int axis, std::vector<framework::Tensor*>* outputs) {
+    // NOTE(zhiqiu): split a tensor of shape [0,3,4] at axis=1, result in 3
+    // tensors of shape [0,1,4]
+    if (input.numel() == 0) {
+      return;
+    }
+
     // TODO(zcd): Add input data validity checking
     int o_num = outputs->size();
     int64_t out_row = 1;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix split on empty tensor at the dimension which is not 0

example:

```
import paddle
import numpy as np

x_arr = np.array([], dtype=np.float32)
x = paddle.to_tensor(np.reshape(x_arr, (0, 10, 1)))

paddle.unbind(x, -2)

'''
[Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       []), Tensor(shape=[0, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       [])]
'''

```