### PR TITLE
support numpy dtype and polish code of list index.

### DIFF
--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -554,20 +554,21 @@ def monkey_patch_varbase():
                         or isinstance(slice_item.step, Variable):
                     return True
             else:
-                if isinstance(slice_item, Variable):
+                if isinstance(slice_item,
+                              Variable) and Variable.dtype != paddle.bool:
                     return True
         return False
 
     def __getitem__(self, item):
         def is_list_tuple(index, contain_type):
             def _is_list_tuple(item):
-                if not (isinstance(item, (list, tuple)) or
-                        type(item) == contain_type):
-                    return False
                 if isinstance(item, (tuple, list)):
                     for s in item:
                         if not _is_list_tuple(s):
                             return False
+                else:
+                    if type(item) != contain_type:
+                        return False
                 return True
 
             if not isinstance(index, (tuple, list)):
@@ -588,11 +589,11 @@ def monkey_patch_varbase():
 
     def __setitem__(self, item, value):
         def contain_tensor_or_list(item):
-            if not isinstance(item, (tuple, list)):
+            if not isinstance(item, tuple):
                 item = [item]
 
             for slice_item in item:
-                if isinstance(slice_item, (list, tuple)):
+                if isinstance(slice_item, list):
                     return True
                 elif isinstance(slice_item, Variable):
                     return True

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -801,6 +801,7 @@ class TestVarBase(unittest.TestCase):
         py_idx = [[0, 2, 0, 1, 3], [0, 0, 1, 2, 0]]
         idx = [paddle.to_tensor(py_idx[0]), paddle.to_tensor(py_idx[1])]
         self.assertTrue(np.array_equal(x[idx].numpy(), array[py_idx]))
+        self.assertTrue(np.array_equal(x[py_idx].numpy(), array[py_idx]))
         # case2:
         tensor_x = paddle.to_tensor(
             np.zeros(12).reshape(2, 6).astype(np.float32))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

- `varbase._getitem__` 支持 np.longlong，np.int64，np.int32 ，np.int16
- 修改 list索引的判断条件。动态图这种联合索引仍然走numpy分支
  ```python
  tensor_x[:, tensor_y1:tensor_y2] = 42
  ```