### PR TITLE
Add 'AsExtra' in SetValueMaker.

### DIFF
--- a/paddle/fluid/operators/set_value_op.cc
+++ b/paddle/fluid/operators/set_value_op.cc
@@ -110,7 +110,8 @@ class SetValueMaker : public framework::OpProtoAndCheckerMaker {
             {framework::proto::VarType::BOOL, framework::proto::VarType::INT32,
              framework::proto::VarType::INT64, framework::proto::VarType::FP32,
              framework::proto::VarType::FP64})
-        .SetDefault(framework::proto::VarType::FP32);
+        .SetDefault(framework::proto::VarType::FP32)
+        .AsExtra();
     AddAttr<std::vector<int64_t>>(
         "axes", "(list<int64_t>) Axes that `starts` and `ends` apply to.");
     AddAttr<std::vector<int64_t>>(
@@ -131,15 +132,20 @@ class SetValueMaker : public framework::OpProtoAndCheckerMaker {
         .SetDefault({});
 
     AddAttr<std::vector<int>>("bool_values", "Store the bool values.")
-        .SetDefault({});
+        .SetDefault({})
+        .AsExtra();
     AddAttr<std::vector<float>>("fp32_values", "Store the float32 values.")
-        .SetDefault({});
+        .SetDefault({})
+        .AsExtra();
     AddAttr<std::vector<int>>("int32_values", "Store the int32 values.")
-        .SetDefault({});
+        .SetDefault({})
+        .AsExtra();
     AddAttr<std::vector<int64_t>>("int64_values", "Store the int64 values.")
-        .SetDefault({});
+        .SetDefault({})
+        .AsExtra();
     AddAttr<std::vector<double>>("fp64_values", "Store the float64 values.")
-        .SetDefault({});
+        .SetDefault({})
+        .AsExtra();
 
     AddAttr<std::vector<int64_t>>("shape", "(vector<int64_t>) Shape of values.")
         .SetDefault({});


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
set_value 相当于Input[starts : ends : step] = value
- StartsTensorList相当于starts为tensor类型。
- EndsTensorList、StepsTensorList同理。
- dtype为input的数据类型，加 **AsExtra** 修饰。
- bool_values、fp32_values、int32_values、int64_values、fp64_values 为value的类型，加 **AsExtra** 修饰

```
class SetValueMaker : public framework::OpProtoAndCheckerMaker {
 public:
  void Make() override {
    // Input
    AddInput("Input", "(Tensor) Input tensor of set_value operator.");
    AddInput("ValueTensor", "(Tensor) Value tensor of set_value operator.")
        .AsDispensable();
    AddInput("StartsTensorList",
             "(vector<Tensor<int32>>, optional) If provided, set_value will "
             "use this. The shape of the tensor in vector must be [1]."
             "It has higher priority compare with attr(starts).")
        .AsDuplicable()
        .AsDispensable();
    AddInput("EndsTensorList",
             "(vector<Tensor<int32>>, optional) If provided, set_value will "
             "use this. The shape of the tensor in vector must BE [1]."
             "It has higher priority compare with attr(ends).")
        .AsDuplicable()
        .AsDispensable();

    AddInput("StepsTensorList",
             "(vector<Tensor<int32>>, optional) If provided, set_value will "
             "use this. The shape of the tensor in vector must BE [1]."
             "It has higher priority compare with attr(steps).")
        .AsDuplicable()
        .AsDispensable();

    // Output
    AddOutput("Out",
              "(Tensor) Output tensor of set_value operator. The output is the "
              "same Tensor as input");

    // Attr
    AddAttr<int>("dtype", "data type of input.")
        .InEnum(
            {framework::proto::VarType::BOOL, framework::proto::VarType::INT32,
             framework::proto::VarType::INT64, framework::proto::VarType::FP32,
             framework::proto::VarType::FP64})
        .SetDefault(framework::proto::VarType::FP32)
        .AsExtra();
    AddAttr<std::vector<int64_t>>(
        "axes", "(list<int64_t>) Axes that `starts` and `ends` apply to.");
    AddAttr<std::vector<int64_t>>(
        "starts",
        "(list<int64_t>) Starting indices of corresponding axis in `axes`.")
        .SetDefault({});
    AddAttr<std::vector<int64_t>>(
        "ends",
        "(list<int64_t>) Ending indices of corresponding axis in `axes`.")
        .SetDefault({});
    AddAttr<std::vector<int64_t>>(
        "steps", "(list<int64_t>) Stride step from the start to the end.")
        .SetDefault({});
    AddAttr<std::vector<int64_t>>("decrease_axes",
                                  "(list<int>) The axes to decrease.")
        .SetDefault({});
    AddAttr<std::vector<int64_t>>("none_axes", "(list<int>) The axes to none.")
        .SetDefault({});

    AddAttr<std::vector<int>>("bool_values", "Store the bool values.")
        .SetDefault({})
        .AsExtra();
    AddAttr<std::vector<float>>("fp32_values", "Store the float32 values.")
        .SetDefault({})
        .AsExtra();
    AddAttr<std::vector<int>>("int32_values", "Store the int32 values.")
        .SetDefault({})
        .AsExtra();
    AddAttr<std::vector<int64_t>>("int64_values", "Store the int64 values.")
        .SetDefault({})
        .AsExtra();
    AddAttr<std::vector<double>>("fp64_values", "Store the float64 values.")
        .SetDefault({})
        .AsExtra();

    AddAttr<std::vector<int64_t>>("shape", "(vector<int64_t>) Shape of values.")
        .SetDefault({});
    AddComment(R"DOC(SetValue operator.
Assignment to a Tensor in static mode.
)DOC");
  }
};
```