### PR TITLE
remove paddle.grad API in __all__ to avoid repetition with paddle.autograd.grad

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -446,7 +446,6 @@ __all__ = [  # noqa
            'ones_like',
            'index_sample',
            'cast',
-           'grad',
            'all',
            'ones',
            'not_equal',

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -471,7 +471,7 @@ def grad(outputs,
                 y = x * x
 
                 # Since y = x * x, dx = 2 * x
-                dx = paddle.grad(
+                dx = paddle.autograd.grad(
                         outputs=[y],
                         inputs=[x],
                         create_graph=create_graph,
@@ -516,7 +516,7 @@ def grad(outputs,
                 # Therefore, the final result would be:
                 # dx = 2 * x * dy1 + 3 * dy2 = 4 * dy1 + 3 * dy2.
 
-                dx = paddle.grad(
+                dx = paddle.autograd.grad(
                     outputs=[y1, y2], 
                     inputs=[x],
                     grad_outputs=grad_outputs)[0]


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
删除暴露的paddle.grad API， 避免和paddle.autograd.grad 重复。
为了保持兼容性，import 语句被保留下来。