### PR TITLE
add third party variant to replace boost::variant

### DIFF
--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -39,8 +39,8 @@ struct ExtractAttribute {
   T* operator()(Attribute& attr) const {
     T* attr_value = nullptr;
     try {
-      attr_value = &boost::get<T>(attr);
-    } catch (boost::bad_get& bad_get) {
+      attr_value = &paddle::get<T>(attr);
+    } catch (paddle::bad_variant_access& bad_get) {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Cannot get attribute (%s) by type %s, its type is %s.", attr_name_,
           paddle::platform::demangle(typeid(T).name()),
@@ -73,8 +73,8 @@ struct ExtractAttribute<bool> {
     }
     bool* attr_value = nullptr;
     try {
-      attr_value = &boost::get<bool>(attr);
-    } catch (boost::bad_get& bad_get) {
+      attr_value = &paddle::get<bool>(attr);
+    } catch (paddle::bad_variant_access& bad_get) {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Cannot get attribute (%s) by type bool, its type is %s.", attr_name_,
           paddle::platform::demangle(attr.type().name())));
@@ -100,8 +100,8 @@ struct ExtractAttribute<int64_t> {
     }
     int64_t* attr_value = nullptr;
     try {
-      attr_value = &boost::get<int64_t>(attr);
-    } catch (boost::bad_get& bad_get) {
+      attr_value = &paddle::get<int64_t>(attr);
+    } catch (paddle::bad_variant_access& bad_get) {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Cannot get attribute (%s) by type int64_t, its type is %s.",
           attr_name_, paddle::platform::demangle(attr.type().name())));
@@ -129,8 +129,8 @@ struct ExtractAttribute<std::vector<int64_t>> {
     }
     std::vector<int64_t>* attr_value = nullptr;
     try {
-      attr_value = &boost::get<std::vector<int64_t>>(attr);
-    } catch (boost::bad_get& bad_get) {
+      attr_value = &paddle::get<std::vector<int64_t>>(attr);
+    } catch (paddle::bad_variant_access& bad_get) {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Cannot get attribute (%s) by type std::vector<int64_t>, its type is "
           "%s.",
@@ -157,8 +157,8 @@ struct ExtractAttribute<float> {
     }
     float* attr_value = nullptr;
     try {
-      attr_value = &boost::get<float>(attr);
-    } catch (boost::bad_get& bad_get) {
+      attr_value = &paddle::get<float>(attr);
+    } catch (paddle::bad_variant_access& bad_get) {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Cannot get attribute (%s) by type float, its type is %s.",
           attr_name_, paddle::platform::demangle(attr.type().name())));
@@ -186,8 +186,8 @@ struct ExtractAttribute<std::vector<double>> {
     }
     std::vector<double>* attr_value = nullptr;
     try {
-      attr_value = &boost::get<std::vector<double>>(attr);
-    } catch (boost::bad_get& bad_get) {
+      attr_value = &paddle::get<std::vector<double>>(attr);
+    } catch (paddle::bad_variant_access& bad_get) {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Cannot get attribute (%s) by type std::vector<double>, its type is "
           "%s.",

--- a/paddle/fluid/framework/data_type.h
+++ b/paddle/fluid/framework/data_type.h
@@ -16,6 +16,12 @@ limitations under the License. */
 #include <string>
 #include <typeindex>
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX  // msvc max/min macro conflict with std::min/max
+#endif
+#endif
+
 #include "paddle/fluid/framework/framework.pb.h"
 #include "paddle/fluid/platform/bfloat16.h"
 #include "paddle/fluid/platform/complex.h"

--- a/paddle/fluid/framework/dlpack_tensor.cc
+++ b/paddle/fluid/framework/dlpack_tensor.cc
@@ -132,7 +132,7 @@ DLPackTensor::DLPackTensor(const Tensor &tensor, LaneType lanes) {
 
   // init ctx, DLContext type with device_type and device_id
   auto place = tensor.place();
-  t_.ctx = boost::apply_visitor(internal::DLContextVisitor(), place);
+  t_.ctx = paddle::apply_visitor(internal::DLContextVisitor(), place);
 
   // init dtype
   t_.dtype = internal::GetDLDataTypeFromTypeIndex(tensor.type());

--- a/paddle/fluid/framework/dlpack_tensor.cc
+++ b/paddle/fluid/framework/dlpack_tensor.cc
@@ -77,7 +77,7 @@ static DLDataType GetDLDataTypeFromTypeIndex(proto::VarType::Type type) {
 #undef REG_DL_DATA_TYPE
 }
 
-struct DLContextVisitor : public boost::static_visitor<::DLContext> {
+struct DLContextVisitor : public paddle::static_visitor<::DLContext> {
   inline ::DLContext operator()(const platform::CPUPlace &place) const {
     ::DLContext ctx;
     ctx.device_type = kDLCPU;

--- a/paddle/fluid/framework/feed_fetch_type.h
+++ b/paddle/fluid/framework/feed_fetch_type.h
@@ -23,11 +23,11 @@ namespace framework {
 using FeedType = LoDTensor;
 using FeedList = std::vector<FeedType>;
 
-using FetchType = boost::variant<LoDTensor, LoDTensorArray>;
+using FetchType = paddle::variant<LoDTensor, LoDTensorArray>;
 using FetchList = std::vector<FetchType>;
 
 using FetchUnmergedList = std::vector<std::vector<FetchType>>;
-using FetchResultType = boost::variant<FetchList, FetchUnmergedList>;
+using FetchResultType = paddle::variant<FetchList, FetchUnmergedList>;
 
 inline bool data_is_lod_tensor(const FetchType &data) {
   if (data.type() == typeid(LoDTensor)) {

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
@@ -261,7 +261,7 @@ void CPUQuantizeSquashPass::RequantOpSquash(Graph* graph) const {
                             "should have requantize output as input.",
                             requant_out->Name()));
       float requant_scale_in =
-          boost::get<float>(requant_op->Op()->GetAttr("Scale_in"));
+          paddle::get<float>(requant_op->Op()->GetAttr("Scale_in"));
 
       auto scale_name = "Scale_in";
       if (any_op->Op()->Type() == "matmul")

--- a/paddle/fluid/framework/ir/mkldnn/reshape_transpose_matmul_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/reshape_transpose_matmul_mkldnn_fuse_pass.cc
@@ -113,9 +113,9 @@ void ReshapeTransposeMatmulMkldnnFusePass::Fuse(
     GET_IR_NODE_FROM_SUBGRAPH(matmul_out, matmul_out, rtm_pattern);
 
     auto reshape_shape =
-        boost::get<std::vector<int>>(reshape_op->Op()->GetAttr("shape"));
+        paddle::get<std::vector<int>>(reshape_op->Op()->GetAttr("shape"));
     auto transpose_axis =
-        boost::get<std::vector<int>>(transpose_op->Op()->GetAttr("axis"));
+        paddle::get<std::vector<int>>(transpose_op->Op()->GetAttr("axis"));
 
     OpDesc *matmul_desc = matmul_op->Op();
     std::string input_var_name = transpose_out->Name();

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -669,7 +669,7 @@ void OpDesc::RenameInput(const std::string &old_name,
   need_update_ = true;
 }
 
-struct SetAttrDescVisitor : public boost::static_visitor<void> {
+struct SetAttrDescVisitor : public paddle::static_visitor<void> {
   explicit SetAttrDescVisitor(proto::OpDesc::Attr *attr) : attr_(attr) {}
   mutable proto::OpDesc::Attr *attr_;
   void operator()(int v) const { attr_->set_i(v); }

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -745,7 +745,7 @@ void OpDesc::Flush() {
       attr_desc->set_type(
           static_cast<proto::AttrType>(attr.second.which() - 1));
       SetAttrDescVisitor visitor(attr_desc);
-      boost::apply_visitor(visitor, attr.second);
+      paddle::apply_visitor(visitor, attr.second);
     }
 
     need_update_ = false;

--- a/paddle/fluid/framework/op_version_registry.h
+++ b/paddle/fluid/framework/op_version_registry.h
@@ -23,6 +23,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_version_proto.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/utils/none.h"
+#include "paddle/utils/variant.hpp"
 
 namespace paddle {
 namespace framework {
@@ -33,18 +34,18 @@ class OpVersionMap;
 }  // namespace pb
 
 using OpAttrVariantT =
-    boost::variant<bool,                     /* AttrType::BOOL */
-                   float,                    /* AttrType::FLOAT */
-                   int32_t,                  /* AttrType::INT */
-                   int64_t,                  /* AttrType::LONG*/
-                   std::string,              /* AttrType::STRING */
-                   std::vector<bool>,        /* AttrType::BOOLS */
-                   std::vector<float>,       /* AttrType::FLOATS */
-                   std::vector<int32_t>,     /* AttrType::INTS */
-                   std::vector<int64_t>,     /* AttrType::LONGS */
-                   std::vector<std::string>, /* AttrType::STRINGS */
-                   paddle::none_t            /* None */
-                   >;
+    ::paddle::variant<bool,                     /* AttrType::BOOL */
+                      float,                    /* AttrType::FLOAT */
+                      int32_t,                  /* AttrType::INT */
+                      int64_t,                  /* AttrType::LONG*/
+                      std::string,              /* AttrType::STRING */
+                      std::vector<bool>,        /* AttrType::BOOLS */
+                      std::vector<float>,       /* AttrType::FLOATS */
+                      std::vector<int32_t>,     /* AttrType::INTS */
+                      std::vector<int64_t>,     /* AttrType::LONGS */
+                      std::vector<std::string>, /* AttrType::STRINGS */
+                      paddle::none_t            /* None */
+                      >;
 
 struct OpUpdateInfo {
   virtual ~OpUpdateInfo() = default;

--- a/paddle/fluid/framework/shape_inference.h
+++ b/paddle/fluid/framework/shape_inference.h
@@ -54,7 +54,7 @@ namespace framework {
 
 class OperatorBase;
 
-using InferShapeVarPtr = boost::variant<VarDesc *, Variable *>;
+using InferShapeVarPtr = paddle::variant<VarDesc *, Variable *>;
 
 class InferShapeContext {
  public:

--- a/paddle/fluid/framework/tensor.cc
+++ b/paddle/fluid/framework/tensor.cc
@@ -68,7 +68,7 @@ void* Tensor::mutable_data(const platform::Place& place,
             requested_size, size));
     size = requested_size;
   }
-  /* some versions of boost::variant don't have operator!= */
+  /* some versions of paddle::variant don't have operator!= */
   if (holder_ == nullptr || !(holder_->place() == place) ||
       holder_->size() < size + offset_) {
     // Reset holder first before re-allocate to save memory

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -24,6 +24,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/platform/complex.h"
 #include "paddle/fluid/platform/profiler.h"
+#include "paddle/utils/variant.hpp"
 #ifdef PADDLE_WITH_MKLDNN
 #include "dnnl_debug.h"  // NOLINT
 #endif
@@ -478,7 +479,7 @@ inline void AnyImpl(Predicate predicate, const framework::Tensor& tensor,
 }
 
 template <typename Predicate>
-class AnyVisitor : public boost::static_visitor<bool> {
+class AnyVisitor : public paddle::static_visitor<bool> {
  private:
   const framework::Tensor& tensor_;
   Predicate predicate_;
@@ -544,7 +545,7 @@ class AnyVisitor : public boost::static_visitor<bool> {
 };
 
 template <typename Predicate>
-class AnyOutVisitor : public boost::static_visitor<> {
+class AnyOutVisitor : public paddle::static_visitor<> {
  private:
   const framework::Tensor& tensor_;
   mutable framework::Tensor* out_;
@@ -606,7 +607,7 @@ inline void AllImpl(Predicate predicate, const framework::Tensor& tensor,
 }
 
 template <typename Predicate>
-class AllOutVisitor : public boost::static_visitor<> {
+class AllOutVisitor : public paddle::static_visitor<> {
  private:
   const framework::Tensor& tensor_;
   mutable framework::Tensor* out_;
@@ -703,7 +704,7 @@ static inline void __global__ BothFalse(const T* cmp, T* out, int element_num) {
 }
 #endif
 
-struct BothFalseVisitor : public boost::static_visitor<> {
+struct BothFalseVisitor : public paddle::static_visitor<> {
   const framework::Tensor& in_;
   mutable framework::Tensor* out_;
   BothFalseVisitor(const framework::Tensor& in, framework::Tensor* out)

--- a/paddle/fluid/framework/tuple.h
+++ b/paddle/fluid/framework/tuple.h
@@ -27,8 +27,8 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
-typedef boost::variant<int, int64_t, float, double, std::string, Tensor,
-                       LoDTensor /*, ChannelHolder*/>
+typedef paddle::variant<int, int64_t, float, double, std::string, Tensor,
+                        LoDTensor /*, ChannelHolder*/>
     ElementVar;
 
 class Tuple {

--- a/paddle/fluid/framework/type_defs.h
+++ b/paddle/fluid/framework/type_defs.h
@@ -22,6 +22,7 @@ limitations under the License. */
 #include <vector>
 #include "paddle/fluid/imperative/type_defs.h"
 #include "paddle/fluid/platform/variant.h"
+#include "paddle/utils/variant.hpp"
 
 namespace paddle {
 namespace framework {
@@ -38,7 +39,7 @@ using VariableNameMap = std::map<std::string, std::vector<std::string>>;
 using VariableValueMap = std::map<std::string, std::vector<Variable*>>;
 
 // The order should be as same as framework.proto
-using Attribute = boost::variant<
+using Attribute = paddle::variant<
     boost::blank, int, float, std::string, std::vector<int>, std::vector<float>,
     std::vector<std::string>, bool, std::vector<bool>, BlockDesc*, int64_t,
     std::vector<BlockDesc*>, std::vector<int64_t>, std::vector<double>>;
@@ -47,11 +48,11 @@ using AttributeMap = std::unordered_map<std::string, Attribute>;
 
 #ifdef PADDLE_WITH_ASCEND_CL
 using NPUAttribute =
-    boost::variant<boost::blank, int, float, std::string, std::vector<int>,
-                   std::vector<float>, std::vector<std::string>, bool,
-                   std::vector<bool>, BlockDesc*, int64_t,
-                   std::vector<BlockDesc*>, std::vector<int64_t>,
-                   std::vector<double>, std::vector<std::vector<int64_t>>>;
+    paddle::variant<boost::blank, int, float, std::string, std::vector<int>,
+                    std::vector<float>, std::vector<std::string>, bool,
+                    std::vector<bool>, BlockDesc*, int64_t,
+                    std::vector<BlockDesc*>, std::vector<int64_t>,
+                    std::vector<double>, std::vector<std::vector<int64_t>>>;
 
 using NPUAttributeMap = std::unordered_map<std::string, NPUAttribute>;
 #endif

--- a/paddle/fluid/imperative/amp_auto_cast.cc
+++ b/paddle/fluid/imperative/amp_auto_cast.cc
@@ -110,8 +110,9 @@ static inline std::shared_ptr<imperative::VarBase> CastToType(
     const framework::proto::VarType::Type dst_type) {
   const auto& tracer = imperative::GetCurrentTracer();
   imperative::NameVarBaseMap ins = {{"X", {var}}};
-  framework::AttributeMap attrs = {{"in_dtype", var->DataType()},
-                                   {"out_dtype", dst_type}};
+  framework::AttributeMap attrs = {
+      {"in_dtype", static_cast<int>(var->DataType())},
+      {"out_dtype", static_cast<int>(dst_type)}};
   auto out = std::shared_ptr<imperative::VarBase>(
       new imperative::VarBase(tracer->GenerateUniqueName()));
   imperative::NameVarBaseMap outs = {{"Out", {out}}};

--- a/paddle/fluid/imperative/gradient_accumulator.cc
+++ b/paddle/fluid/imperative/gradient_accumulator.cc
@@ -70,7 +70,7 @@ static void MoveOrCopyVar(framework::Variable* dst, framework::Variable* src,
 }
 
 template <typename T>
-class TensorAddFunctor : public boost::static_visitor<> {
+class TensorAddFunctor : public paddle::static_visitor<> {
  public:
   TensorAddFunctor(int64_t numel, const T* x, T* y)
       : numel_(numel), x_(x), y_(y) {}

--- a/paddle/fluid/imperative/gradient_accumulator.cc
+++ b/paddle/fluid/imperative/gradient_accumulator.cc
@@ -195,7 +195,7 @@ void TensorAdd(const framework::Variable& src, framework::Variable* dst) {
     TensorAddFunctor<cpp_type> func(                                 \
         numel, src_tensor.data<cpp_type>(),                          \
         dst_tensor->mutable_data<cpp_type>(place));                  \
-    boost::apply_visitor(func, place);                               \
+    paddle::apply_visitor(func, place);                              \
     return;                                                          \
   }
 

--- a/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
@@ -678,7 +678,7 @@ size_t Usage::operator()(const platform::CUDAPinnedPlace &cuda_pinned) const {
 namespace allocation {
 
 Allocation *NaiveBestFitAllocator::AllocateImpl(size_t size) {
-  void *ptr = boost::apply_visitor(legacy::AllocVisitor(size), place_);
+  void *ptr = paddle::apply_visitor(legacy::AllocVisitor(size), place_);
   auto *tmp_alloc = new Allocation(ptr, size, place_);
   platform::MemEvenRecorder::Instance().PushMemRecord(
       static_cast<void *>(tmp_alloc), place_, size);
@@ -686,7 +686,7 @@ Allocation *NaiveBestFitAllocator::AllocateImpl(size_t size) {
 }
 
 void NaiveBestFitAllocator::FreeImpl(Allocation *allocation) {
-  boost::apply_visitor(
+  paddle::apply_visitor(
       legacy::FreeVisitor(allocation->ptr(), allocation->size()),
       allocation->place());
   platform::MemEvenRecorder::Instance().PopMemRecord(
@@ -695,7 +695,7 @@ void NaiveBestFitAllocator::FreeImpl(Allocation *allocation) {
 }
 
 uint64_t NaiveBestFitAllocator::ReleaseImpl(const platform::Place &place) {
-  return boost::apply_visitor(legacy::ReleaseVisitor(), place);
+  return paddle::apply_visitor(legacy::ReleaseVisitor(), place);
 }
 
 }  // namespace allocation

--- a/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc
@@ -60,7 +60,7 @@ uint64_t Release(const Place &place);
 template <typename Place>
 size_t Used(const Place &place);
 
-struct Usage : public boost::static_visitor<size_t> {
+struct Usage : public paddle::static_visitor<size_t> {
   size_t operator()(const platform::CPUPlace &cpu) const;
   size_t operator()(const platform::CUDAPlace &gpu) const;
   size_t operator()(const platform::CUDAPinnedPlace &cuda_pinned) const;
@@ -619,7 +619,7 @@ uint64_t Release<platform::CUDAPinnedPlace>(
 #endif
 }
 
-struct AllocVisitor : public boost::static_visitor<void *> {
+struct AllocVisitor : public paddle::static_visitor<void *> {
   inline explicit AllocVisitor(size_t size) : size_(size) {}
 
   template <typename Place>
@@ -631,7 +631,7 @@ struct AllocVisitor : public boost::static_visitor<void *> {
   size_t size_;
 };
 
-struct FreeVisitor : public boost::static_visitor<void> {
+struct FreeVisitor : public paddle::static_visitor<void> {
   inline explicit FreeVisitor(void *ptr, size_t size)
       : ptr_(ptr), size_(size) {}
 
@@ -645,7 +645,7 @@ struct FreeVisitor : public boost::static_visitor<void> {
   size_t size_;
 };
 
-struct ReleaseVisitor : public boost::static_visitor<uint64_t> {
+struct ReleaseVisitor : public paddle::static_visitor<uint64_t> {
   template <typename Place>
   inline uint64_t operator()(const Place &place) const {
     return Release<Place>(place);

--- a/paddle/fluid/operators/array_to_lod_tensor_op.cc
+++ b/paddle/fluid/operators/array_to_lod_tensor_op.cc
@@ -41,7 +41,7 @@ struct ArrayToLoDFunctorImpl {
   void apply();
 };
 
-struct ArrayToLoDFunctor : public boost::static_visitor<void> {
+struct ArrayToLoDFunctor : public paddle::static_visitor<void> {
   std::vector<framework::Tensor> in;
   mutable framework::Tensor *out;
 

--- a/paddle/fluid/operators/controlflow/op_variant.cc
+++ b/paddle/fluid/operators/controlflow/op_variant.cc
@@ -18,7 +18,7 @@ namespace paddle {
 namespace operators {
 
 struct InputsVisitor
-    : public boost::static_visitor<const framework::VariableNameMap *> {
+    : public paddle::static_visitor<const framework::VariableNameMap *> {
   template <typename OpType>
   const framework::VariableNameMap *operator()(const OpType *op) const {
     return &(op->Inputs());
@@ -26,7 +26,7 @@ struct InputsVisitor
 };
 
 struct OutputsVisitor
-    : public boost::static_visitor<const framework::VariableNameMap *> {
+    : public paddle::static_visitor<const framework::VariableNameMap *> {
   template <typename OpType>
   const framework::VariableNameMap *operator()(const OpType *op) const {
     return &(op->Outputs());
@@ -34,7 +34,7 @@ struct OutputsVisitor
 };
 
 struct AttributeMapVisitor
-    : public boost::static_visitor<const framework::AttributeMap *> {
+    : public paddle::static_visitor<const framework::AttributeMap *> {
   const framework::AttributeMap *operator()(const framework::OpDesc *op) const {
     return &(op->GetAttrMap());
   }
@@ -45,7 +45,7 @@ struct AttributeMapVisitor
   }
 };
 
-struct RawPointerVisitor : public boost::static_visitor<const void *> {
+struct RawPointerVisitor : public paddle::static_visitor<const void *> {
   template <typename OpType>
   const void *operator()(const OpType *op) const {
     return op;

--- a/paddle/fluid/operators/controlflow/op_variant.cc
+++ b/paddle/fluid/operators/controlflow/op_variant.cc
@@ -53,19 +53,19 @@ struct RawPointerVisitor : public boost::static_visitor<const void *> {
 };
 
 const framework::VariableNameMap &OpVariant::Inputs() const {
-  return *boost::apply_visitor(InputsVisitor(), op_);
+  return *paddle::apply_visitor(InputsVisitor(), op_);
 }
 
 const framework::VariableNameMap &OpVariant::Outputs() const {
-  return *boost::apply_visitor(OutputsVisitor(), op_);
+  return *paddle::apply_visitor(OutputsVisitor(), op_);
 }
 
 const framework::AttributeMap &OpVariant::Attrs() const {
-  return *boost::apply_visitor(AttributeMapVisitor(), op_);
+  return *paddle::apply_visitor(AttributeMapVisitor(), op_);
 }
 
 const void *OpVariant::RawPointer() const {
-  return boost::apply_visitor(RawPointerVisitor(), op_);
+  return paddle::apply_visitor(RawPointerVisitor(), op_);
 }
 
 void AppendOpVariantByOpName(const std::vector<framework::OpDesc *> &op_descs,

--- a/paddle/fluid/operators/controlflow/op_variant.h
+++ b/paddle/fluid/operators/controlflow/op_variant.h
@@ -68,8 +68,8 @@ class OpVariant {
   };
 
  private:
-  const boost::variant<const framework::OperatorBase *,
-                       const framework::OpDesc *>
+  const paddle::variant<const framework::OperatorBase *,
+                        const framework::OpDesc *>
       op_;
 };
 

--- a/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
+++ b/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
@@ -169,7 +169,7 @@ class ReadFromArrayOp : public ArrayOp {
       auto &fw_var_tensor = fw_var->Get<framework::LoDTensor>();
 
       framework::AttributeMap attrs;
-      attrs["dtype"] = fw_var_tensor.type();
+      attrs["dtype"] = static_cast<int>(fw_var_tensor.type());
       attrs["shape"] = framework::vectorize<int>(fw_var_tensor.dims());
       attrs["value"] = 0.0f;
 

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -374,7 +374,7 @@ class WhileGradOp : public framework::OperatorBase {
               var->IsType<LoDTensor>()) {
             auto &inside_tensor = var->Get<framework::LoDTensor>();
             framework::AttributeMap attrs;
-            attrs["dtype"] = inside_tensor.type();
+            attrs["dtype"] = static_cast<int>(inside_tensor.type());
             attrs["shape"] = framework::vectorize<int>(inside_tensor.dims());
             attrs["value"] = 0.0f;
 

--- a/paddle/fluid/operators/detection/box_decoder_and_assign_op.cu
+++ b/paddle/fluid/operators/detection/box_decoder_and_assign_op.cu
@@ -118,7 +118,7 @@ class BoxDecoderAndAssignCUDAKernel : public framework::OpKernel<T> {
     int grid = (roi_num * class_num + block - 1) / block;
     auto& device_ctx = context.cuda_device_context();
 
-    const T box_clip = context.Attr<T>("box_clip");
+    const T box_clip = context.Attr<float>("box_clip");
 
     DecodeBoxKernel<T><<<grid, block, 0, device_ctx.stream()>>>(
         prior_box_data, prior_box_var_data, target_box_data, roi_num, class_num,

--- a/paddle/fluid/operators/detection/box_decoder_and_assign_op.h
+++ b/paddle/fluid/operators/detection/box_decoder_and_assign_op.h
@@ -40,7 +40,7 @@ class BoxDecoderAndAssignKernel : public framework::OpKernel<T> {
     output_assign_box->mutable_data<T>({roi_num, 4}, context.GetPlace());
     T* output_box_data = output_box->data<T>();
     T* output_assign_box_data = output_assign_box->data<T>();
-    const T bbox_clip = context.Attr<T>("box_clip");
+    const T bbox_clip = context.Attr<float>("box_clip");
 
     for (int i = 0; i < roi_num; ++i) {
       T prior_box_width = prior_box_data[i * 4 + 2] - prior_box_data[i * 4] + 1;

--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -43,7 +43,7 @@ struct LoDTensorToArrayFunctorImpl {
   void apply();
 };
 
-struct LoDTensorToArrayFunctor : public boost::static_visitor<void> {
+struct LoDTensorToArrayFunctor : public paddle::static_visitor<void> {
   std::vector<const framework::Tensor *> ref_inputs_;
   mutable std::vector<framework::Tensor *> outputs_;
   const framework::Tensor &input_;

--- a/paddle/fluid/operators/math/math_function.cc
+++ b/paddle/fluid/operators/math/math_function.cc
@@ -203,7 +203,8 @@ void set_constant(const platform::DeviceContext& context,
                   framework::Tensor* tensor, float value) {
   TensorSetConstantWithPlace func(context, tensor, value);
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  tensor->place().apply_visitor(func);
+  // tensor->place().apply_visitor(func);
+  paddle::apply_visitor(func, tensor->place());
 #else
   func(platform::CPUPlace());
 #endif

--- a/paddle/fluid/operators/math/matrix_bit_code.cc
+++ b/paddle/fluid/operators/math/matrix_bit_code.cc
@@ -19,7 +19,7 @@ namespace operators {
 namespace math {
 
 template <typename T>
-struct MatrixBitCodeFunctorAdd : public boost::static_visitor<void> {
+struct MatrixBitCodeFunctorAdd : public paddle::static_visitor<void> {
   const framework::Tensor &vec_;
   framework::Tensor *tmat_;
 
@@ -52,7 +52,7 @@ void MatrixBitCodeFunctor<T>::Add(const framework::Tensor &vec,
 }
 
 template <typename T>
-struct MatrixBitCodeFunctorAddGrad : public boost::static_visitor<void> {
+struct MatrixBitCodeFunctorAddGrad : public paddle::static_visitor<void> {
   const framework::Tensor &tmat_;
   framework::Tensor *vec_;
   MatrixBitCodeFunctorAddGrad(const framework::Tensor &tmat,
@@ -85,7 +85,7 @@ void MatrixBitCodeFunctor<T>::AddGrad(const framework::Tensor &tmat,
 }
 
 template <typename T>
-struct MatrixBitCodeFunctorSum : public boost::static_visitor<void> {
+struct MatrixBitCodeFunctorSum : public paddle::static_visitor<void> {
   const framework::Tensor &tmat_;
   framework::Tensor *sum_;
   T scale_sum_;
@@ -126,7 +126,7 @@ void MatrixBitCodeFunctor<T>::Sum(const framework::Tensor &tmat,
 }
 
 template <typename T>
-struct MatrixBitCodeFunctorMul : public boost::static_visitor<void> {
+struct MatrixBitCodeFunctorMul : public paddle::static_visitor<void> {
   framework::Tensor *tmat_;
   const framework::Tensor &weight_;
   const framework::Tensor &input_;
@@ -177,7 +177,7 @@ class ReservedVector : public std::vector<T> {
 };
 
 template <typename T>
-struct MatrixBitCodeFunctorMulGradWeight : public boost::static_visitor<void> {
+struct MatrixBitCodeFunctorMulGradWeight : public paddle::static_visitor<void> {
   const framework::Tensor &tmat_;
   framework::Tensor *weight_;
   const framework::Tensor &input_;
@@ -230,7 +230,7 @@ void MatrixBitCodeFunctor<T>::MulGradWeight(const framework::Tensor &tmat,
 
 template <typename T>
 struct MatrixBitCodeFunctorMulGradWeightSR
-    : public boost::static_visitor<void> {
+    : public paddle::static_visitor<void> {
   const framework::Tensor &tmat_;
   framework::SelectedRows *weight_;
   const framework::Tensor &input_;
@@ -287,7 +287,7 @@ void MatrixBitCodeFunctor<T>::MulGradWeight(const framework::Tensor &tmat,
 }
 
 template <typename T>
-struct MatrixBitCodeFunctorMulGradError : public boost::static_visitor<void> {
+struct MatrixBitCodeFunctorMulGradError : public paddle::static_visitor<void> {
   const framework::Tensor &tmat_;
   const framework::Tensor &weight_;
   framework::Tensor *input_;
@@ -332,7 +332,7 @@ void MatrixBitCodeFunctor<T>::MulGradError(const framework::Tensor &tmat,
 }
 
 template <typename T>
-struct MatrixBitCodeFunctorSub : public boost::static_visitor<void> {
+struct MatrixBitCodeFunctorSub : public paddle::static_visitor<void> {
   framework::Tensor *tmat_;
 
   explicit MatrixBitCodeFunctorSub(framework::Tensor *tmat) : tmat_(tmat) {}

--- a/paddle/fluid/operators/math/matrix_bit_code.cc
+++ b/paddle/fluid/operators/math/matrix_bit_code.cc
@@ -47,7 +47,8 @@ template <typename T>
 void MatrixBitCodeFunctor<T>::Add(const framework::Tensor &vec,
                                   framework::Tensor *tmat) {
   MatrixBitCodeFunctorAdd<T> func(vec, tmat);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template <typename T>
@@ -79,7 +80,8 @@ template <typename T>
 void MatrixBitCodeFunctor<T>::AddGrad(const framework::Tensor &tmat,
                                       framework::Tensor *vec) {
   MatrixBitCodeFunctorAddGrad<T> func(tmat, vec);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template <typename T>
@@ -119,7 +121,8 @@ template <typename T>
 void MatrixBitCodeFunctor<T>::Sum(const framework::Tensor &tmat,
                                   framework::Tensor *sum, T scale_sum) {
   MatrixBitCodeFunctorSum<T> func(tmat, sum, scale_sum);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template <typename T>
@@ -163,7 +166,8 @@ void MatrixBitCodeFunctor<T>::Mul(framework::Tensor *tmat,
                                   const framework::Tensor &weight,
                                   const framework::Tensor &input) {
   MatrixBitCodeFunctorMul<T> func(tmat, weight, input);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template <typename T, size_t N>
@@ -220,7 +224,8 @@ void MatrixBitCodeFunctor<T>::MulGradWeight(const framework::Tensor &tmat,
                                             framework::Tensor *weight,
                                             const framework::Tensor &input) {
   MatrixBitCodeFunctorMulGradWeight<T> func(tmat, weight, input);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template <typename T>
@@ -277,7 +282,8 @@ void MatrixBitCodeFunctor<T>::MulGradWeight(const framework::Tensor &tmat,
                                             framework::SelectedRows *weight,
                                             const framework::Tensor &input) {
   MatrixBitCodeFunctorMulGradWeightSR<T> func(tmat, weight, input);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template <typename T>
@@ -321,7 +327,8 @@ void MatrixBitCodeFunctor<T>::MulGradError(const framework::Tensor &tmat,
                                            const framework::Tensor &weight,
                                            framework::Tensor *input) {
   MatrixBitCodeFunctorMulGradError<T> func(tmat, weight, input);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template <typename T>
@@ -350,7 +357,8 @@ struct MatrixBitCodeFunctorSub : public boost::static_visitor<void> {
 template <typename T>
 void MatrixBitCodeFunctor<T>::Sub(framework::Tensor *tmat) {
   MatrixBitCodeFunctorSub<T> func(tmat);
-  code_table_.apply_visitor(func);
+  // code_table_.apply_visitor(func);
+  paddle::apply_visitor(func, code_table_);
 }
 
 template class MatrixBitCodeFunctor<float>;

--- a/paddle/fluid/operators/math/matrix_bit_code.h
+++ b/paddle/fluid/operators/math/matrix_bit_code.h
@@ -204,7 +204,7 @@ class CustomCodeTable {
   const int64_t* ids_;
 };
 
-using CodeTable = boost::variant<SimpleCodeTable, CustomCodeTable<int64_t>>;
+using CodeTable = paddle::variant<SimpleCodeTable, CustomCodeTable<int64_t>>;
 
 template <typename T>
 class MatrixBitCodeFunctor {

--- a/paddle/fluid/operators/math/matrix_inverse.cu.cc
+++ b/paddle/fluid/operators/math/matrix_inverse.cu.cc
@@ -45,9 +45,9 @@ class MatrixInverseFunctor<platform::CUDADeviceContext, T> {
       // Copy all elements of input matrix A to a temporary memory space to
       // avoid being overriden by getrf.
       tmp_gpu_mat_data = memory::Alloc(context, a.numel() * sizeof(T));
-      memory::Copy(boost::get<platform::CUDAPlace>(context.GetPlace()),
+      memory::Copy(paddle::get<platform::CUDAPlace>(context.GetPlace()),
                    tmp_gpu_mat_data->ptr(),
-                   boost::get<platform::CUDAPlace>(context.GetPlace()),
+                   paddle::get<platform::CUDAPlace>(context.GetPlace()),
                    a.data<void>(), a.numel() * sizeof(T), context.stream());
       gpu_mat = reinterpret_cast<const T*>(tmp_gpu_mat_data->ptr());
     }
@@ -61,7 +61,7 @@ class MatrixInverseFunctor<platform::CUDADeviceContext, T> {
     // Copy the addresses of A and A_inv from host to device.
     memory::allocation::AllocationPtr tmp_gpu_ptrs_data =
         memory::Alloc(context, cpu_ptrs.size() * sizeof(T*));
-    memory::Copy(boost::get<platform::CUDAPlace>(context.GetPlace()),
+    memory::Copy(paddle::get<platform::CUDAPlace>(context.GetPlace()),
                  tmp_gpu_ptrs_data->ptr(), platform::CPUPlace(),
                  static_cast<void*>(cpu_ptrs.data()),
                  cpu_ptrs.size() * sizeof(T*), context.stream());

--- a/paddle/fluid/operators/op_debug_string_test.cc
+++ b/paddle/fluid/operators/op_debug_string_test.cc
@@ -39,8 +39,8 @@ TEST(op_debug_str, test_unknown_dtype) {
   desc.SetOutput(framework::GradVarName("Y"), {framework::GradVarName("Y")});
   desc.SetAttr("axis", -1);
   desc.SetAttr("use_mkldnn", false);
-  desc.SetAttr("x_data_format", "");
-  desc.SetAttr("y_data_format", "");
+  desc.SetAttr("x_data_format", std::string(""));
+  desc.SetAttr("y_data_format", std::string(""));
 
   auto x_tensor = scope.Var("X")->GetMutable<framework::LoDTensor>();
   x_tensor->Resize(dim);

--- a/paddle/fluid/operators/recurrent_op.cc
+++ b/paddle/fluid/operators/recurrent_op.cc
@@ -436,7 +436,7 @@ void RecurrentGradOp::RunImpl(const framework::Scope &scope,
           auto &inside_tensor =
               cur_scope.FindVar(inside_grad_name)->Get<framework::LoDTensor>();
           framework::AttributeMap attrs;
-          attrs["dtype"] = inside_tensor.type();
+          attrs["dtype"] = static_cast<int>(inside_tensor.type());
           attrs["shape"] = framework::vectorize<int>(inside_tensor.dims());
           attrs["value"] = 0.0f;
 

--- a/paddle/fluid/operators/rnn_memory_helper_op.cc
+++ b/paddle/fluid/operators/rnn_memory_helper_op.cc
@@ -116,7 +116,7 @@ class RNNMemoryHelperGradOp : public framework::OperatorBase {
       auto &in_var_tensor = in_var->Get<framework::LoDTensor>();
 
       framework::AttributeMap attrs;
-      attrs["dtype"] = in_var_tensor.type();
+      attrs["dtype"] = static_cast<int>(in_var_tensor.type());
       attrs["shape"] = framework::vectorize<int>(in_var_tensor.dims());
       attrs["value"] = 0.0f;
 

--- a/paddle/fluid/operators/sequence_ops/sequence_mask_op_npu.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_mask_op_npu.cc
@@ -58,9 +58,9 @@ class SequenceMaskNPUKernel : public framework::OpKernel<T> {
 
     Tensor cast_x;
     cast_x.mutable_data<int32_t>(x->dims(), ctx.GetPlace());
-    const auto& cast1_runner =
-        NpuOpRunner("Cast", {*x}, {cast_x},
-                    {{"dst_type", ConvertToNpuDtype(cast_x.type())}});
+    const auto& cast1_runner = NpuOpRunner(
+        "Cast", {*x}, {cast_x},
+        {{"dst_type", static_cast<int>(ConvertToNpuDtype(cast_x.type()))}});
     cast1_runner.Run(dev_ctx.stream());
 
     Tensor tmp;
@@ -120,7 +120,8 @@ class SequenceMaskNPUKernel : public framework::OpKernel<T> {
     }
 
     const auto& cast2_runner = NpuOpRunner(
-        "Cast", {y_tmp}, {*y}, {{"dst_type", ConvertToNpuDtype(out_dtype)}});
+        "Cast", {y_tmp}, {*y},
+        {{"dst_type", static_cast<int>(ConvertToNpuDtype(out_dtype))}});
     cast2_runner.Run(dev_ctx.stream());
   }
 };

--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -158,7 +158,8 @@ class SliceOpVarTypeInference : public framework::VarTypeInference {
     auto x_name = "Input";
     auto out_name = "Out";
     auto decrease_axis = ctx->GetAttr("decrease_axis");
-    auto not_decrease = boost::get<std::vector<int>>(decrease_axis).size() == 0;
+    auto not_decrease =
+        paddle::get<std::vector<int>>(decrease_axis).size() == 0;
     if (not_decrease) {
       // The default type of out is LoDTensor.
       // However, if no axis is decreased and the type of input is not

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -598,20 +598,21 @@ struct EnforceNotMet : public std::exception {
   } while (0)
 
 /*
- * Summary: This BOOST_GET(_**) series macros are used to call boost::get
- *   safely. boost::get is not a completely safe api, although it will not
+ * Summary: This BOOST_GET(_**) series macros are used to call paddle::get
+ *   safely. paddle::get is not a completely safe api, although it will not
  *   go wrong in most cases, but in extreme cases, it may fail and directly
- *   throw a boost::bad_get exception, without any stack information.
+ *   throw a paddle::bad_variant_access exception, without any stack
+ *information.
  *   This kind of problems is difficult to debug, so add these macros to
- *   enrich boost::get error information. At the same time, we restrict
- *   the direct use of boost::get by CI rule.
+ *   enrich paddle::get error information. At the same time, we restrict
+ *   the direct use of paddle::get by CI rule.
  *
  * Parameters:
  *     __TYPE: the target variable type
  *     __VALUE: the target variable to get
  *
  * Examples:
- *     - unsafe writing: int x = boost::get<int>(y);
+ *     - unsafe writing: int x = paddle::get<int>(y);
  *     - safe writing: int x = BOOST_GET(int, y);
  *
  * Note: GCC 4.8 cannot select right overloaded function here, so need
@@ -628,12 +629,12 @@ namespace details {
       ->typename std::conditional<std::is_pointer<InputType>::value,           \
                                   __OutputTypePtr, __OutputType>::type {       \
     try {                                                                      \
-      return boost::get<OutputType>(input);                                    \
-    } catch (boost::bad_get&) {                                                \
+      return paddle::get<OutputType>(input);                                   \
+    } catch (paddle::bad_variant_access&) {                                    \
       HANDLE_THE_ERROR                                                         \
       throw ::paddle::platform::EnforceNotMet(                                 \
           ::paddle::platform::errors::InvalidArgument(                         \
-              "boost::get failed, cannot get value "                           \
+              "paddle::get failed, cannot get value "                          \
               "(%s) by type %s, its type is %s.",                              \
               expression,                                                      \
               paddle::platform::demangle(typeid(OutputType).name()),           \

--- a/paddle/fluid/platform/place.cc
+++ b/paddle/fluid/platform/place.cc
@@ -25,7 +25,7 @@ namespace platform {
 
 namespace detail {
 
-class PlacePrinter : public boost::static_visitor<> {
+class PlacePrinter : public paddle::static_visitor<> {
  public:
   explicit PlacePrinter(std::ostream &os) : os_(os) {}
   void operator()(const CPUPlace &) { os_ << "CPUPlace"; }

--- a/paddle/fluid/platform/place.cc
+++ b/paddle/fluid/platform/place.cc
@@ -44,27 +44,27 @@ class PlacePrinter : public boost::static_visitor<> {
 }  // namespace detail
 
 bool is_gpu_place(const Place &p) {
-  return boost::apply_visitor(IsCUDAPlace(), p);
+  return paddle::apply_visitor(IsCUDAPlace(), p);
 }
 
 bool is_xpu_place(const Place &p) {
-  return boost::apply_visitor(IsXPUPlace(), p);
+  return paddle::apply_visitor(IsXPUPlace(), p);
 }
 
 bool is_npu_place(const Place &p) {
-  return boost::apply_visitor(IsNPUPlace(), p);
+  return paddle::apply_visitor(IsNPUPlace(), p);
 }
 
 bool is_cpu_place(const Place &p) {
-  return boost::apply_visitor(IsCPUPlace(), p);
+  return paddle::apply_visitor(IsCPUPlace(), p);
 }
 
 bool is_cuda_pinned_place(const Place &p) {
-  return boost::apply_visitor(IsCUDAPinnedPlace(), p);
+  return paddle::apply_visitor(IsCUDAPinnedPlace(), p);
 }
 
 bool is_npu_pinned_place(const Place &p) {
-  return boost::apply_visitor(IsNPUPinnedPlace(), p);
+  return paddle::apply_visitor(IsNPUPinnedPlace(), p);
 }
 
 bool places_are_same_class(const Place &p1, const Place &p2) {
@@ -89,7 +89,7 @@ bool is_same_place(const Place &p1, const Place &p2) {
 
 std::ostream &operator<<(std::ostream &os, const Place &p) {
   detail::PlacePrinter printer(os);
-  boost::apply_visitor(printer, p);
+  paddle::apply_visitor(printer, p);
   return os;
 }
 

--- a/paddle/fluid/platform/place.h
+++ b/paddle/fluid/platform/place.h
@@ -147,11 +147,11 @@ struct IsNPUPinnedPlace : public boost::static_visitor<bool> {
   bool operator()(const CUDAPinnedPlace &) const { return false; }
 };
 
-class Place : public boost::variant<CUDAPlace, XPUPlace, NPUPlace, CPUPlace,
-                                    CUDAPinnedPlace, NPUPinnedPlace> {
+class Place : public paddle::variant<CUDAPlace, XPUPlace, NPUPlace, CPUPlace,
+                                     CUDAPinnedPlace, NPUPinnedPlace> {
  private:
-  using PlaceBase = boost::variant<CUDAPlace, XPUPlace, NPUPlace, CPUPlace,
-                                   CUDAPinnedPlace, NPUPinnedPlace>;
+  using PlaceBase = paddle::variant<CUDAPlace, XPUPlace, NPUPlace, CPUPlace,
+                                    CUDAPinnedPlace, NPUPinnedPlace>;
 
  public:
   Place() = default;
@@ -251,7 +251,7 @@ struct PlaceVisitorWrapper
 template <typename Visitor>
 typename Visitor::result_type VisitPlace(const Place &place,
                                          const Visitor &visitor) {
-  return boost::apply_visitor(PlaceVisitorWrapper<Visitor>(visitor), place);
+  return paddle::apply_visitor(PlaceVisitorWrapper<Visitor>(visitor), place);
 }
 
 }  // namespace platform

--- a/paddle/fluid/platform/place.h
+++ b/paddle/fluid/platform/place.h
@@ -93,7 +93,7 @@ struct NPUPinnedPlace {
   inline bool operator<(const NPUPinnedPlace &) const { return false; }
 };
 
-struct IsCUDAPlace : public boost::static_visitor<bool> {
+struct IsCUDAPlace : public paddle::static_visitor<bool> {
   bool operator()(const CPUPlace &) const { return false; }
   bool operator()(const XPUPlace &) const { return false; }
   bool operator()(const NPUPlace &) const { return false; }
@@ -102,7 +102,7 @@ struct IsCUDAPlace : public boost::static_visitor<bool> {
   bool operator()(const CUDAPinnedPlace &) const { return false; }
 };
 
-struct IsCPUPlace : public boost::static_visitor<bool> {
+struct IsCPUPlace : public paddle::static_visitor<bool> {
   bool operator()(const CPUPlace &) const { return true; }
   bool operator()(const XPUPlace &) const { return false; }
   bool operator()(const NPUPlace &) const { return false; }
@@ -111,7 +111,7 @@ struct IsCPUPlace : public boost::static_visitor<bool> {
   bool operator()(const CUDAPinnedPlace &) const { return false; }
 };
 
-struct IsCUDAPinnedPlace : public boost::static_visitor<bool> {
+struct IsCUDAPinnedPlace : public paddle::static_visitor<bool> {
   bool operator()(const CPUPlace &) const { return false; }
   bool operator()(const XPUPlace &) const { return false; }
   bool operator()(const NPUPlace &) const { return false; }
@@ -120,7 +120,7 @@ struct IsCUDAPinnedPlace : public boost::static_visitor<bool> {
   bool operator()(const CUDAPinnedPlace &cuda_pinned) const { return true; }
 };
 
-struct IsXPUPlace : public boost::static_visitor<bool> {
+struct IsXPUPlace : public paddle::static_visitor<bool> {
   bool operator()(const CPUPlace &) const { return false; }
   bool operator()(const XPUPlace &) const { return true; }
   bool operator()(const NPUPlace &) const { return false; }
@@ -129,7 +129,7 @@ struct IsXPUPlace : public boost::static_visitor<bool> {
   bool operator()(const CUDAPinnedPlace &) const { return false; }
 };
 
-struct IsNPUPlace : public boost::static_visitor<bool> {
+struct IsNPUPlace : public paddle::static_visitor<bool> {
   bool operator()(const CPUPlace &) const { return false; }
   bool operator()(const XPUPlace &) const { return false; }
   bool operator()(const NPUPlace &) const { return true; }
@@ -138,7 +138,7 @@ struct IsNPUPlace : public boost::static_visitor<bool> {
   bool operator()(const CUDAPinnedPlace &) const { return false; }
 };
 
-struct IsNPUPinnedPlace : public boost::static_visitor<bool> {
+struct IsNPUPinnedPlace : public paddle::static_visitor<bool> {
   bool operator()(const CPUPlace &) const { return false; }
   bool operator()(const XPUPlace &) const { return false; }
   bool operator()(const NPUPlace &) const { return false; }
@@ -187,7 +187,7 @@ std::ostream &operator<<(std::ostream &, const Place &);
 
 template <typename Visitor>
 struct PlaceVisitorWrapper
-    : public boost::static_visitor<typename Visitor::result_type> {
+    : public paddle::static_visitor<typename Visitor::result_type> {
   const Visitor &visitor_;
   explicit PlaceVisitorWrapper(const Visitor &visitor) : visitor_(visitor) {}
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2129,7 +2129,7 @@ All parameter, weight, gradient are variables in Paddle.
            py::return_value_policy::take_ownership);
 
   py::class_<FetchList>(m, "FetchList", R"DOC( FetchList is a
-        vector of boost::variant<LoDTensor, LoDTensorArray>.
+        vector of paddle::variant<LoDTensor, LoDTensorArray>.
         )DOC")
       .def("_move_to_list",
            [](FetchList &self) -> py::list {
@@ -2173,7 +2173,7 @@ All parameter, weight, gradient are variables in Paddle.
            py::arg("var"));
 
   py::class_<FetchUnmergedList>(m, "FetchUnmergedList", R"DOC(
-        FetchUnmergedList is 2-D array of FetchType(boost::variant(LoDTensor, LoDTensorArray)).
+        FetchUnmergedList is 2-D array of FetchType(paddle::variant(LoDTensor, LoDTensorArray)).
         )DOC")
       .def("_move_to_list",
            [](FetchUnmergedList &self) -> py::list {

--- a/paddle/fluid/pybind/pybind_boost_headers.h
+++ b/paddle/fluid/pybind/pybind_boost_headers.h
@@ -39,7 +39,7 @@ namespace detail {
 
 // Can be replaced by a generic lambda in C++14
 struct PYBIND11_HIDDEN paddle_variant_caster_visitor
-    : public boost::static_visitor<handle> {
+    : public paddle::static_visitor<handle> {
   return_value_policy policy;
   handle parent;
 

--- a/paddle/fluid/pybind/pybind_boost_headers.h
+++ b/paddle/fluid/pybind/pybind_boost_headers.h
@@ -19,10 +19,11 @@ limitations under the License. */
 
 #include "glog/logging.h"
 #include "paddle/fluid/platform/variant.h"
+#include "paddle/utils/variant.hpp"
 #include "pybind11/numpy.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
-// Cast boost::variant for PyBind.
+// Cast paddle::variant for PyBind.
 // Copy from
 // https://github.com/pybind/pybind11/issues/576#issuecomment-269563199
 namespace pybind11 {
@@ -108,7 +109,7 @@ struct paddle_variant_caster<V<Ts...>> {
   static handle cast(Type const &src, return_value_policy policy,
                      handle parent) {
     paddle_variant_caster_visitor visitor(policy, parent);
-    return boost::apply_visitor(visitor, src);
+    return paddle::apply_visitor(visitor, src);
   }
 
   PYBIND11_TYPE_CASTER(Type, _("Variant"));
@@ -117,8 +118,8 @@ struct paddle_variant_caster<V<Ts...>> {
 
 // Add specialization for concrete variant type
 template <class... Args>
-struct type_caster<boost::variant<Args...>>
-    : paddle_variant_caster<boost::variant<Args...>> {};
+struct type_caster<paddle::variant<Args...>>
+    : paddle_variant_caster<paddle::variant<Args...>> {};
 
 }  // namespace detail
 }  // namespace pybind11

--- a/paddle/utils/recursive_wrapper.hpp
+++ b/paddle/utils/recursive_wrapper.hpp
@@ -1,0 +1,105 @@
+#ifndef MAPBOX_UTIL_RECURSIVE_WRAPPER_HPP
+#define MAPBOX_UTIL_RECURSIVE_WRAPPER_HPP
+
+// Based on variant/recursive_wrapper.hpp from boost.
+//
+// Original license:
+//
+// Copyright (c) 2002-2003
+// Eric Friedman, Itay Maman
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cassert>
+#include <utility>
+
+namespace paddle {
+
+template <typename T>
+class recursive_wrapper {
+  T* p_;
+
+  void assign(T const& rhs) { this->get() = rhs; }
+
+ public:
+  using type = T;
+
+  /**
+   * Default constructor default initializes the internally stored value.
+   * For POD types this means nothing is done and the storage is
+   * uninitialized.
+   *
+   * @throws std::bad_alloc if there is insufficient memory for an object
+   *         of type T.
+   * @throws any exception thrown by the default constructur of T.
+   */
+  recursive_wrapper() : p_(new T) {}
+
+  ~recursive_wrapper() noexcept { delete p_; }
+
+  recursive_wrapper(recursive_wrapper const& operand)
+      : p_(new T(operand.get())) {}
+
+  recursive_wrapper(T const& operand) : p_(new T(operand)) {}
+
+  recursive_wrapper(recursive_wrapper&& operand)
+      : p_(new T(std::move(operand.get()))) {}
+
+  recursive_wrapper(T&& operand) : p_(new T(std::move(operand))) {}
+
+  inline recursive_wrapper& operator=(recursive_wrapper const& rhs) {
+    assign(rhs.get());
+    return *this;
+  }
+
+  inline recursive_wrapper& operator=(T const& rhs) {
+    assign(rhs);
+    return *this;
+  }
+
+  inline void swap(recursive_wrapper& operand) noexcept {
+    T* temp = operand.p_;
+    operand.p_ = p_;
+    p_ = temp;
+  }
+
+  recursive_wrapper& operator=(recursive_wrapper&& rhs) noexcept {
+    swap(rhs);
+    return *this;
+  }
+
+  recursive_wrapper& operator=(T&& rhs) {
+    get() = std::move(rhs);
+    return *this;
+  }
+
+  T& get() {
+    assert(p_);
+    return *get_pointer();
+  }
+
+  T const& get() const {
+    assert(p_);
+    return *get_pointer();
+  }
+
+  T* get_pointer() { return p_; }
+
+  const T* get_pointer() const { return p_; }
+
+  operator T const&() const { return this->get(); }
+
+  operator T&() { return this->get(); }
+
+};  // class recursive_wrapper
+
+template <typename T>
+inline void swap(recursive_wrapper<T>& lhs,
+                 recursive_wrapper<T>& rhs) noexcept {
+  lhs.swap(rhs);
+}
+}  // namespace paddle
+
+#endif  // MAPBOX_UTIL_RECURSIVE_WRAPPER_HPP

--- a/paddle/utils/variant.hpp
+++ b/paddle/utils/variant.hpp
@@ -62,6 +62,16 @@
 
 namespace paddle {
 
+// static visitor
+template <typename R = void>
+struct static_visitor {
+  using result_type = R;
+
+ protected:
+  static_visitor() {}
+  ~static_visitor() {}
+};
+
 // XXX This should derive from std::logic_error instead of std::runtime_error.
 //     See https://github.com/mapbox/variant/issues/48 for details.
 class bad_variant_access : public std::runtime_error {

--- a/paddle/utils/variant.hpp
+++ b/paddle/utils/variant.hpp
@@ -577,7 +577,7 @@ class variant {
   VARIANT_INLINE variant<Types...>& operator=(variant<Types...>&& other)
       // note we check for nothrow-constructible, not nothrow-assignable, since
       // move_assign uses move-construction via placement new.
-      noexcept(detail::conjunction<
+      noexcept(paddle::detail::conjunction<
                std::is_nothrow_move_constructible<Types>...>::value) {
     if (this ==
         &other) {  // playing safe in release mode, hit assertion in debug.

--- a/paddle/utils/variant.hpp
+++ b/paddle/utils/variant.hpp
@@ -1,0 +1,1012 @@
+#ifndef MAPBOX_UTIL_VARIANT_HPP
+#define MAPBOX_UTIL_VARIANT_HPP
+
+#include <cassert>
+#include <cstddef>  // size_t
+#include <functional>
+#include <limits>
+#include <new>        // operator new
+#include <stdexcept>  // runtime_error
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <typeinfo>
+#include <utility>
+
+#include "recursive_wrapper.hpp"
+#include "variant_visitor.hpp"
+
+// clang-format off
+// [[deprecated]] is only available in C++14, use this for the time being
+#if __cplusplus <= 201103L
+# ifdef __GNUC__
+#  define MAPBOX_VARIANT_DEPRECATED __attribute__((deprecated))
+# elif defined(_MSC_VER)
+#  define MAPBOX_VARIANT_DEPRECATED __declspec(deprecated)
+# else
+#  define MAPBOX_VARIANT_DEPRECATED
+# endif
+#else
+#  define MAPBOX_VARIANT_DEPRECATED [[deprecated]]
+#endif
+
+
+#ifdef _MSC_VER
+// https://msdn.microsoft.com/en-us/library/bw1hbe6y.aspx
+# ifdef NDEBUG
+#  define VARIANT_INLINE __forceinline
+# else
+#  define VARIANT_INLINE //__declspec(noinline)
+# endif
+#else
+# ifdef NDEBUG
+#  define VARIANT_INLINE //inline __attribute__((always_inline))
+# else
+#  define VARIANT_INLINE __attribute__((noinline))
+# endif
+#endif
+// clang-format on
+
+// Exceptions
+#if defined(__EXCEPTIONS) || defined(_MSC_VER)
+#define HAS_EXCEPTIONS
+#endif
+
+#define VARIANT_MAJOR_VERSION 1
+#define VARIANT_MINOR_VERSION 1
+#define VARIANT_PATCH_VERSION 0
+
+#define VARIANT_VERSION                                              \
+  (VARIANT_MAJOR_VERSION * 100000) + (VARIANT_MINOR_VERSION * 100) + \
+      (VARIANT_PATCH_VERSION)
+
+namespace paddle {
+
+// XXX This should derive from std::logic_error instead of std::runtime_error.
+//     See https://github.com/mapbox/variant/issues/48 for details.
+class bad_variant_access : public std::runtime_error {
+ public:
+  explicit bad_variant_access(const std::string& what_arg)
+      : runtime_error(what_arg) {}
+
+  explicit bad_variant_access(const char* what_arg) : runtime_error(what_arg) {}
+
+};  // class bad_variant_access
+
+#if !defined(MAPBOX_VARIANT_MINIMIZE_SIZE)
+using type_index_t = unsigned int;
+#else
+#if defined(MAPBOX_VARIANT_OPTIMIZE_FOR_SPEED)
+using type_index_t = std::uint_fast8_t;
+#else
+using type_index_t = std::uint_least8_t;
+#endif
+#endif
+
+namespace detail {
+
+static constexpr type_index_t invalid_value = type_index_t(-1);
+
+template <typename T, typename... Types>
+struct direct_type;
+
+template <typename T, typename First, typename... Types>
+struct direct_type<T, First, Types...> {
+  static constexpr type_index_t index = std::is_same<T, First>::value
+                                            ? sizeof...(Types)
+                                            : direct_type<T, Types...>::index;
+};
+
+template <typename T>
+struct direct_type<T> {
+  static constexpr type_index_t index = invalid_value;
+};
+
+#if __cpp_lib_logical_traits >= 201510L
+
+using std::conjunction;
+using std::disjunction;
+
+#else
+
+template <typename...>
+struct conjunction : std::true_type {};
+
+template <typename B1>
+struct conjunction<B1> : B1 {};
+
+template <typename B1, typename B2>
+struct conjunction<B1, B2> : std::conditional<B1::value, B2, B1>::type {};
+
+template <typename B1, typename... Bs>
+struct conjunction<B1, Bs...>
+    : std::conditional<B1::value, conjunction<Bs...>, B1>::type {};
+
+template <typename...>
+struct disjunction : std::false_type {};
+
+template <typename B1>
+struct disjunction<B1> : B1 {};
+
+template <typename B1, typename B2>
+struct disjunction<B1, B2> : std::conditional<B1::value, B1, B2>::type {};
+
+template <typename B1, typename... Bs>
+struct disjunction<B1, Bs...>
+    : std::conditional<B1::value, B1, disjunction<Bs...>>::type {};
+
+#endif
+
+template <typename T, typename... Types>
+struct convertible_type;
+
+template <typename T, typename First, typename... Types>
+struct convertible_type<T, First, Types...> {
+  static constexpr type_index_t index =
+      std::is_convertible<T, First>::value
+          ? disjunction<std::is_convertible<T, Types>...>::value
+                ? invalid_value
+                : sizeof...(Types)
+          : convertible_type<T, Types...>::index;
+};
+
+template <typename T>
+struct convertible_type<T> {
+  static constexpr type_index_t index = invalid_value;
+};
+
+template <typename T, typename... Types>
+struct value_traits {
+  using value_type =
+      typename std::remove_const<typename std::remove_reference<T>::type>::type;
+  using value_type_wrapper = recursive_wrapper<value_type>;
+  static constexpr type_index_t direct_index =
+      direct_type<value_type, Types...>::index;
+  static constexpr bool is_direct = direct_index != invalid_value;
+  static constexpr type_index_t index_direct_or_wrapper =
+      is_direct ? direct_index
+                : direct_type<value_type_wrapper, Types...>::index;
+  static constexpr bool is_direct_or_wrapper =
+      index_direct_or_wrapper != invalid_value;
+  static constexpr type_index_t index =
+      is_direct_or_wrapper ? index_direct_or_wrapper
+                           : convertible_type<value_type, Types...>::index;
+  static constexpr bool is_valid = index != invalid_value;
+  static constexpr type_index_t tindex = is_valid ? sizeof...(Types)-index : 0;
+  using target_type =
+      typename std::tuple_element<tindex, std::tuple<void, Types...>>::type;
+};
+
+template <typename Src, typename Dest>
+struct copy_cvref {
+  using type = Dest;
+};
+
+template <typename Src, typename Dest>
+struct copy_cvref<Src const&, Dest> {
+  using type = Dest const&;
+};
+
+template <typename Src, typename Dest>
+struct copy_cvref<Src&, Dest> {
+  using type = Dest&;
+};
+
+template <typename Src, typename Dest>
+struct copy_cvref<Src&&, Dest> {
+  using type = Dest&&;
+};
+
+template <typename F, typename = void>
+struct deduced_result_type {};
+
+template <typename F, typename... Args>
+struct deduced_result_type<F(Args...),
+                           decltype((void)std::declval<F>()(
+                               std::declval<Args>()...))> {
+  using type = decltype(std::declval<F>()(std::declval<Args>()...));
+};
+
+template <typename F, typename = void>
+struct visitor_result_type : deduced_result_type<F> {};
+
+// specialization for explicit result_type member in visitor class
+template <typename F, typename... Args>
+struct visitor_result_type<
+    F(Args...),
+    decltype((void)std::declval<typename std::decay<F>::type::result_type>())> {
+  using type = typename std::decay<F>::type::result_type;
+};
+
+template <typename F, typename T>
+using result_of_unary_visit = typename visitor_result_type<F && (T &&)>::type;
+
+template <typename F, typename T>
+using result_of_binary_visit =
+    typename visitor_result_type<F && (T&&, T&&)>::type;
+
+template <type_index_t arg1, type_index_t... others>
+struct static_max;
+
+template <type_index_t arg>
+struct static_max<arg> {
+  static const type_index_t value = arg;
+};
+
+template <type_index_t arg1, type_index_t arg2, type_index_t... others>
+struct static_max<arg1, arg2, others...> {
+  static const type_index_t value = arg1 >= arg2
+                                        ? static_max<arg1, others...>::value
+                                        : static_max<arg2, others...>::value;
+};
+
+template <typename... Types>
+struct variant_helper;
+
+template <typename T, typename... Types>
+struct variant_helper<T, Types...> {
+  VARIANT_INLINE static void destroy(const type_index_t type_index,
+                                     void* data) {
+    if (type_index == sizeof...(Types)) {
+      reinterpret_cast<T*>(data)->~T();
+    } else {
+      variant_helper<Types...>::destroy(type_index, data);
+    }
+  }
+
+  VARIANT_INLINE static void move(const type_index_t old_type_index,
+                                  void* old_value,
+                                  void* new_value) {
+    if (old_type_index == sizeof...(Types)) {
+      new (new_value) T(std::move(*reinterpret_cast<T*>(old_value)));
+    } else {
+      variant_helper<Types...>::move(old_type_index, old_value, new_value);
+    }
+  }
+
+  VARIANT_INLINE static void copy(const type_index_t old_type_index,
+                                  const void* old_value,
+                                  void* new_value) {
+    if (old_type_index == sizeof...(Types)) {
+      new (new_value) T(*reinterpret_cast<const T*>(old_value));
+    } else {
+      variant_helper<Types...>::copy(old_type_index, old_value, new_value);
+    }
+  }
+};
+
+template <>
+struct variant_helper<> {
+  VARIANT_INLINE static void destroy(const type_index_t, void*) {}
+  VARIANT_INLINE static void move(const type_index_t, void*, void*) {}
+  VARIANT_INLINE static void copy(const type_index_t, const void*, void*) {}
+};
+
+template <typename T>
+struct unwrapper {
+  using value_type = T;
+
+  template <typename V>
+  static auto apply(typename std::remove_reference<V>::type& var) ->
+      typename std::enable_if<std::is_lvalue_reference<V>::value,
+                              decltype(var.template get_unchecked<T>())>::type {
+    return var.template get_unchecked<T>();
+  }
+
+  template <typename V>
+  static auto apply(typename std::remove_reference<V>::type& var) ->
+      typename std::enable_if<
+          !std::is_lvalue_reference<V>::value,
+          decltype(std::move(var.template get_unchecked<T>()))>::type {
+    return std::move(var.template get_unchecked<T>());
+  }
+};
+
+template <typename T>
+struct unwrapper<recursive_wrapper<T>> : unwrapper<T> {};
+
+template <typename T>
+struct unwrapper<std::reference_wrapper<T>> : unwrapper<T> {};
+
+template <typename R, typename... Types>
+struct dispatcher;
+
+template <typename R, typename T, typename... Types>
+struct dispatcher<R, T, Types...> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& v, F&& f) {
+    if (v.template is<T>()) {
+      return std::forward<F>(f)(unwrapper<T>::template apply<V>(v));
+    } else {
+      return dispatcher<R, Types...>::apply(std::forward<V>(v),
+                                            std::forward<F>(f));
+    }
+  }
+};
+
+template <typename R, typename T>
+struct dispatcher<R, T> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& v, F&& f) {
+    return std::forward<F>(f)(unwrapper<T>::template apply<V>(v));
+  }
+};
+
+template <typename R, typename T, typename... Types>
+struct binary_dispatcher_rhs;
+
+template <typename R, typename T0, typename T1, typename... Types>
+struct binary_dispatcher_rhs<R, T0, T1, Types...> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& lhs, V&& rhs, F&& f) {
+    if (rhs.template is<T1>())  // call binary functor
+    {
+      return std::forward<F>(f)(unwrapper<T0>::template apply<V>(lhs),
+                                unwrapper<T1>::template apply<V>(rhs));
+    } else {
+      return binary_dispatcher_rhs<R, T0, Types...>::apply(
+          std::forward<V>(lhs), std::forward<V>(rhs), std::forward<F>(f));
+    }
+  }
+};
+
+template <typename R, typename T0, typename T1>
+struct binary_dispatcher_rhs<R, T0, T1> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& lhs, V&& rhs, F&& f) {
+    return std::forward<F>(f)(unwrapper<T0>::template apply<V>(lhs),
+                              unwrapper<T1>::template apply<V>(rhs));
+  }
+};
+
+template <typename R, typename T, typename... Types>
+struct binary_dispatcher_lhs;
+
+template <typename R, typename T0, typename T1, typename... Types>
+struct binary_dispatcher_lhs<R, T0, T1, Types...> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& lhs, V&& rhs, F&& f) {
+    if (lhs.template is<T1>())  // call binary functor
+    {
+      return std::forward<F>(f)(unwrapper<T1>::template apply<V>(lhs),
+                                unwrapper<T0>::template apply<V>(rhs));
+    } else {
+      return binary_dispatcher_lhs<R, T0, Types...>::apply(
+          std::forward<V>(lhs), std::forward<V>(rhs), std::forward<F>(f));
+    }
+  }
+};
+
+template <typename R, typename T0, typename T1>
+struct binary_dispatcher_lhs<R, T0, T1> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& lhs, V&& rhs, F&& f) {
+    return std::forward<F>(f)(unwrapper<T1>::template apply<V>(lhs),
+                              unwrapper<T0>::template apply<V>(rhs));
+  }
+};
+
+template <typename R, typename... Types>
+struct binary_dispatcher;
+
+template <typename R, typename T, typename... Types>
+struct binary_dispatcher<R, T, Types...> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& v0, V&& v1, F&& f) {
+    if (v0.template is<T>()) {
+      if (v1.template is<T>()) {
+        return std::forward<F>(f)(
+            unwrapper<T>::template apply<V>(v0),
+            unwrapper<T>::template apply<V>(v1));  // call binary functor
+      } else {
+        return binary_dispatcher_rhs<R, T, Types...>::apply(
+            std::forward<V>(v0), std::forward<V>(v1), std::forward<F>(f));
+      }
+    } else if (v1.template is<T>()) {
+      return binary_dispatcher_lhs<R, T, Types...>::apply(
+          std::forward<V>(v0), std::forward<V>(v1), std::forward<F>(f));
+    }
+    return binary_dispatcher<R, Types...>::apply(
+        std::forward<V>(v0), std::forward<V>(v1), std::forward<F>(f));
+  }
+};
+
+template <typename R, typename T>
+struct binary_dispatcher<R, T> {
+  template <typename V, typename F>
+  VARIANT_INLINE static R apply(V&& v0, V&& v1, F&& f) {
+    return std::forward<F>(f)(
+        unwrapper<T>::template apply<V>(v0),
+        unwrapper<T>::template apply<V>(v1));  // call binary functor
+  }
+};
+
+// comparator functors
+struct equal_comp {
+  template <typename T>
+  bool operator()(T const& lhs, T const& rhs) const {
+    return lhs == rhs;
+  }
+};
+
+struct less_comp {
+  template <typename T>
+  bool operator()(T const& lhs, T const& rhs) const {
+    return lhs < rhs;
+  }
+};
+
+template <typename Variant, typename Comp>
+class comparer {
+ public:
+  explicit comparer(Variant const& lhs) noexcept : lhs_(lhs) {}
+  comparer& operator=(comparer const&) = delete;
+  // visitor
+  template <typename T>
+  bool operator()(T const& rhs_content) const {
+    T const& lhs_content = lhs_.template get_unchecked<T>();
+    return Comp()(lhs_content, rhs_content);
+  }
+
+ private:
+  Variant const& lhs_;
+};
+
+// hashing visitor
+struct hasher {
+  template <typename T>
+  std::size_t operator()(const T& hashable) const {
+    return std::hash<T>{}(hashable);
+  }
+};
+
+// typeid visitor
+struct reflect {
+  template <typename T>
+  const std::type_info& operator()(const T&) const {
+    return typeid(T);
+  }
+};
+
+}  // namespace detail
+
+struct no_init {};
+
+template <typename... Types>
+class variant {
+  static_assert(sizeof...(Types) > 0,
+                "Template parameter type list of variant can not be empty.");
+  static_assert(!detail::disjunction<std::is_reference<Types>...>::value,
+                "Variant can not hold reference types. Maybe use "
+                "std::reference_wrapper?");
+  static_assert(!detail::disjunction<std::is_array<Types>...>::value,
+                "Variant can not hold array types.");
+  static_assert(
+      sizeof...(Types) < std::numeric_limits<type_index_t>::max(),
+      "Internal index type must be able to accommodate all alternatives.");
+
+ private:
+  static const std::size_t data_size =
+      detail::static_max<sizeof(Types)...>::value;
+  static const std::size_t data_align =
+      detail::static_max<alignof(Types)...>::value;
+
+ public:
+  struct adapted_variant_tag;
+  using types = std::tuple<Types...>;
+
+ private:
+  using first_type = typename std::tuple_element<0, types>::type;
+  using unwrap_first_type = typename detail::unwrapper<first_type>::value_type;
+  using data_type = typename std::aligned_storage<data_size, data_align>::type;
+  using helper_type = detail::variant_helper<Types...>;
+
+  template <typename V, typename T = unwrap_first_type>
+  using alternative_ref = typename detail::copy_cvref<V, T>::type;
+
+  type_index_t type_index;
+#ifdef __clang_analyzer__
+  data_type data{};
+#else
+  data_type data;
+#endif
+
+ public:
+  VARIANT_INLINE variant() noexcept(
+      std::is_nothrow_default_constructible<first_type>::value)
+      : type_index(sizeof...(Types)-1) {
+    static_assert(std::is_default_constructible<first_type>::value,
+                  "First type in variant must be default constructible to "
+                  "allow default construction of variant.");
+    new (&data) first_type();
+  }
+
+  VARIANT_INLINE variant(no_init) noexcept : type_index(detail::invalid_value) {
+  }
+
+  // http://isocpp.org/blog/2012/11/universal-references-in-c11-scott-meyers
+  template <typename T,
+            typename Traits = detail::value_traits<T, Types...>,
+            typename Enable = typename std::enable_if<
+                Traits::is_valid &&
+                !std::is_same<variant<Types...>,
+                              typename Traits::value_type>::value>::type>
+  VARIANT_INLINE variant(T&& val) noexcept(
+      std::is_nothrow_constructible<typename Traits::target_type, T&&>::value)
+      : type_index(Traits::index) {
+    new (&data) typename Traits::target_type(std::forward<T>(val));
+  }
+
+  VARIANT_INLINE variant(variant<Types...> const& old)
+      : type_index(old.type_index) {
+    helper_type::copy(old.type_index, &old.data, &data);
+  }
+
+  VARIANT_INLINE variant(variant<Types...>&& old) noexcept(
+      detail::conjunction<std::is_nothrow_move_constructible<Types>...>::value)
+      : type_index(old.type_index) {
+    helper_type::move(old.type_index, &old.data, &data);
+  }
+
+ private:
+  VARIANT_INLINE void copy_assign(variant<Types...> const& rhs) {
+    helper_type::destroy(type_index, &data);
+    type_index = detail::invalid_value;
+    helper_type::copy(rhs.type_index, &rhs.data, &data);
+    type_index = rhs.type_index;
+  }
+
+  VARIANT_INLINE void move_assign(variant<Types...>&& rhs) {
+    helper_type::destroy(type_index, &data);
+    type_index = detail::invalid_value;
+    helper_type::move(rhs.type_index, &rhs.data, &data);
+    type_index = rhs.type_index;
+  }
+
+ public:
+  VARIANT_INLINE variant<Types...>& operator=(variant<Types...>&& other)
+      // note we check for nothrow-constructible, not nothrow-assignable, since
+      // move_assign uses move-construction via placement new.
+      noexcept(detail::conjunction<
+               std::is_nothrow_move_constructible<Types>...>::value) {
+    if (this ==
+        &other) {  // playing safe in release mode, hit assertion in debug.
+      assert(false);
+      return *this;
+    }
+    move_assign(std::move(other));
+    return *this;
+  }
+
+  VARIANT_INLINE variant<Types...>& operator=(variant<Types...> const& other) {
+    if (this != &other) copy_assign(other);
+    return *this;
+  }
+
+  // conversions
+  // move-assign
+  template <typename T,
+            typename Traits = detail::value_traits<T, Types...>,
+            typename Enable = typename std::enable_if<
+                Traits::is_valid &&
+                !std::is_same<variant<Types...>,
+                              typename Traits::value_type>::value>::type>
+  VARIANT_INLINE variant<Types...>& operator=(T&& rhs)
+      // not that we check is_nothrow_constructible<T>, not
+      // is_nothrow_move_assignable<T>,
+      // since we construct a temporary
+      noexcept(std::is_nothrow_constructible<typename Traits::target_type,
+                                             T&&>::value&&
+                   std::is_nothrow_move_assignable<variant<Types...>>::value) {
+    variant<Types...> temp(std::forward<T>(rhs));
+    move_assign(std::move(temp));
+    return *this;
+  }
+
+  // copy-assign
+  template <typename T>
+  VARIANT_INLINE variant<Types...>& operator=(T const& rhs) {
+    variant<Types...> temp(rhs);
+    copy_assign(temp);
+    return *this;
+  }
+
+  template <typename T,
+            typename std::enable_if<(detail::direct_type<T, Types...>::index !=
+                                     detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE bool is() const {
+    return type_index == detail::direct_type<T, Types...>::index;
+  }
+
+  template <typename T,
+            typename std::enable_if<
+                (detail::direct_type<recursive_wrapper<T>, Types...>::index !=
+                 detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE bool is() const {
+    return type_index ==
+           detail::direct_type<recursive_wrapper<T>, Types...>::index;
+  }
+
+  VARIANT_INLINE bool valid() const {
+    return type_index != detail::invalid_value;
+  }
+
+  template <typename T, typename... Args>
+  VARIANT_INLINE void set(Args&&... args) {
+    helper_type::destroy(type_index, &data);
+    type_index = detail::invalid_value;
+    new (&data) T(std::forward<Args>(args)...);
+    type_index = detail::direct_type<T, Types...>::index;
+  }
+
+  // get_unchecked<T>()
+  template <typename T,
+            typename std::enable_if<(detail::direct_type<T, Types...>::index !=
+                                     detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T& get_unchecked() {
+    return *reinterpret_cast<T*>(&data);
+  }
+
+#ifdef HAS_EXCEPTIONS
+  // get<T>()
+  template <typename T,
+            typename std::enable_if<(detail::direct_type<T, Types...>::index !=
+                                     detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T& get() {
+    if (type_index == detail::direct_type<T, Types...>::index) {
+      return *reinterpret_cast<T*>(&data);
+    } else {
+      throw bad_variant_access("in get<T>()");
+    }
+  }
+#endif
+
+  template <typename T,
+            typename std::enable_if<(detail::direct_type<T, Types...>::index !=
+                                     detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T const& get_unchecked() const {
+    return *reinterpret_cast<T const*>(&data);
+  }
+
+#ifdef HAS_EXCEPTIONS
+  template <typename T,
+            typename std::enable_if<(detail::direct_type<T, Types...>::index !=
+                                     detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T const& get() const {
+    if (type_index == detail::direct_type<T, Types...>::index) {
+      return *reinterpret_cast<T const*>(&data);
+    } else {
+      throw bad_variant_access("in get<T>()");
+    }
+  }
+#endif
+
+  // get_unchecked<T>() - T stored as recursive_wrapper<T>
+  template <typename T,
+            typename std::enable_if<
+                (detail::direct_type<recursive_wrapper<T>, Types...>::index !=
+                 detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T& get_unchecked() {
+    return (*reinterpret_cast<recursive_wrapper<T>*>(&data)).get();
+  }
+
+#ifdef HAS_EXCEPTIONS
+  // get<T>() - T stored as recursive_wrapper<T>
+  template <typename T,
+            typename std::enable_if<
+                (detail::direct_type<recursive_wrapper<T>, Types...>::index !=
+                 detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T& get() {
+    if (type_index ==
+        detail::direct_type<recursive_wrapper<T>, Types...>::index) {
+      return (*reinterpret_cast<recursive_wrapper<T>*>(&data)).get();
+    } else {
+      throw bad_variant_access("in get<T>()");
+    }
+  }
+#endif
+
+  template <typename T,
+            typename std::enable_if<
+                (detail::direct_type<recursive_wrapper<T>, Types...>::index !=
+                 detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T const& get_unchecked() const {
+    return (*reinterpret_cast<recursive_wrapper<T> const*>(&data)).get();
+  }
+
+#ifdef HAS_EXCEPTIONS
+  template <typename T,
+            typename std::enable_if<
+                (detail::direct_type<recursive_wrapper<T>, Types...>::index !=
+                 detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T const& get() const {
+    if (type_index ==
+        detail::direct_type<recursive_wrapper<T>, Types...>::index) {
+      return (*reinterpret_cast<recursive_wrapper<T> const*>(&data)).get();
+    } else {
+      throw bad_variant_access("in get<T>()");
+    }
+  }
+#endif
+
+  // get_unchecked<T>() - T stored as std::reference_wrapper<T>
+  template <
+      typename T,
+      typename std::enable_if<
+          (detail::direct_type<std::reference_wrapper<T>, Types...>::index !=
+           detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T& get_unchecked() {
+    return (*reinterpret_cast<std::reference_wrapper<T>*>(&data)).get();
+  }
+
+#ifdef HAS_EXCEPTIONS
+  // get<T>() - T stored as std::reference_wrapper<T>
+  template <
+      typename T,
+      typename std::enable_if<
+          (detail::direct_type<std::reference_wrapper<T>, Types...>::index !=
+           detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T& get() {
+    if (type_index ==
+        detail::direct_type<std::reference_wrapper<T>, Types...>::index) {
+      return (*reinterpret_cast<std::reference_wrapper<T>*>(&data)).get();
+    } else {
+      throw bad_variant_access("in get<T>()");
+    }
+  }
+#endif
+
+  template <typename T,
+            typename std::enable_if<(
+                detail::direct_type<std::reference_wrapper<T const>, Types...>::
+                    index != detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T const& get_unchecked() const {
+    return (*reinterpret_cast<std::reference_wrapper<T const> const*>(&data))
+        .get();
+  }
+
+#ifdef HAS_EXCEPTIONS
+  template <typename T,
+            typename std::enable_if<(
+                detail::direct_type<std::reference_wrapper<T const>, Types...>::
+                    index != detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE T const& get() const {
+    if (type_index ==
+        detail::direct_type<std::reference_wrapper<T const>, Types...>::index) {
+      return (*reinterpret_cast<std::reference_wrapper<T const> const*>(&data))
+          .get();
+    } else {
+      throw bad_variant_access("in get<T>()");
+    }
+  }
+#endif
+
+  // This function is deprecated because it returns an internal index field.
+  // Use which() instead.
+  MAPBOX_VARIANT_DEPRECATED VARIANT_INLINE type_index_t get_type_index() const {
+    return type_index;
+  }
+
+  VARIANT_INLINE int which() const noexcept {
+    return static_cast<int>(sizeof...(Types)-type_index - 1);
+  }
+
+  template <typename T,
+            typename std::enable_if<(detail::direct_type<T, Types...>::index !=
+                                     detail::invalid_value)>::type* = nullptr>
+  VARIANT_INLINE static constexpr int which() noexcept {
+    return static_cast<int>(
+        sizeof...(Types)-detail::direct_type<T, Types...>::index - 1);
+  }
+
+  // visitor
+  // unary
+  template <typename F,
+            typename V,
+            typename T0 = alternative_ref<V>,
+            typename R = detail::result_of_unary_visit<F, T0>>
+  VARIANT_INLINE static R visit(V&& v, F&& f) {
+    return detail::dispatcher<R, Types...>::apply(std::forward<V>(v),
+                                                  std::forward<F>(f));
+  }
+
+  // binary
+  template <typename F,
+            typename V,
+            typename T0 = alternative_ref<V>,
+            typename R = detail::result_of_binary_visit<F, T0>>
+  VARIANT_INLINE static R binary_visit(V&& v0, V&& v1, F&& f) {
+    return detail::binary_dispatcher<R, Types...>::apply(
+        std::forward<V>(v0), std::forward<V>(v1), std::forward<F>(f));
+  }
+
+  // match
+  // unary
+  template <typename... Fs>
+  auto VARIANT_INLINE match(Fs&&... fs) const& -> decltype(
+      variant::visit(*this, ::paddle::make_visitor(std::forward<Fs>(fs)...))) {
+    return variant::visit(*this,
+                          ::paddle::make_visitor(std::forward<Fs>(fs)...));
+  }
+  // non-const
+  template <typename... Fs>
+  auto VARIANT_INLINE match(Fs&&... fs) & -> decltype(
+      variant::visit(*this, ::paddle::make_visitor(std::forward<Fs>(fs)...))) {
+    return variant::visit(*this,
+                          ::paddle::make_visitor(std::forward<Fs>(fs)...));
+  }
+  template <typename... Fs>
+  auto VARIANT_INLINE match(Fs&&... fs) && -> decltype(variant::visit(
+      std::move(*this), ::paddle::make_visitor(std::forward<Fs>(fs)...))) {
+    return variant::visit(std::move(*this),
+                          ::paddle::make_visitor(std::forward<Fs>(fs)...));
+  }
+
+  ~variant() noexcept  // no-throw destructor
+  {
+    helper_type::destroy(type_index, &data);
+  }
+
+  // comparison operators
+  // equality
+  VARIANT_INLINE bool operator==(variant const& rhs) const {
+    assert(valid() && rhs.valid());
+    if (this->which() != rhs.which()) {
+      return false;
+    }
+    detail::comparer<variant, detail::equal_comp> visitor(*this);
+    return visit(rhs, visitor);
+  }
+
+  VARIANT_INLINE bool operator!=(variant const& rhs) const {
+    return !(*this == rhs);
+  }
+
+  // less than
+  VARIANT_INLINE bool operator<(variant const& rhs) const {
+    assert(valid() && rhs.valid());
+    if (this->which() != rhs.which()) {
+      return this->which() < rhs.which();
+    }
+    detail::comparer<variant, detail::less_comp> visitor(*this);
+    return visit(rhs, visitor);
+  }
+  VARIANT_INLINE bool operator>(variant const& rhs) const {
+    return rhs < *this;
+  }
+  VARIANT_INLINE bool operator<=(variant const& rhs) const {
+    return !(*this > rhs);
+  }
+  VARIANT_INLINE bool operator>=(variant const& rhs) const {
+    return !(*this < rhs);
+  }
+
+  const std::type_info& type() const {
+    detail::reflect visitor;
+    return variant::visit(*this,
+                          ::paddle::make_visitor<detail::reflect>(
+                              std::forward<detail::reflect>(visitor)));
+  }
+};
+
+// unary visitor interface
+template <typename F, typename V>
+auto VARIANT_INLINE apply_visitor(F&& f, V&& v)
+    -> decltype(v.visit(std::forward<V>(v), std::forward<F>(f))) {
+  return v.visit(std::forward<V>(v), std::forward<F>(f));
+}
+
+// binary visitor interface
+template <typename F, typename V>
+auto VARIANT_INLINE apply_visitor(F&& f, V&& v0, V&& v1)
+    -> decltype(v0.binary_visit(std::forward<V>(v0),
+                                std::forward<V>(v1),
+                                std::forward<F>(f))) {
+  return v0.binary_visit(
+      std::forward<V>(v0), std::forward<V>(v1), std::forward<F>(f));
+}
+
+// getter interface
+
+#ifdef HAS_EXCEPTIONS
+template <typename ResultType, typename T>
+auto get(T& var) -> decltype(var.template get<ResultType>()) {
+  return var.template get<ResultType>();
+}
+#endif
+
+template <typename ResultType, typename T>
+ResultType& get_unchecked(T& var) {
+  return var.template get_unchecked<ResultType>();
+}
+
+#ifdef HAS_EXCEPTIONS
+template <typename ResultType, typename T>
+auto get(T const& var) -> decltype(var.template get<ResultType>()) {
+  return var.template get<ResultType>();
+}
+#endif
+
+template <typename ResultType, typename T>
+ResultType const& get_unchecked(T const& var) {
+  return var.template get_unchecked<ResultType>();
+}
+// variant_size
+template <typename T>
+struct variant_size;
+
+// variable templates is c++14
+// template <typename T>
+// constexpr std::size_t variant_size_v = variant_size<T>::value;
+
+template <typename T>
+struct variant_size<const T> : variant_size<T> {};
+
+template <typename T>
+struct variant_size<volatile T> : variant_size<T> {};
+
+template <typename T>
+struct variant_size<const volatile T> : variant_size<T> {};
+
+template <typename... Types>
+struct variant_size<variant<Types...>>
+    : std::integral_constant<std::size_t, sizeof...(Types)> {};
+
+// variant_alternative
+template <std::size_t Index, typename T>
+struct variant_alternative;
+
+#if defined(__clang__)
+#if __has_builtin(__type_pack_element)
+#define has_type_pack_element
+#endif
+#endif
+
+#if defined(has_type_pack_element)
+template <std::size_t Index, typename... Types>
+struct variant_alternative<Index, variant<Types...>> {
+  static_assert(sizeof...(Types) > Index, "Index out of range");
+  using type = __type_pack_element<Index, Types...>;
+};
+#else
+template <std::size_t Index, typename First, typename... Types>
+struct variant_alternative<Index, variant<First, Types...>>
+    : variant_alternative<Index - 1, variant<Types...>> {
+  static_assert(sizeof...(Types) > Index - 1, "Index out of range");
+};
+
+template <typename First, typename... Types>
+struct variant_alternative<0, variant<First, Types...>> {
+  using type = First;
+};
+
+#endif
+
+template <size_t Index, typename T>
+using variant_alternative_t = typename variant_alternative<Index, T>::type;
+
+template <size_t Index, typename T>
+struct variant_alternative<Index, const T>
+    : std::add_const<variant_alternative<Index, T>> {};
+
+template <size_t Index, typename T>
+struct variant_alternative<Index, volatile T>
+    : std::add_volatile<variant_alternative<Index, T>> {};
+
+template <size_t Index, typename T>
+struct variant_alternative<Index, const volatile T>
+    : std::add_cv<variant_alternative<Index, T>> {};
+
+}  // namespace paddle
+
+// hashable iff underlying types are hashable
+namespace std {
+template <typename... Types>
+struct hash<::paddle::variant<Types...>> {
+  std::size_t operator()(const ::paddle::variant<Types...>& v) const noexcept {
+    return ::paddle::apply_visitor(::paddle::detail::hasher{}, v);
+  }
+};
+}
+
+#endif  // MAPBOX_UTIL_VARIANT_HPP

--- a/paddle/utils/variant_visitor.hpp
+++ b/paddle/utils/variant_visitor.hpp
@@ -1,0 +1,36 @@
+#ifndef MAPBOX_UTIL_VARIANT_VISITOR_HPP
+#define MAPBOX_UTIL_VARIANT_VISITOR_HPP
+
+#include <utility>
+
+namespace paddle {
+
+template <typename... Fns>
+struct visitor;
+
+template <typename Fn>
+struct visitor<Fn> : Fn {
+  using Fn::operator();
+
+  template <typename T>
+  visitor(T&& fn) : Fn(std::forward<T>(fn)) {}
+};
+
+template <typename Fn, typename... Fns>
+struct visitor<Fn, Fns...> : Fn, visitor<Fns...> {
+  using Fn::operator();
+  using visitor<Fns...>::operator();
+
+  template <typename T, typename... Ts>
+  visitor(T&& fn, Ts&&... fns)
+      : Fn(std::forward<T>(fn)), visitor<Fns...>(std::forward<Ts>(fns)...) {}
+};
+
+template <typename... Fns>
+visitor<typename std::decay<Fns>::type...> make_visitor(Fns&&... fns) {
+  return visitor<typename std::decay<Fns>::type...>(std::forward<Fns>(fns)...);
+}
+
+}  // namespace paddle
+
+#endif  // MAPBOX_UTIL_VARIANT_VISITOR_HPP


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add third party variant to replace boost::variant