### PR TITLE
[NPU] add beam_search npu op

### DIFF
--- a/paddle/fluid/operators/beam_search_op.h
+++ b/paddle/fluid/operators/beam_search_op.h
@@ -51,11 +51,11 @@ class BeamSearchOpKernel : public framework::OpKernel<T> {
     PADDLE_ENFORCE_NOT_NULL(
         selected_ids,
         platform::errors::NotFound(
-            "Output(selected_scores) of BeamSearchOp is not found."));
+            "Output(selected_ids) of BeamSearchOp is not found."));
     PADDLE_ENFORCE_NOT_NULL(
         selected_scores,
         platform::errors::NotFound(
-            "Output(parent_idx) of BeamSearchOp is not found."));
+            "Output(selected_scores) of BeamSearchOp is not found."));
 
     math::BeamSearchFunctor<DeviceContext, T> alg;
     alg(context.template device_context<DeviceContext>(), pre_ids, pre_scores,

--- a/paddle/fluid/operators/beam_search_op_npu.cc
+++ b/paddle/fluid/operators/beam_search_op_npu.cc
@@ -1,0 +1,24 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/beam_search_op.h"
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace ops = paddle::operators;
+REGISTER_OP_NPU_KERNEL(
+    beam_search,
+    ops::BeamSearchOpKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::BeamSearchOpKernel<paddle::platform::NPUDeviceContext, double>,
+    ops::BeamSearchOpKernel<paddle::platform::NPUDeviceContext, int>,
+    ops::BeamSearchOpKernel<paddle::platform::NPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/math/CMakeLists.txt
+++ b/paddle/fluid/operators/math/CMakeLists.txt
@@ -68,7 +68,7 @@ math_library(sequence_padding)
 math_library(sequence_pooling DEPS math_function jit_kernel_helper)
 math_library(sequence_scale)
 math_library(softmax DEPS math_function jit_kernel_helper)
-math_library(beam_search DEPS math_function)
+math_library(beam_search DEPS math_function bean_search_npu)
 math_library(fc DEPS blas)
 
 math_library(matrix_bit_code)

--- a/paddle/fluid/operators/math/CMakeLists.txt
+++ b/paddle/fluid/operators/math/CMakeLists.txt
@@ -39,6 +39,10 @@ function(math_library TARGET)
     endif()
 endfunction()
 
+if (WITH_ASCEND_CL)
+  cc_library(beam_search_npu SRCS beam_search_npu.cc DEPS npu_op_runner)
+endif()
+
 # please add new math_library in alphabetical order
 math_library(concat_and_split)
 math_library(context_project DEPS im2col math_function)
@@ -68,7 +72,11 @@ math_library(sequence_padding)
 math_library(sequence_pooling DEPS math_function jit_kernel_helper)
 math_library(sequence_scale)
 math_library(softmax DEPS math_function jit_kernel_helper)
-math_library(beam_search DEPS math_function bean_search_npu)
+if (WITH_ASCEND_CL)
+    math_library(beam_search DEPS math_function beam_search_npu)
+else()
+    math_library(beam_search DEPS math_function)
+endif()
 math_library(fc DEPS blas)
 
 math_library(matrix_bit_code)

--- a/paddle/fluid/operators/math/beam_search_npu.cc
+++ b/paddle/fluid/operators/math/beam_search_npu.cc
@@ -58,11 +58,12 @@ class BeamSearchFunctor<platform::NPUDeviceContext, T> {
 
     int64_t total_length = num_seqs * beam_size;
     int64_t batch_size = static_cast<int64_t>(scores->dims()[0]);
-    selected_ids->mutable_data<int>(framework::make_ddim({total_length, 1}),
-                                    place);
+    selected_ids->mutable_data<int64_t>(framework::make_ddim({total_length, 1}),
+                                        place);
     selected_scores->mutable_data<float>(
         framework::make_ddim({total_length, 1}), place);
-    parent_idx->mutable_data<int>(framework::make_ddim({total_length}), place);
+    parent_idx->mutable_data<int64_t>(framework::make_ddim({total_length}),
+                                      place);
 
     // Step1: Define Tensors and Preprocess the situation that pre_id == end_id
 

--- a/paddle/fluid/operators/math/beam_search_npu.cc
+++ b/paddle/fluid/operators/math/beam_search_npu.cc
@@ -1,0 +1,377 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/math/beam_search.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace framework {
+class LoDTensor;
+class Tensor;
+}  // namespace framework
+namespace platform {
+class NPUDeviceContext;
+}  // namespace platform
+}  // namespace paddle
+
+namespace paddle {
+namespace operators {
+namespace math {
+
+template <typename T>
+class BeamSearchFunctor<platform::NPUDeviceContext, T> {
+ public:
+  void operator()(const platform::NPUDeviceContext& ctx,
+                  const framework::LoDTensor* pre_ids,
+                  const framework::LoDTensor* pre_scores,
+                  const framework::LoDTensor* ids,
+                  const framework::LoDTensor* scores,
+                  framework::LoDTensor* selected_ids,
+                  framework::LoDTensor* selected_scores,
+                  framework::Tensor* parent_idx, size_t level, size_t beam_size,
+                  int end_id, bool is_accumulated) {
+    auto abs_lod = framework::ToAbsOffset(scores->lod());
+    auto& high_level = abs_lod[level];
+
+    int64_t num_seqs = scores->NumElements(level);
+    // size of the first beam is 1, others are equal to beam_size
+    int64_t real_beam_size = static_cast<int64_t>(scores->dims()[0] / num_seqs);
+    // K(=beam_size)
+    int64_t seq_width = 1;
+    for (int i = 1; i < scores->dims().size(); i++) {
+      seq_width *= scores->dims()[i];
+    }
+
+    auto place = ctx.GetPlace();
+    auto stream = ctx.stream();
+
+    int64_t total_length = num_seqs * beam_size;
+    int64_t batch_size = static_cast<int64_t>(scores->dims()[0]);
+    selected_ids->mutable_data<int64_t>(framework::make_ddim({total_length, 1}),
+                                        place);
+    selected_scores->mutable_data<T>(framework::make_ddim({total_length, 1}),
+                                     place);
+    parent_idx->mutable_data<int64_t>(framework::make_ddim({total_length}),
+                                      place);
+
+    // Step1: Define Tensors and Preprocess the situation that pre_id == end_id
+
+    // expand pre_ids to shape of ids
+    Tensor expand_pre_ids(pre_ids->type());
+    expand_pre_ids.Resize(framework::make_ddim({batch_size, seq_width}));
+    expand_pre_ids.mutable_data<int64_t>(place);
+    const auto& runner_tile_pre_ids =
+        NpuOpRunner("TileWithAxis", {*pre_ids}, {expand_pre_ids},
+                    {{"axis", 1}, {"tiles", seq_width}});
+    runner_tile_pre_ids.Run(stream);
+    expand_pre_ids.Resize(ids->dims());
+
+    // End_id Tensors
+    Tensor end_id_tmp_tensor(framework::proto::VarType::INT64);
+    end_id_tmp_tensor.mutable_data<int64_t>({1}, ctx.GetPlace());
+    FillNpuTensorWithConstant<int64_t>(&end_id_tmp_tensor, end_id);
+
+    Tensor end_id_tensors(ids->type());
+    end_id_tensors.mutable_data<int64_t>(ids->dims(), place);
+    const auto& runner_fill_end_id =
+        NpuOpRunner("FillD", {end_id_tmp_tensor}, {end_id_tensors},
+                    {{"dims", framework::vectorize(ids->dims())}});
+    runner_fill_end_id.Run(stream);
+
+    // whether expand_pre_ids == end_ids?
+    Tensor equal_end_ids(framework::proto::VarType::BOOL);
+    equal_end_ids.mutable_data<bool>(ids->dims(), place);
+    const auto& runner_equal_end_ids = NpuOpRunner(
+        "Equal", {expand_pre_ids, end_id_tensors}, {equal_end_ids}, {});
+    runner_equal_end_ids.Run(stream);
+
+    // construct a Tensor with dimension ids->dims():
+    // [[False, True, True, True, ...],
+    //  [False, True, True, True, ...],
+    //  ...]
+    Tensor false_tmp_tensor(framework::proto::VarType::BOOL);
+    false_tmp_tensor.mutable_data<bool>({1}, ctx.GetPlace());
+    FillNpuTensorWithConstant<bool>(&false_tmp_tensor, false);
+
+    Tensor first_pos_false_tensors(framework::proto::VarType::BOOL);
+    first_pos_false_tensors.Resize(framework::make_ddim({batch_size, 1}));
+    first_pos_false_tensors.mutable_data<bool>(place);
+    std::vector<int64_t> fill_dims = {batch_size, 1};
+    framework::NPUAttributeMap fill_attr = {{"dims", fill_dims}};
+    const auto& runner_fill_false_tensors = NpuOpRunner(
+        "FillD", {false_tmp_tensor}, {first_pos_false_tensors}, fill_attr);
+    runner_fill_false_tensors.Run(stream);
+
+    Tensor true_tmp_tensor(framework::proto::VarType::BOOL);
+    true_tmp_tensor.mutable_data<bool>({1}, ctx.GetPlace());
+    FillNpuTensorWithConstant<bool>(&true_tmp_tensor, true);
+
+    Tensor second_pos_true_tensors(framework::proto::VarType::BOOL);
+    second_pos_true_tensors.Resize(
+        framework::make_ddim({batch_size, seq_width - 1}));
+    second_pos_true_tensors.mutable_data<bool>(place);
+    std::vector<int64_t> fill_dims2 = {batch_size, seq_width - 1};
+    framework::NPUAttributeMap fill_attr2 = {{"dims", fill_dims2}};
+    const auto& runner_fill_true_tensors = NpuOpRunner(
+        "FillD", {true_tmp_tensor}, {second_pos_true_tensors}, fill_attr2);
+    runner_fill_true_tensors.Run(stream);
+
+    Tensor pos_tensors(framework::proto::VarType::BOOL);
+    pos_tensors.Resize(framework::make_ddim({batch_size, seq_width}));
+    pos_tensors.mutable_data<bool>(place);
+    const auto& runner_concat_false_true = NpuOpRunner(
+        "ConcatD", {first_pos_false_tensors, second_pos_true_tensors},
+        {pos_tensors}, {{"concat_dim", 1}, {"N", 2}});
+    runner_concat_false_true.Run(stream);
+    pos_tensors.Resize(ids->dims());
+
+    // if pre_ids == end_ids, save only one score, and others become -inf
+    // construct pre_ids == end_ids and save only one score
+    Tensor save_one_end_score(framework::proto::VarType::BOOL);
+    save_one_end_score.mutable_data<bool>(ids->dims(), place);
+    const auto& runner_logical_and = NpuOpRunner(
+        "LogicalAnd", {equal_end_ids, pos_tensors}, {save_one_end_score}, {});
+    runner_logical_and.Run(stream);
+
+    // if save_one_end_score is True, set score to -inf
+    // define -Inf Tensors
+    Tensor ninf_tmp_tensor(scores->type());
+    ninf_tmp_tensor.mutable_data<float>({1}, ctx.GetPlace());
+    float ninf_value =
+        static_cast<float>(-std::numeric_limits<float>::infinity());
+    FillNpuTensorWithConstant<float>(&ninf_tmp_tensor, ninf_value);
+
+    Tensor ninf_tensors(scores->type());
+    ninf_tensors.mutable_data<T>(scores->dims(), place);
+    const auto& runner_fill_ninf =
+        NpuOpRunner("FillD", {ninf_tmp_tensor}, {ninf_tensors},
+                    {{"dims", framework::vectorize(scores->dims())}});
+    runner_fill_ninf.Run(stream);
+
+    // Step2: calculate topk scores
+
+    // get scores used in topk op
+    Tensor tmp_scores(scores->type());
+    tmp_scores.mutable_data<T>(scores->dims(), place);
+    if (!is_accumulated) {
+      // if pre_id == end_id, cal_scores = pre_score, and id = end_id
+      // else, cal_score = pre_score + log(score)
+
+      // calculate log(scores)
+      Tensor log_scores(scores->type());
+      log_scores.mutable_data<T>(scores->dims(), place);
+
+      Tensor one(scores->type());
+      one.mutable_data<T>(scores->dims(), place);
+      const auto& runner_one = NpuOpRunner("OnesLike", {*scores}, {one}, {});
+      runner_one.Run(stream);
+
+      Tensor sub(scores->type());
+      sub.mutable_data<T>(scores->dims(), place);
+      const auto& runner_sub = NpuOpRunner("Sub", {*scores, one}, {sub}, {});
+      runner_sub.Run(stream);
+
+      const auto& runner_log_scores =
+          NpuOpRunner("Log1p", {sub}, {log_scores}, {});
+      runner_log_scores.Run(stream);
+
+      // tmp_scores = pre_score + log(scores)
+      const auto& runner_add_scores =
+          NpuOpRunner("Add", {log_scores, *pre_scores}, {tmp_scores}, {});
+      runner_add_scores.Run(stream);
+
+      // if pre_ids == end_ids, use pre_score rather than score
+      const auto& runner_select_equal_end_score = NpuOpRunner(
+          "Select", {equal_end_ids, *pre_scores, tmp_scores}, {tmp_scores}, {});
+      runner_select_equal_end_score.Run(stream);
+    } else {
+      // if pre_ids == end_ids, use pre_score rather than score
+      const auto& runner_select_equal_end_score2 = NpuOpRunner(
+          "Select", {equal_end_ids, *pre_scores, *scores}, {tmp_scores}, {});
+      runner_select_equal_end_score2.Run(stream);
+    }
+
+    // if pre_ids == end_ids, save only one score, and others become -inf
+    Tensor cal_scores(scores->type());
+    cal_scores.mutable_data<T>(scores->dims(), place);
+    const auto& runner_select_inf_score =
+        NpuOpRunner("Select", {save_one_end_score, ninf_tensors, tmp_scores},
+                    {cal_scores}, {});
+    runner_select_inf_score.Run(stream);
+
+    // resize scores from [num_seqs * beam_size, K] to [num_seqs, beam_size * K]
+    // real_beam_size = 1 or beam_size
+    cal_scores.Resize(
+        framework::make_ddim({num_seqs, real_beam_size * seq_width}));
+
+    // select topk scores
+    // prepare assit
+    auto dim = cal_scores.dims().size();
+    framework::Tensor assist_seq_tensor;
+    assist_seq_tensor.Resize({2 * dim});
+    assist_seq_tensor.mutable_data<T>(ctx.GetPlace());
+    gen_assist_seq(&assist_seq_tensor, dim, ctx);
+
+    framework::NPUAttributeMap attr_input = {{"sorted", "true"},
+                                             {"k", static_cast<int>(beam_size)},
+                                             {"dim", -1},
+                                             {"largest", true}};
+
+    Tensor topk_scores(scores->type());
+    topk_scores.ShareDataWith(*selected_scores);
+    topk_scores.Resize(
+        framework::make_ddim({num_seqs, static_cast<int64_t>(beam_size)}));
+
+    Tensor tmp_indices(framework::proto::VarType::INT64);
+    tmp_indices.Resize(
+        framework::make_ddim({num_seqs, static_cast<int64_t>(beam_size)}));
+    tmp_indices.mutable_data<int64_t>(ctx.GetPlace());
+
+    // run topk op
+    const auto& runner_topk =
+        NpuOpRunner("TopKD", {cal_scores, assist_seq_tensor},
+                    {topk_scores, tmp_indices}, attr_input);
+    runner_topk.Run(stream);
+
+    // Step 3: infer selected ids from tmp_indices and ids
+
+    // if pre_ids == end_ids, use pre_ids rather than ids
+    Tensor cal_ids(ids->type());
+    cal_ids.mutable_data<int64_t>(ids->dims(), place);
+    const auto& runner_select_equal_end_id =
+        NpuOpRunner("Select", {equal_end_ids, *pre_ids, *ids}, {cal_ids}, {});
+    runner_select_equal_end_id.Run(stream);
+
+    // resize ids from [num_seqs * real_beam_size, K] to [num_seqs,
+    // real_beam_size * K]
+    // real_beam_size = 1 or beam_size
+    cal_ids.Resize(
+        framework::make_ddim({num_seqs, real_beam_size * seq_width}));
+
+    // construct arange(num_seqs*beam_size).reshape((num_seqs, beam_size)) //
+    // beam_size
+    Tensor batch_ids(framework::proto::VarType::INT64);
+    batch_ids.Resize(
+        framework::make_ddim({num_seqs, static_cast<int64_t>(beam_size), 1}));
+    batch_ids.mutable_data<int64_t>(place);
+
+    std::vector<int64_t> vector_batch_ids;
+    for (int64_t i = 0; i < num_seqs * static_cast<int64_t>(beam_size); ++i) {
+      vector_batch_ids.push_back(static_cast<int64_t>(i / beam_size));
+    }
+    framework::TensorFromVector(vector_batch_ids, ctx, &batch_ids);
+
+    // get indices of gather_nd op
+    tmp_indices.Resize(
+        framework::make_ddim({num_seqs, static_cast<int64_t>(beam_size), 1}));
+    Tensor gather_nd_indices(framework::proto::VarType::INT64);
+    gather_nd_indices.Resize(
+        framework::make_ddim({num_seqs, static_cast<int64_t>(beam_size), 2}));
+    gather_nd_indices.mutable_data<int64_t>(place);
+    const auto& runner_concat_indices =
+        NpuOpRunner("ConcatD", {batch_ids, tmp_indices}, {gather_nd_indices},
+                    {{"concat_dim", 1}, {"N", 2}});
+    runner_concat_indices.Run(stream);
+
+    // use gather_nd to get selected_ids
+    Tensor topk_ids(selected_ids->type());
+    topk_ids.ShareDataWith(*selected_ids);
+    topk_ids.Resize(
+        framework::make_ddim({num_seqs, static_cast<int64_t>(beam_size)}));
+
+    const auto& runner_gather_nd =
+        NpuOpRunner("GatherNd", {cal_ids, gather_nd_indices}, {topk_ids}, {});
+    runner_gather_nd.Run(stream);
+
+    // Step 4: set lod of output Tensor
+    // define Tensor with value `beam_size`
+    Tensor beam_size_tensor(framework::proto::VarType::INT64);
+    beam_size_tensor.mutable_data<int64_t>({1}, ctx.GetPlace());
+    FillNpuTensorWithConstant<int64_t>(&beam_size_tensor, beam_size);
+
+    // beam_ids = tmp_indices % beam_size
+    Tensor beam_ids(framework::proto::VarType::INT64);
+    beam_ids.ShareDataWith(*parent_idx);
+    beam_ids.Resize(
+        framework::make_ddim({num_seqs, static_cast<int64_t>(beam_size)}));
+
+    const auto& runner_mod =
+        NpuOpRunner("Mod", {tmp_indices, beam_size_tensor}, {beam_ids}, {});
+    runner_mod.Run(stream);
+
+    std::vector<int64_t> vector_beam_ids;
+    framework::TensorToVector(beam_ids, ctx, &vector_beam_ids);
+
+    // set low level, len(low_level) = high_level[-1]
+    std::vector<int64_t> low_level;
+    std::vector<int64_t> num_beam_ids(num_seqs * beam_size,
+                                      static_cast<int64_t>(0));
+    size_t low_level_size = high_level[num_seqs - 1];
+    size_t sum_beam_id = 0;
+
+    // calculate number of every beam_id
+    for (size_t i = 0; i < num_seqs * beam_size; ++i) {
+      num_beam_ids[vector_beam_ids[i]]++;
+    }
+
+    // update low_level
+    low_level.push_back(0);
+    for (size_t i = 0; i < low_level_size; ++i) {
+      sum_beam_id += num_beam_ids[i];
+      low_level.push_back(sum_beam_id);
+    }
+
+    // fill lod
+    framework::LoD lod(2);
+    lod[0].assign(high_level.begin(), high_level.end());
+    lod[1].assign(low_level.begin(), low_level.end());
+    if (!framework::CheckLoD(lod)) {
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "lod %s is not right in"
+          " beam_search, please check your code.",
+          framework::LoDToString(lod)));
+    }
+    selected_ids->set_lod(lod);
+    selected_scores->set_lod(lod);
+  }
+
+ protected:
+  // used in topk NPU OP
+  void gen_assist_seq(framework::Tensor* assit_tensor, int64_t dim,
+                      const platform::NPUDeviceContext& ctx) {
+    const int64_t dimx2 = dim;
+    std::vector<paddle::platform::float16> assit;
+    assit.resize(2 * dimx2);
+    for (int64_t i = 0; i < dimx2; i++) {
+      // for i in range [0, dim]
+      assit[i] = static_cast<paddle::platform::float16>(i);
+
+      // for i in range [dim, dimx2]
+      int64_t idx =
+          static_cast<int64_t>(static_cast<paddle::platform::float16>(i));
+      int64_t gap = i - idx;
+      assit[i + dim] = static_cast<paddle::platform::float16>(gap);
+    }
+    framework::TensorFromVector(assit, ctx, assit_tensor);
+  }
+};
+
+template class BeamSearchFunctor<platform::NPUDeviceContext, int>;
+template class BeamSearchFunctor<platform::NPUDeviceContext, int64_t>;
+template class BeamSearchFunctor<platform::NPUDeviceContext, float>;
+template class BeamSearchFunctor<platform::NPUDeviceContext, double>;
+
+}  // namespace math
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
@@ -40,7 +40,7 @@ class TestBeamSearchNPUOp(OpTest):
         # The `target_lod` attribute is still based on offset
         self.attrs = {
             'level': 0,
-            'beam_size': 2,
+            'beam_size': self.beam_size,
             'end_id': 0,
             'is_accumulated': self.is_accumulated
         }
@@ -54,6 +54,7 @@ class TestBeamSearchNPUOp(OpTest):
         self.__class__.use_npu = True
 
     def init_data(self):
+        self.beam_size = 2
         self.is_accumulated = True
         self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int64')
         self.ids = np.array(
@@ -80,6 +81,7 @@ class TestBeamSearchNPUOp(OpTest):
 
 class TestBeamSearchNPUOp2(TestBeamSearchNPUOp):
     def init_data(self):
+        self.beam_size = 2
         self.is_accumulated = True
         self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int64')
         self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
@@ -102,6 +104,7 @@ class TestBeamSearchNPUOp2(TestBeamSearchNPUOp):
 class TestBeamSearchNPUOp3(TestBeamSearchNPUOp):
     def init_data(self):
         # end_id = 0
+        self.beam_size = 2
         self.is_accumulated = True
         self.pre_ids = np.array([[1], [0], [0], [4]], dtype='int64')
         self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
@@ -124,6 +127,7 @@ class TestBeamSearchNPUOp3(TestBeamSearchNPUOp):
 class TestBeamSearchNPUOp4(TestBeamSearchNPUOp):
     def init_data(self):
         # is_accumulated = False
+        self.beam_size = 2
         self.is_accumulated = False
         self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int64')
         self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
@@ -142,6 +146,29 @@ class TestBeamSearchNPUOp4(TestBeamSearchNPUOp):
         self.selected_scores = np.array(
             [1.50685, 0.996027, 0.194639, 0.043325])[:, np.newaxis]
         self.parent_idx = np.array([1, 1, 2, 3])
+
+
+class TestBeamSearchNPUOp5(TestBeamSearchNPUOp):
+    def init_data(self):
+        # beam_size = 1
+        self.beam_size = 1
+        self.is_accumulated = True
+        self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int64')
+        self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
+        self.lod = [[1, 1, 1, 1], [1, 1, 1, 1]]
+        self.out_lod = [[1, 1, 1, 1], [1, 1, 1, 1]]
+        self.offset_lod = [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]
+        self.score = np.array(
+            [
+                [0.6, 0.9],
+                [0.5, 0.3],
+                [0.9, 0.5],
+                [0.1, 0.7],
+            ], dtype='float32')
+        self.pre_score = np.array([[0.1], [0.2], [0.3], [0.4]], dtype='float32')
+        self.selected_ids = np.array([2, 7, 3, 1])[:, np.newaxis]
+        self.selected_scores = np.array([0.9, 0.5, 0.9, 0.7])[:, np.newaxis]
+        self.parent_idx = np.array([0, 1, 2, 3])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
@@ -55,9 +55,9 @@ class TestBeamSearchNPUOp(OpTest):
 
     def init_data(self):
         self.is_accumulated = True
-        self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int32')
+        self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int64')
         self.ids = np.array(
-            [[4, 2, 5], [2, 1, 3], [3, 5, 2], [8, 2, 1]], dtype='int32')
+            [[4, 2, 5], [2, 1, 3], [3, 5, 2], [8, 2, 1]], dtype='int64')
         self.lod = [[2, 2], [1, 1, 1, 1]]
         self.out_lod = [[2, 2], [1, 1, 1, 1]]
         self.offset_lod = [[0, 2, 4], [0, 1, 2, 3, 4]]
@@ -81,8 +81,8 @@ class TestBeamSearchNPUOp(OpTest):
 class TestBeamSearchNPUOp2(TestBeamSearchNPUOp):
     def init_data(self):
         self.is_accumulated = True
-        self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int32')
-        self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int32')
+        self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int64')
+        self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
         self.lod = [[2, 2], [1, 1, 1, 1]]
         self.out_lod = [[2, 2], [2, 0, 1, 1]]
         self.offset_lod = [[0, 2, 4], [0, 2, 2, 3, 4]]
@@ -103,8 +103,8 @@ class TestBeamSearchNPUOp3(TestBeamSearchNPUOp):
     def init_data(self):
         # end_id = 0
         self.is_accumulated = True
-        self.pre_ids = np.array([[1], [0], [0], [4]], dtype='int32')
-        self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int32')
+        self.pre_ids = np.array([[1], [0], [0], [4]], dtype='int64')
+        self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
         self.lod = [[2, 2], [1, 1, 1, 1]]
         self.out_lod = [[2, 2], [1, 1, 0, 2]]
         self.offset_lod = [[0, 2, 4], [0, 1, 2, 2, 4]]
@@ -125,8 +125,8 @@ class TestBeamSearchNPUOp4(TestBeamSearchNPUOp):
     def init_data(self):
         # is_accumulated = False
         self.is_accumulated = False
-        self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int32')
-        self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int32')
+        self.pre_ids = np.array([[1], [2], [3], [4]], dtype='int64')
+        self.ids = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
         self.lod = [[2, 2], [1, 1, 1, 1]]
         self.out_lod = [[2, 2], [0, 2, 1, 1]]
         self.offset_lod = [[0, 2, 4], [0, 0, 2, 3, 4]]

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
@@ -1,0 +1,102 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import logging
+from paddle.fluid.op import Operator, DynamicRecurrentOp
+import paddle.fluid.core as core
+import unittest
+import numpy as np
+import paddle.fluid as fluid
+from paddle.fluid.framework import Program, program_guard
+
+
+def create_tensor(scope, name, np_data):
+    tensor = scope.var(name).get_tensor()
+    tensor.set(np_data, core.NPUPlace(0))
+    return tensor
+
+
+class BeamSearchOpTester(unittest.TestCase):
+    """unittest of beam_search_op"""
+
+    def setUp(self):
+        self.scope = core.Scope()
+        self._create_ids()
+        self._create_pre_scores()
+        self._create_scores()
+        self._create_pre_ids()
+        self.scope.var('selected_ids').get_tensor()
+        self.scope.var('selected_scores').get_tensor()
+        self.scope.var('parent_idx').get_tensor()
+
+    def test_run(self):
+        op = Operator(
+            'beam_search',
+            pre_ids='pre_ids',
+            pre_scores='pre_scores',
+            ids='ids',
+            scores='scores',
+            selected_ids='selected_ids',
+            selected_scores='selected_scores',
+            parent_idx='parent_idx',
+            level=0,
+            beam_size=2,
+            end_id=0, )
+        op.run(self.scope, core.NPUPlace(0))
+        selected_ids = self.scope.find_var("selected_ids").get_tensor()
+        selected_scores = self.scope.find_var("selected_scores").get_tensor()
+        parent_idx = self.scope.find_var("parent_idx").get_tensor()
+        self.assertTrue(
+            np.allclose(
+                np.array(selected_ids), np.array([4, 2, 3, 8])[:, np.newaxis]))
+        self.assertTrue(
+            np.allclose(
+                np.array(selected_scores),
+                np.array([0.5, 0.6, 0.9, 0.7])[:, np.newaxis]))
+        self.assertEqual(selected_ids.lod(), [[0, 2, 4], [0, 1, 2, 3, 4]])
+        self.assertTrue(
+            np.allclose(np.array(parent_idx), np.array([0, 1, 2, 3])))
+
+    def _create_pre_ids(self):
+        np_data = np.array([[1], [2], [3], [4]], dtype='int32')
+        tensor = create_tensor(self.scope, 'pre_ids', np_data)
+
+    def _create_pre_scores(self):
+        np_data = np.array([[0.1], [0.2], [0.3], [0.4]], dtype='float32')
+        tensor = create_tensor(self.scope, 'pre_scores', np_data)
+
+    def _create_ids(self):
+        self.lod = [[0, 2, 4], [0, 1, 2, 3, 4]]
+        np_data = np.array(
+            [[4, 2, 5], [2, 1, 3], [3, 5, 2], [8, 2, 1]], dtype='int32')
+        tensor = create_tensor(self.scope, "ids", np_data)
+        tensor.set_lod(self.lod)
+
+    def _create_scores(self):
+        np_data = np.array(
+            [
+                [0.5, 0.3, 0.2],
+                [0.6, 0.3, 0.1],
+                [0.9, 0.5, 0.1],
+                [0.7, 0.5, 0.1],
+            ],
+            dtype='float32')
+        tensor = create_tensor(self.scope, "scores", np_data)
+        tensor.set_lod(self.lod)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
@@ -75,7 +75,7 @@ class TestBeamSearchNPUOp(OpTest):
         self.parent_idx = np.array([0, 1, 2, 3])
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, atol=1e-3)
 
 
 class TestBeamSearchNPUOp2(TestBeamSearchNPUOp):

--- a/python/paddle/fluid/tests/unittests/test_beam_search_op.py
+++ b/python/paddle/fluid/tests/unittests/test_beam_search_op.py
@@ -54,7 +54,7 @@ class BeamSearchOpTester(unittest.TestCase):
             selected_scores='selected_scores',
             parent_idx='parent_idx',
             level=0,
-            beam_size=2,
+            beam_size=self.beam_size,
             end_id=0,
             is_accumulated=self.is_accumulated)
         op.run(self.scope, core.CPUPlace())
