### PR TITLE
[Paddle Inference]Add BN op TRT converter unittest

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -482,7 +482,12 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
           return false;
         }
       }
-
+      auto batch_norm_inputs = desc.Inputs();
+      if (batch_norm_inputs.find("MomentumTensor") != batch_norm_inputs.end()) {
+        if (desc.Input("MomentumTensor").size() >= 1) {
+          return false;
+        }
+      }
       if (desc.Output("Y").size() != 1) {
         VLOG(3) << "Invalid output Y's size of batch_norm TRT "
                    "converter. Expected 1, received "

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
-        # TODO: This is just the example to remove the wrong attrs.
         inputs = program_config.inputs
         weights = program_config.weights
         outputs = program_config.outputs
@@ -30,6 +29,7 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs
             for i in range(len(program_config.ops))
         ]
+
         return True
 
     def sample_program_configs(self):
@@ -186,11 +186,7 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            # TODO: This is just the example, need to be fixed.
-            if self.num_input == 0:
-                return 0, 3
-            else:
-                return 1, 2
+            return 1, 2
 
         attrs = [
             program_config.ops[i].attrs
@@ -215,8 +211,15 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
                                                                      True), 1e-2
 
     def add_skip_trt_case(self):
-        # TODO(wilber): This is just the example to illustrate the skip usage.
-        pass
+        def teller1(program_config, predictor_config):
+            if len(program_config.weights) == 5:
+                return True
+            return False
+
+        self.add_skip_case(
+            teller1, SkipReasons.TRT_NOT_SUPPORT,
+            "INPUT MomentumTensor NOT SUPPORT: we need to add support in the future"
+        )
 
     def test(self):
         self.add_skip_trt_case()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
@@ -191,7 +191,7 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-2
+            attrs, False), 1e-5
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -200,7 +200,7 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
                                                                      True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(attrs,
-                                                                     True), 1e-2
+                                                                     True), 1e-5
 
     def add_skip_trt_case(self):
         def teller1(program_config, predictor_config):
@@ -208,10 +208,8 @@ class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
                 return True
             return False
 
-        self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_SUPPORT,
-            "INPUT MomentumTensor NOT SUPPORT: we need to add support in the future"
-        )
+        self.add_skip_case(teller1, SkipReasons.TRT_NOT_SUPPORT,
+                           "INPUT MomentumTensor NOT SUPPORT")
 
     def test(self):
         self.add_skip_trt_case()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest, SkipReasons
