### PR TITLE
[NPU] add retry in partial_recv npu kernel

### DIFF
--- a/paddle/fluid/operators/collective/partial_recv_op_npu.cc
+++ b/paddle/fluid/operators/collective/partial_recv_op_npu.cc
@@ -73,6 +73,9 @@ class PartialRecvOpASCENDKernel : public framework::OpKernel<T> {
       while (retry_time < FLAGS_npu_comm_retry_times) {
         ++retry_time;
         try {
+          VLOG(4) << "HcclBroadcast retry" << retry_time
+                  << " times, ptr: " << ptr << ", id:" << id
+                  << ", stream:" << stream;
           PADDLE_ENFORCE_NPU_SUCCESS(platform::dynload::HcclBroadcast(
               ptr, numel, dtype, (uint32_t)root, comm->comm(), stream));
           ctx.template device_context<paddle::platform::NPUDeviceContext>()
@@ -80,7 +83,7 @@ class PartialRecvOpASCENDKernel : public framework::OpKernel<T> {
           return;
         } catch (...) {
           VLOG(4) << "HcclBroadcast retry" << retry_time
-                  << " times, ptr: " << ptr << ", id:" << id
+                  << " times failed, ptr: " << ptr << ", id:" << id
                   << ", stream:" << stream;
         }
       }

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -97,6 +97,9 @@ DEFINE_string(
     npu_config_path, "",
     "The absolute path of configuration json file, like: /tmp/config.json. "
     "If proveided, it will be passed to aclInit().");
+DEFINE_uint32(npu_comm_retry_times, "",
+              "The retry times for npu communication between cards, especially "
+              "used in pipeline parallelism.");
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -97,7 +97,7 @@ DEFINE_string(
     npu_config_path, "",
     "The absolute path of configuration json file, like: /tmp/config.json. "
     "If proveided, it will be passed to aclInit().");
-DEFINE_uint32(npu_comm_retry_times, "",
+DEFINE_uint32(npu_comm_retry_times, 0,
               "The retry times for npu communication between cards, especially "
               "used in pipeline parallelism.");
 #endif

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -245,6 +245,7 @@ def __bootstrap__():
             'reallocate_gpu_memory_in_mb',
             'gpu_memory_limit_mb',
             'npu_config_path',
+            'npu_comm_retry_times',
         ]
 
     core.init_gflags(["--tryfromenv=" + ",".join(read_env_flags)])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
add retry in partial_recv npu kernel

In `Megatron-like` pipeline training, there is `long idle time` between the first forward part and the first backward part of micro-batch-0. See details below,
![image](https://user-images.githubusercontent.com/6888866/127733170-82abe639-217f-4abb-84fc-62d5159efd29.png)

During the training, a `partial_recv` will be launched after the first forward part and it needs to wait for the paired `paritial_send`. However, the `hcclBroadcast` used in `partial_recv` will **timeout** in 2-3 minutes. 

Currently, there is no available way to increase the timeout time, so I add a `retry strategy` to solve the problem. 
![image](https://user-images.githubusercontent.com/6888866/127733677-269bcf5b-6ac7-4180-8aa3-068d454913b1.png)

usage: 
`export FLAGS_npu_comm_retry_times=1000`