### PR TITLE
[NPU] Support npu op reciprocal and reciprocal grad

### DIFF
--- a/paddle/fluid/operators/activation_op_npu.cc
+++ b/paddle/fluid/operators/activation_op_npu.cc
@@ -397,6 +397,40 @@ class HardSigmoidGradNPUKernel : public framework::OpKernel<T> {
   }
 };
 
+template <typename DeviceContext, typename T>
+class ReciprocalNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* x = ctx.Input<Tensor>("X");
+    auto* out = ctx.Output<Tensor>("Out");
+    auto place = ctx.GetPlace();
+    out->mutable_data<T>(place);
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+    const auto& runner = NpuOpRunner("Reciprocal", {*x}, {*out}, {});
+    runner.Run(stream);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class ReciprocalGradNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* out = ctx.Input<Tensor>("Out");
+    auto* dout = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
+    auto place = ctx.GetPlace();
+    dx->mutable_data<T>(place);
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+    const auto& runner_dx =
+        NpuOpRunner("ReciprocalGrad", {*out, *dout}, {*dx}, {});
+    runner_dx.Run(stream);
+  }
+};
+
 }  // namespace operators
 }  // namespace paddle
 
@@ -483,3 +517,17 @@ REGISTER_OP_NPU_KERNEL(
     ops::HardSigmoidGradNPUKernel<paddle::platform::NPUDeviceContext, float>,
     ops::HardSigmoidGradNPUKernel<paddle::platform::NPUDeviceContext,
                                   paddle::platform::float16>);
+
+REGISTER_OP_NPU_KERNEL(
+    reciprocal,
+    ops::ReciprocalNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::ReciprocalNPUKernel<paddle::platform::NPUDeviceContext, double>,
+    ops::ReciprocalNPUKernel<paddle::platform::NPUDeviceContext,
+                             paddle::platform::float16>);
+
+REGISTER_OP_NPU_KERNEL(
+    reciprocal_grad,
+    ops::ReciprocalGradNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::ReciprocalGradNPUKernel<paddle::platform::NPUDeviceContext, double>,
+    ops::ReciprocalGradNPUKernel<paddle::platform::NPUDeviceContext,
+                                 paddle::platform::float16>);

--- a/paddle/fluid/operators/mean_op_npu.cc
+++ b/paddle/fluid/operators/mean_op_npu.cc
@@ -91,13 +91,10 @@ class MeanGradNPUKernel : public framework::OpKernel<T> {
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
 REGISTER_OP_NPU_KERNEL(
-    mean, ops::MeanNPUKernel<paddle::platform::NPUDeviceContext, int>,
-    ops::MeanNPUKernel<paddle::platform::NPUDeviceContext, float>,
-    ops::MeanNPUKernel<paddle::platform::NPUDeviceContext, double>,
+    mean, ops::MeanNPUKernel<paddle::platform::NPUDeviceContext, float>,
     ops::MeanNPUKernel<paddle::platform::NPUDeviceContext, plat::float16>)
 
 REGISTER_OP_NPU_KERNEL(
-    mean_grad, ops::MeanGradNPUKernel<paddle::platform::NPUDeviceContext, int>,
+    mean_grad,
     ops::MeanGradNPUKernel<paddle::platform::NPUDeviceContext, float>,
-    ops::MeanGradNPUKernel<paddle::platform::NPUDeviceContext, double>,
     ops::MeanGradNPUKernel<paddle::platform::NPUDeviceContext, plat::float16>)

--- a/python/paddle/fluid/tests/unittests/npu/test_reciprocal_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reciprocal_op_npu.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division
+
+import numpy as np
+import unittest
+import sys
+sys.path.append("..")
+from op_test import OpTest, skip_check_grad_ci
+import paddle
+paddle.enable_static()
+
+
+class TestNPUReciprocal(OpTest):
+    def setUp(self):
+        self.op_type = "reciprocal"
+        self.set_npu()
+        self.init_dtype()
+
+        np.random.seed(1024)
+        x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
+        out = np.reciprocal(x)
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.outputs = {'Out': out}
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def test_check_grad(self):
+        if self.dtype == np.float16:
+            return
+        self.check_grad_with_place(
+            self.place, ['X'], 'Out', max_relative_error=0.01)
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.place = paddle.NPUPlace(0)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+
+class TestNPUReciprocalFp64(TestNPUReciprocal):
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.place = paddle.NPUPlace(0)
+
+    def init_dtype(self):
+        self.dtype = np.float64
+
+
+@skip_check_grad_ci(
+    reason="The backward test is not supported for float16 type on NPU.")
+class TestNPUReciprocalFp16(TestNPUReciprocal):
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.place = paddle.NPUPlace(0)
+        self.__class__.no_need_check_grad = True
+
+    def init_dtype(self):
+        self.dtype = np.float16
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
[NPU] Support npu op reciprocal and reciprocal grad

说明：
1) 数据类型支持：
   NPU端支持的数据类型与CPU端的保持一致：float, float16, double。
2) 单测测试用例测试了fp64，fp32和fp16的情形。
测试fp64类型时，报了如下错误：
`ExternalError:  ACL error, the error code is : 500002.  (at /workspace/limin-workspace/npu-paddle/Paddle/paddle/fluid/operators/npu_op_runner.cc:380)
1226:   [operator < mean > error]。`
原因：reciprocal的单测（反向）会自动添加mean op，但是mean的前向ReduceMeanD不支持double和int，注册mean kernel时却支持了fp64和int类型。
解决：将mean_op_npu.cc中对double和int类型的支持去掉。



#### 运行结果

- 单测运行结果
![6e3a0253ef2a59eb6d9cf6a70597aa5d](https://user-images.githubusercontent.com/11663212/127955955-bf7a95cc-d861-4be7-a8a6-60870ebcf36b.png)

- 调用 reciprocal npu kernel 和 reciprocal grad npu kernel

fp32：
![48053fcbbda8e22804b700b6eba40449](https://user-images.githubusercontent.com/11663212/127956350-39c82425-700a-477d-a2af-561e01a380d8.png)


fp64：
![2e35004355bb4305d4c906ad4a6a9ba6](https://user-images.githubusercontent.com/11663212/127956419-0e144cbe-4538-4658-a32c-ffc92bbd98de.png)


fp16：
![5de13e2e7c4ed7e0b0eb5013d5ba1462](https://user-images.githubusercontent.com/11663212/127956537-b715f2fd-7463-46bc-bbf3-d5b20e94d1ea.png)

