### PR TITLE
[NPU] fix logical NPU OP, test=develop

### DIFF
--- a/paddle/fluid/operators/controlflow/logical_op_npu.cc
+++ b/paddle/fluid/operators/controlflow/logical_op_npu.cc
@@ -79,29 +79,11 @@ class LogicalAndPUKernel : public framework::OpKernel<T> {
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
 
-REGISTER_OP_NPU_KERNEL(
-    logical_not, ops::LogicalNotNPUKernel<plat::NPUDeviceContext, bool>,
-    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int8_t>,
-    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int16_t>,
-    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int>,
-    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, int64_t>,
-    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, float>,
-    ops::LogicalNotNPUKernel<plat::NPUDeviceContext, double>);
+REGISTER_OP_NPU_KERNEL(logical_not,
+                       ops::LogicalNotNPUKernel<plat::NPUDeviceContext, bool>);
 
 REGISTER_OP_NPU_KERNEL(logical_or,
-                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, bool>,
-                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int8_t>,
-                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int16_t>,
-                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int>,
-                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, int64_t>,
-                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, float>,
-                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, double>);
+                       ops::LogicalOrNPUKernel<plat::NPUDeviceContext, bool>);
 
 REGISTER_OP_NPU_KERNEL(logical_and,
-                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, bool>,
-                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int8_t>,
-                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int16_t>,
-                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int>,
-                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, int64_t>,
-                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, float>,
-                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, double>);
+                       ops::LogicalAndPUKernel<plat::NPUDeviceContext, bool>);

--- a/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
@@ -23,9 +23,7 @@ import paddle
 import paddle.fluid as fluid
 from paddle.static import Program, program_guard
 
-SUPPORTED_DTYPES = [
-    bool, np.int8, np.int16, np.int32, np.int64, np.float32, np.float64
-]
+SUPPORTED_DTYPES = [bool]
 
 TEST_META_OP_DATA = [{
     'op_str': 'logical_and',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

OPs

### Describe
<!-- Describe what this PR does -->

Fix Logical NPU ops datatype introduced by PR https://github.com/PaddlePaddle/Paddle/pull/34141

ACL报错信息如下：
[ERROR] GE(37326,python3.7):2021-07-26-14:21:54.716.918 [/home/jenkins/agent/workspace/Compile_GraphEngine_Centos_X86/graphengine/ge/engine_manager/dnnengine_manager.cc:273]37326 GetDNNEngineName: ErrorNo: 1343242282(assign engine failed) [COMP][SUB_OPT][Check][OpSupported]Op type LogicalAnd of ops kernel AIcoreEngine is unsupported, reason : The reason why this op LogicalAnd is not supported by op information library[tbe-custom] is that op type LogicalAnd is not found.
The reason why this op LogicalAnd is not supported by op information library[tbe-builtin] is that [Dynamic check]: data type DT_INT8 of input [x1] is not supported. All supported data type and format of tensor input0.x1 is:
Data Type: {DT_BOOL,DT_BOOL,DT_BOOL,DT_BOOL,DT_BOOL,DT_BOOL,DT_BOOL,DT_BOOL,DT_BOOL,DT_BOOL}