@@ -96,6 +96,7 @@ class BeamSearchOpTester(unittest.TestCase):
         tensor.set_lod(self.lod)
 
     def set_outputs(self):
+        self.beam_size = 2
         self.is_accumulated = True
         self.output_ids = np.array([4, 2, 3, 8])[:, np.newaxis]
         self.output_scores = np.array([0.5, 0.6, 0.9, 0.7])[:, np.newaxis]
@@ -130,6 +131,7 @@ class BeamSearchOpTester2(BeamSearchOpTester):
         tensor.set_lod(self.lod)
 
     def set_outputs(self):
+        self.beam_size = 2
         self.is_accumulated = True
         self.output_ids = np.array([2, 4, 3, 1])[:, np.newaxis]
         self.output_scores = np.array([0.9, 0.6, 0.9, 0.7])[:, np.newaxis]
@@ -165,6 +167,7 @@ class BeamSearchOpTester3(BeamSearchOpTester):
         tensor.set_lod(self.lod)
 
     def set_outputs(self):
+        self.beam_size = 2
         self.is_accumulated = True
         self.output_ids = np.array([2, 0, 1, 8])[:, np.newaxis]
         self.output_scores = np.array([0.9, 1.2, 0.7, 0.6])[:, np.newaxis]
@@ -200,6 +203,7 @@ class BeamSearchOpTester4(BeamSearchOpTester):
         tensor.set_lod(self.lod)
 
     def set_outputs(self):
