### PR TITLE
Bug fix:  gettiem by none index

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -711,6 +711,7 @@ class TestVarBase(unittest.TestCase):
             var_tensor[None, 2, None, 1].numpy(),
             var_tensor[None].numpy(),
             var_tensor[0, 0, None, 0, 0, None].numpy(),
+            var_tensor[None, None, 0, ..., None].numpy(),
             var_tensor[0, 1:10:2, None, None, ...].numpy(),
         ]
 
@@ -724,11 +725,13 @@ class TestVarBase(unittest.TestCase):
         self.assertTrue(np.array_equal(var[7], np_value[None]))
         self.assertTrue(
             np.array_equal(var[8], np_value[0, 0, None, 0, 0, None]))
+        self.assertTrue(
+            np.array_equal(var[9], np_value[None, None, 0, ..., None]))
 
         # TODO(zyfncg) there is a bug of dimensions when slice step > 1 and 
         #              indexs has int type 
         # self.assertTrue(
-        #     np.array_equal(var[9], np_value[0, 1:10:2, None, None, ...]))
+        #     np.array_equal(var[10], np_value[0, 1:10:2, None, None, ...]))
 
     def _test_for_var(self):
         np_value = np.random.random((30, 100, 100)).astype('float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix a bug of slice by none index in dygraph mode

Example:
```
# x.shape [2, 2]
y = x[None, None, :, :, None]
y.shape
# expect result:
[1, 1, 2, 2, 1]
# now:
[1, 1, 1, 2, 2]
```
