### PR TITLE
[NPU] add retry on HcclGetRootInfo to fix "bind fail"

### DIFF
--- a/paddle/fluid/operators/collective/c_gen_hccl_id_op.cc
+++ b/paddle/fluid/operators/collective/c_gen_hccl_id_op.cc
@@ -32,18 +32,23 @@ namespace operators {
 #ifdef PADDLE_WITH_ASCEND_CL
 
 static void GenHCCLID(std::vector<HcclRootInfo>* hccl_ids) {
-  constexpr int timeout = 2 * 60 + 10;  // 2MSL
+  constexpr int timeout = 2 * 60 + 10;  // 2MSL+10s
   constexpr int retry_time = 2;
   for (size_t i = 0; i < hccl_ids->size(); ++i) {
+    bool failed = true;
     for (auto retry_times = 0; retry_times * retry_time < timeout;
          ++retry_times) {
       auto err = platform::dynload::HcclGetRootInfo(&(*hccl_ids)[i]);
       if (err == 0) {
+        failed = false;
         break;
       }
       std::this_thread::sleep_for(std::chrono::seconds(retry_time));
       LOG(WARNING) << "HcclGetRootInfo failed, err is: " << err << ", retry "
                    << retry_times << " times";
+    }
+    if (failed) {
+      PADDLE_THROW(platform::errors::External("HcclGetRootInfo failed!"));
     }
   }
 }

--- a/paddle/fluid/operators/collective/c_gen_hccl_id_op.cc
+++ b/paddle/fluid/operators/collective/c_gen_hccl_id_op.cc
@@ -33,7 +33,7 @@ namespace operators {
 
 static void GenHCCLID(std::vector<HcclRootInfo>* hccl_ids) {
   constexpr int timeout = 2 * 60 + 10;  // 2MSL+10s
-  constexpr int retry_time = 2;
+  constexpr int retry_time = 1;
   for (size_t i = 0; i < hccl_ids->size(); ++i) {
     bool failed = true;
     for (auto retry_times = 0; retry_times * retry_time < timeout;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[NPU] add retry on HcclGetRootInfo to fix bind fail
<img width="1420" alt="0b3ad41f0f0726aacb024d3d868d5ee4" src="https://user-images.githubusercontent.com/6888866/129731522-5c87798e-b1e7-4075-a986-5cf3d191ac2a.png">
