### PR TITLE
[hybrid performance] optim npu coalesce set constant

### DIFF
--- a/paddle/fluid/operators/coalesce_tensor_op.cc
+++ b/paddle/fluid/operators/coalesce_tensor_op.cc
@@ -30,8 +30,14 @@ namespace operators {
 template <typename DeviceContext>
 struct FillConstantVisitor {
   FillConstantVisitor(const DeviceContext &dev_ctx,
-                      framework::LoDTensor *tensor, const float value)
-      : dev_ctx_(dev_ctx), tensor_(tensor), value_(value) {}
+                      framework::LoDTensor *tensor, const float value,
+                      framework::proto::VarType::Type dtype,
+                      const framework::ExecutionContext &context)
+      : dev_ctx_(dev_ctx),
+        tensor_(tensor),
+        value_(value),
+        dtype_(dtype),
+        context_(context) {}
 
   template <typename T>
   void apply(typename std::enable_if<std::is_same<T, int8_t>::value ||
@@ -47,7 +53,17 @@ struct FillConstantVisitor {
                  * = nullptr) const {
 #ifdef PADDLE_WITH_ASCEND_CL
     if (platform::is_npu_place(dev_ctx_.GetPlace())) {
-      FillNpuTensorWithConstant<T>(tensor_, static_cast<T>(value_));
+      Tensor tensor_tmp(dtype_);
+      tensor_tmp.mutable_data<T>({1}, context_.GetPlace());
+      FillNpuTensorWithConstant<T>(&tensor_tmp, static_cast<T>(value_));
+
+      const auto &runner =
+          NpuOpRunner("FillD", {tensor_tmp}, {*tensor_},
+                      {{"dims", framework::vectorize(tensor_->dims())}});
+      auto stream =
+          context_.template device_context<paddle::platform::NPUDeviceContext>()
+              .stream();
+      runner.Run(stream);
     } else {
       math::SetConstant<DeviceContext, T> set_constant;
       set_constant(dev_ctx_, tensor_, static_cast<T>(value_));
@@ -61,6 +77,8 @@ struct FillConstantVisitor {
   const DeviceContext &dev_ctx_;
   framework::LoDTensor *tensor_;
   float value_;
+  framework::proto::VarType::Type dtype_;
+  const framework::ExecutionContext &context_;
 };
 
 template <typename DeviceContext, typename T>
@@ -165,7 +183,8 @@ class CoalesceTensorOpKernel : public framework::OpKernel<T> {
     } else if (context.Attr<bool>("set_constant")) {
       framework::VisitDataType(
           dtype, FillConstantVisitor<DeviceContext>(
-                     dev_ctx, fused_tensor, context.Attr<float>("constant")));
+                     dev_ctx, fused_tensor, context.Attr<float>("constant"),
+                     dtype, context));
     } else if (context.Attr<bool>("persist_output")) {
       for (size_t i = 0; i < out_var_names.size(); ++i) {
         size_t len = static_cast<size_t>(out_tensors[i]->numel());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
Optim the NPU performance of coalesce set constant function.
Aiming to optim the performance of **grad merge fuse**.

#### Performance and loss test
_Following tests are based on Ernie3.0 on 8 NPUs_
_With pp=dp=mp=2_
_Running for 4.5 hours_

#### Throughput
|No fuse throughput|Fuse throughput| Gain|
|:--:|:--:|:--:|
|5528| 6280| +13.6% |
<img width="1287" alt="Screen Shot 2021-08-24 at 6 14 55 PM" src="https://user-images.githubusercontent.com/25279174/130599619-ab48e234-fcc7-44ba-97c6-3b6b540fd5eb.png">


#### Loss
<img width="1284" alt="Screen Shot 2021-08-24 at 6 14 37 PM" src="https://user-images.githubusercontent.com/25279174/130599596-b1bcb92f-c3a4-4d9b-9590-55989fc0ff23.png">


_Following tests are based on Ernie3.0 on 8 NPUs_
_With pp=dp=mp=2_
_Running for 19 hours_

#### Throughput
|No fuse throughput|Fuse throughput| Gain|
|:--:|:--:|:--:|
|5540| 6437| +16.2% |
<img width="1289" alt="Screen Shot 2021-08-25 at 9 04 34 AM" src="https://user-images.githubusercontent.com/25279174/130709576-9656ab02-1b01-487e-8dac-26617320ba00.png">

#### Loss
<img width="1291" alt="Screen Shot 2021-08-25 at 9 04 13 AM" src="https://user-images.githubusercontent.com/25279174/130709582-11af0c6d-b0a5-43a2-9a35-6e7913086fb8.png">

_Following tests are based on Ernie3.0 on 8 * 16 NPUs_
_With pp=16 dp=1 mp=8_
_Running for 2 hours_

#### Throughput
|No fuse throughput|Fuse throughput| Gain|
|:--:|:--:|:--:|
|2072 | 2172| +4.8%|
<img width="1289" alt="Screen Shot 2021-08-24 at 5 57 42 PM" src="https://user-images.githubusercontent.com/25279174/130597646-e80ec2eb-0c9d-40a8-84e7-3c1f193f5322.png">


#### Loss
<img width="1293" alt="Screen Shot 2021-08-24 at 5 57 18 PM" src="https://user-images.githubusercontent.com/25279174/130597621-1654f84a-08c3-431c-b6de-500c1f2ebb8f.png">
