### PR TITLE
[NPU] Support npu op: (1) cos (2) cos_grad

### DIFF
--- a/paddle/fluid/operators/activation_op_npu.cc
+++ b/paddle/fluid/operators/activation_op_npu.cc
@@ -440,7 +440,7 @@ class CosNPUKernel : public framework::OpKernel<T> {
 
     auto place = ctx.GetPlace();
     out->mutable_data<T>(place);
-    
+
     auto stream =
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
@@ -450,6 +450,7 @@ class CosNPUKernel : public framework::OpKernel<T> {
   }
 };
 
+template <typename DeviceContext, typename T>
 class CosGradNPUKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {

--- a/paddle/fluid/operators/activation_op_npu.cc
+++ b/paddle/fluid/operators/activation_op_npu.cc
@@ -456,7 +456,6 @@ class CosGradNPUKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto* dout = ctx.Input<Tensor>(framework::GradVarName("Out"));
     auto* x = ctx.Input<Tensor>("X");
-
     auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
 
     auto place = ctx.GetPlace();
@@ -477,13 +476,12 @@ class CosGradNPUKernel : public framework::OpKernel<T> {
 
     Tensor tmp(x->type());  // Temporary Tensor
     tmp.Resize(framework::make_ddim({1, 1}));
-    tmp.mutable_data<T>({1}, place);
+    tmp.mutable_data<T>(place);
     float factor = -1.;
     FillNpuTensorWithConstant<T>(&tmp, static_cast<T>(factor));
 
     const auto& runner_dx_ = NpuOpRunner("Xdivy", {*dx, tmp}, {*dx}, {});
     runner_dx_.Run(stream);
-
     // dx = -dout * Sine(x);
   }
 };

--- a/paddle/fluid/operators/activation_op_npu.cc
+++ b/paddle/fluid/operators/activation_op_npu.cc
@@ -431,6 +431,62 @@ class ReciprocalGradNPUKernel : public framework::OpKernel<T> {
   }
 };
 
+template <typename DeviceContext, typename T>
+class CosNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* x = ctx.Input<Tensor>("X");
+    auto* out = ctx.Output<Tensor>("Out");
+
+    auto place = ctx.GetPlace();
+    out->mutable_data<T>(place);
+    
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+
+    const auto& runner = NpuOpRunner("Cos", {*x}, {*out}, {});
+    runner.Run(stream);
+  }
+};
+
+class CosGradNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* dout = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    auto* x = ctx.Input<Tensor>("X");
+
+    auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
+
+    auto place = ctx.GetPlace();
+    dx->mutable_data<T>(place);
+
+    Tensor sin_out(x->type());  // Temporary Tensor
+    sin_out.Resize(x->dims());
+    sin_out.mutable_data<T>(place);
+
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+    const auto& runner = NpuOpRunner("Sin", {*x}, {sin_out}, {});
+    runner.Run(stream);
+
+    const auto& runner_dx = NpuOpRunner("Mul", {*dout, sin_out}, {*dx}, {});
+    runner_dx.Run(stream);
+
+    Tensor tmp(x->type());  // Temporary Tensor
+    tmp.Resize(framework::make_ddim({1, 1}));
+    tmp.mutable_data<T>({1}, place);
+    float factor = -1.;
+    FillNpuTensorWithConstant<T>(&tmp, static_cast<T>(factor));
+
+    const auto& runner_dx_ = NpuOpRunner("Xdivy", {*dx, tmp}, {*dx}, {});
+    runner_dx_.Run(stream);
+
+    // dx = -dout * Sine(x);
+  }
+};
+
 }  // namespace operators
 }  // namespace paddle
 
@@ -531,3 +587,13 @@ REGISTER_OP_NPU_KERNEL(
     ops::ReciprocalGradNPUKernel<paddle::platform::NPUDeviceContext, double>,
     ops::ReciprocalGradNPUKernel<paddle::platform::NPUDeviceContext,
                                  paddle::platform::float16>);
+
+REGISTER_OP_NPU_KERNEL(
+    cos, ops::CosNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::CosNPUKernel<paddle::platform::NPUDeviceContext,
+                      paddle::platform::float16>);
+
+REGISTER_OP_NPU_KERNEL(
+    cos_grad, ops::CosGradNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::CosGradNPUKernel<paddle::platform::NPUDeviceContext,
+                          paddle::platform::float16>);

