### PR TITLE
Added numpy bf16 datatype support

### DIFF
--- a/paddle/fluid/operators/fused/fusion_lstm_op.cc
+++ b/paddle/fluid/operators/fused/fusion_lstm_op.cc
@@ -249,11 +249,6 @@ void FusionLSTMOpMaker::Make() {
   AddAttr<bool>("use_mkldnn",
                 "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
-  AddAttr<std::string>(
-      "mkldnn_data_type",
-      "(string, default \"float32\"). Data type of mkldnn kernel")
-      .SetDefault("float32")
-      .InEnum({"float32", "int8", "bfloat16"});
   AddAttr<float>("Scale_data",
                  "Scale to be used for int8 input/output data."
                  "Only used with MKL-DNN INT8.")

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_python_bf16_datatype.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_python_bf16_datatype.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from bfloat16 import bfloat16
+import unittest
+
+
+class TestBF16DataType(unittest.TestCase):
+    def test_matmul(self):
+        a_bf16 = np.random.random((6, 7)).astype(bfloat16)
+        b_bf16 = np.random.random((7, 8)).astype(bfloat16)
+        c_bf16 = np.matmul(a_bf16, b_bf16)
+
+        a_fp32 = a_bf16.astype(np.float32)
+        b_fp32 = b_bf16.astype(np.float32)
+        c_fp32 = np.matmul(a_fp32, b_fp32)
+
+        self.assertTrue(np.allclose(c_bf16, c_fp32))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,4 +6,4 @@ Pillow
 six
 decorator
 astor
-bfloat16==1.1
+git+https://github.com/jakpiase/bfloat16.git@develop

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,3 +6,4 @@ Pillow
 six
 decorator
 astor
+bfloat16==1.1


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
This PR adds bfloat16 datatype support for numpy via an external package. Sample usage is included in UT. That will shorten the time of loading word2vec BF16 model significantly and will allow us to remove "convert_float_to_uint16" functions from UTs.