### PR TITLE
Add linalg.solve op, test=develop

### DIFF
--- a/paddle/fluid/operators/solve_op.cc
+++ b/paddle/fluid/operators/solve_op.cc
@@ -1,0 +1,249 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/solve_op.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "paddle/fluid/framework/ddim.h"
+#ifdef PADDLE_WITH_MKLDNN
+#include "paddle/fluid/platform/mkldnn_helper.h"
+#endif
+
+namespace paddle {
+namespace operators {
+
+using framework::OpKernelType;
+using framework::Tensor;
+
+class SolveOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "Solve");
+    OP_INOUT_CHECK(ctx->HasInput("Y"), "Input", "Y", "Solve");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "Solve");
+
+    auto x_dims = ctx->GetInputDim("X");
+    // auto y_dims = ctx->GetInputDim("Y");
+
+    std::vector<int64_t> x_dims_vec =
+        paddle::framework::vectorize(ctx->GetInputDim("X"));
+    std::vector<int64_t> y_dims_vec =
+        paddle::framework::vectorize(ctx->GetInputDim("Y"));
+
+    auto x_dims_n = x_dims_vec.size();
+    auto y_dims_n = y_dims_vec.size();
+
+    PADDLE_ENFORCE_GT(x_dims_n, 1,
+                      platform::errors::InvalidArgument(
+                          "The input tensor X's dimensions of SolveOp "
+                          "should be larger than 1. But received X's "
+                          "dimensions = %d, X's shape = [%s]",
+                          x_dims_n, x_dims));
+
+    PADDLE_ENFORCE_EQ(x_dims[x_dims_n - 2], x_dims[x_dims_n - 1],
+                      platform::errors::InvalidArgument(
+                          "The inner-most 2 dimensions of Input(X) all should "
+                          "be square matrices "
+                          "But received X's shape[-2] = %d and shape[-1] = %d.",
+                          x_dims[x_dims_n - 2], x_dims[x_dims_n - 1]));
+
+    bool x_broadcasted = false, y_broadcasted = false;
+    bool trans_x = false, trans_y = false;
+    if (x_dims_n == 1) {
+      x_dims_vec.insert(x_dims_vec.begin(), 1);
+      x_dims_n = 2;
+      x_broadcasted = true;
+    }
+
+    if (y_dims_n == 1) {
+      y_dims_vec.push_back(1);
+      y_dims_n = 2;
+      y_broadcasted = true;
+    }
+
+    size_t M, N;
+    if (trans_x) {
+      M = x_dims_vec[x_dims_n - 1];
+    } else {
+      M = x_dims_vec[x_dims_n - 2];
+    }
+    if (trans_y) {
+      N = y_dims_vec[y_dims_n - 2];
+    } else {
+      N = y_dims_vec[y_dims_n - 1];
+    }
+
+    std::vector<int64_t> new_dims;
+    if (x_dims_n >= y_dims_n) {
+      new_dims.assign(x_dims_vec.begin(), x_dims_vec.end() - 2);
+    } else {
+      new_dims.assign(y_dims_vec.begin(), y_dims_vec.end() - 2);
+    }
+    if (!x_broadcasted) {
+      new_dims.push_back(M);
+    }
+    if (!y_broadcasted) {
+      new_dims.push_back(N);
+    }
+    if (x_broadcasted && y_broadcasted) {
+      new_dims.push_back(1);
+    }
+
+    auto out_dims = framework::make_ddim(new_dims);
+    ctx->SetOutputDim("Out", out_dims);
+    ctx->ShareLoD("X", /*->*/ "Out");
+  }
+
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const {
+    framework::LibraryType library = framework::LibraryType::kPlain;
+    framework::DataLayout layout = framework::DataLayout::kAnyLayout;
+    int customized_type_value =
+        framework::OpKernelType::kDefaultCustomizedTypeValue;
+    auto input_data_type = OperatorWithKernel::IndicateVarDataType(ctx, "X");
+#ifdef PADDLE_WITH_MKLDNN
+    if (library == framework::LibraryType::kPlain &&
+        this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      library = framework::LibraryType::kMKLDNN;
+      layout = framework::DataLayout::kMKLDNN;
+
+      if (input_data_type == framework::DataTypeTrait<int8_t>::DataType() ||
+          input_data_type == framework::DataTypeTrait<uint8_t>::DataType()) {
+        customized_type_value = kMULMKLDNNINT8;
+      }
+    }
+#endif
+
+    return framework::OpKernelType(input_data_type, ctx.GetPlace(), layout,
+                                   library, customized_type_value);
+  }
+};
+
+class SolveOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor), The first input tensor of solve op.");
+    AddInput("Y", "(Tensor), The second input tensor of solve op.");
+    AddOutput("Out", "(Tensor), The output tensor of solve op.");
+    AddAttr<bool>("use_mkldnn",
+                  "(bool, default false) Only used in mkldnn kernel")
+        .SetDefault(false);
+    AddAttr<float>(
+        "scale_x",
+        "scale_x to be used for int8 solve input data x. scale_x has the"
+        "same purpose as scale_in in OPs that support quantization."
+        "Only to be used with MKL-DNN INT8")
+        .SetDefault(1.0f);
+    AddAttr<std::vector<float>>(
+        "scale_y",
+        "scale_y to be used for int8 solve input data y. scale_y has the"
+        "same purpose as scale_weights in OPs that support quantization."
+        "Only to be used with MKL-DNN INT8")
+        .SetDefault({1.0f});
+    AddAttr<float>("scale_out",
+                   "scale_out to be used for int8 output data."
+                   "Only used with MKL-DNN INT8")
+        .SetDefault(1.0f);
+    AddAttr<bool>(
+        "force_fp32_output",
+        "(bool, default false) Force quantize kernel output FP32, only "
+        "used in quantized MKL-DNN.")
+        .SetDefault(false);
+    AddComment(R"DOC(
+Solve Operator.
+
+This operator is used to computes the solution of a square system of linear equations with a unique solution for input $X$ and $Y$.
+
+The equation is:
+
+$$Out = X^-1 * Y$$
+
+Both the input $X$ and $Y$ can carry the LoD (Level of Details) information,
+or not. But the output only shares the LoD information with input $X$.
+
+)DOC");
+  }
+};
+
+class SolveOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
+ protected:
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
+      const override {
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
+  }
+};
+
+class SolveGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "solve");
+    OP_INOUT_CHECK(ctx->HasInput("Y"), "Input", "Y", "solve");
+    OP_INOUT_CHECK(ctx->HasInput(framework::GradVarName("Out")), "Input",
+                   "Out@GRAD", "solve");
+    auto x_dims = ctx->GetInputDim("X");
+    auto y_dims = ctx->GetInputDim("Y");
+
+    auto x_grad_name = framework::GradVarName("X");
+    auto y_grad_name = framework::GradVarName("Y");
+
+    if (ctx->HasOutput(x_grad_name)) {
+      ctx->SetOutputDim(x_grad_name, x_dims);
+    }
+    if (ctx->HasOutput(y_grad_name)) {
+      ctx->SetOutputDim(y_grad_name, y_dims);
+    }
+  }
+};
+
+template <typename T>
+class SolveOpGradMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> retv) const override {
+    retv->SetType("solve_grad");
+    retv->SetInput("X", this->Input("X"));
+    retv->SetInput("Y", this->Input("Y"));
+    retv->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    retv->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    retv->SetOutput(framework::GradVarName("Y"), this->InputGrad("Y"));
+    retv->SetAttrMap(this->Attrs());
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(solve, ops::SolveOp, ops::SolveOpMaker,
+                  ops::SolveOpInferVarType,
+                  ops::SolveOpGradMaker<paddle::framework::OpDesc>,
+                  ops::SolveOpGradMaker<paddle::imperative::OpBase>);
+
+REGISTER_OPERATOR(solve_grad, ops::SolveGradOp);
+
+REGISTER_OP_CPU_KERNEL(
+    solve, ops::SolveKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SolveKernel<paddle::platform::CPUDeviceContext, double>);
+REGISTER_OP_CPU_KERNEL(
+    solve_grad, ops::SolveGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SolveGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/solve_op.cu
+++ b/paddle/fluid/operators/solve_op.cu
@@ -1,0 +1,24 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/solve_op.h"
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+REGISTER_OP_CUDA_KERNEL(solve, ops::SolveKernel<plat::CUDADeviceContext, float>,
+                        ops::SolveKernel<plat::CUDADeviceContext, double>);
+
+REGISTER_OP_CUDA_KERNEL(solve_grad,
+                        ops::SolveGradKernel<plat::CUDADeviceContext, float>,
+                        ops::SolveGradKernel<plat::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/solve_op.h
+++ b/paddle/fluid/operators/solve_op.h
@@ -1,0 +1,403 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/operators/dot_op.h"
+#include "paddle/fluid/operators/math/blas.h"
+#include "paddle/fluid/operators/math/math_function.h"
+#include "paddle/fluid/operators/math/matrix_inverse.h"
+#include "paddle/fluid/operators/matmul_v2_op.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+
+constexpr int kMULMKLDNNINT8 = 1;
+
+template <typename DeviceContext, typename T>
+class SolveKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* input = context.Input<framework::Tensor>("X");
+    Tensor tmp_x(input->type());
+    tmp_x.Resize(input->dims());
+    tmp_x.mutable_data<T>(context.GetPlace());
+
+    auto& dev_ctx = context.template device_context<DeviceContext>();
+    math::MatrixInverseFunctor<DeviceContext, T> mat_inv;
+    mat_inv(dev_ctx, *input, &tmp_x);
+
+    const Tensor x_matrix = tmp_x;
+    const Tensor* y = context.Input<Tensor>("Y");
+    const Tensor y_matrix = *y;
+
+    Tensor* z = context.Output<Tensor>("Out");
+    z->mutable_data<T>(context.GetPlace());
+
+    // special case: input likes A(2,3,3) B(2,3)
+    auto x_dim = input->dims();
+    auto y_dim = y->dims();
+    auto x_dim_size = x_dim.size();
+    auto y_dim_size = y_dim.size();
+    bool is_special = false;
+    if (x_dim_size - y_dim_size == 1) {
+      is_special = true;
+      for (int i = 0; i < y_dim_size; i++) {
+        if (x_dim[i] != y_dim[i]) {
+          is_special = false;
+        }
+      }
+    }
+
+    Tensor tmp_y;
+    if (is_special) {  // reshape operation
+      std::vector<int64_t> y_dims_vec = paddle::framework::vectorize(y_dim);
+      y_dims_vec.push_back(1);
+      auto y_new_dims = framework::make_ddim(y_dims_vec);
+      tmp_y.ShareDataWith(*y).Resize(y_new_dims);
+      MatMulFunction<DeviceContext, T>(&x_matrix, &tmp_y, z, false, false,
+                                       context);
+      z->Resize(y_dim);
+    } else {  // normal case
+      PADDLE_ENFORCE_EQ(
+          x_dim[x_dim_size - 1], y_dim[y_dim_size - 2],
+          platform::errors::InvalidArgument(
+              "Matrix X1 with dimension greater than 2 and any matrix Y1,"
+              "the matrix X1's width must be equal with matrix Y1's "
+              "height. But received X's shape = [%s], X1's shape = [%s], X1's "
+              "width = %s; Y's shape = [%s], Y1's shape = [%s], Y1's height = "
+              "%s.",
+              x_dim, x_dim, x_dim[x_dim_size - 1], y_dim, y_dim,
+              y_dim[y_dim_size - 2]));
+      // defined in matmul_v2_op.h
+      MatMulFunction<DeviceContext, T>(&x_matrix, &y_matrix, z, false, false,
+                                       context);
+    }
+  }
+};
+
+template <typename DeviceContext, typename T>
+class SolveGradKernel : public framework::OpKernel<T> {
+ public:
+  void MatMul(const framework::ExecutionContext& context,
+              const framework::Tensor& a, bool trans_a,
+              const framework::Tensor& b, bool trans_b,
+              framework::Tensor* out) const {
+    out->mutable_data<T>(context.GetPlace());
+    auto blas = math::GetBlas<DeviceContext, T>(context);
+    auto mat_dim_a = math::CreateMatrixDescriptor(a.dims(), 0, trans_a);
+    auto mat_dim_b = math::CreateMatrixDescriptor(b.dims(), 0, trans_b);
+    if (a.dims().size() == 3 && b.dims().size() <= 2) {
+      // the transpose_X must be false, if is true, the transpose cost much time
+      if (!trans_a) {
+        mat_dim_a.height_ *= mat_dim_a.batch_size_;
+        mat_dim_a.batch_size_ = 0;
+      }
+    }
+    blas.MatMul(a, mat_dim_a, b, mat_dim_b, static_cast<T>(1), out,
+                static_cast<T>(0));
+  }
+
+  void CalcInputGrad(const framework::ExecutionContext& context,
+                     const framework::Tensor& a, bool trans_a,
+                     bool is_fold_init_dims_a, const framework::Tensor& b,
+                     bool trans_b, bool is_fold_init_dims_b,
+                     framework::Tensor* out) const {
+    if (out == nullptr) return;
+    bool need_combine = (a.dims().size() == 3 || b.dims().size() == 3) &&
+                        out->dims().size() == 2;
+    if (!need_combine) {
+      MatMul(context, a, trans_a, b, trans_b, out);
+    } else {
+      auto& ctx = context.template device_context<DeviceContext>();
+      MatMul(context, is_fold_init_dims_a
+                          ? FoldInitDims(a)
+                          : FoldHeadAndLastDims<DeviceContext, T>(ctx, a),
+             trans_a, is_fold_init_dims_b
+                          ? FoldInitDims(b)
+                          : FoldHeadAndLastDims<DeviceContext, T>(ctx, b),
+             trans_b, out);
+    }
+  }
+  void InvBackwardGrad(const framework::ExecutionContext& ctx,
+                       const framework::Tensor& x_inv,
+                       framework::Tensor* dx) const {
+    Tensor x_inv_grad = *dx;
+    x_inv_grad.mutable_data<T>(ctx.GetPlace());
+    Tensor* dx_matrix = dx;
+    dx_matrix->mutable_data<T>(ctx.GetPlace());
+
+    auto& dev_ctx = ctx.template device_context<DeviceContext>();
+    framework::Tensor tmp_out =
+        ctx.AllocateTmpTensor<T, DeviceContext>(x_inv.dims(), dev_ctx);
+
+    // dx = -(x^-1)'dout(x^-1)'
+    auto blas = math::GetBlas<DeviceContext, T>(ctx);
+    auto mat_dim_a0 = math::CreateMatrixDescriptor(x_inv_grad.dims(), 0, false);
+    auto mat_dim_b0 = math::CreateMatrixDescriptor(x_inv.dims(), 0, true);
+    blas.MatMul(x_inv_grad, mat_dim_a0, x_inv, mat_dim_b0, T(1), &tmp_out,
+                T(0));
+    auto mat_dim_a1 = math::CreateMatrixDescriptor(x_inv.dims(), 0, true);
+    auto mat_dim_b1 = math::CreateMatrixDescriptor(tmp_out.dims(), 0, false);
+    blas.MatMul(x_inv, mat_dim_a1, tmp_out, mat_dim_b1, T(-1), dx_matrix, T(0));
+  }
+
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    bool transpose_x = false;
+    bool transpose_y = false;
+
+    auto* input = ctx.Input<framework::LoDTensor>("X");
+
+    Tensor x_inv(input->type());  // temporary tensor x_inv
+    x_inv.Resize(input->dims());
+    x_inv.mutable_data<T>(ctx.GetPlace());
+    auto& dev_ctx = ctx.template device_context<DeviceContext>();
+
+    math::MatrixInverseFunctor<DeviceContext, T> mat_inv;
+    mat_inv(dev_ctx, *input, &x_inv);  // inverse operation for input X
+    auto x = static_cast<const Tensor&>(x_inv);
+
+    auto tmp_y = *ctx.Input<framework::Tensor>("Y");
+
+    // special operation for input y
+    // special case: input likes A(2,3,3) B(2,3)
+    auto x_dim = input->dims();
+    auto y_dim = tmp_y.dims();
+    auto x_dim_size = x_dim.size();
+    auto y_dim_size = y_dim.size();
+    bool is_special = false;
+    if (x_dim_size - y_dim_size == 1) {
+      is_special = true;
+      for (int i = 0; i < y_dim_size; i++) {
+        if (x_dim[i] != y_dim[i]) {
+          is_special = false;
+        }
+      }
+    }
+    Tensor y;
+    if (is_special) {  // reshape
+      std::vector<int64_t> y_dims_vec = paddle::framework::vectorize(y_dim);
+      y_dims_vec.push_back(1);
+      auto y_new_dims = framework::make_ddim(y_dims_vec);
+      y.ShareDataWith(tmp_y).Resize(y_new_dims);
+    } else {
+      y.ShareDataWith(tmp_y);
+    }
+
+    auto dout = *ctx.Input<framework::Tensor>(framework::GradVarName("Out"));
+    framework::Tensor y_conj(y.type());
+    framework::Tensor x_conj(y.type());
+
+    // get dims
+    std::vector<std::int64_t> x_dims = vectorize(x.dims());
+    std::vector<std::int64_t> y_dims = vectorize(y.dims());
+    std::vector<std::int64_t> dout_dims = vectorize(dout.dims());
+
+    int x_ndim = x_dims.size();
+    int y_ndim = y_dims.size();
+    int ndim = dout_dims.size();
+
+    auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
+    auto* dy = ctx.Output<Tensor>(framework::GradVarName("Y"));
+
+    // Case1 : x's or y's dim = 1
+    if (x_ndim == 1 && y_ndim == 1) {
+      if (dx) dx->mutable_data<T>(ctx.GetPlace());
+      if (dy) dy->mutable_data<T>(ctx.GetPlace());
+      if (dout.numel() == 1) {
+        DotGradFunction<DeviceContext, T>()(&x, &y, &dout, dx, dy, ctx);
+        InvBackwardGrad(ctx, x_inv, dx);
+        if (is_special) {
+          dy->Resize(y_dim);
+        }
+        return;
+      }
+    }
+
+    bool is_broadcast = true;
+    if (x_ndim <= 2 || y_ndim <= 2) {
+      is_broadcast = false;
+    } else if (x_ndim != y_ndim) {
+      is_broadcast = true;
+    } else {
+      is_broadcast = !std::equal(x_dims.cbegin(), x_dims.cbegin() + x_ndim - 2,
+                                 y_dims.cbegin());
+    }
+    // Case2: no broadcast or no batch size, it aims to speed and it is same as
+    // matmul in old version.
+    if (!is_broadcast) {
+      ReshapeXYOutIntoMatrixSequence(&x, &y, &dout, transpose_x, transpose_y);
+      framework::DDim dx_dims;
+      if (dx) {
+        dx_dims = dx->dims();
+        if (dx_dims != x.dims()) {
+          dx->Resize(x.dims());
+        }
+        // for complex
+        ConjHelper<DeviceContext, T> conj_helper(ctx);
+        conj_helper(y, y_conj);
+      }
+      framework::DDim dy_dims;
+      if (dy) {
+        dy_dims = dy->dims();
+        if (dy_dims != y.dims()) {
+          dy->Resize(y.dims());
+        }
+        // for complex
+        ConjHelper<DeviceContext, T> conj_helper(ctx);
+        conj_helper(x, x_conj);
+      }
+      if (transpose_x && transpose_y) {
+        CalcInputGrad(ctx, y_conj, true, true, dout, true, false, dx);
+        CalcInputGrad(ctx, dout, true, true, x_conj, true, false, dy);
+      } else if (transpose_x) {
+        CalcInputGrad(ctx, y_conj, false, false, dout, true, false, dx);
+        CalcInputGrad(ctx, x_conj, false, false, dout, false, true, dy);
+      } else if (transpose_y) {
+        CalcInputGrad(ctx, dout, false, false, y_conj, false, true, dx);
+        CalcInputGrad(ctx, dout, true, true, x_conj, false, true, dy);
+      } else {
+        CalcInputGrad(ctx, dout, false, false, y_conj, true, false, dx);
+        if (dx) InvBackwardGrad(ctx, x_inv, dx);
+        CalcInputGrad(ctx, x_conj, true, true, dout, false, true, dy);
+      }
+
+      if (dx) {
+        if (dx_dims != x.dims()) {
+          dx->Resize(dx_dims);
+        }
+      }
+      if (dy) {
+        if (dy_dims != y.dims()) {
+          dy->Resize(dy_dims);
+
+          if (is_special) {
+            dy->Resize(y_dim);
+          }
+        }
+      }
+    } else {
+      // Case3: broadcast. It need cost much time to reduce sum for the
+      // broadcast and wastes the memory.
+      // So we should avoid the case in reality.
+      VLOG(3) << "It need cost much time to reduce sum for the broadcast and "
+                 "wastes the memory. So we should avoid the case in reality";
+      Tensor dx_help, dy_help;
+
+      ConjHelper<DeviceContext, T> conj_helper(ctx);
+      conj_helper(x, x_conj);
+      conj_helper(y, y_conj);
+      if (transpose_x) {
+        if (transpose_y) {
+          // X'Y': dA = Y'G', dB = G'X'
+          if (dx)
+            MatMulFunction<DeviceContext, T>(&y_conj, &dout, y_dims, dout_dims,
+                                             &dx_help, true, true, ctx);
+          if (dy)
+            MatMulFunction<DeviceContext, T>(&dout, &x_conj, dout_dims, x_dims,
+                                             &dy_help, true, true, ctx);
+        } else {
+          // X'Y: dX = YG', dY = XG
+          if (dx)
+            MatMulFunction<DeviceContext, T>(&y_conj, &dout, y_dims, dout_dims,
+                                             &dx_help, false, true, ctx);
+          if (dy)
+            MatMulFunction<DeviceContext, T>(&x_conj, &dout, x_dims, dout_dims,
+                                             &dy_help, false, false, ctx);
+        }
+      } else {
+        if (transpose_y) {
+          // XY': dX = GY, dY = G'X
+          if (dx)
+            MatMulFunction<DeviceContext, T>(&dout, &y_conj, dout_dims, y_dims,
+                                             &dx_help, false, false, ctx);
+          if (dy)
+            MatMulFunction<DeviceContext, T>(&dout, &x_conj, dout_dims, x_dims,
+                                             &dy_help, true, false, ctx);
+        } else {
+          // XY: dX = GY', dY = X'G
+          if (dx) {
+            MatMulFunction<DeviceContext, T>(&dout, &y_conj, dout_dims, y_dims,
+                                             &dx_help, false, true, ctx);
+            InvBackwardGrad(ctx, x_inv, dx);
+          }
+          if (dy) {
+            MatMulFunction<DeviceContext, T>(&x_conj, &dout, x_dims, dout_dims,
+                                             &dy_help, true, false, ctx);
+            if (is_special) {
+              dy->Resize(y_dim);
+            }
+          }
+        }
+      }
+
+      // get help dims
+      const std::vector<std::int64_t> dx_help_dims = vectorize(dx_help.dims());
+      const std::vector<std::int64_t> dy_help_dims = vectorize(dy_help.dims());
+
+      std::vector<std::int64_t> dx_broadcast_dims(ndim);
+      std::vector<std::int64_t> dy_broadcast_dims(ndim);
+
+      std::fill(dx_broadcast_dims.data(),
+                dx_broadcast_dims.data() + ndim - x_ndim, 1);
+      std::fill(dy_broadcast_dims.data(),
+                dy_broadcast_dims.data() + ndim - y_ndim, 1);
+      std::copy(x_dims.data(), x_dims.data() + x_ndim,
+                dx_broadcast_dims.data() + ndim - x_ndim);
+      std::copy(y_dims.data(), y_dims.data() + y_ndim,
+                dy_broadcast_dims.data() + ndim - y_ndim);
+
+      std::vector<int> dx_reduce_dims;
+      std::vector<int> dy_reduce_dims;
+      for (int idx = 0; idx <= ndim - 3; idx++) {
+        if (dx_help_dims[idx] != 1 && dx_broadcast_dims[idx] == 1) {
+          dx_reduce_dims.push_back(idx);
+        }
+        if (dy_help_dims[idx] != 1 && dy_broadcast_dims[idx] == 1) {
+          dy_reduce_dims.push_back(idx);
+        }
+      }
+      // reduce sum to get grad by ReduceSum
+      if (dx) {
+        if (dx_reduce_dims.empty()) {
+          *dx = std::move(dx_help);
+        } else {
+          ReduceSumForMatmulGrad<DeviceContext, T>(&dx_help, dx, dx_reduce_dims,
+                                                   ctx);
+        }
+        dx->Resize(x.dims());
+        InvBackwardGrad(ctx, x_inv, dx);
+      }
+      if (dy) {
+        if (dy_reduce_dims.empty()) {
+          *dy = std::move(dy_help);
+        } else {
+          ReduceSumForMatmulGrad<DeviceContext, T>(&dy_help, dy, dy_reduce_dims,
+                                                   ctx);
+        }
+        dy->Resize(y.dims());
+        if (is_special) {
+          dy->Resize(y_dim);
+        }
+      }
+    }
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/fluid/tests/unittests/test_solve_op.py
+++ b/python/paddle/fluid/tests/unittests/test_solve_op.py
@@ -1,0 +1,313 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.w
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle
+import paddle.fluid.core as core
+import sys
+sys.path.append("..")
+from op_test import OpTest
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
+
+
+class TestSolveOp(OpTest):
+    def config(self):
+        self.input_x_matrix_shape = [30, 30]
+        self.input_y_matrix_shape = [30, 10]
+        self.dtype = "float64"
+
+    def setUp(self):
+        paddle.enable_static()
+        self.config()
+        self.op_type = "solve"
+
+        np.random.seed(2021)
+        self.inputs = {
+            'X': np.random.random(self.input_x_matrix_shape).astype(self.dtype),
+            'Y': np.random.random(self.input_y_matrix_shape).astype(self.dtype)
+        }
+        self.outputs = {
+            'Out': np.linalg.solve(self.inputs['X'], self.inputs['Y'])
+        }
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad_normal(self):
+        self.check_grad(['X', 'Y'], 'Out')
+
+    def test_check_grad_ingore_x(self):
+        self.check_grad(['Y'], 'Out', no_grad_set=set("X"))
+
+    def test_check_grad_ingore_y(self):
+        self.check_grad(['X'], 'Out', no_grad_set=set('Y'))
+
+
+class TestSolveOpBatched_case1(OpTest):
+    def setUp(self):
+        self.op_type = "solve"
+        self.dtype = "float64"
+        np.random.seed(2021)
+        self.inputs = {
+            'X': np.random.random((3, 20, 20)).astype(self.dtype),
+            'Y': np.random.random((3, 20, 10)).astype(self.dtype)
+        }
+        result = np.linalg.solve(self.inputs['X'], self.inputs['Y'])
+        self.outputs = {'Out': result}
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad_normal(self):
+        self.check_grad(['X', 'Y'], 'Out')
+
+    def test_check_grad_ingore_x(self):
+        self.check_grad(['Y'], 'Out', no_grad_set=set('X'))
+
+    def test_check_grad_ignore_y(self):
+        self.check_grad(['X'], 'Out', no_grad_set=set('Y'))
+
+
+class TestSolveOpBatched_case2(OpTest):
+    def setUp(self):
+        self.op_type = "solve"
+        self.dtype = "float64"
+        self.init_dtype_type()
+        np.random.seed(2021)
+        self.inputs = {
+            'X': np.random.random((2, 3, 8, 8)).astype(self.dtype),
+            'Y': np.random.random((2, 3, 8, 7)).astype(self.dtype)
+        }
+        result = np.linalg.solve(self.inputs['X'], self.inputs['Y'])
+        self.outputs = {'Out': result}
+
+    def init_dtype_type(self):
+        pass
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad_normal(self):
+        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.008)
+
+    def test_check_grad_ingore_x(self):
+        self.check_grad(['Y'], 'Out', no_grad_set=set('X'))
+
+    def test_check_grad_ignore_y(self):
+        self.check_grad(
+            ['X'], 'Out', max_relative_error=0.008, no_grad_set=set('Y'))
+
+
+class TestSolveOpBatched_case3(OpTest):
+    def setUp(self):
+        self.op_type = "solve"
+        self.dtype = "float64"
+        np.random.seed(2021)
+        self.inputs = {
+            'X': np.random.random((2, 2, 2, 5, 5)).astype(self.dtype),
+            'Y': np.random.random((2, 2, 2, 5, 8)).astype(self.dtype)
+        }
+        result = np.linalg.solve(self.inputs['X'], self.inputs['Y'])
+        self.outputs = {'Out': result}
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad_normal(self):
+        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.6)
+
+    def test_check_grad_ingore_x(self):
+        self.check_grad(
+            ['Y'], 'Out', max_relative_error=0.1, no_grad_set=set('X'))
+
+    def test_check_grad_ignore_y(self):
+        self.check_grad(
+            ['X'], 'Out', max_relative_error=0.6, no_grad_set=set('Y'))
+
+
+class TestSolveOpError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of solve_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            y1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, paddle.linalg.solve, x1, y1)
+
+            # The data type of input must be float32 or float64.        
+            x2 = fluid.data(name="x2", shape=[30, 30], dtype="bool")
+            y2 = fluid.data(name="y2", shape=[30, 10], dtype="bool")
+            self.assertRaises(TypeError, paddle.linalg.solve, x2, y2)
+
+            x3 = fluid.data(name="x3", shape=[30, 30], dtype="int32")
+            y3 = fluid.data(name="y3", shape=[30, 10], dtype="int32")
+            self.assertRaises(TypeError, paddle.linalg.solve, x3, y3)
+
+            x4 = fluid.data(name="x4", shape=[30, 30], dtype="int64")
+            y4 = fluid.data(name="y4", shape=[30, 10], dtype="int64")
+            self.assertRaises(TypeError, paddle.linalg.solve, x4, y4)
+
+            x5 = fluid.data(name="x5", shape=[30, 30], dtype="float16")
+            y5 = fluid.data(name="y5", shape=[30, 10], dtype="float16")
+            self.assertRaises(TypeError, paddle.linalg.solve, x5, y5)
+
+            # The number of dimensions of input must be >= 2.
+            x6 = fluid.data(name="x6", shape=[30], dtype="float64")
+            y6 = fluid.data(name="y6", shape=[30], dtype="float64")
+            self.assertRaises(ValueError, paddle.linalg.solve, x6, y6)
+
+            # The inner-most 2 dimensions of input'X should be equal to each other
+            x7 = fluid.data(name="x7", shape=[2, 3, 4], dtype="float64")
+            y7 = fluid.data(name="y7", shape=[2, 4, 3], dtype="float64")
+            self.assertRaises(ValueError, paddle.linalg.solve, x7, y7)
+
+
+class TestSolveOpAPI(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(2021)
+        self.place = [paddle.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            self.place.append(paddle.CUDAPlace(0))
+
+    def check_static_result(self, place):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            paddle_input_x = fluid.data(
+                name="input_x", shape=[20, 20], dtype="float64")
+            paddle_input_y = fluid.data(
+                name="input_y", shape=[20, 4], dtype="float64")
+            paddle_result = paddle.linalg.solve(paddle_input_x, paddle_input_y)
+
+            np_input_x = np.random.random([20, 20]).astype("float64")
+            np_input_y = np.random.random([20, 4]).astype("float64")
+
+            np_result = np.linalg.solve(np_input_x, np_input_y)
+
+            exe = fluid.Executor(place)
+            fetches = exe.run(
+                fluid.default_main_program(),
+                feed={"input_x": np_input_x,
+                      "input_y": np_input_y},
+                fetch_list=[paddle_result])
+            self.assertTrue(
+                np.allclose(fetches[0], np.linalg.solve(np_input_x,
+                                                        np_input_y)))
+
+    def test_static(self):
+        for place in self.place:
+            self.check_static_result(place=place)
+
+    def test_dygraph(self):
+        def run(place):
+            paddle.disable_static(place)
+            np.random.seed(2021)
+            input_x_np = np.random.random([30, 30]).astype("float64")
+            input_y_np = np.random.random([30, 10]).astype("float64")
+
+            tensor_input_x = paddle.to_tensor(input_x_np)
+            tensor_input_y = paddle.to_tensor(input_y_np)
+
+            numpy_output = np.linalg.solve(input_x_np, input_y_np)
+            paddle_output = paddle.linalg.solve(tensor_input_x, tensor_input_y)
+            self.assertEqual(
+                np.allclose(numpy_output, paddle_output.numpy()), True)
+            self.assertEqual(numpy_output.shape, paddle_output.numpy().shape)
+            paddle.enable_static()
+
+        for place in self.place:
+            run(place)
+
+
+class TestSolveOpSingularAPI(unittest.TestCase):
+    # Singular matrix is ​​not invertible
+    def setUp(self):
+        self.places = [fluid.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            self.places.append(fluid.CUDAPlace(0))
+
+    def check_static_result(self, place):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            x = fluid.data(name="x", shape=[4, 4], dtype="float64")
+            y = fluid.data(name="y", shape=[4, 4], dtype="float64")
+
+            result = paddle.linalg.solve(x, y)
+
+            input_x_np = np.ones([4, 4]).astype("float64")
+            input_y_np = np.ones([4, 4]).astype("float64")
+
+            exe = fluid.Executor(place)
+            try:
+                fetches = exe.run(fluid.default_main_program(),
+                                  feed={"x": input_x_np,
+                                        "y": input_y_np},
+                                  fetch_list=[result])
+            except RuntimeError as ex:
+                print("The mat is singular")
+                pass
+            except ValueError as ex:
+                print("The mat is singular")
+                pass
+
+    def test_static(self):
+        for place in self.places:
+            paddle.enable_static()
+            self.check_static_result(place=place)
+
+    def test_dygraph(self):
+        for place in self.places:
+            with fluid.dygraph.guard(place):
+                input_x_np = np.ones([4, 4]).astype("float64")
+                input_y_np = np.ones([4, 4]).astype("float64")
+                input_x = fluid.dygraph.to_variable(input_x_np)
+                input_y = fluid.dygraph.to_variable(input_y_np)
+
+                try:
+                    result = paddle.linalg.solve(input_x, input_y)
+                except RuntimeError as ex:
+                    print("The mat is singular")
+                    pass
+                except ValueError as ex:
+                    print("The mat is singular")
+                    pass
+
+
+@unittest.skipIf(not core.is_compiled_with_cuda(),
+                 "core is not compiled with CUDA")
+class TestFP64SolveOp1(TestSolveOp):
+    def init_dtype_type(self):
+        self.dtype = np.float64
+
+    def test_check_output(self):
+        place = core.CUDAPlace(0)
+        self.check_output_with_place(place)
+
+    def test_check_grad_normal(self):
+        place = core.CUDAPlace(0)
+        self.check_grad_with_place(place, ['X', 'Y'], 'Out')
+
+    def test_check_grad_ingore_x(self):
+        place = core.CUDAPlace(0)
+        self.check_grad_with_place(place, ['Y'], 'Out', no_grad_set=set("X"))
+
+    def test_check_grad_ingore_y(self):
+        place = core.CUDAPlace(0)
+        self.check_grad_with_place(place, ['X'], 'Out', no_grad_set=set('Y'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -65,6 +65,7 @@ NEED_TO_FIX_OP_LIST = [
     'rank_loss',
     'sequence_conv',
     'smooth_l1_loss',
-    'spectral_norm'
+    'spectral_norm',
+    'solve'
 ]
 # yapf: enable

--- a/python/paddle/fluid/tests/unittests/white_list/op_threshold_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_threshold_white_list.py
@@ -47,6 +47,7 @@ NEED_FIX_FP64_CHECK_GRAD_THRESHOLD_OP_LIST = [
     'rnn', \
     'lgamma', \
     'matrix_power', \
+    'solve',\
 ]
 
 NEED_FIX_FP64_CHECK_OUTPUT_THRESHOLD_OP_LIST = ['bilinear_interp',\

--- a/python/paddle/linalg.py
+++ b/python/paddle/linalg.py
@@ -22,6 +22,6 @@ __all__ = [
     'cholesky',  #noqa
     'norm',
     'inv',
-    'matrix_power'
+    'matrix_power',
     'solve'
 ]

--- a/python/paddle/linalg.py
+++ b/python/paddle/linalg.py
@@ -15,6 +15,7 @@
 from .tensor.linalg import cholesky  # noqa: F401
 from .tensor.linalg import norm  # noqa: F401
 from .tensor.linalg import matrix_power  # noqa: F401
+from .tensor.linalg import solve  # noqa: F401
 from .tensor import inverse as inv  # noqa: F401
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     'norm',
     'inv',
     'matrix_power'
+    'solve'
 ]

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -45,6 +45,7 @@ from .linalg import bmm  # noqa: F401
 from .linalg import histogram  # noqa: F401
 from .linalg import mv  # noqa: F401
 from .linalg import matrix_power  # noqa: F401
+from .linalg import solve  # noqa: F401
 from .logic import equal  # noqa: F401
 from .logic import greater_equal  # noqa: F401
 from .logic import greater_than  # noqa: F401
@@ -371,6 +372,7 @@ tensor_method_func  = [ #noqa
            'bitwise_xor',
            'bitwise_not',
            'broadcast_tensors',
+           'solve',
 ]
 
 #this list used in math_op_patch.py for magic_method bind

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -1010,8 +1010,9 @@ def matrix_power(x, n, name=None):
         inputs={'X': x},
         outputs={'Out': out},
         attrs={'n': n})
+    return out
 
-        
+
 def solve(x, y, name=None):
     """
     To computes the solution of a square system of linear equations with a unique solution for input 'X' and 'Y'.

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -947,7 +947,7 @@ def matrix_power(x, n, name=None):
     r"""
     Computes the n-th power of a square matrix or a batch of square matrices.
 
-    Let :math:`X` be a sqaure matrix or a batch of square matrices, :math:`n` be
+    Let :math: `X` be a sqaure matrix or a batch of square matrices, :math:`n` be
     an exponent, the equation should be:
 
     .. math::
@@ -1015,18 +1015,14 @@ def matrix_power(x, n, name=None):
 
 def solve(x, y, name=None):
     """
-    To computes the solution of a square system of linear equations with a unique solution for input 'X' and 'Y'.
-    `solve` follows the complete broadcast rules,
-    and its behavior is consistent with `torch.linalg.solve`.
-    
-    The equation is:
+    Computes the solution of a square system of linear equations with a unique solution for input 'X' and 'Y'.
+
+    Let :math: `X` be a sqaure matrix or a batch of square matrices, 
+    this system of linear equations has one solution if and only if input 'X' is invertible. 
+
+    the equation should be:
     $$Out = X^-1 * Y$$
     
-    This system of linear equations has one solution if and only if input 'X' is invertible. 
-    This function assumes that 'X' is invertible.
-
-    The input tensor X's dimensions should be larger than 1 and the inner-most 2 dimensions all should be square matrices.
-
     Also see comments of `matmul_v2` for more details about * operation.
 
     Args:


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs 

### Describe
This PR supports to computes the solution of a square system of linear equations in Paddle. One may call paddle.linalg.solve or paddle.solve to use it.

An example is listed below, which is a python3 script:

```python
# a square system of linear equations:
# 2*X0 + X1 = 9
# X0 + 2*X1 = 8
        
import paddle
import numpy as np
       
np_x = np.array([[3, 1],[1, 2]])
np_y = np.array([9, 8])
x = paddle.to_tensor(np_x, dtype="float64", stop_gradient=False)
y = paddle.to_tensor(np_y, dtype="float64", stop_gradient=False)
out = paddle.linalg.solve(x, y)
        
# out
# Tensor(shape=[2], dtype=float64, place=CUDAPlace(0), stop_gradient=False,
# [2.00000000, 3.        ])
```
