### PR TITLE
[HybridParallel]Support 1f1b for PipelineParallel

### DIFF
--- a/python/paddle/distributed/fleet/base/topology.py
+++ b/python/paddle/distributed/fleet/base/topology.py
@@ -157,7 +157,6 @@ class HybridCommunicateGroup(object):
         self.is_last_stage = (self.stage_id == (self._pp_degree - 1))
 
         # create p2p_groups
-        self._p2p_groups = self._build_p2p_lists()
         if self._pp_degree > 1:
             self._set_p2p_group()
             print("send_next_group: ", self.send_next_group)
@@ -176,21 +175,6 @@ class HybridCommunicateGroup(object):
 
         global _HYBRID_PARALLEL_GROUP
         _HYBRID_PARALLEL_GROUP = self
-
-    def _build_p2p_lists(self):
-        comm_lists = self._topo.get_comm_list('pipe')
-        p2p_lists = []
-        for rank in range(self.nranks):
-            for comm_ranks in comm_lists:
-                assert len(comm_ranks) == self._pp_degree
-                if rank in comm_ranks:
-                    idx = comm_ranks.index(rank)
-                    next_rank = comm_ranks[(idx + 1) % self._pp_degree]
-                    p2p_lists.append([rank, next_rank])
-                    break
-        assert len(
-            p2p_lists) == self.nranks, "len(p2p_lists) should be equal nranks"
-        return p2p_lists
 
     def get_parallel_mode(self):
         # there are four modes : DataParallel / TensorParallel / PipelineParallel / ShardingParallel
@@ -345,9 +329,6 @@ class HybridCommunicateGroup(object):
     def get_sharding_parallel_group_src_rank(self):
         # TODO should the src rank related to the shard rank for each parameter ?
         return self._sharding_comm_group.ranks[0]
-
-    def get_p2p_groups(self):
-        return self._p2p_groups
 
     # check parallel group
     def get_check_parallel_group(self):

--- a/python/paddle/distributed/fleet/base/topology.py
+++ b/python/paddle/distributed/fleet/base/topology.py
@@ -159,11 +159,6 @@ class HybridCommunicateGroup(object):
         # create p2p_groups
         if self._pp_degree > 1:
             self._set_p2p_group()
