### PR TITLE
fix bug that cmake find python

### DIFF
--- a/cmake/external/python.cmake
+++ b/cmake/external/python.cmake
@@ -27,7 +27,7 @@ print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
             OUTPUT_VARIABLE _PYTHON_VALUES
             ERROR_VARIABLE _PYTHON_ERROR_VALUE)
 
-    if(NOT _PYTHON_SUCCESS MATCHES 0)
+    if(NOT _PYTHON_SUCCESS EQUAL 0)
         set(PYTHONLIBS_FOUND FALSE)
         return()
     endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修改cmake判断是否找到Python环境的bug。

错误情况下的返回码，虽不为0，但可能包含0，例如9009。这里如果使用正则匹配，容易导致判断失误。
![infoflow 2021-08-31 14-13-32](https://user-images.githubusercontent.com/52485244/131452301-a233ab1d-0a71-4264-b3e4-143e82813d81.png)

