### PR TITLE
quant: fix a export bug

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/qat.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/qat.py
@@ -566,11 +566,12 @@ class ImperativeQuantizeOutputs(object):
                 out_scale = utils.fp_numpy_to_naive(out_scale)
 
                 if previous_op.type != "feed":
-                    argname, index = utils._get_output_name_index(previous_op,
-                                                                  in_var_name)
-                    previous_op._set_attr(argname + str(index) + "_threshold",
-                                          out_scale)
-                    previous_op._set_attr("out_threshold", out_scale)
+                    res = utils._get_output_name_index(previous_op, in_var_name)
+                    if res is not None:
+                        argname, index = res
+                        previous_op._set_attr(
+                            argname + str(index) + "_threshold", out_scale)
+                        previous_op._set_attr("out_threshold", out_scale)
 
                 for next_op in next_ops:
                     next_op._rename_input(out_var_name, in_var_name)

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -134,6 +134,7 @@ _op_real_in_out_name = {
     "flatten": [["X"], ["Out"]],
     "flatten2": [["X"], ["Out"]],
     "unsqueeze2": [["X"], ["Out"]],
+    "flatten_contiguous_range": [['X'], ["Out", "XShape"]],
 }
 
 _conv_ops = ['conv2d', 'depthwise_conv2d', 'conv2d_transpose']


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
支持为 flatten_contiguous_range 这个op写入out_threshold。并修复了遇到不支持统计out scale的op时报错的bug。