-            print("send_next_group: ", self.send_next_group)
-            print("send_prev_group: ", self.send_prev_group)
-            print("recv_next_group: ", self.recv_next_group)
-            print("recv_prev_group: ", self.recv_prev_group)
-
 
         debug_str = "HybridParallelInfo: rank_id: %d, mp_degree: %d, " \
                     "sharding_degree: %d, pp_degree: %d, dp_degree: %d" % (self.global_rank, self._mp_degree,
@@ -312,6 +307,9 @@ class HybridCommunicateGroup(object):
 
     def get_pipe_parallel_group(self):
         return self._pp_comm_group
+
+    def get_p2p_groups(self):
+        return self.send_next_group, self.send_prev_group, self.recv_next_group, self.recv_prev_group
 
     # sharding parallel message:
     def _get_sharding_parallel_id(self):

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -121,13 +121,20 @@ class PipelineParallel(MetaParallelBase):
         num_warmup_microbatches = min(num_warmup_microbatches, num_microbatches)
         num_microbatches_remaining = num_microbatches - num_warmup_microbatches
 
+        print("num_warmup_microbatches: ", num_warmup_microbatches,
+              "num_microbatches_remaining: ", num_microbatches_remaining)
+
         input_tensors = []
         output_tensors = []
         losses_reduced = []
 
         for step_id in range(num_warmup_microbatches):
+            logger("==recv F==")
             input_tensor = p2p.recv_forward()
+            if input_tensor is not None:
+                input_tensor.stop_gradient = False
             output_tensor = self._forward_step(input_tensor)
+            print("==send F==")
             p2p.send_forward(output_tensor)
 
             input_tensors.append(input_tensor)
@@ -136,6 +143,7 @@ class PipelineParallel(MetaParallelBase):
         #print("warmup is endding..")
 
         if num_microbatches_remaining > 0:
+            print("==recv F==")
             input_tensor = p2p.recv_forward()
 
         for i in range(num_microbatches_remaining):
@@ -145,6 +153,7 @@ class PipelineParallel(MetaParallelBase):
                 input_tensor.stop_gradient = False
             output_tensor = self._forward_step(input_tensor)
 
+            print("==send F; recv B==")
             output_tensor_grad = p2p.send_forward_recv_backward(output_tensor)
 
             input_tensors.append(input_tensor)
@@ -153,16 +162,20 @@ class PipelineParallel(MetaParallelBase):
             input_tensor, output_tensor = input_tensors.pop(
                 0), output_tensors.pop(0)
 
-            #print("input_tensor: ", input_tensor, "output_tensor: ", output_tensor, "output_tensor_grad: ", output_tensor_grad)
+            print("input_tensor: ", input_tensor, "output_tensor: ",
+                  output_tensor, "output_tensor_grad: ", output_tensor_grad)
             input_tensor_grad = \
                 self._backward_step(input_tensor, output_tensor, output_tensor_grad)
 
-            #print("input_tensor_grad: ", input_tensor_grad)
+            print("input_tensor_grad: ", input_tensor_grad)
             if last_iteration:
                 input_tensor = None
                 #print("start send backward")
+                print("==send B==")
                 p2p.send_backward(input_tensor_grad)
             else:
+                print("==send B; recv F==")
+                print("input_tensor_grad: ", input_tensor_grad)
                 input_tensor = \
                     p2p.send_backward_recv_forward(input_tensor_grad)
 
@@ -170,10 +183,12 @@ class PipelineParallel(MetaParallelBase):
             input_tensor = input_tensors.pop(0)
             output_tensor = output_tensors.pop(0)
 
+            print("==recv B==")
             output_tensor_grad = p2p.recv_backward()
 
             input_tensor_grad = \
                 self._backward_step(input_tensor, output_tensor, output_tensor_grad)
+            print("==send B==")
             p2p.send_backward(input_tensor_grad)
 
         self.data_id = 0

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -85,31 +85,7 @@ class PipelineParallel(MetaParallelBase):
         if self.use_data_parallel:
             logger.info("start broadcast dp parameters")
             broadcast_dp_parameters(self._layers, self._hcg)
-
-    def _init_caches(self, num_caches):
-        if self.num_caches >= num_caches:
-            return
-        self.num_caches = num_caches - self.num_caches
-        for key in self.caches:
-            self.caches[key].extend([None] * self.num_caches)
-
-    def _reduce_final_loss(self):
-        if self.is_last_stage:
-            assert self.total_loss is not None, "train_batch() in last stage should obtain vaild loss"
-            loss = self.total_loss.clone() / self.accumulate_steps
-            paddle.distributed.broadcast(
-                loss,
-                src=self.global_rank,
-                use_calc_stream=True,
-                group=self.pp_group)
-        else:
-            loss = paddle.to_tensor(0.0)
-            paddle.distributed.broadcast(
-                loss,
-                src=self._hcg.get_rank_from_stage(self.num_stages - 1),
-                use_calc_stream=True,
-                group=self.pp_group)
-        return loss
+        self.data_id = 0
 
     def train_batch(self, data, optimizer, lr_scheduler=None, scaler=None):
         assert isinstance(optimizer, HybridParallelOptimizer), (
@@ -131,113 +107,100 @@ class PipelineParallel(MetaParallelBase):
 
         # store total loss of entire batch
         self.total_loss = None
-        self._init_caches(self.accumulate_steps)
-        startup_steps = self.num_stages - self.stage_id - 1
-        forward_steps = 0
-        backward_steps = 0
 
-        # forward
-        while (forward_steps < self.accumulate_steps):
-            self._forward(cache_id=forward_steps)
-            forward_steps += 1
+        self.micro_batch_size = self._strategy.pipeline_configs[
+            'micro_batch_size']
+        self.accumulate_steps = self._strategy.pipeline_configs[
+            'accumulate_steps']
 
-        # backward
-        while (backward_steps < self.accumulate_steps):
-            self._backward(cache_id=backward_steps)
-            backward_steps += 1
+        self.num_stages = self._hcg.get_pipe_parallel_world_size()
 
-        self._layers.allreduce_shared_weight_gradients()
+        # Compute number of warmup microbatches.
+        num_microbatches = self.accumulate_steps
+        num_warmup_microbatches = (self.num_stages - self.stage_id - 1)
+        num_warmup_microbatches = min(num_warmup_microbatches, num_microbatches)
+        num_microbatches_remaining = num_microbatches - num_warmup_microbatches
 
-        # optimizer
-        self.train_loss = self._reduce_final_loss()
-        self._step()
-        return self.train_loss
+        input_tensors = []
+        output_tensors = []
+        losses_reduced = []
 
-    def _forward(self, cache_id):
-        # load data
-        self._load_micro_batch(cache_id)
-        if self.stage_id != 0:
-            self._recv_activations(cache_id)
+        for step_id in range(num_warmup_microbatches):
+            input_tensor = p2p.recv_forward()
+            output_tensor = self._forward_step(input_tensor)
+            p2p.send_forward(output_tensor)
 
-        if isinstance(self.caches['inputs'][cache_id], tuple):
-            inputs = tuple(t for t in self.caches['inputs'][cache_id])
-        else:
-            inputs = self.caches['inputs'][cache_id]
+            input_tensors.append(input_tensor)
+            output_tensors.append(output_tensor)
 
-        self._clear_grads(inputs)
-        outputs = self._layers.forward(inputs)
+        #print("warmup is endding..")
 
-        self.caches['outputs'][cache_id] = outputs
+        if num_microbatches_remaining > 0:
+            input_tensor = p2p.recv_forward()
 
-        if self.is_last_stage:
-            if self._layers._loss_fn is not None:
-                labels = self.caches['labels'][cache_id]
-                outputs = self._layers._loss_fn(outputs, labels)
+        for i in range(num_microbatches_remaining):
+            last_iteration = (i == (num_microbatches_remaining - 1))
 
-        if self.is_last_stage:
-            self.current_loss = outputs
-            if isinstance(self.current_loss, paddle.Tensor):
-                if self.total_loss is None:
-                    self.total_loss = paddle.zeros_like(self.current_loss)
-                self.total_loss += self.current_loss.detach()
+            if input_tensor is not None:
+                input_tensor.stop_gradient = False
+            output_tensor = self._forward_step(input_tensor)
+
+            output_tensor_grad = p2p.send_forward_recv_backward(output_tensor)
+
+            input_tensors.append(input_tensor)
+            output_tensors.append(output_tensor)
+
+            input_tensor, output_tensor = input_tensors.pop(
+                0), output_tensors.pop(0)
+
+            #print("input_tensor: ", input_tensor, "output_tensor: ", output_tensor, "output_tensor_grad: ", output_tensor_grad)
+            input_tensor_grad = \
+                self._backward_step(input_tensor, output_tensor, output_tensor_grad)
+
+            #print("input_tensor_grad: ", input_tensor_grad)
+            if last_iteration:
+                input_tensor = None
+                #print("start send backward")
+                p2p.send_backward(input_tensor_grad)
             else:
-                if self.total_loss is None:
-                    self.total_loss = [
-                        paddle.zeros_like(v) for v in self.current_loss
-                    ]
-                for idx, v in enumerate(self.current_loss):
-                    self.total_loss[idx] += v.detach()
+                input_tensor = \
+                    p2p.send_backward_recv_forward(input_tensor_grad)
 
-            if self.accumulate_steps > 1:
-                self.current_loss = self.current_loss / self.accumulate_steps
+        for i in range(num_warmup_microbatches):
+            input_tensor = input_tensors.pop(0)
+            output_tensor = output_tensors.pop(0)
 
-            self.caches['outputs'][cache_id] = self.current_loss.clone()
+            output_tensor_grad = p2p.recv_backward()
 
-        else:
-            self._send_activations(cache_id)
+            input_tensor_grad = \
+                self._backward_step(input_tensor, output_tensor, output_tensor_grad)
+            p2p.send_backward(input_tensor_grad)
 
-    def _backward(self, cache_id):
+        self.data_id = 0
+        return 10.0
+
+    def _forward_step(self, input_tensor):
+        if self.stage_id == 0:
+            input_tensor = self._load_micro_batch(self.data_id)
+
+        output_tensor = self._layers.forward(input_tensor)
+
         if self.is_last_stage:
-            if self.scaler:
-                paddle.autograd.backward(
-                    self.scaler.scale(self.caches['outputs'][cache_id]))
-            else:
-                paddle.autograd.backward(self.caches['outputs'][cache_id])
+            labels = self._load_micro_batch(self.data_id)
+            output_tensor = self._layers._loss_fn(output_tensor, labels)
+        #print("micro batch id: ", self.data_id, "output_tensor: ", output_tensor)
+        self.data_id += 1
+        return output_tensor
 
-            self._send_gradients(cache_id)
-            return
-        self._recv_gradients(cache_id)
+    def _backward_step(self, input_tensor, output_tensor, output_tensor_grad):
+        #print("output_tensor: ", output_tensor, "output_tensor_grad", output_tensor_grad)
+        paddle.autograd.backward(
+            tensors=[output_tensor], grad_tensors=[output_tensor_grad])
+        input_tensor_grad = None
+        if input_tensor is not None:
+            input_tensor_grad = input_tensor.grad
 
-        outputs = self.caches['outputs'][cache_id]
-
-        grad_tensors = self.grad_tensors
-        if isinstance(outputs, tuple):
-            out_tensors = [t for t in outputs if is_float_tensor(t)]
-            assert len(out_tensors) == len(grad_tensors)
-            paddle.autograd.backward(
-                tensors=out_tensors, grad_tensors=grad_tensors)
-        else:
-            paddle.autograd.backward(
-                tensors=[outputs], grad_tensors=[grad_tensors])
-
-        grad_tensors = None
-        if self.stage_id != 0: self._send_gradients(cache_id)
-        self.caches['outputs'][cache_id] = None
-
-    def _broadcast_data(self, data):
-        if isinstance(data, paddle.Tensor):
-            paddle.distributed.broadcast(
-                data,
-                src=self._hcg.get_model_parallel_group_src_rank(),
-                group=self._hcg.get_model_parallel_group())
-        else:
-            for d in data:
-                assert isinstance(d, paddle.Tensor)
-                paddle.distributed.broadcast(
-                    d,
-                    src=self._hcg.get_model_parallel_group_src_rank(),
-                    group=self._hcg.get_model_parallel_group())
-        return data
+        return input_tensor_grad
 
     def _load_micro_batch(self, cache_id):
         inputs = self.data
@@ -246,8 +209,6 @@ class PipelineParallel(MetaParallelBase):
 
         if self.is_first_stage:
             assert len(inputs) == 2, "length of input should be 2"
-            if self.use_model_parallel:
-                inputs[0] = self._broadcast_data(inputs[0])
             if isinstance(inputs[0], tuple):
                 batch_size = inputs[0][0].shape[0]
                 assert self.micro_batch_size * self.accumulate_steps == batch_size, (
@@ -258,329 +219,24 @@ class PipelineParallel(MetaParallelBase):
                 data = [
                     input[begin:end, :].clone().detach() for input in inputs[0]
                 ]
-                self.caches['inputs'][cache_id] = tuple(data)
+                return tuple(data)
             else:
                 batch_size = inputs[0].shape[0]
                 assert self.micro_batch_size * self.accumulate_steps == batch_size
-                self.caches['inputs'][cache_id] = inputs[0][begin:end, :].clone(
-                ).detach()
+                return inputs[0][begin:end, :].clone().detach()
         elif self.is_last_stage:
             assert len(inputs) == 2, "length of input should be 2"
-            if self.use_model_parallel:
-                inputs[1] = self._broadcast_data(inputs[1])
             if isinstance(inputs[1], tuple):
                 batch_size = inputs[1][0].shape[0]
                 assert self.micro_batch_size * self.accumulate_steps == batch_size
                 data = [
                     input[begin:end, :].clone().detach() for input in inputs[1]
                 ]
-                self.caches['labels'][cache_id] = tuple(data)
+                return tuple(data)
             else:
                 batch_size = inputs[1].shape[0]
                 assert self.micro_batch_size * self.accumulate_steps == batch_size
-                self.caches['labels'][cache_id] = inputs[1][begin:end, :].clone(
-                ).detach()
+                return inputs[1][begin:end, :].clone().detach()
         else:
             # No data input is required for other stages
             inputs = None
-
-    def _send_meta(self, data, peer):
-        if isinstance(data, paddle.Tensor):
-            tensor_type = paddle.to_tensor([0])
-            # send tensor type
-            p2p.send(tensor_type, self.next_stage_id)
-
-            # send len(shape)
-            dims = paddle.to_tensor(len(data.shape))
-            p2p.send(dims, self.next_stage_id)
-
-            # send shape
-            shape = paddle.to_tensor(data.shape)
-            p2p.send(shape, self.next_stage_id)
-
-            # send dtype
-            dtype = paddle.to_tensor(paddle_2_number(data.dtype))
-            p2p.send(dtype, self.next_stage_id)
-
-        elif isinstance(data, tuple):
-            tensor_type = paddle.to_tensor([1])
-            p2p.send(tensor_type, self.next_stage_id)
-
-            nums = paddle.to_tensor(len(data))
-            p2p.send(nums, self.next_stage_id)
-
-            for idx, d in enumerate(data):
-                assert isinstance(d, paddle.Tensor)
-                # send len(shape)
-                dims = paddle.to_tensor(len(d.shape))
-                p2p.send(dims, self.next_stage_id)
-
-                # send shape
-                shape = paddle.to_tensor(d.shape)
-                p2p.send(shape, self.next_stage_id)
-
-                # send dtype
-                dtype = paddle.to_tensor(paddle_2_number(d.dtype))
-                p2p.send(dtype, self.next_stage_id)
-
-    def _recv_meta(self, peer):
-        tensor_type = paddle.to_tensor([0])
-        p2p.recv(tensor_type, self.prev_stage_id)
-
-        tensor_type = tensor_type.item()
-
-        if tensor_type == 0:
-            # recv len(shape)
-            dims = paddle.to_tensor([0])
-            p2p.recv(dims, self.prev_stage_id)
-
-            dims = dims.item()
-
-            # recv shape
-            shape = paddle.to_tensor([0] * dims)
-            p2p.recv(shape, self.prev_stage_id)
-
-            shape = shape.numpy().tolist()
-
-            # recv dtype
-            dtype = paddle.to_tensor([0])
-            p2p.recv(dtype, self.prev_stage_id)
-
-            return self._allocate_cache(
-                shape, dtype=number_2_dtype(dtype.item()), num_caches=1)[0]
-        elif tensor_type == 1:
-            num = paddle.to_tensor([0])
-            p2p.recv(num, self.prev_stage_id)
-            num = num.item()
-            shapes = []
-            dtypes = []
-            for i in range(num):
-                # recv len(shape)
-                dims = paddle.to_tensor([0])
-                p2p.recv(dims, self.prev_stage_id)
-
-                # recv shape
-                dims = dims.item()
-                shape = paddle.to_tensor([0] * dims)
-                p2p.recv(shape, self.prev_stage_id)
-                shapes.append(shape.numpy().tolist())
-
-                # recv dtype
-                dtype = paddle.to_tensor([0])
-                p2p.recv(dtype, self.prev_stage_id)
-                dtypes.append(number_2_dtype(dtype.item()))
-
-            caches = self._allocate_caches(shapes, dtypes, num_caches=1)[0]
-            caches = tuple(caches)
-            return caches
-
-    def _is_valid_send_recv(self, tensor):
-        tensor_numel = np.prod(tensor.shape)
-        assert tensor_numel != 0, "can't send/recv zero element"
-        return tensor_numel % self.mp_degree == 0
-
-    def _send_activations(self, cache_id):
-        outputs = self.caches['outputs'][cache_id]
-
-        if self.send_meta:
-            self.send_meta = False
-            self._send_meta(outputs, self.next_stage_id)
-
-        if isinstance(outputs, paddle.Tensor):
-            if self.is_pipe_partitioned and self._is_valid_send_recv(outputs):
-                p2p.send_partial(
-                    outputs.detach(),
-                    self.next_stage_id,
-                    mp_degree=self.mp_degree,
-                    mp_rank=self.mp_rank)
-            else:
-                p2p.send(outputs.detach(), self.next_stage_id)
-
-        elif isinstance(outputs, tuple):
-            for output in outputs:
-                if self.is_pipe_partitioned and self._is_valid_send_recv(
-                        output):
-                    p2p.send_partial(
-                        output.detach(),
-                        self.next_stage_id,
-                        mp_degree=self.mp_degree,
-                        mp_rank=self.mp_rank)
-                else:
-                    p2p.send(output.detach(), self.next_stage_id)
-
-    def _send_gradients(self, cache_id):
-        inputs = self.caches['inputs'][cache_id]
-        if isinstance(inputs, paddle.Tensor):
-            assert inputs.grad is not None
-            if self.is_pipe_partitioned and self._is_valid_send_recv(
-                    inputs.grad):
-                grad = p2p.send_partial(
-                    inputs.grad,
-                    self.prev_stage_id,
-                    mp_degree=self.mp_degree,
-                    mp_rank=self.mp_rank)
-            else:
-                p2p.send(inputs.grad, self.prev_stage_id)
-        else:
-            for idx, d in enumerate(inputs):
-                # Skip tensors that will not produce a grad
-                if not is_float_tensor(d):
-                    assert d.grad is None
-                    continue
-
-                if self.is_pipe_partitioned and self._is_valid_send_recv(
-                        d.grad):
-                    grad = p2p.send_partial(
-                        d.grad,
-                        self.prev_stage_id,
-                        mp_degree=self.mp_degree,
-                        mp_rank=self.mp_rank)
-                else:
-                    p2p.send(d.grad, self.prev_stage_id)
-
-        self.caches['inputs'][cache_id] = None
-
-    def _recv_activations(self, cache_id):
-        inputs = None
-        if self.recv_cache is None:
-            self.recv_cache = self._recv_meta(self.prev_stage_id)
-
-        if isinstance(self.recv_cache, paddle.Tensor):
-            if self.is_pipe_partitioned and self._is_valid_send_recv(
-                    self.recv_cache):
-                p2p.recv_partial(self.recv_cache, self.prev_stage_id,
-                                 self.mp_degree, self.mp_rank)
-                p2p.partial_allgather_operator(
-                    self.recv_cache,
-                    mp_ranks=self.mp_degree,
-                    mp_rank_id=self.mp_rank,
-                    group=self._hcg.get_model_parallel_group(),
-                    use_calc_stream=True)
-            else:
-                p2p.recv(self.recv_cache, self.prev_stage_id)
-
-            inputs = self.recv_cache.clone().detach()
-            inputs.stop_gradient = not is_float_tensor(inputs)
-
-        else:
-            assert isinstance(self.recv_cache, tuple)
-            inputs = [None] * len(self.recv_cache)
-            for idx, d in enumerate(self.recv_cache):
-                if self.is_pipe_partitioned and self._is_valid_send_recv(d):
-                    assert isinstance(d, paddle.Tensor)
-                    p2p.recv_partial(d, self.prev_stage_id, self.mp_degree,
-                                     self.mp_rank)
-                    p2p.partial_allgather_operator(
-                        d,
-                        mp_ranks=self.mp_degree,
-                        mp_rank_id=self.mp_rank,
-                        group=self._hcg.get_model_parallel_group(),
-                        use_calc_stream=True)
-                else:
-                    assert isinstance(d, paddle.Tensor)
-                    p2p.recv(d, self.prev_stage_id)
-                inputs[idx] = d.clone().detach()
-
-            inputs = tuple(inputs)
-
-            for d in inputs:
-                d.stop_gradient = not is_float_tensor(d)
-
-        self.caches['inputs'][cache_id] = inputs
-
-    def _recv_gradients(self, cache_id):
-        outputs = self.caches['outputs'][cache_id]
-        if self.grad_tensors is None:
-            if isinstance(outputs, paddle.Tensor):
-                s = list(outputs.shape)
-                dtype = get_tensor_dtype(outputs.dtype)
-                self.grad_tensors = self._allocate_cache(
-                    s, dtype, num_caches=1)[0]
-            else:
-                sizes = [list(d.shape) for d in outputs if is_float_tensor(d)]
-                dtypes = [
-                    get_tensor_dtype(d.dtype) for d in outputs
-                    if is_float_tensor(d)
-                ]
-                self.grad_tensors = self._allocate_caches(
-                    sizes, dtypes, num_caches=1)[0]
-
-        if isinstance(self.grad_tensors, paddle.Tensor):
-            if self.is_pipe_partitioned and self._is_valid_send_recv(
-                    self.grad_tensors):
-                p2p.recv_partial(self.grad_tensors, self.next_stage_id,
-                                 self.mp_degree, self.mp_rank)
-                p2p.partial_allgather_operator(
-                    self.grad_tensors,
-                    mp_ranks=self.mp_degree,
-                    mp_rank_id=self.mp_rank,
-                    group=self._hcg.get_model_parallel_group(),
-                    use_calc_stream=True)
-            else:
-                p2p.recv(self.grad_tensors, self.next_stage_id)
-
-        else:
-            assert isinstance(outputs, tuple)
-            for d in self.grad_tensors:
-                if self.is_pipe_partitioned and self._is_valid_send_recv(d):
-                    p2p.recv_partial(d, self.next_stage_id, self.mp_degree,
-                                     self.mp_rank)
-                    p2p.partial_allgather_operator(
-                        d,
-                        mp_ranks=self.mp_degree,
-                        mp_rank_id=self.mp_rank,
-                        group=self._hcg.get_model_parallel_group(),
-                        use_calc_stream=True)
-                else:
-                    p2p.recv(d, self.next_stage_id)
-
-    def _step(self):
-        if self.scaler:
-            self.scaler.minimize(self.optimizer, self.train_loss)
-        else:
-            self.optimizer.step()
-        self.optimizer.clear_grad()
-        if self.lr_scheduler:
-            self.lr_scheduler.step()
-
-    def _clear_grads(self, inputs):
-        if isinstance(inputs, paddle.Tensor):
-            if inputs.grad is not None:
-                inputs.clear_gradient()
-        else:
-            for d in inputs:
-                if d.grad is not None:
-                    d.clear_gradient()
-
-    def _allocate_zeros(self, shape, dtype):
-        return paddle.zeros(shape, dtype)
-
-    def _allocate_cache(self, shape, dtype, num_caches=-1):
-        caches = []
-        if num_caches == -1:
-            num_caches = self.num_caches
-        for count in range(num_caches):
-            caches.append(self._allocate_zeros(shape, dtype))
-        return caches
-
-    def _allocate_caches(self, shapes, dtypes, num_caches=-1):
-        caches = []
-        if num_caches == -1:
-            num_caches = self.num_caches
-        for count in range(num_caches):
-            cache = []
-            for shape, dtype in zip(shapes, dtypes):
-                cache.append(self._allocate_zeros(shape, dtype))
-            caches.append(cache)
-        return caches
-
-    def save_state_dict(self, model_path):
-        state_dict = self._layers.state_dict()
-        paddle.save(state_dict, model_path)
-
-    def load_state_dict(self, model_path):
-        state_dict = paddle.load(self.model_path)
-        self._layers.set_state_dict(state_dict)
-
-    def forward(self, *inputs, **kwargs):
-        raise RuntimeError("Call train_batch for pipeline instead of forward.")

--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
@@ -195,8 +195,10 @@ class PipelineParallel(MetaParallelBase):
     def _backward_step(self, input_tensor, output_tensor, output_tensor_grad):
         if self.is_last_stage:
             assert output_tensor_grad is None
-            paddle.autograd.backward(
-                tensors=[output_tensor], grad_tensors=[None])
+            if self.scaler:
+                paddle.autograd.backward(self.scaler.scale(output_tensor))
+            else:
+                paddle.autograd.backward(output_tensor)
         else:
             if isinstance(output_tensor, tuple):
                 outputs = [t for t in output_tensor if not t.stop_gradient]

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -21,10 +21,10 @@ _tensor_shape = (2, 1024, 768)
 
 def initialize_p2p_groups(hcg):
     global _groups, _hcg
-    _groups = [
-        paddle.distributed.new_group(ranks=group)
-        for group in hcg.get_p2p_groups()
-    ]
+    # _groups = [
+    #     paddle.distributed.new_group(ranks=group)
+    #     for group in hcg.get_p2p_groups()
+    # ]
     _hcg = hcg
 
 
@@ -164,33 +164,45 @@ def _communicate(tensor_send_next, tensor_send_prev, recv_prev, recv_next):
         tensor_recv_next = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
 
     if tensor_send_prev is not None:
-        group = _get_send_recv_group(
-            src_stage=current_stage, dest_stage=prev_stage)
+        # group = _get_send_recv_group(
+        # src_stage=current_stage, dest_stage=prev_stage)
         #print("group msg:", group)
         paddle.distributed.wait(tensor_send_prev, use_calc_stream=True)
         paddle.distributed.send(
-            tensor_send_prev, dst=0, group=group, use_calc_stream=False)
+            tensor_send_prev,
+            dst=0,
+            group=_hcg.send_prev_group,
+            use_calc_stream=False)
     if tensor_recv_prev is not None:
-        group = _get_send_recv_group(
-            src_stage=prev_stage, dest_stage=current_stage)
+        # group = _get_send_recv_group(
+        # src_stage=prev_stage, dest_stage=current_stage)
         #print("group msg:", group)
         paddle.distributed.recv(
-            tensor_recv_prev, src=0, group=group, use_calc_stream=True)
+            tensor_recv_prev,
+            src=0,
+            group=_hcg.recv_prev_group,
+            use_calc_stream=True)
         #print("tensor_recv_prev", tensor_recv_prev.numpy())
 
     if tensor_send_next is not None:
-        group = _get_send_recv_group(
-            src_stage=current_stage, dest_stage=next_stage)
+        # group = _get_send_recv_group(
+        # src_stage=current_stage, dest_stage=next_stage)
         #print("group msg:", group)
         paddle.distributed.wait(tensor_send_next, use_calc_stream=True)
         paddle.distributed.send(
-            tensor_send_next, dst=1, group=group, use_calc_stream=False)
+            tensor_send_next,
+            dst=1,
+            group=_hcg.send_next_group,
+            use_calc_stream=False)
     if tensor_recv_next is not None:
