### PR TITLE
Fix roll_op by avoiding DivisionByZeroError, test=develop

### DIFF
--- a/paddle/fluid/operators/roll_op.cu
+++ b/paddle/fluid/operators/roll_op.cu
@@ -80,9 +80,11 @@ class RollKernel<platform::CUDADeviceContext, T>
         int dim = dims[i] >= 0 ? dims[i] : dims[i] + input_dim.size();
         int64_t size = input_dim[dim];
 
-        shifts[i] = (shifts[i] % size + size) % size;
-        strides[i] = stride_dim[dim];
-        sizes[i] = size;
+        if (size != 0) {
+          shifts[i] = (shifts[i] % size + size) % size;
+          strides[i] = stride_dim[dim];
+          sizes[i] = size;
+        }
       }
     }
 
@@ -151,10 +153,11 @@ class RollGradKernel<platform::CUDADeviceContext, T>
       for (size_t i = 0; i < nums; i++) {
         int dim = dims[i] >= 0 ? dims[i] : dims[i] + input_dim.size();
         int64_t size = input_dim[dim];
-
-        shifts[i] = ((-shifts[i]) % size + size) % size;
-        strides[i] = stride_dim[dim];
-        sizes[i] = size;
+        if (size != 0) {
+          shifts[i] = ((-shifts[i]) % size + size) % size;
+          strides[i] = stride_dim[dim];
+          sizes[i] = size;
+        }
       }
     }
 

--- a/paddle/fluid/operators/roll_op.h
+++ b/paddle/fluid/operators/roll_op.h
@@ -30,6 +30,9 @@ inline void shift_along_dim(T* data, const DDim& input_dim, int64_t dim,
   if (dim < 0) {
     dim += input_dim.size();
   }
+  if (input_dim[dim] == 0) {
+    return;
+  }
   shift = shift % input_dim[dim];
   if (shift < 0) {
     shift += input_dim[dim];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix roll_op by avoiding DivisionByZeroError

Test Code (CPU / GPU) : 
![0f16a533dd13ebf4450727534f287062](https://user-images.githubusercontent.com/86215757/127597702-aa1e50ce-0361-4ab3-a470-7ab9ef768cc9.png)

CPU :
Result of Execution Before Fixing : 
![664cff708cbc3e1b5b286f2f18212570](https://user-images.githubusercontent.com/86215757/127597893-0cebd706-31b3-4b76-a9c7-fd6db2e020b2.png)

Result of Execution After Fixing : 
![0855f16ad44183057747aa4bf4453868](https://user-images.githubusercontent.com/86215757/127597963-59020b27-3f37-4185-979a-17b5b13b4123.png)

GPU : 
Result of Execution Before Fixing : 
![a68a42288f992170f1e7a962f2c02acf](https://user-images.githubusercontent.com/86215757/127597995-122d5fab-524e-4671-8a36-24f157c23e9e.png)

Result of Execution After Fixing : 
![7e8d1b06a413c596a44626ed7737ec05](https://user-images.githubusercontent.com/86215757/127598007-1c1f7c9d-3959-4584-95ac-7a2de79da24e.png)
