### PR TITLE
modify dy2stat error message in compile time

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -31,7 +31,7 @@ DISABLE_ERROR_ENV_NAME = "TRANSLATOR_DISABLE_NEW_ERROR"
 DEFAULT_DISABLE_NEW_ERROR = 0
 
 SOURCE_CODE_RANGE = 5
-BLANK_COUNT_BDFORE_FILE_STR = 4
+BLANK_COUNT_BEFORE_FILE_STR = 4
 
 
 def attach_error_data(error, in_runtime=False):
@@ -87,7 +87,7 @@ class TraceBackFrame(OriginInfo):
     def formated_message(self):
         # self.source_code may be empty in some functions.
         # For example, decorator generated function
-        return ' ' * BLANK_COUNT_BDFORE_FILE_STR + 'File "{}", line {}, in {}\n\t{}'.format(
+        return ' ' * BLANK_COUNT_BEFORE_FILE_STR + 'File "{}", line {}, in {}\n\t{}'.format(
             self.location.filepath, self.location.lineno, self.function_name,
             self.source_code.lstrip()
             if isinstance(self.source_code, str) else self.source_code)
@@ -120,11 +120,11 @@ class TraceBackFrameRange(OriginInfo):
         min_black_count = min(blank_count)
         for i in range(len(self.source_code)):
             self.source_code[i] = ' ' * (blank_count[i] - min_black_count +
-                                         BLANK_COUNT_BDFORE_FILE_STR * 2
+                                         BLANK_COUNT_BEFORE_FILE_STR * 2
                                          ) + self.source_code[i]
 
     def formated_message(self):
-        msg = ' ' * BLANK_COUNT_BDFORE_FILE_STR + 'File "{}", line {}, in {}\n'.format(
+        msg = ' ' * BLANK_COUNT_BEFORE_FILE_STR + 'File "{}", line {}, in {}\n'.format(
             self.location.filepath, self.location.lineno, self.function_name)
         # add empty line after range code
         return msg + '\n'.join(self.source_code) + '\n'
@@ -195,7 +195,7 @@ class ErrorData(object):
         format_exception = traceback.format_exception_only(self.error_type,
                                                            self.error_value)
         error_message = [
-            " " * BLANK_COUNT_BDFORE_FILE_STR + line
+            " " * BLANK_COUNT_BEFORE_FILE_STR + line
             for line in format_exception
         ]
         message_lines.extend(error_message)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -218,7 +218,10 @@ class TestErrorStaticLayerCallInCompiletime(TestErrorBase):
             ['File "{}", line 35, in func_error_in_compile_time'.format(self.filepath),
              'inner_func()',
              'File "{}", line 28, in inner_func'.format(self.filepath),
+             'def inner_func():',
              'fluid.layers.fill_constant(shape=[1, 2], value=9, dtype="int")',
+             '<--- HERE',
+             'return',
              ]
 
     def set_func_call(self):
@@ -242,7 +245,11 @@ class TestErrorStaticLayerCallInCompiletime_2(
         self.expected_message = \
             [
              'File "{}", line 46, in func_error_in_compile_time_2'.format(self.filepath),
-             'x = fluid.layers.reshape(x, shape=[1, 2])'
+             'def func_error_in_compile_time_2(x):',
+             'x = fluid.dygraph.to_variable(x)',
+             'x = fluid.layers.reshape(x, shape=[1, 2])',
+             '<--- HERE',
+             'return x'
              ]
 
 
@@ -261,7 +268,10 @@ class TestErrorStaticLayerCallInCompiletime_3(
     def set_message(self):
         self.expected_message = \
             ['File "{}", line 91, in forward'.format(self.filepath),
+             '@paddle.jit.to_static',
+             'def forward(self):',
              'self.test_func()',
+             '<--- HERE'
              ]
 
     def set_func_call(self):
@@ -318,7 +328,12 @@ class TestJitSaveInCompiletime(TestErrorBase):
     def set_message(self):
         self.expected_message = \
             ['File "{}", line 80, in forward'.format(self.filepath),
-             'fluid.layers.fill_constant(shape=[1, 2], value=9, dtype="int")',
+             'def forward(self, x):',
+             'y = self._linear(x)',
+             'z = fluid.layers.fill_constant(shape=[1, 2], value=9, dtype="int")',
+             '<--- HERE',
+             'out = fluid.layers.mean(y[z])',
+             'return out'
              ]
 
     def set_func_call(self):
@@ -329,7 +344,7 @@ class TestJitSaveInCompiletime(TestErrorBase):
         self._test_raise_new_exception()
 
 
-# Situation 4: NotImplementedError
+# # Situation 4: NotImplementedError
 class TestErrorInOther(unittest.TestCase):
     def test(self):
         paddle.disable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
modify dy2stat error message in compile time
对动转静编译期报错信息进行了修改，主要修改了红框内的报错信息。上图是修改之前的报错信息，下图为修改之后的报错信息：将最后报错的用户代码进行了扩展，展示了前后总共5行的相关代码，加入了提示HERE提示词提示具体出错位置；同时将报错栈的框架层信息进行了隐藏。
![image-20210831201250397](https://user-images.githubusercontent.com/23097963/131500940-853653c3-40d5-47dc-abc2-71238a934161.png)
![image-20210831200939057](https://user-images.githubusercontent.com/23097963/131500949-950b48e5-bef3-41f8-b966-6d01d317c05a.png)