-        group = _get_send_recv_group(
-            src_stage=next_stage, dest_stage=current_stage)
+        # group = _get_send_recv_group(
+        # src_stage=next_stage, dest_stage=current_stage)
         #print("group msg:", group)
         paddle.distributed.recv(
-            tensor_recv_next, src=1, group=group, use_calc_stream=True)
+            tensor_recv_next,
+            src=1,
+            group=_hcg.recv_next_group,
+            use_calc_stream=True)
         #print("tensor_recv_next", tensor_recv_next.numpy())
 
     return tensor_recv_prev, tensor_recv_next

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -23,7 +23,7 @@ _tensor_shape = (2, 1024, 768)
 class SendRecvMeta:
     def __init__(self):
         self.send_shape_message = None
-        self.send_dtype_messgae = None
+        self.send_dtype_message = None
 
         self.recv_shape_message = None
         self.recv_dtype_message = None
@@ -31,51 +31,85 @@ class SendRecvMeta:
         self.has_send_meta = False
         self.has_recv_meta = False
 
+    def _recv_shape_dtype(self, group):
+        # recv len(shape)
+        dims = paddle.to_tensor([0])
+        paddle.distributed.recv(dims, src=0, group=group)
+        dims = dims.item()
+
+        # recv shape
+        shape = paddle.to_tensor([0] * dims)
+        paddle.distributed.recv(shape, src=0, group=group)
+
+        # recv dtype
+        dtype = paddle.to_tensor([0])
+        paddle.distributed.recv(dtype, src=0, group=group)
+        return shape.numpy().tolist(), dtype.item()
+
     def recv_meta(self, group):
         tensor_type = paddle.to_tensor([0])
         paddle.distributed.recv(tensor_type, src=0, group=group)
