### PR TITLE
remove FloatStatus in npu check finite and unscale op

### DIFF
--- a/python/paddle/fluid/contrib/mixed_precision/amp_nn.py
+++ b/python/paddle/fluid/contrib/mixed_precision/amp_nn.py
@@ -20,7 +20,7 @@ from paddle.fluid import core
 __all__ = ['check_finite_and_unscale', 'update_loss_scaling']
 
 
-def check_finite_and_unscale(x, scale, name=None, float_status=None):
+def check_finite_and_unscale(x, scale, name=None):
     """
     Check if input X contains all finite data, if yes, scale it by input Scale.
 
@@ -34,7 +34,6 @@ def check_finite_and_unscale(x, scale, name=None, float_status=None):
     Args:
         x(list|tuple): The input tensors of check_finite_and_unscale operator.
         scale: The scale of check_finite_and_unscale operator.
-        float_status(Tensor): (Only used on NPU) The float status to check overflow.
     """
     check_type(x, 'x', (tuple, list), 'check_finite_and_unscale')
     for e in x:
@@ -45,11 +44,6 @@ def check_finite_and_unscale(x, scale, name=None, float_status=None):
     found_inf = helper.create_variable_for_type_inference(dtype='bool')
 
     inputs = {'X': x, 'Scale': scale}
-    if core.is_compiled_with_npu():
-        check_variable_and_dtype(float_status, "float_status",
-                                 ['float16', 'float32'],
-                                 'check_finite_and_unscale')
-        inputs['FloatStatus'] = float_status
     outputs = {'Out': x, 'FoundInfinite': found_inf}
     helper.append_op(
         type='check_finite_and_unscale', inputs=inputs, outputs=outputs)

--- a/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
@@ -33,32 +33,20 @@ class TestCheckFiniteAndUnscale(unittest.TestCase):
             a = paddle.static.data(name="a", shape=[32, 32], dtype='float32')
             b = paddle.static.data(name="b", shape=[32, 32], dtype='float32')
             scale = paddle.static.data(name="scale", shape=[1], dtype='float32')
-            float_status = paddle.static.data(
-                name="status", shape=[8], dtype='float32')
-            main_program.global_block().append_op(
-                type="alloc_float_status",
-                outputs={"FloatStatus": float_status})
-            main_program.global_block().append_op(
-                type="clear_float_status",
-                inputs={"FloatStatus": float_status},
-                outputs={"FloatStatusOut": float_status})
             c = paddle.fluid.layers.elementwise_div(a, b)
-            out, found_inf = check_finite_and_unscale(
-                [c], scale, float_status=float_status)
+            out, found_inf = check_finite_and_unscale([c], scale)
 
-        return main_program, out, found_inf, float_status
+        return main_program, out, found_inf
 
     def run_prog(self, a, b, scale):
-        main_program, out, found_inf, float_status = self.get_prog()
+        main_program, out, found_inf = self.get_prog()
         place = fluid.NPUPlace(0)
         exe = fluid.Executor(place)
-        out_, founf_inf_, float_status_ = exe.run(
-            main_program,
-            feed={"a": a,
-                  "b": b,
-                  "scale": scale},
-            fetch_list=[out, found_inf, float_status])
-        print(float_status_)
+        out_, founf_inf_ = exe.run(main_program,
+                                   feed={"a": a,
+                                         "b": b,
+                                         "scale": scale},
+                                   fetch_list=[out, found_inf])
         return out_, founf_inf_
 
     def test_contains_nan(self):
@@ -101,42 +89,22 @@ class TestCheckFiniteAndUnscaleClearFloatStatus(unittest.TestCase):
             a = paddle.static.data(name="a", shape=[32, 32], dtype='float32')
             b = paddle.static.data(name="b", shape=[32, 32], dtype='float32')
             scale = paddle.static.data(name="scale", shape=[1], dtype='float32')
