### PR TITLE
fix bug:When axes in paddle.slice is a tuple, an error occurs.

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10977,7 +10977,7 @@ def slice(input, axes, starts, ends):
         ends_tensor = None
 
         if isinstance(axes, (list, tuple)):
-            axes = axes if isinstance(axes, list) else list(axes)
+            axes = list(axes)
             if len(axes) == 0:
                 raise ValueError(
                     "Input axes should not be an empty list/tuple.")

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10977,6 +10977,7 @@ def slice(input, axes, starts, ends):
         ends_tensor = None
 
         if isinstance(axes, (list, tuple)):
+            axes = axes if isinstance(axes, list) else list(axes)
             if len(axes) == 0:
                 raise ValueError(
                     "Input axes should not be an empty list/tuple.")

--- a/python/paddle/fluid/tests/unittests/test_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_slice_op.py
@@ -705,7 +705,7 @@ class TestInferShape(unittest.TestCase):
             np_slice = x_arr[:, :, 0:1]
             self.assertTrue(np.array_equal(pp_slice, np_slice))
 
-            pp_slice = paddle.slice(x, [-100, ], [0], [1])
+            pp_slice = paddle.slice(x, (-100, ), [0], [1])
             np_slice = x_arr[0:1]
             self.assertTrue(np.array_equal(pp_slice, np_slice))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
在paddle.slice中，当axes为tuple时报错。