### PR TITLE
add exclude rules of pre-commit for paddle/utils and third_party

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,11 @@ repos:
         entry: bash ./tools/codestyle/clang_format.hook -i
         language: system
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto)$
+        exclude: |
+            (?x)^(
+                paddle/fluid/distributed/thirdparty/.* |
+                paddle/utils/.*
+            )$
 -   repo: local
     hooks:
     -   id: cpplint-cpp-source
@@ -34,6 +39,11 @@ repos:
         entry: bash ./tools/codestyle/cpplint_pre_commit.hook
         language: system
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
+        exclude: |
+            (?x)^(
+                paddle/fluid/distributed/thirdparty/.* |
+                paddle/utils/.*
+            )$
 -   repo: local
     hooks:
     -   id: pylint-doc-string
@@ -49,4 +59,8 @@ repos:
         entry: python ./tools/codestyle/copyright.hook
         language: system
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto|py|sh)$
-        exclude: (?!.*third_party)^.*$ | (?!.*book)^.*$
+        exclude: |
+            (?x)^(
+                paddle/fluid/distributed/thirdparty/.* |
+                paddle/utils/.*
+            )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto)$
         exclude: |
             (?x)^(
-                paddle/fluid/distributed/thirdparty/.* |
                 paddle/utils/.*
             )$
 -   repo: local
@@ -41,7 +40,6 @@ repos:
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
         exclude: |
             (?x)^(
-                paddle/fluid/distributed/thirdparty/.* |
                 paddle/utils/.*
             )$
 -   repo: local
@@ -61,6 +59,5 @@ repos:
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto|py|sh)$
         exclude: |
             (?x)^(
-                paddle/fluid/distributed/thirdparty/.* |
                 paddle/utils/.*
             )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,6 @@ repos:
         entry: bash ./tools/codestyle/clang_format.hook -i
         language: system
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto)$
-        exclude: |
-            (?x)^(
-                paddle/utils/.*
-            )$
 -   repo: local
     hooks:
     -   id: cpplint-cpp-source
@@ -38,10 +34,6 @@ repos:
         entry: bash ./tools/codestyle/cpplint_pre_commit.hook
         language: system
         files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
-        exclude: |
-            (?x)^(
-                paddle/utils/.*
-            )$
 -   repo: local
     hooks:
     -   id: pylint-doc-string


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add exclude rules for paddle/utils and paddle/fluid/distributed/thirdparty.
The files in paddle/utils and paddle/fluid/distributed/thirdparty do not need to execute the pre-commit check.