### PR TITLE
add NPU_BLACK_LIST env to run specific op on cpu

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -191,6 +191,9 @@ cc_library(unused_var_check SRCS unused_var_check.cc DEPS glog no_need_buffer_va
 IF(WITH_XPU)
 cc_library(operator SRCS operator.cc DEPS xpu_op_list op_info device_context tensor scope glog trainer_desc_proto data_feed_proto
     shape_inference data_transform lod_tensor profiler transfer_scope_cache op_kernel_type op_call_stack unused_var_check nan_inf_utils)
+ELSEIF(WITH_ASCEND_CL)
+cc_library(operator SRCS operator.cc DEPS npu_blacklist_op op_info device_context tensor scope glog trainer_desc_proto data_feed_proto
+    shape_inference data_transform lod_tensor profiler transfer_scope_cache op_kernel_type op_call_stack unused_var_check nan_inf_utils)
 ELSE()
 cc_library(operator SRCS operator.cc DEPS op_info device_context tensor scope glog trainer_desc_proto data_feed_proto
     shape_inference data_transform lod_tensor profiler transfer_scope_cache op_kernel_type op_call_stack unused_var_check nan_inf_utils)

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -44,6 +44,10 @@ class LoDTensor;
 #include "paddle/fluid/platform/mkldnn_helper.h"
 #endif
 
+#ifdef PADDLE_WITH_ASCEND_CL
+#include "paddle/fluid/platform/npu_blacklist_op.h"
+#endif
+
 DECLARE_bool(benchmark);
 DECLARE_bool(check_nan_inf);
 DECLARE_bool(enable_unused_var_check);
@@ -1267,7 +1271,8 @@ void OperatorWithKernel::ChooseKernel(const RuntimeContext& ctx,
 #endif
 #ifdef PADDLE_WITH_ASCEND_CL
   if (kernel_iter == kernels.end() &&
-      is_npu_place(expected_kernel_key.place_)) {
+      is_npu_place(expected_kernel_key.place_) ||
+      paddle::platform::is_in_npu_black_list(type_)) {
     VLOG(3) << "missing NPU kernel: " << type_
             << ", expected_kernel_key:" << expected_kernel_key
             << ", fallbacking to CPU one!";

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/operator.h"
 
 #include <glog/logging.h>
+
 #include <sstream>
 #include <string>
 
@@ -42,6 +43,10 @@ class LoDTensor;
 
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
+#endif
+
+#ifdef PADDLE_WITH_ASCEND_CL
+#include "paddle/fluid/platform/npu_blacklist_op.h"
 #endif
 
 DECLARE_bool(benchmark);
@@ -1267,7 +1272,8 @@ void OperatorWithKernel::ChooseKernel(const RuntimeContext& ctx,
 #endif
 #ifdef PADDLE_WITH_ASCEND_CL
   if (kernel_iter == kernels.end() &&
-      is_npu_place(expected_kernel_key.place_)) {
+          is_npu_place(expected_kernel_key.place_) ||
+      paddle::platform::is_in_npu_black_list(type_)) {
     VLOG(3) << "missing NPU kernel: " << type_
             << ", expected_kernel_key:" << expected_kernel_key
             << ", fallbacking to CPU one!";

--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -20,6 +20,9 @@
 #ifdef PADDLE_WITH_XPU
 #include "paddle/fluid/platform/xpu/xpu_op_list.h"
 #endif
+#ifdef PADDLE_WITH_ASCEND_CL
+#include "paddle/fluid/platform/npu_blacklist_op.h"
+#endif
 DECLARE_bool(check_nan_inf);
 
 namespace paddle {
@@ -144,7 +147,8 @@ PreparedOp PrepareImpl(const NameVarMap<VarType>& ins,
 #endif
 #ifdef PADDLE_WITH_ASCEND_CL
   if (kernel_iter == kernels.end() &&
-      is_npu_place(expected_kernel_key.place_)) {
+          is_npu_place(expected_kernel_key.place_) ||
+      paddle::platform::is_in_npu_black_list(op.Type())) {
     VLOG(3) << "missing NPU kernel: " << op.Type()
             << ", expected_kernel_key:" << expected_kernel_key
             << ", fallbacking to CPU one!";

--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -20,6 +20,9 @@
 #ifdef PADDLE_WITH_XPU
 #include "paddle/fluid/platform/xpu/xpu_op_list.h"
 #endif
+#ifdef PADDLE_WITH_ASCEND_CL
+#include "paddle/fluid/platform/npu_blacklist_op.h"
+#endif
 DECLARE_bool(check_nan_inf);
 
 namespace paddle {
@@ -144,7 +147,8 @@ PreparedOp PrepareImpl(const NameVarMap<VarType>& ins,
 #endif
 #ifdef PADDLE_WITH_ASCEND_CL
   if (kernel_iter == kernels.end() &&
-      is_npu_place(expected_kernel_key.place_)) {
+      is_npu_place(expected_kernel_key.place_) ||
+      paddle::platform::is_in_npu_black_list(op.Type())) {
     VLOG(3) << "missing NPU kernel: " << op.Type()
             << ", expected_kernel_key:" << expected_kernel_key
             << ", fallbacking to CPU one!";

--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -79,6 +79,8 @@ endif()
 
 if(WITH_ASCEND_CL)
     cc_library(npu_info SRCS npu_info.cc DEPS gflags glog enforce monitor ascendcl acl_op_compiler)
+    cc_library(npu_blacklist_op SRCS npu_blacklist_op.cc)
+    cc_test(npu_blacklist_op_test SRCS npu_blacklist_op_test.cc DEPS npu_blacklist_op)
 endif()
 
 add_subdirectory(dynload)

--- a/paddle/fluid/platform/npu_blacklist_op.cc
+++ b/paddle/fluid/platform/npu_blacklist_op.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#ifdef PADDLE_WITH_ASCEND_CL
+#include "paddle/fluid/platform/npu_blacklist_op.h"
+
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+#include "glog/logging.h"
+#include "paddle/fluid/string/split.h"
+
+namespace paddle {
+namespace platform {
+
+bool is_in_npu_black_list(const std::string& op_name) {
+  static bool inited = false;
+  static std::unordered_set<std::string> npu_black_list;
+  static std::mutex s_mtx;
+  if (!inited) {
+    std::lock_guard<std::mutex> guard(s_mtx);
+    if (!inited) {
+      if (std::getenv("NPU_BLACK_LIST") != nullptr) {
+        std::string ops(std::getenv("NPU_BLACK_LIST"));
+        npu_black_list = paddle::string::SplitToSet(ops, ',');
+      }
+      inited = true;
+      VLOG(3) << "NPU Black List: ";
+      for (auto iter = npu_black_list.begin(); iter != npu_black_list.end();
+           ++iter) {
+        VLOG(3) << *iter << " ";
+      }
+    }
+  }
+  if (npu_black_list.find(op_name) != npu_black_list.end()) {
+    return true;
+  }
+  return false;
+}
+
+}  // namespace platform
+}  // namespace paddle
+#endif

--- a/paddle/fluid/platform/npu_blacklist_op.h
+++ b/paddle/fluid/platform/npu_blacklist_op.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#ifdef PADDLE_WITH_ASCEND_CL
+#include <string>
+
+namespace paddle {
+namespace platform {
+
+bool is_in_npu_black_list(const std::string& op_name);
+
+}  // namespace platform
+}  // namespace paddle
+#endif

--- a/paddle/fluid/platform/npu_blacklist_op_test.cc
+++ b/paddle/fluid/platform/npu_blacklist_op_test.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#ifdef PADDLE_WITH_ASCEND_CL
+#include "paddle/fluid/platform/npu_blacklist_op.h"
+
+#include "gtest/gtest.h"
+
+TEST(NpuBlackList, NpuBlackList) {
+  setenv("NPU_BLACK_LIST", "add,add_grad,sub", 1);
+  ASSERT_TRUE(paddle::platform::is_in_npu_black_list("add"));
+  ASSERT_TRUE(paddle::platform::is_in_npu_black_list("add_grad"));
+  ASSERT_TRUE(paddle::platform::is_in_npu_black_list("sub"));
+  ASSERT_FALSE(paddle::platform::is_in_npu_black_list("sub_grad"));
+}
+
+#endif

--- a/paddle/fluid/string/split.h
+++ b/paddle/fluid/string/split.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 #include <sstream>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace paddle {
@@ -28,6 +29,19 @@ static inline std::vector<std::string> Split(std::string const& original,
   while (std::getline(is, token, separator)) {
     if (!token.empty()) {
       results.push_back(token);
+    }
+  }
+  return results;
+}
+
+static inline std::unordered_set<std::string> SplitToSet(
+    std::string const& original, char separator) {
+  std::unordered_set<std::string> results;
+  std::string token;
+  std::istringstream is(original);
+  while (std::getline(is, token, separator)) {
+    if (!token.empty()) {
+      results.insert(token);
     }
   }
   return results;

--- a/paddle/fluid/string/split_test.cc
+++ b/paddle/fluid/string/split_test.cc
@@ -26,3 +26,11 @@ TEST(StringSplit, StringSplit) {
     i++;
   }
 }
+
+TEST(StringSplitToSet, StringSplitToSet) {
+  std::string to_split = "0,1,2,3,0";
+  std::unordered_set<std::string> result =
+      paddle::string::SplitToSet(to_split, ',');
+  std::unordered_set<std::string> expected = {"0", "1", "2", "3"};
+  EXPECT_EQ(result, expected);
+}


### PR DESCRIPTION
### PR types
New features

### PR changes
Others

### Describe
类似XPU的#34605，给NPU也增加了“根据环境变量，指定某些NPU算子在CPU上运行”的功能。
用途：在怀疑某些NPU算子实现有问题而导致模型算不对的时候，可以用NPU_BLACK_LIST把疑似有问题的算子干掉，让它在CPU上执行（而不需要重新编译）。
