### PR TITLE
[Paddle-TRT] Add reshape op teller volume check

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -718,25 +718,26 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
       std::vector<int> shape =
           BOOST_GET_CONST(std::vector<int>, desc.GetAttr("shape"));
       if (shape.size() >= nvinfer1::Dims::MAX_DIMS) return false;
-      if (!with_dynamic_shape && shape[0] == -1) return false;
-
-      auto* block = desc.Block();
-      std::string input_name = desc.Input("X")[0];
-      auto* var_desc = block->FindVar(input_name);
-      const auto input_shape = var_desc->GetShape();
-      if (shape.size() <= 1 || input_shape.size() <= 1) return false;
-      int input_volume = 1;
-      int shape_volume = 1;
-      for (size_t i = 1; i < input_shape.size(); i++) {
-        input_volume *= input_shape[i];
-      }
-      for (size_t i = 1; i < shape.size(); i++) {
-        shape_volume *= shape[i];
-      }
-      if (input_volume != shape_volume) {
-        VLOG(2) << "reshape2 input volume not equals to shape volume, not "
-                   "convert to TRT.";
-        return false;
+      if (!with_dynamic_shape) {
+        if (shape[0] == -1) return false;
+        auto* block = desc.Block();
+        std::string input_name = desc.Input("X")[0];
+        auto* var_desc = block->FindVar(input_name);
+        const auto input_shape = var_desc->GetShape();
+        if (shape.size() <= 1 || input_shape.size() <= 1) return false;
+        int input_volume = 1;
+        int shape_volume = 1;
+        for (size_t i = 1; i < input_shape.size(); i++) {
+          input_volume *= input_shape[i];
+        }
+        for (size_t i = 1; i < shape.size(); i++) {
+          shape_volume *= shape[i];
+        }
+        if (input_volume != shape_volume) {
+          VLOG(2) << "reshape2 input volume not equals to shape volume, not "
+                     "convert to TRT.";
+          return false;
+        }
       }
     }
 

--- a/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
+++ b/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
@@ -84,7 +84,7 @@ class TRTCalibratorEngine {
   std::unique_ptr<TensorRTEngine> engine_;
 };
 /*
- * Manager to control the TensorRT Int8 calibration creation and deltetion.
+ * Manager to control the TensorRT Int8 calibration creation and deletion.
  */
 class TRTCalibratorEngineManager {
  public:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
check if the volume of reshape/reshape2 op's shape and input dims are consistent in static shape mode.