+from program_config import TensorConfig, ProgramConfig
+import numpy as np
+import paddle.inference as paddle_infer
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+
+
+class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        # TODO: This is just the example to remove the wrong attrs.
+        inputs = program_config.inputs
+        weights = program_config.weights
+        outputs = program_config.outputs
+        attrs = [
+            program_config.ops[i].attrs
+            for i in range(len(program_config.ops))
+        ]
+        return True
+
+    def sample_program_configs(self):
+        def generate_input1(attrs: List[Dict[str, Any]], batch):
+            if self.dims == 4:
+                if attrs[0]['data_layout'] == "NCHW":
+                    return np.ones([batch, 3, 24, 24]).astype(np.float32)
+                elif attrs[0]['data_layout'] == "NHWC":
+                    return np.ones([batch, 24, 24, 3]).astype(np.float32)
+            elif self.dims == 3:
+                return np.ones([batch, 3, 24]).astype(np.float32)
+            elif self.dims == 2:
+                return np.ones([batch, 3]).astype(np.float32)
+
+        def generate_bias(attrs: List[Dict[str, Any]], batch):
+            return np.full((3), 0.9).astype("float32")
+
+        def generate_mean(attrs: List[Dict[str, Any]], batch):
+            return np.full((3), 0.9).astype("float32")
+
+        def generate_scale(attrs: List[Dict[str, Any]], batch):
+            return np.full((3), 1.1).astype("float32")
+
+        def generate_variance(attrs: List[Dict[str, Any]], batch):
+            return np.full((3), 1.2).astype("float32")
+
+        for dims in [2, 3, 4]:
+            for batch in [1, 2, 4]:
+                for epsilon in [1e-6, 1e-5, 1e-4]:
+                    for data_layout in ["NCHW"]:
+                        self.dims = dims
+                        dics = [{
+                            "epsilon": epsilon,
+                            "data_layout": data_layout,
+                            "is_test": True,
+                            "trainable_statistics": False
+                        }, {}]
+                        ops_config = [{
+                            "op_type": "batch_norm",
+                            "op_inputs": {
+                                "X": ["batch_norm_input"],
+                                "Bias": ["Bias"],
+                                "Mean": ["Mean"],
+                                "Scale": ["Scale"],
+                                "Variance": ["Variance"]
+                            },
+                            "op_outputs": {
+                                "Y": ["batch_norm_out"],
+                                "MeanOut": ["Mean"],
+                                "VarianceOut": ["Variance"],
+                                "SavedMean": ["SavedMean"],
+                                "SavedVariance": ["SavedVariance"]
+                            },
+                            "op_attrs": dics[0]
+                        }]
+                        ops = self.generate_op_config(ops_config)
+                        program_config = ProgramConfig(
+                            ops=ops,
+                            weights={
+                                "Bias": TensorConfig(data_gen=partial(
+                                    generate_bias, dics, batch)),
+                                "Mean": TensorConfig(data_gen=partial(
+                                    generate_mean, dics, batch)),
+                                "Scale": TensorConfig(data_gen=partial(
+                                    generate_scale, dics, batch)),
+                                "Variance": TensorConfig(data_gen=partial(
+                                    generate_variance, dics, batch))
+                            },
+                            inputs={
+                                "batch_norm_input":
+                                TensorConfig(data_gen=partial(generate_input1,
+                                                              dics, batch))
+                            },
+                            outputs=["batch_norm_out"])
+
+                        yield program_config
+
+    def sample_predictor_configs(
+            self, program_config) -> (paddle_infer.Config, List[int], float):
+        def generate_dynamic_shape(attrs):
+            if self.dims == 4:
+                if attrs[0]['data_layout'] == "NCHW":
+                    self.dynamic_shape.min_input_shape = {
+                        "batch_norm_input": [1, 3, 24, 24]
+                    }
+                    self.dynamic_shape.max_input_shape = {
+                        "batch_norm_input": [4, 3, 48, 48]
+                    }
+                    self.dynamic_shape.opt_input_shape = {
+                        "batch_norm_input": [1, 3, 24, 48]
+                    }
+                elif attrs[0]['data_layout'] == "NHWC":
+                    self.dynamic_shape.min_input_shape = {
+                        "batch_norm_input": [1, 24, 24, 3]
+                    }
+                    self.dynamic_shape.max_input_shape = {
+                        "batch_norm_input": [4, 48, 48, 3]
+                    }
+                    self.dynamic_shape.opt_input_shape = {
+                        "batch_norm_input": [1, 24, 48, 3]
+                    }
+            elif self.dims == 3:
+                self.dynamic_shape.min_input_shape = {
+                    "batch_norm_input": [1, 3, 24]
+                }
+                self.dynamic_shape.max_input_shape = {
+                    "batch_norm_input": [4, 3, 48]
+                }
+                self.dynamic_shape.opt_input_shape = {
+                    "batch_norm_input": [1, 3, 48]
+                }
+            elif self.dims == 2:
+                self.dynamic_shape.min_input_shape = {
+                    "batch_norm_input": [1, 3]
+                }
+                self.dynamic_shape.max_input_shape = {
+                    "batch_norm_input": [4, 3]
+                }
+                self.dynamic_shape.opt_input_shape = {
+                    "batch_norm_input": [1, 3]
+                }
+
+        def clear_dynamic_shape():
+            self.dynamic_shape.min_input_shape = {}
+            self.dynamic_shape.max_input_shape = {}
+            self.dynamic_shape.opt_input_shape = {}
+
+        def generate_trt_nodes_num(attrs, dynamic_shape):
+            # TODO: This is just the example, need to be fixed.
+            return 1, 2
+
+        attrs = [
+            program_config.ops[i].attrs
+            for i in range(len(program_config.ops))
+        ]
+        # for static_shape
+        clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False), 1e-2
+
+        # for dynamic_shape
+        generate_dynamic_shape(attrs)
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(attrs,
+                                                                     True), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(attrs,
+                                                                     True), 1e-2
+
+    def add_skip_trt_case(self):
+        # TODO(wilber): This is just the example to illustrate the skip usage.
+        pass
+
+    def test(self):
+        self.add_skip_trt_case()
+        self.run_test()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_batch_norm.py
@@ -22,14 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 class TrtConvertBatchNormTest(TrtLayerAutoScanTest):
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
-        inputs = program_config.inputs
-        weights = program_config.weights
-        outputs = program_config.outputs
-        attrs = [
-            program_config.ops[i].attrs
-            for i in range(len(program_config.ops))
-        ]
-
         return True
 
     def sample_program_configs(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
增加batch_norm op converter单测
1. 将MomentumTensor属性在op_telller中过滤掉
2. 待解决问题：当输入为二维时，TRT输出为四维，出现diff