### PR TITLE
Add function to disable paddle signal handler (#34577)

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -11,6 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
+#include <csignal>
 #include <fstream>
 #include <string>
 
@@ -245,15 +246,16 @@ void InitDevices(const std::vector<int> devices) {
 // Description Quoted from
 // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html
 const struct {
+  int signal_number;
   const char *name;
   const char *error_string;
 } SignalErrorStrings[] = {
-    {"SIGSEGV", "Segmentation fault"},
-    {"SIGILL", "Illegal instruction"},
-    {"SIGFPE", "Erroneous arithmetic operation"},
-    {"SIGABRT", "Process abort signal"},
-    {"SIGBUS", "Access to an undefined portion of a memory object"},
-    {"SIGTERM", "Termination signal"},
+    {SIGSEGV, "SIGSEGV", "Segmentation fault"},
+    {SIGILL, "SIGILL", "Illegal instruction"},
+    {SIGFPE, "SIGFPE", "Erroneous arithmetic operation"},
+    {SIGABRT, "SIGABRT", "Process abort signal"},
+    {SIGBUS, "SIGBUS", "Access to an undefined portion of a memory object"},
+    {SIGTERM, "SIGTERM", "Termination signal"},
 };
 
 bool StartsWith(const char *str, const char *prefix) {
@@ -309,7 +311,21 @@ void SignalHandle(const char *data, int size) {
     // will Kill program by the default signal handler
   }
 }
+#endif  // _WIN32
+
+void DisableSignalHandler() {
+#ifndef _WIN32
+  for (size_t i = 0;
+       i < (sizeof(SignalErrorStrings) / sizeof(*(SignalErrorStrings))); ++i) {
+    int signal_number = SignalErrorStrings[i].signal_number;
+    struct sigaction sig_action;
+    memset(&sig_action, 0, sizeof(sig_action));
+    sigemptyset(&sig_action.sa_mask);
+    sig_action.sa_handler = SIG_DFL;
+    sigaction(signal_number, &sig_action, NULL);
+  }
 #endif
+}
 
 #ifdef WITH_WIN_DUMP_DBG
 typedef BOOL(WINAPI *MINIDUMP_WRITE_DUMP)(

--- a/paddle/fluid/platform/init.h
+++ b/paddle/fluid/platform/init.h
@@ -61,5 +61,7 @@ class SignalMessageDumper {
 void SignalHandle(const char* data, int size);
 #endif
 
+void DisableSignalHandler();
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -477,6 +477,8 @@ PYBIND11_MODULE(core_noavx, m) {
 
   m.def("set_num_threads", &platform::SetNumThreads);
 
+  m.def("disable_signal_handler", &DisableSignalHandler);
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   m.def("cudnn_version", &platform::CudnnVersion);
 #endif

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -255,6 +255,7 @@ from .device import set_device  # noqa: F401
 from .device import get_device  # noqa: F401
 from .fluid.framework import is_compiled_with_cuda  # noqa: F401
 from .fluid.framework import is_compiled_with_rocm  # noqa: F401
+from .fluid.framework import disable_signal_handler  # noqa: F401
 from .device import is_compiled_with_xpu  # noqa: F401
 from .device import is_compiled_with_npu  # noqa: F401
 from .device import XPUPlace  # noqa: F401
@@ -457,6 +458,7 @@ __all__ = [  # noqa
            'enable_static',
            'scatter_nd',
            'set_default_dtype',
+           'disable_signal_handler',
            'expand_as',
            'stack',
            'sqrt',

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -384,6 +384,31 @@ def is_compiled_with_xpu():
     return core.is_compiled_with_xpu()
 
 
+def disable_signal_handler():
+    """
+    Reset signal handler registered by Paddle.
+
+    Paddle installs signal handlers at C++ level to log debug information upon failing.
+    However, conflicts can happen if another python module is making use of such signal.
+    Such being the case, one may disblae paddle signal handler via this interface.
+    
+    Known frameworks that require disabling signal handler includes:
+    1. TVM
+    2. ADLIK
+
+    Make sure you called paddle.disable_signal_handler() before using above mentioned frameworks.
+
+    Returns: None 
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+            paddle.disable_signal_handler()
+    """
+    core.disable_signal_handler()
+
+
 def is_compiled_with_cuda():
     """
     Whether this whl package can be used to run the model on GPU.

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -103,6 +103,8 @@ if(((NOT WITH_ROCM) AND (NOT WITH_GPU)) OR WIN32)
     LIST(REMOVE_ITEM TEST_OPS test_collective_wait)
     LIST(REMOVE_ITEM TEST_OPS test_memcpy_op)
     LIST(REMOVE_ITEM TEST_OPS test_raw_program_optimizer)
+    LIST(REMOVE_ITEM TEST_OPS test_fleet_gradient_scale)
+    LIST(REMOVE_ITEM TEST_OPS test_disable_signal_handler)
 endif()
 
 if(WIN32)

--- a/python/paddle/fluid/tests/unittests/test_disable_signal_handler.py
+++ b/python/paddle/fluid/tests/unittests/test_disable_signal_handler.py
@@ -1,0 +1,48 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import signal, os
+import paddle
+import subprocess
+
+SignalsToTest = {
+    signal.SIGTERM, signal.SIGBUS, signal.SIGABRT, signal.SIGSEGV,
+    signal.SIGILL, signal.SIGFPE
+}
+
+
+class TestSignOpError(unittest.TestCase):
+    def test_errors(self):
+        try:
+            for sig in SignalsToTest:
+                output = subprocess.check_output(
+                    [
+                        "python", "-c",
+                        f"import paddle; import signal,os; paddle.disable_signal_handler(); os.kill(os.getpid(), {sig})"
+                    ],
+                    stderr=subprocess.STDOUT)
+        except Exception as e:
+            # If paddle signal handler is enabled
+            # One would expect "paddle::framework::SignalHandle" in STDERR
+            stdout_message = str(e.output)
+            if "paddle::framework::SignalHandle" in stdout_message:
+                raise Exception("Paddle signal handler not disabled")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
APIs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
Paddle used google::InstallFaultSignalHandler to handle selected system signals,
mainly for debugging and bug report purposes.

However, this can be conflicted with other python packages whoever captures similar signals.
Such python package involves tvm and more

To resolve this issue, we support a function to disable signal handler

Note that Paddle does not register signal handlers on Windows platform. So this function is only needed on Linux/Unix.

CN doc: https://github.com/PaddlePaddle/docs/pull/3700
CN preview:
![image](https://user-images.githubusercontent.com/22334008/129307060-824a778e-b51e-4acf-84ca-4a29bb316eaa.png)

EN preview:
![image](https://user-images.githubusercontent.com/22334008/129307084-f1ae9443-c6be-4c1f-a754-8a0055925e30.png)


<!-- Describe what this PR does -->