+        self.beam_size = 2
         self.is_accumulated = True
         self.output_ids = np.array([1, 8])[:, np.newaxis]
         self.output_scores = np.array([0.7, 0.6])[:, np.newaxis]
@@ -235,12 +239,49 @@ class BeamSearchOpTester5(BeamSearchOpTester):
         tensor.set_lod(self.lod)
 
     def set_outputs(self):
+        self.beam_size = 2
         self.is_accumulated = False
         self.output_ids = np.array([7, 3, 3, 1])[:, np.newaxis]
         self.output_scores = np.array(
             [1.50685, 0.996027, 0.194639, 0.043325])[:, np.newaxis]
         self.output_lod = [[0, 2, 4], [0, 0, 2, 3, 4]]
         self.output_parent_idx = np.array([1, 1, 2, 3])
+
+
+class BeamSearchOpTester6(BeamSearchOpTester):
+    # beam_size = 1
+    def _create_pre_ids(self):
+        np_data = np.array([[1], [2], [3], [4]], dtype='int64')
+        tensor = create_tensor(self.scope, 'pre_ids', np_data)
+
+    def _create_pre_scores(self):
+        np_data = np.array([[0.1, 0.2, 0.3, 0.4]], dtype='float32')
+        tensor = create_tensor(self.scope, 'pre_scores', np_data)
+
+    def _create_ids(self):
+        self.lod = [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]
+        np_data = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
+        tensor = create_tensor(self.scope, "ids", np_data)
+        tensor.set_lod(self.lod)
+
+    def _create_scores(self):
+        np_data = np.array(
+            [
+                [0.6, 0.9],
+                [0.5, 0.3],
+                [0.9, 0.5],
+                [0.1, 0.7],
+            ], dtype='float32')
+        tensor = create_tensor(self.scope, "scores", np_data)
+        tensor.set_lod(self.lod)
+
+    def set_outputs(self):
+        self.beam_size = 1
+        self.is_accumulated = True
+        self.output_ids = np.array([2, 7, 3, 1])[:, np.newaxis]
+        self.output_scores = np.array([0.9, 0.5, 0.9, 0.7])[:, np.newaxis]
+        self.output_lod = [[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]
+        self.output_parent_idx = np.array([0, 1, 2, 3])
 
 
 class TestBeamSearchOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_beam_search_op.py
+++ b/python/paddle/fluid/tests/unittests/test_beam_search_op.py
@@ -38,6 +38,7 @@ class BeamSearchOpTester(unittest.TestCase):
         self._create_pre_scores()
         self._create_scores()
         self._create_pre_ids()
+        self.set_outputs()
         self.scope.var('selected_ids').get_tensor()
         self.scope.var('selected_scores').get_tensor()
         self.scope.var('parent_idx').get_tensor()
@@ -54,21 +55,22 @@ class BeamSearchOpTester(unittest.TestCase):
             parent_idx='parent_idx',
             level=0,
             beam_size=2,
-            end_id=0, )
+            end_id=0,
+            is_accumulated=self.is_accumulated)
         op.run(self.scope, core.CPUPlace())
         selected_ids = self.scope.find_var("selected_ids").get_tensor()
         selected_scores = self.scope.find_var("selected_scores").get_tensor()
         parent_idx = self.scope.find_var("parent_idx").get_tensor()
