### PR TITLE
update stop_gradient of the inplace var

### DIFF
--- a/paddle/fluid/pybind/op_function.h
+++ b/paddle/fluid/pybind/op_function.h
@@ -200,6 +200,10 @@ static inline void HandleViewBetweenInputAndOutput(
 static inline void HandleStopGradientInInplaceVar(
     const std::shared_ptr<imperative::VarBase>& inplace_var,
     const imperative::NameVarBaseMap& ins) {
+  if (!inplace_var->OverridedStopGradient()) return;
+  // In inplace op, for multiple inputs, as long as the stop_gradient
+  // of a var in the input is false, the stop_gradient of the inplace
+  // var is updated to false.
   bool find_grad = false;
   for (const auto& name_pair : ins) {
     for (const auto& var_base : name_pair.second) {

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -232,6 +232,19 @@ class TestDygraphInplace(unittest.TestCase):
         self.assertTrue(np.array_equal(grad_var_a_inplace, grad_var_a))
 
 
+class TestStopGradient(unittest.TestCase):
+    def test_stop_gradient(self):
+        a = paddle.to_tensor(2.)
+        b = paddle.to_tensor(3., stop_gradient=False)
+
+        a.add_(b)
+        self.assertTrue(not a.stop_gradient)
+
+        a.sum().backward()
+        grad_a = a.grad.numpy()
+        self.assertTrue(np.array_equal(grad_a, np.array([1.])))
+
+
 class TestDygraphInplaceUnsqueeze(TestDygraphInplace):
     def non_inplace_api_processing(self, var):
         return paddle.unsqueeze(var, -1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
在inplace op中，对多输入的情况，只要输入中某一个var的stop_gradient为false，就应该将inplace var的stop_gradient更新为false。

在自动生成的动态图执行函数中，添加了`HandleStopGradientInInplaceVar`方法，用来处理`inplace var`的`stop_gradient`属性。
![图片](https://user-images.githubusercontent.com/26408901/132125800-54efb855-b10a-476c-9aa8-1bfed8c34250.png)


### 以`add_`为例
```
import paddle

a = paddle.to_tensor(2.)
b = paddle.to_tensor(3., stop_gradient=False)

a.add_(b)
print(a)

a.sum().backward()
print(a.grad)
```

- 修复前，`a.add_(b)`中，若`a.stop_gradient=True, b.stop_gradient=False`，则`a.add_(b)`计算结束后，`a.stop_gradient`仍然为`True`：
![图片](https://user-images.githubusercontent.com/26408901/132125308-5c23ade5-81d3-4ab3-9825-da16b56ec80d.png)

- 修复后，`a.stop_gradient`变为`False`：
![图片](https://user-images.githubusercontent.com/26408901/132125664-a57bcea9-7adf-4fb6-b964-0e4a09e374cb.png)


