### PR TITLE
[NPU] add lock for npu_pinned_allocator

### DIFF
--- a/paddle/fluid/memory/allocation/npu_pinned_allocator.cc
+++ b/paddle/fluid/memory/allocation/npu_pinned_allocator.cc
@@ -39,7 +39,7 @@ void NPUPinnedAllocator::ProcessEventsAndFree() {
 }
 
 Allocation *NPUPinnedAllocator::AllocateImpl(size_t size) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mtx_);
   ProcessEventsAndFree();
   void *ptr;
   int error = posix_memalign(&ptr, kAlignment, size);
@@ -51,7 +51,7 @@ Allocation *NPUPinnedAllocator::AllocateImpl(size_t size) {
 }
 
 void NPUPinnedAllocator::FreeImpl(Allocation *allocation) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mtx_);
   void *ptr = allocation->ptr();
   auto iter = npu_events_.find(allocation);
   aclrtEvent event = iter->second;
@@ -67,14 +67,14 @@ void NPUPinnedAllocator::FreeImpl(Allocation *allocation) {
 }
 
 uint64_t NPUPinnedAllocator::ReleaseImpl(const platform::Place &place) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mtx_);
   // Empty implementation
   return static_cast<uint64_t>(0);
 }
 
 void NPUPinnedAllocator::RecordEvent(Allocation *allocation,
                                      aclrtStream stream) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::lock_guard<std::mutex> lock(mtx_);
   aclrtEvent event = nullptr;
   PADDLE_ENFORCE_NPU_SUCCESS(aclrtCreateEvent(&event));
   PADDLE_ENFORCE_NPU_SUCCESS(aclrtRecordEvent(event, stream));

--- a/paddle/fluid/memory/allocation/npu_pinned_allocator.cc
+++ b/paddle/fluid/memory/allocation/npu_pinned_allocator.cc
@@ -39,6 +39,7 @@ void NPUPinnedAllocator::ProcessEventsAndFree() {
 }
 
 Allocation *NPUPinnedAllocator::AllocateImpl(size_t size) {
+  std::lock_guard<std::mutex> lock(mutex_);
   ProcessEventsAndFree();
   void *ptr;
   int error = posix_memalign(&ptr, kAlignment, size);
@@ -50,6 +51,7 @@ Allocation *NPUPinnedAllocator::AllocateImpl(size_t size) {
 }
 
 void NPUPinnedAllocator::FreeImpl(Allocation *allocation) {
+  std::lock_guard<std::mutex> lock(mutex_);
   void *ptr = allocation->ptr();
   auto iter = npu_events_.find(allocation);
   aclrtEvent event = iter->second;
@@ -65,11 +67,14 @@ void NPUPinnedAllocator::FreeImpl(Allocation *allocation) {
 }
 
 uint64_t NPUPinnedAllocator::ReleaseImpl(const platform::Place &place) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  // Empty implementation
   return static_cast<uint64_t>(0);
 }
 
 void NPUPinnedAllocator::RecordEvent(Allocation *allocation,
                                      aclrtStream stream) {
+  std::lock_guard<std::mutex> lock(mutex_);
   aclrtEvent event = nullptr;
   PADDLE_ENFORCE_NPU_SUCCESS(aclrtCreateEvent(&event));
   PADDLE_ENFORCE_NPU_SUCCESS(aclrtRecordEvent(event, stream));

--- a/paddle/fluid/memory/allocation/npu_pinned_allocator.h
+++ b/paddle/fluid/memory/allocation/npu_pinned_allocator.h
@@ -42,6 +42,7 @@ class NPUPinnedAllocator : public Allocator {
 
  private:
   std::unordered_map<Allocation *, aclrtEvent> npu_events_;
+  mutable std::mutex mtx_;
 };
 
 }  // namespace allocation


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add lock for npu_pinned_allocator to support multi-thread usage, for example, Parallel executor.