### PR TITLE
Fix Inference CE Error by Topo Order

### DIFF
--- a/paddle/fluid/framework/ir/graph.cc
+++ b/paddle/fluid/framework/ir/graph.cc
@@ -17,7 +17,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/ir/graph.h"
 #include "paddle/fluid/framework/operator.h"
 
-DEFINE_bool(convert_all_blocks, false,
+DEFINE_bool(convert_all_blocks, true,
             "Convert all blocks in program into SSAgraphs");
 
 namespace paddle {

--- a/paddle/fluid/framework/ir/graph_helper.h
+++ b/paddle/fluid/framework/ir/graph_helper.h
@@ -77,9 +77,34 @@ std::vector<Node *> TopologyVarientSort(const Graph &graph, SortKind sort_kind);
 // Clean the nodes that doesn't connect to others.
 void CleanIndividualNodes(Graph *graph);
 
-// Build an adjacency list of operations for the `graph`.
-std::map<ir::Node *, std::set<ir::Node *, ir::NodeComp>, ir::NodeComp>
-BuildOperationAdjList(const Graph &graph);
+// Build an in-link adjacency list of operations for the `graph`.
+template <class NodeComparator = ir::NodeComp>
+std::map<ir::Node *, std::set<ir::Node *, NodeComparator>, NodeComparator>
+BuildOperationAdjList(const Graph &graph) {
+  std::map<ir::Node *, std::set<ir::Node *, NodeComparator>, NodeComparator>
+      adj_list;
+
+  for (auto &n : graph.Nodes()) {
+    if (!n->IsOp()) continue;
+    if (adj_list.find(n) == adj_list.end()) {
+      adj_list[n] = std::set<ir::Node *, NodeComparator>();
+    }
+    for (auto &var : n->inputs) {
+      for (auto &adj_n : var->inputs) {
+        PADDLE_ENFORCE_EQ(
+            adj_n->NodeType(), ir::Node::Type::kOperation,
+            platform::errors::InvalidArgument(
+                "Node(%s)'s type(%d) must be kOperation type.", adj_n->Name(),
+                static_cast<int>(adj_n->NodeType())));
+        VLOG(4) << "adj " << adj_n->Name() << reinterpret_cast<void *>(adj_n)
+                << " -> " << n->Name() << reinterpret_cast<void *>(n)
+                << "  via " << var->Name() << reinterpret_cast<void *>(var);
+        adj_list[n].insert(adj_n);
+      }
+    }
+  }
+  return adj_list;
+}
 
 template <typename T>
 std::vector<T *> FilterByNodeWrapper(const Graph &graph) {

--- a/paddle/fluid/pybind/ir.cc
+++ b/paddle/fluid/pybind/ir.cc
@@ -31,6 +31,7 @@
 namespace py = pybind11;
 using paddle::framework::ir::Graph;
 using paddle::framework::ir::Node;
+using paddle::framework::ir::NodeComp;
 using paddle::framework::ir::GraphSafeRemoveNodes;
 using paddle::framework::ir::HasCircle;
 using paddle::framework::ir::GraphNum;
@@ -50,7 +51,7 @@ void BindGraph(py::module *m) {
   m->def("graph_num", GraphNum);
   m->def("topology_sort", TopologySortOperations,
          return_value_policy::reference);
-  m->def("build_adjacency_list", BuildOperationAdjList,
+  m->def("build_adjacency_list", BuildOperationAdjList<NodeComp>,
          return_value_policy::reference);
   py::class_<Graph, std::shared_ptr<Graph>>(
       *m, "Graph",

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -179,6 +179,7 @@ def __bootstrap__():
     sysstr = platform.system()
     read_env_flags = [
         'check_nan_inf',
+        'convert_all_blocks',
         'benchmark',
         'eager_delete_scope',
         'fraction_of_cpu_memory_to_use',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR changed Topological Order Sort from Graph to Program. The TopologySortGraphByDescOrder caused Inference CE error. After debug, we used an image to illustrate the reason:

![47905d81fd23548b6b6db38b4d7dfd0b](https://user-images.githubusercontent.com/7913861/127736874-c36d6a7f-422b-4c75-8f1f-d87518f3c711.jpeg)

From above sub-graph, some fusions didn't solve Hazard like WAW or WAR (reference: https://en.wikipedia.org/wiki/Hazard_(computer_architecture)#Write_after_read_(WAR) ) for the Var Node "res2c.add.output.5.tmp_0" which makes different topological orders can have different outputs because Inference translates from Graph to Program to run.

Why didn't the old system have the problem? The reason is that old Topological Sort also had fixed order by node id! (see: https://github.com/PaddlePaddle/Paddle/blob/8b72a1a73d3913d4d8aca88e6c47988278c392d4/paddle/fluid/framework/ir/graph_helper.cc#L129). The old system combined wrong Graph format and special Topological Sort Order to run the correct output.

I don't have time to debug on lots of fusions to resolve Hazard, so this PR just make our new Topological Sort Order to be close to the old Topological Sort Order.