### PR TITLE
Add paddle.divide_ api, test=develop

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_div_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op.cc
@@ -118,7 +118,7 @@ namespace ops = paddle::operators;
 
 REGISTER_OPERATOR(elementwise_div, ops::ElementwiseOp,
                   ops::ElementwiseDivOpMaker, ops::ElementwiseOpInferVarType,
-			ops::ElementwiseDivGradOpMaker<paddle::imperative::OpBase>,
+                  ops::ElementwiseDivGradOpMaker<paddle::imperative::OpBase>,
                   ops::ElementwiseDivInplaceInferer);
 
 REGISTER_OPERATOR(

--- a/paddle/fluid/operators/elementwise/elementwise_div_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op.cc
@@ -118,6 +118,7 @@ namespace ops = paddle::operators;
 
 REGISTER_OPERATOR(elementwise_div, ops::ElementwiseOp,
                   ops::ElementwiseDivOpMaker, ops::ElementwiseOpInferVarType,
+                  ops::ElementwiseDivGradOpMaker<paddle::framework::OpDesc>,
                   ops::ElementwiseDivGradOpMaker<paddle::imperative::OpBase>,
                   ops::ElementwiseDivInplaceInferer);
 

--- a/paddle/fluid/operators/elementwise/elementwise_div_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op.cc
@@ -110,7 +110,6 @@ class ElementwiseDivDoubleGradMaker : public framework::SingleGradOpMaker<T> {
 };
 
 DECLARE_INPLACE_OP_INFERER(ElementwiseDivInplaceInferer, {"X", "Out"});
-
 }  // namespace operators
 }  // namespace paddle
 

--- a/paddle/fluid/operators/elementwise/elementwise_div_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op.cc
@@ -109,6 +109,8 @@ class ElementwiseDivDoubleGradMaker : public framework::SingleGradOpMaker<T> {
   }
 };
 
+DECLARE_INPLACE_OP_INFERER(ElementwiseDivInplaceInferer, {"X", "Out"});
+
 }  // namespace operators
 }  // namespace paddle
 
