### PR TITLE
Add unpool2d op & Expose max_unpool2d API

### DIFF
--- a/paddle/fluid/operators/math/unpooling.cc
+++ b/paddle/fluid/operators/math/unpooling.cc
@@ -38,6 +38,7 @@ class Unpool2dMaxFunctor<platform::CPUDeviceContext, T> {
       for (int c = 0; c < output_channels; ++c) {
         for (int i = 0; i < input_feasize; ++i) {
           int index = indices_data[i];
+
           PADDLE_ENFORCE_LT(
               index, output_feasize,
               platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/math/unpooling.cu
+++ b/paddle/fluid/operators/math/unpooling.cu
@@ -25,48 +25,27 @@ __global__ void KernelUnpool2dMax(const int nthreads, const T* input_data,
                                   const int channels, T* output_data,
                                   const int output_height,
                                   const int output_width) {
-  int in_n_stride = input_height * input_width * channels;
-  int in_c_stride = input_height * input_width;
-  int out_n_stride = output_height * output_width * channels;
-  int out_c_stride = output_height * output_width;
-  int index = blockIdx.x * blockDim.x + threadIdx.x;
-  int offset = blockDim.x * gridDim.x;
-  for (int i = index; i < nthreads; i += offset) {
-    int bidx = i / in_n_stride;
-    int boffset = i % in_n_stride;
-    int cidx = boffset / in_c_stride;
-    int out_offset = bidx * out_n_stride + cidx * out_c_stride;
-    int out_index = indices_data[i];
-    PADDLE_ENFORCE(out_index < out_c_stride,
-                   "out_index < out_c_stride. Expected %ld < %ld, but got "
-                   "%ld >= %ld. Please check input value.",
-                   out_index, out_c_stride, out_index, out_c_stride);
-    output_data[out_offset + out_index] = input_data[i];
+  CUDA_KERNEL_LOOP(linearIndex, nthreads) {
+    int c = (linearIndex / input_width / input_height) % channels;
+    int n = linearIndex / input_width / input_height / channels;
+    output_data += (n * channels + c) * output_height * output_width;
+    int maxind = indices_data[linearIndex];
+    output_data[maxind] = input_data[linearIndex];
   }
 }
+
 template <typename T>
 __global__ void KernelUnpool2dMaxGrad(
     const int nthreads, const T* input_data, const int* indices_data,
     const int input_height, const int input_width, const int channels,
     const T* output_data, const T* output_grad, const int output_height,
     const int output_width, T* input_grad) {
-  int in_n_stride = input_height * input_width * channels;
-  int in_c_stride = input_height * input_width;
-  int out_n_stride = output_height * output_width * channels;
-  int out_c_stride = output_height * output_width;
-  int index = blockIdx.x * blockDim.x + threadIdx.x;
-  int offset = blockDim.x * gridDim.x;
-  for (int i = index; i < nthreads; i += offset) {
-    int bidx = i / in_n_stride;
-    int boffset = i % in_n_stride;
-    int cidx = boffset / in_c_stride;
-    int out_offset = bidx * out_n_stride + cidx * out_c_stride;
-    int out_index = indices_data[i];
-    PADDLE_ENFORCE(out_index < out_c_stride,
-                   "out_index < out_c_stride. Expected %ld < %ld, but got "
-                   "%ld >= %ld. Please check input value.",
-                   out_index, out_c_stride, out_index, out_c_stride);
-    input_grad[i] = output_grad[out_offset + out_index];
+  CUDA_KERNEL_LOOP(linearIndex, nthreads) {
+    int c = (linearIndex / input_width / input_height) % channels;
+    int n = linearIndex / input_width / input_height / channels;
+    input_grad += (n * channels + c) * output_height * output_width;
+    int maxind = indices_data[linearIndex];
+    input_grad[linearIndex] = output_grad[maxind];
   }
 }
 /*

--- a/paddle/fluid/operators/math/unpooling.cu
+++ b/paddle/fluid/operators/math/unpooling.cu
@@ -43,7 +43,7 @@ __global__ void KernelUnpool2dMaxGrad(
   CUDA_KERNEL_LOOP(linearIndex, nthreads) {
     int c = (linearIndex / input_width / input_height) % channels;
     int n = linearIndex / input_width / input_height / channels;
-    input_grad += (n * channels + c) * output_height * output_width;
+    output_grad += (n * channels + c) * output_height * output_width;
     int maxind = indices_data[linearIndex];
     input_grad[linearIndex] = output_grad[maxind];
   }

--- a/paddle/fluid/operators/unpool_op.cc
+++ b/paddle/fluid/operators/unpool_op.cc
@@ -167,15 +167,15 @@ class UnpoolOpGrad : public framework::OperatorWithKernel {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-REGISTER_OPERATOR(unpool2d, ops::UnpoolOp, ops::Unpool2dOpMaker,
+REGISTER_OPERATOR(unpool, ops::UnpoolOp, ops::Unpool2dOpMaker,
                   ops::UnpoolOpGradMaker<paddle::framework::OpDesc>,
                   ops::UnpoolOpGradMaker<paddle::imperative::OpBase>);
 
-REGISTER_OPERATOR(unpool2d_grad, ops::UnpoolOpGrad);
+REGISTER_OPERATOR(unpool_grad, ops::UnpoolOpGrad);
 REGISTER_OP_CPU_KERNEL(
-    unpool2d, ops::UnpoolKernel<paddle::platform::CPUDeviceContext, float>,
+    unpool, ops::UnpoolKernel<paddle::platform::CPUDeviceContext, float>,
     ops::UnpoolKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
-    unpool2d_grad,
+    unpool_grad,
     ops::UnpoolGradKernel<paddle::platform::CPUDeviceContext, float>,
     ops::UnpoolGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/unpool_op.cu.cc
+++ b/paddle/fluid/operators/unpool_op.cu.cc
@@ -16,9 +16,9 @@ limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
-    unpool2d, ops::UnpoolKernel<paddle::platform::CUDADeviceContext, float>,
+    unpool, ops::UnpoolKernel<paddle::platform::CUDADeviceContext, float>,
     ops::UnpoolKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
-    unpool2d_grad,
+    unpool_grad,
     ops::UnpoolGradKernel<paddle::platform::CUDADeviceContext, float>,
     ops::UnpoolGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/unpool_op.cu.cc
+++ b/paddle/fluid/operators/unpool_op.cu.cc
@@ -16,9 +16,9 @@ limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
-    unpool, ops::UnpoolKernel<paddle::platform::CUDADeviceContext, float>,
+    unpool2d, ops::UnpoolKernel<paddle::platform::CUDADeviceContext, float>,
     ops::UnpoolKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
-    unpool_grad,
+    unpool2d_grad,
     ops::UnpoolGradKernel<paddle::platform::CUDADeviceContext, float>,
     ops::UnpoolGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -19,10 +19,26 @@ import numpy as np
 from op_test import OpTest
 
 
-def unpool2dmax_forward_naive(input, indices, ksize, strides, paddings):
+def _unpool_output_size(x, kernel_size, stride, padding, output_size):
+    input_size = x.shape
+    default_size = []
+    for d in range(len(kernel_size)):
+        default_size.append((input_size[-len(kernel_size) + d] - 1) * stride[d]
+                            + kernel_size[d] - 2 * padding[d])
+    if output_size is None:
+        ret = default_size
+    else:
+        ret = output_size
+    return ret
+
+
+def unpool2dmax_forward_naive(input, indices, ksize, strides, paddings,
+                              output_size):
     s0, s1, s2, s3 = input.shape
-    out_hsize = (s2 - 1) * strides[0] - 2 * paddings[0] + ksize[0]
-    out_wsize = (s2 - 1) * strides[1] - 2 * paddings[1] + ksize[1]
+    output_size = _unpool_output_size(input, ksize, strides, paddings,
+                                      output_size)
+    out_hsize = output_size[0]
+    out_wsize = output_size[1]
     out = np.zeros((s0, s1, out_hsize, out_wsize))
     for nidx in range(s0):
         for cidx in range(s1):
@@ -31,7 +47,7 @@ def unpool2dmax_forward_naive(input, indices, ksize, strides, paddings):
                     index = indices[nidx, cidx, h, w]
                     hidx = (index - index % out_wsize) // out_wsize
                     widx = index % out_wsize
-                    out[nidx, cidx, int(hidx), int(widx)] = \
+                    out[nidx, cidx, hidx, widx] = \
                             input[nidx, cidx, h, w]
 
     return out
@@ -39,35 +55,27 @@ def unpool2dmax_forward_naive(input, indices, ksize, strides, paddings):
 
 class TestUnpoolOp(OpTest):
     def setUp(self):
-        self.op_type = "unpool"
+        self.op_type = "unpool2d"
         self.init_test_case()
-        pre_input = np.random.random(self.shape).astype("float64")
-        nsize, csize, hsize, wsize = pre_input.shape
-        hsize_out = (hsize - self.ksize[0] + 2 * self.paddings[0]) // \
-                self.strides[0] + 1
-        wsize_out = (wsize - self.ksize[1] + 2 * self.paddings[1]) // \
-                self.strides[1] + 1
-        input = np.zeros((nsize, csize, hsize_out, wsize_out))
-        indices = np.zeros((nsize, csize, hsize_out, wsize_out))
-        for i in range(hsize_out):
-            for j in range(wsize_out):
-                r_start = np.max((i * self.strides[0] - self.paddings[0], 0))
-                r_end = np.min((i * self.strides[0] + self.ksize[0] - \
-                        self.paddings[0], hsize))
-                c_start = np.max((j * self.strides[1] - self.paddings[1], 0))
-                c_end = np.min((j * self.strides[1] + self.ksize[1] - \
-                        self.paddings[1], wsize))
-                for nidx in range(nsize):
-                    for cidx in range(csize):
-                        x_masked = pre_input[nidx, cidx, r_start:r_end, \
-                                c_start:c_end]
-                        input[nidx, cidx, i, j] = x_masked.max()
-                        arg = x_masked.argmax()
-                        indices[nidx, cidx, i, j] = \
-                                (r_start + arg // self.ksize[1]) * wsize + \
-                                c_start + arg % self.ksize[1]
+        input = np.random.randint(0, 100, self.shape)
+        nsize, csize, hsize, wsize = input.shape
+        self.output_size = _unpool_output_size(input, self.ksize, self.strides,
+                                               self.paddings, self.output_size)
+        indices = np.random.permutation(
+            np.arange(0, self.output_size[0] * self.output_size[1]))[:hsize *
+                                                                     wsize]
+        indices = np.reshape(indices, [hsize, wsize])
+        idx_list = []
+        for n in range(nsize):
+            c_list = []
+            for c in range(csize):
+                c_list.append(indices.tolist())
+            idx_list.append(c_list)
+        indices = np.array(idx_list)
+
         output = self.unpool2d_forward_naive(input, indices, self.ksize, \
-                self.strides, self.paddings).astype("float64")
+                self.strides, self.paddings, self.output_size).astype("float64")
+
         self.inputs = {
             'X': input.astype('float64'),
             'Indices': indices.astype('int32')
@@ -77,6 +85,7 @@ class TestUnpoolOp(OpTest):
             'paddings': self.paddings,
             'ksize': self.ksize,
             'unpooling_type': self.unpooling_type,
+            'output_size': self.output_size,
         }
         self.outputs = {'Out': output.astype('float64')}
 
@@ -89,10 +98,62 @@ class TestUnpoolOp(OpTest):
     def init_test_case(self):
         self.unpool2d_forward_naive = unpool2dmax_forward_naive
         self.unpooling_type = "max"
-        self.shape = [6, 4, 7, 7]
-        self.ksize = [3, 3]
+        self.shape = [2, 4, 7, 8]
+        self.ksize = [2, 2]
         self.strides = [2, 2]
         self.paddings = [0, 0]
+        self.output_size = None
+
+
+class TestUnpoolOpcase1(TestUnpoolOp):
+    def init_test_case(self):
+        self.unpool2d_forward_naive = unpool2dmax_forward_naive
+        self.unpooling_type = "max"
+        self.shape = [3, 2, 5, 5]
+        self.ksize = [4, 4]
+        self.strides = [2, 2]
+        self.paddings = [0, 0]
+        self.output_size = None
+
+
+class TestUnpoolOpOuputsize(TestUnpoolOp):
+    def init_test_case(self):
+        self.unpool2d_forward_naive = unpool2dmax_forward_naive
+        self.unpooling_type = "max"
+        self.shape = [3, 2, 5, 5]
+        self.ksize = [4, 4]
+        self.strides = [2, 2]
+        self.paddings = [0, 0]
+        self.output_size = [9, 9]
+
+
+class TestUnpoolOpOuput(TestUnpoolOp):
+    def init_test_case(self):
+        self.unpool2d_forward_naive = unpool2dmax_forward_naive
+        self.unpooling_type = "max"
+        self.shape = [3, 2, 5, 5]
+        self.ksize = [4, 4]
+        self.strides = [2, 2]
+        self.paddings = [0, 0]
+        self.output_size = [9, 9]
+
+
+class TestUnpoolOpException(unittest.TestCase):
+    def test_exception(self):
+        import paddle.nn.functional as F
+
+        def indices_size_error():
+            data = paddle.randint(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(paddle.arange(0, 12), shape[1, 1, 3, 4])
+            MaxPool2D = F.maxunpool2d(data, indices, kernel_size=2, stride=2)
+
+        def indices_value_error():
+            data = paddle.randint(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(paddle.arange(4, 40), shape[1, 1, 3, 4])
+            MaxPool2D = F.maxunpool2d(data, indices, kernel_size=2, stride=2)
+
+        self.assertRaises(ValueError, indices_size_error)
+        self.assertRaises(ValueError, indices_value_error)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -55,7 +55,7 @@ def unpool2dmax_forward_naive(input, indices, ksize, strides, paddings,
 
 class TestUnpoolOp(OpTest):
     def setUp(self):
-        self.op_type = "unpool2d"
+        self.op_type = "unpool"
         self.init_test_case()
         input = np.random.randint(0, 100, self.shape)
         nsize, csize, hsize, wsize = input.shape

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -140,6 +140,7 @@ class TestUnpoolOpOuput(TestUnpoolOp):
 
 class TestUnpoolOpException(unittest.TestCase):
     def test_exception(self):
+        import paddle
         import paddle.nn.functional as F
 
         def indices_size_error():

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -178,6 +178,8 @@ class TestUnpoolOpException(unittest.TestCase):
         self.assertRaises(ValueError, indices_size_error)
         self.assertRaises(ValueError, indices_value_error)
         self.assertRaises(ValueError, data_format_error)
+        self.assertRaises(ValueError, data_outputsize_error)
+        self.assertRaises(ValueError, data_outputsize_error2)
 
 
 class TestUnpoolOpAPI_dy(unittest.TestCase):
@@ -262,7 +264,7 @@ class TestUnpoolOpAPI_dy3(unittest.TestCase):
             output_np = output.numpy()
             indices_np = indices.numpy()
             expect_res =unpool2dmax_forward_naive(output_np, indices_np, [2,2], \
-                [2,2], [0,0], [5,5]).astype("float64")
+                [2,2], [0,0], [4,4]).astype("float64")
             self.assertTrue(np.allclose(out_pp.numpy(), expect_res))
 
 

--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -73,6 +73,7 @@ from .layer.pooling import AvgPool3D  # noqa: F401
 from .layer.pooling import MaxPool1D  # noqa: F401
 from .layer.pooling import MaxPool2D  # noqa: F401
 from .layer.pooling import MaxPool3D  # noqa: F401
+from .layer.pooling import MaxUnPool2D  # noqa: F401
 from .layer.pooling import AdaptiveAvgPool1D  # noqa: F401
 from .layer.pooling import AdaptiveAvgPool2D  # noqa: F401
 from .layer.pooling import AdaptiveAvgPool3D  # noqa: F401

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -100,7 +100,7 @@ from .pooling import adaptive_max_pool3d  # noqa: F401
 from .pooling import adaptive_avg_pool1d  # noqa: F401
 from .pooling import adaptive_avg_pool2d  # noqa: F401
 from .pooling import adaptive_avg_pool3d  # noqa: F401
-from .pooling import max_unpool2d
+from .pooling import max_unpool2d  # noqa: F401
 
 from .vision import affine_grid  # noqa: F401
 from .vision import grid_sample  # noqa: F401

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -100,6 +100,7 @@ from .pooling import adaptive_max_pool3d  # noqa: F401
 from .pooling import adaptive_avg_pool1d  # noqa: F401
 from .pooling import adaptive_avg_pool2d  # noqa: F401
 from .pooling import adaptive_avg_pool3d  # noqa: F401
+from .pooling import maxunpool2d
 
 from .vision import affine_grid  # noqa: F401
 from .vision import grid_sample  # noqa: F401
@@ -165,6 +166,7 @@ __all__ = [     #noqa
            'max_pool1d',
            'max_pool2d',
            'max_pool3d',
+           'maxunpool_2d',
            'adaptive_avg_pool1d',
            'adaptive_avg_pool2d',
            'adaptive_avg_pool3d',

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -100,7 +100,7 @@ from .pooling import adaptive_max_pool3d  # noqa: F401
 from .pooling import adaptive_avg_pool1d  # noqa: F401
 from .pooling import adaptive_avg_pool2d  # noqa: F401
 from .pooling import adaptive_avg_pool3d  # noqa: F401
-from .pooling import maxunpool2d
+from .pooling import max_unpool2d
 
 from .vision import affine_grid  # noqa: F401
 from .vision import grid_sample  # noqa: F401
@@ -166,7 +166,7 @@ __all__ = [     #noqa
            'max_pool1d',
            'max_pool2d',
            'max_pool3d',
-           'maxunpool_2d',
+           'max_unpool2d',
            'adaptive_avg_pool1d',
            'adaptive_avg_pool2d',
            'adaptive_avg_pool3d',

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -743,7 +743,7 @@ def max_unpool2d(x,
                                       output_size)
 
     if in_dygraph_mode():
-        output = _C_ops.unpool2d(x, Indices, 'unpooling_type', 'max', 'ksize',
+        output = _C_ops.unpool2d(x, indices, 'unpooling_type', 'max', 'ksize',
                                  kernel_size, 'strides', stride, 'paddings',
                                  padding, "output_size", output_size,
                                  "data_format", data_format)

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -724,8 +724,8 @@ def max_unpool2d(x,
             # unpool_out shape: [1, 1, 6, 6]
 
             # specify a different output size than input size 
-            unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0, output_size=[5,5])
-            # unpool_out shape: [1, 1, 5, 5] 
+            unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0, output_size=[7,7])
+            # unpool_out shape: [1, 1, 7, 7] 
 
     """
     kernel_size = utils.convert_to_list(kernel_size, 2, 'pool_size')
@@ -757,7 +757,7 @@ def max_unpool2d(x,
     helper.append_op(
         type=op_type,
         inputs={"X": x,
-                "Indices": Indices},
+                "Indices": indices},
         outputs={"Out": unpool_out},
         attrs={
             "unpooling_type": "max",

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -743,13 +743,13 @@ def max_unpool2d(x,
                                       output_size)
 
     if in_dygraph_mode():
-        output = _C_ops.unpool2d(x, indices, 'unpooling_type', 'max', 'ksize',
-                                 kernel_size, 'strides', stride, 'paddings',
-                                 padding, "output_size", output_size,
-                                 "data_format", data_format)
+        output = _C_ops.unpool(x, indices, 'unpooling_type', 'max', 'ksize',
+                               kernel_size, 'strides', stride, 'paddings',
+                               padding, "output_size", output_size,
+                               "data_format", data_format)
         return output
 
-    op_type = "unpool2d"
+    op_type = "unpool"
     helper = LayerHelper(op_type, **locals())
     dtype = helper.input_dtype(input_param_name="x")
     unpool_out = helper.create_variable_for_type_inference(dtype)

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -720,11 +720,11 @@ def max_unpool2d(x,
             data = paddle.to_tensor(np.random.uniform(-1, 1, [1, 1, 7, 7]).astype(np.float32))
             pool_out, indices = F.max_pool2d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             # pool_out shape: [1, 1, 3, 3],  indices shape: [1, 1, 3, 3]
-            unpool_out = F.maxunpool_2d(pool_out, indices, kernel_size=2, padding=0)
+            unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0)
             # unpool_out shape: [1, 1, 6, 6]
 
             # specify a different output size than input size 
-            unpool_out = F.maxunpool_2d(pool_out, indices, kernel_size=2, padding=0, output_size=[5,5])
+            unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0, output_size=[5,5])
             # unpool_out shape: [1, 1, 5, 5] 
 
     """

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -717,7 +717,7 @@ def max_unpool2d(x,
             import paddle.nn.functional as F
             import numpy as np
 
-            data = paddle.to_tensor(np.random.uniform(-1, 1, [1, 1, 7, 7]).astype(np.float32))
+            data = paddle.to_tensor(np.random.uniform(-1, 1, [1, 1, 6, 6]).astype(np.float32))
             pool_out, indices = F.max_pool2d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
             # pool_out shape: [1, 1, 3, 3],  indices shape: [1, 1, 3, 3]
             unpool_out = F.max_unpool2d(pool_out, indices, kernel_size=2, padding=0)

--- a/python/paddle/nn/layer/__init__.py
+++ b/python/paddle/nn/layer/__init__.py
@@ -54,7 +54,7 @@ from .pooling import AdaptiveAvgPool3D  # noqa: F401
 from .pooling import AdaptiveMaxPool1D  # noqa: F401
 from .pooling import AdaptiveMaxPool2D  # noqa: F401
 from .pooling import AdaptiveMaxPool3D  # noqa: F401
-from .pooling import MaxUnPool2D
+from .pooling import MaxUnPool2D  # noqa: F401
 from .conv import Conv1D  # noqa: F401
 from .conv import Conv2D  # noqa: F401
 from .conv import Conv3D  # noqa: F401

--- a/python/paddle/nn/layer/__init__.py
+++ b/python/paddle/nn/layer/__init__.py
@@ -54,6 +54,7 @@ from .pooling import AdaptiveAvgPool3D  # noqa: F401
 from .pooling import AdaptiveMaxPool1D  # noqa: F401
 from .pooling import AdaptiveMaxPool2D  # noqa: F401
 from .pooling import AdaptiveMaxPool3D  # noqa: F401
+from .pooling import MaxUnPool2D
 from .conv import Conv1D  # noqa: F401
 from .conv import Conv2D  # noqa: F401
 from .conv import Conv3D  # noqa: F401

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -1199,7 +1199,7 @@ class MaxUnPool2D(Layer):
                  data_format="NCHW",
                  output_size=None,
                  name=None):
-        super(MaxPool2D, self).__init__()
+        super(MaxUnPool2D, self).__init__()
         self.ksize = kernel_size
         self.stride = stride
         self.padding = padding
@@ -1208,7 +1208,7 @@ class MaxUnPool2D(Layer):
         self.name = name
 
     def forward(self, x, indices):
-        return F.maxunpool2d(
+        return F.max_unpool2d(
             x,
             indices,
             kernel_size=self.ksize,

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -1128,3 +1128,95 @@ class AdaptiveMaxPool3D(Layer):
     def extra_repr(self):
         return 'output_size={}, return_mask={}'.format(self._output_size,
                                                        self._return_mask)
+
+
+class MaxUnPool2D(Layer):
+    """
+    This API implements max unpooling 2d opereation.
+
+    `max_unpool2d` is not fully invertible, since the non-maximal values are lost.
+
+    `max_unpool2d` takes in as input the output of `max_unpool2d`
+    including the indices of the maximal values and computes a partial inverse
+    in which all non-maximal values are set to zero.
+    
+    `max_unpool2d` can map several input sizes to the same output
+    sizes. Hence, the inversion process can get ambiguous.
+    To accommodate this, you can provide the needed output size
+    as an additional argument `output_size` in the forward call.
+
+    Parameters:
+        kernel_size (int|list|tuple): The unpool kernel size. If unpool kernel size is a tuple or list,
+            it must contain an integer.
+        stride (int|list|tuple): The unpool stride size. If unpool stride size is a tuple or list,
+            it must contain an integer.
+        kernel_size (int|tuple): Size of the max unpooling window.
+        padding (int | tuple): Padding that was added to the input.
+        output_size(list|tuple, optional): The target output size. If output_size is not specified, 
+                           the actual output shape will be automatically calculated by (input_shape,
+                           kernel_size, padding).
+        name(str, optional): For detailed information, please refer
+                             to :ref:`api_guide_Name`. Usually name is no need to set and
+                             None by default.
+
+
+        - Input: :math:`(N, C, H_{in}, W_{in})`
+        - Output: :math:`(N, C, H_{out}, W_{out})`, where
+
+          .. math::
+            H_{out} = (H_{in} - 1) \times \text{stride[0]} - 2 \times \text{padding[0]} + \text{kernel\_size[0]}
+
+          .. math::
+            W_{out} = (W_{in} - 1) \times \text{stride[1]} - 2 \times \text{padding[1]} + \text{kernel\_size[1]}
+
+          or as given by :attr:`output_size` in the call operator
+
+    Returns:
+        A callable object of MaxUnPool2D.
+
+            
+
+    Examples:
+        .. code-block:: python
+        
+        import paddle
+        import paddle.nn.functional as F
+        import numpy as np
+
+        data = paddle.to_tensor(np.random.uniform(-1, 1, [1, 1, 7, 7]).astype(np.float32))
+        pool_out, indices = F.max_pool2d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
+        # pool_out shape: [1, 1, 3, 3],  indices shape: [1, 1, 3, 3]
+        Unpool2D = paddle.nn.MaxUnPool2D(kernel_size=2, padding=0)
+        unpool_out = UnPool2D(pool_out, indices)
+        # unpool_out shape: [1, 1, 6, 6]
+
+    """
+
+    def __init__(self,
+                 kernel_size,
+                 stride=None,
+                 padding=0,
+                 data_format="NCHW",
+                 output_size=None,
+                 name=None):
+        super(MaxPool2D, self).__init__()
+        self.ksize = kernel_size
+        self.stride = stride
+        self.padding = padding
+        self.data_format = data_format
+        self.output_size = output_size
+        self.name = name
+
+    def forward(self, x, indices):
+        return F.maxunpool2d(
+            x,
+            indices,
+            kernel_size=self.ksize,
+            stride=self.stride,
+            padding=self.padding,
+            data_format=self.data_format,
+            output_size=self.output_size,
+            name=self.name)
+
+    def extra_repr(self):
+        return 'output_size={}'.format(self.output_size)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Ops
### Describe
<!-- Describe what this PR does -->
Add max_unpool2d operation

```
import paddle
import numpy as np
import paddle.nn.functional as F

data = paddle.to_tensor([[[[ 1.,  2,  3,  4],
                            [ 5,  6,  7,  8],
                            [ 9, 10, 11, 12],
                            [13, 14, 15, 16]]]])

output, indices = F.max_pool2d(data, kernel_size=2, stride=2, return_mask=True)
out = F.max_unpool2d(output, indices, kernel_size=2, stride=2,output_size=(5,5))
# paddle: Tensor(shape=[1, 1, 5, 5], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
#        [[[[0. , 0. , 0. , 0. , 0. ],
#           [6. , 0. , 8. , 0. , 0. ],
#           [0. , 0. , 0. , 14., 0. ],
#           [16., 0. , 0. , 0. , 0. ],
#           [0. , 0. , 0. , 0. , 0. ]]]])

```