### PR TITLE
Add attribute for masked select op defination

### DIFF
--- a/paddle/fluid/operators/masked_select_op.cc
+++ b/paddle/fluid/operators/masked_select_op.cc
@@ -43,13 +43,15 @@ class MaskedSelectOp : public framework::OperatorWithKernel {
 class MaskedSelectOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
-    AddInput("X", "The input tensor.");
+    AddInput("X", "The input tensor.").AsPrimitive();
     AddInput("Mask",
-             "The mask of Input Tensor to be selected which is a bool Tensor.");
+             "The mask of Input Tensor to be selected which is a bool Tensor.")
+        .AsPrimitive();
     AddOutput(
         "Y",
         "The returned tensor, the data type "
-        "is same as input, will be on the same device with the input Tensor.");
+        "is same as input, will be on the same device with the input Tensor.")
+        .AsPrimitive();
     AddComment(R"DOC(
 Size Operator.
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
为 masked_select 在 op 定义时增加原生字段属性标记