### PR TITLE
[NPU] optimize dropout npu op

### DIFF
--- a/paddle/fluid/operators/dropout_op_npu.cc
+++ b/paddle/fluid/operators/dropout_op_npu.cc
@@ -44,9 +44,12 @@ class DropoutNPUKernel : public framework::OpKernel<T> {
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
+    uint32_t mask_length = (x->numel() + 128 - 1) / 128 * 128;
+
     if (dropout_prob == 1.) {
       const auto& runner_zeros_out = NpuOpRunner("ZerosLike", {*out}, {*out});
       runner_zeros_out.Run(stream);
+      mask->Resize(framework::make_ddim({mask_length / 8}));
       mask->mutable_data<uint8_t>(ctx.GetPlace());
       const auto& runner_zeros_mask =
           NpuOpRunner("ZerosLike", {*mask}, {*mask});
@@ -84,14 +87,8 @@ class DropoutNPUKernel : public framework::OpKernel<T> {
       FillNpuTensorWithConstant<T>(&keep_prob_tensor,
                                    static_cast<T>(keep_prob));
 
+      mask->Resize(framework::make_ddim({mask_length / 8}));
       mask->mutable_data<uint8_t>(ctx.GetPlace());
-
-      // mask used in `DropOutGenMask` NPU OP is different from
-      // the output `Mask`.
-      Tensor npu_mask(framework::proto::VarType::UINT8);
-      uint32_t length = (x->numel() + 128 - 1) / 128 * 128;
-      npu_mask.Resize(framework::make_ddim({length / 8}));
-      npu_mask.mutable_data<uint8_t>(ctx.GetPlace());
 
       // TODO(pangyoki): `keep_prob` used in `DropOutGenMask` NPU
       // OP must be a scalar with shape[0]. At present, the shape
@@ -101,35 +98,14 @@ class DropoutNPUKernel : public framework::OpKernel<T> {
       runner_gen_mask.SetType("DropOutGenMask")
           .AddInput(framework::vectorize(tmp_out.dims()))
           .AddInput(keep_prob_tensor)
-          .AddOutput(npu_mask)
+          .AddOutput(*mask)
           .AddAttr("seed", seed)
           .AddAttr("seed2", seed2);
       runner_gen_mask.Run(stream);
 
-      NpuOpRunner runner_dropout;
-      runner_dropout.SetType("DropOutDoMask")
-          .AddInput(tmp_x)
-          .AddInput(npu_mask)
-          .AddInput(keep_prob_tensor)
-          .AddOutput(tmp_out);
+      const auto& runner_dropout = NpuOpRunner(
+          "DropOutDoMask", {tmp_x, *mask, keep_prob_tensor}, {tmp_out}, {});
       runner_dropout.Run(stream);
-
-      // cast `out` from float/float16 to bool
-      Tensor cast_mask(framework::proto::VarType::BOOL);
-      cast_mask.Resize(mask->dims());
-      cast_mask.mutable_data<bool>(ctx.GetPlace());
-      auto dst_dtype_bool = ConvertToNpuDtype(cast_mask.type());
-      const auto& runner_cast_mask_bool =
-          NpuOpRunner("Cast", {*out}, {cast_mask},
-                      {{"dst_type", static_cast<int>(dst_dtype_bool)}});
-      runner_cast_mask_bool.Run(stream);
-
-      // cast cast_mask from bool to uint8
-      auto dst_dtype_uint8 = ConvertToNpuDtype(mask->type());
-      const auto& runner_cast_mask_uint8 =
-          NpuOpRunner("Cast", {cast_mask}, {*mask},
-                      {{"dst_type", static_cast<int>(dst_dtype_uint8)}});
-      runner_cast_mask_uint8.Run(stream);
     } else {
       framework::TensorCopy(
           *x, ctx.GetPlace(),
@@ -165,20 +141,26 @@ class DropoutGradNPUKernel : public framework::OpKernel<T> {
       return;
     }
 
-    // cast mask from uint8 to float32/float16
-    Tensor cast_mask(dx->type());
-    cast_mask.Resize(mask->dims());
-    cast_mask.mutable_data<T>(ctx.GetPlace());
-    auto dst_dtype = ConvertToNpuDtype(dx->type());
-    const auto& runner_cast_mask =
-        NpuOpRunner("Cast", {*mask}, {cast_mask},
-                    {{"dst_type", static_cast<int>(dst_dtype)}});
-    runner_cast_mask.Run(stream);
+    Tensor tmp_dout(dout->type());
+    Tensor tmp_dx(dx->type());
+    tmp_dout.ShareDataWith(*dout);
+    tmp_dx.ShareDataWith(*dx);
+    if (dout->dims().size() == 1) {
+      // DropOutDoMask will get error result when input
+      // is 1-D. Make it become 2-D.
+      std::vector<int> vec_dim = framework::vectorize<int>(dout->dims());
+      tmp_dout.Resize(framework::make_ddim({vec_dim[0], 1}));
+      tmp_dx.Resize(framework::make_ddim({vec_dim[0], 1}));
+    }
 
-    const auto& runner =
-        NpuOpRunner("MaskedScale", {*dout, cast_mask}, {*dx},
-                    {{"value", static_cast<float>(1. / (1 - dropout_prob))}});
-    runner.Run(stream);
+    float keep_prob = 1. - dropout_prob;
+    Tensor keep_prob_tensor(dout->type());
+    keep_prob_tensor.mutable_data<T>({1}, ctx.GetPlace());
+    FillNpuTensorWithConstant<T>(&keep_prob_tensor, static_cast<T>(keep_prob));
+
+    const auto& runner_dropout_grad = NpuOpRunner(
+        "DropOutDoMask", {tmp_dout, *mask, keep_prob_tensor}, {tmp_dx}, {});
+    runner_dropout_grad.Run(stream);
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_dropout_op_npu.py
@@ -53,7 +53,9 @@ class TestDropoutOp(OpTest):
         self.place = paddle.NPUPlace(0)
 
     def test_check_output(self):
-        self.check_output_with_place(self.place)
+        # mask used in `DropOutGenMask` NPU OP is different from the
+        # output `Mask`. So don't check value of Mask in npu unittest.
+        self.check_output_with_place(self.place, no_check_set=['Mask'])
 
     def test_check_grad_normal(self):
         if self.dtype == np.float16:
@@ -61,7 +63,7 @@ class TestDropoutOp(OpTest):
         self.check_grad_with_place(self.place, ['X'], 'Out')
 
 
-class TestDropoutOpInput1d(TestDropoutOp):
+class TestDropoutOpInputShape2(TestDropoutOp):
     # change input shape
     def setUp(self):
         self.op_type = "dropout"

--- a/python/paddle/fluid/tests/unittests/white_list/no_check_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_check_set_white_list.py
@@ -33,4 +33,5 @@ no_check_set_white_list = [
     'softmax_with_cross_entropy',
     'svd',
     'class_center_sample',
+    'dropout',
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

优化dropout npu op的实现。
`dropout` NPU op 调用 `DropOutDoMask` CANN OP 实现。`DropOutDoMask` CANN OP 中的 `Mask` 与 paddle 中 Mask 的定义不一样（shape不一样，CANN OP中，mask的长度为：`uint32_t mask_length = (x->numel() + 128 - 1) / 128 * 128;`）。因此，在原`dropout` NPU op 的实现中，会通过类型转化操作，构造出 paddle 需要的`Mask`。

但是，实际上，这个`Mask`只是反向求导时使用，不会暴露给用户。所以，我们可以不用将 CANN OP 输出的`Mask`转化为paddle需要的`Mask`。直接使用CANN OP的`Mask`计算反向即可。OP的复杂度小了很多。

因为`Mask`意义与paddle原`Mask`不同了，因此单测中，不对`Mask`进行检查。