### PR TITLE
optimize ClipGradByGlobalNorm

### DIFF
--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -39,8 +39,14 @@ def _squared_l2_norm(x):
     r"""
     This OP returns the squared L2 norm of a tensor.
     """
+
+    if core.is_compiled_with_npu() or core.is_compiled_with_xpu():
+        square = layers.square(x)
+        sum_square = layers.reduce_sum(square)
+        return sum_square
+
     if in_dygraph_mode():
-        core.ops.squared_l2_norm(x)
+        return core.ops.squared_l2_norm(x)
 
     op_type = 'squared_l2_norm'
     check_variable_and_dtype(x, 'x', ['float32'], op_type)

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -264,8 +264,8 @@ class TestFleetShardingMetaOptimizer(TestFleetMetaOptimizer):
             'elementwise_add_grad', 'mul_grad', 'tanh_grad',
             'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream',
             'c_reduce_sum', 'c_reduce_sum', 'c_reduce_sum', 'c_reduce_sum',
-            'c_reduce_sum', 'c_reduce_sum', 'c_sync_comm_stream', 'square',
-            'reduce_sum', 'square', 'reduce_sum', 'square', 'reduce_sum', 'sum',
+            'c_reduce_sum', 'c_reduce_sum', 'c_sync_comm_stream',
+            'squared_l2_norm', 'squared_l2_norm', 'squared_l2_norm', 'sum',
             'c_allreduce_sum', 'sqrt', 'fill_constant', 'elementwise_max',
             'elementwise_div', 'elementwise_mul', 'elementwise_mul',
             'elementwise_mul', 'momentum', 'momentum', 'momentum'

--- a/python/paddle/fluid/tests/unittests/test_gradient_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_gradient_clip.py
@@ -151,9 +151,6 @@ class TestGradientClipByGlobalNorm(TestGradientClip):
     def check_clip_result(self, out, out_clip):
         global_norm = 0
         for v in out:
-            # if encounter numerical accuracy problem, use
-            # global_norm += np.square(np.linalg.norm(v))
-            # and maybe paddle need a reduce_square_sum op better
             global_norm += np.sum(np.square(v))
         global_norm = np.sqrt(global_norm)
         scale = self.clip_norm / np.maximum(self.clip_norm, global_norm)
@@ -222,8 +219,8 @@ class TestGradientClipByGlobalNorm(TestGradientClip):
 
         ops = [op.type for op in x.block.ops]
         self.assertListEqual(ops, [
-            'frobenius_norm', 'square', 'frobenius_norm', 'square', 'sum',
-            'sqrt', 'fill_constant', 'elementwise_max', 'elementwise_div',
+            'squared_l2_norm', 'squared_l2_norm', 'sum', 'sqrt',
+            'fill_constant', 'elementwise_max', 'elementwise_div',
             'elementwise_mul', 'elementwise_mul'
         ])
 

--- a/python/paddle/fluid/tests/unittests/test_gradient_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_gradient_clip.py
@@ -22,6 +22,8 @@ import paddle.fluid as fluid
 import six
 from fake_reader import fake_imdb_reader
 
+paddle.enable_static()
+
 
 def bow_net(data,
             label,
@@ -149,7 +151,10 @@ class TestGradientClipByGlobalNorm(TestGradientClip):
     def check_clip_result(self, out, out_clip):
         global_norm = 0
         for v in out:
-            global_norm += np.sum(np.power(v, 2))
+            # if encounter numerical accuracy problem, use
+            # global_norm += np.square(np.linalg.norm(v))
+            # and maybe paddle need a reduce_square_sum op better
+            global_norm += np.sum(np.square(v))
         global_norm = np.sqrt(global_norm)
         scale = self.clip_norm / np.maximum(self.clip_norm, global_norm)
         res = []
@@ -160,7 +165,8 @@ class TestGradientClipByGlobalNorm(TestGradientClip):
             self.assertTrue(
                 np.allclose(
                     a=u, b=v, rtol=1e-5, atol=1e-8),
-                "gradient clip by global norm has wrong results!")
+                "gradient clip by global norm has wrong results!, \nu={}\nv={}\ndiff={}".
+                format(u, v, u - v))
 
     # test whether the ouput is right when use 'set_gradient_clip'
     def test_old_gradient_clip(self):
@@ -210,12 +216,16 @@ class TestGradientClipByGlobalNorm(TestGradientClip):
         params_grads = [(x, None), (x, y), (y, x)]
         params_grads = clip(params_grads)
         self.assertTrue(
-            len(clip(params_grads)) == 2,
+            len(params_grads) == 2,
             "ClipByGlobalNorm: when grad is None, it shouldn't be returned by gradient clip!"
         )
-        self.assertTrue(
-            params_grads[0][1].name != 'y',
-            "ClipByGlobalNorm: param_grad (x, y) should be clipped!")
+
+        ops = [op.type for op in x.block.ops]
+        self.assertListEqual(ops, [
+            'frobenius_norm', 'square', 'frobenius_norm', 'square', 'sum',
+            'sqrt', 'fill_constant', 'elementwise_max', 'elementwise_div',
+            'elementwise_mul', 'elementwise_mul'
+        ])
 
     # raise typeError
     def test_tpyeError(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Optimize ClipGradByGlobalNorm memory usage and performance.
Major changes:
1、Replace reduce_sum(square(x)) to squared_l2_norm(x).
2、scale grad use inplace elementwise_mul.
#### Test
single cards:  run `gpt3-1.3B-en`, with recompute and amp, seq_len=1024 batch_size=2
16 cards hybrid:  run `gpt3-13B-en`, with mp=4 pp=4, recompute and amp, seq_len=1024 gbs=256 micro_batch_size=2. we record cards(0, 15) memory
Ernie3.0: "hidden_size": 4096, "num_attention_heads": 128, "num_hidden_layers": 76, "num_sharing_layers": 64, mp=8, pp=2, amp, recompute, gbs=32, micro_bs=2
| | Memory(MB) | | |  Speed(tokens/s) | | |
| -- | -- | -- | -- | -- | -- | -- |
| | develop | PR | Save | develop | PR | Improve |
| GPT(PE 1card) | 25786 | 25392 | **394** | 3505 | 3605 | **2.85%** |
| GPT(Executor 1card) | 26114 | 25720 | **394** | 3517 |  3611 | **2.67%** |
| GPT(Hybrid 16cards) | (19592,19530) | (19068,17784) | **(524, 1746)** | 5854 | 5859 | **0.08%** |
| Ernie3.0(16cards) | (18724, 25004) | (17276, 23340) | **(1448, 1664)** | 2445 | 2362 | -3.5% |

In Ernie3.0 is slow... Because squared_l2_norm is slow than reduce_sum(square), need optimize...