### PR TITLE
Remove incorrect signal error stack trace

### DIFF
--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -270,12 +270,14 @@ inline std::string SimplifyDemangleStr(std::string str) {
   return str;
 }
 
-inline std::string GetCurrentTraceBackString() {
+inline std::string GetCurrentTraceBackString(bool for_signal = false) {
   std::ostringstream sout;
 
-  sout << "\n\n--------------------------------------\n";
-  sout << "C++ Traceback (most recent call last):";
-  sout << "\n--------------------------------------\n";
+  if (!for_signal) {
+    sout << "\n\n--------------------------------------\n";
+    sout << "C++ Traceback (most recent call last):";
+    sout << "\n--------------------------------------\n";
+  }
 #if !defined(_WIN32) && !defined(PADDLE_WITH_MUSL)
   static constexpr int TRACE_STACK_LIMIT = 100;
 
@@ -284,7 +286,12 @@ inline std::string GetCurrentTraceBackString() {
   auto symbols = backtrace_symbols(call_stack, size);
   Dl_info info;
   int idx = 0;
-  for (int i = size - 1; i >= 0; --i) {
+  // `for_signal` used to remove the stack trace introduced by
+  // obtaining the error stack trace when the signal error occurred,
+  // that is not related to the signal error self, remove it to
+  // avoid misleading users and developers
+  int end_idx = 0 ? for_signal : 2;
+  for (int i = size - 1; i >= end_idx; --i) {
     if (dladdr(call_stack[i], &info) && info.dli_sname) {
       auto demangled = demangle(info.dli_sname);
       std::string path(info.dli_fname);

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -290,7 +290,7 @@ inline std::string GetCurrentTraceBackString(bool for_signal = false) {
   // obtaining the error stack trace when the signal error occurred,
   // that is not related to the signal error self, remove it to
   // avoid misleading users and developers
-  int end_idx = 0 ? for_signal : 2;
+  int end_idx = for_signal ? 2 : 0;
   for (int i = size - 1; i >= end_idx; --i) {
     if (dladdr(call_stack[i], &info) && info.dli_sname) {
       auto demangled = demangle(info.dli_sname);

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -294,7 +294,17 @@ void SignalHandle(const char *data, int size) {
       // Here does not throw an exception,
       // otherwise it will casue "terminate called recursively"
       std::ostringstream sout;
-      sout << platform::GetCurrentTraceBackString();
+      sout << "\n\n--------------------------------------\n";
+      sout << "C++ Traceback (most recent call last):";
+      sout << "\n--------------------------------------\n";
+      auto traceback = platform::GetCurrentTraceBackString(/*for_signal=*/true);
+      if (traceback.empty()) {
+        sout
+            << "No stack trace in paddle, may be caused by external reasons.\n";
+      } else {
+        sout << traceback;
+      }
+
       sout << "\n----------------------\nError Message "
               "Summary:\n----------------------\n";
       sout << platform::errors::Fatal(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

The original signal error stacktrace like follow

```
--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::framework::SignalHandle(char const*, int)
1   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()

----------------------
Error Message Summary:
----------------------
FatalError: `Segmentation fault` is detected by the operating system.
  [TimeInfo: *** Aborted at 1628745164 (unix time) try "date -d @1628745164" if you are using GNU date ***]
  [SignalInfo: *** SIGSEGV (@0x15e6) received by PID 5606 (TID 0x7fe7d4604700) from PID 5606 ***]

[1]    5606 segmentation fault  python sig_segv.py
```

The trace of `SignalHandle` and `GetCurrentTraceBackString` are not the signal error stack, which are introduced by getting traceback, this may misleading users, so this PR remove this two line.

And if no paddle stack trace when signal error occurred, we also give users hint. For this case, the new result like:

```
--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
No stack trace in paddle, may be caused by external reasons.

----------------------
Error Message Summary:
----------------------
FatalError: `Segmentation fault` is detected by the operating system.
  [TimeInfo: *** Aborted at 1628743780 (unix time) try "date -d @1628743780" if you are using GNU date ***]
  [SignalInfo: *** SIGSEGV (@0xaa6) received by PID 2726 (TID 0x7f599fa2f700) from PID 2726 ***]

[1]    2726 segmentation fault  python sig_segv.py
```
