### PR TITLE
[cherry-pick] Logical Ops support more data types

### DIFF
--- a/paddle/fluid/operators/controlflow/logical_op.cc
+++ b/paddle/fluid/operators/controlflow/logical_op.cc
@@ -1,11 +1,8 @@
 /* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,15 +23,16 @@ class BinaryLogicalOpProtoMaker : public framework::OpProtoAndCheckerMaker {
   void Make() override {
     OpComment comment;
     AddInput("X", string::Sprintf("Left hand operand of %s operator. Must be "
-                                  "a Variable of type bool.",
+                                  "a Variable of type being one of bool, int8, "
+                                  "int16, int32, int64, float32, float64.",
                                   comment.type));
     AddInput("Y", string::Sprintf("Right hand operand of %s operator. Must be "
-                                  "a Variable of type bool.",
+                                  "a Variable of type being one of bool, int8, "
+                                  "int16, int32, int64, float32, float64.",
                                   comment.type));
     AddOutput("Out", string::Sprintf("n-dim bool Variable"));
     AddComment(string::Sprintf(R"DOC(%s Operator
-
-It operates element-wise on X and Y, and returns the Out. X, Y and Out are N-dim boolean LoDTensor or Tensor.
+It operates element-wise on X and Y, and returns the Out. X, Y and Out are N-dim LoDTensor or Tensor.
 Each element of Out is calculated by %s
 )DOC",
                                comment.type, comment.equation));
@@ -46,13 +44,14 @@ class UnaryLogicalOpProtoMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
     OpComment comment;
-    AddInput("X", string::Sprintf("Operand of %s operator. Must be "
-                                  "a LoDTensor or Tensor of type bool.",
-                                  comment.type));
+    AddInput("X",
+             string::Sprintf("Operand of %s operator. Must be "
+                             "a LoDTensor or Tensor of type being one of bool, "
+                             "int8, int16, int32, int64, float32, float64.",
+                             comment.type));
     AddOutput("Out", string::Sprintf("n-dim bool LoDTensor or Tensor."));
     AddComment(string::Sprintf(R"DOC(%s Operator
-
-It operates element-wise on X, and returns the Out. X and Out are N-dim boolean LoDTensor or Tensor.
+It operates element-wise on X, and returns the Out. X and Out are N-dim LoDTensor or Tensor.
 Each element of Out is calculated by %s
 )DOC",
                                comment.type, comment.equation));

--- a/paddle/fluid/operators/controlflow/logical_op.cu
+++ b/paddle/fluid/operators/controlflow/logical_op.cu
@@ -10,6 +10,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/controlflow/logical_op.h"
+#include "paddle/fluid/operators/elementwise/elementwise_op_broadcast.cu.h"
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;

--- a/paddle/fluid/operators/controlflow/logical_op.cu
+++ b/paddle/fluid/operators/controlflow/logical_op.cu
@@ -1,11 +1,8 @@
 /* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,11 +11,72 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/controlflow/logical_op.h"
 
-REGISTER_BINARY_LOGICAL_KERNEL(logical_and, CUDA,
-                               paddle::operators::LogicalAndFunctor);
-REGISTER_BINARY_LOGICAL_KERNEL(logical_or, CUDA,
-                               paddle::operators::LogicalOrFunctor);
-REGISTER_UNARY_LOGICAL_KERNEL(logical_not, CUDA,
-                              paddle::operators::LogicalNotFunctor);
-REGISTER_BINARY_LOGICAL_KERNEL(logical_xor, CUDA,
-                               paddle::operators::LogicalXorFunctor);
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+namespace paddle {
+namespace operators {
+
+#define LOGICAL_BINARY_FUNCTOR(func_name, op)                          \
+  template <typename T>                                                \
+  struct func_name {                                                   \
+    using ELEMENT_TYPE = T;                                            \
+    HOSTDEVICE bool operator()(const T* args) const {                  \
+      return static_cast<bool>(args[0]) op static_cast<bool>(args[1]); \
+    }                                                                  \
+  };
+
+LOGICAL_BINARY_FUNCTOR(CudaOrFunctor, ||)
+LOGICAL_BINARY_FUNCTOR(CudaAndFunctor, &&)
+LOGICAL_BINARY_FUNCTOR(CudaXorFunctor, ^)
+#undef LOGICAL_BINARY_FUNCTOR
+
+template <typename T>
+struct CudaNotFunctor {
+  using ELEMENT_TYPE = T;
+  HOSTDEVICE bool operator()(const T* args) const { return !args[0]; }
+};
+
+template <typename Functor>
+class BinaryLogicalOpKernel<platform::CUDADeviceContext, Functor>
+    : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
+ public:
+  using InT = typename Functor::ELEMENT_TYPE;
+  using OutT = bool;
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto functor = Functor();
+    std::vector<const framework::Tensor*> ins;
+    std::vector<framework::Tensor*> outs;
+    const auto& cuda_ctx =
+        ctx.template device_context<platform::CUDADeviceContext>();
+    int axis = PackTensorsIntoVector<OutT>(ctx, &ins, &outs);
+
+    if (ins.size() == 1) {
+      LaunchElementwiseCudaKernel<ElementwiseType::kUnary, InT, OutT>(
+          cuda_ctx, ins, &outs, axis, functor);
+    } else {
+      LaunchElementwiseCudaKernel<ElementwiseType::kBinary, InT, OutT>(
+          cuda_ctx, ins, &outs, axis, functor);
+    }
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+#define REGISTER_LOGICAL_CUDA_KERNEL(op_name, func)                            \
+  REGISTER_OP_CUDA_KERNEL(                                                     \
+      op_name,                                                                 \
+      ops::BinaryLogicalOpKernel<plat::CUDADeviceContext, ops::func<bool>>,    \
+      ops::BinaryLogicalOpKernel<plat::CUDADeviceContext, ops::func<int8_t>>,  \
+      ops::BinaryLogicalOpKernel<plat::CUDADeviceContext, ops::func<int16_t>>, \
+      ops::BinaryLogicalOpKernel<plat::CUDADeviceContext, ops::func<int>>,     \
+      ops::BinaryLogicalOpKernel<plat::CUDADeviceContext, ops::func<int64_t>>, \
+      ops::BinaryLogicalOpKernel<plat::CUDADeviceContext, ops::func<float>>,   \
+      ops::BinaryLogicalOpKernel<plat::CUDADeviceContext, ops::func<double>>);
+
+REGISTER_LOGICAL_CUDA_KERNEL(logical_or, CudaOrFunctor)
+REGISTER_LOGICAL_CUDA_KERNEL(logical_and, CudaAndFunctor)
+REGISTER_LOGICAL_CUDA_KERNEL(logical_xor, CudaXorFunctor)
+REGISTER_LOGICAL_CUDA_KERNEL(logical_not, CudaNotFunctor)
+#undef REGISTER_LOGICAL_CUDA_KERNEL

--- a/paddle/fluid/operators/controlflow/logical_op.h
+++ b/paddle/fluid/operators/controlflow/logical_op.h
@@ -1,11 +1,8 @@
 /* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -82,12 +79,36 @@ class UnaryLogicalOpKernel
 }  // namespace operators
 }  // namespace paddle
 
-#define REGISTER_BINARY_LOGICAL_KERNEL(op_type, dev, functor) \
-  REGISTER_OP_##dev##_KERNEL(                                 \
-      op_type, ::paddle::operators::BinaryLogicalOpKernel<    \
-                   ::paddle::platform::dev##DeviceContext, functor<bool>>);
+#define REGISTER_BINARY_LOGICAL_KERNEL(op_type, dev, functor)              \
+  REGISTER_OP_##dev##_KERNEL(                                              \
+      op_type, ::paddle::operators::BinaryLogicalOpKernel<                 \
+                   ::paddle::platform::dev##DeviceContext, functor<bool>>, \
+      ::paddle::operators::BinaryLogicalOpKernel<                          \
+          ::paddle::platform::dev##DeviceContext, functor<int8_t>>,        \
+      ::paddle::operators::BinaryLogicalOpKernel<                          \
+          ::paddle::platform::dev##DeviceContext, functor<int16_t>>,       \
+      ::paddle::operators::BinaryLogicalOpKernel<                          \
+          ::paddle::platform::dev##DeviceContext, functor<int>>,           \
+      ::paddle::operators::BinaryLogicalOpKernel<                          \
+          ::paddle::platform::dev##DeviceContext, functor<int64_t>>,       \
+      ::paddle::operators::BinaryLogicalOpKernel<                          \
+          ::paddle::platform::dev##DeviceContext, functor<float>>,         \
+      ::paddle::operators::BinaryLogicalOpKernel<                          \
+          ::paddle::platform::dev##DeviceContext, functor<double>>);
 
-#define REGISTER_UNARY_LOGICAL_KERNEL(op_type, dev, functor) \
-  REGISTER_OP_##dev##_KERNEL(                                \
-      op_type, ::paddle::operators::UnaryLogicalOpKernel<    \
-                   ::paddle::platform::dev##DeviceContext, functor<bool>>);
+#define REGISTER_UNARY_LOGICAL_KERNEL(op_type, dev, functor)               \
+  REGISTER_OP_##dev##_KERNEL(                                              \
+      op_type, ::paddle::operators::UnaryLogicalOpKernel<                  \
+                   ::paddle::platform::dev##DeviceContext, functor<bool>>, \
+      ::paddle::operators::UnaryLogicalOpKernel<                           \
+          ::paddle::platform::dev##DeviceContext, functor<int8_t>>,        \
+      ::paddle::operators::UnaryLogicalOpKernel<                           \
+          ::paddle::platform::dev##DeviceContext, functor<int16_t>>,       \
+      ::paddle::operators::UnaryLogicalOpKernel<                           \
+          ::paddle::platform::dev##DeviceContext, functor<int>>,           \
+      ::paddle::operators::UnaryLogicalOpKernel<                           \
+          ::paddle::platform::dev##DeviceContext, functor<int64_t>>,       \
+      ::paddle::operators::UnaryLogicalOpKernel<                           \
+          ::paddle::platform::dev##DeviceContext, functor<float>>,         \
+      ::paddle::operators::UnaryLogicalOpKernel<                           \
+          ::paddle::platform::dev##DeviceContext, functor<double>>);

--- a/paddle/fluid/operators/controlflow/logical_op_npu.cc
+++ b/paddle/fluid/operators/controlflow/logical_op_npu.cc
@@ -1,11 +1,8 @@
 /* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,9 +46,31 @@ class LogicalNotNPUKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
+namespace plat = paddle::platform;
 
 REGISTER_OP_NPU_KERNEL(
-    logical_not,
-    ops::LogicalNotNPUKernel<paddle::platform::NPUDeviceContext, bool>);
+    logical_not, ops::LogicalNotNPUKernel<plat::NPUDeviceContext, bool>,
+    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int8_t>,
+    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int16_t>,
+    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int>,
+    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int64_t>,
+    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, float>,
+    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, double>);
 
-#endif
+REGISTER_OP_NPU_KERNEL(logical_or,
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, bool>,
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int8_t>,
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int16_t>,
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int>,
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int64_t>,
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, float>,
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, double>);
+
+REGISTER_OP_NPU_KERNEL(logical_and,
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, bool>,
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int8_t>,
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int16_t>,
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int>,
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int64_t>,
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, float>,
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, double>);

--- a/paddle/fluid/operators/controlflow/logical_op_xpu.h
+++ b/paddle/fluid/operators/controlflow/logical_op_xpu.h
@@ -45,7 +45,7 @@ class BinaryLogicalOpXPUKernel : public framework::OpKernel<T> {
     auto* x = context.Input<framework::Tensor>("X");
     auto* y = context.Input<framework::Tensor>("Y");
     auto* out = context.Output<framework::Tensor>("Out");
-    T* out_ptr = out->mutable_data<T>(context.GetPlace());
+    bool* out_ptr = out->mutable_data<bool>(context.GetPlace());
     const T* x_ptr = x->data<T>();
     const T* y_ptr = y->data<T>();
     auto& dev_ctx =
@@ -153,7 +153,7 @@ class UnaryLogicalOpXPUKernel : public framework::OpKernel<T> {
     if (x->numel() == 0) {
       return;
     }
-    out->mutable_data<T>(context.GetPlace());
+    out->mutable_data<bool>(context.GetPlace());
     auto& dev_ctx =
         context.template device_context<paddle::platform::XPUDeviceContext>();
     int ret = xpu::logical_not<bool>(dev_ctx.x_context(), x->data<T>(),

--- a/paddle/fluid/operators/controlflow/logicaland_op_xpu.cc
+++ b/paddle/fluid/operators/controlflow/logicaland_op_xpu.cc
@@ -17,5 +17,11 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_XPU_KERNEL(
     logical_and,
-    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, bool>);
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, bool>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, int8_t>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, int16_t>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, int>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, int64_t>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, float>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_AND, double>);
 #endif

--- a/paddle/fluid/operators/controlflow/logicalnot_op_xpu.cc
+++ b/paddle/fluid/operators/controlflow/logicalnot_op_xpu.cc
@@ -15,5 +15,11 @@ limitations under the License. */
 #ifdef PADDLE_WITH_XPU
 #include "paddle/fluid/operators/controlflow/logical_op_xpu.h"
 namespace ops = paddle::operators;
