### PR TITLE
[hybrid performance] optim the grad fuse for pipeline mode by sorting the grad by dtype

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -5413,9 +5413,10 @@ class PipelineOptimizer(object):
         return fused_merged_gradients
 
     def _sort_grad_param_by_dtype(self, main_block, grad_param_pairs):
-        # sort the grad param paris by the dtype, for now, only supports fp16 and fp32 sorting
+        # sort the grad param paris by the dtype
         fp16_pairs = []
         fp32_pairs = []
+        other_pairs = []
         for pairs in grad_param_pairs:
             dtype = main_block.var(pairs[0]).dtype
             if dtype == paddle.float32:
@@ -5423,9 +5424,10 @@ class PipelineOptimizer(object):
             elif dtype == paddle.float16:
                 fp16_pairs.append(pairs)
             else:
-                return grad_param_pairs
+                other_pairs.append(pairs)
         sorted_pairs = fp16_pairs
         sorted_pairs.extend(fp32_pairs)
+        sorted_pairs.extend(other_pairs)
         return sorted_pairs
 
     def _get_var_size(self, var):

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -5216,6 +5216,9 @@ class PipelineOptimizer(object):
         if len(grad_param_pairs) == 0:
             return
 
+        grad_param_pairs = self._sort_grad_param_by_dtype(main_block,
+                                                          grad_param_pairs)
+
         grad_param_segments = []
         merged_suffix = '@MERGED@FP16' if fp16 else '@MERGED'
         dtype = paddle.float16 if fp16 else paddle.float32
@@ -5408,6 +5411,22 @@ class PipelineOptimizer(object):
         main_block._sync_with_cpp()
 
         return fused_merged_gradients
+
+    def _sort_grad_param_by_dtype(self, main_block, grad_param_pairs):
+        # sort the grad param paris by the dtype, for now, only supports fp16 and fp32 sorting
+        fp16_pairs = []
+        fp32_pairs = []
+        for pairs in grad_param_pairs:
+            dtype = main_block.var(pairs[0]).dtype
+            if dtype == paddle.float32:
+                fp32_pairs.append(pairs)
+            elif dtype == paddle.float16:
+                fp16_pairs.append(pairs)
+            else:
+                return grad_param_pairs
+        sorted_pairs = fp16_pairs
+        sorted_pairs.extend(fp32_pairs)
+        return sorted_pairs
 
     def _get_var_size(self, var):
         dtype_to_size = {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
Sorted the grad by dtype before coalescing, can decrease the number of coalescing op.
Besides, by reducing the number of coalesce op, the number of c_allreduce_sum op can also be reduced.

_All test are based on Ernie3.0, pp=dp=mp=2_
_fp16_allreduce=True_ 
_optimize_cast=True_ 

#### Decrease in number of coalesce op
|| number before this opt | number after this opt | gain | 
|:--:|:--:|:--:|:--:|
|card 0/4| 48| 6 | -700% |
|card 1/5| 48|6| -700%|
|card 2/6| 120|12 | -900%|
|card 3/7| 120| 12| -900%|
|one dp group|336 | 36| -833%|

#### Loss diff
![Screen Shot 2021-08-23 at 10 44 10 AM](https://user-images.githubusercontent.com/25279174/130382968-fddac78e-750d-4d65-9eb6-dcc9911b41b3.png)
![Screen Shot 2021-08-23 at 10 44 24 AM](https://user-images.githubusercontent.com/25279174/130382973-f97cf702-f8cc-49a0-a5e1-79e6a9b2e06f.png)

#### Performance 
| throughput  before this opt | throughput after this opt | gain | 
|:--:|:--:|:--:|
| 39146 | 39232| + 0.2%|