### PR TITLE
fix the crash when input variable is bool type.

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1378,7 +1378,7 @@ def save_inference_model(dirname,
     with program_guard(main_program):
         uniq_target_vars = []
         for i, var in enumerate(target_vars):
-            if isinstance(var, Variable):
+            if isinstance(var, Variable) and var.dtype != paddle.bool:
                 var = layers.scale(
                     var, 1., name="save_infer_model/scale_{}".format(i))
             uniq_target_vars.append(var)

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -192,8 +192,9 @@ def normalize_program(program, feed_vars, fetch_vars):
     with program_guard(program):
         uniq_fetch_vars = []
         for i, var in enumerate(fetch_vars):
-            var = layers.scale(
-                var, 1., name="save_infer_model/scale_{}".format(i))
+            if var.dtype != paddle.bool:
+                var = layers.scale(
+                    var, 1., name="save_infer_model/scale_{}".format(i))
             uniq_fetch_vars.append(var)
         fetch_vars = uniq_fetch_vars
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
scale op不支持bool类型的输入。paddle在保存模型时，会在某些条件下针对某些variable插入缩放值为1的scale op。当该variable的类型为bool时，就会导致崩溃。在pr中，针对bool类型variable，跳过插入scale op操作。 
卡片链接： https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-20041/show?cid=5&from=hi&noticeStatistics=65319290