### PR TITLE
Add api paddle.device.cuda.empty_cache to release idle gpu memory hold by allocator。

### DIFF
--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -22,10 +22,12 @@ limitations under the License. */
 #else
 #include "paddle/fluid/platform/dynload/cudnn.h"
 #endif
+#include "paddle/fluid/memory/malloc.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/lock_guard_ptr.h"
 #include "paddle/fluid/platform/macros.h"
 #include "paddle/fluid/platform/monitor.h"
+#include "paddle/fluid/platform/place.h"
 #include "paddle/fluid/string/split.h"
 
 DECLARE_double(fraction_of_gpu_memory_to_use);
@@ -628,6 +630,13 @@ uint64_t RecordedCudaMallocSize(int dev_id) {
 
 bool IsCudaMallocRecorded(int dev_id) {
   return RecordedCudaMallocHelper::Instance(dev_id)->NeedRecord();
+}
+
+void EmptyCache(void) {
+  std::vector<int> devices = GetSelectedDevices();
+  for (auto device : devices) {
+    memory::Release(CUDAPlace(device));
+  }
 }
 
 }  // namespace platform

--- a/paddle/fluid/platform/gpu_info.h
+++ b/paddle/fluid/platform/gpu_info.h
@@ -138,7 +138,7 @@ uint64_t RecordedCudaMallocSize(int dev_id);
 bool IsCudaMallocRecorded(int dev_id);
 
 //! Empty idle cached memory held by the allocator.
-void EmptyCache(void)
+void EmptyCache(void);
 
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/gpu_info.h
+++ b/paddle/fluid/platform/gpu_info.h
@@ -137,6 +137,9 @@ uint64_t RecordedCudaMallocSize(int dev_id);
 
 bool IsCudaMallocRecorded(int dev_id);
 
+//! Empty idle cached memory held by the allocator.
+void EmptyCache(void)
+
 }  // namespace platform
 }  // namespace paddle
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2241,7 +2241,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("op_support_gpu", OpSupportGPU);
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   m.def("get_cuda_device_count", platform::GetCUDADeviceCount);
-  m.def("_cuda_emptyCache", platform::EmptyCache);
+  m.def("cuda_empty_cache", platform::EmptyCache);
 
 #if !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
   m.def("nvprof_init", platform::CudaProfilerInit);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2241,6 +2241,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("op_support_gpu", OpSupportGPU);
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   m.def("get_cuda_device_count", platform::GetCUDADeviceCount);
+  m.def("_cuda_emptyCache", platform::EmptyCache);
 
 #if !defined(PADDLE_WITH_HIP) && !defined(_WIN32)
   m.def("nvprof_init", platform::CudaProfilerInit);

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -141,4 +141,5 @@ def empty_cache():
     """
 
     if core.is_compiled_with_cuda():
-        core._cuda_emptyCache()
+        if hasattr(core, "cuda_empty_cache"):
+            core.cuda_empty_cache()

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -129,6 +129,7 @@ def empty_cache():
 
     Examples:
         .. code-block:: python
+
             import paddle
 
             # required: gpu

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -141,5 +141,4 @@ def empty_cache():
     """
 
     if core.is_compiled_with_cuda():
-        if hasattr(core, "cuda_empty_cache"):
-            core.cuda_empty_cache()
+        core.cuda_empty_cache()

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     'current_stream',
     'synchronize',
     'device_count',
+    'empty_cache',
 ]
 
 
@@ -117,3 +118,27 @@ def device_count():
         core, 'get_cuda_device_count') else 0
 
     return num_gpus
