### PR TITLE
add the extra and quantization for op def.

### DIFF
--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -322,8 +322,19 @@ class TypedAttrChecker {
   typedef std::function<void(const T&)> ValueChecker;
 
  public:
-  explicit TypedAttrChecker(const std::string& attr_name)
-      : attr_name_(attr_name) {}
+  explicit TypedAttrChecker(const std::string& attr_name,
+                            proto::OpProto_Attr* attr)
+      : attr_name_(attr_name), attr_(attr) {}
+
+  TypedAttrChecker& AsExtra() {
+    attr_->set_extra(true);
+    return *this;
+  }
+
+  TypedAttrChecker& AsQuant() {
+    attr_->set_quant(true);
+    return *this;
+  }
 
   TypedAttrChecker& InEnum(const std::unordered_set<T>& range) {
     value_checkers_.push_back(EnumInContainer<T>(range));
@@ -398,6 +409,7 @@ class TypedAttrChecker {
 
  private:
   std::string attr_name_;
+  proto::OpProto_Attr* attr_;
   std::vector<ValueChecker> value_checkers_;
   std::vector<DefaultValueChecker> default_value_setter_;
 };
@@ -408,8 +420,9 @@ class OpAttrChecker {
 
  public:
   template <typename T>
-  TypedAttrChecker<T>& AddAttrChecker(const std::string& attr_name) {
-    attr_checkers_.push_back(TypedAttrChecker<T>(attr_name));
+  TypedAttrChecker<T>& AddAttrChecker(const std::string& attr_name,
+                                      proto::OpProto_Attr* attr) {
+    attr_checkers_.push_back(TypedAttrChecker<T>(attr_name, attr));
     AttrChecker& checker = attr_checkers_.back();
     return *(checker.target<TypedAttrChecker<T>>());
   }

--- a/paddle/fluid/framework/framework.proto
+++ b/paddle/fluid/framework/framework.proto
@@ -90,6 +90,8 @@ message OpProto {
     optional bool duplicable = 3 [ default = false ];
     optional bool intermediate = 4 [ default = false ];
     optional bool dispensable = 5 [ default = false ];
+    optional bool extra = 6 [ default = false ];
+    optional bool quant = 7 [ default = false ];
   }
 
   // AttrProto describes the C++ type Attribute.
@@ -101,6 +103,8 @@ message OpProto {
     // language binding has responsibility to fill that
     // attribute. End-User should not set that attribute.
     optional bool generated = 4 [ default = false ];
+    optional bool extra = 5 [ default = false ];
+    optional bool quant = 6 [ default = false ];
   }
 
   required string type = 1;

--- a/paddle/fluid/framework/ir/op_compat_sensible_pass_tester.cc
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass_tester.cc
@@ -102,7 +102,7 @@ TEST(OpCompatSensiblePass, compatOpAttribute) {
   EXPECT_FALSE(compat.Judge(fc_op, "test_pass"));
 
   OpCompat compat_1("fc_test");
-  info.checker_->AddAttrChecker<int>("in_num_col_dims").SetDefault(1);
+  info.checker_->AddAttrChecker<int>("in_num_col_dims", nullptr).SetDefault(1);
   EXPECT_TRUE(compat_1.Judge(fc_op, "test_pass"));
   delete info.checker_;
   delete info.proto_;

--- a/paddle/fluid/framework/op_proto_maker.cc
+++ b/paddle/fluid/framework/op_proto_maker.cc
@@ -65,6 +65,12 @@ void OpProtoAndCheckerMaker::operator()(proto::OpProto* proto,
   proto_ = proto;
   op_checker_ = attr_checker;
   Make();
+  AddAttr<bool>("is_test",
+                "(bool, default false) Set to true for inference only, false "
+                "for training. Some layers may run faster when this is true.")
+      .SetDefault(false)
+      .AsExtra();
+
   op_checker_->RecordExplicitCheckerNum();
   op_checker_->InitDefaultAttributeMap();
 
@@ -80,19 +86,24 @@ void OpProtoAndCheckerMaker::operator()(proto::OpProto* proto,
            static_cast<int>(OpRole::kOptimize) |
                static_cast<int>(OpRole::kLRSched),
            static_cast<int>(OpRole::kNotSpecified)})
-      .SetDefault(static_cast<int>(OpRole::kNotSpecified));
+      .SetDefault(static_cast<int>(OpRole::kNotSpecified))
+      .AsExtra();
   AddAttr<std::vector<std::string>>(OpRoleVarAttrName(),
                                     "Optimized for variable")
-      .SetDefault({});
+      .SetDefault({})
+      .AsExtra();
 
   AddAttr<std::string>(OpNamescopeAttrName(), "Operator name with namesope.")
-      .SetDefault("");
+      .SetDefault("")
+      .AsExtra();
 
   AddAttr<std::vector<std::string>>(OpCreationCallstackAttrName(),
                                     "Callstack for Op Creatation.")
-      .SetDefault({});
+      .SetDefault({})
+      .AsExtra();
   AddAttr<std::string>(OpDeviceAttrName(), "Device type of this operator.")
-      .SetDefault("");
+      .SetDefault("")
+      .AsExtra();
   Validate();
 }
 

--- a/paddle/fluid/framework/op_proto_maker.h
+++ b/paddle/fluid/framework/op_proto_maker.h
@@ -75,6 +75,16 @@ class OpProtoAndCheckerMaker {
       var_->set_dispensable(true);
       return *this;
     }
+
+    VariableBuilder &AsExtra() {
+      var_->set_extra(true);
+      return *this;
+    }
+
+    VariableBuilder &AsQuant() {
+      var_->set_quant(true);
+      return *this;
+    }
   };
 
   VariableBuilder AddInput(const std::string &name, const std::string &comment);
@@ -91,7 +101,7 @@ class OpProtoAndCheckerMaker {
     attr->set_comment(comment);
     attr->set_generated(generated);
     attr->set_type(AttrTypeID<T>());
-    return op_checker_->AddAttrChecker<T>(name);
+    return op_checker_->AddAttrChecker<T>(name, attr);
   }
 
   void AddComment(const std::string &comment) { proto_->set_comment(comment); }

--- a/paddle/fluid/operators/batch_norm_op.cc
+++ b/paddle/fluid/operators/batch_norm_op.cc
@@ -204,10 +204,6 @@ framework::OpKernelType BatchNormOp::GetKernelTypeForVar(
 }
 
 void BatchNormOpMaker::Make() {
-  AddAttr<bool>("is_test",
-                "(bool, default false) Set to true for inference only, false "
-                "for training. Some layers may run faster when this is true.")
-      .SetDefault(false);
   AddAttr<float>("momentum", "").SetDefault(0.9);
   AddAttr<float>("epsilon", "")
       .SetDefault(1e-5)

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -191,10 +191,6 @@ class WhileOpMaker : public framework::OpProtoAndCheckerMaker {
               "variables generated in the i'th step.");
     AddAttr<framework::BlockDesc *>(kStepBlock,
                                     "The step block inside WhileOp");
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddAttr<std::vector<std::string>>(kSkipEagerDeletionVars,
                                       "Vars that would skip eager deletion."
                                       "Users should not set this manually.")

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -243,10 +243,6 @@ framework::OpKernelType ConvOp::GetKernelTypeForVar(
 }
 
 void Conv2DOpMaker::Make() {
-  AddAttr<bool>("is_test",
-                "(bool, default false) Set to true for inference only, false "
-                "for training. Some layers may run faster when this is true.")
-      .SetDefault(false);
   AddInput("Input",
            "(Tensor) The input tensor of convolution operator. "
            "The format of input tensor is NCHW or NHWC, where N is batch size, "
@@ -264,12 +260,14 @@ void Conv2DOpMaker::Make() {
            "(Tensor) Bias to be added to each output of filter application."
            "The format of output tensor is X (one-dimensional) of size equal"
            "to the number of output channels. Only used with MKL-DNN.")
-      .AsDispensable();
+      .AsDispensable()
+      .AsExtra();
   AddInput("ResidualData",
            "(Tensor) Tensor with residual data "
            "to which convolution output will be added."
            "Used with fuse_residual_connection fusion.")
-      .AsDispensable();
+      .AsDispensable()
+      .AsExtra();
   AddOutput("Output",
             "(Tensor) The output tensor of convolution operator. "
             "It has same data fromat and data type as the Input.");
@@ -306,69 +304,87 @@ void Conv2DOpMaker::Make() {
   AddAttr<bool>(
       "use_cudnn",
       "(bool, default false) Only used in cudnn kernel, need install cudnn")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<bool>("fuse_relu_before_depthwise_conv",
                 "(bool, default false) Only used in cuda depthwise kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<bool>("use_mkldnn",
                 "(bool, default false) Only used in mkldnn kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<bool>(
       "use_quantizer",
       "(bool, default false) "
       "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<std::string>(
       "mkldnn_data_type",
       "(string, default \"float32\"). Data type of mkldnn kernel")
       .SetDefault("float32")
-      .InEnum({"float32", "int8", "bfloat16"});
+      .InEnum({"float32", "int8", "bfloat16"})
+      .AsExtra();
   AddAttr<bool>("fuse_relu", "(bool, default false) Only used in mkldnn kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<bool>("fuse_brelu",
                 "(bool, default false) Only used in mkldnn kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<float>("fuse_brelu_threshold",
                  "(float, default false 6.0) Only used in mkldnn kernel")
-      .SetDefault(6.0f);
+      .SetDefault(6.0f)
+      .AsExtra();
   AddAttr<std::string>("fuse_activation",
                        "(string, default \"\") Only used in mkldnn kernel")
-      .SetDefault("");
+      .SetDefault("")
+      .AsExtra();
   AddAttr<float>("fuse_alpha",
                  "(float, default 0.0) Only used in mkldnn kernel")
-      .SetDefault(0.0f);
+      .SetDefault(0.0f)
+      .AsExtra();
   AddAttr<float>("fuse_beta", "(float, default 0.0) Only used in mkldnn kernel")
-      .SetDefault(0.0f);
+      .SetDefault(0.0f)
+      .AsExtra();
   AddAttr<bool>(
       "use_addto",
       "(bool, default false) If use addto strategy or not, only used in "
       "cudnn kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<bool>("fuse_residual_connection",
                 "(bool, default false) Only used in mkldnn kernel. Used "
                 "whenever convolution output is as an input to residual "
                 "connection.")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<float>("Scale_in",
                  "Scale_in to be used for int8 input data."
                  "Only used with MKL-DNN INT8.")
-      .SetDefault(1.0f);
+      .SetDefault(1.0f)
+      .AsExtra();
   AddAttr<float>("Scale_out",
                  "Scale_out to be used for int8 output data."
                  "Only used with MKL-DNN INT8.")
-      .SetDefault(1.0f);
+      .SetDefault(1.0f)
+      .AsExtra();
   AddAttr<float>("Scale_in_eltwise",
                  "Scale_in_eltwise to be used for int8 eltwise input data."
                  "Only used with MKL-DNN INT8.")
-      .SetDefault(1.0f);
+      .SetDefault(1.0f)
+      .AsExtra();
   AddAttr<std::vector<float>>("Scale_weights",
                               "Scale_weights to be used for int8 weights data."
                               "Only used with MKL-DNN INT8.")
-      .SetDefault({1.0f});
+      .SetDefault({1.0f})
+      .AsExtra();
   AddAttr<bool>("force_fp32_output",
                 "(bool, default false) Force INT8 kernel output FP32, only "
                 "used in MKL-DNN INT8")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<std::string>(
       "data_format",
       "(string, default NCHW) Only used in "
@@ -384,12 +400,14 @@ void Conv2DOpMaker::Make() {
                "allocated/freed each time the operator runs, larger "
                "workspace size can increase performance but also requires "
                "better hardware. This size should be chosen carefully.")
-      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB());
+      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB())
+      .AsExtra();
   AddAttr<bool>("exhaustive_search",
                 "(bool, default false) cuDNN has many algorithm to calculation "
                 "convolution, whether enable exhaustive search "
                 "for cuDNN convolution or not, default is False.")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
 
   AddComment(R"DOC(
 Convolution Operator.
@@ -423,10 +441,6 @@ $$
 }
 
 void Conv3DOpMaker::Make() {
-  AddAttr<bool>("is_test",
-                "(bool, default false) Set to true for inference only, false "
-                "for training. Some layers may run faster when this is true.")
-      .SetDefault(false);
   AddInput(
       "Input",
       "(Tensor) The input tensor of convolution operator. "
@@ -447,7 +461,8 @@ void Conv3DOpMaker::Make() {
            "(Tensor) Tensor with residual data "
            "to which convolution output will be added."
            "Used with fuse_residual_connection fusion.")
-      .AsDispensable();
+      .AsDispensable()
+      .AsExtra();
   AddOutput("Output",
             "(Tensor) The output tensor of convolution operator."
             "It has same data fromat and data type as the Input.");
@@ -485,35 +500,44 @@ void Conv3DOpMaker::Make() {
   AddAttr<bool>(
       "use_cudnn",
       "(bool, default false) Only used in cudnn kernel, need install cudnn")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<bool>("use_mkldnn",
                 "(bool, default false) Only used in mkldnn kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<std::string>(
       "mkldnn_data_type",
       "(string, default \"float32\"). Data type of mkldnn kernel")
       .SetDefault("float32")
-      .InEnum({"float32", "int8", "bfloat16"});
+      .InEnum({"float32", "int8", "bfloat16"})
+      .AsExtra();
   AddAttr<bool>("fuse_relu", "(bool, default false) Only used in mkldnn kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<std::string>("fuse_activation",
                        "(string, default \"\") Only used in mkldnn kernel")
-      .SetDefault("");
+      .SetDefault("")
+      .AsExtra();
   AddAttr<float>("fuse_alpha",
                  "(float, default 0.0) Only used in mkldnn kernel")
-      .SetDefault(0.0f);
+      .SetDefault(0.0f)
+      .AsExtra();
   AddAttr<float>("fuse_beta", "(float, default 0.0) Only used in mkldnn kernel")
-      .SetDefault(0.0f);
+      .SetDefault(0.0f)
+      .AsExtra();
   AddAttr<bool>(
       "use_addto",
       "(bool, default false) If use addto strategy or not, only used in "
       "cudnn kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<bool>("fuse_residual_connection",
                 "(bool, default false) Only used in mkldnn kernel. Used "
                 "whenever convolution output is as an input to residual "
                 "connection.")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddAttr<std::string>(
       "data_format",
       "(string, default NCDHW) Only used in "
@@ -523,7 +547,8 @@ void Conv3DOpMaker::Make() {
       .SetDefault("NCDHW");
   AddAttr<bool>("force_fp32_output",
                 "(bool, default false) Only used in mkldnn INT8 kernel")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   // TODO(dzhwinter): need to registered layout transform function
   AddAttr<int>("workspace_size_MB",
                "Only used in cudnn kernel. workspace size for cudnn, in MB, "
@@ -531,12 +556,14 @@ void Conv3DOpMaker::Make() {
                "allocated/freed each time the operator runs, larger "
                "workspace size can increase performance but also requires "
                "better hardware. This size should be chosen carefully.")
-      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB());
+      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB())
+      .AsExtra();
   AddAttr<bool>("exhaustive_search",
                 "(bool, default false) cuDNN has many algorithm to calculation "
                 "convolution, whether enable exhaustive search "
                 "for cuDNN convolution or not, default is False.")
-      .SetDefault(false);
+      .SetDefault(false)
+      .AsExtra();
   AddComment(R"DOC(
 Convolution3D Operator.
 

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -242,10 +242,6 @@ framework::OpKernelType ConvTransposeOp::GetKernelTypeForVar(
 }
 
 void Conv2DTransposeOpMaker::Make() {
-  AddAttr<bool>("is_test",
-                "(bool, default false) Set to true for inference only, false "
-                "for training. Some layers may run faster when this is true.")
-      .SetDefault(false);
   AddInput("Input",
            "(Tensor) The input tensor of convolution transpose operator. "
            "The format of input tensor is NCHW or NHWC. Where N is batch size, "

--- a/paddle/fluid/operators/cudnn_lstm_op.cc
+++ b/paddle/fluid/operators/cudnn_lstm_op.cc
@@ -175,7 +175,6 @@ class CudnnLSTMOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<int>("hidden_size", "hidden size of the LSTM").SetDefault(100);
     AddAttr<int>("num_layers", "the total layer number of the LSTM")
         .SetDefault(1);
-    AddAttr<bool>("is_test", "True if in test phase.").SetDefault(false);
     AddAttr<int>("seed", "seed to used if fix_seed is True").SetDefault(0);
     AddComment(R"DOC(
 CUDNN LSTM implementation

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -198,7 +198,6 @@ class DataNormOp : public framework::OperatorWithKernel {
 class DataNormOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
-    // AddAttr<bool>("is_test", "").SetDefault(false);
     AddAttr<float>("epsilon", "")
         .SetDefault(1e-4)
         .AddCustomChecker([](const float &epsilon) {

--- a/paddle/fluid/operators/dropout_op.cc
+++ b/paddle/fluid/operators/dropout_op.cc
@@ -62,10 +62,6 @@ class DropoutOpMaker : public framework::OpProtoAndCheckerMaker {
                             platform::errors::InvalidArgument(
                                 "'dropout_prob' must be between 0.0 and 1.0."));
         });
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddAttr<bool>("fix_seed",
                   "A flag indicating whether to use a fixed seed to generate "
                   "random mask. NOTE: DO NOT set this flag to true in "

--- a/paddle/fluid/operators/fake_quantize_op.cc
+++ b/paddle/fluid/operators/fake_quantize_op.cc
@@ -405,10 +405,6 @@ class FakeChannelWiseQuantizeAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddComment(R"DOC(
 The scale of FakeChannelWiseQuantize operator is a vector.
 In detail, each channel of the input X has a scale value.
@@ -544,10 +540,6 @@ class FakeQuantizeRangeAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddComment(R"DOC(
 FakeQuantize operator is used in static quantization.
 
@@ -618,10 +610,6 @@ class FakeQuantOrWithDequantMovingAverageAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddComment(R"DOC(
 This is a Base Op which supports FakeQuantMovingAverageAbsMaxOp and FakeQuantDequantMovingAverageAbsMaxOp.
 FakeQuantMovingAverageAbsMaxOp operator is used in the static quantization.
@@ -686,10 +674,6 @@ class MovingAverageAbsMaxScaleOpMaker
     AddOutput("OutAccum", "(Tensor) accum buffer.").AsDispensable();
     AddAttr<float>("moving_rate", "(float, default 0.9) moving rate.")
         .SetDefault(0.9);
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set true for inference only and false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddComment(R"DOC(
 MovingAverageAbsMaxScale operator is only used for calculating the quantization scale.
 And it will not quantize the input tensor.

--- a/paddle/fluid/operators/layer_norm_op.cc
+++ b/paddle/fluid/operators/layer_norm_op.cc
@@ -185,10 +185,6 @@ class LayerNormOpMaker : public framework::OpProtoAndCheckerMaker {
         "(string, default \"float32\"). Data type of mkldnn kernel")
         .SetDefault("float32")
         .InEnum({"float32", "bfloat16"});
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
 
     AddComment(R"DOC(
 Assume feature vectors exist on dimensions

--- a/paddle/fluid/operators/lookup_table_op.cc
+++ b/paddle/fluid/operators/lookup_table_op.cc
@@ -108,11 +108,6 @@ class LookupTableOpMaker : public framework::OpProtoAndCheckerMaker {
                          "entry")
         .SetDefault("");
 
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training.")
-        .SetDefault(false);
-
     AddAttr<std::string>("entry",
                          "(std::string, default "
                          ") for entry attribute.")

--- a/paddle/fluid/operators/lrn_op.cc
+++ b/paddle/fluid/operators/lrn_op.cc
@@ -282,10 +282,6 @@ class LRNOpMaker : public framework::OpProtoAndCheckerMaker {
         "Defaults to \"NHWC\". Specify the data format of the output data, "
         "the input will be transformed automatically. ")
         .SetDefault("AnyLayout");
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
 
     AddComment(R"DOC(
 Local Response Normalization Operator.

--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -363,10 +363,6 @@ void Pool2dOpMaker::Make() {
       "Defaults to \"NHWC\". Specify the data format of the output data, "
       "the input will be transformed automatically. ")
       .SetDefault("NCHW");
-  AddAttr<bool>("is_test",
-                "(bool, default false) Set to true for inference only, false "
-                "for training. Some layers may run faster when this is true.")
-      .SetDefault(false);
 
   AddAttr<std::string>(
       "padding_algorithm",

--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -142,10 +142,6 @@ There are modes:
         "(string, default \"float32\"). Data type of mkldnn kernel")
         .SetDefault("float32")
         .InEnum({"float32", "bfloat16"});
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
   }
 };
 

--- a/paddle/fluid/operators/pscore/distributed_lookup_table_op.cc
+++ b/paddle/fluid/operators/pscore/distributed_lookup_table_op.cc
@@ -119,11 +119,6 @@ class DistributedLookupTableOpMaker : public framework::OpProtoAndCheckerMaker {
                  "Output data type")
         .SetDefault(framework::proto::VarType::FP32);
 
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training.")
-        .SetDefault(false);
-
     AddComment(R"DOC(
 Lookup Tablel Prefetch Operator.
 This operator is used to perform lookup on parameter W,

--- a/paddle/fluid/operators/rnn_op.cc
+++ b/paddle/fluid/operators/rnn_op.cc
@@ -162,7 +162,6 @@ class RNNOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::string>(
         "mode",
         "(string) rnn types, including: LSTM, GRU, RNN_RELU, RNN_TANH.");
-    AddAttr<bool>("is_test", "True if in test phase.").SetDefault(false);
     AddAttr<int>("seed", "seed to used if fix_seed is True").SetDefault(0);
     AddComment(R"DOC(
 )DOC");

--- a/paddle/fluid/operators/run_program_op.cc
+++ b/paddle/fluid/operators/run_program_op.cc
@@ -99,10 +99,6 @@ class RunProgramOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<int64_t>("end_op_index",
                      "(int64_t)"
                      "The index of the op to stop execution");
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training.")
-        .SetDefault(false);
     AddAttr<int64_t>(
         "program_id",
         "(int64_t)"

--- a/paddle/fluid/operators/sequence_ops/sequence_pool_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_pool_op.cc
@@ -58,10 +58,6 @@ class SequencePoolOpMaker : public framework::OpProtoAndCheckerMaker {
               "(Tensor<int>) This tensor is used for the sequence max-pooling "
               "to record the max indexes.")
         .AsIntermediate();
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddAttr<std::string>(
         "pooltype",
         "(string, default 'AVERAGE') the pooling pooltype of SequencePoolOp.")

--- a/paddle/fluid/operators/softmax_op.cc
+++ b/paddle/fluid/operators/softmax_op.cc
@@ -126,10 +126,6 @@ class SoftmaxOpMaker : public framework::OpProtoAndCheckerMaker {
         "(string, default \"float32\"). Data type of mkldnn kernel")
         .SetDefault("float32")
         .InEnum({"float32", "bfloat16"});
-    AddAttr<bool>("is_test",
-                  "(bool, default false) Set to true for inference only, false "
-                  "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
     AddComment(R"DOC(
 Softmax Operator.
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. 为op_def中的属性、输入、输出添加extra、quant标记，分别表示前向推理所必须的、量化推理时新增必须的字段。
2. 在OpMaker中添加AsExtra()和AsQuant()的标记接口。
3. 将“is_test”属性从各个OpMaker子类分别进行注册移到基类中，一次性注册。