### PR TITLE
[oneDNN] Fix to #34492

### DIFF
--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -476,10 +476,8 @@ inline std::string CreateKey(const platform::MKLDNNDeviceContext& dev_ctx,
 
 inline std::string ExtendKeyWithThreadInfoIfNeeded(
     const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key) {
-  return ((paddle::platform::MKLDNNDeviceContext::tls().is_tid_used_in_key() ==
-           true) &&
-          (platform::MKLDNNDeviceContext::tls().get_cur_mkldnn_session_id() ==
-           platform::MKLDNNDeviceContextThreadLocals::kMKLDNNSessionID_Default))
+  return (paddle::platform::MKLDNNDeviceContext::tls().is_tid_used_in_key() ==
+          true)
              ? key + "-t:" + ThreadIDasStr()
              : key;
 }


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
PR introduces TID for keys during cache clearing mode . This is needed for scenario from #34492
