### PR TITLE
fix set_grad_ivar bug of Tensor.backward

### DIFF
--- a/paddle/fluid/imperative/gradient_accumulator.cc
+++ b/paddle/fluid/imperative/gradient_accumulator.cc
@@ -184,6 +184,12 @@ void TensorAdd(const framework::Variable& src, framework::Variable* dst) {
   auto data_type = src_tensor.type();
   auto place = src_tensor.place();
 
+  PADDLE_ENFORCE_EQ(dst_tensor->type(), data_type,
+                    platform::errors::PreconditionNotMet(
+                        "The data type of source tensor and destination tensor "
+                        "should be equal, Otherwise, the calculation results "
+                        "will be incorrect."));
+
 #define PADDLE_TENSOR_ADD(cpp_type)                                  \
   if (data_type == framework::DataTypeTrait<cpp_type>::DataType()) { \
     TensorAddFunctor<cpp_type> func(                                 \
@@ -422,9 +428,9 @@ void GradientAccumulator::AccumulateGrad() {
   auto* src = inner_var_->MutableVar();
   auto* dst = var_->MutableVar();
   if (!var_->IsEmpty()) {
-    VLOG(6) << "Leaf Gradient Var(" << var_->Name()
-            << ") has been calculated by previous graph, will accumulate on "
-               "previous graph.";
+    VLOG(6) << "Leaf Var(" << var_->Name()
+            << ")'s Gradient has been initizlized, will accumulate on "
+               "previous gradient.";
     if (dst->IsType<framework::LoDTensor>()) {
       if (src->IsType<framework::LoDTensor>()) {
         TensorAdd(*src, dst);
@@ -444,8 +450,9 @@ void GradientAccumulator::AccumulateGrad() {
           "Only support LoDTensor and SelectedRows for gradient var"));
     }
   } else {
-    VLOG(6) << "Leaf Gradient Var(" << var_->Name()
-            << ") has not been initialized, not accumulate. Just move";
+    VLOG(6)
+        << "Leaf Var(" << var_->Name()
+        << ")'s Gradient has not been initialized, not accumulate. Just move";
     *(dst) = std::move(*src);
     var_->SetType(inner_var_->Type());
     var_->SetDataType(inner_var_->DataType());

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -110,6 +110,7 @@ class VarBase {
 
   void SetGradVarBase(const VarBase& grad_var) {
     MutableGradVarBase()->CopyFrom(grad_var, true);
+    MutableGradVarBase()->SharedVar()->SetIsEmpty(false);
   }
 
   const std::shared_ptr<VarBase>& MutableGradVarBase() {
@@ -142,6 +143,8 @@ class VarBase {
     return grad_var_->MutableVar();
   }
 
+  bool IsLeaf() const { return var_->IsLeaf(); }
+
   void SetOverridedStopGradient(bool stop_gradient) {
     var_->SetOverridedStopGradient(stop_gradient);
     if (grad_var_) {
@@ -151,15 +154,17 @@ class VarBase {
 
   bool OverridedStopGradient() const { return var_->OverridedStopGradient(); }
 
-  bool IsLeaf() const { return var_->IsLeaf(); }
-
   void InnerSetOverridedStopGradient(bool stop_gradient) {
-    if (var_->InnerOverridedStopGradient() == -1) {
+    if (InnerOverridedStopGradient() == -1) {
       var_->InnerSetOverridedStopGradient(stop_gradient);
       if (grad_var_) {
         grad_var_->InnerSetOverridedStopGradient(stop_gradient);
       }
     }
+  }
+
+  int InnerOverridedStopGradient() const {
+    return var_->InnerOverridedStopGradient();
   }
 
   void SetPersistable(bool persistable) { var_->SetPersistable(persistable); }

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -41,7 +41,6 @@ class MyLayer(fluid.Layer):
 class MLP(fluid.Layer):
     def __init__(self, input_size):
         super(MLP, self).__init__()
-        self._linear1 = None
         self._linear1 = Linear(
             input_size,
             3,
@@ -607,11 +606,20 @@ class TestImperative(unittest.TestCase):
 
                 mlp2.clear_gradients()
                 self.assertTrue(np.array_equal(clear_loss.grad.numpy(), [1]))
-                if ((batch_id + 1) % 10) == 0:
+                if ((batch_id + 1) % 10) % 2 == 0:
                     mlp1.clear_gradients()
                     expected_weight1_grad = 0.
                     expected_bias1_grad = 0.
                     expected_weight2_grad = 0.
+                    expected_bias2_grad = 0.
+                elif ((batch_id + 1) % 10) % 2 == 1:
+                    mlp1.clear_gradients()
+                    mlp1._linear1.weight._set_grad_ivar(
+                        paddle.ones([input_size, 3]))
+                    mlp1._linear2.weight._set_grad_ivar(paddle.ones([3, 4]))
+                    expected_weight1_grad = 1.
+                    expected_bias1_grad = 0.
+                    expected_weight2_grad = 1.
                     expected_bias2_grad = 0.
 
         with fluid.dygraph.guard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

**手动设置的梯度是to_tensor出来的，to_tensor默认的stop_gradient为true，导致反向var的stop_gradient变成了true，而前向var为false，因此前向var认为可以创建反向OP，而反向var又在SetOutput时把自己从输出里剪掉了，这导致了后面到inplace时执行报错。**

**该PR修改了手动设置梯度的逻辑，修复了这个问题 。**