-
         tensor_type = tensor_type.item()
+
         if tensor_type == 0:
-            # recv len(shape)
-            dims = paddle.to_tensor([0])
-            paddle.distributed.recv(dims, src=0, group=group)
-            dims = dims.item()
-
-            # recv shape
-            shape = paddle.to_tensor([0] * dims)
-            paddle.distributed.recv(shape, src=0, group=group)
-            shape = shape.numpy().tolist()
-
-            # recv dtype
-            dtype = paddle.to_tensor([0])
-            paddle.distributed.recv(dtype, src=0, group=group)
-
+            shape, dtype = self._recv_shape_dtype(group)
             self.recv_shape_message = shape
-            self.recv_dtype_message = dtype.item()
+            self.recv_dtype_message = dtype
+
+        elif tensor_type == 1:
+            num = paddle.to_tensor([0])
+            paddle.distributed.recv(num, src=0, group=group)
+            num = num.item()
+            shapes = []
+            dtypes = []
+            for i in range(num):
+                shape, dtype = self._recv_shape_dtype()
+                shapes.append(shape)
+                dtypes.append(dtype)
+
+            self.recv_shape_message = tuple(shapes)
+            self.recv_dtype_message = tuple(dtypes)
+
+    def _send_dims_shape_dtype(self, tensor, group):
+        # send len(shape)
+        dims = paddle.to_tensor(len(tensor.shape))
+        paddle.distributed.send(dims, dst=1, group=group)
+
+        # send shape
+        shape = paddle.to_tensor(tensor.shape)
+        paddle.distributed.send(shape, dst=1, group=group)
+
+        # send dtype
+        dtype = paddle.to_tensor(paddle_2_number(tensor.dtype))
+        paddle.distributed.send(dtype, dst=1, group=group)
 
     def send_meta(self, tensor, group):
         if isinstance(tensor, paddle.Tensor):
             tensor_type = paddle.to_tensor([0])
-
             # send tensor type
             paddle.distributed.send(tensor_type, dst=1, group=group)
 
-            # send len(shape)
-            dims = paddle.to_tensor(len(tensor.shape))
-            paddle.distributed.send(dims, dst=1, group=group)
+            self._send_dims_shape_dtype(tensor, group)
+        elif isinstance(tensor, tuple):
+            tensor_type = paddle.to_tensor([1])
+            # send tensor type
+            paddle.distributed.send(tensor_type, dst=1, group=group)
 
-            # send shape
-            shape = paddle.to_tensor(tensor.shape)
-            paddle.distributed.send(shape, dst=1, group=group)
+            nums = paddle.to_tensor(len(tensor))
+            paddle.distributed.send(nums, dst=1, group=group)
 
-            # send dtype
-            dtype = paddle.to_tensor(paddle_2_number(tensor.dtype))
-            paddle.distributed.send(dtype, dst=1, group=group)
+            for d in tensor:
+                assert isinstance(d, paddle.Tensor)
+                self._send_dims_shape_dtype(d)
 
     def set_send_message(self, tensor):
