### PR TITLE
修改了英文文档中存在的格式问题

### DIFF
--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -1117,6 +1117,7 @@ class DistributedStrategy(object):
                                     This value should be an integer greater than 0.
                                     If it is not set, or set to -1, its value will be inferred 
                                     based on the total number of cards.
+
             mp_degree(int): set number of GPUs in a model parallel group. Default 1
             pp_degree(int): set number of GPUs in a pipeline parallel group. Default 1
 
@@ -1232,6 +1233,7 @@ class DistributedStrategy(object):
             init_k_steps(int) The initial steps for training before adaptive localsgd.
                               Then, the adaptive localsgd method will modify init_k_steps automatically.
                               Default 1.
+
             begin_step(int) The step of begining training by adaptive localsgd. Default 1.
 
         Examples:

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -259,9 +259,11 @@ class DistributedStrategy(object):
     def gradient_scale_configs(self):
         """
         Set the strategy of gradient scale
+
         Examples:
 
           .. code-block:: python
+
             import paddle.distributed.fleet as fleet
             strategy = fleet.DistributedStrategy()
             strategy.gradient_scale_configs = {'scale_strategy': 'avg'}
@@ -968,8 +970,11 @@ class DistributedStrategy(object):
     def fuse_grad_size_in_num(self):
         """
         This based on raw_program_optimizer program and allreduce the num of the fused op
+
         Examples:
+
           .. code-block:: python
+
             import paddle.distributed.fleet as fleet
             strategy = fleet.DistributedStrategy()
             strategy.fuse_grad_size_in_num = 2
@@ -1123,7 +1128,9 @@ class DistributedStrategy(object):
 
 
         Examples:
+
           .. code-block:: python
