### PR TITLE
[NPU] add get_float_status op and refine NPU check_nan_inf

### DIFF
--- a/paddle/fluid/framework/details/CMakeLists.txt
+++ b/paddle/fluid/framework/details/CMakeLists.txt
@@ -64,7 +64,11 @@ elseif(WITH_ROCM)
     hip_library(broadcast_op_handle SRCS broadcast_op_handle.cc DEPS op_handle_base scope ddim memory variable_visitor dynload_cuda)
     hip_library(fused_broadcast_op_handle SRCS fused_broadcast_op_handle.cc DEPS broadcast_op_handle)
 else()
-    cc_library(nan_inf_utils SRCS nan_inf_utils_detail.cc DEPS framework_proto scope place)
+    if (WITH_ASCEND_CL)
+        cc_library(nan_inf_utils SRCS nan_inf_utils_detail.cc DEPS npu_op_runner framework_proto scope place)
+    else()
+        cc_library(nan_inf_utils SRCS nan_inf_utils_detail.cc DEPS framework_proto scope place)
+    endif()
     cc_library(all_reduce_op_handle SRCS all_reduce_op_handle.cc DEPS op_handle_base scope lod_tensor ddim memory
              variable_visitor)
     cc_library(fused_all_reduce_op_handle SRCS fused_all_reduce_op_handle.cc DEPS op_handle_base scope lod_tensor ddim memory

--- a/paddle/fluid/framework/details/nan_inf_utils.h
+++ b/paddle/fluid/framework/details/nan_inf_utils.h
@@ -53,6 +53,12 @@ void CheckOpHasNanOrInfInDygraph(const std::string& op_type,
   }
 }
 
+#ifdef PADDLE_WITH_ASCEND_CL
+void NPUAllocAndClearFloatStatus(const framework::OperatorBase& op,
+                                 const framework::Scope& scope,
+                                 const platform::Place& place);
+#endif
+
 }  // namespace details
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -429,6 +429,9 @@ void NPUAllocAndClearFloatStatus(const framework::OperatorBase& op,
                                  const platform::Place& place) {
   if (!platform::is_npu_place(place)) return;
 
+  std::call_once(white_list_init_flag, InitWhiteListFormEnv);
+  if (IsSkipOp(op)) return;
+
   auto* dev_ctx = reinterpret_cast<platform::NPUDeviceContext*>(
       platform::DeviceContextPool::Instance().Get(place));
   auto stream = dev_ctx->stream();

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1105,6 +1105,16 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(place);
 
+#ifdef PADDLE_WITH_ASCEND_CL
+  // NOTE(wangxi): nan/inf cannot be detected on NPU by checking the variable
+  // values, but only through special `float_status` to checks whether
+  // the operation is overflow. More about `float_status`, see:
+  // https://gitee.com/ascend/modelzoo/issues/I3NF8V?from=project-issue
+  if (FLAGS_check_nan_inf) {
+    framework::details::NPUAllocAndClearFloatStatus(*this, scope, place);
+  }
+#endif
+
   if (kernel_type_.get() == nullptr || kernel_func_.get() == nullptr) {
     ChooseKernel(*runtime_ctx, scope, place);
   }

--- a/paddle/fluid/operators/amp/get_float_status_op.cc
+++ b/paddle/fluid/operators/amp/get_float_status_op.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+class GetFloatStatusOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    OP_INOUT_CHECK(ctx->HasOutput("FloatStatusOut"), "Output", "FloatStatusOut",
+                   "get_float_status");
+    ctx->SetOutputDim("FloatStatusOut", ctx->GetInputDim("FloatStatus"));
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(framework::proto::VarType::FP32,
+                                   ctx.GetPlace());
+  }
+};
+
+class GetFloatStatusMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("FloatStatus",
+             "(Tensor) of shape {8} that holds the float status.");
+    AddOutput("FloatStatusOut",
+              "(Tensor) of shape {8} that holds the get float status.");
+    AddComment(R"DOC(
+      Get the float status
+)DOC");
+  }
+};
+
+template <typename DeviceContext, typename T>
+class GetFloatStatusKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    PADDLE_THROW(platform::errors::Unimplemented(
+        "Operator get_float_status is not supported on CPU"));
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+using CPU = paddle::platform::CPUDeviceContext;
+
+REGISTER_OPERATOR(
+    get_float_status, ops::GetFloatStatusOp, ops::GetFloatStatusMaker,
+    paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
+    paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);
+
+REGISTER_OP_CPU_KERNEL(get_float_status, ops::GetFloatStatusKernel<CPU, float>);

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -157,6 +157,8 @@ std::map<std::string, std::set<std::string>> op_passing_outs_map = {
      {"ParamOut", "Moment1Out", "Moment2Out", "Beta1PowOut", "Beta2PowOut"}},
     {"rnn", {"DropoutState"}},
     {"run_program", {"Out", "DOut", "OutScope"}},