-        self.send_shape_message = tensor.shape
-        self.send_dtype_message = paddle_2_number(tensor.dtype)
+        if isinstance(tensor, paddle.Tensor):
+            self.send_shape_message = tensor.shape
+            self.send_dtype_message = paddle_2_number(tensor.dtype)
+        elif isinstance(tensor, tuple):
+            self.send_shape_message = tuple([d.shape for d in tensor])
+            self.send_dtype_message = tuple(
+                [paddle_2_number(d.dtype) for d in tensor])
 
 
 _send_recv_meta = SendRecvMeta()
@@ -86,100 +120,90 @@ def initialize_p2p_groups(hcg):
     _hcg = hcg
 
 
-def send(tensor, dest_stage):
-    global _groups, _hcg
-    src_stage = _hcg.get_stage_id()
-    _is_valid_communciate(src_stage, dest_stage)
-    group = _get_send_recv_group(src_stage, dest_stage)
-    return paddle.distributed.send(
-        tensor, dst=1 if dest_stage > src_stage else 0, group=group)
-
-
-def recv(tensor, src_stage):
-    global _groups, _hcg
-    dest_stage = _hcg.get_stage_id()
-
-    _is_valid_communciate(src_stage, dest_stage)
-    group = _get_send_recv_group(src_stage, dest_stage)
-    return paddle.distributed.recv(
-        tensor, src=0 if dest_stage > src_stage else 1, group=group)
-
-
-def _get_send_recv_group(src_stage, dest_stage):
-    global _groups, _hcg
-    stage_id = None
-    first_stage = 0
-    last_stage = _hcg.get_pipe_parallel_world_size() - 1
-    group_id = _hcg.get_rank_from_stage(stage_id=src_stage)
-    return _groups[group_id]
-
-
 def _communicate(tensor_send_next, tensor_send_prev, recv_prev, recv_next):
+    global _groups, _hcg
 
     tensor_recv_prev = None
     tensor_recv_next = None
 
-    global _tensor_shape, _groups, _hcg
-    tensor_chunk_shape = _tensor_shape
-    dtype = "float32"
-
-    current_stage = _hcg.get_stage_id()
-    prev_stage = current_stage - 1
-    next_stage = current_stage + 1
+    recv_shape_msg = _send_recv_meta.recv_shape_message
+    recv_dtype_msg = _send_recv_meta.recv_dtype_message
+    send_shape_msg = _send_recv_meta.send_shape_message
+    send_dtype_msg = _send_recv_meta.send_dtype_message
 
     if recv_prev:
-        # tensor_recv_prev = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
-        tensor_recv_prev = paddle.empty(
-            shape=_send_recv_meta.recv_shape_message,
-            dtype=number_2_dtype(_send_recv_meta.recv_dtype_message))
+        if isinstance(recv_shape_msg, tuple):
+            for idx, shape in enumerate(recv_shape_msg):
+                tensor_recv_prev = tuple([
+                    paddle.empty(
+                        shape=shape, dtype=number_2_dtype(recv_dtype_msg[idx]))
+                ])
+        else:
+            tensor_recv_prev = paddle.empty(
+                shape=recv_shape_msg, dtype=number_2_dtype(recv_dtype_msg))
 
     if recv_next:
-        # tensor_recv_next = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
-        tensor_recv_next = paddle.empty(
-            shape=_send_recv_meta.send_shape_message,
-            dtype=number_2_dtype(_send_recv_meta.send_dtype_message))
+        if isinstance(send_shape_msg, tuple):
+            for idx, shape in enumerate(send_shape_msg):
+                tensor_recv_next = tuple([
+                    paddle.empty(
+                        shape=shape, dtype=number_2_dtype(send_dtype_msg[idx]))
+                ])
+        else:
+            tensor_recv_next = paddle.empty(
+                shape=send_shape_msg, dtype=number_2_dtype(send_dtype_msg))
 
     if tensor_send_prev is not None:
-        # group = _get_send_recv_group(
-        # src_stage=current_stage, dest_stage=prev_stage)
-        #print("group msg:", group)
-        paddle.distributed.wait(tensor_send_prev, use_calc_stream=True)
-        paddle.distributed.send(
-            tensor_send_prev,
-            dst=0,
-            group=_hcg.send_prev_group,
-            use_calc_stream=False)
+        if isinstance(tensor_send_prev, tuple):
+            for d in tensor_send_prev:
+                paddle.distributed.wait(d, use_calc_stream=True)
+                paddle.distributed.send(
+                    d, dst=0, group=_hcg.send_prev_group, use_calc_stream=False)
+        else:
+            paddle.distributed.wait(tensor_send_prev, use_calc_stream=True)
+            paddle.distributed.send(
+                tensor_send_prev,
+                dst=0,
+                group=_hcg.send_prev_group,
+                use_calc_stream=False)
+
     if tensor_recv_prev is not None:
-        # group = _get_send_recv_group(
-        # src_stage=prev_stage, dest_stage=current_stage)
-        #print("group msg:", group)
-        paddle.distributed.recv(
-            tensor_recv_prev,
-            src=0,
-            group=_hcg.recv_prev_group,
-            use_calc_stream=True)
-        #print("tensor_recv_prev", tensor_recv_prev.numpy())
+        if isinstance(tensor_recv_prev, tuple):
+            for d in tensor_recv_prev:
+                paddle.distributed.recv(
+                    d, src=0, group=_hcg.recv_prev_group, use_calc_stream=True)
+        else:
+            paddle.distributed.recv(
+                tensor_recv_prev,
+                src=0,
+                group=_hcg.recv_prev_group,
+                use_calc_stream=True)
 
     if tensor_send_next is not None:
-        # group = _get_send_recv_group(
-        # src_stage=current_stage, dest_stage=next_stage)
-        #print("group msg:", group)
-        paddle.distributed.wait(tensor_send_next, use_calc_stream=True)
-        paddle.distributed.send(
-            tensor_send_next,
-            dst=1,
-            group=_hcg.send_next_group,
-            use_calc_stream=False)
+        if isinstance(tensor_send_next, tuple):
+            for d in tensor_send_next:
+                paddle.distributed.wait(d, use_calc_stream=True)
+                paddle.distributed.send(
+                    d, dst=1, group=_hcg.send_next_group, use_calc_stream=False)
+        else:
+            paddle.distributed.wait(tensor_send_next, use_calc_stream=True)
+            paddle.distributed.send(
+                tensor_send_next,
+                dst=1,
+                group=_hcg.send_next_group,
+                use_calc_stream=False)
+
     if tensor_recv_next is not None:
-        # group = _get_send_recv_group(
-        # src_stage=next_stage, dest_stage=current_stage)
-        #print("group msg:", group)
-        paddle.distributed.recv(
-            tensor_recv_next,
-            src=1,
-            group=_hcg.recv_next_group,
-            use_calc_stream=True)
-        #print("tensor_recv_next", tensor_recv_next.numpy())
+        if isinstance(tensor_recv_next, tuple):
+            for d in tensor_recv_next:
+                paddle.distributed.recv(
+                    d, src=1, group=_hcg.recv_next_group, use_calc_stream=True)
+        else:
+            paddle.distributed.recv(
+                tensor_recv_next,
+                src=1,
+                group=_hcg.recv_next_group,
+                use_calc_stream=True)
 
     return tensor_recv_prev, tensor_recv_next
 
@@ -188,7 +212,6 @@ def recv_forward():
     if _hcg.is_first_stage:
         input_tensor = None
     else:
-        # check recv forward
         if not _send_recv_meta.has_recv_meta:
             _send_recv_meta.recv_meta(_hcg.recv_prev_group)
             _send_recv_meta.has_recv_meta = True
@@ -215,7 +238,6 @@ def recv_backward():
 
 def send_forward(output_tensor):
     if not _hcg.is_last_stage:
-
         if not _send_recv_meta.has_send_meta:
             _send_recv_meta.set_send_message(output_tensor)
             _send_recv_meta.send_meta(output_tensor, _hcg.send_next_group)
@@ -241,11 +263,6 @@ def send_forward_recv_backward(output_tensor):
     if _hcg.is_last_stage:
         output_tensor_grad = None
     else:
