### PR TITLE
modify dy2stat error message in runtime and format error message

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -98,6 +98,16 @@ class LayerErrorInCompiletime2(fluid.dygraph.Layer):
         return
 
 
+@paddle.jit.to_static
+def func_error_in_runtime_with_empty_line(x):
+    x = fluid.dygraph.to_variable(x)
+    two = fluid.layers.fill_constant(shape=[1], value=2, dtype="int32")
+
+    x = fluid.layers.reshape(x, shape=[1, two])
+
+    return x
+
+
 class TestFlags(unittest.TestCase):
     def setUp(self):
         self.reset_flags_to_default()
@@ -293,7 +303,26 @@ class TestErrorStaticLayerCallInRuntime(TestErrorStaticLayerCallInCompiletime):
         self.expected_message = \
             [
                 'File "{}", line 54, in func_error_in_runtime'.format(self.filepath),
-                'x = fluid.layers.reshape(x, shape=[1, two])'
+                'x = fluid.dygraph.to_variable(x)',
+                'two = fluid.layers.fill_constant(shape=[1], value=2, dtype="int32")',
+                'x = fluid.layers.reshape(x, shape=[1, two])',
+                '<--- HERE',
+                'return x'
+            ]
+
+
+class TestErrorStaticLayerCallInRuntime2(TestErrorStaticLayerCallInRuntime):
+    def set_func(self):
+        self.func = func_error_in_runtime_with_empty_line
+
+    def set_message(self):
+        self.expected_message = \
+            [
+                'File "{}", line 106, in func_error_in_runtime_with_empty_line'.format(self.filepath),
+                'two = fluid.layers.fill_constant(shape=[1], value=2, dtype="int32")',
+                'x = fluid.layers.reshape(x, shape=[1, two])',
+                '<--- HERE',
+                'return x'
             ]
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
modify dy2stat error message in runtime and format error message
1.对动转静运行期报错信息进行了修改，主要修改了红框内的报错信息。上图是修改之前的报错信息，下图为修改之后的报错信息：将最后报错的用户代码进行了扩展，展示了前后总共5行的相关代码，加入了提示HERE提示词提示具体出错位置；同时将报错栈的框架层信息进行了隐藏。
2.将所显示关联代码的格式进行调整，对展示代码顶部、底部存在空行以及代码中间存在空行的情况进行了修改。
![image-20210901115941397](https://user-images.githubusercontent.com/23097963/131661880-e9fd288e-b5c3-43f1-b05e-22877239f001.png)
![image-20210901155433634](https://user-images.githubusercontent.com/23097963/131661910-f9a4ace5-f702-481c-9d75-40bce1d466d7.png)