-REGISTER_OP_XPU_KERNEL(logicalnot, ops::UnaryLogicalOpXPUKernel<bool>);
+REGISTER_OP_XPU_KERNEL(logicalnot, ops::UnaryLogicalOpXPUKernel<bool>,
+                       ops::UnaryLogicalOpXPUKernel<int8_t>,
+                       ops::UnaryLogicalOpXPUKernel<int16_t>,
+                       ops::UnaryLogicalOpXPUKernel<int>,
+                       ops::UnaryLogicalOpXPUKernel<int64_t>,
+                       ops::UnaryLogicalOpXPUKernel<float>,
+                       ops::UnaryLogicalOpXPUKernel<double>);
 #endif

--- a/paddle/fluid/operators/controlflow/logicalor_op_xpu.cc
+++ b/paddle/fluid/operators/controlflow/logicalor_op_xpu.cc
@@ -18,5 +18,11 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_XPU_KERNEL(
     logical_or,
-    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, bool>);
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, bool>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, int8_t>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, int16_t>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, int>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, int64_t>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, float>,
+    ops::BinaryLogicalOpXPUKernel<ops::XpuLogicalType::XPU_OR, double>);
 #endif

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12133,17 +12133,22 @@ def _logical_op(op_name, x, y, out=None, name=None, binary_op=True):
             return op(x, y)
         else:
             return op(x)
