### PR TITLE
Optimization batch_norm forward on GPU.

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cu
+++ b/paddle/fluid/operators/batch_norm_op.cu
@@ -358,7 +358,6 @@ void BNForwardTrainingCLastFastInterface(
   }
 }
 
-// todo: need to rethink and refine.
 void SetBNConfigForNCHW(const int reduce_num, const int left_num,
                         bool *should_reduce_again, dim3 *block_dim,
                         dim3 *grid_dim) {

--- a/paddle/fluid/operators/batch_norm_op.cu
+++ b/paddle/fluid/operators/batch_norm_op.cu
@@ -741,7 +741,7 @@ void BNForwardTrainingNCHWFastInterface(
         reduce_num, epsilon, this_factor, mean_out, variance_out, saved_mean,
         saved_inv_variance);
 
-    // step-3: elementwisely update y:
+    // step-3: elementwisely update y.
     // y = scale * (x - mean) / sqrt(var) + bias
     const int block_size = 256;
     const int grid_size = (N * C * HxW + block_size - 1) / block_size;


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
OPs

### Describe
Optimize batch_norm op for forward on GPU.

1 Motivation：
Improve the performance of batch_norm forward  by hand-writing  kernels.

2 ctest结果：

test 291
    Start 291: test_batch_norm_op
1/2 Test 291: test_batch_norm_op ...............   Passed    6.04 sec
test 292
    Start 292: test_batch_norm_op_v2
2/2 Test 292: test_batch_norm_op_v2 ............   Passed    5.77 sec
The following tests passed:
	test_batch_norm_op
	test_batch_norm_op_v2
100% tests passed, 0 tests failed out of 2
Total Test time (real) =  11.88 sec


3 统计了op-benchmark batch_norm forward 的性能情况，性能数据如下：
环境：Driver API Version: 11.0, Runtime API Version: 10.1, cuDNN Version: 7.6.
统计量：gpu time of bn forward kernel (unit: ms)

(a) 动态图，与pytorch对比：

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{border:.5pt solid windowtext;}
.xl66
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;}
.xl67
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;}
.xl68
	{border:.5pt solid windowtext;
	background:#D0CECE;
	mso-pattern:black none;}
.xl69
	{border:.5pt solid windowtext;
	background:#FFF2CC;
	mso-pattern:black none;}
.xl70
	{border:.5pt solid windowtext;
	background:#E2EFDA;
	mso-pattern:black none;}
.xl71
	{border:.5pt solid windowtext;
	background:#DDEBF7;
	mso-pattern:black none;}
.xl72
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;
	background:#E2EFDA;
	mso-pattern:black none;}
.xl73
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;
	background:#DDEBF7;
	mso-pattern:black none;}
.xl74
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;
	background:#FFF2CC;
	mso-pattern:black none;}
.xl75
	{color:red;
	mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;}
.xl76
	{mso-number-format:"0\.00_ ";}
.xl77
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#E2EFDA;
	mso-pattern:black none;}
.xl78
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#DDEBF7;
	mso-pattern:black none;}
.xl79
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#FFF2CC;
	mso-pattern:black none;}
.xl80
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#D0CECE;
	mso-pattern:black none;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#0563C1" vlink="#954F72">



fp32，NCHW |   | paddle-rocm | pytorch | paddle-cudnn | paddle-opt-without-fastdiv | paddle-opt-with-fastdiv | pytorch/paddle-without | cudnn/paddle-without
-- | -- | -- | -- | -- | -- | -- | -- | --
  | config-2 | 554.94 | 546.01 | 543.01 | 580.90 | 577.91 | 0.94 | 0.93
  | config-4 | 3566.98 | 736.00 | 760.45 | 523.12 | 537.12 | 1.41 | 1.45
  |   |   |   |   |   |   |   |  
  |   | paddle-rocm | pytorch | paddle-cudnn | paddle-opt | pytorch/paddle-opt | cudnn/paddle-opt |  
fp32，NC | config-0 | 3.68 | 8.90 | 5.09 | 3.67 | 2.42 | 1.39 |  
  | config-1 | 145.95 | 12.13 | 12.52 | 8.83 | 1.37 | 1.42 |  
  | config-3 | 3.80 | 5.92 | 5.02 | 3.15 | 1.88 | 1.60 |  



</body>

</html>


(b) 静态图，与tf相比

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/limin29/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-number-format:General;
	text-align:general;
	vertical-align:middle;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{border:.5pt solid windowtext;}
.xl66
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;}
.xl67
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;}
.xl68
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;
	background:#E2EFDA;
	mso-pattern:black none;}
.xl69
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;
	background:#DDEBF7;
	mso-pattern:black none;}
.xl70
	{mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;
	background:#FFF2CC;
	mso-pattern:black none;}
.xl71
	{color:red;
	mso-number-format:"0\.00_ ";
	text-align:left;
	border:.5pt solid windowtext;}
.xl72
	{mso-number-format:"0\.00_ ";}
.xl73
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#E2EFDA;
	mso-pattern:black none;}
.xl74
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#DDEBF7;
	mso-pattern:black none;}
.xl75
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#FFF2CC;
	mso-pattern:black none;}
.xl76
	{mso-number-format:"0\.00_ ";
	border:.5pt solid windowtext;
	background:#D0CECE;
	mso-pattern:black none;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:等线;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#0563C1" vlink="#954F72">



  |   |   |   | 不开环境变量 | 打开环境变量 |   |   |   |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
  |   | paddle-rocm | tf | paddle-cudnn | paddle-cudnn-persist-bn | paddle-opt | tf/paddle-opt | cudnn/paddle | cudnn-persist-bn/paddle
fp16，NHWC | config-0 | 3.82 | 23.23 | 6.31 | 7.94 | 3.82 | 6.09 | 1.65 | 2.08
  | config-1 | 112.74 | 37.14 | 17.81 | 27.89 | 7.45 | 4.98 | 2.39 | 3.74
  | config-2 | 10382.34 | 1338.50 | 26222.76 | 243.47 | 283.52 | 4.72 | 92.49 | 0.86
  | config-3 | 3.29 | 23.05 | 6.42 | 7.92 | 3.83 | 6.02 | 1.68 | 2.07
  | config-4 | 3776.57 | 1909.10 | 8251.43 | 309.75 | 515.39 | 3.70 | 16.01 | 0.60



</body>

</html>


实验结果：
1) FP32-NCHW性能和Pytorch及其他竞品基本打平；
2) FP16-NHWC性能优于TF，优于未开『FLAGS_cudnn_batchnorm_spatial_persistent』环境变量时cudnn-bn的性能；但与开启『FLAGS_cudnn_batchnorm_spatial_persistent』环境变量cudnn-bn相比，仍有一些差距。该环境变量默认是不开启的。