### PR TITLE
Fix CI file revision check bug

### DIFF
--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -94,7 +94,7 @@ if [[ $git_files -gt 19 || $git_count -gt 999 ]];then
 fi
 
 for API_FILE in ${API_FILES[*]}; do
-  API_CHANGE=`git diff --name-only upstream/$BRANCH | grep "${API_FILE}" | grep -v "/CMakeLists.txt" || true`
+  API_CHANGE=`git diff --name-only upstream/$BRANCH | grep -F "${API_FILE}" | grep -v "/CMakeLists.txt" || true`
   if [ "${API_CHANGE}" ] && [ "${GIT_PR_ID}" != "" ]; then
       # NOTE: per_page=10000 should be ok for all cases, a PR review > 10000 is not human readable.
       # You can use http://caius.github.io/github_id/ to find Github user id.


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
CI `check_file_diff_approvals.sh` have the following bug.
```
~ % echo "paddle/fluid/framework/ir/graph_helper.h" | grep "paddle/fluid/framework/ir/graph.h"
paddle/fluid/framework/ir/graph_helper.h
```

It is because `grep` would use regular expression by default. To disable regular expression, use `grep -F` instead. See: https://stackoverflow.com/questions/9416390/grep-not-as-a-regular-expression

```
~ % echo "paddle/fluid/framework/ir/graph_helper.h" | grep -F "paddle/fluid/framework/ir/graph.h" | wc -l
0
~ % echo "paddle/fluid/framework/ir/graph.h" | grep -F "paddle/fluid/framework/ir/graph.h"
paddle/fluid/framework/ir/graph.h
```
