### PR TITLE
zero_copy_tensor unittest: support XPU.

### DIFF
--- a/paddle/fluid/framework/ir/multi_devices_graph_pass/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/multi_devices_graph_pass/CMakeLists.txt
@@ -18,4 +18,4 @@ cc_library(fuse_all_reduce_op_pass SRCS fuse_all_reduce_op_pass.cc DEPS graph gr
 cc_library(all_reduce_deps_pass SRCS all_reduce_deps_pass.cc DEPS all_reduce_op_handle graph graph_helper pass)
 cc_library(backward_optimizer_op_deps_pass SRCS backward_optimizer_op_deps_pass.cc DEPS graph graph_helper pass)
 cc_library(add_reader_dependency_pass SRCS add_reader_dependency_pass.cc DEPS graph graph_helper pass)
-cc_library(fix_op_run_order_pass SRCS fix_op_run_order_pass DEPS graph graph_helper multi_devices_helper pass op_handle_base eager_deletion_op_handle)   
+cc_library(fix_op_run_order_pass SRCS fix_op_run_order_pass.cc DEPS graph graph_helper multi_devices_helper pass op_handle_base eager_deletion_op_handle)

--- a/paddle/fluid/inference/api/details/zero_copy_tensor_test.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor_test.cc
@@ -137,6 +137,10 @@ TEST(Tensor, FillRandomDataAndCheck) {
   ASSERT_TRUE(FillRandomDataAndCheck(PlaceType::kNPU));
   ASSERT_TRUE(SetPlaceAndCheck(PlaceType::kNPU));
 #endif
+#ifdef PADDLE_WITH_XPU
+  ASSERT_TRUE(FillRandomDataAndCheck(PlaceType::kXPU));
+  ASSERT_TRUE(SetPlaceAndCheck(PlaceType::kXPU));
+#endif
 }
 
 }  // namespace paddle_infer


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
1、`zero_copy_tensor_test.cc`单测里面少了对XPU的测试，其实本来也能跑过。
2、顺手，细节修改了某个`CMakeLists.txt`，要不在用高版本的`cmake`的时候会报一个warning如下。
虽然就是个warning，但干掉总比留着好。

> CMake Warning (dev) at cmake/generic.cmake:311 (add_library):
>   Policy CMP0115 is not set: Source file extensions must be explicit.  Run
>   "cmake --help-policy CMP0115" for policy details.  Use the cmake_policy
>   command to set the policy and suppress this warning.
>   File:
>     /root/houjue/build_paddle/Paddle/paddle/fluid/framework/ir/multi_devices_graph_pass/fix_op_run_order_pass.cc
> Call Stack (most recent call first):
>   paddle/fluid/framework/ir/multi_devices_graph_pass/CMakeLists.txt:21 (cc_library)
> This warning is for project developers.  Use -Wno-dev to suppress it.

