### PR TITLE
cache runtime ctx for executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -47,9 +47,11 @@ class InterpreterCore {
  private:
   void Convert();
 
-  void RunInstruction(const Instruction& instr_node,
-                      const VariableScope& var_scope,
-                      const platform::Place& place);
+  void BuildInstructionCtx(Instruction* instr_node,
+                           const VariableScope& var_scope,
+                           const platform::Place& place);
+
+  void RunInstruction(const Instruction& instr_node);
 
   void ExecuteInstructionList(const std::vector<Instruction>& vec_instr,
                               const VariableScope& var_scope,

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -59,6 +59,9 @@ struct EventRun {
 
 struct Instruction {
   OpKernelFunc kernel_func_;
+  std::shared_ptr<RuntimeContext> runtime_ctx_;
+  std::shared_ptr<RuntimeInferShapeContext> infershape_ctx_;
+  std::shared_ptr<ExecutionContext> execution_ctx_;
   std::map<std::string, std::vector<int>> input_index_;
   std::map<std::string, std::vector<int>> output_index_;
 

--- a/paddle/fluid/framework/new_executor/standalone_executor_test.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor_test.cc
@@ -23,6 +23,43 @@
 
 #include "paddle/fluid/framework/new_executor/standalone_executor.h"
 
+USE_OP(fill_constant);
+USE_OP(uniform_random);
+USE_OP(lookup_table);
+USE_OP(transpose2);
+USE_OP(reshape2);
+USE_OP(split);
+USE_OP(slice);
+USE_OP(concat);
+USE_OP(matmul);
+USE_OP(elementwise_add);
+USE_OP(sigmoid);
+USE_OP(tanh);
+USE_OP(elementwise_mul);
+USE_OP(softmax_with_cross_entropy);
+USE_OP(reduce_mean);
+USE_OP(reduce_sum);
+USE_OP(reduce_sum_grad);
+USE_OP(reduce_mean_grad);
+USE_OP(reshape2_grad);
+USE_OP(softmax_with_cross_entropy_grad);
+USE_OP(elementwise_add_grad);
+USE_OP(matmul_grad);
+USE_OP(square);
+USE_OP(transpose2_grad);
+USE_OP(concat_grad);
+USE_OP(elementwise_mul_grad);
+USE_OP(sigmoid_grad);
+USE_OP(tanh_grad);
+USE_OP(sum);
+USE_OP(slice_grad);
+USE_OP(lookup_table_grad);
+USE_OP(sqrt);
+USE_OP(elementwise_max);
+USE_OP(elementwise_div);
+USE_OP(sgd);
+USE_OP(squared_l2_norm);
+
 paddle::framework::ProgramDesc load_from_file(const std::string& file_name) {
   std::ifstream fin(file_name, std::ios::in | std::ios::binary);
   fin.seekg(0, std::ios::end);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
cache RuntimeContext以加速Executor执行效率。
使用standalone_executor_test，PTB模型，BatchSize=20测试。添加`Cache RuntimeContext`机制前后的运行时间为`20.4s`，`15.3s`。