-
-    check_variable_and_dtype(x, "x", ["bool"], op_name)
+    check_variable_and_dtype(x, "x", [
+        "bool", "int8", "int16", "int32", "int64", "float32", "float64"
+    ], op_name)
     if y is not None:
-        check_variable_and_dtype(y, "y", ["bool"], op_name)
+        check_variable_and_dtype(y, "y", [
+            "bool", "int8", "int16", "int32", "int64", "float32", "float64"
+        ], op_name)
     if out is not None:
         check_type(out, "out", Variable, op_name)
 
     helper = LayerHelper(op_name, **locals())
 
-    if binary_op:
-        assert x.dtype == y.dtype
+    if binary_op and x.dtype != y.dtype:
+        raise ValueError(
+            "(InvalidArgument) The DataType of %s Op's Variable must be consistent, but received %s and %s."
+            % (op_name, x.dtype, y.dtype))
 
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=x.dtype)
@@ -12161,7 +12166,7 @@ def _logical_op(op_name, x, y, out=None, name=None, binary_op=True):
 def logical_and(x, y, out=None, name=None):
     r"""
 
-    ``logical_and`` operator computes element-wise logical AND on ``x`` and ``y``, and returns ``out``. ``x``, ``y`` and ``out`` are N-dim boolean ``Tensor``.
+    ``logical_and`` operator computes element-wise logical AND on ``x`` and ``y``, and returns ``out``. ``out`` is N-dim boolean ``Tensor``.
     Each element of ``out`` is calculated by
 
     .. math::
@@ -12172,8 +12177,8 @@ def logical_and(x, y, out=None, name=None):
         ``paddle.logical_and`` supports broadcasting. If you want know more about broadcasting, please refer to :ref:`user_guide_broadcasting`.
 
     Args:
-        x (Tensor): the input tensor, it's data type should be bool.
-        y (Tensor): the input tensor, it's data type should be bool.
+        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
+        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
         out(Tensor): The ``Tensor`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor`` will be created to save the output.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
@@ -12197,7 +12202,7 @@ def logical_and(x, y, out=None, name=None):
 def logical_or(x, y, out=None, name=None):
     """
 