+        print("yoki: selected_ids: ", selected_ids)
+        print("yoki: selected_scores: ", selected_scores)
+        print("yoki: lod", selected_ids.lod())
+        print("yoki: np.array(parent_idx): ", np.array(parent_idx))
+        self.assertTrue(np.allclose(np.array(selected_ids), self.output_ids))
         self.assertTrue(
-            np.allclose(
-                np.array(selected_ids), np.array([4, 2, 3, 8])[:, np.newaxis]))
+            np.allclose(np.array(selected_scores), self.output_scores))
+        self.assertEqual(selected_ids.lod(), self.output_lod)
         self.assertTrue(
-            np.allclose(
-                np.array(selected_scores),
-                np.array([0.5, 0.6, 0.9, 0.7])[:, np.newaxis]))
-        self.assertEqual(selected_ids.lod(), [[0, 2, 4], [0, 1, 2, 3, 4]])
-        self.assertTrue(
-            np.allclose(np.array(parent_idx), np.array([0, 1, 2, 3])))
+            np.allclose(np.array(parent_idx), self.output_parent_idx))
 
     def _create_pre_ids(self):
         np_data = np.array([[1, 2, 3, 4]], dtype='int64')
@@ -96,6 +98,118 @@ class BeamSearchOpTester(unittest.TestCase):
             dtype='float32')
         tensor = create_tensor(self.scope, "scores", np_data)
         tensor.set_lod(self.lod)
