### PR TITLE
Fix paddle buffered data reader bug

### DIFF
--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from paddle.fluid import core
+from paddle.fluid.wrapped_decorator import signature_safe_contextmanager
 
 from .streams import Stream  # noqa: F401
 from .streams import Event  # noqa: F401
@@ -63,6 +64,11 @@ def current_stream(device=None):
     return core._get_current_stream(device_id)
 
 
+def set_current_stream(stream):
+
+    return core._set_current_stream(stream)
+
+
 def synchronize(device=None):
     '''
     Wait for the compute on the given CUDA device to finish.
@@ -94,3 +100,12 @@ def synchronize(device=None):
             raise ValueError("device type must be int or paddle.CUDAPlace")
 
     return core._device_synchronize(device_id)
+
+
+@signature_safe_contextmanager
+def stream_guard(stream):
+    pre_stream = set_current_stream(stream)
+    try:
+        yield
+    finally:
+        stream = set_current_stream(pre_stream)

--- a/python/paddle/reader/decorator.py
+++ b/python/paddle/reader/decorator.py
@@ -337,15 +337,10 @@ def buffered(reader, size):
                 print(i)
     """
 
-    class EndSignal():
-        pass
-
-    end = EndSignal()
-
     def read_worker(r, q):
         for d in r:
             q.put(d)
-        q.put(end)
+        q.put(None)
 
     def data_reader():
         r = reader()
@@ -357,7 +352,7 @@ def buffered(reader, size):
         t.daemon = True
         t.start()
         e = q.get()
-        while e != end:
+        while e is not None:
             yield e
             e = q.get()
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
When a class object compares with a data array, it may raise problems.  Therefore, fix the bug by changing buffered data reader's `EndSignal`to `None`.  

![屏幕快照 2021-08-04 下午9 03 22](https://user-images.githubusercontent.com/20554008/128185481-078d4ec4-30b6-4cde-bb1d-b538a4fe31fd.png)
