### PR TITLE
Fix elementwise_add quantization

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -2249,9 +2249,9 @@ PDNode *patterns::MultipleQuantize::operator()() {
 PDNode *patterns::QuantizePlacement::operator()(
     const std::unordered_set<std::string> &quantize_enabled_op_types) {
   std::unordered_set<std::string> supported_op_types =
-      std::unordered_set<std::string>(
-          {"concat", "conv2d", "elementwise_add", "fc", "matmul", "pool2d",
-           "prior_box", "relu", "reshape2", "transpose2", "fusion_gru"});
+      std::unordered_set<std::string>({"concat", "conv2d", "elementwise_add",
+                                       "fc", "matmul", "pool2d", "prior_box",
+                                       "reshape2", "transpose2", "fusion_gru"});
   if (!quantize_enabled_op_types.empty()) {
     supported_op_types = quantize_enabled_op_types;
   }

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -770,7 +770,8 @@ void CPUQuantizePass::QuantizeElementwiseAdd(Graph* graph) const {
     GET_IR_NODE_FROM_SUBGRAPH(elementwise_add_out, elementwise_add_out,
                               elementwise_add_pattern);
 
-    if (!AreScalesPresentForNodes({elementwise_add_x, elementwise_add_y})) {
+    if (!AreScalesPresentForNodes({elementwise_add_x, elementwise_add_y}) ||
+        !AreScalesPresentForNodes({elementwise_add_out})) {
       LogCannotQuantizeOp(elementwise_add_op);
       return;
     }
@@ -793,16 +794,12 @@ void CPUQuantizePass::QuantizeElementwiseAdd(Graph* graph) const {
     QuantizeInput(g, elementwise_add_op, elementwise_add_y, "Y", input_y_scale,
                   is_y_unsigned, "Scale_y");
 
-    // if quantization scale is missing for output tensor, return fp32 data
-    if (AreScalesPresentForNodes({elementwise_add_out})) {
-      bool is_output_unsigned{false};
-      auto output_scale =
-          GetScaleValueForNode(elementwise_add_out, &is_output_unsigned);
-      DequantizeOutput(g, elementwise_add_op, elementwise_add_out, "Out",
-                       output_scale, is_output_unsigned, "Scale_out");
-    } else {
-      elementwise_add_op->Op()->SetAttr("force_fp32_output", true);
-    }
+    bool is_output_unsigned{false};
+    auto output_scale =
+        GetScaleValueForNode(elementwise_add_out, &is_output_unsigned);
+
+    DequantizeOutput(g, elementwise_add_op, elementwise_add_out, "Out",
+                     output_scale, is_output_unsigned, "Scale_out");
 
     ++quantize_elementwise_add_count;
   };

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -770,8 +770,8 @@ void CPUQuantizePass::QuantizeElementwiseAdd(Graph* graph) const {
     GET_IR_NODE_FROM_SUBGRAPH(elementwise_add_out, elementwise_add_out,
                               elementwise_add_pattern);
 
-    if (!AreScalesPresentForNodes({elementwise_add_x, elementwise_add_y}) ||
-        !AreScalesPresentForNodes({elementwise_add_out})) {
+    if (!AreScalesPresentForNodes(
+            {elementwise_add_x, elementwise_add_y, elementwise_add_out})) {
       LogCannotQuantizeOp(elementwise_add_op);
       return;
     }

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
@@ -854,13 +854,12 @@ TEST(CpuQuantizePass, elementwise_add) {
 
 TEST(CpuQuantizePass, elementwise_add_output_scale_missing) {
   int elementwise_add_count = 1;
-  int quant_count = 2;
+  int quant_count = 0;
   int dequant_count = 2;
-  // 2 Quant + 2 IN
-  int added_nodes_count = 4;
+  int added_nodes_count = 0;
   MainTestElementwiseAdd(BuildProgramDescElementwiseAdd(),
                          elementwise_add_count, quant_count, dequant_count,
-                         added_nodes_count, 2.0f * 127, true);
+                         added_nodes_count, 1.f, true);
 }
 
 TEST(CpuQuantizePass, elementwise_add_unsigned_and_signed_input) {

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
@@ -131,12 +131,12 @@ TEST(QuantizerPlacementPass, enabled_conv_excluded_one) {
 }
 
 TEST(QuantizerPlacementPass, empty_list) {
-  // all quantized operators, except relu
+  // all operators except relu should be quantized
   MainTest({}, {}, 5);
 }
 
 TEST(QuantizerPlacementPass, default_attr_value) {
-  //  all quantized operators, except relu
+  // all operators except relu should be quantized
   DefaultAttrTest(5);
 }
 

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
@@ -131,13 +131,13 @@ TEST(QuantizerPlacementPass, enabled_conv_excluded_one) {
 }
 
 TEST(QuantizerPlacementPass, empty_list) {
-  // all operators quantized
-  MainTest({}, {}, 6);
+  // all quantized operators, except relu
+  MainTest({}, {}, 5);
 }
 
 TEST(QuantizerPlacementPass, default_attr_value) {
-  //  all operators quantized
-  DefaultAttrTest(6);
+  //  all quantized operators, except relu
+  DefaultAttrTest(5);
 }
 
 }  // namespace ir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
This PR:
- removes `relu` from the list of quantizable operators because so far `relu` has no quantization support,
- modifies quantization process for `elementwise_add`: if there is no output tensor scale, the operator is not quantized. Previously, when there was no output scale, the `force_fp32_output` attribute was set, unfortunately, it was an error because the operator does not have such an attribute or functionality. 

This PR should fix the problem https://github.com/PaddlePaddle/Paddle/issues/34574