### PR TITLE
[hybrid] remove the using of global ring in hybrid parallel

### DIFF
--- a/paddle/fluid/imperative/bkcl_context.cc
+++ b/paddle/fluid/imperative/bkcl_context.cc
@@ -92,7 +92,7 @@ void BKCLParallelContext::Init() {
             << " local rank: " << strategy_.local_rank_ << " xpu id: " << xpu_id
             << " ring id: " << ring_id;
     // it will assign bkcl_comm in XPUDeviceContext within ring_id
-    platform::BKCLCommContext::Instance().CreateBKCLComm(
+    platform::BKCLCommContext::Instance().CreateComm(
         &bkcl_ids[ring_id], strategy_.nranks_, strategy_.local_rank_, xpu_id,
         ring_id);
   }
@@ -116,7 +116,7 @@ void BKCLParallelContext::InitWithRingID(int ring_id) {
           << " local rank: " << strategy_.local_rank_ << " xpu id: " << xpu_id
           << " ring id: " << ring_id;
   // it will assign bkcl_comm in XPUDeviceContext within ring_id
-  platform::BKCLCommContext::Instance().CreateBKCLComm(
+  platform::BKCLCommContext::Instance().CreateComm(
       &bkcl_ids[0], strategy_.nranks_, strategy_.local_rank_, xpu_id, ring_id);
 }
 

--- a/paddle/fluid/imperative/nccl_context.cc
+++ b/paddle/fluid/imperative/nccl_context.cc
@@ -75,7 +75,7 @@ void NCCLParallelContext::Init() {
             << " local rank: " << strategy_.local_rank_ << " gpu id: " << gpu_id
             << " ring id: " << ring_id;
     // it will assign nccl_comm in CUDADeviceContext within ring_id
-    platform::NCCLCommContext::Instance().CreateNCCLComm(
+    platform::NCCLCommContext::Instance().CreateComm(
         &nccl_ids[ring_id], strategy_.nranks_, strategy_.local_rank_, gpu_id,
         ring_id);
 
@@ -108,7 +108,7 @@ void NCCLParallelContext::InitWithRingID(int ring_id) {
           << " local rank: " << strategy_.local_rank_ << " gpu id: " << gpu_id
           << " ring id: " << ring_id;
   // it will assign nccl_comm in CUDADeviceContext within ring_id
-  platform::NCCLCommContext::Instance().CreateNCCLComm(
+  platform::NCCLCommContext::Instance().CreateComm(
       &nccl_ids[0], strategy_.nranks_, strategy_.local_rank_, gpu_id, ring_id);
 
   compute_events_.emplace_back(platform::CudaEventResourcePool::Instance().New(

--- a/paddle/fluid/operators/collective/c_comm_init_op.cc
+++ b/paddle/fluid/operators/collective/c_comm_init_op.cc
@@ -24,15 +24,16 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
 
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
+    defined(PADDLE_WITH_XPU_BKCL)
+#include "paddle/fluid/platform/collective_helper.h"
+#endif
+
 namespace paddle {
 namespace framework {
 class Scope;
 }  // namespace framework
 }  // namespace paddle
-#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
-    defined(PADDLE_WITH_XPU_BKCL)
-#include "paddle/fluid/platform/collective_helper.h"
-#endif
 
 namespace paddle {
 namespace operators {
@@ -46,56 +47,50 @@ class CCommInitOp : public framework::OperatorBase {
 
   void RunImpl(const framework::Scope& scope,
                const platform::Place& place) const override {
+// TODO(wangxi): Put this in the unified header file
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+    using UniqueId = ncclUniqueId;
+    using Place = platform::CUDAPlace;
+    auto CreateCommFunc = platform::NCCLCommContext::Instance().CreateNCCLComm;
+#elif defined(PADDLE_WITH_XPU_BKCL)
+    using UniqueId = BKCLUniqueId;
+    using Place = platform::XPUPlace;
+    auto CreateCommFunc = platform::BKCLCommContext::Instance().CreateBKCLComm;
+#else
+    PADDLE_THROW(platform::errors::PreconditionNotMet(
+        "PaddlePaddle should be compiled with GPU or XPU."));
+#endif
+
     PADDLE_ENFORCE_EQ(is_gpu_place(place) || is_xpu_place(place), true,
                       platform::errors::PreconditionNotMet(
                           "CCommInitOp can run on gpu or xpu place only."));
 
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
+    defined(PADDLE_WITH_XPU_BKCL)
     auto var = scope.FindVar(Input("X"));
     PADDLE_ENFORCE_NOT_NULL(
         var, platform::errors::InvalidArgument("Input con not be empty."));
-    if (is_gpu_place(place)) {
-#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
-      ncclUniqueId* nccl_id = var->GetMutable<ncclUniqueId>();
 
-      int nranks = Attr<int>("nranks");
-      int rank_id = Attr<int>("rank");
-      int rid = Attr<int>("ring_id");
-      int device_id = BOOST_GET_CONST(platform::CUDAPlace, place).device;
-      if (Attr<int>("device_id") >= 0) {
-        device_id = Attr<int>("device_id");
-      }
-      platform::NCCLCommContext::Instance().CreateNCCLComm(
-          nccl_id, nranks, rank_id, device_id, rid);
-#else
-      PADDLE_THROW(platform::errors::PreconditionNotMet(
-          "PaddlePaddle should be compiled with GPU."));
-#endif
-    } else if (is_xpu_place(place)) {
+    UniqueId* comm_id = var->GetMutable<UniqueId>();
+
+    int nranks = Attr<int>("nranks");
+    int rank_id = Attr<int>("rank");
+    int rid = Attr<int>("ring_id");
+
 #if defined(PADDLE_WITH_XPU_BKCL)
-      BKCLUniqueId* bkcl_id = var->GetMutable<BKCLUniqueId>();
-
-      int nranks = Attr<int>("nranks");
-      int rank_id = Attr<int>("rank");
-      int rid = Attr<int>("ring_id");
-      PADDLE_ENFORCE_EQ(
-          rid, 0,
-          platform::errors::OutOfRange(
-              "Ring id must equal 0 in multi Kunlun cards training, but got %d",
-              rid));
-      int device_id = BOOST_GET_CONST(platform::XPUPlace, place).device;
-      if (Attr<int>("device_id") >= 0) {
-        device_id = Attr<int>("device_id");
-      }
-      platform::BKCLCommContext::Instance().CreateBKCLComm(
-          bkcl_id, nranks, rank_id, device_id, rid);
-#else
-      PADDLE_THROW(platform::errors::PreconditionNotMet(
-          "PaddlePaddle should be compiled with XPU."));
+    PADDLE_ENFORCE_EQ(
+        rid, 0,
+        platform::errors::OutOfRange(
+            "Ring id must equal 0 in multi Kunlun cards training, but got %d",
+            rid));
 #endif
-    } else {
-      PADDLE_THROW(platform::errors::PreconditionNotMet(
-          "CCommInitOp can run on gpu or xpu place only."));
+
+    int device_id = BOOST_GET_CONST(Place, place).device;
+    if (Attr<int>("device_id") >= 0) {
+      device_id = Attr<int>("device_id");
     }
+    CreateCommFunc(comm_id, nranks, rank_id, device_id, rid);
+#endif
   }
 };
 

--- a/paddle/fluid/operators/collective/c_comm_init_op.cc
+++ b/paddle/fluid/operators/collective/c_comm_init_op.cc
@@ -51,11 +51,11 @@ class CCommInitOp : public framework::OperatorBase {
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
     using UniqueId = ncclUniqueId;
     using Place = platform::CUDAPlace;
-    auto CreateCommFunc = platform::NCCLCommContext::Instance().CreateNCCLComm;
+    using CommContext = platform::NCCLCommContext;
 #elif defined(PADDLE_WITH_XPU_BKCL)
     using UniqueId = BKCLUniqueId;
     using Place = platform::XPUPlace;
-    auto CreateCommFunc = platform::BKCLCommContext::Instance().CreateBKCLComm;
+    using CommContext = platform::BKCLCommContext;
 #else
     PADDLE_THROW(platform::errors::PreconditionNotMet(
         "PaddlePaddle should be compiled with GPU or XPU."));
@@ -89,7 +89,8 @@ class CCommInitOp : public framework::OperatorBase {
     if (Attr<int>("device_id") >= 0) {
       device_id = Attr<int>("device_id");
     }
-    CreateCommFunc(comm_id, nranks, rank_id, device_id, rid);
+    CommContext::Instance().CreateComm(comm_id, nranks, rank_id, device_id,
+                                       rid);
 #endif
   }
 };

--- a/paddle/fluid/operators/collective/c_gen_bkcl_id_op.cc
+++ b/paddle/fluid/operators/collective/c_gen_bkcl_id_op.cc
@@ -62,7 +62,7 @@ class CGenBKCLIdOp : public framework::OperatorBase {
   void RunImpl(const framework::Scope& scope,
                const platform::Place& dev_place) const override {
     int rank = Attr<int>("rank");
-    framework::Scope& local_scope = scope.NewScope();
+    int ring_id = Attr<int>("ring_id");
 
     std::function<std::string(size_t)> func = [&](size_t i) -> std::string {
       return Output("Out");
@@ -75,14 +75,13 @@ class CGenBKCLIdOp : public framework::OperatorBase {
       GenBKCLID(&bkcl_ids);
       std::vector<std::string> endpoint_list =
           Attr<std::vector<std::string>>("other_endpoints");
-      platform::SendBroadCastCommID(endpoint_list, &bkcl_ids);
+      platform::SendBroadCastCommID(endpoint_list, &bkcl_ids, ring_id);
     } else {
       std::string endpoint = Attr<std::string>("endpoint");
-      platform::RecvBroadCastCommID(endpoint, &bkcl_ids);
+      platform::RecvBroadCastCommID(endpoint, &bkcl_ids, ring_id);
     }
 
     CopyBKCLIDToVar(bkcl_ids, func, scope);
-    scope.DeleteScope(&local_scope);
   }
 };
 
@@ -107,6 +106,8 @@ For trainer 1~n: start a gRPC server to get the UniqueId, once got, stop the ser
     AddAttr<int>("rank",
                  "(int default 0) "
                  "The rank of the trainer in distributed training.")
+        .SetDefault(0);
+    AddAttr<int>("ring_id", "(int default 0) user specified ring id")
         .SetDefault(0);
   }
 };

--- a/paddle/fluid/platform/collective_helper.cc
+++ b/paddle/fluid/platform/collective_helper.cc
@@ -72,8 +72,8 @@ class NCCLCommImpl : public NCCLComm {
   std::shared_ptr<platform::CudaEventObject> comm_event_;
 };
 
-NCCLComm* NCCLCommContext::CreateNCCLComm(ncclUniqueId* nccl_id, int nranks,
-                                          int rank, int dev_id, int ring_id) {
+NCCLComm* NCCLCommContext::CreateComm(ncclUniqueId* nccl_id, int nranks,
+                                      int rank, int dev_id, int ring_id) {
   PADDLE_ENFORCE_NOT_NULL(nccl_id,
                           platform::errors::InvalidArgument(
                               "The nccl unique id should not be null."));
@@ -225,8 +225,8 @@ class BKCLCommImpl : public BKCLComm {
   std::unique_ptr<XPUDeviceContext> dev_ctx_;
 };
 
-BKCLComm* BKCLCommContext::CreateBKCLComm(BKCLUniqueId* bkcl_id, int nranks,
-                                          int rank, int dev_id, int ring_id) {
+BKCLComm* BKCLCommContext::CreateComm(BKCLUniqueId* bkcl_id, int nranks,
+                                      int rank, int dev_id, int ring_id) {
   PADDLE_ENFORCE_NOT_NULL(bkcl_id,
                           platform::errors::InvalidArgument(
                               "The bkcl unique id should not be null."));

--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -72,8 +72,8 @@ class NCCLCommContext {
     return comm_ctx;
   }
 
-  NCCLComm* CreateNCCLComm(ncclUniqueId* nccl_id, int nranks, int rank,
-                           int dev_id, int ring_id = 0);
+  NCCLComm* CreateComm(ncclUniqueId* nccl_id, int nranks, int rank, int dev_id,
+                       int ring_id = 0);
 
   void CreateAllNCCLComms(const std::vector<int>& dev_ids, int ring_id = 0);
 
@@ -274,8 +274,8 @@ class BKCLCommContext {
     return comm_ctx;
   }
 
-  BKCLComm* CreateBKCLComm(BKCLUniqueId* bkcl_id, int nranks, int rank,
-                           int dev_id, int ring_id = 0);
+  BKCLComm* CreateComm(BKCLUniqueId* bkcl_id, int nranks, int rank, int dev_id,
+                       int ring_id = 0);
 
   void CreateAllBKCLComms(const std::vector<int>& dev_ids, int ring_id = 0);
 

--- a/paddle/fluid/platform/gen_comm_id_helper.h
+++ b/paddle/fluid/platform/gen_comm_id_helper.h
@@ -31,16 +31,16 @@ void CloseSocket(int fd);
 
 template <typename CommUniqueId>
 void SendBroadCastCommID(std::vector<std::string> servers,
-                         std::vector<CommUniqueId>* nccl_ids);
+                         std::vector<CommUniqueId>* nccl_ids, int ring_id = 0);
 
 template <typename CommUniqueId>
 void RecvBroadCastCommID(std::string endpoint,
-                         std::vector<CommUniqueId>* nccl_ids);
+                         std::vector<CommUniqueId>* nccl_ids, int ring_id = 0);
 
 // recv nccl id from socket
 template <typename CommUniqueId>
 void RecvBroadCastCommID(int server_fd, std::string endpoint,
-                         std::vector<CommUniqueId>* nccl_ids);
+                         std::vector<CommUniqueId>* nccl_ids, int ring_id = 0);
 
 class SocketServer {
  public:

--- a/python/paddle/distributed/fleet/meta_optimizers/common.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/common.py
@@ -139,6 +139,7 @@ class CollectiveHelper(object):
                     'rank': rank,
                     'endpoint': current_endpoint,
                     'other_endpoints': other_endpoints,
+                    'ring_id': ring_id,
                     OP_ROLE_KEY: OpRole.Forward
                 })
             block.append_op(

--- a/python/paddle/distributed/fleet/meta_optimizers/common.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/common.py
@@ -126,11 +126,11 @@ class CollectiveHelper(object):
             _add_sync_by_allreduce(block)
             return
 
+        comm_id_var = block.create_var(
+            name=unique_name.generate('comm_id'),
+            persistable=True,
+            type=core.VarDesc.VarType.RAW)
         if core.is_compiled_with_cuda():
-            comm_id_var = block.create_var(
-                name=unique_name.generate('nccl_id'),
-                persistable=True,
-                type=core.VarDesc.VarType.RAW)
             block.append_op(
                 type='c_gen_nccl_id',
                 inputs={},
@@ -153,10 +153,6 @@ class CollectiveHelper(object):
                     OP_ROLE_KEY: OpRole.Forward
                 })
         elif core.is_compiled_with_xpu():
-            comm_id_var = block.create_var(
-                name=unique_name.generate('bkcl_id'),
-                persistable=True,
-                type=core.VarDesc.VarType.RAW)
             block.append_op(
                 type='c_gen_bkcl_id',
                 inputs={},
@@ -165,6 +161,7 @@ class CollectiveHelper(object):
                     'rank': rank,
                     'endpoint': current_endpoint,
                     'other_endpoints': other_endpoints,
+                    'ring_id': ring_id,
                     OP_ROLE_KEY: OpRole.Forward
                 })
             block.append_op(
@@ -178,24 +175,20 @@ class CollectiveHelper(object):
                     OP_ROLE_KEY: OpRole.Forward
                 })
         elif core.is_compiled_with_npu():
-            hccl_id_var = block.create_var(
-                name=unique_name.generate('hccl_id'),
-                persistable=True,
-                type=core.VarDesc.VarType.RAW)
-            endpoint_to_index_map = {e: idx for idx, e in enumerate(endpoints)}
             block.append_op(
                 type='c_gen_hccl_id',
                 inputs={},
-                outputs={'Out': hccl_id_var},
+                outputs={'Out': comm_id_var},
                 attrs={
                     'rank': rank,
                     'endpoint': current_endpoint,
                     'other_endpoints': other_endpoints,
+                    'ring_id': ring_id,
                     OP_ROLE_KEY: OpRole.Forward
                 })
             block.append_op(
                 type='c_comm_init_hccl',
-                inputs={'X': hccl_id_var},
+                inputs={'X': comm_id_var},
                 outputs={},
                 attrs={
                     'rank': rank,

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
@@ -25,7 +25,7 @@ class GradientClipHelper(object):
         return op.desc.has_attr("op_namescope") \
             and op.desc.attr("op_namescope").startswith("/gradient_clip")
 
-    def prune_gradient_clip(self, block, shard, pure_dp_degree=1):
+    def prune_gradient_clip(self, block, shard, ring_ids):
         """
         prune gradient_clip related ops for params that not belong to cur shard
         prune: square, reduce_sum, elementwise_mul
@@ -82,33 +82,23 @@ class GradientClipHelper(object):
                 assert (len(op.desc.output_arg_names()) == 1)
                 sum_res = op.desc.output_arg_names()[0]
 
-                # this allreduce should not overlap with calc and should be scheduled in calc stream
-                block._insert_op_without_sync(
-                    idx + 1,
-                    type='c_allreduce_sum',
-                    inputs={'X': sum_res},
-                    outputs={'Out': sum_res},
-                    attrs={
-                        'ring_id': self.mp_ring_id,
-                        'op_namescope': "/gradient_clip_model_parallelism",
-                        'use_calc_stream': True,
-                        OP_ROLE_KEY: OpRole.Optimize,
-                    })
-
-                # global norm should only be sum within each model parallelism word size when use global group
-                if pure_dp_degree > 1:
+                # allreduce(mp)->allreduce(sharding)->allreduce(pp)
+                idx_offset = 1
+                for ring_id in ring_ids:
+                    if ring_id == -1: continue
+                    # this allreduce should not overlap with calc and should be scheduled in calc stream
                     block._insert_op_without_sync(
-                        idx + 2,
-                        type='scale',
+                        idx + idx_offset,
+                        type='c_allreduce_sum',
                         inputs={'X': sum_res},
                         outputs={'Out': sum_res},
                         attrs={
-                            'scale': 1.0 / float(pure_dp_degree),
+                            'ring_id': ring_id,
                             'op_namescope': "/gradient_clip_model_parallelism",
-                            'bias': 0.0,
-                            'bias_after_scale': False,
-                            OP_ROLE_KEY: OpRole.Optimize
+                            'use_calc_stream': True,
+                            OP_ROLE_KEY: OpRole.Optimize,
                         })
+                    idx_offset += 1
 
         # the grad sum here should take the all and only param in the current shard
         to_check_param = set(reversed_x_paramname)
@@ -126,43 +116,32 @@ class GradientClipHelper(object):
         return
 
     # TODO (JZ-LIANG) revise this for uniform mixed parallelism
-    def sync_global_norm(self, block, ring_id, pure_dp_degree=1):
+    def sync_global_norm(self, block, ring_ids):
         """
         prune gradient_clip related ops for params that not belong to cur shard
         prune: square, reduce_sum, elementwise_mul
         keep: sum, sqrt, elementwise_max, elementwise_div
         """
+        # FIXME(wangxi): mp should prune duplicated param_grads
         for idx, op in reversed(list(enumerate(block.ops))):
             if not self._is_gradient_clip_op(op):
                 continue
 
             if op.type == "sum":
                 sum_res = op.desc.output_arg_names()[0]
-                block._insert_op_without_sync(
-                    idx + 1,
-                    type='c_allreduce_sum',
-                    inputs={'X': sum_res},
-                    outputs={'Out': sum_res},
-                    attrs={
-                        'ring_id': ring_id,
-                        'op_namescope': "/gradient_clip_model_parallelism",
-                        'use_calc_stream': True,
-                        OP_ROLE_KEY: OpRole.Optimize,
-                    })
+                for ring_id in ring_ids:
+                    if ring_id == -1: continue
 
-                # global norm should only be sum within each model parallelism word size
-                if pure_dp_degree > 1:
+                    idx = idx + 1
                     block._insert_op_without_sync(
-                        idx + 2,
-                        type='scale',
+                        idx,
+                        type='c_allreduce_sum',
                         inputs={'X': sum_res},
                         outputs={'Out': sum_res},
                         attrs={
-                            'scale': 1.0 / float(pure_dp_degree),
+                            'ring_id': ring_id,
                             'op_namescope': "/gradient_clip_model_parallelism",
-                            'bias': 0.0,
-                            'bias_after_scale': False,
-                            OP_ROLE_KEY: OpRole.Optimize
+                            'use_calc_stream': True,
+                            OP_ROLE_KEY: OpRole.Optimize,
                         })
-
-        return
+                return

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
@@ -690,6 +690,7 @@ def get_grad_device(grad_name, shard):
 
 
 def append_naive_sync(block, sync_var, ring_id):
+    if core.is_compiled_with_cuda(): return
     # NOTE (JZ-LIANG) update this to use barrier sync for more elegent logic
     # sync within global 
     block.append_op(

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/utils.py
@@ -690,7 +690,6 @@ def get_grad_device(grad_name, shard):
 
 
 def append_naive_sync(block, sync_var, ring_id):
-    if core.is_compiled_with_cuda(): return
     # NOTE (JZ-LIANG) update this to use barrier sync for more elegent logic
     # sync within global 
     block.append_op(

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
@@ -328,13 +328,17 @@ class ShardingOptimizer(MetaOptimizerBase):
         # if not use sharding, adapt amp/clip, for remain parallelism.
         # cast --> amp --> clip --> opt
         if self.sharding_degree <= 1:
+            # FIXME(wangxi): mp should prune duplicated param_grads when calc
+            # amp inf_var & clip global_norm_var
+
             # amp
-            FP16Utils.sync_amp_check_nan_inf(main_block, self.global_ring_id)
+            FP16Utils.sync_amp_check_nan_inf(
+                main_block, [self.mp_ring_id, self.pp_ring_id])
 
             # clip
-            gradientclip_helper = GradientClipHelper(self.global_ring_id)
+            gradientclip_helper = GradientClipHelper(None)
             gradientclip_helper.sync_global_norm(
-                main_block, self.global_ring_id, self.dp_degree)
+                main_block, [self.mp_ring_id, self.pp_ring_id])
 
         # step6: loss div dp_degree 
         global_dp_degree = self.sharding_degree * self.dp_degree
@@ -392,7 +396,6 @@ class ShardingOptimizer(MetaOptimizerBase):
             pp_rank,
             ring_id,
             False,
-            global_ring_id=self.global_ring_id,
             sync=False)
 
     def _init_npu_pipeline_comm(self, startup_block):
@@ -426,8 +429,6 @@ class ShardingOptimizer(MetaOptimizerBase):
         pair = send_to_next_pair if even else recv_from_prev_pair
         ring_id = self.pp_ring_map[pair[0] * 1000 + pair[1]]
         self._init_pair_comm(pair, ring_id)
-        append_naive_sync(startup_block, self.startup_prog_sync_var,
-                          self.global_ring_id)
         my_pair.remove(pair)
         logger.info("pair0(even->odd): pp pair:{}, ring_id: {}".format(pair,
                                                                        ring_id))
@@ -436,8 +437,6 @@ class ShardingOptimizer(MetaOptimizerBase):
         pair = recv_from_next_pair if even else send_to_prev_pair
         ring_id = self.pp_ring_map[pair[0] * 1000 + pair[1]]
         self._init_pair_comm(pair, ring_id)
-        append_naive_sync(startup_block, self.startup_prog_sync_var,
-                          self.global_ring_id)
         my_pair.remove(pair)
         logger.info("pair1(even<-odd): pp pair:{}, ring_id: {}".format(pair,
                                                                        ring_id))
@@ -450,8 +449,6 @@ class ShardingOptimizer(MetaOptimizerBase):
                 pair[0] * 1000 + pair[1],
                 max_ring_id + 1)  # 3->0 not in pp_ring_map
             self._init_pair_comm(pair, ring_id)
-            append_naive_sync(startup_block, self.startup_prog_sync_var,
-                              self.global_ring_id)
             if self.pp_rank != 0 and self.pp_rank != self.pp_degree - 1:
                 my_pair.remove(pair)
             logger.info("pair2(odd->even): pp pair:{}, ring_id: {}".format(
@@ -463,8 +460,6 @@ class ShardingOptimizer(MetaOptimizerBase):
                 pair[0] * 1000 + pair[1],
                 max_ring_id + 2)  # 0->3 not in pp_ring_map
             self._init_pair_comm(pair, ring_id)
-            append_naive_sync(startup_block, self.startup_prog_sync_var,
-                              self.global_ring_id)
             if self.pp_rank != 0 and self.pp_rank != self.pp_degree - 1:
                 my_pair.remove(pair)
             logger.info("pair3(odd<-even): pp pair:{}, ring_id: {}".format(
@@ -478,6 +473,15 @@ class ShardingOptimizer(MetaOptimizerBase):
         assert self.pp_rank_ == self.pp_rank, "pp rank for pp opt [{}], pp rank for sharding opt [{}]".format(
             self.pp_rank_, self.pp_rank)
 
+        self._collective_helper._init_communicator(
+            self._startup_program,
+            self.current_endpoint,
+            self.pp_group_endpoints,
+            self.pp_rank,
+            self.pp_ring_id,
+            False,
+            sync=False)
+
         if core.is_compiled_with_npu():
             self._init_npu_pipeline_comm(startup_block)
             return
@@ -489,8 +493,6 @@ class ShardingOptimizer(MetaOptimizerBase):
             logger.info("pp pair:{}, ring_id: {}".format(pair, ring_id))
             if self.pp_rank in pair:
                 self._init_pair_comm(pair, ring_id)
-            append_naive_sync(startup_block, self.startup_prog_sync_var,
-                              self.global_ring_id)
 
     def _init_comm(self):
 
@@ -505,19 +507,6 @@ class ShardingOptimizer(MetaOptimizerBase):
             dtype=core.VarDesc.VarType.INT32,
             persistable=False)
 
-        # global ring
-        self._collective_helper._init_communicator(
-            self._startup_program,
-            self.current_endpoint,
-            self.global_endpoints,
-            self.global_rank,
-            self.global_ring_id,
-            False,
-            global_ring_id=self.global_ring_id,
-            sync=False)
-        append_naive_sync(startup_block, self.startup_prog_sync_var,
-                          self.global_ring_id)
-
         # mp ring
         if self.mp_degree > 1:
             self._collective_helper._init_communicator(
@@ -527,10 +516,7 @@ class ShardingOptimizer(MetaOptimizerBase):
                 self.mp_rank,
                 self.mp_ring_id,
                 False,
-                global_ring_id=self.global_ring_id,
                 sync=False)
-            append_naive_sync(startup_block, self.startup_prog_sync_var,
-                              self.global_ring_id)
 
         # sharding ring
         if self.sharding_degree > 1:
@@ -541,10 +527,7 @@ class ShardingOptimizer(MetaOptimizerBase):
                 self.sharding_rank,
                 self.sharding_ring_id,
                 False,
-                global_ring_id=self.global_ring_id,
                 sync=False)
-            append_naive_sync(startup_block, self.startup_prog_sync_var,
-                              self.global_ring_id)
 
         # pp ring
         if self.pp_degree > 1:
@@ -559,10 +542,7 @@ class ShardingOptimizer(MetaOptimizerBase):
                 self.dp_rank,
                 self.dp_ring_id,
                 False,
-                global_ring_id=self.global_ring_id,
                 sync=False)
-            append_naive_sync(startup_block, self.startup_prog_sync_var,
-                              self.global_ring_id)
 
         startup_block._sync_with_cpp()
 
@@ -736,21 +716,20 @@ class ShardingOptimizer(MetaOptimizerBase):
         """
         weightdecay_helper = WeightDecayHelper()
         weightdecay_helper.prune_weight_decay(block, self._shard)
+
+        # FIXME(wangxi): mp should prune duplicated param_grads
         # NOTE (JZ-LIANG) the sync of FoundInfinite should among one entire Model Parallelism
         # group. and each Data Parallelism group should have its own sync of FoundInfinite
         # amp could use global group for sync
-        FP16Utils.prune_fp16(block, self._shard, self._reduced_grads_to_param,
-                             self.global_ring_id)
+        FP16Utils.prune_fp16(
+            block, self._shard, self._reduced_grads_to_param,
+            [self.mp_ring_id, self.sharding_ring_id, self.pp_ring_id])
+
         # clipbyglobalnorm should only use the Model paramllelism group (mp-sharding-pp)
-        if self.mp_degree * self.pp_degree == 1:
-            # separate the sharding-hybrid senario to keep the accuracy
-            gradientclip_helper = GradientClipHelper(self.sharding_ring_id)
-            gradientclip_helper.prune_gradient_clip(
-                block, self._shard, pure_dp_degree=1)
-        else:
-            gradientclip_helper = GradientClipHelper(self.global_ring_id)
-            gradientclip_helper.prune_gradient_clip(
-                block, self._shard, pure_dp_degree=self.dp_degree)
+        gradientclip_helper = GradientClipHelper(None)
+        gradientclip_helper.prune_gradient_clip(
+            block, self._shard,
+            [self.mp_ring_id, self.sharding_ring_id, self.pp_ring_id])
 
         # build prog deps
         reduced_grads = []
@@ -1143,7 +1122,9 @@ class ShardingOptimizer(MetaOptimizerBase):
 
         # pp
         if self.pp_degree > 1:
-            self.pp_ring_id = 20
+            self.pp_pair_ring_id = 20
+            # pipeline global ring_id set to 4 for sharding0, mp1, dp2, global3
+            self.pp_ring_id = 4
             self.pp_rank = self.global_rank // (self.sharding_degree *
                                                 self.mp_degree) % self.pp_degree
             # (NOTE): Already adjust for (outter-pure) dp
@@ -1159,8 +1140,9 @@ class ShardingOptimizer(MetaOptimizerBase):
                     pp_first_stage_idx + pp_stage_offset * i])
             assert self.current_endpoint in self.pp_group_endpoints
         else:
-            self.pp_degree = 1
             self.pp_ring_id = -1
+            self.pp_degree = 1
+            self.pp_pair_ring_id = -1
             self.pp_rank = -1
             self.pp_group_id = -1
             self.pp_group_endpoints = []
@@ -1256,9 +1238,6 @@ class ShardingOptimizer(MetaOptimizerBase):
             outputs={'Out': params},
             attrs={'ring_id': self.dp_ring_id,
                    OP_ROLE_KEY: OpRole.Forward})
-        # sync within global group
-        append_naive_sync(startup_block, self.startup_prog_sync_var,
-                          self.global_ring_id)
 
     # sharding gradient merge
     def create_persistable_gradients_and_insert_merge_ops(

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -336,7 +336,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_0":
+                    0] == "comm_id_0":
                 sharding_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(sharding_group_waiting_ports, ['127.0.0.1:36003'])
@@ -345,7 +345,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_1":
+                    0] == "comm_id_1":
                 dp_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(dp_group_waiting_ports, ['127.0.0.1:36002'])
@@ -381,7 +381,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_0":
+                    0] == "comm_id_0":
                 sharding_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(sharding_group_waiting_ports, ['127.0.0.1:36003'])
@@ -390,7 +390,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_1":
+                    0] == "comm_id_1":
                 dp_group_waiting_ports = op.desc.attr("other_endpoints")
         self.assertEqual(dp_group_waiting_ports, ['127.0.0.1:36002'])
 
@@ -450,7 +450,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_0":
+                    0] == "comm_id_0":
                 sharding_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(sharding_group_waiting_ports, ['127.0.0.1:36003'])
@@ -459,7 +459,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_1":
+                    0] == "comm_id_1":
                 dp_group_waiting_ports = op.desc.attr("other_endpoints")
         self.assertEqual(dp_group_waiting_ports, ['127.0.0.1:36002'])
 
@@ -568,7 +568,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_0":
+                    0] == "comm_id_0":
                 sharding_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(sharding_group_waiting_ports, ['127.0.0.1:36003'])
@@ -577,7 +577,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_1":
+                    0] == "comm_id_1":
                 dp_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(dp_group_waiting_ports, ['127.0.0.1:36002'])
@@ -678,7 +678,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_0":
+                    0] == "comm_id_0":
                 mp_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(mp_group_waiting_ports, ['127.0.0.1:36003'])
@@ -687,7 +687,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         sharding_group_waiting_port = None
         for op in startup_prog_ops:
             if op.type == "c_gen_nccl_id" and op.desc.output_arg_names()[
-                    0] == "nccl_id_1":
+                    0] == "comm_id_1":
                 pp_group_waiting_ports = op.desc.attr("other_endpoints")
 
         self.assertEqual(pp_group_waiting_ports, ['127.0.0.1:36002'])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1、Refine some code of c_comm_init_op.
2、c_gen_{nccl,bkcl,hccl}_id_op add Attr(ring_id) to distinguish different group's comm_id broadcast.
3、Remove the using of global ring in hybrid parallel.