### PR TITLE
squared_l2_distance_op `sub_result` as extra

### DIFF
--- a/paddle/fluid/operators/squared_l2_distance_op.cc
+++ b/paddle/fluid/operators/squared_l2_distance_op.cc
@@ -120,7 +120,8 @@ class SquaredL2DistanceOpMaker : public framework::OpProtoAndCheckerMaker {
     AddOutput("sub_result",
               "(Tensor) Buffering subtraction result which "
               "will be reused in backward.")
-        .AsIntermediate();
+        .AsIntermediate()
+        .AsExtra();
     AddOutput("Out", "(Tensor) Squared l2 distance between input and target.");
     AddComment(R"DOC(
 SquaredL2Distance operator


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

set output `sub_result` in `squared_l2_distance_op` as  extra.