### PR TITLE
Fix error of HSigmoidLoss

### DIFF
--- a/paddle/fluid/operators/hierarchical_sigmoid_op.cc
+++ b/paddle/fluid/operators/hierarchical_sigmoid_op.cc
@@ -71,8 +71,17 @@ class HierarchicalSigmoidOp : public framework::OperatorWithKernel {
     if (with_prefetch) {
       OP_INOUT_CHECK(ctx->HasOutput("W_Out"), "Output", "W_Out", "hsigmoid");
     }
-    const int64_t batch_size = ctx->GetInputDim("X")[0];
-    std::vector<int64_t> output_shape({batch_size, 1});
+    const int64_t input_dims = ctx->GetInputDim("X")[0];
+    const int64_t label_dims = ctx->GetInputDim("Label")[0];
+    PADDLE_ENFORCE_EQ(input_dims, label_dims,
+                      platform::errors::InvalidArgument(
+                          "The first dimension of "
+                          "input and label is expected to be the same. "
+                          "But received input's first dimension is %d; "
+                          "label's first dimension is %d.",
+                          input_dims, label_dims));
+
+    std::vector<int64_t> output_shape({input_dims, 1});
     ctx->SetOutputDim("Out", framework::make_ddim(output_shape));
     ctx->ShareLoD("X", /*->*/ "Out");
   }

--- a/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
@@ -519,7 +519,6 @@ class TestHSigmoidLossAPI(unittest.TestCase):
             self.assertTrue(np.allclose(ret, self.out_np))
 
     def test_errors(self):
- 
         with paddle.static.program_guard(paddle.static.Program(),
                                          paddle.static.Program()):
             # test paddle.nn.HSigmoidLoss
@@ -576,23 +575,21 @@ class TestHSigmoidLossAPI(unittest.TestCase):
                 weight,
                 path_code=path_code_int32)
 
-        paddle.disable_static()
         # test paddle.nn.HSigmoidLoss
+        paddle.disable_static()
         x_arr = np.array([], dtype=np.float32)
         x = paddle.to_tensor(np.reshape(x_arr, (100000, 0)))
         label = paddle.to_tensor(0, dtype='int64')
-
+        paddle.enable_static()
         self.assertRaises(ValueError, paddle.nn.HSigmoidLoss, x, label)
 
         # test paddle.nn.functional.hsigmoid_loss
-        x_arr = np.array([], dtype=np.float32)
+        paddle.disable_static()
         x = paddle.to_tensor(np.reshape(x_arr, (10, 0)), dtype='float32')
-
         label = paddle.to_tensor([], dtype='int64')
-
         weight = paddle.to_tensor([], dtype='float32')
-
-        self.assertRaises(TypeError, F.hsigmoid_loss, x, label, 0, weight)
+        paddle.enable_static()
+        self.assertRaises(ValueError, F.hsigmoid_loss, x, label, 0, weight)
 
         # test paddle.fluid.layers.hsigmoid
         with program_guard(Program()):

--- a/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
@@ -519,6 +519,7 @@ class TestHSigmoidLossAPI(unittest.TestCase):
             self.assertTrue(np.allclose(ret, self.out_np))
 
     def test_errors(self):
+ 
         with paddle.static.program_guard(paddle.static.Program(),
                                          paddle.static.Program()):
             # test paddle.nn.HSigmoidLoss
@@ -574,6 +575,24 @@ class TestHSigmoidLossAPI(unittest.TestCase):
                 8,
                 weight,
                 path_code=path_code_int32)
+
+        paddle.disable_static()
+        # test paddle.nn.HSigmoidLoss
+        x_arr = np.array([], dtype=np.float32)
+        x = paddle.to_tensor(np.reshape(x_arr, (100000, 0)))
+        label = paddle.to_tensor(0, dtype='int64')
+
+        self.assertRaises(ValueError, paddle.nn.HSigmoidLoss, x, label)
+
+        # test paddle.nn.functional.hsigmoid_loss
+        x_arr = np.array([], dtype=np.float32)
+        x = paddle.to_tensor(np.reshape(x_arr, (10, 0)), dtype='float32')
+
+        label = paddle.to_tensor([], dtype='int64')
+
+        weight = paddle.to_tensor([], dtype='float32')
+
+        self.assertRaises(TypeError, F.hsigmoid_loss, x, label, 0, weight)
 
         # test paddle.fluid.layers.hsigmoid
         with program_guard(Program()):

--- a/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
@@ -576,20 +576,18 @@ class TestHSigmoidLossAPI(unittest.TestCase):
                 path_code=path_code_int32)
 
         # test paddle.nn.HSigmoidLoss
-        paddle.disable_static()
+        paddle.disable_static(self.place)
         x_arr = np.array([], dtype=np.float32)
         x = paddle.to_tensor(np.reshape(x_arr, (100000, 0)))
         label = paddle.to_tensor(0, dtype='int64')
-        paddle.enable_static()
         self.assertRaises(ValueError, paddle.nn.HSigmoidLoss, x, label)
 
         # test paddle.nn.functional.hsigmoid_loss
-        paddle.disable_static()
         x = paddle.to_tensor(np.reshape(x_arr, (10, 0)), dtype='float32')
         label = paddle.to_tensor([], dtype='int64')
         weight = paddle.to_tensor([], dtype='float32')
-        paddle.enable_static()
         self.assertRaises(ValueError, F.hsigmoid_loss, x, label, 0, weight)
+        paddle.enable_static()
 
         # test paddle.fluid.layers.hsigmoid
         with program_guard(Program()):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix bugs of HSigmoidLoss where memory overflow occurs if the first dimension of input and label is not equal.