### PR TITLE
Modify ci time count & fix resnet50_quant multi_thread tests

### DIFF
--- a/paddle/fluid/inference/tests/infer_ut/run.sh
+++ b/paddle/fluid/inference/tests/infer_ut/run.sh
@@ -245,5 +245,9 @@ if [[ -f ${exe_dir}/test_summary.txt ]];then
   cat ${exe_dir}/test_summary.txt
   echo "========================================================"
 fi
+
+# tar Gtest output report
+tar -zcvf infer_ut_log.tgz ${log_dir}
+
 echo "infer_ut script finished"
 exit ${EXIT_CODE}

--- a/paddle/fluid/inference/tests/infer_ut/test_resnet50_quant.cc
+++ b/paddle/fluid/inference/tests/infer_ut/test_resnet50_quant.cc
@@ -52,7 +52,7 @@ paddle::test::Record PrepareInput(int batch_size) {
   return image_Record;
 }
 
-TEST(DISABLED_test_resnet50_quant, multi_thread4_trt_int8_bz1) {
+TEST(test_resnet50_quant, multi_thread4_trt_int8_bz1) {
   int thread_num = 4;
   // init input data
   std::map<std::string, paddle::test::Record> input_data_map;
@@ -64,7 +64,7 @@ TEST(DISABLED_test_resnet50_quant, multi_thread4_trt_int8_bz1) {
   config.SetModel(FLAGS_int8dir);
   config.EnableUseGpu(1000, 0);
   config.EnableTensorRtEngine(1 << 20, 10, 3,
-                              paddle_infer::PrecisionType::kInt8, true, false);
+                              paddle_infer::PrecisionType::kInt8, false, false);
   // get infer results from multi threads
   std::vector<std::thread> threads;
   services::PredictorPool pred_pool(config, thread_num);
@@ -94,7 +94,7 @@ TEST(DISABLED_test_resnet50_quant, multi_thread4_trt_int8_bz1) {
   std::cout << "finish test" << std::endl;
 }
 
-TEST(DISABLED_test_resnet50_quant, multi_thread_multi_instance) {
+TEST(test_resnet50_quant, multi_thread_multi_instance) {
   int thread_num = 4;
   // init input data
   std::map<std::string, paddle::test::Record> input_data_fp32, input_data_quant;
@@ -109,12 +109,12 @@ TEST(DISABLED_test_resnet50_quant, multi_thread_multi_instance) {
                        FLAGS_modeldir + "/inference.pdiparams");
   config_fp32.EnableUseGpu(1000, 0);
   config_fp32.EnableTensorRtEngine(
-      1 << 20, 10, 3, paddle_infer::PrecisionType::kFloat32, true, false);
+      1 << 20, 10, 3, paddle_infer::PrecisionType::kFloat32, false, false);
 
   config_quant.SetModel(FLAGS_int8dir);
   config_quant.EnableUseGpu(1000, 0);
   config_quant.EnableTensorRtEngine(
-      1 << 20, 10, 3, paddle_infer::PrecisionType::kInt8, true, false);
+      1 << 20, 10, 3, paddle_infer::PrecisionType::kInt8, false, false);
 
   // get infer results from multi threads
   std::vector<std::thread> threads;

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2131,20 +2131,25 @@ function test_fluid_lib() {
     Testing fluid library for inference ...
     ========================================
 EOF
-    fluid_startTime_s=`date +%s`
+    demo_ci_startTime_s=`date +%s`
     cd ${PADDLE_ROOT}/paddle/fluid/inference/api/demo_ci
     ./run.sh ${PADDLE_ROOT} ${WITH_MKL:-ON} ${WITH_GPU:-OFF} ${INFERENCE_DEMO_INSTALL_DIR} \
              ${TENSORRT_INCLUDE_DIR:-/usr/local/TensorRT/include} \
              ${TENSORRT_LIB_DIR:-/usr/local/TensorRT/lib}
     DEMO_EXIT_CODE=$?
     ./clean.sh
+    demo_ci_endTime_s=`date +%s`
+    echo "demo_ci tests Total time: $[ $demo_ci_endTime_s - $demo_ci_startTime_s ]s"
+    echo "ipipe_log_param_Demo_Ci_Tests_Total_Time: $[ $fluid_endTime_s - $fluid_startTime_s ]s" >> ${PADDLE_ROOT}/build/build_summary.txt
+
+    infer_ut_startTime_s=`date +%s`
     cd ${PADDLE_ROOT}/paddle/fluid/inference/tests/infer_ut
     ./run.sh ${PADDLE_ROOT} ${WITH_MKL:-ON} ${WITH_GPU:-OFF} ${INFERENCE_DEMO_INSTALL_DIR} \
              ${TENSORRT_ROOT_DIR:-/usr}
     TEST_EXIT_CODE=$?
-    fluid_endTime_s=`date +%s`
-    echo "test_fluid_lib Total Time: $[ $fluid_endTime_s - $fluid_startTime_s ]s"
-    echo "ipipe_log_param_Test_Fluid_Lib_Total_Time: $[ $fluid_endTime_s - $fluid_startTime_s ]s" >> ${PADDLE_ROOT}/build/build_summary.txt     
+    infer_ut_endTime_s=`date +%s`
+    echo "infer_ut tests Total time: $[ $infer_ut_endTime_s - $infer_ut_startTime_s ]s"
+    echo "ipipe_log_param_Infer_Ut_Tests_Total_Time: $[ $infer_ut_endTime_s - $infer_ut_startTime_s ]s" >> ${PADDLE_ROOT}/build/build_summary.txt  
     if [[ "$DEMO_EXIT_CODE" != "0" || "$TEST_EXIT_CODE" != "0" ]]; then
         exit 8;
     fi

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2140,7 +2140,7 @@ EOF
     ./clean.sh
     demo_ci_endTime_s=`date +%s`
     echo "demo_ci tests Total time: $[ $demo_ci_endTime_s - $demo_ci_startTime_s ]s"
-    echo "ipipe_log_param_Demo_Ci_Tests_Total_Time: $[ $fluid_endTime_s - $fluid_startTime_s ]s" >> ${PADDLE_ROOT}/build/build_summary.txt
+    echo "ipipe_log_param_Demo_Ci_Tests_Total_Time: $[ $demo_ci_endTime_s - $demo_ci_startTime_s ]s" >> ${PADDLE_ROOT}/build/build_summary.txt
 
     infer_ut_startTime_s=`date +%s`
     cd ${PADDLE_ROOT}/paddle/fluid/inference/tests/infer_ut


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
1. separate `test_fluid_lib ci` time to `demo_ci` time & `infer_ut` time
2. disable TensorRT serialization of `resnet50_quant` multi_thread test case
