### PR TITLE
quantize_transpiler_v2 supports quantize fp16 tensor

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantize_transpiler_v2.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantize_transpiler_v2.py
@@ -185,7 +185,10 @@ class QuantizeTranspilerV2(object):
                 new_in_name = var_rename_map[block_id][in_name]
             else:
                 in_var = block.var(in_name)
-                if in_var.dtype != core.VarDesc.VarType.FP32:
+                target_dtype = [
+                    core.VarDesc.VarType.FP32, core.VarDesc.VarType.FP16
+                ]
+                if in_var.dtype not in target_dtype:
                     continue
 
                 quant_bits = self._weight_bits if in_var.persistable \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
quantize_transpiler_v2 supports quantize fp16 tensor