+    {"clear_float_status", {"FloatStatusOut"}},
+    {"get_float_status", {"FloatStatusOut"}},
 };
 
 // NOTE(pangyoki): Tensor View Strategy.

--- a/python/paddle/fluid/tests/unittests/npu/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/npu/CMakeLists.txt
@@ -5,4 +5,12 @@ if (WITH_ASCEND_CL)
     foreach(TEST_OP ${TEST_OPS})
         py_test_modules(${TEST_OP} MODULES ${TEST_OP})
     endforeach(TEST_OP)
+
+    # NOTE: NPU `get_float_status` read the value from register, During the test,
+    # it is found that this register will be overwritten by any program on the card.
+    # In order to prevent the interference of nan/inf in the other unittests, we
+    # need to set the unittests related to `float_status` to exclusive.
+    set_tests_properties(test_amp_check_finite_and_scale_op_npu PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
+    set_tests_properties(test_flags_check_nan_inf_npu PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
+    set_tests_properties(test_float_status_op_npu PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 endif()

--- a/python/paddle/fluid/tests/unittests/npu/test_flags_check_nan_inf_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_flags_check_nan_inf_npu.py
@@ -1,0 +1,86 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import sys
+sys.path.append("..")
+from op_test import OpTest, skip_check_grad_ci
+import paddle
+import paddle.static as static
+import paddle.fluid as fluid
+from paddle.static import Program, program_guard
+
+paddle.enable_static()
+
+
+class TestCheckFiniteAndUnscale(unittest.TestCase):
+    def setUp(self):
+        fluid.set_flags({'FLAGS_check_nan_inf': True})
+
+    def get_prog(self):
+        main_program = Program()
+        with program_guard(main_program):
+            a = static.data(name="a", shape=[32, 32], dtype='float32')
+            b = static.data(name="b", shape=[32, 32], dtype='float32')
+            out = a / b
+            fp16_a = a.cast(paddle.float16)
+            fp16_b = b.cast(paddle.float16)
+            out = fp16_a + fp16_b
+        return main_program, out
+
+    def run_prog(self, a, b):
+        main_program, out = self.get_prog()
+        place = paddle.set_device('npu')
+
+        exe = static.Executor(place)
+        out_ = exe.run(main_program, feed={"a": a, "b": b}, fetch_list=[out])
+        return out_
+
+    def test_contains_nan(self):
+        a = np.zeros((32, 32)).astype('float32')
+        b = np.zeros((32, 32)).astype('float32')
+
+        with self.assertRaisesRegex(RuntimeError, "contains Nan/Inf"):
+            out = self.run_prog(a, b)
+            print(out)
+
+    def test_contains_inf(self):
+        a = np.ones((32, 32)).astype('float32')
+        b = np.zeros((32, 32)).astype('float32')
+
+        with self.assertRaisesRegex(RuntimeError, "contains Nan/Inf"):
+            out = self.run_prog(a, b)
+            print(out)
+
+    def test_not_contains_nan_inf(self):
+        a = np.ones((32, 32)).astype('float32')
+        b = np.ones((32, 32)).astype('float32')
+
+        out = self.run_prog(a, b)
+        print(out)
+
+    def test_fp16_overflow(self):
+        a = np.ones((32, 32)).astype('float32')
+        b = np.ones((32, 32)).astype('float32')
+        a[0][0] = 50000
+        b[0][0] = 50000
+
+        with self.assertRaisesRegex(RuntimeError, "contains Nan/Inf"):
+            out = self.run_prog(a, b)
+            print(out)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/npu/test_float_status_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_float_status_op_npu.py
@@ -1,0 +1,103 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import sys
+sys.path.append("..")
+from op_test import OpTest, skip_check_grad_ci
+import paddle
+import paddle._C_ops as ops
+
+
+class TestGetFloatStatusOp(unittest.TestCase):
+    def setUp(self):
+        device = paddle.set_device('npu')
+
+    def run_prog(self, a, b):
+        a = paddle.to_tensor(a)
+        b = paddle.to_tensor(b)
+
+        flag = ops.alloc_float_status()
+        ops.clear_float_status(flag, flag)
+
+        out = a / b
+        ops.get_float_status(flag, flag)
+        return out.numpy(), flag.numpy()
+
+    def test_contains_nan(self):
+        a = np.zeros((32, 32)).astype('float32')
+        b = np.zeros((32, 32)).astype('float32')
+
+        out, flag = self.run_prog(a, b)
+        print(out, flag)
+        self.assertGreaterEqual(np.sum(flag), 1.0)
+
+    def test_contains_inf(self):
+        a = np.ones((32, 32)).astype('float32')
+        b = np.zeros((32, 32)).astype('float32')
+
+        out, flag = self.run_prog(a, b)
+        print(out, flag)
+        self.assertGreaterEqual(np.sum(flag), 1.0)
+
+    def test_not_contains_nan_inf(self):
+        a = np.ones((32, 32)).astype('float32')
+        b = np.ones((32, 32)).astype('float32')
+
+        out, flag = self.run_prog(a, b)
+        print(out, flag)
+        self.assertLess(np.sum(flag), 1.0)
+
+
+class TestClearFloatStatusOp(unittest.TestCase):
+    def setUp(self):
+        device = paddle.set_device('npu')
+
+    def run_prog(self, a, b):
+        a = paddle.to_tensor(a)
+        b = paddle.to_tensor(b)
+
+        flag = ops.alloc_float_status()
+        ops.clear_float_status(flag, flag)
+
+        out = a / b
+        ops.get_float_status(flag, flag)
+
+        ops.clear_float_status(flag, flag)
+        out = a + b
+        ops.get_float_status(flag, flag)
+        return out.numpy(), flag.numpy()
+
+    def test_not_contains_nan_inf(self):
+        a = np.ones((32, 32)).astype('float32')
+        b = np.zeros((32, 32)).astype('float32')
+
+        out, flag = self.run_prog(a, b)
+        print(out, flag)
+        self.assertLess(np.sum(flag), 1.0)
+
+    def test_fp16_overflow(self):
+        a = np.ones((32, 32)).astype('float16')
+        b = np.zeros((32, 32)).astype('float16')
+        a[0][0] = 50000
+        b[0][0] = 50000
+
+        out, flag = self.run_prog(a, b)
+        print(out, flag)
+        self.assertGreaterEqual(np.sum(flag), 1.0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
1. NPU添加get_float_status op。由于NPU的特殊硬件逻辑，需要使用{alloc,clear,get}_float_status获取算子是否出现overflow，具体用法见 https://gitee.com/ascend/modelzoo/issues/I3NF8V?from=project-issue
2. 修复 NPUClearFloatStatus 输出位置放置错误的问题。
3. clear_float_status、get_float_status输入输出需相同，加入动态图op_passing_outs_map中，方便使用动态图调试。
4. 修改FLAGS_check_nan_inf中npu关于nan/inf的check逻辑，使用float_status。

动态图中`get_float_status`使用如下：
<img width="646" alt="bea745188c6ba727faf101b4163855ed" src="https://user-images.githubusercontent.com/10208305/131321750-bcad09bd-27a6-4e87-b25d-83cd543cea3f.png">

`FLAGS_check_nan_inf`中打印的关于出现nan/inf的信息：
![image](https://user-images.githubusercontent.com/10208305/131481924-8142a14c-7c2d-48d1-8066-90922d830f4f.png)
![image](https://user-images.githubusercontent.com/10208305/131482005-3fa3f44d-d4e7-4f22-aab1-ff7331788208.png)