### PR TITLE
add NPU support for zero_copy_tensor.

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -196,9 +196,8 @@ void Tensor::CopyToCpu(T *data) {
 #ifdef PADDLE_WITH_MKLDNN
     if (tensor->layout() == paddle::framework::DataLayout::kMKLDNN)
       paddle::framework::innerTransDataLayoutFromMKLDNN(
-          tensor->layout(),
-          paddle::platform::MKLDNNDeviceContext::tls()
-              .get_cur_paddle_data_layout(),
+          tensor->layout(), paddle::platform::MKLDNNDeviceContext::tls()
+                                .get_cur_paddle_data_layout(),
           *tensor, &out, paddle::platform::CPUPlace(), true);
     else
       std::memcpy(static_cast<void *>(data), t_data, ele_num * sizeof(T));

--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -196,9 +196,8 @@ void Tensor::CopyToCpu(T *data) {
 #ifdef PADDLE_WITH_MKLDNN
     if (tensor->layout() == paddle::framework::DataLayout::kMKLDNN)
       paddle::framework::innerTransDataLayoutFromMKLDNN(
-          tensor->layout(),
-          paddle::platform::MKLDNNDeviceContext::tls()
-              .get_cur_paddle_data_layout(),
+          tensor->layout(), paddle::platform::MKLDNNDeviceContext::tls()
+                                     .get_cur_paddle_data_layout(),
           *tensor, &out, paddle::platform::CPUPlace(), true);
     else
       std::memcpy(static_cast<void *>(data), t_data, ele_num * sizeof(T));

--- a/paddle/fluid/inference/api/details/zero_copy_tensor_test.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor_test.cc
@@ -133,6 +133,10 @@ TEST(Tensor, FillRandomDataAndCheck) {
   ASSERT_TRUE(FillRandomDataAndCheck(PlaceType::kGPU));
   ASSERT_TRUE(SetPlaceAndCheck(PlaceType::kGPU));
 #endif
+#ifdef PADDLE_WITH_ASCEND_CL
+  ASSERT_TRUE(FillRandomDataAndCheck(PlaceType::kNPU));
+  ASSERT_TRUE(SetPlaceAndCheck(PlaceType::kNPU));
+#endif
 }
 
 }  // namespace paddle_infer


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
ZeroCopyTensor的基类Tensor，在copy_to_cpu和copy_from_cpu，在NPU环境下会有问题，因为原有的代码里面少写了NPU的分支。

所以简单修改了一把，单测的修改也只是简单的加了两行。