-        if not _send_recv_meta.has_send_meta:
-            _send_recv_meta.set_send_message(output_tensor)
-            _send_recv_meta.send_meta(output_tensor, _hcg.send_next_group)
-            _send_recv_meta.has_send_meta = True
-
         _, output_tensor_grad = _communicate(
             tensor_send_next=output_tensor,
             tensor_send_prev=None,

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -14,7 +14,7 @@
 
 import paddle
 from .utils import paddle_2_number, number_2_dtype
-from ...utils import log_util as logger
+from ...utils.log_util import logger
 
 _hcg = None
 

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -14,8 +14,22 @@
 
 import paddle
 from .utils import paddle_2_number, number_2_dtype
+from ...utils import log_util as logger
 
 _hcg = None
+_send_recv_meta = SendRecvMeta()
+
+
+def initialize_p2p_groups(hcg):
+    global _hcg
+    _hcg = hcg
+    send_next_group, send_prev_group, recv_next_group, recv_prev_group = _hcg.get_p2p_groups(
+    )
+
+    debug_str = "P2pInfo: send_next_group: %s, send_prev_group: %s, " \
+                    "recv_next_group: %s, recv_prev_group: %s" % (repr(send_next_group),
+                    repr(send_prev_group),repr(recv_next_group), repr(recv_prev_group))
+    logger.info(debug_str)
 
 
 class SendRecvMeta:
@@ -113,9 +127,6 @@ class SendRecvMeta:
                 [paddle_2_number(d.dtype) for d in tensor])
 
 
