### PR TITLE
[Inference] Replace unordered_map with map to support subgraph stability

### DIFF
--- a/paddle/fluid/framework/ir/subgraph_detector.cc
+++ b/paddle/fluid/framework/ir/subgraph_detector.cc
@@ -117,7 +117,7 @@ void SubgraphDetector::MarkNodesInsideSubGraph() {
 // Use the Union Find(UF) algorithm to find fully connected sub-graphs, if node
 // a's output is node b, that is a and b is in the same sub-graph. The UF
 // algorithm will group them to the same cluster.
-using node_map_t = std::unordered_map<int, Node *>;
+using node_map_t = std::map<int, Node *>;
 // Find the ancestor id of a node.
 int UnionFindGetAncestor(const node_map_t &node_map, size_t id) {
   int tmp = id;
@@ -155,7 +155,7 @@ struct BriefNode {
 // 3. change all the dst's inputs and outputs
 // corresponding inlinks and outlinks to src node.
 // 4. delete all dst's inlinks and outlinks.
-void UnionContractedNodes(const std::unordered_map<int, BriefNode *> &node_map,
+void UnionContractedNodes(const std::map<int, BriefNode *> &node_map,
                           int src_id, int dst_id) {
   // merge the two adjacent nodes into one node.
   BriefNode *src_node = node_map.at(src_id);
@@ -262,7 +262,7 @@ std::vector<std::vector<Node *>> SubgraphDetector::ExtractSubGraphs() {
   std::vector<Node *> marked_nodes;
   //  We use brief_node_map to represent the original graph in order to avoid
   //  changing the original graph.
-  std::unordered_map<int, BriefNode *> brief_node_map;
+  std::map<int, BriefNode *> brief_node_map;
 
   std::unordered_set<int32_t> valid_node_ids;
   for (auto *node : graph_->Nodes()) {

--- a/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
@@ -167,7 +167,7 @@ class FusionGroupPassSumTest(FusionGroupPassTest):
 
         self.append_gradients(tmp_3)
 
-        self.num_fused_ops = 4
+        self.num_fused_ops = 3
         self.fetch_list = [tmp_3, self.grad(tmp_0)]
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
子图检测算法是贪心的，对于遍历到的每一个节点，都会通过union find算法，找出能划分到同一个子图的其它节点；正因为贪心性质，当遍历顺序无法保证时，就无法保证检测出的子图稳定性。

unorderd_map内部可能会rehash，使得顺序无法保证，此处更换为map，保证子图稳定性。