### PR TITLE
[CPU-PSLIB] Fix bug for consistency insepection of op's embedding name and sparse table name in config_fleet.py

### DIFF
--- a/python/paddle/fluid/incubate/fleet/parameter_server/pslib/optimizer_factory.py
+++ b/python/paddle/fluid/incubate/fleet/parameter_server/pslib/optimizer_factory.py
@@ -313,7 +313,7 @@ class DistributedAdam(DistributedOptimizerImplBase):
             if op.type in self.supported_embedding_types:
                 if op.attr('is_distributed') is True:
                     table_name = op.input("W")[0]
-                    emb_size = local_vars[table_name].shape[1]
+                    emb_size = local_vars[table_name].shape[-1]
                     if d_size.get(table_name) is None:
                         d_size[table_name] = emb_size
                     elif d_size[table_name] != emb_size:
@@ -328,12 +328,9 @@ class DistributedAdam(DistributedOptimizerImplBase):
             strategy[table_name] = dict()
         st = strategy[table_name]
 
-        accessor = None
+        accessor = "DownpourCtrAccessor"
         if st.get("sparse_accessor_class") is not None:
             accessor = st["sparse_accessor_class"]
-
-        if accessor is None:
-            accessor = "DownpourCtrAccessor"
 
         # set sparse_embedx_dim in strategy,
         # user do not have to set it in config_fleet
@@ -344,12 +341,12 @@ class DistributedAdam(DistributedOptimizerImplBase):
             if st.get("sparse_embedx_dim") is not None \
                     and st["sparse_embedx_dim"] != emb_to_size[table_name] - 3:
                 raise ValueError("fleet config sparse_embedx_dim=%s not"
-                                 " equal to embedding size - 3 = %s" %
+                                 " equal to embedding dim - 3 = %s" %
                                  (st["sparse_embedx_dim"],
                                   emb_to_size[table_name] - 3))
             if st.get("sparse_embedx_dim") is None:
                 logger.warning(
-                    "sparse embedding size for table name '{}' is: {}, while sparse_embedx_dim "
+                    "sparse embedding dim for table name '{}' is: {}, while sparse_embedx_dim "
                     "with same sparse table name is not set in config_fleet.py. "
                     "Hence automatically set sparse_embedx_dim = {} - 3.".
                     format(table_name, emb_to_size[table_name], emb_to_size[
@@ -359,12 +356,12 @@ class DistributedAdam(DistributedOptimizerImplBase):
             if st.get("sparse_embedx_dim") is not None \
                     and st["sparse_embedx_dim"] != emb_to_size[table_name]:
                 raise ValueError("fleet config sparse_embedx_dim=%s not"
-                                 " equal to embedding size = %s" %
+                                 " equal to embedding dim = %s" %
                                  (st["sparse_embedx_dim"],
                                   emb_to_size[table_name]))
             if st.get("sparse_embedx_dim") is None:
                 logger.warning(
-                    "sparse embedding size for table name '{}' is: {}, while sparse_embedx_dim "
+                    "sparse embedding dim for table name '{}' is: {}, while sparse_embedx_dim "
                     "with same sparse table name is not set in config_fleet.py. "
                     "Hence automatically set sparse_embedx_dim = {}.".format(
                         table_name, emb_to_size[table_name], emb_to_size[


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
**问题描述：**
- 目前optimizer_factory.py支持四种embedding_types: self.supported_embedding_types = ["lookup_table", "pull_sparse", "pull_sparse_v2", "pull_box_sparse"]；其中lookup_table传入的size是两维，pull_sparse/pull_sparse_v2/pull_box_sparse传入的size都只是一维的；
- 但在optimizer_factory.py中的_gen_distributed_emb_to_size_dict函数，local_vars[table_name].shape[1]只考虑了两维的情况，因此调用pull_box_sparse时报index out of range的错误
![image](https://user-images.githubusercontent.com/24829556/127124944-bc1e6d1f-6ace-41c1-9c26-e1020b1c8cde.png)

**解决方法：**
- 考虑size为1维和2维的情况，改为从shape最后一维获取emb_size