### PR TITLE
check the name and its order in docstring for the api's parameters

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1003,7 +1003,11 @@ function generate_api_spec() {
     fi
     pip --no-cache-dir install ${PADDLE_ROOT}/build/python/dist/*whl
     spec_path=${PADDLE_ROOT}/paddle/fluid/API_${spec_kind}.spec
-    python ${PADDLE_ROOT}/tools/print_signatures.py paddle > $spec_path
+    if [ "$spec_kind" == "DEV" ]; then
+        python ${PADDLE_ROOT}/tools/print_signatures.py --skip-api-args-doc-check paddle > $spec_path
+    else
+        python ${PADDLE_ROOT}/tools/print_signatures.py paddle > $spec_path
+    fi
 
     # used to log op_register data_type
     op_type_path=${PADDLE_ROOT}/paddle/fluid/OP_TYPE_${spec_kind}.spec

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -158,7 +158,8 @@ def check_api_args_doc(fullargspec, docstr):
 
     v = extract_args_desc_from_docstr(docstr)
 
-    if v.args != fullargspec.args and not (fullargspec.args[0] == 'self' and
+    if v.args != fullargspec.args and not (fullargspec.args and
+                                           fullargspec.args[0] == 'self' and
                                            v.args == fullargspec.args[1:]):
         logger.error(f'v.text={v.text}')
         logger.error('v.args is %s, not equal to FullArgSpec.args %s',

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -158,7 +158,8 @@ def check_api_args_doc(fullargspec, docstr):
 
     v = extract_args_desc_from_docstr(docstr)
 
-    if v.args != fullargspec.args:
+    if v.args != fullargspec.args and not (fullargspec.args[0] == 'self' and
+                                           v.args == fullargspec.args[1:]):
         logger.error(f'v.text={v.text}')
         logger.error('v.args is %s, not equal to FullArgSpec.args %s',
                      str(v.args), str(fullargspec.args))

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -90,6 +90,15 @@ class ArgsDescResult:
 
 
 def extract_args_desc_from_docstr(docstr):
+    """
+    extract args description from the docstring.
+
+    Args:
+        docstr (string): the docstring of the api. all the `tab` charactor will replaced by 4 spaces.
+    
+    Returns:
+        ArgsDescResult, a simple object similar to the result of the `inpect.getfullargspec`.
+    """
     docstr = inspect.cleandoc(docstr.replace("\t", '    '))
     lines = docstr.split('\n')
     args_started = False
@@ -151,13 +160,7 @@ def check_api_args_doc(fullargspec, docstr):
     Returns:
         boolean, check result
     """
-    #document = new_document('~', parser_settings)
-    #parser.parse(docstr, document)
-    #v = MyArgsVisitor(document)
-    #document.walkabout(v)
-
     v = extract_args_desc_from_docstr(docstr)
-
     if v.args != fullargspec.args and not (fullargspec.args and
                                            fullargspec.args[0] == 'self' and
                                            v.args == fullargspec.args[1:]):
@@ -218,6 +221,7 @@ def get_all_api(root_path='paddle', attr="__all__"):
 def insert_api_into_dict(full_name, gen_doc_anno=None):
     """
     insert add api into the api_info_dict
+
     Return:
         api_info object or None
     """
@@ -391,10 +395,6 @@ def parse_args():
         help="0 - don't report; 1 - all the exposed apis; 2 - all the apis.")
     parser.add_argument(
         'module', type=str, help='module', default='paddle')  # not used
-    parser.add_argument(
-        '--skip-api-args-doc-check',
-        dest='skip_api_args_doc_check',
-        action="store_true")
 
     if len(sys.argv) == 1:
         args = parser.parse_args(['paddle'])
@@ -441,7 +441,7 @@ if __name__ == '__main__':
             api_args_check_failed.append(api_name)
 
     exit_value = 0
-    if (not args.skip_api_args_doc_check) and api_args_check_failed:
+    if api_args_check_failed:
         exit_value = 1
         logger.error("some apis' args check failed: %s",
                      str(api_args_check_failed))

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -73,8 +73,8 @@ def is_primitive(instance):
         return False
 
 
-arg_pat = re.compile(r'^\s*[-\*]{1}\s*(\*{0,2}\s*\w*)\b\s*\([^\)]*\)\s*[:-].*')
-arg_pat_no_type_desc = re.compile(r'^\s*[-\*]{1}\s*(\*{0,2}\s*\w*)\b\s*[:-].*')
+arg_pat = re.compile(r'^\s*[-\*]?\s*(\*{0,2}\s*\w*)\b\s*\([^\)]*\)\s*[:-].*')
+arg_pat_no_type_desc = re.compile(r'^\s*[-\*]?\s*(\*{0,2}\s*\w*)\b\s*[:-].*')
 
 
 class ArgsDescResult:

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -143,6 +143,13 @@ def check_api_args_doc(fullargspec, docstr):
     check the name and order of the args.
 
     The Default value has so many formats.
+
+    Args:
+        fullargspec: the inpect.FullArgSpec object
+        docstr: the docstring of the function
+    
+    Returns:
+        boolean, check result
     """
     #document = new_document('~', parser_settings)
     #parser.parse(docstr, document)
@@ -423,7 +430,9 @@ def parse_args():
     parser.add_argument(
         'module', type=str, help='module', default='paddle')  # not used
     parser.add_argument(
-        '--check-api-args', dest='check_api_args', action="store_true")
+        '--skip-api-args-doc-check',
+        dest='skip_api_args_doc_check',
+        action="store_true")
 
     if len(sys.argv) == 1:
         args = parser.parse_args(['paddle'])
@@ -468,7 +477,7 @@ if __name__ == '__main__':
             print(
                 "Error, new function {} is unreachable".format(erroritem),
                 file=sys.stderr)
-    if args.check_api_args and api_args_check_failed:
+    if (not args.skip_api_args_doc_check) and api_args_check_failed:
         exit_value = 1
         logger.error("some apis' args check failed: %s",
                      str(api_args_check_failed))

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -26,11 +26,6 @@ import pkgutil
 import logging
 import argparse
 import re
-import docutils
-from docutils import nodes
-from docutils.parsers.rst import Directive, directives, roles, Parser
-from docutils.frontend import OptionParser
-from docutils.utils import new_document
 
 member_dict = collections.OrderedDict()
 
@@ -78,75 +73,8 @@ def is_primitive(instance):
         return False
 
 
-class RefNode(nodes.Inline, nodes.TextElement):
-    tagname = 'ref'
-    attributes = {}
-    children = tuple()
-
-    def __init__(self, data, rawsource=''):
-        """The raw text from which this element was constructed."""
-        self.rawsource = rawsource
-
-    def astext(self):
-        return f':ref:`{self.rawsource}`'
-
-
-def ref_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
-    roles.set_classes(options)
-    text = rawtext.split('`')[1]
-    node = RefNode(rawtext, text, **options)
-    return [node], []
-
-
 arg_pat = re.compile(r'^\s*(\*{0,2}\s*\w*)\b\s*\([^\)]*\)\s*:.*')
 arg_pat_no_type_desc = re.compile(r'^\s*(\*{0,2}\s*\w*)\b\s*:.*')
-
-
-class MyArgsVisitor(nodes.NodeVisitor):
-    def __init__(self, document):
-        nodes.NodeVisitor.__init__(self, document)
-        self.body = []
-        self.text = None
-        self.args = []
-        self.varargs = None
-        self.varkw = None
-        self.defaults = None
-        self.kwonlyargs = []
-        self.kwonlydefaults = None
-        self.annotations = {}
-
-    def unknown_visit(self, node):
-        pass
-
-    def unknown_departure(self, node):
-        pass
-
-    def visit_definition_list_item(self, node):
-        if node[0].astext(
-        ) in ['Args:', 'Parameters:', 'Parameter:', 'Params:', 'Param:']:
-            # print('Args: found')
-            self.text = node[1].astext()
-            self.args_names = []
-            for line in self.text.split('\n'):
-                mo = arg_pat.search(line)
-                if not mo:
-                    logger.debug('try another pattern')
-                    mo = arg_pat_no_type_desc.search(line)
-                if mo:
-                    arg_name = mo.group(1)
-                    self.args_names.append(arg_name)
-                    if arg_name.startswith('**'):
-                        self.varkw = arg_name[2:].strip()
-                    elif arg_name.startswith('*'):
-                        self.varargs = arg_name[1:].strip()
-                    else:
-                        self.args.append(arg_name)
-
-
-roles.register_local_role('ref', ref_role)
-parser = Parser()
-parser_settings = OptionParser(
-    components=(Parser, ), defaults={'report_level': 5}).get_default_values()
 
 
 class ArgsDescResult:

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -450,7 +450,12 @@ if __name__ == '__main__':
                 if 'signature' in api_info else 'ArgSpec()'))
         if argcheckit and 'argsdoc_check' in api_info and (
                 not api_info['argsdoc_check']):
-            api_args_check_failed.append(api_name)
+            if api_name.endswith('_'):
+                logger.debug(
+                    "%s args check failed. but it's an inplace api, skip it.",
+                    api_name)
+            else:
+                api_args_check_failed.append(api_name)
 
     exit_value = 0
     if (not args.skip_api_args_doc_check) and api_args_check_failed:

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -296,7 +296,7 @@ def insert_api_into_dict(full_name, gen_doc_anno=None):
             if gen_doc_anno:
                 api_info_dict[fc_id]["gen_doc_anno"] = gen_doc_anno
             if inspect.isfunction(obj):
-                argspec = inspect.getfullargspec(obj)
+                argspec = inspect.getfullargspec(inspect.unwrap(obj))
                 api_info_dict[fc_id]["signature"] = repr(argspec).replace(
                     'FullArgSpec', 'ArgSpec', 1)
                 if docstr:

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -73,8 +73,8 @@ def is_primitive(instance):
         return False
 
 
-arg_pat = re.compile(r'^\s*(\*{0,2}\s*\w*)\b\s*\([^\)]*\)\s*:.*')
-arg_pat_no_type_desc = re.compile(r'^\s*(\*{0,2}\s*\w*)\b\s*:.*')
+arg_pat = re.compile(r'^\s*[-\*]{1}\s*(\*{0,2}\s*\w*)\b\s*\([^\)]*\)\s*[:-].*')
+arg_pat_no_type_desc = re.compile(r'^\s*[-\*]{1}\s*(\*{0,2}\s*\w*)\b\s*[:-].*')
 
 
 class ArgsDescResult:

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -25,6 +25,12 @@ import hashlib
 import pkgutil
 import logging
 import argparse
+import re
+import docutils
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives, roles, Parser
+from docutils.frontend import OptionParser
+from docutils.utils import new_document
 
 member_dict = collections.OrderedDict()
 
@@ -70,6 +76,109 @@ def is_primitive(instance):
         return True
     else:
         return False
+
+
+class RefNode(nodes.Inline, nodes.TextElement):
+    tagname = 'ref'
+    attributes = {}
+    children = tuple()
+
+    def __init__(self, data, rawsource=''):
+        """The raw text from which this element was constructed."""
+        self.rawsource = rawsource
+        print(self.rawsource)
+
+    def astext(self):
+        return f':ref:`${self.rawsource}`'
+
+
+def ref_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
+    roles.set_classes(options)
+    text = rawtext.split('`')[1]
+    node = RefNode(rawtext, text, **options)
+    return [node], []
+
+
+arg_pat = re.compile(r'^\s*(\*{0,2}\s*\w*)\b\s*\([^\)]*\)\s*:.*')
+arg_pat_no_type_desc = re.compile(r'^\s*(\*{0,2}\s*\w*)\b\s*:.*')
+
+
+class MyArgsVisitor(nodes.NodeVisitor):
+    def __init__(self, document):
+        nodes.NodeVisitor.__init__(self, document)
+        self.body = []
+        self.text = None
+        self.args = []
+        self.varargs = None
+        self.varkw = None
+        self.defaults = None
+        self.kwonlyargs = []
+        self.kwonlydefaults = None
+        self.annotations = {}
+
+    def unknown_visit(self, node):
+        pass
+
+    def unknown_departure(self, node):
+        pass
+
+    def visit_definition_list_item(self, node):
+        if node[0].astext(
+        ) in ['Args:', 'Parameters:', 'Parameter:', 'Params:', 'Param:']:
+            # print('Args: found')
+            self.text = node[1].astext()
+            self.args_names = []
+            for line in self.text.split('\n'):
+                mo = arg_pat.search(line)
+                if not mo:
+                    logger.debug('try another pattern')
+                    mo = arg_pat_no_type_desc.search(line)
+                if mo:
+                    arg_name = mo.group(1)
+                    self.args_names.append(arg_name)
+                    print(f'###arg_name={arg_name}###')
+                    if arg_name.startswith('**'):
+                        self.varkw = arg_name[2:].strip()
+                    elif arg_name.startswith('*'):
+                        self.varargs = arg_name[1:].strip()
+                    else:
+                        self.args.append(arg_name)
+
+
+roles.register_local_role('ref', ref_role)
+parser = Parser()
+parser_settings = OptionParser(
+    components=(Parser, ), defaults={'report_level': 5}).get_default_values()
+
+
+def check_api_args_doc(fullargspec, docstr):
+    """
+    check the name and order of the args.
+
+    The Default value has so many formats.
+    """
+    document = new_document('~', parser_settings)
+    parser.parse(docstr, document)
+    v = MyArgsVisitor(document)
+    document.walkabout(v)
+
+    if v.args != fullargspec.args:
+        logger.error(f'v.text={v.text}')
+        logger.error('v.args is %s, not equal to FullArgSpec.args %s',
+                     str(v.args), str(fullargspec.args))
+        return False
+    if v.varargs != fullargspec.varargs:
+        logger.error(f'v.text={v.text}')
+        logger.error('v.varargs is %s, not equal to FullArgSpec.varargs %s',
+                     str(v.varargs), str(fullargspec.varargs))
+        return False
+    if v.varkw != fullargspec.varkw:
+        logger.error(f'v.text={v.text}')
+        logger.error('v.varkw is %s, not equal to FullArgSpec.varkw %s',
+                     str(v.varkw), str(fullargspec.varkw))
+        return False
+
+    return True
 
 
 ErrorSet = set()

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -401,6 +401,10 @@ def parse_args():
         default=1,
         help="0 - don't report; 1 - all the exposed apis; 2 - all the apis.")
     parser.add_argument(
+        '--skip-api-args-doc-check',
+        dest='skip_api_args_doc_check',
+        action="store_true")
+    parser.add_argument(
         'module', type=str, help='module', default='paddle')  # not used
 
     if len(sys.argv) == 1:
@@ -449,7 +453,7 @@ if __name__ == '__main__':
             api_args_check_failed.append(api_name)
 
     exit_value = 0
-    if api_args_check_failed:
+    if (not args.skip_api_args_doc_check) and api_args_check_failed:
         exit_value = 1
         logger.error("some apis' args check failed: %s",
                      str(api_args_check_failed))

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -440,7 +440,6 @@ def get_filenames(full_test=False):
     '''
     global whl_error
     import paddle
-    import paddle.fluid.contrib.slim.quantization
     whl_error = []
     if full_test:
         get_full_api_from_pr_spec()

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -128,7 +128,7 @@ def extract_code_blocks_from_docstr(docstr):
     lastlineindex = len(ds_list) - 1
 
     cb_start_pat = re.compile(r"code-block::\s*python")
-    cb_param_pat = re.compile(r"^\s*:(\w+):\s*(\S*)\s*$")
+    cb_param_pat = re.compile(r"^\s*:(\w+):\s*(.*)\s*$")
     cb_required_pat = re.compile(r"^\s*#\s*require[s|d]\s*:\s*(\S+)\s*$")
 
     cb_info = {}

--- a/tools/test_print_signatures.py
+++ b/tools/test_print_signatures.py
@@ -21,16 +21,22 @@ sample lines from API_DEV.spec:
     paddle.autograd.PyLayer (paddle.autograd.py_layer.PyLayer, ('document', 'c26adbbf5f1eb43d16d4a399242c979e'))
     paddle.autograd.PyLayer.apply (ArgSpec(args=['cls'], varargs=args, keywords=kwargs, defaults=None), ('document', 'cb78696dc032fb8af2cba8504153154d'))
 """
+import inspect
 import unittest
 import hashlib
 import functools
 from print_signatures import md5
 from print_signatures import is_primitive
+from print_signatures import check_api_args_doc
 
 
 def func_example(param_a, param_b):
     """
     example function
+
+    Parameters:
+        param_a : param a
+        param_b (int|string) : param b
     """
     pass
 
@@ -82,6 +88,55 @@ class Test_is_primitive(unittest.TestCase):
         self.assertFalse(is_primitive(range(3)))  # True for python2
         self.assertFalse(is_primitive({}))
         self.assertFalse(is_primitive([1, 1j]))
+
+
+def func_no_args():
+    """
+    example function
+    """
+    pass
+
+
+def func_no_args_2():
+    """
+    example function
+
+    Args:
+        None
+    """
+    pass
+
+
+def func_varargs(param_a, *param_b, **param_c):
+    """
+    example function
+
+    Args:
+        param_a (string): param a
+        *param_b : param b
+        ** param_c: param c
+    """
+    pass
+
+
+class Test_check_api_args_doc(unittest.TestCase):
+    def test_no_args_func(self):
+        func = func_no_args
+        self.assertTrue(
+            check_api_args_doc(inspect.getfullargspec(func), func.__doc__))
+        func = func_no_args_2
+        self.assertTrue(
+            check_api_args_doc(inspect.getfullargspec(func), func.__doc__))
+
+    def test_args_func_only(self):
+        func = func_example
+        self.assertTrue(
+            check_api_args_doc(inspect.getfullargspec(func), func.__doc__))
+
+    def test_varargs(self):
+        func = func_varargs
+        self.assertTrue(
+            check_api_args_doc(inspect.getfullargspec(func), func.__doc__))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Describe
check the name and its order at first.

AS the descriptions for the default values have many formats, It's difficult to refine a pattern to check them.
And, our codes don't utilize the function annotations, so the type check is skipped now.

- https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-29233/show
- http://agroup.baidu.com/paddlepaddle-org-cn/md/article/4202017