### PR TITLE
[NPU] Support npu op index_select

### DIFF
--- a/paddle/fluid/operators/index_select_op_npu.cc
+++ b/paddle/fluid/operators/index_select_op_npu.cc
@@ -1,0 +1,57 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/index_select_op.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename DeviceContext, typename T>
+class IndexSelectNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    auto *x = ctx.Input<Tensor>("X");
+    auto *index = ctx.Input<Tensor>("Index");
+    auto dim = ctx.Attr<int>("dim");
+
+    auto *out = ctx.Output<Tensor>("Out");
+    out->mutable_data<T>(ctx.GetPlace());
+
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+
+    NpuOpRunner runner;
+    runner.SetType("GatherV2")
+        .AddInput(*x)
+        .AddInput(*index)
+        .AddInput(std::vector<int32_t>{dim})
+        .AddOutput(*out);
+    runner.Run(stream);
+  }
+};
+
+// todo: add class 'IndexSelectGradNPUKernel' here.
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OP_NPU_KERNEL(
+    index_select,
+    ops::IndexSelectNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::IndexSelectNPUKernel<paddle::platform::NPUDeviceContext, int>,
+    ops::IndexSelectNPUKernel<paddle::platform::NPUDeviceContext, int64_t>);
+// todo: register npu index_select_grad kernel here.

--- a/python/paddle/fluid/tests/unittests/npu/test_index_select_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_index_select_op_npu.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+sys.path.append("..")
+from op_test import OpTest
+import paddle
+from paddle.static import Program, program_guard
+
+paddle.enable_static()
+SEED = 2021
+
+
+class TestNPUIndexSelect(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.place = paddle.NPUPlace(0)
+        self.op_type = "index_select"
+        self.config()
+
+        x_np = np.random.random(self.x_shape).astype(self.x_type)
+        index_np = np.random.randint(
+            low=0, high=self.x_shape[self.dim], size=self.index_size)
+
+        # compute real output as baseline.
+        outer_loop = np.prod(self.x_shape[:self.dim])
+        outer_loop = outer_loop.astype(self.index_type)
+        x_reshape = [outer_loop] + list(self.x_shape[self.dim:])
+        x_np_reshape = np.reshape(x_np, tuple(x_reshape))
+
+        out_list = []
+        for i in range(outer_loop):
+            for j in range(self.index_size):
+                out_list.append(x_np_reshape[i, index_np[j]])
+        self.out_shape = list(self.x_shape)
+        self.out_shape[self.dim] = self.index_size
+        self.out_shape = tuple(self.out_shape)
+        out = np.reshape(out_list, self.out_shape)
+
+        self.inputs = {'X': x_np, 'Index': index_np}
+        self.attrs = {'dim': self.dim}
+        self.outputs = {'Out': out}
+
+    # todo: comment second line when index_select grad npu op is ready. 
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.__class__.no_need_check_grad = True
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    # todo: replace first line with second line when index_select grad npu op is ready. 
+    def test_check_grad(self):
+        pass
+        #self.check_grad_with_place(self.place, ['X'], 'Out')
+
+    def config(self):
+        self.x_shape = (100, 4, 5)
+        self.x_type = np.float32
+        self.dim = 1
+        self.index_size = 100
+        self.index_type = np.int64
+
+
+class TestNPUIndexSelectCase2(TestNPUIndexSelect):
+    def config(self):
+        self.dim = -2
+        self.x_type = np.float32
+        self.index_type = np.int32
+        self.x_shape = (10, 10, 4, 10)
+        self.index_size = 10
+
+
+class TestNPUIndexSelectAPI(unittest.TestCase):
+    def input_data(self):
+        self.data_x = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0],
+                                [9.0, 10.0, 11.0, 12.0]]).astype('float32')
+        self.data_index = np.array([0, 1, 1]).astype('int32')
+
+    def test_index_select_api(self):
+        paddle.set_device("npu:0")
+        paddle.enable_static()
+        self.input_data()
+
+        # case 1:
+        with program_guard(Program(), Program()):
+            x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
+            index = paddle.static.data(name='index', shape=[3], dtype='int32')
+            z = paddle.index_select(x, index, axis=1)
+            exe = paddle.static.Executor(paddle.NPUPlace(0))
+            res, = exe.run(feed={'x': self.data_x,
+                                 'index': self.data_index},
+                           fetch_list=[z.name],
+                           return_numpy=False)
+        expect_out = np.array([[1.0, 2.0, 2.0], [5.0, 6.0, 6.0],
+                               [9.0, 10.0, 10.0]]).astype('float32')
+        self.assertTrue(np.allclose(expect_out, np.array(res)))
+
+        # case 2:
+        with program_guard(Program(), Program()):
+            x = paddle.static.data(name='x', shape=[-1, 4], dtype='float32')
+            index = paddle.static.data(name='index', shape=[3], dtype='int32')
+            z = paddle.index_select(x, index)
+            exe = paddle.static.Executor(paddle.NPUPlace(0))
+            res, = exe.run(feed={'x': self.data_x,
+                                 'index': self.data_index},
+                           fetch_list=[z.name],
+                           return_numpy=False)
+        expect_out = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0],
+                               [5.0, 6.0, 7.0, 8.0]]).astype('float32')
+        self.assertTrue(np.allclose(expect_out, np.array(res)))
+
+    def test_dygraph_index_select_api(self):
+        paddle.set_device("npu:0")
+        paddle.disable_static()
+        self.input_data()
+
+        # case 1:
+        x = paddle.to_tensor(self.data_x)
+        index = paddle.to_tensor(self.data_index)
+        z = paddle.index_select(x, index)
+        np_z = z.numpy()
+        expect_out = np.array([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0],
+                               [5.0, 6.0, 7.0, 8.0]]).astype('float32')
+        self.assertTrue(np.allclose(expect_out, np_z))
+
+        # case 2:
+        x = paddle.to_tensor(self.data_x)
+        index = paddle.to_tensor(self.data_index)
+        z = paddle.index_select(x, index, axis=1)
+        np_z = z.numpy()
+        expect_out = np.array([[1.0, 2.0, 2.0], [5.0, 6.0, 6.0],
+                               [9.0, 10.0, 10.0]]).astype('float32')
+        self.assertTrue(np.allclose(expect_out, np_z))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
[NPU] Support npu op index_select (forward op)

说明：
1.关于数据类型
cpu端的index_select算子支持的数据类型有float, double, int, int64；相比cpu端，npu端没有支持double，因为index_select前向是通过调用CANN GatherV2 API 实现的，该 API 不支持double类型。
2.该PR在npu端的单测覆盖了cpu端的所有测试情况。
3.本PR实现了index_select的前向计算，添加反向时，可参考代码中标注'todo'的注释。


#### 运行结果
- 单测运行结果
![7bfbc9797ca6c39c8af57ab8e2b0a3ea](https://user-images.githubusercontent.com/11663212/128286164-791d5b9d-1245-4926-8987-ad84a2f9cf56.png)

- 调用 index_select npu kernel
![16425dea3557fecc7cd361e1014d2e21](https://user-images.githubusercontent.com/11663212/128168715-80d8d076-4357-40a9-a844-a1cbff39fc7b.png)



