### PR TITLE
Add dimension check for inverse to avoid dividing by 0 error when input's shape is [0, 0, 0].

### DIFF
--- a/paddle/fluid/operators/inverse_op.cc
+++ b/paddle/fluid/operators/inverse_op.cc
@@ -35,6 +35,14 @@ class InverseOp : public framework::OperatorWithKernel {
             "The dimension of Input(Input) is expected to be no less than 2. "
             "But recieved: Input(Input)'s dimension = %d, shape = [%s].",
             input_rank, input_dims));
+    for (int64_t i = 0; i < input_rank; ++i) {
+      PADDLE_ENFORCE_EQ(
+          (input_dims[i] == -1) || (input_dims[i] > 0), true,
+          platform::errors::InvalidArgument(
+              "Each dimension of input tensor is expected to be -1 or a "
+              "positive number, but recieved %d. Input's shape is [%s].",
+              input_dims[i], input_dims));
+    }
     if (input_dims[input_rank - 2] > 0 && input_dims[input_rank - 1] > 0) {
       PADDLE_ENFORCE_EQ(input_dims[input_rank - 2], input_dims[input_rank - 1],
                         platform::errors::InvalidArgument(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
- 问题背景：输入Tensor的形状为[0, 0, 0]时，inverse OP CPU执行会出现除0错误。
   - 测试代码
    ```python
    import paddle
    import numpy as np

    x_arr = np.array([], dtype=np.float32)
    x = paddle.to_tensor(np.reshape(x_arr, (0, 0, 0)))

    paddle.inverse(x)
    ```

    - 错误log
 
    ```
    ==74287==ERROR: AddressSanitizer: FPE on unknown address 0x7fa8f548a40e (pc 0x7fa8f548a40e bp 0x7ffce0b1a0b0 sp 0x7ffce0b19b20 T0)
       #0 0x7fa8f548a40e in void paddle::operators::math::compute_inverse_eigen<paddle::platform::CPUDeviceContext, float>(paddle::platform::CPUDeviceContext const&, paddle::framework::Tensor const&, paddle::framework::Tensor*) /home/work/yakun/py-paddle/Paddle/paddle/fluid/operators/math/matrix_inverse.h:38:41
       #1 0x7fa8ef720084 in paddle::operators::InverseKernel<paddle::platform::CPUDeviceContext, float>::Compute(paddle::framework::ExecutionContext const&) const /home/work/yakun/py-paddle/Paddle/paddle/fluid/operators/inverse_op.h:34:5
       #2 0x7fa8ef71fc5e in paddle::framework::OpKernelRegistrarFunctor<paddle::platform::CPUPlace, false, 0ul, paddle::operators::InverseKernel<paddle::platform::CPUDeviceContext, float>, paddle::operators::InverseKernel<paddle::platform::CPUDeviceContext, double> >::operator()(char const*, char const*, int) const::'lambda'(paddle::framework::ExecutionContext const&)::operator()(paddle::framework::ExecutionContext const&) const /home/work/yakun/py-paddle/Paddle/paddle/fluid/framework/op_registry.h:182:25
       #3 0x7fa8ef71fc5e in std::_Function_handler<void (paddle::framework::ExecutionContext const&), paddle::framework::OpKernelRegistrarFunctor<paddle::platform::CPUPlace, false, 0ul, paddle::operators::InverseKernel<paddle::platform::CPUDeviceContext, float>, paddle::operators::InverseKernel<paddle::platform::CPUDeviceContext, double> >::operator()(char const*, char const*, int) const::'lambda'(paddle::framework::ExecutionContext const&)>::_M_invoke(std::_Any_data const&, paddle::framework::ExecutionContext const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_function.h:297:2
       #4 0x7fa8f6d776dc in std::function<void (paddle::framework::ExecutionContext const&)>::operator()(paddle::framework::ExecutionContext const&) const /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_function.h:687:14
    ...
    ```

- 解决方法：dimension为0是非法输入，通过在`InferShape`中添加输入维度不能为0的检查解决。修复后报错如下：
```
$ CUDA_VISIBLE_DEVICES="" python
Python 3.8.0 (default, Nov 13 2020, 03:27:04)
[GCC 8.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.

>>> import paddle

/work/.virtualenvs_cuda10.1/paddle_py38/lib/python3.8/site-packages/paddle/fluid/framework.py:311: UserWarning: You are using GPU version Paddle, but your CUDA device is not set properly. CPU device will be used by default.
  warnings.warn(

>>> import numpy as np
>
>>> x_arr = np.array([], dtype=np.float32)
>>> x = paddle.to_tensor(np.reshape(x_arr, (0, 0, 0)))
>
>>> paddle.inverse(x)
>>> Traceback (most recent call last):
>>> File "<stdin>", line 1, in <module>
>>> File "/work/.virtualenvs_cuda10.1/paddle_py38/lib/python3.8/site-packages/paddle/tensor/math.py", line 1161, in inverse
>>> return _C_ops.inverse(x)
>>> ValueError: (InvalidArgument) Each dimension of input tensor is expected to be -1 or a positive number, but recieved 0. Input's shape is [0, 0, 0].
>>> [Hint: Expected (input_dims[i] == -1) || (input_dims[i] > 0) == true, but received (input_dims[i] == -1) || (input_dims[i] > 0):0 != true:1.] (at /work/Paddle/paddle/fluid/operators/inverse_op.cc:45)
>>> [operator < inverse > error]
```