### PR TITLE
[NPU] use squared_l2_norm in GradientClipByGlobalNorm

### DIFF
--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -40,7 +40,7 @@ def _squared_l2_norm(x):
     This OP returns the squared L2 norm of a tensor.
     """
 
-    if core.is_compiled_with_npu() or core.is_compiled_with_xpu():
+    if core.is_compiled_with_xpu():
         square = layers.square(x)
         sum_square = layers.reduce_sum(square)
         return sum_square


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
We replace reduce_sum(square(x)) to squared_l2_norm(x) in PR https://github.com/PaddlePaddle/Paddle/pull/34586 . But we didn't add it into NPU because NPU doesn't support it at that time. Now NPU supports squared_l2_norm in https://github.com/PaddlePaddle/Paddle/pull/34708, so we add it back.

#### Performance
![image](https://user-images.githubusercontent.com/10208305/129828876-b71ee203-ed67-4516-8ecb-1ee3d5f03f72.png)
improve 3.4%