### PR TITLE
[NPU] Support npu op (1)priorbox

### DIFF
--- a/paddle/fluid/operators/detection/CMakeLists.txt
+++ b/paddle/fluid/operators/detection/CMakeLists.txt
@@ -20,7 +20,7 @@ detection_library(box_coder_op SRCS box_coder_op.cc box_coder_op.cu)
 detection_library(iou_similarity_op SRCS iou_similarity_op.cc
 iou_similarity_op.cu)
 detection_library(mine_hard_examples_op SRCS mine_hard_examples_op.cc)
-detection_library(prior_box_op SRCS prior_box_op.cc prior_box_op.cu)
+detection_library(prior_box_op SRCS prior_box_op.cc prior_box_op.cu prior_box_op_npu.cc)
 detection_library(density_prior_box_op SRCS density_prior_box_op.cc density_prior_box_op.cu)
 detection_library(anchor_generator_op SRCS anchor_generator_op.cc
 anchor_generator_op.cu)

--- a/paddle/fluid/operators/detection/prior_box_op_npu.cc
+++ b/paddle/fluid/operators/detection/prior_box_op_npu.cc
@@ -1,0 +1,188 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/detection/prior_box_op.h"
+
+#include <memory>
+#include <string>
+
+#include "paddle/fluid/framework/ddim.h"
+#include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+template <typename T>
+void PrintTensor(const paddle::framework::Tensor& src,
+                 const paddle::framework::ExecutionContext& ctx) {
+  std::vector<T> vec(src.numel());
+  VLOG(3) << "======= printing ======== ";
+  TensorToVector(src, ctx.device_context(), &vec);
+  for (int i = 0; i < 10; ++i) {  // static_cast<int>(vec.size());
+    VLOG(3) << "vec[" << i << "] : " << vec[i];
+  }
+}
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+template <typename DeviceContext, typename T>
+class PriorBoxNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    VLOG(3) << "======== PriorBoxNPUKernel begin ========";
+    auto* input = ctx.Input<paddle::framework::Tensor>("Input");
+    auto* image = ctx.Input<paddle::framework::Tensor>("Image");
+
+    VLOG(3) << "======== input dims  ========" << input->dims();
+    VLOG(3) << "======== image dims  ========" << image->dims();
+
+    auto* boxes = ctx.Output<paddle::framework::Tensor>("Boxes");
+    auto place = ctx.GetPlace();
+    boxes->mutable_data<T>(place);
+
+    auto* vars = ctx.Output<paddle::framework::Tensor>("Variances");
+    vars->mutable_data<T>(place);
+
+    // Tensor tmp_out(input->type());  // Temporary Tensor
+    // tmp_out.Resize(framework::make_ddim({1, 2, 32*32*12*4, 1}));
+    // tmp_out.mutable_data<T>(place);
+
+    VLOG(3) << "======== vars output dims  ========" << vars->dims();
+    VLOG(3) << "======== PriorBoxNPUKernel 1 ========";
+    auto min_sizes = ctx.Attr<std::vector<float>>("min_sizes");  // required
+    auto max_sizes = ctx.Attr<std::vector<float>>("max_sizes");  // required
+    auto input_aspect_ratio =
+        ctx.Attr<std::vector<float>>("aspect_ratios");  // required
+
+    VLOG(3) << "======== PriorBoxNPUKernel 2 ========";
+    // optional
+    auto variances = ctx.Attr<std::vector<float>>("variances");
+    auto flip = ctx.Attr<bool>("flip");
+    auto clip = ctx.Attr<bool>("clip");
+    // auto min_max_aspect_ratios_order =
+    //     ctx.Attr<bool>("min_max_aspect_ratios_order");
+
+    VLOG(3) << "======== PriorBoxNPUKernel 3 ========";
+    std::vector<float> aspect_ratios;
+    ExpandAspectRatios(input_aspect_ratio, flip, &aspect_ratios);
+
+    auto img_h = static_cast<int>(image->dims()[2]);
+    auto img_w = static_cast<int>(image->dims()[3]);
+
+    auto step_w = static_cast<T>(ctx.Attr<float>("step_w"));
+    auto step_h = static_cast<T>(ctx.Attr<float>("step_h"));
+    auto offset = static_cast<T>(ctx.Attr<float>("offset"));
+
+    VLOG(3) << "======== PriorBoxNPUKernel 4 ========";
+
+    auto feature_width = input->dims()[3];
+    auto feature_height = input->dims()[2];
+
+    T step_width, step_height;
+    if (step_w == 0 || step_h == 0) {
+      step_width = static_cast<T>(img_w) / feature_width;
+      step_height = static_cast<T>(img_h) / feature_height;
+    } else {
+      step_width = step_w;
+      step_height = step_h;
+    }
+
+    int num_priors = aspect_ratios.size() * min_sizes.size();  // aspect_ratios
+    if (max_sizes.size() > 0) {
+      num_priors += max_sizes.size();
+    }
+    VLOG(3) << "======== num_priors size() ======== " << num_priors;
+
+    Tensor tmp_out(input->type());  // Temporary Tensor
+    tmp_out.Resize(framework::make_ddim(
+        {1, 2, feature_width * feature_height * num_priors * 4, 1}));
+    tmp_out.mutable_data<T>(place);
+
+    VLOG(3) << "======== PriorBoxNPUKernel 5 ========";
+    VLOG(3) << "======== boxes output:" << boxes->dims();
+    VLOG(3) << "======== PriorBoxNPUKernel 6 ========";
+
+    VLOG(3) << "======== input h " << input->dims()[2];
+    VLOG(3) << "======== input w " << input->dims()[3];
+
+    NpuOpRunner runner;
+    runner.SetType("PriorBox")
+        .AddInput(*input)
+        .AddInput(*image)
+        .AddOutput(tmp_out)
+        .AddAttr("min_size", std::vector<float>{min_sizes})
+        .AddAttr("max_size", std::vector<float>{max_sizes})
+        .AddAttr("aspect_ratio",
+                 std::vector<float>{aspect_ratios})  // aspect_ratios
+        .AddAttr("img_h", std::vector<int>{img_h})
+        .AddAttr("img_w", std::vector<int>{img_w})
+        .AddAttr("step_h", std::vector<float>{step_height})
+        .AddAttr("step_w", std::vector<float>{step_width})
+        .AddAttr("flip", std::vector<bool>{flip})
+        .AddAttr("clip", std::vector<bool>{clip})
+        .AddAttr("offset", std::vector<float>{offset})
+        .AddAttr("variance", std::vector<float>{variances});
+
+    // const auto& runner = NpuOpRunner("PriorBox", {*input, *image}, {*boxes},
+    // {attr_input});
+
+    VLOG(3) << "======== PriorBoxNPUKernel 7 ========";
+    auto stream =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+    VLOG(3) << "======== PriorBoxNPUKernel 8 ========";
+    runner.Run(stream);
+
+    tmp_out.Resize(framework::make_ddim(
+        {2, feature_width, feature_height, num_priors, 4}));
+
+    VLOG(3) << "========== tmp_out Slice(0,1).dims() "
+            << tmp_out.Slice(0, 1).dims();
+    VLOG(3) << "========== tmp_out Slice(1,2).dims() "
+            << tmp_out.Slice(1, 2).dims();
+
+    paddle::framework::TensorCopy(
+        tmp_out.Slice(0, 1), place,
+        ctx.template device_context<platform::DeviceContext>(), boxes);
+    ctx.template device_context<paddle::platform::NPUDeviceContext>().Wait();
+
+    paddle::framework::TensorCopy(
+        tmp_out.Slice(1, 2), place,
+        ctx.template device_context<platform::DeviceContext>(), vars);
+    ctx.template device_context<paddle::platform::NPUDeviceContext>().Wait();
+
+    boxes->Resize(boxes->dims());
+    vars->Resize(vars->dims());
+
+    VLOG(3) << "-------------------------打印 boxes 的值 前 10 个 "
+               "=======================";
+    PrintTensor<T>(*boxes, ctx);
+    VLOG(3) << "-------------------------打印 vars 的值 前 10 个 "
+               "=======================";
+    PrintTensor<T>(*vars, ctx);
+
+    // boxes->Resize(boxes->dims());
+    // vars->Resize(vars->dims());
+    VLOG(3) << "======== PriorBoxNPUKernel end ========";
+    VLOG(3) << "======== boxes output:" << boxes->dims();
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OP_NPU_KERNEL(
+    prior_box,
+    ops::PriorBoxNPUKernel<paddle::platform::NPUDeviceContext, float>);

