### PR TITLE
Add bcast semantics checks at C++ level to BroadcastTensorsOp

### DIFF
--- a/paddle/fluid/operators/broadcast_tensors_op.cc
+++ b/paddle/fluid/operators/broadcast_tensors_op.cc
@@ -38,6 +38,7 @@ class BroadcastTensorsOp : public framework::OperatorWithKernel {
 
     int target_rank = 0;
     const auto& input_dims = ctx->GetInputsDim("X");
+
     // 1. Find Output rank = max(Inputs rank)
     for (const auto& input_ddim : input_dims) {
       target_rank = std::max(target_rank, input_ddim.size());
@@ -62,6 +63,14 @@ class BroadcastTensorsOp : public framework::OperatorWithKernel {
         int dim_size = 1;
         if (axis >= 0) {
           dim_size = input_ddim[axis];
+        }
+
+        if (target_dim_size != 1 && dim_size != 1 &&
+            target_dim_size != dim_size) {
+          PADDLE_THROW(platform::errors::InvalidArgument(
+              "BroadcastTensorsOp inputs does not satisfy bcast semantics,"
+              "Please check axis = %d in reverse order",
+              index));
         }
 
         // We performed bcast semantics check at python level

--- a/python/paddle/fluid/tests/unittests/test_broadcast_tensors_op.py
+++ b/python/paddle/fluid/tests/unittests/test_broadcast_tensors_op.py
@@ -192,5 +192,47 @@ class TestRaiseBroadcastTensorsError(unittest.TestCase):
         self.assertRaises(TypeError, test_bcast_semantics)
 
 
+class TestRaiseBroadcastTensorsErrorDyGraph(unittest.TestCase):
+    def test_errors(self):
+        def test_type():
+            inputs = [
+                paddle.to_tensor(
+                    np.ones(
+                        shape=[1, 1, 1, 1], dtype='float32', name="x4")),
+                paddle.to_tensor(
+                    np.ones(
+                        shape=[1, 4, 1, 1], dtype='float64', name="x5"))
+            ]
+            paddle.broadcast_tensors(inputs)
+
+        def test_dtype():
+            inputs = [
+                paddle.to_tensor(
+                    np.ones(
+                        shape=[1, 1, 1, 1], dtype='int8', name="x6")),
+                paddle.to_tensor(
+                    np.ones(
+                        shape=[1, 4, 1, 1], dtype='int8', name="x7"))
+            ]
+            paddle.broadcast_tensors(inputs)
+
+        def test_bcast_semantics():
+            inputs = [
+                paddle.to_tensor(
+                    np.ones(
+                        shape=[1, 3, 1, 1], dtype='float32', name="x9")),
+                paddle.to_tensor(
+                    np.ones(
+                        shape=[1, 8, 1, 1], dtype='float32', name="x10"))
+            ]
+            paddle.broadcast_tensors(inputs)
+
+        paddle.disable_static()
+        self.assertRaises(TypeError, test_type)
+        self.assertRaises(TypeError, test_dtype)
+        self.assertRaises(TypeError, test_bcast_semantics)
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
OPs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
Checks bcast semantics at C++ level
<!-- Describe what this PR does -->
