### PR TITLE
Fix ut test_pe_fix_op_run_order by using smaller model and batch size

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -497,6 +497,7 @@ set_tests_properties(test_conv2d_api PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_conv_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_norm_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
+set_tests_properties(test_parallel_executor_fix_op_run_order PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 if(WITH_DISTRIBUTE)
     # FIXME(typhoonzero): add these tests back
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_transformer")

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -497,7 +497,6 @@ set_tests_properties(test_conv2d_api PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_conv_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_norm_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 set_tests_properties(test_nn_grad PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
-set_tests_properties(test_parallel_executor_fix_op_run_order PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 if(WITH_DISTRIBUTE)
     # FIXME(typhoonzero): add these tests back
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_transformer")

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_fix_op_run_order.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_fix_op_run_order.py
@@ -16,7 +16,7 @@ import paddle
 import paddle.fluid as fluid
 import unittest
 import numpy as np
-from paddle.vision.models import resnet50
+from paddle.vision.models import resnet18
 from paddle.nn import CrossEntropyLoss
 
 
@@ -33,7 +33,7 @@ class TestFixOpRunOrder(unittest.TestCase):
         ) else paddle.CPUPlace()
 
     def get_feed(self):
-        batch_size = 32
+        batch_size = 4
         image = np.random.random([batch_size, 3, 224, 224]).astype('float32')
         label = np.random.randint(0, 1000, [batch_size, 1]).astype('int64')
         return {"image": image, "label": label}
@@ -47,7 +47,7 @@ class TestFixOpRunOrder(unittest.TestCase):
                 name="image", shape=[None, 3, 224, 224], dtype="float32")
             label = paddle.static.data(
                 name="label", shape=[None, 1], dtype="int64")
-            model = resnet50()
+            model = resnet18()
             pred = model(image)
             loss_fn = CrossEntropyLoss()
             loss = loss_fn(pred, label)


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
Fix ut test_pe_fix_op_run_order randomly fail on Windows CI, by using smaller model and smaller batch size.