-    ``logical_or`` operator computes element-wise logical OR on ``x`` and ``y``, and returns ``out``. ``x``, ``y`` and ``out`` are N-dim boolean ``Tensor``.
+    ``logical_or`` operator computes element-wise logical OR on ``x`` and ``y``, and returns ``out``. ``out`` is N-dim boolean ``Tensor``.
     Each element of ``out`` is calculated by
 
     .. math::
@@ -12208,8 +12213,8 @@ def logical_or(x, y, out=None, name=None):
         ``paddle.logical_or`` supports broadcasting. If you want know more about broadcasting, please refer to :ref:`user_guide_broadcasting`.
     
     Args:
-        x (Tensor): the input tensor, it's data type should be bool.
-        y (Tensor): the input tensor, it's data type should be bool.
+        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
+        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
         out(Tensor): The ``Variable`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor`` will be created to save the output.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
@@ -12236,7 +12241,7 @@ def logical_or(x, y, out=None, name=None):
 def logical_xor(x, y, out=None, name=None):
     r"""
 
-    ``logical_xor`` operator computes element-wise logical XOR on ``x`` and ``y``, and returns ``out``. ``x``, ``y`` and ``out`` are N-dim boolean ``Tensor``.
+    ``logical_xor`` operator computes element-wise logical XOR on ``x`` and ``y``, and returns ``out``. ``out`` is N-dim boolean ``Tensor``.
     Each element of ``out`` is calculated by
 
     .. math::
@@ -12247,8 +12252,8 @@ def logical_xor(x, y, out=None, name=None):
         ``paddle.logical_xor`` supports broadcasting. If you want know more about broadcasting, please refer to :ref:`user_guide_broadcasting`.
 
     Args:
-        x (Tensor): the input tensor, it's data type should be bool.
-        y (Tensor): the input tensor, it's data type should be bool.
+        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
+        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
         out(Tensor): The ``Tensor`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor`` will be created to save the output.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