+
             import paddle.distributed.fleet as fleet
             strategy = fleet.DistributedStrategy()
             strategy.hybrid_configs = {

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -499,6 +499,7 @@ def upsample(x,
         'trilinear' : Trilinear interpolation
         'nearest' : Nearest neighbor interpolation
         'bicubic' : Bicubic interpolation
+
     Linear interpolation is the method of using a line connecting two known quantities 
     to determine the value of an unknown quantity between the two known quantities. 
     
@@ -532,6 +533,7 @@ def upsample(x,
 
     Example:
     .. code-block:: text
+
         For scale_factor:
             if align_corners = True && out_size > 1 :
               scale_factor = (in_size-1.0)/(out_size-1.0)
@@ -599,6 +601,7 @@ def upsample(x,
               D_out = D_{in} * scale_{factor}
               H_out = H_{in} * scale_{factor}
               W_out = W_{in} * scale_{factor}
+
     https://en.wikipedia.org/wiki/Linear_interpolation.
     For details of linear interpolation, please refer to Wikipedia:
     

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -531,7 +531,6 @@ def upsample(x,
     area will directly call `paddle.nn.functional.adaptive_avg_pool1d` or
     `paddle.nn.functional.adaptive_avg_pool2d` or `paddle.nn.functional.adaptive_avg_pool3d`.
 
-    Example:
     .. code-block:: text
 
         For scale_factor:
@@ -647,10 +646,12 @@ def upsample(x,
         name(str, optional): The default value is None.
                              Normally there is no need for user to set this property.
                              For more information, please refer to :ref:`api_guide_Name`
+
     Returns:
         A 3-D Tensor of the shape (num_batches, channels, out_w) or (num_batches, out_w, channels),
         A 4-D Tensor of the shape (num_batches, channels, out_h, out_w) or (num_batches, out_h, out_w, channels),
         or 5-D Tensor of the shape (num_batches, channels, out_d, out_h, out_w) or (num_batches, out_d, out_h, out_w, channels).
+
     Raises:
         TypeError: size should be a list or tuple or Tensor.
         ValueError: The 'mode' of image_resize can only be 'linear', 'bilinear',
@@ -666,8 +667,10 @@ def upsample(x,
         TypeError: align_corners should be a bool value
         ValueError: align_mode can only be '0' or '1'
         ValueError: data_format can only be 'NCW', 'NWC', 'NCHW', 'NHWC', 'NCDHW' or 'NDHWC'.
-        Examples:
+
+    Examples:
         .. code-block:: python
+
             import paddle
             import numpy as np
             import paddle.nn.functional as F

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -657,7 +657,7 @@ def l1_loss(input, label, reduction='mean', name=None):
 
     Returns:
         Tensor, the L1 Loss of Tensor ``input`` and ``label``.
-            If `reduction` is ``'none'``, the shape of output loss is [N, *], the same as ``input`` .
+            If `reduction` is ``'none'``, the shape of output loss is `[N, *]`, the same as ``input`` .
             If `reduction` is ``'mean'`` or ``'sum'``, the shape of output loss is [1].
 
     Examples:

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -628,62 +628,63 @@ def max_pool2d(x,
     This API implements max pooling 2d operation.
     See more details in :ref:`api_nn_pooling_MaxPool2d` .
 
-   Args:
-        - x (Tensor): The input tensor of pooling operator which is a 4-D tensor with
-          shape [N, C, H, W]. The format of input tensor is `"NCHW"` or
-          `"NHWC"`, where `N` is batch size, `C` is the number of channels,
-          `H` is the height of the feature, and `W` is the width of the
-          feature. The data type if float32 or float64.
-        - kernel_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
-          it must contain two integers, (kernel_size_Height, kernel_size_Width).
-          Otherwise, the pool kernel size will be a square of an int.
-        - stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
-          it must contain two integers, (stride_Height, stride_Width).
-          Otherwise, the pool stride size will be a square of an int.
-        - padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
-            - A string in ['valid', 'same'].
-            - An int, which means the feature map is zero padded by size of `padding` on every sides.
-            - A list[int] or tuple(int) whose length is 2, [pad_height, pad_weight] whose value means the padding size of each dimension.
-            - A list[int] or tuple(int) whose length is 4. [pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
-            - A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).The default value is 0.
+    Args:
+        x (Tensor): The input tensor of pooling operator which is a 4-D tensor with
+                          shape [N, C, H, W]. The format of input tensor is `"NCHW"` or
+                          `"NHWC"`, where `N` is batch size, `C` is the number of channels,
+                          `H` is the height of the feature, and `W` is the width of the
+                          feature. The data type if float32 or float64.
+        kernel_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
+            it must contain two integers, (kernel_size_Height, kernel_size_Width).
+            Otherwise, the pool kernel size will be a square of an int.
+        stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
+            it must contain two integers, (stride_Height, stride_Width).
+            Otherwise, the pool stride size will be a square of an int.
+        padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
+            1. A string in ['valid', 'same'].
+            2. An int, which means the feature map is zero padded by size of `padding` on every sides.
+            3. A list[int] or tuple(int) whose length is 2, [pad_height, pad_weight] whose value means the padding size of each dimension.
+            4. A list[int] or tuple(int) whose length is 4. [pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
+            5. A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).
+            The default value is 0.
+        ceil_mode (bool): when True, will use `ceil` instead of `floor` to
+            compute the output shape
+        return_mask (bool): Whether to return the max indices along with the outputs. Default False, only support `"NCHW"` data format
+        data_format (string): The data format of the input and output data. An optional string from: `"NCHW"`, `"NHWC"`.
+            The default is `"NCHW"`. When it is `"NCHW"`, the data is stored in the order of:
+            `[batch_size, input_channels, input_height, input_width]`.
+        name(str, optional): For detailed information, please refer
+                             to :ref:`api_guide_Name`. Usually name is no need to set and
+                             None by default.
 
-        - ceil_mode (bool): when True, will use `ceil` instead of `floor` to
-          compute the output shape
-        - return_mask (bool): Whether to return the max indices along with the outputs. Default False, only support `"NCHW"` data format
-        - data_format (string): The data format of the input and output data. An optional string from: `"NCHW"`, `"NHWC"`.
-          The default is `"NCHW"`. When it is `"NCHW"`, the data is stored in the order of:
-          `[batch_size, input_channels, input_height, input_width]`.
-        - name(str, optional): For detailed information, please refer
-          to :ref:`api_guide_Name`. Usually name is no need to set and None by default.
-
-    Returns:
-        Tensor: The output tensor of pooling result. The data type is same as input tensor.
+   Returns:
+       Tensor: The output tensor of pooling result. The data type is same as input tensor.
    
    Raises:
         ValueError: If `padding` is a string, but not "SAME" or "VALID".
         ValueError: If `padding` is "VALID", but `ceil_mode` is True.
         ShapeError: If the output's shape calculated is not greater than 0.
     
-    Examples:
-        .. code-block:: python
+   Examples:
+       .. code-block:: python
 
-            import paddle
-            import paddle.nn.functional as F
-            import numpy as np
-            
-            # max pool2d
-            x = paddle.to_tensor(np.random.uniform(-1, 1, [1, 3, 32, 32]).astype(np.float32))
-            out = F.max_pool2d(x,
-                                  kernel_size=2,
-                                  stride=2, padding=0)
-            # output.shape [1, 3, 16, 16]
-            # for return_mask=True
-            out, max_indices = F.max_pool2d(x,
-                                               kernel_size=2,
-                                               stride=2,
-                                               padding=0,
-                                               return_mask=True)
-            # out.shape [1, 3, 16, 16], max_indices.shape [1, 3, 16, 16],
+         import paddle
+         import paddle.nn.functional as F
+         import numpy as np
+
+         # max pool2d
+         x = paddle.to_tensor(np.random.uniform(-1, 1, [1, 3, 32, 32]).astype(np.float32))
+         out = F.max_pool2d(x,
+                               kernel_size=2,
+                               stride=2, padding=0)
+         # output.shape [1, 3, 16, 16]
+         # for return_mask=True
+         out, max_indices = F.max_pool2d(x,
+                                            kernel_size=2,
+                                            stride=2,
+                                            padding=0,
+                                            return_mask=True)
+         # out.shape [1, 3, 16, 16], max_indices.shape [1, 3, 16, 16]
     """
     kernel_size = utils.convert_to_list(kernel_size, 2, 'pool_size')
     if stride is None:
@@ -765,32 +766,32 @@ def max_pool3d(x,
     """
     This API implements max pooling 2d operation.
     See more details in :ref:`api_nn_pooling_MaxPool3d` .
+
     Args:
-        - x (Tensor): The input tensor of pooling operator, which is a 5-D tensor with
-          shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` or `"NDHWC"`,
-          where N represents batch size, C represents the number of channels, D, H and W represent the depth, height and width of the feature respectively.
-        - kernel_size (int|list|tuple): The pool kernel size. If the kernel size
-          is a tuple or list, it must contain three integers,
-          (kernel_size_Depth, kernel_size_Height, kernel_size_Width).
-          Otherwise, the pool kernel size will be the cube of an int.
-        - stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
-          it must contain three integers, [stride_Depth, stride_Height, stride_Width).
-          Otherwise, the pool stride size will be a cube of an int.
-        - padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
-          1. A string in ['valid', 'same'].
-          2. An int, which means the feature map is zero padded by size of `padding` on every sides.
-          3. A list[int] or tuple(int) whose length is 3, [pad_depth, pad_height, pad_weight] whose value means the padding size of each dimension.
-          4. A list[int] or tuple(int) whose length is 6. [pad_depth_front, pad_depth_back, pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
-          5. A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).
-          the default value is 0.
-        - ceil_mode (bool): ${ceil_mode_comment}
-        - return_mask (bool): Whether to return the max indices along with the outputs. Default False. Only support "NDCHW" data_format.
-        - data_format (string): The data format of the input and output data. An optional string from: `"NCDHW"`, `"NDHWC"`.
-          The default is `"NCDHW"`. When it is `"NCDHW"`, the data is stored in the order of:
-          `[batch_size, input_channels, input_depth, input_height, input_width]`.
-        - name(str, optional): For detailed information, please refer
-          to :ref:`api_guide_Name`. Usually name is no need to set and
-          None by default.
+        x (Tensor): The input tensor of pooling operator, which is a 5-D tensor with
+                          shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` or `"NDHWC"`,
+                          where N represents batch size, C represents the number of channels, D, H and W represent the depth, height and width of the feature respectively.
+        kernel_size (int|list|tuple): The pool kernel size. If the kernel size is a tuple or list, it must contain three integers,
+            (kernel_size_Depth, kernel_size_Height, kernel_size_Width).
+            Otherwise, the pool kernel size will be the cube of an int.
+        stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
+            it must contain three integers, [stride_Depth, stride_Height, stride_Width).
+            Otherwise, the pool stride size will be a cube of an int.
+        padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
+            1. A string in ['valid', 'same'].
+            2. An int, which means the feature map is zero padded by size of `padding` on every sides.
+            3. A list[int] or tuple(int) whose length is 3, [pad_depth, pad_height, pad_weight] whose value means the padding size of each dimension.
+            4. A list[int] or tuple(int) whose length is 6. [pad_depth_front, pad_depth_back, pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
+            5. A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).
+            the default value is 0.
+        ceil_mode (bool): ${ceil_mode_comment}
+        return_mask (bool): Whether to return the max indices along with the outputs. Default False. Only support "NDCHW" data_format.
+        data_format (string): The data format of the input and output data. An optional string from: `"NCDHW"`, `"NDHWC"`.
+            The default is `"NCDHW"`. When it is `"NCDHW"`, the data is stored in the order of:
+            `[batch_size, input_channels, input_depth, input_height, input_width]`.
+        name(str, optional): For detailed information, please refer
+                             to :ref:`api_guide_Name`. Usually name is no need to set and
+                             None by default.
     
     Returns:
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
@@ -820,7 +821,7 @@ def max_pool3d(x,
                                           stride = 2,
                                           padding=0,
                                           return_mask=True)
-            # output.shape [None, 3, 16, 16, 16], max_indices.shape [None, 3, 16, 16, 16],
+            # output.shape [None, 3, 16, 16, 16], max_indices.shape [None, 3, 16, 16, 16]
     """
     kernel_size = utils.convert_to_list(kernel_size, 3, 'pool_size')
     if stride is None:

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -657,34 +657,34 @@ def max_pool2d(x,
                              to :ref:`api_guide_Name`. Usually name is no need to set and
                              None by default.
 
-   Returns:
-       Tensor: The output tensor of pooling result. The data type is same as input tensor.
+    Returns:
+        Tensor: The output tensor of pooling result. The data type is same as input tensor.
    
-   Raises:
-        ValueError: If `padding` is a string, but not "SAME" or "VALID".
-        ValueError: If `padding` is "VALID", but `ceil_mode` is True.
-        ShapeError: If the output's shape calculated is not greater than 0.
+    Raises:
+         ValueError: If `padding` is a string, but not "SAME" or "VALID".
+         ValueError: If `padding` is "VALID", but `ceil_mode` is True.
+         ShapeError: If the output's shape calculated is not greater than 0.
     
-   Examples:
-       .. code-block:: python
+    Examples:
+        .. code-block:: python
 
-         import paddle
-         import paddle.nn.functional as F
-         import numpy as np
+          import paddle
+          import paddle.nn.functional as F
+          import numpy as np
 
-         # max pool2d
-         x = paddle.to_tensor(np.random.uniform(-1, 1, [1, 3, 32, 32]).astype(np.float32))
-         out = F.max_pool2d(x,
-                               kernel_size=2,
-                               stride=2, padding=0)
-         # output.shape [1, 3, 16, 16]
-         # for return_mask=True
-         out, max_indices = F.max_pool2d(x,
-                                            kernel_size=2,
-                                            stride=2,
-                                            padding=0,
-                                            return_mask=True)
-         # out.shape [1, 3, 16, 16], max_indices.shape [1, 3, 16, 16]
+          # max pool2d
+          x = paddle.to_tensor(np.random.uniform(-1, 1, [1, 3, 32, 32]).astype(np.float32))
+          out = F.max_pool2d(x,
+                                kernel_size=2,
+                                stride=2, padding=0)
+          # output.shape [1, 3, 16, 16]
+          # for return_mask=True
+          out, max_indices = F.max_pool2d(x,
+                                             kernel_size=2,
+                                             stride=2,
+                                             padding=0,
+                                             return_mask=True)
+          # out.shape [1, 3, 16, 16], max_indices.shape [1, 3, 16, 16]
     """
     kernel_size = utils.convert_to_list(kernel_size, 2, 'pool_size')
     if stride is None:

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -628,7 +628,7 @@ def max_pool2d(x,
     This API implements max pooling 2d operation.
     See more details in :ref:`api_nn_pooling_MaxPool2d` .
 
-    Args:
+   Args:
         - x (Tensor): The input tensor of pooling operator which is a 4-D tensor with
           shape [N, C, H, W]. The format of input tensor is `"NCHW"` or
           `"NHWC"`, where `N` is batch size, `C` is the number of channels,
@@ -766,30 +766,31 @@ def max_pool3d(x,
     This API implements max pooling 2d operation.
     See more details in :ref:`api_nn_pooling_MaxPool3d` .
     Args:
-        x (Tensor): The input tensor of pooling operator, which is a 5-D tensor with
-            shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` or `"NDHWC"`, where N represents batch size, C represents the number of channels, D, H and W represent the depth, height and width of the feature respectively.
-        kernel_size (int|list|tuple): The pool kernel size. If the kernel size
-            is a tuple or list, it must contain three integers,
-            (kernel_size_Depth, kernel_size_Height, kernel_size_Width).
-            Otherwise, the pool kernel size will be the cube of an int.
-        stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
-            it must contain three integers, [stride_Depth, stride_Height, stride_Width).
-            Otherwise, the pool stride size will be a cube of an int.
-        padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
-            1. A string in ['valid', 'same'].
-            2. An int, which means the feature map is zero padded by size of `padding` on every sides.
-            3. A list[int] or tuple(int) whose length is 3, [pad_depth, pad_height, pad_weight] whose value means the padding size of each dimension.
-            4. A list[int] or tuple(int) whose length is 6. [pad_depth_front, pad_depth_back, pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
-            5. A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).
-            The default value is 0.
-        ceil_mode (bool): ${ceil_mode_comment}
-        return_mask (bool): Whether to return the max indices along with the outputs. Default False. Only support "NDCHW" data_format.
-        data_format (string): The data format of the input and output data. An optional string from: `"NCDHW"`, `"NDHWC"`.
-                        The default is `"NCDHW"`. When it is `"NCDHW"`, the data is stored in the order of:
-                        `[batch_size, input_channels, input_depth, input_height, input_width]`.
-        name(str, optional): For detailed information, please refer
-                             to :ref:`api_guide_Name`. Usually name is no need to set and
-                             None by default.
+        - x (Tensor): The input tensor of pooling operator, which is a 5-D tensor with
+          shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` or `"NDHWC"`,
+          where N represents batch size, C represents the number of channels, D, H and W represent the depth, height and width of the feature respectively.
+        - kernel_size (int|list|tuple): The pool kernel size. If the kernel size
+          is a tuple or list, it must contain three integers,
+          (kernel_size_Depth, kernel_size_Height, kernel_size_Width).
+          Otherwise, the pool kernel size will be the cube of an int.
+        - stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
+          it must contain three integers, [stride_Depth, stride_Height, stride_Width).
+          Otherwise, the pool stride size will be a cube of an int.
+        - padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
+          1. A string in ['valid', 'same'].
+          2. An int, which means the feature map is zero padded by size of `padding` on every sides.
+          3. A list[int] or tuple(int) whose length is 3, [pad_depth, pad_height, pad_weight] whose value means the padding size of each dimension.
+          4. A list[int] or tuple(int) whose length is 6. [pad_depth_front, pad_depth_back, pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
+          5. A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).
+          the default value is 0.
+        - ceil_mode (bool): ${ceil_mode_comment}
+        - return_mask (bool): Whether to return the max indices along with the outputs. Default False. Only support "NDCHW" data_format.
+        - data_format (string): The data format of the input and output data. An optional string from: `"NCDHW"`, `"NDHWC"`.
+          The default is `"NCDHW"`. When it is `"NCDHW"`, the data is stored in the order of:
+          `[batch_size, input_channels, input_depth, input_height, input_width]`.
+        - name(str, optional): For detailed information, please refer
+          to :ref:`api_guide_Name`. Usually name is no need to set and
+          None by default.
     
     Returns:
         Tensor: The output tensor of pooling result. The data type is same as input tensor.

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -629,32 +629,33 @@ def max_pool2d(x,
     See more details in :ref:`api_nn_pooling_MaxPool2d` .
 
     Args:
-        x (Tensor): The input tensor of pooling operator which is a 4-D tensor with
-                          shape [N, C, H, W]. The format of input tensor is `"NCHW"` or
-                          `"NHWC"`, where `N` is batch size, `C` is the number of channels,
-                          `H` is the height of the feature, and `W` is the width of the
-                          feature. The data type if float32 or float64.
-        kernel_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
-            it must contain two integers, (kernel_size_Height, kernel_size_Width).
-            Otherwise, the pool kernel size will be a square of an int.
-        stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
-            it must contain two integers, (stride_Height, stride_Width).
-            Otherwise, the pool stride size will be a square of an int.
-        padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
-            1. A string in ['valid', 'same'].
-            2. An int, which means the feature map is zero padded by size of `padding` on every sides.
-            3. A list[int] or tuple(int) whose length is 2, [pad_height, pad_weight] whose value means the padding size of each dimension.
-            4. A list[int] or tuple(int) whose length is 4. [pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
-            5. A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).
-            The default value is 0.
-        ceil_mode (bool): when True, will use `ceil` instead of `floor` to compute the output shape
-        return_mask (bool): Whether to return the max indices along with the outputs. Default False, only support `"NCHW"` data format
-        data_format (string): The data format of the input and output data. An optional string from: `"NCHW"`, `"NHWC"`.
-                        The default is `"NCHW"`. When it is `"NCHW"`, the data is stored in the order of:
-                        `[batch_size, input_channels, input_height, input_width]`.
-        name(str, optional): For detailed information, please refer
-                             to :ref:`api_guide_Name`. Usually name is no need to set and
-                             None by default.
+        - x (Tensor): The input tensor of pooling operator which is a 4-D tensor with
+          shape [N, C, H, W]. The format of input tensor is `"NCHW"` or
+          `"NHWC"`, where `N` is batch size, `C` is the number of channels,
+          `H` is the height of the feature, and `W` is the width of the
+          feature. The data type if float32 or float64.
+        - kernel_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
+          it must contain two integers, (kernel_size_Height, kernel_size_Width).
+          Otherwise, the pool kernel size will be a square of an int.
+        - stride (int|list|tuple): The pool stride size. If pool stride size is a tuple or list,
+          it must contain two integers, (stride_Height, stride_Width).
+          Otherwise, the pool stride size will be a square of an int.
+        - padding (string|int|list|tuple): The padding size. Padding could be in one of the following forms.
+            - A string in ['valid', 'same'].
+            - An int, which means the feature map is zero padded by size of `padding` on every sides.
+            - A list[int] or tuple(int) whose length is 2, [pad_height, pad_weight] whose value means the padding size of each dimension.
+            - A list[int] or tuple(int) whose length is 4. [pad_height_top, pad_height_bottom, pad_width_left, pad_width_right] whose value means the padding size of each side.
+            - A list or tuple of pairs of integers. It has the form [[pad_before, pad_after], [pad_before, pad_after], ...]. Note that, the batch dimension and channel dimension should be [0,0] or (0,0).The default value is 0.
+
+        - ceil_mode (bool): when True, will use `ceil` instead of `floor` to
+          compute the output shape
+        - return_mask (bool): Whether to return the max indices along with the outputs. Default False, only support `"NCHW"` data format
+        - data_format (string): The data format of the input and output data. An optional string from: `"NCHW"`, `"NHWC"`.
+          The default is `"NCHW"`. When it is `"NCHW"`, the data is stored in the order of:
+          `[batch_size, input_channels, input_height, input_width]`.
+        - name(str, optional): For detailed information, please refer
+          to :ref:`api_guide_Name`. Usually name is no need to set and None by default.
+
     Returns:
         Tensor: The output tensor of pooling result. The data type is same as input tensor.
    
@@ -766,7 +767,7 @@ def max_pool3d(x,
     See more details in :ref:`api_nn_pooling_MaxPool3d` .
     Args:
         x (Tensor): The input tensor of pooling operator, which is a 5-D tensor with
-                          shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` or `"NDHWC"`, where N represents batch size, C represents the number of channels, D, H and W represent the depth, height and width of the feature respectively.
+            shape [N, C, D, H, W]. The format of input tensor is `"NCDHW"` or `"NDHWC"`, where N represents batch size, C represents the number of channels, D, H and W represent the depth, height and width of the feature respectively.
         kernel_size (int|list|tuple): The pool kernel size. If the kernel size
             is a tuple or list, it must contain three integers,
             (kernel_size_Depth, kernel_size_Height, kernel_size_Width).

--- a/python/paddle/nn/layer/activation.py
+++ b/python/paddle/nn/layer/activation.py
@@ -917,12 +917,13 @@ class Silu(Layer):
     Silu Activation.
 
     .. math::
+
         Silu(x) = \frac{x}{1 + e^{-x}}
 
     Parameters:
-        - x (Tensor): The input Tensor with data type float32, or float64.
-        - name (str, optional): Name for the operation (optional, default is None).
-          For more information, please refer to :ref:`api_guide_Name`.
+        x (Tensor): The input Tensor with data type float32, or float64.
+        name (str, optional): Name for the operation (optional, default is None).
+            For more information, please refer to :ref:`api_guide_Name`.
 
     Shape:
         - input: Tensor with any shape.

--- a/python/paddle/nn/layer/activation.py
+++ b/python/paddle/nn/layer/activation.py
@@ -917,7 +917,6 @@ class Silu(Layer):
     Silu Activation.
 
     .. math::
-
         Silu(x) = \frac{x}{1 + e^{-x}}
 
     Parameters:

--- a/python/paddle/nn/layer/activation.py
+++ b/python/paddle/nn/layer/activation.py
@@ -918,7 +918,7 @@ class Silu(Layer):
 
     .. math::
 
-        Silu(x) = \frac{x}{1 + e^{-x}}
+        Silu(x) = \\frac{x}{1 + e^{-x}}
 
     Parameters:
         x (Tensor): The input Tensor with data type float32, or float64.

--- a/python/paddle/nn/layer/activation.py
+++ b/python/paddle/nn/layer/activation.py
@@ -915,14 +915,15 @@ class ThresholdedReLU(Layer):
 class Silu(Layer):
     """
     Silu Activation.
+
     .. math::
 
         Silu(x) = \frac{x}{1 + e^{-x}}
 
     Parameters:
-        x (Tensor): The input Tensor with data type float32, or float64.
-        name (str, optional): Name for the operation (optional, default is None).
-            For more information, please refer to :ref:`api_guide_Name`.
+        - x (Tensor): The input Tensor with data type float32, or float64.
+        - name (str, optional): Name for the operation (optional, default is None).
+          For more information, please refer to :ref:`api_guide_Name`.
 
     Shape:
         - input: Tensor with any shape.

--- a/python/paddle/nn/layer/distance.py
+++ b/python/paddle/nn/layer/distance.py
@@ -45,11 +45,11 @@ class PairwiseDistance(Layer):
             For more information, please refer to :ref:`api_guide_Name`.
 
     Shape:
-        x: :math:`[N, D]` where `D` is the dimension of vector, available dtype
-            is float32, float64.
-        y: :math:`[N, D]`, y have the same shape and dtype as x.
-        out: :math:`[N]`. If :attr:`keepdim` is ``True``, the out shape is :math:`[N, 1]`.
-            The same dtype as input tensor.
+        - x:`[N, D]` where `D` is the dimension of vector, available dtype
+          is float32, float64.
+        - y:`[N, D]`, y have the same shape and dtype as x.
+        - out:`[N]`. If :attr:`keepdim` is ``True``, the out shape is `[N, 1]`.
+          The same dtype as input tensor.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -82,7 +82,7 @@ class BCEWithLogitsLoss(Layer):
             For more information, please refer to :ref:`api_guide_Name`.
 
     Shapes:
-        logit (Tensor): The input predications tensor. 2-D tensor with shape: [N, *],
+        logit (Tensor): The input predications tensor. 2-D tensor with shape: `[N, *]`,
             N is batch_size, `*` means number of additional dimensions. The ``logit``
             is usually the output of Linear layer. Available dtype is float32, float64.
         label (Tensor): The target labels tensor. 2-D tensor with the same shape as
@@ -639,11 +639,15 @@ class L1Loss(Layer):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Shape:
-        input (Tensor): The input tensor. The shapes is [N, *], where N is batch size and `*` means any number of additional dimensions. It's data type should be float32, float64, int32, int64.
-        label (Tensor): label. The shapes is [N, *], same shape as ``input`` . It's data type should be float32, float64, int32, int64.
-        output (Tensor): The L1 Loss of ``input`` and ``label``.
-            If `reduction` is ``'none'``, the shape of output loss is [N, *], the same as ``input`` .
-            If `reduction` is ``'mean'`` or ``'sum'``, the shape of output loss is [1].
+        - input (Tensor): The input tensor. The shapes is `[N, *]`, where N is batch size and `*`
+          means any number of additional dimensions. It's data type should be float32, float64,
+          int32, int64.
+        - label (Tensor): label. The shapes is `[N, *]`, same shape as ``input`` . It's data type
+          should be float32, float64, int32, int64.
+        - output (Tensor): The L1 Loss of ``input`` and ``label``.
+          If `reduction` is ``'none'``, the shape of output loss is `[N, *]`, the same as
+          ``input`` .
+          If `reduction` is ``'mean'`` or ``'sum'``, the shape of output loss is [1].
 
     Examples:
         .. code-block:: python
@@ -701,7 +705,8 @@ class BCELoss(Layer):
     If :attr:`weight` is None, the loss is:
 
     .. math::
-        Out = -1 * (label * log(input) + (1 - label) * log(1 - input))
+        Out = -1 * (label * log(input)
+     + (1 - label) * log(1 - input))
 
     If :attr:`reduction` set to ``'none'``, the interface will return the original loss `Out`.
 
@@ -732,14 +737,14 @@ class BCELoss(Layer):
             For more information, please refer to :ref:`api_guide_Name`.
 
     Shape:
-        input (Tensor): 2-D tensor with shape: [N, *], N is batch_size, `*` means
-            number of additional dimensions. The input ``input`` should always
-            be the output of sigmod.  Available dtype is float32, float64.
-        label (Tensor): 2-D tensor with the same shape as ``input``. The target
-            labels which values should be numbers between 0 and 1. Available
-            dtype is float32, float64.
-        output (Tensor): If ``reduction`` is ``'none'``, the shape of output is
-            same as ``input`` , else the shape of output is scalar.
+        - input (Tensor): 2-D tensor with shape: `[N, *]`, N is batch_size, `*` means
+          number of additional dimensions. The input ``input`` should always
+          be the output of sigmod.  Available dtype is float32, float64.
+        - label (Tensor): 2-D tensor with the same shape as ``input``. The target
+          labels which values should be numbers between 0 and 1. Available
+          dtype is float32, float64.
+        - output (Tensor): If ``reduction`` is ``'none'``, the shape of output is
+          same as ``input`` , else the shape of output is scalar.
 
     Returns:
         A callable object of BCELoss.
@@ -909,12 +914,11 @@ class KLDivLoss(Layer):
              Default is ``'mean'``.
 
     Shape:
+        - input(Tensor): `(N, *)`, where `*` means, any number of additional dimensions.
 
-        - input (Tensor): (N, *), where * means, any number of additional dimensions.
+        - label(Tensor): `(N, *)`, same shape as input.
 
-        - label (Tensor): (N, *), same shape as input.
-
-        - output (Tensor): tensor with shape: [1] by default.
+        - output(Tensor): tensor with shape: [1] by default.
 
 
     Examples:

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -82,14 +82,14 @@ class BCEWithLogitsLoss(Layer):
             For more information, please refer to :ref:`api_guide_Name`.
 
     Shapes:
-        logit (Tensor): The input predications tensor. 2-D tensor with shape: `[N, *]`,
-            N is batch_size, `*` means number of additional dimensions. The ``logit``
-            is usually the output of Linear layer. Available dtype is float32, float64.
-        label (Tensor): The target labels tensor. 2-D tensor with the same shape as
-            ``logit``. The target labels which values should be numbers between 0 and 1.
-            Available dtype is float32, float64.
-        output (Tensor): If ``reduction`` is ``'none'``, the shape of output is
-            same as ``logit`` , else the shape of output is scalar.
+        - logit (Tensor): The input predications tensor. 2-D tensor with shape: `[N, *]`,
+          N is batch_size, `*` means number of additional dimensions. The ``logit``
+          is usually the output of Linear layer. Available dtype is float32, float64.
+        - label (Tensor): The target labels tensor. 2-D tensor with the same shape as
+          ``logit``. The target labels which values should be numbers between 0 and 1.
+          Available dtype is float32, float64.
+        - output (Tensor): If ``reduction`` is ``'none'``, the shape of output is
+          same as ``logit`` , else the shape of output is scalar.
 
     Returns:
         A callable object of BCEWithLogitsLoss.

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -266,6 +266,7 @@ class AvgPool3D(Layer):
           The data type can be float32, float64.
         - output(Tensor): The output tensor of avg pool3d  operator, which is a 5-D tensor.
           The data type is same as input x.
+
     Examples:
         .. code-block:: python
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -715,7 +715,7 @@ def triu(x, diagonal=0, name=None):
 
 def meshgrid(*args, **kwargs):
     """
-    This op takes a list of N tensors as input *args, each of which is 1-dimensional 
+    This op takes a list of N tensors as input `*args`, each of which is 1-dimensional
     vector, and creates N-dimensional grids.
     
     Args:


### PR DESCRIPTION
PR types
New features

PR changes
OPs

Describe
修正了部分英文文档的格式问题：

**错误文档链接：**
./api/paddle/nn/AvgPool3D_en.html（268行，shape列表结束后未空行,待检查）(已修正)
./api/paddle/nn/Silu_en.html（1、918行未空行，导致公式错误，已解决；2、926行，error,除去缩进效果）（公式错误未解决，error已修正）（删除math下方空行）（公式错误未解决）
./api/paddle/nn/KLDivLoss_en.html(Inline emphasis start-string without end-string.，因为【】内有*,导致系统以为是特殊字符，所以错误！！！【】两侧加``反引号转义)(已修正)
./api/paddle/nn/BCELoss_en.html（Inline emphasis start-string without end-string.，因为【】内有*,导致系统以为是特殊字符，所以错误！！！【】两侧加``反引号转义）(已修正)
./api/paddle/nn/BCEWithLogitsLoss_en.html（Inline emphasis start-string without end-string,【】两侧加``反引号转义）(已修正，已经将shape改为列表格式）
./api/paddle/nn/L1Loss_en.html*(Inline emphasis start-string without end-string,error; 1、因为【】内有*,导致系统以为是特殊字符，所以错误！！！【】两侧加``反引号转义 2、使用列表除去error)(已修正)
./api/paddle/nn/PairwiseDistance_en.html(Definition list ends without a blank line; unexpected unindent.,Unexpected indentation.改为列表格式，去除 ：math：)(已修正)
./api/paddle/nn/functional/silu_en.html(官网未报错)(无报错)
./api/paddle/nn/functional/max_pool2d_en.html（已将该模块改为列表形式）（args格式不太正规）
./api/paddle/nn/functional/upsample_en.html(加三个空行)（格式不太正规，历史遗留问题）
./api/paddle/nn/functional/max_pool3d_en.html(前进空格，待检查)（已经改为列表格式）(未解决)
./api/paddle/nn/functional/l1_loss_en.html(因为【】内有*,导致系统以为是特殊字符，所以错误！！！【】两侧加``反引号转义 2、使用列表除去error)(已修正)
./api/paddle/distributed/fleet/DistributedStrategy_en.html(warn解决，error未解决)(加空行,已修正)
./api/paddle/meshgrid_en.html(有*,导致系统以为是特殊字符，所以错误！！！  *args 两侧加``反引号转义 )(已修正)

预览链接：http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1033