### PR TITLE
add backward inplace for dygraph

### DIFF
--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -383,6 +383,9 @@ void BasicEngine::Execute() {
               }
             }
           }
+          if (!in_tensor) {
+            continue;
+          }
           for (auto& p : cur_op.GetOutsMap()) {
             if (p.first == pair.second) {
               if (p.second.size() > 0 && p.second[0]) {

--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -314,7 +314,7 @@ static std::shared_ptr<NameVarMap<VariableWrapper>> CallGradientHooks(
   return tmp_ins_ptr;
 }
 
-bool IsInputCanInplace(const std::shared_ptr<VariableWrapper>& var) {
+static bool IsInputCanInplace(const std::shared_ptr<VariableWrapper>& var) {
   auto* inner_var = var->MutableVar();
   if (inner_var->IsInitialized() && inner_var->IsType<framework::LoDTensor>()) {
     auto tensor = inner_var->GetMutable<framework::LoDTensor>();
@@ -323,6 +323,57 @@ bool IsInputCanInplace(const std::shared_ptr<VariableWrapper>& var) {
     }
   }
   return false;
+}
+
+static void PerformBackwardInplace(const std::string& op_type,
+                                   const NameVarMap<VariableWrapper>& ins,
+                                   NameVarMap<VariableWrapper>* outs) {
+  auto& infer_inplace =
+      paddle::framework::OpInfoMap::Instance().Get(op_type).infer_inplace_;
+
+  if (infer_inplace) {
+    auto in_to_outs = infer_inplace(true);
+    for (auto& pair : in_to_outs) {
+      framework::LoDTensor *in_tensor = nullptr, *out_tensor = nullptr;
+      for (auto& p : ins) {
+        if (p.first == pair.first) {
+          // has at least one var
+          if (p.second.size() > 0 && p.second[0]) {
+            auto& in_var = p.second[0];
+            VLOG(10) << p.first << " use_count: " << in_var.use_count();
+            // the refcount of var to be inplaced should be 1
+            if (in_var.use_count() == 1) {
+              if (IsInputCanInplace(in_var)) {
+                in_tensor =
+                    in_var->MutableVar()->GetMutable<framework::LoDTensor>();
+              }
+            }
+          }
+        }
+      }
+      if (!in_tensor) {
+        continue;
+      }
+      for (auto& p : *outs) {
+        if (p.first == pair.second) {
+          if (p.second.size() > 0 && p.second[0]) {
+            auto& out_var = p.second[0];
+            if (out_var->Type() == framework::proto::VarType::LOD_TENSOR) {
+              out_tensor =
+                  out_var->MutableVar()->GetMutable<framework::LoDTensor>();
+            }
+          }
+        }
+      }
+      if (!out_tensor) {
+        continue;
+      }
+      out_tensor->ShareBufferWith(*in_tensor);
+      out_tensor->Resize(in_tensor->dims());
+      VLOG(4) << "Inplace performed in op " << op_type << ": " << pair.second
+              << " -> " << pair.first;
+    }
+  }
 }
 
 void BasicEngine::Execute() {
@@ -358,50 +409,6 @@ void BasicEngine::Execute() {
       // Step 1: Run Backward OP
       auto& bwd_ins = cur_op.GetInsMap();
       auto& bwd_outs = cur_op.GetOutsMap();
-
-      auto& infer_inplace = paddle::framework::OpInfoMap::Instance()
-                                .Get(cur_op.Type())
-                                .infer_inplace_;
-
-      if (infer_inplace) {
-        auto in_to_outs = infer_inplace(true);
-        for (auto& pair : in_to_outs) {
-          framework::LoDTensor *in_tensor = nullptr, *out_tensor = nullptr;
-          for (auto& p : cur_op.GetInsMap()) {
-            if (p.first == pair.first) {
-              // has at least one var
-              if (p.second.size() > 0 && p.second[0]) {
-                auto& in_var = p.second[0];
-                VLOG(10) << p.first << " use_count: " << in_var.use_count();
-                // the refcount of var to be inplaced should be 1
-                if (in_var.use_count() == 1) {
-                  if (IsInputCanInplace(in_var)) {
-                    in_tensor = in_var->MutableVar()
-                                    ->GetMutable<framework::LoDTensor>();
-                  }
-                }
-              }
-            }
-          }
-          if (!in_tensor) {
-            continue;
-          }
-          for (auto& p : cur_op.GetOutsMap()) {
-            if (p.first == pair.second) {
-              if (p.second.size() > 0 && p.second[0]) {
-                auto& out_var = p.second[0];
-                if (out_var->Type() == framework::proto::VarType::LOD_TENSOR) {
-                  out_tensor =
-                      out_var->MutableVar()->GetMutable<framework::LoDTensor>();
-                }
-              }
-            }
-          }
-          out_tensor->ShareBufferWith(*in_tensor);
-          VLOG(4) << "Inplace performed in op " << cur_op.Type() << ": "
-                  << pair.second << " -> " << pair.first;
-        }
-      }
 
       /**
        * [ Why need temporary outputs here? ]
@@ -537,6 +544,10 @@ void BasicEngine::Execute() {
        *   hold hooks
        */
       auto tmp_ins_ptr = CallGradientHooks(bwd_ins, cur_op.Type());
+
+      if (!tmp_ins_ptr) {
+        PerformBackwardInplace(cur_op.Type(), bwd_ins, &tmp_outs);
+      }
 
       {
         VLOG(3) << "Start to execute grad op " << cur_op.Type();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add backward inplace for dygraph

### how
In dygraph mode, the forward part is not determined, while the backward computation graph is determined after forward. So the graph optimization can be performed. And, the reference count used to guide inplace optimization can be easily get `shared_ptr` of input tensor.

Two benefits: (1) reduce d2d copy and speed up training, (2) reduce memory usage

### performance
GPT model, speed up **+2.8%**.
![f5f2b2cb62e7531cf3d5f698e4de5734](https://user-images.githubusercontent.com/6888866/132615159-9f884791-7983-43b0-bf26-7d048ea17998.png)
