### PR TITLE
[hybrid] refine pipeline stage and mp send/recv check

### DIFF
--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -40,7 +40,7 @@ def _squared_l2_norm(x):
     This OP returns the squared L2 norm of a tensor.
     """
 
-    if core.is_compiled_with_xpu():
+    if core.is_compiled_with_npu() or core.is_compiled_with_xpu():
         square = layers.square(x)
         sum_square = layers.reduce_sum(square)
         return sum_square

--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -40,7 +40,7 @@ def _squared_l2_norm(x):
     This OP returns the squared L2 norm of a tensor.
     """
 
-    if core.is_compiled_with_npu() or core.is_compiled_with_xpu():
+    if core.is_compiled_with_xpu():
         square = layers.square(x)
         sum_square = layers.reduce_sum(square)
         return sum_square

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -4397,6 +4397,10 @@ class PipelineOptimizer(object):
         return op_role & int(self._op_role.Backward) and op_role & int(
             self._op_role.Loss)
 
+    def _is_forward_op(self, op):
+        return self._op_role_key in op.attr_names and (
+            int(op.attr(self._op_role_key)) == int(self._op_role.Forward))
+
     def _is_backward_op(self, op):
         return self._op_role_key in op.attr_names and (
             int(op.attr(self._op_role_key)) & int(self._op_role.Backward))
@@ -4705,10 +4709,6 @@ class PipelineOptimizer(object):
             int(self._op_role.Optimize),
             int(self._op_role.Backward) | int(self._op_role.Loss),
         ]
-        pre_stage_id = None
-        decrease_flag = False
-        in_optimize = False
-        in_forward = True
         for op in block.ops:
             if not op._has_kernel(op.type):
                 assert op.type == "conditional_block" and (
@@ -4724,10 +4724,6 @@ class PipelineOptimizer(object):
                     op_role,
                     op.type,
                     valid_op_role_value)
-            if int(op_role) == int(self._op_role.Optimize):
-                in_optimize = True
-            if int(op_role) == int(self._op_role.Backward):
-                in_forward = False
 
             assert op.has_attr(self._op_device_key), (
                 "op ({}) has no {} attribute.".format(op.type,
@@ -4739,35 +4735,12 @@ class PipelineOptimizer(object):
             if device == f"{self._device}:all": continue
 
             dev_type = device.split(':')[0]
-            stage_id = int(device.split(':')[1])
             assert dev_type == "gpu" or dev_type == 'npu', (
                 "Now only gpu and npu devices are supported "
                 "for pipeline parallelism.")
 
             if device not in device_list:
                 device_list.append(device)
-
-            if not in_optimize:
-                if pre_stage_id is not None:
-                    interval = stage_id - pre_stage_id
-                    # assert abs(interval) <= 1, \
-                    #     "The stage interval of two consecutive ops in the pipeline must be < = 1," \
-                    #     "but the interval of op={} and prev op is {}".format(op, interval)
-
-                    # stage must be in order, such as Forward(0 1 2 3 4), Backward(4 3 2 1 0)
-                    # if stage is unordered, such as Forward(0 1 2 3 4 3 4), will report error
-                    if in_forward:
-                        pass
-                        # assert interval >= 0, \
-                        #     "Pipeline stage must be sequential increment in Forward, prev_stage={}, " \
-                        #     "please check the stage of op={}".format(pre_stage_id, op)
-                    else:
-                        # FIXME(wangxi): recompute check failed
-                        pass
-                        #assert interval <=0, \
-                        #    "Pipeline stage must be sequential decrement in Backward, prev_stage={}, " \
-                        #    "please check the stage of op={}".format(pre_stage_id, op)
-                pre_stage_id = stage_id
 
         return device_list
 
@@ -5007,9 +4980,25 @@ class PipelineOptimizer(object):
                             "Now only 'F-then-B' and '1F1B' are supported."
                             "The given value is {}.".format(self.schedule_mode))
 
-                _insert_send_recv(
-                    int(cur_device.split(':')[1]),
-                    int(prev_device.split(':')[1]))
+                cur_stage = int(cur_device.split(':')[1])
+                prev_stage = int(prev_device.split(':')[1])
+
+                is_forward = self._is_forward_op(op)
+                is_backward = self._is_backward_op(op)
+                assert is_forward or is_backward, \
+                    'send/recv in pipeline should only be inserted in forward or backward,' \
+                    'please check the op_role of op={}'.format(op)
+
+                if is_forward:
+                    assert prev_stage < cur_stage, \
+                        "In forward, send/recv can only be passed forward, but now " \
+                        "prev_stage={} great than cur_stage={}, please check op_device of op={}".format(prev_stage, cur_stage, op)
+                elif is_backward:
+                    assert prev_stage > cur_stage, \
+                        "In backward, send/recv can only be passed backward, but now " \
+                        "prev_stage={} less than cur_stage={}, please check op_device of op={}".format(prev_stage, cur_stage, op)
+
+                _insert_send_recv(cur_stage, prev_stage)
         block._sync_with_cpp()
 
     def _insert_loss_scale(self, block):

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -4750,15 +4750,17 @@ class PipelineOptimizer(object):
             if not in_optimize:
                 if pre_stage_id is not None:
                     interval = stage_id - pre_stage_id
-                    assert abs(interval) <= 1, \
-                        "The stage interval of two consecutive ops in the pipeline must be < = 1," \
-                        "but the interval of op={} and prev op is {}".format(op, interval)
+                    # assert abs(interval) <= 1, \
+                    #     "The stage interval of two consecutive ops in the pipeline must be < = 1," \
+                    #     "but the interval of op={} and prev op is {}".format(op, interval)
+
                     # stage must be in order, such as Forward(0 1 2 3 4), Backward(4 3 2 1 0)
                     # if stage is unordered, such as Forward(0 1 2 3 4 3 4), will report error
                     if in_forward:
-                        assert interval >= 0, \
-                            "Pipeline stage must be sequential increment in Forward, prev_stage={}, " \
-                            "please check the stage of op={}".format(pre_stage_id, op)
+                        pass
+                        # assert interval >= 0, \
+                        #     "Pipeline stage must be sequential increment in Forward, prev_stage={}, " \
+                        #     "please check the stage of op={}".format(pre_stage_id, op)
                     else:
                         # FIXME(wangxi): recompute check failed
                         pass


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. Refine pipeline stage check, move the check into insert_send_recv. Even if the stage is unordered, as long as send/recv inserted in order, it can pass the check.
2. Remove the check of that size of send/recv var must be divisible by mp_degree. If it cannot be divisible, send/recv full data.