### PR TITLE
fix for div zero

### DIFF
--- a/paddle/fluid/operators/warpctc_op.h
+++ b/paddle/fluid/operators/warpctc_op.h
@@ -257,20 +257,6 @@ class WarpCTCKernel : public framework::OpKernel<T> {
                             "but received %d. ",
                             logits_dims[0]));
 
-      PADDLE_ENFORCE_GT(logits_dims[1], 0,
-                        platform::errors::InvalidArgument(
-                            "The second dimension of Input(Logits) should be "
-                            "greater than zero "
-                            "but received %d. ",
-                            logits_dims[1]));
-
-      PADDLE_ENFORCE_GT(logits_dims[2], 0,
-                        platform::errors::InvalidArgument(
-                            "The third dimension of Input(Logits) should be "
-                            "greater than zero "
-                            "but received %d. ",
-                            logits_dims[2]));
-
       PADDLE_ENFORCE_EQ(
           logits_dims[0], static_cast<int64_t>(logits_lod.back()),
           platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/warpctc_op.h
+++ b/paddle/fluid/operators/warpctc_op.h
@@ -220,13 +220,6 @@ class WarpCTCKernel : public framework::OpKernel<T> {
                             "but received %d. ",
                             sequence_width));
 
-      PADDLE_ENFORCE_GT(logits_dims[2], 0,
-                        platform::errors::InvalidArgument(
-                            "The third dimension of Input(Logits) should be "
-                            "greater than zero "
-                            "but received %d. ",
-                            logits_dims[2]));
-
       auto* logits_length = ctx.Input<framework::Tensor>("LogitsLength");
       auto* labels_length = ctx.Input<framework::Tensor>("LabelLength");
       framework::Tensor logits_length_cpu;

