### PR TITLE
fix flatten infershape

### DIFF
--- a/paddle/fluid/operators/flatten_op.cc
+++ b/paddle/fluid/operators/flatten_op.cc
@@ -55,9 +55,17 @@ class FlattenOp : public framework::OperatorWithKernel {
     int64_t outer = 1, inner = 1;
     for (int i = 0; i < in_dims.size(); ++i) {
       if (i < axis) {
-        outer *= in_dims[i];
+        if (in_dims[i] == -1 || outer == -1) {
+          outer = -1;
+        } else {
+          outer *= in_dims[i];
+        }
       } else {
-        inner *= in_dims[i];
+        if (in_dims[i] == -1 || inner == -1) {
+          inner = -1;
+        } else {
+          inner *= in_dims[i];
+        }
       }
     }
     std::vector<int32_t> out_shape(2);
@@ -296,7 +304,11 @@ class FlattenContiguousRangeOp : public framework::OperatorWithKernel {
       out_shape.push_back(in_dims[i]);
     }
     for (int i = start_axis; i <= stop_axis; i++) {
-      outer *= in_dims[i];
+      if (in_dims[i] == -1 || outer == -1) {
+        outer = -1;
+      } else {
+        outer *= in_dims[i];
+      }
     }
     out_shape.push_back(outer);
     for (int i = stop_axis + 1; i < in_dims_size; i++) {

--- a/python/paddle/fluid/tests/unittests/test_flatten2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten2_op.py
@@ -76,17 +76,12 @@ class TestStaticFlattenPythonAPI(unittest.TestCase):
 
     def test_static_api(self):
         paddle.enable_static()
-        np_x = np.random.rand(2, 3, 4, 4).astype('float32')
-
         main_prog = paddle.static.Program()
         with paddle.static.program_guard(main_prog, paddle.static.Program()):
             x = paddle.static.data(
                 name="x", shape=[-1, 3, -1, -1], dtype='float32')
             out = self.execute_api(x, axis=2)
-
-        exe = paddle.static.Executor(place=paddle.CPUPlace())
-        fetch_out = exe.run(main_prog, feed={"x": np_x}, fetch_list=[out])
-        self.assertTrue((6, 16) == fetch_out[0].shape)
+        self.assertTrue((-1, -1) == out.shape)
 
 
 class TestFlatten2OpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_flatten2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten2_op.py
@@ -70,7 +70,7 @@ class TestFlattenOpSixDims(TestFlattenOp):
         self.new_shape = (36, 16)
 
 
-class TestStaticFlattenPythonAPI(unittest.TestCase):
+class TestStaticFlattenInferShapePythonAPI(unittest.TestCase):
     def execute_api(self, x, axis=1):
         return fluid.layers.flatten(x, axis=axis)
 

--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -201,7 +201,7 @@ class TestStaticFlattenPythonAPI(unittest.TestCase):
         self.assertTrue((2, 3, 16) == fetch_out[0].shape)
 
 
-class TestStaticFlattenPythonAPI(unittest.TestCase):
+class TestStaticFlattenInferShapePythonAPI(unittest.TestCase):
     def execute_api(self, x, start_axis=0, stop_axis=-1):
         return paddle.flatten(x, start_axis, stop_axis)
 

--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -207,17 +207,12 @@ class TestStaticFlattenPythonAPI(unittest.TestCase):
 
     def test_static_api(self):
         paddle.enable_static()
-        np_x = np.random.rand(2, 3, 4, 4).astype('float32')
-
         main_prog = paddle.static.Program()
         with paddle.static.program_guard(main_prog, paddle.static.Program()):
             x = paddle.static.data(
                 name="x", shape=[-1, 3, -1, -1], dtype='float32')
             out = self.execute_api(x, start_axis=2, stop_axis=3)
-
-        exe = paddle.static.Executor(place=paddle.CPUPlace())
-        fetch_out = exe.run(main_prog, feed={"x": np_x}, fetch_list=[out])
-        self.assertTrue((2, 3, 16) == fetch_out[0].shape)
+        self.assertTrue((-1, 3, -1) == out.shape)
 
 
 class TestStaticInplaceFlattenPythonAPI(TestStaticFlattenPythonAPI):

--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -201,6 +201,25 @@ class TestStaticFlattenPythonAPI(unittest.TestCase):
         self.assertTrue((2, 3, 16) == fetch_out[0].shape)
 
 
+class TestStaticFlattenPythonAPI(unittest.TestCase):
+    def execute_api(self, x, start_axis=0, stop_axis=-1):
+        return paddle.flatten(x, start_axis, stop_axis)
+
+    def test_static_api(self):
+        paddle.enable_static()
+        np_x = np.random.rand(2, 3, 4, 4).astype('float32')
+
+        main_prog = paddle.static.Program()
+        with paddle.static.program_guard(main_prog, paddle.static.Program()):
+            x = paddle.static.data(
+                name="x", shape=[-1, 3, -1, -1], dtype='float32')
+            out = self.execute_api(x, start_axis=2, stop_axis=3)
+
+        exe = paddle.static.Executor(place=paddle.CPUPlace())
+        fetch_out = exe.run(main_prog, feed={"x": np_x}, fetch_list=[out])
+        self.assertTrue((2, 3, 16) == fetch_out[0].shape)
+
+
 class TestStaticInplaceFlattenPythonAPI(TestStaticFlattenPythonAPI):
     def execute_api(self, x, start_axis=0, stop_axis=-1):
         return x.flatten_(start_axis, stop_axis)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix flatten op infershape

ori:
```
>>> x_var = paddle.static.data(name="y", shape=[None,None,1], dtype='float32')
>>> out = paddle.flatten(x_var)
>>> print(out.shape)
(1,)
```

fix after:
```
>>> x_var = paddle.static.data(name="y", shape=[None,None,1], dtype='float32')
>>> out = paddle.flatten(x_var)
>>> print(out.shape)
(-1,)
```