+
+    def set_outputs(self):
+        self.is_accumulated = True
+        self.output_ids = np.array([4, 2, 3, 8])[:, np.newaxis]
+        self.output_scores = np.array([0.5, 0.6, 0.9, 0.7])[:, np.newaxis]
+        self.output_lod = [[0, 2, 4], [0, 1, 2, 3, 4]]
+        self.output_parent_idx = np.array([0, 1, 2, 3])
+
+
+class BeamSearchOpTester2(BeamSearchOpTester):
+    def _create_pre_ids(self):
+        np_data = np.array([[1], [2], [3], [4]], dtype='int64')
+        tensor = create_tensor(self.scope, 'pre_ids', np_data)
+
+    def _create_pre_scores(self):
+        np_data = np.array([[0.1, 0.2, 0.3, 0.4]], dtype='float32')
+        tensor = create_tensor(self.scope, 'pre_scores', np_data)
+
+    def _create_ids(self):
+        self.lod = [[0, 2, 4], [0, 1, 2, 3, 4]]
+        np_data = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
+        tensor = create_tensor(self.scope, "ids", np_data)
+        tensor.set_lod(self.lod)
+
+    def _create_scores(self):
+        np_data = np.array(
+            [
+                [0.6, 0.9],
+                [0.5, 0.3],
+                [0.9, 0.5],
+                [0.1, 0.7],
+            ], dtype='float32')
+        tensor = create_tensor(self.scope, "scores", np_data)
+        tensor.set_lod(self.lod)
+
+    def set_outputs(self):
+        self.is_accumulated = True
+        self.output_ids = np.array([2, 4, 3, 1])[:, np.newaxis]
+        self.output_scores = np.array([0.9, 0.6, 0.9, 0.7])[:, np.newaxis]
+        self.output_lod = [[0, 2, 4], [0, 2, 2, 3, 4]]
+        self.output_parent_idx = np.array([0, 0, 2, 3])
+
+
+class BeamSearchOpTester3(BeamSearchOpTester):
+    # pre_id = end_id
+    def _create_pre_ids(self):
+        np_data = np.array([[1], [0], [0], [4]], dtype='int64')
+        tensor = create_tensor(self.scope, 'pre_ids', np_data)
+
+    def _create_pre_scores(self):
+        np_data = np.array([[0.1], [1.2], [0.5], [0.4]], dtype='float32')
+        tensor = create_tensor(self.scope, 'pre_scores', np_data)
+
+    def _create_ids(self):
+        self.lod = [[0, 2, 4], [0, 1, 2, 3, 4]]
+        np_data = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
+        tensor = create_tensor(self.scope, "ids", np_data)
+        tensor.set_lod(self.lod)
+
+    def _create_scores(self):
+        np_data = np.array(
+            [
+                [0.6, 0.9],
+                [0.5, 0.3],
+                [0.9, 0.5],
+                [0.6, 0.7],
+            ], dtype='float32')
+        tensor = create_tensor(self.scope, "scores", np_data)
+        tensor.set_lod(self.lod)
+
+    def set_outputs(self):
+        self.is_accumulated = True
+        self.output_ids = np.array([2, 0, 1, 8])[:, np.newaxis]
+        self.output_scores = np.array([0.9, 1.2, 0.7, 0.6])[:, np.newaxis]
+        self.output_lod = [[0, 2, 4], [0, 1, 2, 2, 4]]
+        self.output_parent_idx = np.array([0, 1, 3, 3])
+
+
+class BeamSearchOpTester4(BeamSearchOpTester):
+    # is_accumulated = False
+    def _create_pre_ids(self):
+        np_data = np.array([[1], [2], [3], [4]], dtype='int64')
+        tensor = create_tensor(self.scope, 'pre_ids', np_data)
+
+    def _create_pre_scores(self):
+        np_data = np.array([[0.1, 2.2, 0.3, 0.4]], dtype='float32')
+        tensor = create_tensor(self.scope, 'pre_scores', np_data)
+
+    def _create_ids(self):
+        self.lod = [[0, 2, 4], [0, 1, 2, 3, 4]]
+        np_data = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
+        tensor = create_tensor(self.scope, "ids", np_data)
+        tensor.set_lod(self.lod)
+
+    def _create_scores(self):
+        np_data = np.array(
+            [
+                [0.6, 0.9],
+                [0.5, 0.3],
+                [0.9, 0.5],
+                [0.1, 0.7],
+            ], dtype='float32')
+        tensor = create_tensor(self.scope, "scores", np_data)
+        tensor.set_lod(self.lod)
+
+    def set_outputs(self):
+        self.is_accumulated = False
+        self.output_ids = np.array([7, 3, 3, 1])[:, np.newaxis]
+        self.output_scores = np.array(
+            [1.50685, 0.996027, 0.194639, 0.043325])[:, np.newaxis]
+        self.output_lod = [[0, 2, 4], [0, 0, 2, 3, 4]]
+        self.output_parent_idx = np.array([1, 1, 2, 3])
 
 
 class TestBeamSearchOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_beam_search_op.py