-_send_recv_meta = SendRecvMeta()
-
-
 def send_partial(tensor,
                  dst=0,
                  nranks=1,
@@ -160,11 +171,6 @@ def allgather_partial(tensor,
     return paddle.fluid.core.ops.partial_allgather_(
         tensor, 'use_calc_stream', use_calc_stream, 'ring_id', ring_id,
         'nranks', nranks, 'rank', rank_id)
-
-
-def initialize_p2p_groups(hcg):
-    global _hcg
-    _hcg = hcg
 
 
 def _p2p_helper(tensor_send_next, tensor_send_prev, recv_prev, recv_next):

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import paddle
-from .utils import is_float_tensor, get_tensor_dtype, paddle_2_number, number_2_dtype
+from .utils import paddle_2_number, number_2_dtype
 
 _hcg = None
 
 
 class SendRecvMeta:
+    """Mainly used to help p2p communication context information"""
+
     def __init__(self):
         self.send_shape_message = None
         self.send_dtype_message = None
@@ -263,7 +265,6 @@ def _p2p_helper(tensor_send_next, tensor_send_prev, recv_prev, recv_next):
         if isinstance(tensor_send_next, tuple):
             for d in tensor_send_next:
                 paddle.distributed.wait(d, use_calc_stream=True)
-
                 send_partial(
                     d,
                     dst=1,

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -16,6 +16,7 @@ import paddle
 
 _groups = None
 _hcg = None
+_tensor_shape = (2, 1024, 768)
 
 
 def initialize_p2p_groups(hcg):
@@ -132,12 +133,172 @@ def _get_send_recv_group(src_stage, dest_stage):
     stage_id = None
     first_stage = 0
     last_stage = _hcg.get_pipe_parallel_world_size() - 1
-    if (src_stage == first_stage and dest_stage == last_stage) or \
-            (dest_stage == first_stage and src_stage == last_stage):
-        stage_id = last_stage
-    elif src_stage > dest_stage:
-        stage_id = dest_stage
-    else:
-        stage_id = src_stage
-    group_id = _hcg.get_rank_from_stage(stage_id=stage_id)
+    #if (src_stage == first_stage and dest_stage == last_stage) or \
+    #        (dest_stage == first_stage and src_stage == last_stage):
+    #    stage_id = last_stage
+    #if src_stage > dest_stage:
+    #    stage_id = dest_stage
+    #else:
+    #    stage_id = src_stage
+    #group_id = _hcg.get_rank_from_stage(stage_id=stage_id)
+    group_id = _hcg.get_rank_from_stage(stage_id=src_stage)
     return _groups[group_id]
+
+
+def _communicate(tensor_send_next, tensor_send_prev, recv_prev, recv_next):
+
+    tensor_recv_prev = None
+    tensor_recv_next = None
+
+    global _tensor_shape, _groups, _hcg
+    tensor_chunk_shape = _tensor_shape
+    dtype = "float32"
+
+    current_stage = _hcg.get_stage_id()
+    prev_stage = current_stage - 1
+    next_stage = current_stage + 1
+
+    if recv_prev:
+        tensor_recv_prev = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
+    if recv_next:
+        tensor_recv_next = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
+
+    if tensor_send_prev is not None:
+        group = _get_send_recv_group(
+            src_stage=current_stage, dest_stage=prev_stage)
+        #print("group msg:", group)
+        paddle.distributed.wait(tensor_send_prev, use_calc_stream=True)
+        paddle.distributed.send(
+            tensor_send_prev, dst=0, group=group, use_calc_stream=False)
+    if tensor_recv_prev is not None:
+        group = _get_send_recv_group(
+            src_stage=prev_stage, dest_stage=current_stage)
+        #print("group msg:", group)
+        paddle.distributed.recv(
+            tensor_recv_prev, src=0, group=group, use_calc_stream=True)
+        #print("tensor_recv_prev", tensor_recv_prev.numpy())
+
+    if tensor_send_next is not None:
+        group = _get_send_recv_group(
+            src_stage=current_stage, dest_stage=next_stage)
+        #print("group msg:", group)
+        paddle.distributed.wait(tensor_send_next, use_calc_stream=True)
+        paddle.distributed.send(
+            tensor_send_next, dst=1, group=group, use_calc_stream=False)
+    if tensor_recv_next is not None:
+        group = _get_send_recv_group(
+            src_stage=next_stage, dest_stage=current_stage)
+        #print("group msg:", group)
+        paddle.distributed.recv(
+            tensor_recv_next, src=1, group=group, use_calc_stream=True)
+        #print("tensor_recv_next", tensor_recv_next.numpy())
+
+    return tensor_recv_prev, tensor_recv_next
+
+
+def recv_forward():
+    if _hcg.is_first_stage:
+        input_tensor = None
+    else:
+        input_tensor, _ = _communicate(
+            tensor_send_next=None,
+            tensor_send_prev=None,
+            recv_prev=True,
+            recv_next=False)
+    return input_tensor
+
+
+def recv_backward():
+    if _hcg.is_last_stage:
+        output_tensor_grad = None
+    else:
+        _, output_tensor_grad = _communicate(
+            tensor_send_next=None,
+            tensor_send_prev=None,
+            recv_prev=False,
+            recv_next=True)
+    return output_tensor_grad
+
+
+def send_forward(output_tensor):
+    if not _hcg.is_last_stage:
+        _communicate(
+            tensor_send_next=output_tensor,
+            tensor_send_prev=None,
+            recv_prev=False,
+            recv_next=False)
+
+
+def send_backward(input_tensor_grad):
+    if not _hcg.is_first_stage:
+        _communicate(
+            tensor_send_next=None,
+            tensor_send_prev=input_tensor_grad,
+            recv_prev=False,
+            recv_next=False)
+
+
+def send_forward_recv_backward(output_tensor):
+    if _hcg.is_last_stage:
+        output_tensor_grad = None
+    else:
+        _, output_tensor_grad = _communicate(
+            tensor_send_next=output_tensor,
+            tensor_send_prev=None,
+            recv_prev=False,
+            recv_next=True)
+    return output_tensor_grad
+
+
+def send_backward_recv_forward(input_tensor_grad):
+    if _hcg.is_first_stage:
+        input_tensor = None
+    else:
+        input_tensor, _ = _communicate(
+            tensor_send_next=None,
+            tensor_send_prev=input_tensor_grad,
+            recv_prev=True,
+            recv_next=False)
+    return input_tensor
+
+
+# def send_forward_recv_forward(output_tensor, recv_prev, timers=None):
+#     """Batched recv from previous rank and send to next rank in pipeline."""
+#     if timers is not None:
+#         timers('forward-send-forward-recv').start()
+#     input_tensor, _ = _communicate(
+#         tensor_send_next=output_tensor,
+#         tensor_send_prev=None,
+#         recv_prev=recv_prev,
+#         recv_next=False)
+#     if timers is not None:
+#         timers('forward-send-forward-recv').stop()
+#     return input_tensor
+
+# def send_backward_recv_backward(input_tensor_grad, recv_next, timers=None):
+#     """Batched recv from next rank and send to previous rank in pipeline."""
+#     if timers is not None:
+#         timers('backward-send-backward-recv').start()
+#     _, output_tensor_grad = _communicate(
+#         tensor_send_next=None,
+#         tensor_send_prev=input_tensor_grad,
+#         recv_prev=False,
+#         recv_next=recv_next)
+#     if timers is not None:
+#         timers('backward-send-backward-recv').stop()
+#     return output_tensor_grad
+
+# def send_forward_backward_recv_forward_backward(
+#         output_tensor, input_tensor_grad, recv_prev,
+#         recv_next, timers=None):
+#     """Batched send and recv with previous and next ranks in pipeline."""
+#     if timers is not None:
+#         timers('forward-backward-send-forward-backward-recv').start()
+#     input_tensor, output_tensor_grad = _communicate(
+#         tensor_send_next=output_tensor,
+#         tensor_send_prev=input_tensor_grad,
+#         recv_prev=recv_prev,
+#         recv_next=recv_next)
+#     if timers is not None:
+#         timers('forward-backward-send-forward-backward-recv').stop()
+#     return input_tensor, output_tensor_grad

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -13,73 +13,77 @@
 # limitations under the License.
 
 import paddle
+from .utils import is_float_tensor, get_tensor_dtype, paddle_2_number, number_2_dtype
 
 _groups = None
 _hcg = None
 _tensor_shape = (2, 1024, 768)
 
 
+class SendRecvMeta:
+    def __init__(self):
+        self.send_shape_message = None
+        self.send_dtype_messgae = None
+
+        self.recv_shape_message = None
+        self.recv_dtype_message = None
+
+        self.has_send_meta = False
+        self.has_recv_meta = False
+
+    def recv_meta(self, group):
+        tensor_type = paddle.to_tensor([0])
+        paddle.distributed.recv(tensor_type, src=0, group=group)
+
+        tensor_type = tensor_type.item()
+        if tensor_type == 0:
+            # recv len(shape)
+            dims = paddle.to_tensor([0])
+            paddle.distributed.recv(dims, src=0, group=group)
+            dims = dims.item()
+
+            # recv shape
+            shape = paddle.to_tensor([0] * dims)
+            paddle.distributed.recv(shape, src=0, group=group)
+            shape = shape.numpy().tolist()
+
+            # recv dtype
+            dtype = paddle.to_tensor([0])
+            paddle.distributed.recv(dtype, src=0, group=group)
+
+            self.recv_shape_message = shape
+            self.recv_dtype_message = dtype.item()
+
+    def send_meta(self, tensor, group):
+        if isinstance(tensor, paddle.Tensor):
+            tensor_type = paddle.to_tensor([0])
+
+            # send tensor type
+            paddle.distributed.send(tensor_type, dst=1, group=group)
+
+            # send len(shape)
+            dims = paddle.to_tensor(len(tensor.shape))
+            paddle.distributed.send(dims, dst=1, group=group)
+
+            # send shape
+            shape = paddle.to_tensor(tensor.shape)
+            paddle.distributed.send(shape, dst=1, group=group)
+
+            # send dtype
+            dtype = paddle.to_tensor(paddle_2_number(tensor.dtype))
+            paddle.distributed.send(dtype, dst=1, group=group)
+
+    def set_send_message(self, tensor):
+        self.send_shape_message = tensor.shape
+        self.send_dtype_message = paddle_2_number(tensor.dtype)
+
+
+_send_recv_meta = SendRecvMeta()
+
+
 def initialize_p2p_groups(hcg):
     global _groups, _hcg
-    # _groups = [
-    #     paddle.distributed.new_group(ranks=group)
-    #     for group in hcg.get_p2p_groups()
-    # ]
     _hcg = hcg
-
-
-def _is_valid_communciate(src_stage, dest_stage):
-    first_stage = 0
-    last_stage = _hcg.get_pipe_parallel_world_size() - 1
-    assert abs(src_stage-dest_stage) == 1 or \
-        (src_stage == first_stage and dest_stage == last_stage) or \
-        (src_stage == last_stage and dest_stage == first_stage)
-
-
-def partial_send_operator(tensor,
-                          dst=0,
-                          mp_ranks=1,
-                          mp_rank_id=0,
-                          group=None,
-                          use_calc_stream=True):
-
-    if group is not None and not group.is_member():
-        return
-    ring_id = 0 if group is None else group.id
-    return paddle.fluid.core.ops.partial_send(
-        tensor, 'use_calc_stream', use_calc_stream, 'ring_id', ring_id, 'peer',
-        dst, 'num', mp_ranks, 'id', mp_rank_id)
-
-
-def partial_recv_operator(tensor,
-                          src=0,
-                          mp_ranks=1,
-                          mp_rank_id=0,
-                          group=None,
-                          use_calc_stream=True):
-
-    if group is not None and not group.is_member():
-        return
-    ring_id = 0 if group is None else group.id
-
-    return paddle.fluid.core.ops.partial_recv(
-        tensor, 'use_calc_stream', use_calc_stream, 'ring_id', ring_id, 'peer',
-        src, 'num', mp_ranks, 'id', mp_rank_id, 'dtype', tensor.dtype,
-        'out_shape', tensor.shape)
-
-
-def partial_allgather_operator(tensor,
-                               mp_ranks=1,
-                               mp_rank_id=0,
-                               group=None,
-                               use_calc_stream=True):
-    if group is not None and not group.is_member():
-        return
-    ring_id = 0 if group is None else group.id
-
-    return paddle.fluid.core.ops.partial_allgather_(
-        tensor, 'use_calc_stream', use_calc_stream, 'ring_id', ring_id,
-        'nranks', mp_ranks, 'rank', mp_rank_id)
 
 
 def send(tensor, dest_stage):
@@ -101,46 +105,11 @@ def recv(tensor, src_stage):
         tensor, src=0 if dest_stage > src_stage else 1, group=group)
 
 
-def send_partial(tensor, dest_stage, mp_degree, mp_rank):
-    global _groups, _hcg
-    src_stage = _hcg.get_stage_id()
-    _is_valid_communciate(src_stage, dest_stage)
-    group = _get_send_recv_group(src_stage, dest_stage)
-    return partial_send_operator(
-        tensor,
-        dst=1 if dest_stage > src_stage else 0,
-        mp_ranks=mp_degree,
-        mp_rank_id=mp_rank,
-        group=group)
-
-
-def recv_partial(tensor, src_stage, mp_degree, mp_rank):
-    global _groups, _hcg
-    dest_stage = _hcg.get_stage_id()
-
-    _is_valid_communciate(src_stage, dest_stage)
-    group = _get_send_recv_group(src_stage, dest_stage)
-    return partial_recv_operator(
-        tensor,
-        src=0 if dest_stage > src_stage else 1,
-        mp_ranks=mp_degree,
-        mp_rank_id=mp_rank,
-        group=group)
-
-
 def _get_send_recv_group(src_stage, dest_stage):
     global _groups, _hcg
     stage_id = None
     first_stage = 0
     last_stage = _hcg.get_pipe_parallel_world_size() - 1
-    #if (src_stage == first_stage and dest_stage == last_stage) or \
-    #        (dest_stage == first_stage and src_stage == last_stage):
-    #    stage_id = last_stage
-    #if src_stage > dest_stage:
-    #    stage_id = dest_stage
-    #else:
-    #    stage_id = src_stage
-    #group_id = _hcg.get_rank_from_stage(stage_id=stage_id)
     group_id = _hcg.get_rank_from_stage(stage_id=src_stage)
     return _groups[group_id]
 
@@ -159,9 +128,16 @@ def _communicate(tensor_send_next, tensor_send_prev, recv_prev, recv_next):
     next_stage = current_stage + 1
 
     if recv_prev:
-        tensor_recv_prev = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
+        # tensor_recv_prev = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
+        tensor_recv_prev = paddle.empty(
+            shape=_send_recv_meta.recv_shape_message,
+            dtype=number_2_dtype(_send_recv_meta.recv_dtype_message))
+
     if recv_next:
-        tensor_recv_next = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
+        # tensor_recv_next = paddle.empty(shape=tensor_chunk_shape, dtype=dtype)
+        tensor_recv_next = paddle.empty(
+            shape=_send_recv_meta.send_shape_message,
+            dtype=number_2_dtype(_send_recv_meta.send_dtype_message))
 
     if tensor_send_prev is not None:
         # group = _get_send_recv_group(
@@ -212,6 +188,11 @@ def recv_forward():
     if _hcg.is_first_stage:
         input_tensor = None
     else:
+        # check recv forward
+        if not _send_recv_meta.has_recv_meta:
+            _send_recv_meta.recv_meta(_hcg.recv_prev_group)
+            _send_recv_meta.has_recv_meta = True
+
         input_tensor, _ = _communicate(
             tensor_send_next=None,
             tensor_send_prev=None,
@@ -234,6 +215,12 @@ def recv_backward():
 
 def send_forward(output_tensor):
     if not _hcg.is_last_stage:
+
+        if not _send_recv_meta.has_send_meta:
+            _send_recv_meta.set_send_message(output_tensor)
+            _send_recv_meta.send_meta(output_tensor, _hcg.send_next_group)
+            _send_recv_meta.has_send_meta = True
+
         _communicate(
             tensor_send_next=output_tensor,
             tensor_send_prev=None,
@@ -254,6 +241,11 @@ def send_forward_recv_backward(output_tensor):
     if _hcg.is_last_stage:
         output_tensor_grad = None
     else:
+        if not _send_recv_meta.has_send_meta:
+            _send_recv_meta.set_send_message(output_tensor)
+            _send_recv_meta.send_meta(output_tensor, _hcg.send_next_group)
+            _send_recv_meta.has_send_meta = True
+
         _, output_tensor_grad = _communicate(
             tensor_send_next=output_tensor,
             tensor_send_prev=None,
@@ -272,45 +264,3 @@ def send_backward_recv_forward(input_tensor_grad):
             recv_prev=True,
             recv_next=False)
     return input_tensor
-
-
-# def send_forward_recv_forward(output_tensor, recv_prev, timers=None):
-#     """Batched recv from previous rank and send to next rank in pipeline."""
-#     if timers is not None:
-#         timers('forward-send-forward-recv').start()
-#     input_tensor, _ = _communicate(
-#         tensor_send_next=output_tensor,
-#         tensor_send_prev=None,
-#         recv_prev=recv_prev,
-#         recv_next=False)
-#     if timers is not None:
-#         timers('forward-send-forward-recv').stop()
-#     return input_tensor
-
-# def send_backward_recv_backward(input_tensor_grad, recv_next, timers=None):
-#     """Batched recv from next rank and send to previous rank in pipeline."""
-#     if timers is not None:
-#         timers('backward-send-backward-recv').start()
-#     _, output_tensor_grad = _communicate(
-#         tensor_send_next=None,
-#         tensor_send_prev=input_tensor_grad,
-#         recv_prev=False,
-#         recv_next=recv_next)
-#     if timers is not None:
-#         timers('backward-send-backward-recv').stop()
-#     return output_tensor_grad
-
-# def send_forward_backward_recv_forward_backward(
-#         output_tensor, input_tensor_grad, recv_prev,
-#         recv_next, timers=None):
-#     """Batched send and recv with previous and next ranks in pipeline."""
-#     if timers is not None:
-#         timers('forward-backward-send-forward-backward-recv').start()
-#     input_tensor, output_tensor_grad = _communicate(
-#         tensor_send_next=output_tensor,
-#         tensor_send_prev=input_tensor_grad,
-#         recv_prev=recv_prev,
-#         recv_next=recv_next)
-#     if timers is not None:
-#         timers('forward-backward-send-forward-backward-recv').stop()
-#     return input_tensor, output_tensor_grad

--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -17,7 +17,6 @@ from .utils import paddle_2_number, number_2_dtype
 from ...utils import log_util as logger
 
 _hcg = None
-_send_recv_meta = SendRecvMeta()
 
 
 def initialize_p2p_groups(hcg):
@@ -125,6 +124,9 @@ class SendRecvMeta:
                 [d.shape for d in tensor if not d.stop_gradient])
             self.send_dtype_message = tuple(
                 [paddle_2_number(d.dtype) for d in tensor])
+
+
+_send_recv_meta = SendRecvMeta()
 
 
 def send_partial(tensor,

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_transformer.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_transformer.py
@@ -1,0 +1,187 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+import paddle
+import numpy as np
+import random
+import paddle
+import paddle.distributed as dist
+import paddle.distributed.fleet as fleet
+from hybrid_parallel_pp_layer import AlexNetPipeDesc, AlexNet
+from paddle.fluid.dygraph.layers import Layer
+from paddle.fluid import layers
+import paddle.nn.functional as F
+
+import paddle
+import numpy as np
+import random
+import paddle
+import paddle.distributed as dist
+import paddle.distributed.fleet as fleet
+from paddle.fluid.dygraph.container import Sequential
+from paddle.distributed.fleet.meta_parallel import PipelineLayer, LayerDesc
+from paddle.fluid.dygraph.layers import Layer
+import paddle.nn as nn
+import paddle.fluid as fluid
+
+
+def set_random_seed(seed, dp_id, rank_id):
+    """Set random seed for reproducability."""
+    random.seed(seed)
+    np.random.seed(seed + dp_id)
+    paddle.seed(seed + dp_id)
+
+
+batch_size = 4
+length = 8
+micro_batch_size = 2
+vocab_size = 128
+hidden_size = 3
+d_model = hidden_size
+dim_feedforward = 4 * d_model
+
+
+class EmbeddingNet(Layer):
+    def __init__(self):
+        super(EmbeddingNet, self).__init__()
+        self.word_embeddings = nn.Embedding(vocab_size, hidden_size)
+        self.position_embeddings = nn.Embedding(vocab_size, hidden_size)
+
+    def forward(self, x):
+        attention_mask = paddle.tensor.triu(
+            (paddle.ones(
+                (length, length), dtype="float32") * -1e9), 1)
+        attention_mask.stop_gradient = True
+        w_emb = self.word_embeddings(x)
+        p_emb = self.position_embeddings(x)
+
+        return w_emb, attention_mask, p_emb.detach()
+
+
+class TransformerNet(Layer):
+    def __init__(self):
+        super(TransformerNet, self).__init__()
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.k_proj = nn.Linear(d_model, d_model)
+        self.v_proj = nn.Linear(d_model, d_model)
+
+        self.norm1 = nn.LayerNorm(d_model, epsilon=1e-5)
+
+    def forward(self, x, mask):
+        q = self.q_proj(x)
+        k = self.k_proj(x)
+        v = self.v_proj(x)
+        product = layers.matmul(x=q, y=k, transpose_y=True, alpha=d_model**-0.5)
+
+        weights = F.softmax(product + mask)
+        weights = F.dropout(weights, 0.2)
+        tgt = layers.matmul(weights, v)
+        residual = tgt
+        tgt = self.norm1(tgt)
+        tgt = residual + tgt
+
+        out = self.linear2(F.gelu(self.linear1(tgt), approximate=True))
+        return out
+
+
+class EmbeddingPipe(EmbeddingNet):
+    def forward(self, x):
+        return super().forward(x)
+
+
+class TransformerNetPipe(TransformerNet):
+    def forward(self, args):
+        x, mask, p_emb = args[0], args[1], args[2]
+
+        output = super().forward(x, mask)
+        output = output + p_emb
+        mask.stop_gradient = True
+        return output, mask, p_emb
+
+
+class CriterionPipe(Layer):
+    def __init__(self):
+        super(CriterionPipe, self).__init__()
+
+    def forward(self, out, label):
+        loss = out.mean()
+        return loss
+
+
+class ModelPipe(PipelineLayer):
+    def __init__(self, topology):
+        self.descs = []
+        self.descs.append(LayerDesc(EmbeddingPipe))
+
+        for x in range(4):
+            self.descs.append(LayerDesc(TransformerNetPipe))
+
+        self.descs.append(lambda x: x[0])
+
+        super().__init__(
+            layers=self.descs, loss_fn=CriterionPipe(), topology=topology)
+
+
+class TestDistPPTraning(unittest.TestCase):
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.model_parallel_size = 1
+        self.data_parallel_size = 1
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": self.data_parallel_size,
+            "mp_degree": self.model_parallel_size,
+            "pp_degree": self.pipeline_parallel_size,
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": batch_size // micro_batch_size,
+            "micro_batch_size": micro_batch_size
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+
+    def test_pp_model(self):
+        hcg = fleet.get_hybrid_communicate_group()
+        word_size = hcg.get_model_parallel_world_size()
+        dp_id = hcg.get_data_parallel_rank()
+        pp_id = hcg.get_stage_id()
+        rank_id = dist.get_rank()
+        topology = hcg.topology()
+        set_random_seed(1024, dp_id, rank_id)
+
+        model = ModelPipe(topology)
+        scheduler = paddle.optimizer.lr.PiecewiseDecay(
+            boundaries=[2], values=[0.001, 0.002], verbose=True)
+        optimizer = paddle.optimizer.SGD(learning_rate=scheduler,
+                                         parameters=model.parameters())
+
+        model = fleet.distributed_model(model)
+        optimizer = fleet.distributed_optimizer(optimizer)
+
+        for step_id in range(5):
+            x_data = np.random.randint(0, vocab_size, size=[batch_size, length])
+            x = paddle.to_tensor(x_data)
+            x.stop_gradient = True
+            loss = model.train_batch([x, x], optimizer, scheduler)
+            print("loss: ", loss.numpy())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
@@ -33,6 +33,9 @@ class TestHybridPipeParallel(TestMultipleGpus):
     def test_pipeline_parallel(self):
         self.run_mnist_2gpu('hybrid_parallel_pp_amp.py')
 
+    def test_hybrid_parallel_transformer(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[HybridParallel]Support 1f1b for PipelineParallel

修改当前流水线并行的调度方式，采用更省显存的1f1b的调度方式,类似于Megatron的 https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/schedules.py。
具体的调度图如下：
![image](https://user-images.githubusercontent.com/19485646/127492500-43abbdde-8765-4dcd-8d98-acc13bf8aced.png)

<img src="https://user-images.githubusercontent.com/19485646/127494294-1121cea1-c6c7-4d86-8b4b-8996e23576f5.png" width="500">

GPT-117M模型，V100-32G，PP=8， mircrobatch=2
|  global batch  | 优化前显存 |优化后显存 |
|  ----  | ----  |----  |
|128  | OOM |5876 |
|512 | OOM |5882|
|1024  |OOM |5886 |