### PR TITLE
Add AsExtra() for conditional_block_op.h

### DIFF
--- a/paddle/fluid/operators/controlflow/conditional_block_op.h
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.h
@@ -117,7 +117,8 @@ class ConditionalBlockOpProtoMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::vector<std::string>>(ConditionalOp::kSkipEagerDeletionVars,
                                       "Vars that would not be deleted when "
                                       "garbage collection strategy enables")
-        .SetDefault(std::vector<std::string>());
+        .SetDefault(std::vector<std::string>())
+        .AsExtra();
     AddComment(R"DOC(Conditional block operator
 
 If `is_scalar_condition` is True, the conditional variable (Cond) is a scalar,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
原生字段截图为：
<img width="517" alt="2165299326cfc86c6ac1a289394ce598" src="https://user-images.githubusercontent.com/7913861/131312523-1bee2379-7708-45ed-8034-65b310675ffe.png">

故需给kSkipEagerDeletionVars标注为AsExtra()
