### PR TITLE
fix format_string_append test cast,test=develop

### DIFF
--- a/paddle/fluid/string/string_helper_test.cc
+++ b/paddle/fluid/string/string_helper_test.cc
@@ -33,10 +33,10 @@ TEST(StringHelper, EndsWith) {
 
 TEST(StringHelper, FormatStringAppend) {
   std::string str("hello");
-  char fmt[] = "hhh";
+  char fmt[] = "%d";
 
-  paddle::string::format_string_append(str, fmt);
-  EXPECT_EQ(str, "hellohhh");
+  paddle::string::format_string_append(str, fmt, 10);
+  EXPECT_EQ(str, "hello10");
 }
 
 TEST(StringHelper, JoinStrings) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

修改 string_helper_test.cc 的测试case。该case 使用不当，会引起intel的CI 失败。
详见issue: https://github.com/PaddlePaddle/Paddle/issues/34745

