### PR TITLE
install lsof in npu docker

### DIFF
--- a/tools/dockerfile/Dockerfile.npu_aarch64
+++ b/tools/dockerfile/Dockerfile.npu_aarch64
@@ -96,6 +96,8 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 RUN apt-get install libprotobuf-dev -y
 
+RUN apt install lsof -y
+
 # Older versions of patchelf limited the size of the files being processed and were fixed in this pr.
 # https://github.com/NixOS/patchelf/commit/ba2695a8110abbc8cc6baf0eea819922ee5007fa
 # So install a newer version here.

--- a/tools/dockerfile/Dockerfile.npu_x86_64
+++ b/tools/dockerfile/Dockerfile.npu_x86_64
@@ -96,6 +96,8 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
 RUN apt-get install libprotobuf-dev -y
 
+RUN apt install lsof -y
+
 # Older versions of patchelf limited the size of the files being processed and were fixed in this pr.
 # https://github.com/NixOS/patchelf/commit/ba2695a8110abbc8cc6baf0eea819922ee5007fa
 # So install a newer version here.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
install `lsof` in npu docker, so users can use it to check which card is used.

usage: `lsof /dev/davinci_manager`