### PR TITLE
Fix typos in English docs for diag and diagflat.

### DIFF
--- a/paddle/fluid/operators/diag_v2_op.cc
+++ b/paddle/fluid/operators/diag_v2_op.cc
@@ -79,7 +79,7 @@ class DiagV2OpMaker : public framework::OpProtoAndCheckerMaker {
                    "Tensor. The default value is 0.")
         .SetDefault(0.0f);
     AddComment(R"DOC(
-      If ``x`` is a vector (1-D tensor), a 2-D square tensor whth the elements of ``x`` as the diagonal is returned.
+      If ``x`` is a vector (1-D tensor), a 2-D square tensor with the elements of ``x`` as the diagonal is returned.
 
       If ``x`` is a matrix (2-D tensor), a 1-D tensor with the diagonal elements of ``x`` is returned.
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13327,7 +13327,7 @@ def shuffle_channel(x, group, name=None):
                           [[0.7, 0.8],
                            [0.8, 0.9]]]]
             Given group: 2
-            then we get a 4-D tensor out whth the same shape of input:
+            then we get a 4-D tensor out with the same shape of input:
             out.shape = (1, 4, 2, 2)
             out.data = [[[[0.1, 0.2],
                           [0.2, 0.3]],

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13355,7 +13355,9 @@ def shuffle_channel(x, group, name=None):
     Examples:
         .. code-block:: python
 
-            import paddle.fluid as fluid
+            import paddle
+	    import paddle.fluid as fluid
+	    paddle.enable_static()
             input = fluid.data(name='input', shape=[None,4,2,2], dtype='float32')
             out = fluid.layers.shuffle_channel(x=input, group=2)
     """

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13356,8 +13356,8 @@ def shuffle_channel(x, group, name=None):
         .. code-block:: python
 
             import paddle
-	    import paddle.fluid as fluid
-	    paddle.enable_static()
+	      import paddle.fluid as fluid
+	      paddle.enable_static()
             input = fluid.data(name='input', shape=[None,4,2,2], dtype='float32')
             out = fluid.layers.shuffle_channel(x=input, group=2)
     """

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -777,7 +777,7 @@ def meshgrid(*args, **kwargs):
 
 def diagflat(x, offset=0, name=None):
     """
-    If ``x`` is a vector (1-D tensor), a 2-D square tensor whth the elements of ``x`` as the diagonal is returned.
+    If ``x`` is a vector (1-D tensor), a 2-D square tensor with the elements of ``x`` as the diagonal is returned.
 
     If ``x`` is a tensor (more than 1-D), a 2-D square tensor with the elements of flattened ``x`` as the diagonal is returned.
 
@@ -902,7 +902,7 @@ def diagflat(x, offset=0, name=None):
 
 def diag(x, offset=0, padding_value=0, name=None):
     """
-    If ``x`` is a vector (1-D tensor), a 2-D square tensor whth the elements of ``x`` as the diagonal is returned.
+    If ``x`` is a vector (1-D tensor), a 2-D square tensor with the elements of ``x`` as the diagonal is returned.
 
     If ``x`` is a matrix (2-D tensor), a 1-D tensor with the diagonal elements of ``x`` is returned.
 


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
Docs 

### Describe
Fix typos in English docs for diag and diagflat, replacing "whth" with "with".
Fix shuffle_channel bugs in docs by enabling static.
