### PR TITLE
[amp] dygraph amp support param_group

### DIFF
--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -146,6 +146,47 @@ class GradScaler(AmpScaler):
         """
         return super(GradScaler, self).minimize(optimizer, *args, **kwargs)
 
+    def step(self, optimizer):
+        """
+        This function is similar as `optimizer.step()`, which performs parameters updating.
+        
+        If the scaled gradients of parameters contains NAN or INF, the parameters updating is skipped.
+        Otherwise, it first unscales the scaled gradients of parameters, then updates the parameters.
+        Args:
+            optimizer(Optimizer):  The optimizer used to update parameters.
+        Examples:
+            .. code-block:: python
+                import paddle
+                model = paddle.nn.Conv2D(3, 2, 3, bias_attr=True)
+                optimizer = paddle.optimizer.SGD(learning_rate=0.01, parameters=model.parameters())
+                scaler = paddle.amp.GradScaler(init_loss_scaling=1024)
+                data = paddle.rand([10, 3, 32, 32])
+                with paddle.amp.auto_cast():
+                    conv = model(data)
+                    loss = paddle.mean(conv)
+                scaled = scaler.scale(loss)  # scale the loss 
+                scaled.backward()            # do backward
+                scaler.step(optimizer)
+                optimizer.clear_grad()
+        """
+        if not self._enable:
+            return optimizer.step()
+
+        #  unscale the grad
+        self._unscale(optimizer)
+
+        optimize_ops, params_grads = (None, None)
+
+        if self._found_inf:
+            self._cache_founf_inf = True
+        else:
+            optimizer.step()
+            self._cache_founf_inf = False
+
+        if self._use_dynamic_loss_scaling:
+            # uopdate the scale
+            self._update()
+
     def is_enable(self):
         """
         Enable loss scaling or not.

--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -152,10 +152,14 @@ class GradScaler(AmpScaler):
         
         If the scaled gradients of parameters contains NAN or INF, the parameters updating is skipped.
         Otherwise, it first unscales the scaled gradients of parameters, then updates the parameters.
+
         Args:
             optimizer(Optimizer):  The optimizer used to update parameters.
+
         Examples:
             .. code-block:: python
+            
+                # required: gpu
                 import paddle
                 model = paddle.nn.Conv2D(3, 2, 3, bias_attr=True)
                 optimizer = paddle.optimizer.SGD(learning_rate=0.01, parameters=model.parameters())

--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -175,8 +175,6 @@ class GradScaler(AmpScaler):
         #  unscale the grad
         self._unscale(optimizer)
 
-        optimize_ops, params_grads = (None, None)
-
         if self._found_inf:
             self._cache_founf_inf = True
         else:

--- a/python/paddle/fluid/dygraph/amp/loss_scaler.py
+++ b/python/paddle/fluid/dygraph/amp/loss_scaler.py
@@ -212,10 +212,19 @@ class AmpScaler(object):
     def _unscale(self, optimizer):
         if not self._enable:
             return
-        param_grads = [
-            param._grad_ivar() for param in optimizer._parameter_list
-            if param._grad_ivar() is not None
-        ]
+
+        if getattr(optimizer, '_param_groups', None) and isinstance(
+                optimizer._param_groups[0], dict):
+            param_grads = []
+            for group in optimizer._param_groups:
+                for param in group['params']:
+                    if param._grad_ivar() is not None:
+                        param_grads.append(param._grad_ivar())
+        else:
+            param_grads = [
+                param._grad_ivar() for param in optimizer._parameter_list
+                if param._grad_ivar() is not None
+            ]
         _C_ops.check_finite_and_unscale(param_grads, self._scale, param_grads,
                                         self._found_inf)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- dygraph amp support param_group

```
linear_1 = paddle.nn.Linear(10, 10)
linear_2 = paddle.nn.Linear(10, 10)
inp = paddle.uniform(shape=[10, 10], min=-0.1, max=0.1)
with paddle.amp.auto_cast():
    out = linear_1(inp)
    out = linear_2(out)
loss = paddle.mean(out)
sgd = paddle.optimizer.SGD(
    learning_rate=0.1,
    parameters=[{
        'params': linear_1.parameters()
    }, {
        'params': linear_2.parameters(),
        'weight_decay': 0.001,
        'learning_rate': 0.1
    }],
    weight_decay=0.01)              
scaler=paddle.amp.GradScaler()     
scaler.scale(out).backward()
scaler.step(sgd)
sgd.clear_grad()
```
- add `step` method for `class GradScaler`, to be consistent with `class Optimizer`, since `Optimizer.minimize()` does not support `param_group` 
