### PR TITLE
add c_embedding npu op

### DIFF
--- a/paddle/fluid/operators/collective/c_embedding_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_embedding_op_npu.cc
@@ -1,0 +1,228 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#include <memory>
+#include <string>
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/fluid/operators/collective/c_embedding_op.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+#include "paddle/fluid/platform/npu_info.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename T>
+void shard_index(const Tensor &table_t, const Tensor &ids_t, int64_t start_idx,
+                 Tensor id_t, const framework::ExecutionContext &context) {
+  int table_w = table_t.dims()[0];
+  auto stream =
+      context.template device_context<paddle::platform::NPUDeviceContext>()
+          .stream();
+
+  framework::Tensor id_t_d;
+  id_t_d.mutable_data<T>(ids_t.dims(), context.GetPlace());
+  FillNpuTensorWithConstant(&id_t_d, static_cast<T>(0.0));
+  id_t_d.Resize(ids_t.dims());
+  framework::Tensor id_t_u;
+  id_t_u.mutable_data<T>(ids_t.dims(), context.GetPlace());
+  FillNpuTensorWithConstant(&id_t_u, static_cast<T>(table_w - 1));
+  id_t_u.Resize(ids_t.dims());
+
+  framework::Tensor id_matched_d;
+  id_matched_d.mutable_data<bool>(ids_t.dims(), context.GetPlace());
+  framework::Tensor id_matched_u;
+  id_matched_u.mutable_data<bool>(ids_t.dims(), context.GetPlace());
+  framework::Tensor ignore_tensor;
+  ignore_tensor.mutable_data<T>(ids_t.dims(), context.GetPlace());
+  FillNpuTensorWithConstant(&ignore_tensor, static_cast<T>(table_w));
+  ignore_tensor.Resize(ids_t.dims());
+
+  NpuOpRunner sub_runner;
+  sub_runner.SetType("Sub")
+      .AddInput(ids_t)
+      .AddInput(std::vector<int>{static_cast<int>(start_idx)})
+      .AddOutput(id_t);
+  sub_runner.Run();
+
+  NpuOpRunner lessequal1_runner;
+  lessequal1_runner.SetType("LessEqual")
+      .AddInput(id_t)
+      .AddInput(id_t_u)
+      .AddOutput(id_matched_u);
+  lessequal1_runner.Run();
+
+  NpuOpRunner lessequal2_runner;
+  lessequal2_runner.SetType("LessEqual")
+      .AddInput(id_t_d)
+      .AddInput(id_t)
+      .AddOutput(id_matched_d);
+  lessequal2_runner.Run();
+
+  NpuOpRunner("Equal", {id_matched_u, id_matched_d}, {id_matched_d}, {})
+      .Run(stream);
+  NpuOpRunner("Select", {id_matched_d, id_t, ignore_tensor}, {id_t}, {})
+      .Run(stream);
+}
+
+template <typename DeviceContext, typename T>
+class CEmbeddingNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &context) const override {
+    auto *table_t = context.Input<LoDTensor>("W");
+    auto *ids_t = context.Input<LoDTensor>("Ids");
+    auto *output_t = context.Output<LoDTensor>("Out");
+
+    auto stream =
+        context.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+    const int64_t start_idx = context.Attr<int64_t>("start_index");
+    framework::Tensor id_t;
+    id_t.mutable_data<int>(ids_t->dims(), context.GetPlace());
+
+    VLOG(3) << "start to shard index"
+            << "ids_t: " << ids_t->dims();
+
+    shard_index<int>(*table_t, *ids_t, start_idx, id_t, context);
+
+    PADDLE_ENFORCE_EQ(table_t->dims().size(), 2,
+                      platform::errors::InvalidArgument(
+                          "NPU only accept the dims of table_t == 2"));
+    PADDLE_ENFORCE_EQ(table_t->dims()[1] % 64, 0,
+                      platform::errors::InvalidArgument(
+                          "NPU only accept the second dim must align by 64"));
+    auto pad_shape =
+        framework::make_ddim({table_t->dims()[0] + 1, table_t->dims()[1]});
+    framework::LoDTensor table_t_pad;
+
+    size_t mem_size = table_t->memory_size();
+    size_t line_mem_size =
+        table_t->dims()[1] * framework::SizeOfType(table_t->type());
+
+    VLOG(3) << "pad_shape done. "
+            << "mem_size:" << mem_size << ",line_mem_size:" << line_mem_size
+            << ", pad_shape:" << pad_shape
+            << ", table_dims:" << table_t->dims();
+
+    uint8_t *pad_data = reinterpret_cast<uint8_t *>(
+        table_t_pad.mutable_data<T>(pad_shape, context.GetPlace()));
+    PADDLE_ENFORCE_NPU_SUCCESS(
+        aclrtMemcpyAsync(pad_data, mem_size, table_t->data<T>(), mem_size,
+                         ACL_MEMCPY_DEVICE_TO_DEVICE, stream));
+    PADDLE_ENFORCE_NPU_SUCCESS(aclrtMemsetAsync(
+        pad_data + mem_size, line_mem_size, 0, line_mem_size, stream));
+
+    output_t->mutable_data<T>(context.GetPlace());
+    NpuOpRunner runner;
+    runner.SetType("GatherV2")
+        .AddInput(table_t_pad)
+        .AddInput(id_t)
+        .AddInput(std::vector<int32_t>{0})
+        .AddOutput(*output_t);
+    runner.Run();
+  }
+};
+
+template <typename DeviceContext, typename T>
+class CEmbeddingGradNPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &context) const override {
+    const int64_t start_idx = context.Attr<int64_t>("start_index");
+    auto ids_t = context.Input<LoDTensor>("Ids");
+    auto *table_t = context.Input<LoDTensor>("W");
+    auto d_output_t = context.Input<LoDTensor>(framework::GradVarName("Out"));
+    auto table_grad_t = context.Output<LoDTensor>(framework::GradVarName("W"));
+    auto table_grad_shape =
+        framework::make_ddim({table_t->dims()[0], table_t->dims()[1]});
+    table_grad_t->mutable_data<T>(table_grad_shape, context.GetPlace());
+
+    auto stream =
+        context.template device_context<paddle::platform::NPUDeviceContext>()
+            .stream();
+    framework::Tensor id_t;
+    id_t.mutable_data<int>(ids_t->dims(), context.GetPlace());
+
+    VLOG(3) << "start to shard index"
+            << "ids_t: " << ids_t->dims();
+    shard_index<int>(*table_grad_t, *ids_t, start_idx, id_t, context);
+
+    auto pad_shape = framework::make_ddim(
+        {table_grad_t->dims()[0] + 1, table_grad_t->dims()[1]});
+    framework::LoDTensor table_t_tmp;
+
+    size_t mem_size = table_grad_t->memory_size();
+    size_t line_mem_size =
+        table_grad_t->dims()[1] * framework::SizeOfType(table_grad_t->type());
+
+    uint8_t *pad_data = reinterpret_cast<uint8_t *>(
+        table_t_tmp.mutable_data<T>(pad_shape, context.GetPlace()));
+    PADDLE_ENFORCE_NPU_SUCCESS(
+        aclrtMemcpyAsync(pad_data, mem_size, table_grad_t->data<T>(), mem_size,
+                         ACL_MEMCPY_DEVICE_TO_DEVICE, stream));
+    PADDLE_ENFORCE_NPU_SUCCESS(aclrtMemsetAsync(
+        pad_data + mem_size, line_mem_size, 0, line_mem_size, stream));
+
+    VLOG(3) << "pad_shape done. "
+            << "mem_size:" << mem_size;
+
+    const auto &runner_zeros =
+        NpuOpRunner("ZerosLike", {table_t_tmp}, {table_t_tmp});
+    runner_zeros.Run(stream);
+
+    // NOTE(zhiqiu): It seems in cann 20.1, the first input and output
+    // can be different tensor, but in cann 20.2+, it does inplace operation.
+    // Thus, the first input and output should be same tensor.
+    const auto &runner_scatter =
+        NpuOpRunner("ScatterAdd", {table_t_tmp, id_t, *d_output_t},
+                    {table_t_tmp}, {{"use_locking", true}});
+    runner_scatter.Run(stream);
+
+    framework::Tensor out1;
+    framework::Tensor out2;
+    auto out_shape1 = framework::make_ddim(
+        {table_t_tmp.dims()[0] - 1, table_t_tmp.dims()[1]});
+    auto out_shape2 = framework::make_ddim({1, table_t_tmp.dims()[1]});
+    out1.mutable_data<T>(out_shape1, context.GetPlace());
+    out2.mutable_data<T>(out_shape2, context.GetPlace());
+    std::vector<framework::Tensor> outputs = {out1, out2};
+    std::vector<int> sections = {static_cast<int>(table_t_tmp.dims()[0] - 1),
+                                 1};
+    framework::NPUAttributeMap attr_input = {
+        {"size_splits", sections},
+        {"split_dim", 0},
+        {"num_split", static_cast<int32_t>(sections.size())}};
+    NpuOpRunner runner_split;
+    runner_split.SetType("SplitVD")
+        .AddInput(table_t_tmp)
+        .AddOutputs(outputs)
+        .AddAttrs(attr_input);
+    runner_split.Run(stream);
+    table_grad_t->ShareDataWith(out1);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+REGISTER_OP_NPU_KERNEL(
+    c_embedding, ops::CEmbeddingNPUKernel<plat::NPUDeviceContext, float>,
+    ops::CEmbeddingNPUKernel<plat::NPUDeviceContext, double>,
+    ops::CEmbeddingNPUKernel<plat::NPUDeviceContext, plat::float16>);
+REGISTER_OP_NPU_KERNEL(
+    c_embedding_grad,
+    ops::CEmbeddingGradNPUKernel<plat::NPUDeviceContext, float>,
+    ops::CEmbeddingGradNPUKernel<plat::NPUDeviceContext, double>,
+    ops::CEmbeddingGradNPUKernel<plat::NPUDeviceContext, plat::float16>);

--- a/python/paddle/distributed/collective.py
+++ b/python/paddle/distributed/collective.py
@@ -1403,28 +1403,17 @@ def split(x,
             "but received vocabulary={} num_partitions={}".format(size[0], num_partitions)
 
         per_part_size = size[0] // num_partitions
-        if core.is_compiled_with_npu():
-            emb_out = _parallel_embedding_npu(
-                x,
-                per_part_size,
-                size,
-                weight_attr,
-                inner_rank,
-                num_partitions,
-                name,
-                group=None)
-            return emb_out
-        else:
-            emb_out = _parallel_embedding(
-                x,
-                per_part_size,
-                size,
-                weight_attr,
-                inner_rank,
-                num_partitions,
-                name,
-                group=None)
-            return emb_out
+        ## FIXME(baiyangfan) Unified NPU\GPU embedding.
+        emb_out = _parallel_embedding(
+            x,
+            per_part_size,
+            size,
+            weight_attr,
+            inner_rank,
+            num_partitions,
+            name,
+            group=None)
+        return emb_out
     else:
         should_split = False
         if axis == 0:

--- a/python/paddle/fluid/tests/unittests/npu/c_embedding_grad_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/c_embedding_grad_npu.py
@@ -1,0 +1,67 @@
+#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle import _C_ops
+
+SEED = 2021
+
+
+def get_c_lookup_tablev2_grad(dtype):
+    device = paddle.set_device('npu:0')
+    start = 2
+    end = 12
+    np.random.seed(SEED)
+    ids = np.random.randint(low=0, high=20, size=(6, 8)).astype(np.int32)
+    index = ids.flatten()
+    input_mask = (index < start) | (index >= end)
+    masked_input = index - start
+    masked_input[input_mask] = 10
+    masked_input.resize(6, 8)
+    table = np.zeros([11, 64]).astype(dtype)
+    tmp = np.ones([10, 64]).astype(dtype)
+    table[:10, :] = tmp[:]
+    table = paddle.to_tensor(table, stop_gradient=False)
+    masked_input = paddle.to_tensor(masked_input, stop_gradient=False)
+    c_embedding = _C_ops.lookup_table_v2(table, masked_input)
+    c_embedding.backward()
+    return table.grad.numpy()[:-1]
+
+
+def _get_c_embedding_grad(dtype):
+    device = paddle.set_device('npu:0')
+    start = 2
+    np.random.seed(SEED)
+    ids = np.random.randint(low=0, high=20, size=(6, 8)).astype(np.int32)
+    table = np.ones([10, 64]).astype(dtype)
+    table = paddle.to_tensor(table, stop_gradient=False)
+    ids = paddle.to_tensor(ids, stop_gradient=False)
+    c_embedding = _C_ops.c_embedding(table, ids, 'start_index', start)
+    c_embedding.backward()
+    return (table.grad.numpy() == get_c_lookup_tablev2_grad(dtype)).all
+
+
+def get_c_embedding_grad():
+    result = []
+    for table_dtype in [np.float32, np.float16]:
+        res = _get_c_embedding_grad(table_dtype)
+        assert res, "c_embedding_grad {} dtype find error!".format(table_dtype)
+        result.append(res)
+    return np.array(result).all()

--- a/python/paddle/fluid/tests/unittests/npu/test_c_embedding_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_c_embedding_op_npu.py
@@ -1,0 +1,86 @@
+#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+import sys
+sys.path.append("..")
+from op_test import OpTest
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from c_embedding_grad_npu import get_c_embedding_grad
+
+c_embedding_grad = get_c_embedding_grad()
+paddle.enable_static()
+SEED = 2021
+
+
+def get_c_embedding(start, end, table, ids):
+    index = ids.flatten()
+    input_mask = (index < start) | (index >= end)
+    masked_input = index - start
+    masked_input[input_mask] = 0
+    output = table[masked_input]
+    output[input_mask] = 0.0
+    return output
+
+
+class TestCEmbeddingOpFP32(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.place = fluid.NPUPlace(0)
+        self.init_dtype()
+        np.random.seed(SEED)
+        self.op_type = "c_embedding"
+        table = np.ones([10, 64]).astype(self.dtype)
+        ids = np.random.randint(low=0, high=20, size=(6, 8)).astype(np.int32)
+        self.start_index = 2
+        self.end_index = self.start_index + 10
+
+        self.inputs = {'W': table, 'Ids': ids}
+        np_out = get_c_embedding(self.start_index, self.end_index, table, ids)
+        self.outputs = {'Out': np_out.reshape(6, 8, 64)}
+        self.attrs = {'start_index': self.start_index}
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def test_check_grad(self):
+        if self.dtype == np.float16:
+            return
+        self.assertTrue(c_embedding_grad)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+
+class TestCEmbeddingOpFP16(TestCEmbeddingOpFP32):
+    no_need_check_grad = True
+
+    def init_dtype(self):
+        self.dtype = np.float16
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+        self.__class__.no_need_check_grad = True
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_collective_split_embedding.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_split_embedding.py
@@ -27,6 +27,7 @@ class TestParallelEmbeddingAPI(TestDistBase):
         pass
 
     def test_parallel_embedding(self):
+        ## Unified split embedding.
         self.check_with_place("parallel_embedding_api.py", "parallel_embedding",
                               "nccl")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Add a c_embedding op to unify NPU\GPU split embedding.
NPU c_embedding op support FP32 and FP16 for table, INT32 for ids.
Method:
A. Inner function shard_index to handle out ids in collective.
B. Auto add last dim for table to choose out ids.
C. Split auto add dim in backward.
![image](https://user-images.githubusercontent.com/39549453/132087775-09a0292c-0ca6-4b1f-bc98-f91060f37b71.png)

Test result
Seed=2021 
![image](https://user-images.githubusercontent.com/39549453/132089484-08e6e767-7350-4a75-8ab6-be8c1e3319e7.png)


GPU  forward
![image](https://user-images.githubusercontent.com/39549453/132088910-5fac129e-cb3e-4e71-97e7-f513ac6f32c7.png)

NPU  forward
![image](https://user-images.githubusercontent.com/39549453/132088919-31c5b12e-fc86-473b-b591-8b8a802ba9e5.png)

GPU backward
![image](https://user-images.githubusercontent.com/39549453/132089092-29232503-799f-4581-be83-d7726009d7c1.png)

NPU backward
![image](https://user-images.githubusercontent.com/39549453/132089116-80c96a65-4454-4325-8b46-24a6c7c10acf.png)