--- a/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
@@ -1,0 +1,204 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import sys
+import math
+import paddle
+import paddle.fluid as fluid
+sys.path.append("..")
+from op_test import OpTest
+
+paddle.enable_static()
+
+
+class TestPriorBoxOp(OpTest):
+    def set_data(self):
+        self.init_test_params()
+        self.init_test_input()
+        self.init_test_output()
+        self.inputs = {'Input': self.input, 'Image': self.image}
+
+        self.attrs = {
+            'min_sizes': self.min_sizes,
+            'aspect_ratios': self.aspect_ratios,
+            'variances': self.variances,
+            'flip': self.flip,
+            'clip': self.clip,
+            'min_max_aspect_ratios_order': self.min_max_aspect_ratios_order,
+            'step_w': self.step_w,
+            'step_h': self.step_h,
+            'offset': self.offset
+        }
+        if len(self.max_sizes) > 0:
+            self.attrs['max_sizes'] = self.max_sizes
+
+        self.outputs = {'Boxes': self.out_boxes, 'Variances': self.out_var}
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def setUp(self):
+        self.__class__.use_npu = True
+        self.place = paddle.NPUPlace(0)
+        self.op_type = "prior_box"
+        self.set_data()
+
+    def set_max_sizes(self):
+        max_sizes = [5, 10]
+        self.max_sizes = np.array(max_sizes).astype('float32').tolist()
+
+    def set_min_max_aspect_ratios_order(self):
+        self.min_max_aspect_ratios_order = False
+
+    def init_test_params(self):
+        self.layer_w = 32
+        self.layer_h = 32
+
+        self.image_w = 40
+        self.image_h = 40
+
+        self.step_w = float(self.image_w) / float(self.layer_w)
+        self.step_h = float(self.image_h) / float(self.layer_h)
+
+        self.input_channels = 2
+        self.image_channels = 3
+        self.batch_size = 10
+
+        self.min_sizes = [2, 4]
+        self.min_sizes = np.array(self.min_sizes).astype('float32').tolist()
+        self.set_max_sizes()
+        self.aspect_ratios = [2.0, 3.0]
+        self.flip = True
+        self.set_min_max_aspect_ratios_order()
+        self.real_aspect_ratios = [1, 2.0, 1.0 / 2.0, 3.0, 1.0 / 3.0]
+        self.aspect_ratios = np.array(
+            self.aspect_ratios, dtype=np.float).flatten()
+        self.variances = [0.1, 0.1, 0.2, 0.2]
+        self.variances = np.array(self.variances, dtype=np.float).flatten()
+
+        self.clip = True
+        self.num_priors = len(self.real_aspect_ratios) * len(self.min_sizes)
+        if len(self.max_sizes) > 0:
+            self.num_priors += len(self.max_sizes)
+        self.offset = 0.5
+
+    def init_test_input(self):
+        self.image = np.random.random(
+            (self.batch_size, self.image_channels, self.image_w,
+             self.image_h)).astype('float32')
+
+        self.input = np.random.random(
+            (self.batch_size, self.input_channels, self.layer_w,
+             self.layer_h)).astype('float32')
+
+    def init_test_output(self):
+        out_dim = (self.layer_h, self.layer_w, self.num_priors, 4)
+        out_boxes = np.zeros(out_dim).astype('float32')
+        out_var = np.zeros(out_dim).astype('float32')
+
+        idx = 0
+        for h in range(self.layer_h):
+            for w in range(self.layer_w):
+                c_x = (w + self.offset) * self.step_w
+                c_y = (h + self.offset) * self.step_h
+                idx = 0
+                for s in range(len(self.min_sizes)):
+                    min_size = self.min_sizes[s]
+                    if not self.min_max_aspect_ratios_order:
+                        # rest of priors
+                        for r in range(len(self.real_aspect_ratios)):
+                            ar = self.real_aspect_ratios[r]
+                            c_w = min_size * math.sqrt(ar) / 2
+                            c_h = (min_size / math.sqrt(ar)) / 2
+                            out_boxes[h, w, idx, :] = [
+                                (c_x - c_w) / self.image_w, (c_y - c_h) /
+                                self.image_h, (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h
+                            ]
+                            idx += 1
+
+                        if len(self.max_sizes) > 0:
+                            max_size = self.max_sizes[s]
+                            # second prior: aspect_ratio = 1,
+                            c_w = c_h = math.sqrt(min_size * max_size) / 2
+                            out_boxes[h, w, idx, :] = [
+                                (c_x - c_w) / self.image_w, (c_y - c_h) /
+                                self.image_h, (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h
+                            ]
+                            idx += 1
+                    else:
+                        c_w = c_h = min_size / 2.
+                        out_boxes[h, w, idx, :] = [(c_x - c_w) / self.image_w,
+                                                   (c_y - c_h) / self.image_h,
+                                                   (c_x + c_w) / self.image_w,
+                                                   (c_y + c_h) / self.image_h]
+                        idx += 1
+                        if len(self.max_sizes) > 0:
+                            max_size = self.max_sizes[s]
+                            # second prior: aspect_ratio = 1,
+                            c_w = c_h = math.sqrt(min_size * max_size) / 2
+                            out_boxes[h, w, idx, :] = [
+                                (c_x - c_w) / self.image_w, (c_y - c_h) /
+                                self.image_h, (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h
+                            ]
+                            idx += 1
+
+                        # rest of priors
+                        for r in range(len(self.real_aspect_ratios)):
+                            ar = self.real_aspect_ratios[r]
+                            if abs(ar - 1.) < 1e-6:
+                                continue
+                            c_w = min_size * math.sqrt(ar) / 2
+                            c_h = (min_size / math.sqrt(ar)) / 2
+                            out_boxes[h, w, idx, :] = [
+                                (c_x - c_w) / self.image_w, (c_y - c_h) /
+                                self.image_h, (c_x + c_w) / self.image_w,
+                                (c_y + c_h) / self.image_h
+                            ]
+                            idx += 1
+
+        # clip the prior's coordidate such that it is within[0, 1]
+        if self.clip:
+            out_boxes = np.clip(out_boxes, 0.0, 1.0)
+        # set the variance.
+        out_var = np.tile(self.variances, (self.layer_h, self.layer_w,
+                                           self.num_priors, 1))
+        self.out_boxes = out_boxes.astype('float32')
+        self.out_var = out_var.astype('float32')
+        print("=============================== self.out_boxes.shape:",
+              self.out_boxes.shape)
+        print("==== self.out_boxes valve:", self.out_boxes[0:1])
+        print("=============================== self.out_var.shape:",
+              self.out_var.shape)
+        print("==== self.out_varis valve:", self.out_var[0:1])
+
+
+#class TestPriorBoxOpWithoutMaxSize(TestPriorBoxOp):
+#    def set_max_sizes(self):
+#        self.max_sizes = []
+#
+#
+#class TestPriorBoxOpWithSpecifiedOutOrder(TestPriorBoxOp):
+#    def set_min_max_aspect_ratios_order(self):
+#        self.min_max_aspect_ratios_order = True
+#
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs 

### Describe
存在一些问题：
NPU PriorBox 输出只有 1 个：y（其实包含了 boxes + variance）。paddle prior_box 有两个输出：Boxes、Variances。目前的做法：用一个临时张量来接收 NPU 运算的结果，然后用 slice(0,1) slice(1,2) 将该临时张量切分到 boxes 和 variances。发现 boxes 的结果差别较大，variance 结果接近。底层逻辑存在差异的可能。
![图片](https://user-images.githubusercontent.com/87417304/130994883-f273166b-c4fb-4950-ae5e-e8375a2493c7.png)

