### PR TITLE
[hybrid] optimize pipeline performance with recompute and amp

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -944,6 +944,13 @@ def _append_backward_ops_with_checkpoints_(
         for op_desc in reversed(added_descs):
             grad_op_desc, op_grad_to_var = core.get_grad_op_desc(
                 op_desc, cpt.to_text(no_grad_dict[block.idx]), [])
+
+            # Set device for grad_op according to forward Op
+            if op_desc.has_attr(device_attr_name):
+                op_device = op_desc.attr(device_attr_name)
+                for g_op_desc in grad_op_desc:
+                    g_op_desc._set_attr(device_attr_name, op_device)
+
             for key in var_name_dict:
                 _rename_arg_(grad_op_desc, key, var_name_dict[key])
             grad_op_descs.extend(grad_op_desc)

--- a/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
@@ -150,6 +150,8 @@ gray_list = {
     'c_identity',
     'c_concat',
     'c_allreduce_sum',
+    'concat',
+    'split',
 }
 
 # The set of ops that don't support fp16 calculation

--- a/python/paddle/fluid/tests/unittests/test_fleet_pipeline_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_pipeline_meta_optimizer.py
@@ -14,6 +14,10 @@
 
 import unittest
 import paddle
+import paddle.fluid as fluid
+import paddle.static as static
+import paddle.distributed.fleet as fleet
+import paddle.distributed.fleet.base.role_maker as role_maker
 import os
 
 paddle.enable_static()
@@ -25,26 +29,34 @@ class TestFleetMetaOptimizer(unittest.TestCase):
         os.environ[
             "PADDLE_TRAINER_ENDPOINTS"] = "127.0.0.1:36001,127.0.0.1:36002"
 
-    def test_pipeline_optimizer(self):
-        import paddle.distributed.fleet as fleet
-        import paddle.distributed.fleet.base.role_maker as role_maker
-        role = role_maker.PaddleCloudRoleMaker(is_collective=True)
-        fleet.init(role)
-        with paddle.fluid.device_guard("gpu:0"):
+    def net(self):
+        with static.device_guard("gpu:0"):
             input_x = paddle.fluid.layers.data(
                 name="x", shape=[32], dtype='float32')
             input_y = paddle.fluid.layers.data(
                 name="y", shape=[1], dtype='int64')
+            input_z = paddle.fluid.layers.data(
+                name="z", shape=[1], dtype="float32")
+            with static.device_guard("gpu:all"):
+                input_z = input_z * 1.0
+                input_z.stop_gradient = True
             fc_1 = paddle.fluid.layers.fc(input=input_x, size=64, act='tanh')
+            fc_1 = fc_1 * input_z
 
-        with paddle.fluid.device_guard("gpu:1"):
+        with static.device_guard("gpu:1"):
             fc_2 = paddle.fluid.layers.fc(input=fc_1, size=64, act='tanh')
+            fc_2 = fc_2 * input_z
             prediction = paddle.fluid.layers.fc(input=[fc_2],
                                                 size=2,
                                                 act='softmax')
             cost = paddle.fluid.layers.cross_entropy(
                 input=prediction, label=input_y)
             avg_cost = paddle.fluid.layers.mean(x=cost)
+        return avg_cost
+
+    def test_pipeline_optimizer(self):
+        role = role_maker.PaddleCloudRoleMaker(is_collective=True)
+        fleet.init(role)
 
         strategy = paddle.distributed.fleet.DistributedStrategy()
         strategy.pipeline = True
@@ -53,9 +65,43 @@ class TestFleetMetaOptimizer(unittest.TestCase):
             'accumulate_steps': 2
         }
 
-        optimizer = paddle.fluid.optimizer.Adam(0.01)
-        optimizer = fleet.distributed_optimizer(optimizer, strategy=strategy)
-        optimizer.minimize(avg_cost)
+        train_prog, startup_prog = static.Program(), static.Program()
+        with static.program_guard(train_prog, startup_prog):
+            with fluid.unique_name.guard():
+                avg_cost = self.net()
+
+                optimizer = paddle.fluid.optimizer.Adam(0.01)
+                optimizer = fleet.distributed_optimizer(
+                    optimizer, strategy=strategy)
+                optimizer.minimize(avg_cost)
+
+    def test_pipeline_amp_optimizer(self):
+        """ test pipeline&amp with device:all """
+        role = role_maker.PaddleCloudRoleMaker(is_collective=True)
+        fleet.init(role)
+
+        strategy = paddle.distributed.fleet.DistributedStrategy()
+        strategy.amp = True
+        strategy.pipeline = True
+        strategy.pipeline_configs = {
+            'micro_batch_size': 1,
+            'accumulate_steps': 2
+        }
+
+        train_prog, startup_prog = static.Program(), static.Program()
+        with static.program_guard(train_prog, startup_prog):
+            with fluid.unique_name.guard():
+                avg_cost = self.net()
+
+                optimizer = paddle.fluid.optimizer.Adam(0.01)
+                optimizer = fleet.distributed_optimizer(
+                    optimizer, strategy=strategy)
+                optimizer.minimize(avg_cost)
+
+        ops = train_prog._pipeline_opt['section_program'].global_block().ops
+        ops = [op.type for op in ops]
+        self.assertEqual(ops.count('send_v2'), 1)
+        self.assertEqual(ops.count('recv_v2'), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
optimize pipeline performance with recompute and amp.
Main optimization points
1. Recompute doesn't set op_device attr to backward op, will led Pipeline send/recv sub grad.
![image](https://user-images.githubusercontent.com/10208305/128182658-0a256cc0-ea21-4eff-8774-87473a605602.png)
After we add op_device attr to recompute backward op, Pipeline send/recv is ok.
![image](https://user-images.githubusercontent.com/10208305/128182975-1a4bda94-1e04-4527-a90a-8fb3522a7e63.png)
2. Add concat and split into amp gray_list. Before we add, concat only run fp32.
![image](https://user-images.githubusercontent.com/10208305/128183538-e0557a30-f02b-4cb8-bff7-8f4e78ce34ef.png)
After we add concat into amp gray_list, concat can run will fp16 if inputs is fp16
![image](https://user-images.githubusercontent.com/10208305/128183617-e8b551f8-782d-4f16-a7d2-d3a1dce83875.png)
3. When use Pipeline, if op's device is all, this op will compute in all PipelineStage. While when we use AMP,  AMP will insert cast op after this device:all op, and cast op's device is not all, the Pipeline will send cast var.
![image](https://user-images.githubusercontent.com/10208305/128185271-3ac5c310-3c45-431e-b6ac-01dbfea60d16.png)
For optimize, we set this cast op as device:all if prev op is device:all, and Pipeline will not send this var.
![image](https://user-images.githubusercontent.com/10208305/128186048-7e7990d2-bf75-41fe-a8a4-ce39b0eb5cf6.png)

#### Performance test
Test with Ernie3.0,  "hidden_size": 4096,  "num_attention_heads": 128,  "num_hidden_layers": 76,  "num_sharing_layers": 64,
16cards 32G V100，mp=8, pp=2, amp, recompute, gbs=32, micro_bs=2
| develop(tokens/s) | PR(tokens/s) | improve |
| -- | -- | -- |
| 2164.5 | 2445.2 | 12.96% |