--- a/python/paddle/fluid/tests/unittests/npu/test_cos_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cos_op_npu.py
@@ -1,0 +1,146 @@
+#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+sys.path.append("..")
+from op_test import OpTest
+import paddle
+import paddle.fluid as fluid
+
+paddle.enable_static()
+SEED = 2021
+
+
+class TestCos(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "cos"
+        self.place = paddle.NPUPlace(0)
+
+        self.init_dtype()
+        np.random.seed(SEED)
+        x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
+        out = np.cos(x)
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.attrs = {}
+        self.outputs = {'Out': out}
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place, atol=1e-7)
+
+    def test_check_grad(self):
+        if self.dtype == np.float16:
+            return
+        self.check_grad_with_place(self.place, ['X'], 'Out')
+
+
+class TestCosFp16(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "cos"
+        self.place = paddle.NPUPlace(0)
+
+        self.init_dtype()
+        np.random.seed(SEED)
+        x = np.random.uniform(1, 2, [3, 4]).astype(self.dtype)
+        out = np.cos(x)
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.attrs = {}
+        self.outputs = {'Out': out}
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.__class__.no_need_check_grad = True
+
+    def init_dtype(self):
+        self.dtype = np.float16
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place, atol=1e-3)
+
+
+class TestCosNet(unittest.TestCase):
+    def _test(self, run_npu=True):
+        main_prog = paddle.static.Program()
+        startup_prog = paddle.static.Program()
+        main_prog.random_seed = SEED
+        startup_prog.random_seed = SEED
+        np.random.seed(SEED)
+
+        a_np = np.random.random(size=(32, 32)).astype('float32')
+        b_np = np.random.random(size=(32, 32)).astype('float32')
+        label_np = np.random.randint(2, size=(32, 1)).astype('int64')
+
+        with paddle.static.program_guard(main_prog, startup_prog):
+            a = paddle.static.data(name="a", shape=[32, 32], dtype='float32')
+            b = paddle.static.data(name="b", shape=[32, 32], dtype='float32')
+            label = paddle.static.data(
+                name="label", shape=[32, 1], dtype='int64')
+
+            c = paddle.multiply(a, b)
+            d = paddle.cos(c)
+
+            fc_1 = fluid.layers.fc(input=d, size=128)
+            prediction = fluid.layers.fc(input=fc_1, size=2, act='softmax')
+
+            cost = fluid.layers.cross_entropy(input=prediction, label=label)
+            loss = fluid.layers.reduce_mean(cost)
+            sgd = fluid.optimizer.SGD(learning_rate=0.01)
+            sgd.minimize(loss)
+
+        if run_npu:
+            place = paddle.NPUPlace(0)
+        else:
+            place = paddle.CPUPlace()
+
+        exe = paddle.static.Executor(place)
+        exe.run(startup_prog)
+
+        print("Start run on {}".format(place))
+        for epoch in range(100):
+
+            pred_res, loss_res = exe.run(
+                main_prog,
+                feed={"a": a_np,
+                      "b": b_np,
+                      "label": label_np},
+                fetch_list=[prediction, loss])
+            if epoch % 10 == 0:
+                print("Epoch {} | Prediction[0]: {}, Loss: {}".format(
+                    epoch, pred_res[0], loss_res))
+
+        return pred_res, loss_res
+
+    def test_npu(self):
+        cpu_pred, cpu_loss = self._test(False)
+        npu_pred, npu_loss = self._test(True)
+
+        self.assertTrue(np.allclose(npu_pred, cpu_pred))
+        self.assertTrue(np.allclose(npu_loss, cpu_loss))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/npu/test_cos_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cos_op_npu.py
@@ -79,7 +79,7 @@ class TestCosFp16(OpTest):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-3)
+        self.check_output_with_place(self.place)
 
 
 class TestCosNet(unittest.TestCase):


### PR DESCRIPTION
### PR types
New features 

### PR changes
OPs

### Describe
[NPU] Support npu op: (1) cos (2) cos_grad
1. Add test_cos_op_npu.py for Unit tests.
2. Register and implementation of cos npu、cos_grad npu in activation_op_npu.cc.

<img width="562" alt="图片" src="https://user-images.githubusercontent.com/87417304/127955774-493c72f3-ecb6-4fc1-9683-395918f87689.png">

<img width="843" alt="图片" src="https://user-images.githubusercontent.com/87417304/127955782-1bfbc962-687c-4f69-84bd-bc86c8399f84.png">