@@ -12276,7 +12281,7 @@ def logical_xor(x, y, out=None, name=None):
 def logical_not(x, out=None, name=None):
     """
 
-    ``logical_not`` operator computes element-wise logical NOT on ``x``, and returns ``out``. ``x`` and ``out`` are N-dim boolean ``Variable``.
+    ``logical_not`` operator computes element-wise logical NOT on ``x``, and returns ``out``. ``out`` is N-dim boolean ``Variable``.
     Each element of ``out`` is calculated by
 
     .. math::
@@ -12284,7 +12289,7 @@ def logical_not(x, out=None, name=None):
         out = !x
 
     Args:
-        x(Tensor):  Operand of logical_not operator. Must be a Tensor of type bool.
+        x(Tensor):  Operand of logical_not operator. Must be a Tensor of type bool, int8, int16, in32, in64, float32, or float64.
         out(Tensor): The ``Tensor`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor` will be created to save the output.
         name(str|None): The default value is None. Normally there is no need for users to set this property. For more information, please refer to :ref:`api_guide_Name`.
 

--- a/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
@@ -21,101 +21,240 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.static import Program, program_guard
 
-paddle.enable_static()
-SEED = 2021
+SUPPORTED_DTYPES = [
+    bool, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64
+]
+
+TEST_META_OP_DATA = [{
+    'op_str': 'logical_and',
+    'binary_op': True
+}, {
+    'op_str': 'logical_or',
+    'binary_op': True
+}, {
+    'op_str': 'logical_not',
+    'binary_op': False
+}]
+
+TEST_META_SHAPE_DATA = {
+    'XDimLargerThanYDim1': {
+        'x_shape': [2, 3, 4, 5],
+        'y_shape': [4, 5]
+    },
+    'XDimLargerThanYDim2': {
+        'x_shape': [2, 3, 4, 5],
+        'y_shape': [4, 1]
+    },
+    'XDimLargerThanYDim3': {
+        'x_shape': [2, 3, 4, 5],
+        'y_shape': [1, 4, 1]
+    },
+    'XDimLargerThanYDim4': {
+        'x_shape': [2, 3, 4, 5],
+        'y_shape': [3, 4, 1]
+    },
+    'XDimLargerThanYDim5': {
+        'x_shape': [2, 3, 1, 5],
+        'y_shape': [3, 1, 1]
+    },
+    'XDimLessThanYDim1': {
+        'x_shape': [4, 1],
+        'y_shape': [2, 3, 4, 5]
+    },
+    'XDimLessThanYDim2': {
+        'x_shape': [1, 4, 1],
+        'y_shape': [2, 3, 4, 5]
+    },
+    'XDimLessThanYDim3': {
+        'x_shape': [3, 4, 1],
+        'y_shape': [2, 3, 4, 5]
+    },
+    'XDimLessThanYDim4': {
+        'x_shape': [3, 1, 1],
+        'y_shape': [2, 3, 1, 5]
+    },
+    'XDimLessThanYDim5': {
+        'x_shape': [4, 5],
+        'y_shape': [2, 3, 4, 5]
+    },
+    'Axis1InLargerDim': {
+        'x_shape': [1, 4, 5],
+        'y_shape': [2, 3, 1, 5]
+    },
+    'EqualDim1': {
+        'x_shape': [10, 7],
+        'y_shape': [10, 7]
+    },
+    'EqualDim2': {
+        'x_shape': [1, 1, 4, 5],
+        'y_shape': [2, 3, 1, 5]
+    }
+}
+
+TEST_META_WRONG_SHAPE_DATA = {
+    'ErrorDim1': {
+        'x_shape': [2, 3, 4, 5],
+        'y_shape': [3, 4]
+    },
+    'ErrorDim2': {
+        'x_shape': [2, 3, 4, 5],
+        'y_shape': [4, 3]
+    }
+}
 
 
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
-class TestLogicalNot(OpTest):
-    def setUp(self):
-        self.set_npu()
-        self.op_type = "logical_not"
-        self.place = paddle.NPUPlace(4)
-
-        self.init_dtype()
-        np.random.seed(SEED)
-        x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
-        out = np.logical_not(x)
-
-        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
-        self.attrs = {}
-        self.outputs = {'Out': out}
-
-    def set_npu(self):
-        self.__class__.use_npu = True
-
-    def init_dtype(self):
-        self.dtype = np.bool
-
-    def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
-
-    # TODO(ascendrc): Add grad test
-    # def test_check_grad(self):
-    #     if self.dtype == np.float16:
-    #         return
-    #     self.check_grad(['X'], 'Out')
-    #
-
-
-@unittest.skipIf(not paddle.is_compiled_with_npu(),
-                 "core is not compiled with NPU")
-class TestLogcialNotNet(unittest.TestCase):
-    def _test(self, run_npu=True):
-        main_prog = paddle.static.Program()
-        startup_prog = paddle.static.Program()
-        main_prog.random_seed = SEED
-        startup_prog.random_seed = SEED
-        np.random.seed(SEED)
-
-        a_np = np.random.random(size=(32, 32)).astype('bool')
-        label_np = np.random.randint(2, size=(32, 1)).astype('int64')
-
-        with paddle.static.program_guard(main_prog, startup_prog):
-            a = paddle.static.data(name="a", shape=[32, 32], dtype='bool')
-            label = paddle.static.data(
-                name="label", shape=[32, 1], dtype='int64')
-
-            c = paddle.logical_not(a)
-            d = paddle.cast(c, dtype="float32")
-
-            fc_1 = fluid.layers.fc(input=d, size=128)
-            prediction = fluid.layers.fc(input=fc_1, size=2, act='softmax')
-
-            cost = fluid.layers.cross_entropy(input=prediction, label=label)
-            loss = fluid.layers.reduce_mean(cost)
-            sgd = fluid.optimizer.SGD(learning_rate=0.01)
-            sgd.minimize(loss)
-
-        if run_npu:
-            place = paddle.NPUPlace(4)
+def run_static(x_np, y_np, op_str, use_npu=False, binary_op=True):
+    paddle.enable_static()
+    startup_program = fluid.Program()
+    main_program = fluid.Program()
+    place = paddle.CPUPlace()
+    if use_npu and fluid.core.is_compiled_with_npu():
+        place = paddle.NPUPlace(0)
+    exe = fluid.Executor(place)
+    with fluid.program_guard(main_program, startup_program):
+        x = paddle.static.data(name='x', shape=x_np.shape, dtype=x_np.dtype)
+        op = getattr(paddle, op_str)
+        feed_list = {'x': x_np}
+        if not binary_op:
+            res = op(x)
         else:
-            place = paddle.CPUPlace()
+            y = paddle.static.data(name='y', shape=y_np.shape, dtype=y_np.dtype)
+            feed_list['y'] = y_np
+            res = op(x, y)
+        exe.run(startup_program)
+        static_result = exe.run(main_program, feed=feed_list, fetch_list=[res])
+    return static_result
 
-        exe = paddle.static.Executor(place)
-        exe.run(startup_prog)
 
-        print("Start run on {}".format(place))
-        for epoch in range(100):
+def run_dygraph(x_np, y_np, op_str, use_npu=False, binary_op=True):
+    place = paddle.CPUPlace()
+    if use_npu and fluid.core.is_compiled_with_npu():
+        place = paddle.NPUPlace(0)
+    paddle.disable_static(place)
+    op = getattr(paddle, op_str)
+    x = paddle.to_tensor(x_np, dtype=x_np.dtype)
+    if not binary_op:
+        dygraph_result = op(x)
+    else:
+        y = paddle.to_tensor(y_np, dtype=y_np.dtype)
+        dygraph_result = op(x, y)
+    return dygraph_result
 
-            pred_res, loss_res = exe.run(main_prog,
-                                         feed={"a": a_np,
-                                               "label": label_np},
-                                         fetch_list=[prediction, loss])
-            if epoch % 10 == 0:
-                print("Epoch {} | Prediction[0]: {}, Loss: {}".format(
-                    epoch, pred_res[0], loss_res))
 
-        return pred_res, loss_res
+def np_data_generator(np_shape, dtype, *args, **kwargs):
+    if dtype == bool:
+        return np.random.choice(a=[True, False], size=np_shape).astype(bool)
+    else:
+        return np.random.randn(*np_shape).astype(dtype)
 
-    def test_npu(self):
-        cpu_pred, cpu_loss = self._test(False)
-        npu_pred, npu_loss = self._test(True)
 
-        self.assertTrue(np.allclose(npu_pred, cpu_pred))
-        self.assertTrue(np.allclose(npu_loss, cpu_loss))
+def test(unit_test, use_npu=False, test_error=False):
+    for op_data in TEST_META_OP_DATA:
+        meta_data = dict(op_data)
+        meta_data['use_npu'] = use_npu
+        np_op = getattr(np, meta_data['op_str'])
+        META_DATA = dict(TEST_META_SHAPE_DATA)
+        if test_error:
+            META_DATA = dict(TEST_META_WRONG_SHAPE_DATA)
+        for shape_data in META_DATA.values():
+            for data_type in SUPPORTED_DTYPES:
+                meta_data['x_np'] = np_data_generator(
+                    shape_data['x_shape'], dtype=data_type)
+                meta_data['y_np'] = np_data_generator(
+                    shape_data['y_shape'], dtype=data_type)
+                if meta_data['binary_op'] and test_error:
+                    # catch C++ Exception
+                    unit_test.assertRaises(BaseException, run_static,
+                                           **meta_data)
+                    unit_test.assertRaises(BaseException, run_dygraph,
+                                           **meta_data)
+                    continue
+                static_result = run_static(**meta_data)
+                dygraph_result = run_dygraph(**meta_data)
+                if meta_data['binary_op']:
+                    np_result = np_op(meta_data['x_np'], meta_data['y_np'])
+                else:
+                    np_result = np_op(meta_data['x_np'])
+                unit_test.assertTrue((static_result == np_result).all())
+                unit_test.assertTrue((dygraph_result.numpy() == np_result).all(
+                ))
+
+
+def test_type_error(unit_test, use_npu, type_str_map):
+    def check_type(op_str, x, y, binary_op):
+        op = getattr(paddle, op_str)
+        error_type = ValueError
+        if isinstance(x, np.ndarray):
+            x = paddle.to_tensor(x)
+            y = paddle.to_tensor(y)
+            error_type = BaseException
+        if binary_op:
+            if type_str_map['x'] != type_str_map['y']:
+                unit_test.assertRaises(error_type, op, x=x, y=y)
+            if not fluid.in_dygraph_mode():
+                error_type = TypeError
+                unit_test.assertRaises(error_type, op, x=x, y=y, out=1)
+        else:
+            if not fluid.in_dygraph_mode():
+                error_type = TypeError
+                unit_test.assertRaises(error_type, op, x=x, out=1)
+
+    place = paddle.CPUPlace()
+    if use_npu and fluid.core.is_compiled_with_npu():
+        place = paddle.NPUPlace(0)
+    for op_data in TEST_META_OP_DATA:
+        meta_data = dict(op_data)
+        binary_op = meta_data['binary_op']
+
+        paddle.disable_static(place)
+        x = np.random.choice(a=[0, 1], size=[10]).astype(type_str_map['x'])
+        y = np.random.choice(a=[0, 1], size=[10]).astype(type_str_map['y'])
+        check_type(meta_data['op_str'], x, y, binary_op)
+
+        paddle.enable_static()
+        startup_program = paddle.static.Program()
+        main_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, startup_program):
+            x = paddle.static.data(
+                name='x', shape=[10], dtype=type_str_map['x'])
+            y = paddle.static.data(
+                name='y', shape=[10], dtype=type_str_map['y'])
+            check_type(meta_data['op_str'], x, y, binary_op)
+
+
+def type_map_factory():
+    return [{
+        'x': x_type,
+        'y': y_type
+    } for x_type in SUPPORTED_DTYPES for y_type in SUPPORTED_DTYPES]
+
+
+class TestCPU(unittest.TestCase):
+    def test(self):
+        test(self)
+
+    def test_error(self):
+        test(self, False, True)
+
+    def test_type_error(self):
+        type_map_list = type_map_factory()
+        for type_map in type_map_list:
+            test_type_error(self, False, type_map)
+
+
+class TestNPU(unittest.TestCase):
+    def test(self):
+        test(self, True)
+
+    def test_error(self):
+        test(self, True, True)
+
+    def test_type_error(self):
+        type_map_list = type_map_factory()
+        for type_map in type_map_list:
+            test_type_error(self, True, type_map)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_logical_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logical_op.py
@@ -21,6 +21,10 @@ import paddle
 import paddle.fluid as fluid
 from paddle.static import Program, program_guard
 
+SUPPORTED_DTYPES = [
+    bool, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64
+]
+
 TEST_META_OP_DATA = [{
     'op_str': 'logical_and',
     'binary_op': True
@@ -111,13 +115,13 @@ def run_static(x_np, y_np, op_str, use_gpu=False, binary_op=True):
         place = paddle.CUDAPlace(0)
     exe = fluid.Executor(place)
     with fluid.program_guard(main_program, startup_program):
-        x = paddle.static.data(name='x', shape=x_np.shape, dtype='bool')
+        x = paddle.static.data(name='x', shape=x_np.shape, dtype=x_np.dtype)
         op = getattr(paddle, op_str)
         feed_list = {'x': x_np}
         if not binary_op:
             res = op(x)
         else:
-            y = paddle.static.data(name='y', shape=y_np.shape, dtype='bool')
+            y = paddle.static.data(name='y', shape=y_np.shape, dtype=y_np.dtype)
             feed_list['y'] = y_np
             res = op(x, y)
         exe.run(startup_program)
@@ -131,17 +135,20 @@ def run_dygraph(x_np, y_np, op_str, use_gpu=False, binary_op=True):
         place = paddle.CUDAPlace(0)
     paddle.disable_static(place)
     op = getattr(paddle, op_str)
-    x = paddle.to_tensor(x_np)
+    x = paddle.to_tensor(x_np, dtype=x_np.dtype)
     if not binary_op:
         dygraph_result = op(x)
     else:
-        y = paddle.to_tensor(y_np)
+        y = paddle.to_tensor(y_np, dtype=y_np.dtype)
         dygraph_result = op(x, y)
     return dygraph_result
 
 
-def np_data_generator(np_shape, *args, **kwargs):
-    return np.random.choice(a=[True, False], size=np_shape).astype(bool)
+def np_data_generator(np_shape, dtype, *args, **kwargs):
+    if dtype == bool:
+        return np.random.choice(a=[True, False], size=np_shape).astype(bool)
+    else:
+        return np.random.randn(*np_shape).astype(dtype)
 
 
 def test(unit_test, use_gpu=False, test_error=False):
@@ -153,40 +160,46 @@ def test(unit_test, use_gpu=False, test_error=False):
         if test_error:
             META_DATA = dict(TEST_META_WRONG_SHAPE_DATA)
         for shape_data in META_DATA.values():
-            meta_data['x_np'] = np_data_generator(shape_data['x_shape'])
-            meta_data['y_np'] = np_data_generator(shape_data['y_shape'])
-            if meta_data['binary_op'] and test_error:
-                # catch C++ Exception
-                unit_test.assertRaises(BaseException, run_static, **meta_data)
-                unit_test.assertRaises(BaseException, run_dygraph, **meta_data)
-                continue
-            static_result = run_static(**meta_data)
-            dygraph_result = run_dygraph(**meta_data)
-            if meta_data['binary_op']:
-                np_result = np_op(meta_data['x_np'], meta_data['y_np'])
-            else:
-                np_result = np_op(meta_data['x_np'])
-            unit_test.assertTrue((static_result == np_result).all())
-            unit_test.assertTrue((dygraph_result.numpy() == np_result).all())
+            for data_type in SUPPORTED_DTYPES:
+                meta_data['x_np'] = np_data_generator(
+                    shape_data['x_shape'], dtype=data_type)
+                meta_data['y_np'] = np_data_generator(
+                    shape_data['y_shape'], dtype=data_type)
+                if meta_data['binary_op'] and test_error:
+                    # catch C++ Exception
+                    unit_test.assertRaises(BaseException, run_static,
+                                           **meta_data)
+                    unit_test.assertRaises(BaseException, run_dygraph,
+                                           **meta_data)
+                    continue
+                static_result = run_static(**meta_data)
+                dygraph_result = run_dygraph(**meta_data)
+                if meta_data['binary_op']:
+                    np_result = np_op(meta_data['x_np'], meta_data['y_np'])
+                else:
+                    np_result = np_op(meta_data['x_np'])
+                unit_test.assertTrue((static_result == np_result).all())
+                unit_test.assertTrue((dygraph_result.numpy() == np_result).all(
+                ))
 
 
 def test_type_error(unit_test, use_gpu, type_str_map):
     def check_type(op_str, x, y, binary_op):
         op = getattr(paddle, op_str)
-        error_type = TypeError
+        error_type = ValueError
         if isinstance(x, np.ndarray):
             x = paddle.to_tensor(x)
             y = paddle.to_tensor(y)
             error_type = BaseException
         if binary_op:
-            if type_str_map['x'] != 'bool' or type_str_map['y'] != 'bool':
+            if type_str_map['x'] != type_str_map['y']:
                 unit_test.assertRaises(error_type, op, x=x, y=y)
             if not fluid.in_dygraph_mode():
+                error_type = TypeError
                 unit_test.assertRaises(error_type, op, x=x, y=y, out=1)
         else:
-            if type_str_map['x'] != 'bool':
-                unit_test.assertRaises(error_type, op, x=x)
             if not fluid.in_dygraph_mode():
+                error_type = TypeError
                 unit_test.assertRaises(error_type, op, x=x, out=1)
 
     place = paddle.CPUPlace()
@@ -213,12 +226,10 @@ def test_type_error(unit_test, use_gpu, type_str_map):
 
 
 def type_map_factory():
-    x_type_list = ['float32', 'float64', 'int32', 'int64', 'bool']
-    y_type_list = ['float32', 'float64', 'int32', 'int64', 'bool']
     return [{
         'x': x_type,
         'y': y_type
-    } for x_type in x_type_list for y_type in y_type_list]
+    } for x_type in SUPPORTED_DTYPES for y_type in SUPPORTED_DTYPES]
 
 
 class TestCPU(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/xpu/test_logical_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_logical_op_xpu.py
@@ -25,6 +25,10 @@ import paddle
 from op_test_xpu import XPUOpTest
 from paddle.static import Program, program_guard
 
+SUPPORTED_DTYPES = [
+    bool, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64
+]
+
 TEST_META_OP_DATA = [{
     'op_str': 'logical_and',
     'binary_op': True
@@ -110,13 +114,13 @@ def run_static_xpu(x_np, y_np, op_str, binary_op=True):
     place = paddle.XPUPlace(0)
     exe = fluid.Executor(place)
     with fluid.program_guard(main_program, startup_program):
-        x = paddle.static.data(name='x', shape=x_np.shape, dtype='bool')
+        x = paddle.static.data(name='x', shape=x_np.shape, dtype=x_np.dtype)
         op = getattr(paddle, op_str)
         feed_list = {'x': x_np}
         if not binary_op:
             res = op(x)
         else:
-            y = paddle.static.data(name='y', shape=y_np.shape, dtype='bool')
+            y = paddle.static.data(name='y', shape=y_np.shape, dtype=y_np.dtype)
             feed_list['y'] = y_np
             res = op(x, y)
         exe.run(startup_program)
@@ -128,17 +132,20 @@ def run_dygraph_xpu(x_np, y_np, op_str, binary_op=True):
     place = paddle.XPUPlace(0)
     paddle.disable_static(place)
     op = getattr(paddle, op_str)
-    x = paddle.to_tensor(x_np)
+    x = paddle.to_tensor(x_np, dtype=x_np.dtype)
     if not binary_op:
         dygraph_result = op(x)
     else:
-        y = paddle.to_tensor(y_np)
+        y = paddle.to_tensor(y_np, dtype=y_np.dtype)
         dygraph_result = op(x, y)
     return dygraph_result
 
 
-def np_data_generator(np_shape, *args, **kwargs):
-    return np.random.choice(a=[True, False], size=np_shape).astype(bool)
+def np_data_generator(np_shape, dtype, *args, **kwargs):
+    if dtype == bool:
+        return np.random.choice(a=[True, False], size=np_shape).astype(bool)
+    else:
+        return np.random.randn(*np_shape).astype(dtype)
 
 
 def test_xpu(unit_test, test_error=False):
@@ -149,40 +156,44 @@ def test_xpu(unit_test, test_error=False):
         if test_error:
             META_DATA = dict(TEST_META_WRONG_SHAPE_DATA)
         for shape_data in META_DATA.values():
-            meta_data['x_np'] = np_data_generator(shape_data['x_shape'])
-            meta_data['y_np'] = np_data_generator(shape_data['y_shape'])
-            if meta_data['binary_op'] and test_error:
-                # catch C++ Exception
-                unit_test.assertRaises(BaseException, run_static_xpu,
-                                       **meta_data)
-                continue
-            static_result = run_static_xpu(**meta_data)
-            dygraph_result = run_dygraph_xpu(**meta_data)
-            if meta_data['binary_op']:
-                np_result = np_op(meta_data['x_np'], meta_data['y_np'])
-            else:
-                np_result = np_op(meta_data['x_np'])
-            unit_test.assertTrue((static_result == np_result).all())
-            unit_test.assertTrue((dygraph_result.numpy() == np_result).all())
+            for data_type in SUPPORTED_DTYPES:
+                meta_data['x_np'] = np_data_generator(
+                    shape_data['x_shape'], dtype=data_type)
+                meta_data['y_np'] = np_data_generator(
+                    shape_data['y_shape'], dtype=data_type)
+                if meta_data['binary_op'] and test_error:
+                    # catch C++ Exception
+                    unit_test.assertRaises(BaseException, run_static_xpu,
+                                           **meta_data)
+                    continue
+                static_result = run_static_xpu(**meta_data)
+                dygraph_result = run_dygraph_xpu(**meta_data)
+                if meta_data['binary_op']:
+                    np_result = np_op(meta_data['x_np'], meta_data['y_np'])
+                else:
+                    np_result = np_op(meta_data['x_np'])
+                unit_test.assertTrue((static_result == np_result).all())
+                unit_test.assertTrue((dygraph_result.numpy() == np_result).all(
+                ))
 
 
 def test_type_error(unit_test, type_str_map):
     def check_type(op_str, x, y, binary_op):
         op = getattr(paddle, op_str)
-        error_type = TypeError
+        error_type = ValueError
         if isinstance(x, np.ndarray):
             x = paddle.to_tensor(x)
             y = paddle.to_tensor(y)
             error_type = BaseException
         if binary_op:
-            if type_str_map['x'] != 'bool' or type_str_map['y'] != 'bool':
+            if type_str_map['x'] != type_str_map['y']:
                 unit_test.assertRaises(error_type, op, x=x, y=y)
             if not fluid.in_dygraph_mode():
+                error_type = TypeError
                 unit_test.assertRaises(error_type, op, x=x, y=y, out=1)
         else:
-            if type_str_map['x'] != 'bool':
-                unit_test.assertRaises(error_type, op, x=x)
             if not fluid.in_dygraph_mode():
+                error_type = TypeError
                 unit_test.assertRaises(error_type, op, x=x, out=1)
 
     place = paddle.XPUPlace(0)
@@ -208,12 +219,10 @@ def test_type_error(unit_test, type_str_map):
 
 
 def type_map_factory():
-    x_type_list = ['float32', 'float64', 'int32', 'int64', 'bool']
-    y_type_list = ['float32', 'float64', 'int32', 'int64', 'bool']
     return [{
         'x': x_type,
         'y': y_type
-    } for x_type in x_type_list for y_type in y_type_list]
+    } for x_type in SUPPORTED_DTYPES for y_type in SUPPORTED_DTYPES]
 
 
 @unittest.skipIf(not paddle.is_compiled_with_xpu(),


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
Solve issue https://github.com/PaddlePaddle/Paddle/issues/34133 .
Logical Ops now support `bool`, `int8`, `int16`, `int32`, `int64`, `float`, and `double`.