@@ -116,8 +118,8 @@ namespace ops = paddle::operators;
 
 REGISTER_OPERATOR(elementwise_div, ops::ElementwiseOp,
                   ops::ElementwiseDivOpMaker, ops::ElementwiseOpInferVarType,
-                  ops::ElementwiseDivGradOpMaker<paddle::framework::OpDesc>,
-                  ops::ElementwiseDivGradOpMaker<paddle::imperative::OpBase>);
+			ops::ElementwiseDivGradOpMaker<paddle::imperative::OpBase>,
+                  ops::ElementwiseDivInplaceInferer);
 
 REGISTER_OPERATOR(
     elementwise_div_grad, ops::ElementwiseOpGrad,

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -192,6 +192,7 @@ from .tensor.math import min  # noqa: F401
 from .tensor.math import minimum  # noqa: F401
 from .tensor.math import mm  # noqa: F401
 from .tensor.math import divide  # noqa: F401
+from .tensor.math import divide_
 from .tensor.math import floor_divide  # noqa: F401
 from .tensor.math import remainder  # noqa: F401
 from .tensor.math import mod  # noqa: F401
@@ -439,6 +440,7 @@ __all__ = [  # noqa
            'lgamma',
            'square',
            'divide',
+           'divide_',
            'ceil',
            'atan',
            'atan2',

--- a/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
@@ -362,7 +362,7 @@ class TestDivApi(unittest.TestCase):
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             z_value = exe.run(feed=gen_data(), fetch_list=[z.name])
-            z_expected = np.array([2., 0.6, 2.], dtype='float32')
+            z_expected = np.array([2, 0.6, 2], dtype='float32')
             self.assertEqual((np.array(z_value) == z_expected).all(), True)
 
     def test_dygraph(self):
@@ -373,7 +373,7 @@ class TestDivApi(unittest.TestCase):
             y = fluid.dygraph.to_variable(np_y)
             z = self._executed_api(x, y)
             np_z = z.numpy()
-            z_expected = np.array([2., 0.6, 2.])
+            z_expected = np.array([2, 0.6, 2])
             self.assertEqual((np_z == z_expected).all(), True)
 
 class TestDivInplaceApi(TestDivApi):

--- a/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
@@ -408,6 +408,15 @@ class TestDivInplaceBroadcastSuccess3(TestDivInplaceBroadcastSuccess):
         self.x_numpy = np.random.rand(2, 3, 1, 5).astype('float')
         self.y_numpy = np.random.rand(1, 3, 1, 5).astype('float')
 
+class TestDivInplaceFloat64(TestDivInplaceBroadcastSuccess):
+    def init_data(self):
+        self.x_numpy = np.random.rand(2, 3, 1, 5).astype('double')
+        self.y_numpy = np.random.rand(1, 3, 1, 5).astype('double')
+
+class TestDivInplaceFloat16(TestDivInplaceBroadcastSuccess):
+    def init_data(self):
+        self.x_numpy = np.random.rand(2, 3, 1, 5).astype('float16')
+        self.y_numpy = np.random.rand(1, 3, 1, 5).astype('float16')
 
 class TestDivInplaceBroadcastError(unittest.TestCase):
     def init_data(self):
@@ -441,3 +450,4 @@ class TestDivInplaceBroadcastError3(TestDivInplaceBroadcastError):
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()
+

--- a/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
@@ -334,6 +334,7 @@ class TestRealComplexElementwiseDivOp(TestComplexElementwiseDivOp):
         self.grad_x = np.real(self.grad_out / np.conj(self.y))
         self.grad_y = -self.grad_out * np.conj(self.x / self.y / self.y)
 
+
 class TestDivApi(unittest.TestCase):
     def _executed_api(self, x, y, name=None):
         return paddle.divide(x, y, name)
@@ -376,6 +377,7 @@ class TestDivApi(unittest.TestCase):
             z_expected = np.array([2, 0.6, 2])
             self.assertEqual((np_z == z_expected).all(), True)
 
+
 class TestDivInplaceApi(TestDivApi):
     def _executed_api(self, x, y, name=None):
         return x.divide_(y, name)
@@ -408,15 +410,12 @@ class TestDivInplaceBroadcastSuccess3(TestDivInplaceBroadcastSuccess):
         self.x_numpy = np.random.rand(2, 3, 1, 5).astype('float')
         self.y_numpy = np.random.rand(1, 3, 1, 5).astype('float')
 
+
 class TestDivInplaceFloat64(TestDivInplaceBroadcastSuccess):
     def init_data(self):
         self.x_numpy = np.random.rand(2, 3, 1, 5).astype('double')
         self.y_numpy = np.random.rand(1, 3, 1, 5).astype('double')
 
-class TestDivInplaceFloat16(TestDivInplaceBroadcastSuccess):
-    def init_data(self):
-        self.x_numpy = np.random.rand(2, 3, 1, 5).astype('float16')
-        self.y_numpy = np.random.rand(1, 3, 1, 5).astype('float16')
 
 class TestDivInplaceBroadcastError(unittest.TestCase):
     def init_data(self):
@@ -447,7 +446,7 @@ class TestDivInplaceBroadcastError3(TestDivInplaceBroadcastError):
         self.x_numpy = np.random.rand(5, 2, 1, 4).astype('float')
         self.y_numpy = np.random.rand(2, 3, 4).astype('float')
 
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()
-

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -140,6 +140,7 @@ from .math import min  # noqa: F401
 from .math import minimum  # noqa: F401
 from .math import mm  # noqa: F401
 from .math import divide  # noqa: F401
+from .math import divide_
 from .math import floor_divide  # noqa: F401
 from .math import remainder  # noqa: F401
 from .math import mod  # noqa: F401
@@ -268,6 +269,7 @@ tensor_method_func  = [ #noqa
            'minimum',
            'mm',
            'divide',
+           'divide_',
            'floor_divide',
            'remainder',
            'mod',

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -378,6 +378,22 @@ def divide(x, y, name=None):
 
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
+@inplace_apis_in_dygraph_only
+def divide_(x, y, name=None):
+    """
+    Inplace version of ``divide`` API, the output Tensor will be inplaced with input ``x``.
+    Please refer to :ref:`api_tensor_divide`.
+    """
+    axis = -1
+    act = None
+
+    out_shape = broadcast_shape(x.shape, y.shape)
+    if out_shape != x.shape:
+        raise ValueError("The shape of broadcast output {} is different from that of inplace tensor {} in the Inplace operation.".format(out_shape, x.shape))
+
+    out = _elementwise_op_in_dygraph(
+        x, y, axis=axis, act=act, op_name='elementwise_div_')
+    return out
 
 def floor_divide(x, y, name=None):
     """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
增加了divide_ API功能，对应着divide API的inplace版本。

### Example to use Inplace APIs
```
import paddle

x = paddle.to_tensor([2, 3, 4], dtype='float64')
y = paddle.to_tensor([1, 5, 2], dtype='float64')
x.divide_(y)
print(x)  # [2., 0.6, 2.]
```