### PR TITLE
[NPU] Fix the performance problem of elementwise_add when 'axis' is not specified

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_add_op_npu.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op_npu.cc
@@ -42,27 +42,22 @@ class ElementwiseAddNPUKernel : public framework::OpKernel<T> {
     auto y_dims = y->dims();
     axis = (axis == -1 ? std::abs(x_dims.size() - y_dims.size()) : axis);
     if (x_dims.size() >= y_dims.size()) {
-      direct_compute =
-          y_dims == framework::slice_ddim(x_dims, axis, x_dims.size());
+      direct_compute = x_dims.size() == (y_dims.size() + axis);
     } else {
-      direct_compute =
-          x_dims == framework::slice_ddim(y_dims, axis, y_dims.size());
+      direct_compute = y_dims.size() == (x_dims.size() + axis);
     }
 
-    Tensor transformed_x, transformed_y;
     if (direct_compute) {
-      transformed_x.ShareDataWith(*x);
-      transformed_y.ShareDataWith(*y);
+      const auto& runner = NpuOpRunner("Add", {*x, *y}, {*out}, {});
+      runner.Run(dev_ctx.stream());
     } else {
+      Tensor transformed_x, transformed_y;
       NpuElementWiseOpBroadcast<T>(dev_ctx, x, y, axis, &transformed_x,
                                    &transformed_y);
+      const auto& runner =
+          NpuOpRunner("Add", {transformed_x, transformed_y}, {*out}, {});
+      runner.Run(dev_ctx.stream());
     }
-    const auto& runner =
-        NpuOpRunner("Add", {transformed_x, transformed_y}, {*out}, {});
-    auto stream =
-        ctx.template device_context<paddle::platform::NPUDeviceContext>()
-            .stream();
-    runner.Run(stream);
   }
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix the performance problem of elementwise_add when 'axis' is not specified
![373310ab6a54301ced349f6cc6465f3b](https://user-images.githubusercontent.com/25691046/130592517-304de281-e004-4dda-99ca-5567e31f5973.png)
![4a1d6f0f212db93290a98d1c016ee598](https://user-images.githubusercontent.com/25691046/130592532-f0b50278-f596-4648-918f-0b7c9575ef0e.png)