+++ b/python/paddle/fluid/tests/unittests/test_beam_search_op.py
@@ -61,10 +61,6 @@ class BeamSearchOpTester(unittest.TestCase):
         selected_ids = self.scope.find_var("selected_ids").get_tensor()
         selected_scores = self.scope.find_var("selected_scores").get_tensor()
         parent_idx = self.scope.find_var("parent_idx").get_tensor()
-        print("yoki: selected_ids: ", selected_ids)
-        print("yoki: selected_scores: ", selected_scores)
-        print("yoki: lod", selected_ids.lod())
-        print("yoki: np.array(parent_idx): ", np.array(parent_idx))
         self.assertTrue(np.allclose(np.array(selected_ids), self.output_ids))
         self.assertTrue(
             np.allclose(np.array(selected_scores), self.output_scores))
@@ -177,6 +173,41 @@ class BeamSearchOpTester3(BeamSearchOpTester):
 
 
 class BeamSearchOpTester4(BeamSearchOpTester):
+    # prune beam search while pre_id of in all beams is end_id
+    def _create_pre_ids(self):
+        np_data = np.array([[0], [0], [0], [4]], dtype='int64')
+        tensor = create_tensor(self.scope, 'pre_ids', np_data)
+
+    def _create_pre_scores(self):
+        np_data = np.array([[0.1], [1.2], [0.5], [0.4]], dtype='float32')
+        tensor = create_tensor(self.scope, 'pre_scores', np_data)
+
+    def _create_ids(self):
+        self.lod = [[0, 2, 4], [0, 1, 2, 3, 4]]
+        np_data = np.array([[4, 2], [7, 3], [3, 5], [8, 1]], dtype='int64')
+        tensor = create_tensor(self.scope, "ids", np_data)
+        tensor.set_lod(self.lod)
+
+    def _create_scores(self):
+        np_data = np.array(
+            [
+                [0.6, 0.9],
+                [0.5, 0.3],
+                [0.9, 0.5],
+                [0.6, 0.7],
+            ], dtype='float32')
+        tensor = create_tensor(self.scope, "scores", np_data)
+        tensor.set_lod(self.lod)
+
+    def set_outputs(self):
+        self.is_accumulated = True
+        self.output_ids = np.array([1, 8])[:, np.newaxis]
+        self.output_scores = np.array([0.7, 0.6])[:, np.newaxis]
+        self.output_lod = [[0, 2, 4], [0, 0, 0, 0, 2]]
+        self.output_parent_idx = np.array([3, 3])
+
+
+class BeamSearchOpTester5(BeamSearchOpTester):
     # is_accumulated = False
     def _create_pre_ids(self):
         np_data = np.array([[1], [2], [3], [4]], dtype='int64')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

beam search op：
- 单测结果：
<img width="663" alt="图片" src="https://user-images.githubusercontent.com/26408901/129670648-d4be3dc0-0e08-41fa-abaf-fe1524160749.png">


- log：
<img width="1440" alt="图片" src="https://user-images.githubusercontent.com/26408901/129670416-3fdabadf-b080-413b-9a11-7750418afd06.png">


- 后续问题：
  - cpu版本的`score`只支持了float版本，npu目前也只支持了float版本，后续根据模型情况可能需要支持float16等类型。
  - cpu版本有剪枝过程，对beam search这个过程的性能有提升。npu还未实现，暂时看起来不影响结果。
  - topk计算出来的结果顺序与cpu不同，但是对整个beam search的计算没有影响。


