### PR TITLE
fix convert ut framework problem

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/program_config.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/program_config.py
@@ -137,8 +137,11 @@ def create_fake_model(program_config):
             op_desc._set_attr(name, values)
         for name, values in op_config.outputs.items():
             op_desc.set_output(name, values)
-            var_desc = main_block_desc.var(cpt.to_bytes(name))
-            var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+            for v in values:
+                var_desc = main_block_desc.var(cpt.to_bytes(v))
+                var_desc.set_type(core.VarDesc.VarType.LOD_TENSOR)
+                var_desc.set_dtype(
+                    convert_np_dtype_to_dtype_(tensor_config.dtype))
         op_desc.infer_var_type(main_block_desc)
         op_desc.infer_shape(main_block_desc)
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/trt_layer_auto_scan_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/trt_layer_auto_scan_test.py
@@ -104,7 +104,7 @@ class TrtLayerAutoScanTest(AutoScanTest):
             if not self.program_weights:
                 self.program_weights = {
                     "place_holder_weight": TensorConfig(
-                        shape=[1], data=np.array(1).astype(np.float32))
+                        shape=[1], data=np.array([1]).astype(np.float32))
                 }
             program_config = ProgramConfig(
                 ops=ops,

--- a/python/paddle/fluid/tests/unittests/ir/inference/trt_layer_auto_scan_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/trt_layer_auto_scan_test.py
@@ -100,6 +100,12 @@ class TrtLayerAutoScanTest(AutoScanTest):
                         attrs=op_attr))
 
             self.update_program_input_and_weight_with_attr(op_attr_list)
+            # if no weight need to save, we create a place_holder to help seriazlie params.
+            if not self.program_weights:
+                self.program_weights = {
+                    "place_holder_weight": TensorConfig(
+                        shape=[1], data=np.array(1).astype(np.float32))
+                }
             program_config = ProgramConfig(
                 ops=ops,
                 weights=self.program_weights,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- convert单测框架修复没有权重无法save的问题（通过添加place_holder权重，避免用户再额外添加权重）
- 找不到op output的问题（目前还有问题，无法推导出op out的var type，设置了输入的var_type，当遇到int64的op时，应该会挂）