### PR TITLE
Add function named apply_optimizer in paddle.optimizer.Optimizer

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -860,6 +860,12 @@ class Optimizer(object):
         optimize_ops = self._create_optimization_pass(params_grads)
         return optimize_ops
 
+    def apply_optimize(self, loss, startup_program, params_grads):
+        """
+        See self._applay_optimize
+        """
+        return self._apply_optimize(loss, startup_program, params_grads)
+
     def _apply_optimize(self, loss, startup_program, params_grads):
         """
         Second part of `minimize`, appending optimization operators for


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
add function named apply_optimizer, which has the same usage as _apply_optimize
The instance of `paddle.optimizer.Optimizer` may be used in other optimizers (like `paddle.fluid.RecomputeOptimizer`) .
However,  its function `apply_optimize` rather than `_apply_optimize` will be called in `RecomputeOptimizer.apply_optimize` .