### PR TITLE
use spinlock in auto growth

### DIFF
--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.cc
@@ -45,7 +45,7 @@ AutoGrowthBestFitAllocator::AutoGrowthBestFitAllocator(
 Allocation *AutoGrowthBestFitAllocator::AllocateImpl(size_t size) {
   size = AlignedSize(size, alignment_);
 
-  std::lock_guard<std::mutex> guard(mtx_);
+  std::lock_guard<SpinLock> guard(spinlock_);
   auto iter = free_blocks_.lower_bound(std::make_pair(size, nullptr));
   BlockIt block_it;
   if (iter != free_blocks_.end()) {
@@ -98,7 +98,7 @@ Allocation *AutoGrowthBestFitAllocator::AllocateImpl(size_t size) {
 }
 
 void AutoGrowthBestFitAllocator::FreeImpl(Allocation *allocation) {
-  std::lock_guard<std::mutex> guard(mtx_);
+  std::lock_guard<SpinLock> guard(spinlock_);
   auto block_it = static_cast<BlockAllocation *>(allocation)->block_it_;
   auto &blocks = block_it->chunk_->blocks_;
 

--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.h
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.h
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "paddle/fluid/memory/allocation/allocator.h"
+#include "paddle/fluid/memory/allocation/spin_lock.h"
 
 namespace paddle {
 namespace memory {
@@ -86,7 +87,7 @@ class AutoGrowthBestFitAllocator : public Allocator {
   size_t alignment_;
   size_t chunk_size_;
 
-  mutable std::mutex mtx_;
+  SpinLock spinlock_;
 };
 
 }  // namespace allocation

--- a/paddle/fluid/memory/allocation/spin_lock.h
+++ b/paddle/fluid/memory/allocation/spin_lock.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#if !defined(_WIN32)
+#include <sched.h>
+#else
+#include <windows.h>
+#endif  // !_WIN32
+
+namespace paddle {
+namespace memory {
+
+class SpinLock {
+ public:
+  SpinLock() : mlock_(false) {}
+
+  void lock() {
+    bool expect = false;
+    uint64_t spin_cnt = 0;
+    while (!mlock_.compare_exchange_weak(expect, true)) {
+      expect = false;
+      if ((++spin_cnt & 0xFFFFF) == 0) {
+#if defined(_WIN32)
+        SleepEx(50, FALSE);
+#else
+        sched_yield();
+#endif
+      }
+    }
+  }
+
+  void unlock() { mlock_.store(false); }
+  DISABLE_COPY_AND_ASSIGN(SpinLock);
+
+ private:
+  std::atomic<bool> mlock_;
+};
+
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/spin_lock.h
+++ b/paddle/fluid/memory/allocation/spin_lock.h
@@ -33,7 +33,7 @@ class SpinLock {
     uint64_t spin_cnt = 0;
     while (!mlock_.compare_exchange_weak(expect, true)) {
       expect = false;
-      if ((++spin_cnt & 0xFFFFF) == 0) {
+      if ((++spin_cnt & 0xFF) == 0) {
 #if defined(_WIN32)
         SleepEx(50, FALSE);
 #else


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
测试发现，在多线程申请显存、释放显存过程中，会发生锁碰撞。此时，会有1个线程进入休眠状态。当该线程获得锁后，再从休眠状态唤醒。这个过程是非常耗时的。直接影响了执行器的调度性能。
为此，我们将std::mutex 换成 自旋锁，自旋锁在发现锁已经被lock时，本线程会自旋等待，不进入休眠状态，实测性能比std::mutex好很多。
本PR只修改了auto growth allocator，其它的allocator不清楚都是什么依赖关系，暂未修改。