--- a/paddle/fluid/operators/warpctc_op.h
+++ b/paddle/fluid/operators/warpctc_op.h
@@ -199,6 +199,34 @@ class WarpCTCKernel : public framework::OpKernel<T> {
       sequence_width = logits->dims()[2];
       max_sequence_length = logits->dims()[0];
 
+      PADDLE_ENFORCE_GT(max_sequence_length, 0,
+                        platform::errors::InvalidArgument(
+                            "The first dimension of Input(Logits) should be "
+                            "greater than zero "
+                            "but received %d. ",
+                            max_sequence_length));
+
+      PADDLE_ENFORCE_GT(num_sequences, 0,
+                        platform::errors::InvalidArgument(
+                            "The second dimension of Input(Logits) should be "
+                            "greater than zero "
+                            "but received %d. ",
+                            num_sequences));
+
+      PADDLE_ENFORCE_GT(sequence_width, 0,
+                        platform::errors::InvalidArgument(
+                            "The third dimension of Input(Logits) should be "
+                            "greater than zero "
+                            "but received %d. ",
+                            sequence_width));
+
+      PADDLE_ENFORCE_GT(logits_dims[2], 0,
+                        platform::errors::InvalidArgument(
+                            "The third dimension of Input(Logits) should be "
+                            "greater than zero "
+                            "but received %d. ",
+                            logits_dims[2]));
+
       auto* logits_length = ctx.Input<framework::Tensor>("LogitsLength");
       auto* labels_length = ctx.Input<framework::Tensor>("LabelLength");
       framework::Tensor logits_length_cpu;
@@ -228,6 +256,27 @@ class WarpCTCKernel : public framework::OpKernel<T> {
 
       logits_lod = framework::ToAbsOffset(logits->lod())[0];
       auto logits_dims = logits->dims();
+
+      PADDLE_ENFORCE_GT(logits_dims[0], 0,
+                        platform::errors::InvalidArgument(
+                            "The first dimension of Input(Logits) should be "
+                            "greater than zero "
+                            "but received %d. ",
+                            logits_dims[0]));
+
+      PADDLE_ENFORCE_GT(logits_dims[1], 0,
+                        platform::errors::InvalidArgument(
+                            "The second dimension of Input(Logits) should be "
+                            "greater than zero "
+                            "but received %d. ",
+                            logits_dims[1]));
+
+      PADDLE_ENFORCE_GT(logits_dims[2], 0,
+                        platform::errors::InvalidArgument(
+                            "The third dimension of Input(Logits) should be "
+                            "greater than zero "
+                            "but received %d. ",
+                            logits_dims[2]));
 
       PADDLE_ENFORCE_EQ(
           logits_dims[0], static_cast<int64_t>(logits_lod.back()),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes 

### PR changes
OPs

### Describe
fix for div zero error

functional.ctc_loss存在除0异常
调用paddle.nn.functional.ctc_loss进行计算的时候，在sequence_padding.cc中存在除0异常。

PoC:

import paddle
from paddle.nn import TransformerEncoderLayer
import numpy as np


input_arr = np.array([], dtype=np.float32)
log_probs = paddle.to_tensor(np.reshape(input_arr, (3, 0, 19)), dtype='float32')

labels_arr = np.array([], dtype=np.float32)
labels = paddle.to_tensor(np.reshape(input_arr, (0, 0)), dtype='float32')

input_lengths = paddle.to_tensor([], dtype='float32')

label_lengths = paddle.to_tensor([], dtype='float32')

paddle.nn.functional.ctc_loss(log_probs, labels, input_lengths, label_lengths, blank=0)
ASAN Info:

==162441==ERROR: AddressSanitizer: FPE on unknown address 0x7f3bb9b98db4 (pc 0x7f3bb9b98db4 bp 0x7ffc8f998740 sp 0x7ffc8f9985c0 T0)
   #0 0x7f3bb9b98db4 in paddle::operators::math::UnpaddingLoDTensorFunctor<paddle::platform::CPUDeviceContext, int>::operator()(paddle::platform::CPUDeviceContext const&, paddle::framework::LoDTensor const&, paddle::framework::LoDTensor*, int, int, bool, paddle::operators::math::PadLayout) /home/work/yakun/py-paddle/Paddle/paddle/fluid/operators/math/sequence_padding.cc:152:42
   #1 0x7f3bb118672d in paddle::operators::WarpCTCKernel<paddle::platform::CPUDeviceContext, float>::Compute(paddle::framework::ExecutionContext const&) const /home/work/yakun/py-paddle/Paddle/paddle/fluid/operators/warpctc_op.h:321:9
   #2 0x7f3bb1181fae in paddle::framework::OpKernelRegistrarFunctor<paddle::platform::CPUPlace, false, 0ul, paddle::operators::WarpCTCKernel<paddle::platform::CPUDeviceContext, float>, paddle::operators::WarpCTCKernel<paddle::platform::CPUDeviceContext, double> >::operator()(char const*, char const*, int) const::'lambda'(paddle::framework::ExecutionContext const&)::operator()(paddle::framework::ExecutionContext const&) const /home/work/yakun/py-paddle/Paddle/paddle/fluid/framework/op_registry.h:182:25
   #3 0x7f3bb1181fae in std::_Function_handler<void (paddle::framework::ExecutionContext const&), paddle::framework::OpKernelRegistrarFunctor<paddle::platform::CPUPlace, false, 0ul, paddle::operators::WarpCTCKernel<paddle::platform::CPUDeviceContext, float>, paddle::operators::WarpCTCKernel<paddle::platform::CPUDeviceContext, double> >::operator()(char const*, char const*, int) const::'lambda'(paddle::framework::ExecutionContext const&)>::_M_invoke(std::_Any_data const&, paddle::framework::ExecutionContext const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_function.h:297:2
   #4 0x7f3bbb5b56dc in std::function<void (paddle::framework::ExecutionContext const&)>::operator()(paddle::framework::ExecutionContext const&) const /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_function.h:687:14
Python version: 3.8

paddlepaddle版本：Develop （2021-07-14 pull）



漏洞代码
paddlepaddle develop中，代码位置：https://sourcegraph.com/github.com/PaddlePaddle/Paddle@develop/-/blob/paddle/fluid/operators/math/sequence_padding.cc?L152

问题代码：

int step_width = seq_tensor->numel() / seq_tensor_dims[0];
其中，由于没做check，seq_tensor_dims[0]为0，触发异常