+
+
+def empty_cache():
+    """
+    Releases idle cached memory held by the allocator so that those can be used in other GPU
+    application and visible in `nvidia-smi`. In most cases you don't need to use this function,
+    Paddle does not release the memory back to the OS when you remove Tensors on the GPU,
+    Because it keeps gpu memory in a pool so that next allocations can be done much faster.
+
+    Examples:
+        .. code-block:: python
+            import paddle
+
+            # required: gpu
+            paddle.set_device("gpu")
+            # nvidia-smi
+            tensor = paddle.randn([512, 512, 512], "float")
+            del tensor
+            # nvidia-smi
+            paddle.device.cuda.empty_cache()
+    """
+
+    if core.is_compiled_with_cuda():
+        core._cuda_emptyCache()

--- a/python/paddle/device/cuda/__init__.py
+++ b/python/paddle/device/cuda/__init__.py
@@ -134,10 +134,8 @@ def empty_cache():
 
             # required: gpu
             paddle.set_device("gpu")
-            # nvidia-smi
             tensor = paddle.randn([512, 512, 512], "float")
             del tensor
-            # nvidia-smi
             paddle.device.cuda.empty_cache()
     """
 

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -276,6 +276,7 @@ if avx_supported():
         from .core_avx import _set_cached_executor_build_strategy
         from .core_avx import _device_synchronize
         from .core_avx import _get_current_stream
+        from .core_avx import _cuda_emptyCache
         if sys.platform != 'win32':
             from .core_avx import _set_process_pids
             from .core_avx import _erase_process_pids
@@ -328,6 +329,7 @@ if load_noavx:
         from .core_noavx import _set_cached_executor_build_strategy
         from .core_noavx import _device_synchronize
         from .core_noavx import _get_current_stream
+        from .core_noavx import _cuda_emptyCache
         if sys.platform != 'win32':
             from .core_noavx import _set_process_pids
             from .core_noavx import _erase_process_pids

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -276,7 +276,6 @@ if avx_supported():
         from .core_avx import _set_cached_executor_build_strategy
         from .core_avx import _device_synchronize
         from .core_avx import _get_current_stream
-        from .core_avx import _cuda_emptyCache
         if sys.platform != 'win32':
             from .core_avx import _set_process_pids
             from .core_avx import _erase_process_pids
@@ -329,7 +328,6 @@ if load_noavx:
         from .core_noavx import _set_cached_executor_build_strategy
         from .core_noavx import _device_synchronize
         from .core_noavx import _get_current_stream
-        from .core_noavx import _cuda_emptyCache
         if sys.platform != 'win32':
             from .core_noavx import _set_process_pids
             from .core_noavx import _erase_process_pids

--- a/python/paddle/fluid/tests/unittests/test_cuda_empty_cache.py
+++ b/python/paddle/fluid/tests/unittests/test_cuda_empty_cache.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import unittest
+
+
+class TestEmptyCache(unittest.TestCase):
+    def test_empty_cache(self):
+        x = paddle.randn((2, 10, 12)).astype('float32')
+        del x
+        paddle.device.cuda.empty_cache()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_cuda_empty_cache.py
+++ b/python/paddle/fluid/tests/unittests/test_cuda_empty_cache.py
@@ -20,7 +20,7 @@ class TestEmptyCache(unittest.TestCase):
     def test_empty_cache(self):
         x = paddle.randn((2, 10, 12)).astype('float32')
         del x
-        paddle.device.cuda.empty_cache()
+        self.assertIsNone(paddle.device.cuda.empty_cache())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR types
New features

### PR changes
APIs

### Describe
Add API paddle.device.cuda.empty_cache to releases idle cached memory held by the allocator so that those can be used in other GPU application and visible in `nvidia-smi`. In most cases you don't need to use this function, Paddle does not release the memory back to the OS when you remove Tensors on the GPU, Because it keeps gpu memory in a pool so that next allocations can be done much faster.

exaples:

```python
            import paddle

            # required: gpu
            paddle.set_device("gpu")
            # nvidia-smi
            tensor = paddle.randn([512, 512, 512], "float")
            del tensor
            # nvidia-smi
            paddle.device.cuda.empty_cache()
```
