### PR TITLE
[2.2]add API Tensor.T for reverse dim of Tensor

### DIFF
--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -148,6 +148,16 @@ def monkey_patch_math_varbase():
     def _size_(var):
         return np.prod(var.shape)
 
+    @property
+    def _T_(var):
+        if len(var.shape) == 1:
+            return var
+        perm = []
+        for i in range(len(var.shape)):
+            perm.insert(0, i)
+        out, _ = _C_ops.transpose2(var, 'axis', perm)
+        return out
+
     def _scalar_add_(var, value):
         return _scalar_elementwise_op_(var, 1.0, value)
 
@@ -271,6 +281,7 @@ def monkey_patch_math_varbase():
         ('ndimension', lambda x: len(x.shape)),
         ('ndim', _ndim_),
         ('size', _size_),
+        ('T', _T_),
         ('__add__',
          _binary_creator_('__add__', 'elementwise_add', False, _scalar_add_)),
         ##  a+b == b+a. Do not need to reverse explicitly

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -88,17 +88,17 @@ def monkey_patch_varbase():
         """
 
         # Note: getattr(self, attr, None) will call x.grad=x.gradient(), but gradient() only available in dygraph.
-        # It will fail. So, for propery in dygraph only, should not let it getattr(self, attr, None).
-        attr_not_need_keys = ['grad']
+        # It will fail. So, for propery that different between dynamic and static graph, should not getattr(self, attr, None).
+        attr_not_need_keys = ['grad', 'T']
         if isinstance(self, ParamBase):
             attr_kwargs = self.__dict__.copy()
         else:
             attr_names = []
             for name in dir(self):
-                if name not in attr_not_need_keys and not (
-                        inspect.ismethod(getattr(self, name)) or
-                        name.startswith('_')):
-                    attr_names.append(name)
+                if name not in attr_not_need_keys:
+                    if not inspect.ismethod(getattr(
+                            self, name)) and not name.startswith('_'):
+                        attr_names.append(name)
             attr_kwargs = {name: getattr(self, name) for name in attr_names}
 
         attr_keys = ['block', 'shape', 'dtype', 'type', 'name', 'persistable']

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch.py
@@ -336,6 +336,20 @@ class TestMathOpPatches(unittest.TestCase):
         self.assertTrue(np.array_equal(out[0], out_np))
 
     @prog_scope()
+    def test_T(self):
+        x_np = np.random.randint(-100, 100, [2, 8, 5, 3]).astype("int32")
+        out_np = x_np.T
+
+        x = paddle.static.data(name="x", shape=[2, 8, 5, 3], dtype="int32")
+        z = x.T
+
+        exe = fluid.Executor()
+        out = exe.run(fluid.default_main_program(),
+                      feed={"x": x_np},
+                      fetch_list=[z])
+        self.assertTrue(np.array_equal(out[0], out_np))
+
+    @prog_scope()
     def test_ndim(self):
         a = paddle.static.data(name="a", shape=[10, 1])
         self.assertEqual(a.dim(), 2)

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
@@ -527,6 +527,12 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             np.array_equal(
                 x.where(a, b).numpy(), paddle.where(x, a, b).numpy()))
 
+        x_np = np.random.randn(3, 6, 9, 7)
+        x = paddle.to_tensor(x_np)
+        x_T = x.T
+        self.assertTrue(x_T.shape, [7, 9, 6, 3])
+        self.assertTrue(np.array_equal(x_T.numpy(), x_np.T))
+
         self.assertTrue(inspect.ismethod(a.dot))
         self.assertTrue(inspect.ismethod(a.logsumexp))
         self.assertTrue(inspect.ismethod(a.multiplex))

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -367,8 +367,8 @@ tensor_method_func  = [ #noqa
            'real',
            'imag',
            'digamma',
-           'diagonal'
-           'trunc'
+           'diagonal',
+           'trunc',
            'bitwise_and',
            'bitwise_or',
            'bitwise_xor',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

为动态图的Tensor和静态图Variable，添加类成员API：``x.T`` 将N-D Tensor维度翻转 数据重排。

示例代码：
```
x = paddle.ones(shape=[2, 3, 4])
print(x)
Tensor(shape=[2, 3, 4], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       [[[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]],

        [[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]]])


x_T = x.T
print(x_T)
Tensor(shape=[4, 3, 2], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
       [[[1., 1.],
         [1., 1.],
         [1., 1.]],

        [[1., 1.],
         [1., 1.],
         [1., 1.]],

        [[1., 1.],
         [1., 1.],
         [1., 1.]],

        [[1., 1.],
         [1., 1.],
         [1., 1.]]])
```