-            float_status = paddle.static.data(
-                name="status", shape=[8], dtype='float32')
-            main_program.global_block().append_op(
-                type="alloc_float_status",
-                outputs={"FloatStatus": float_status})
-            main_program.global_block().append_op(
-                type="clear_float_status",
-                inputs={"FloatStatus": float_status},
-                outputs={"FloatStatusOut": float_status})
             c = paddle.fluid.layers.elementwise_div(a, b)
-            out, found_inf = check_finite_and_unscale(
-                [c], scale, float_status=float_status)
-            main_program.global_block().append_op(
-                type="alloc_float_status",
-                outputs={"FloatStatus": float_status})
-            main_program.global_block().append_op(
-                type="clear_float_status",
-                inputs={"FloatStatus": float_status},
-                outputs={"FloatStatusOut": float_status})
+            out, found_inf = check_finite_and_unscale([c], scale)
             d = paddle.fluid.layers.elementwise_add(a, b)
-            out, found_inf = check_finite_and_unscale(
-                [d], scale, float_status=float_status)
+            out, found_inf = check_finite_and_unscale([d], scale)
 
-        return main_program, out, found_inf, float_status
+        return main_program, out, found_inf
 
     def run_prog(self, a, b, scale):
-        main_program, out, found_inf, float_status = self.get_prog()
+        main_program, out, found_inf = self.get_prog()
         place = fluid.NPUPlace(0)
         exe = fluid.Executor(place)
-        out_, founf_inf_, float_status_ = exe.run(
-            main_program,
-            feed={"a": a,
-                  "b": b,
-                  "scale": scale},
-            fetch_list=[out, found_inf, float_status])
-        print(float_status_)
+        out_, founf_inf_ = exe.run(main_program,
+                                   feed={"a": a,
+                                         "b": b,
+                                         "scale": scale},
+                                   fetch_list=[out, found_inf])
         return out_, founf_inf_
 
     def test_not_contains_nan_inf(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
移除check_finite_and_unscale_op_npu中`FloatStatus`的使用，修改NPU check_finite_and_unscale的逻辑。
#### 一、修改前NPU上check_finite原理
1. 反向开始插入`NPUAllocFloatStatus`分配float_status
2. 接着调用`NPUClearFloatStatus`清空float_status
3. 反向结束后，Update调用`check_finite_and_unscale` op时，使用`NPUGetFloatStatus`获取float_status，判断反向计算阶段是否出现nan/inf。

*该方式存在的问题*：
1. pipeline是按照1F1B的方式执行的，在每次Backward阶段，`float_status`都会被清空一次，只有最后一次Backward的`float_status`生效。
2. 在数据并行的模式下，每张卡的`float_status`可能不一致，无法保证数据并行的数据一致性。
3. 混合并行开启`fuse_grad_merge`时，会调用`coalesce_tensor` op，分配内存时，有一段内存是未初始化的，在后续进行grad add和cast阶段，会导致`float_status`判断出nan/inf。但实际上这段未初始化内存最终是不会被使用生效的，所以在程序逻辑上是正确的。

#### 二、修改后NPU上check_finite原理
由于`check_finite_and_unscale` op中，无论grad中是否出现nan/inf，都会进行unscale操作。
1. 基于此，我们在unscale之前调用`NPUAllocFloatStatus`和`NPUClearFloatStatus`分配清空`float_status`
2. 对梯度进行unscale操作。若梯度中存在nan/inf，那么unscale操作会导致`float_status`置位到overflow的状态。
3. 使用`NPUGetFloatStatus`获取float_status，判断梯度中是否出现nan/inf。

*上述问题解决与否*
1. Done. `check_finite_and_unscale`在Update阶段调用，与pipeline调度方式没有关系，判断nan/inf不受影响。
2. Done. 由于修改后判断是梯度中是否存在nan/inf，而非反向op的计算。所以在梯度allreduce完成后，可以保证数据并行的数据一致性。
3. Done. 只检查梯度，所以即使由于fuse_var的初始化部分导致了grad add和cast计算出现nan/inf，但由于没有影响到正常梯度，对最终梯度nan/inf检查没有影响。
