### PR TITLE
Fix hub fname error [cherry-pick 33214]

### DIFF
--- a/python/paddle/hapi/hub.py
+++ b/python/paddle/hapi/hub.py
@@ -109,7 +109,8 @@ def _get_cache_or_reload(repo, force_reload, verbose=True, source='github'):
 
         url = _git_archive_link(repo_owner, repo_name, branch, source=source)
 
-        get_path_from_url(url, hub_dir, decompress=False)
+        fpath = get_path_from_url(url, hub_dir, decompress=False)
+        shutil.move(fpath, cached_file)
 
         with zipfile.ZipFile(cached_file) as cached_zipfile:
             extraced_repo_name = cached_zipfile.infolist()[0].filename


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- align download filename with cache filename in hub https://github.com/PaddlePaddle/Paddle/pull/33214
 