### PR TITLE
change metaclass of Layer from pybind11_builtins.pybind11_type to type

### DIFF
--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1783,7 +1783,11 @@ void BindImperative(py::module *m_ptr) {
       .def_property_readonly("type", &imperative::VarBase::Type)
       .def_property_readonly("dtype", &imperative::VarBase::DataType);
 
-  py::class_<imperative::Layer, Layer /* <--- trampoline*/> layer(m, "Layer");
+  // NOTE(zhiqiu): set the metaclass of Layer.
+  // See details: https://github.com/pybind/pybind11/pull/679
+  // https://github.com/pybind/pybind11/blob/028812ae7eee307dca5f8f69d467af7b92cc41c8/tests/test_methods_and_attributes.cpp#L284
+  py::class_<imperative::Layer, Layer /* <--- trampoline*/> layer(
+      m, "Layer", py::metaclass(static_cast<PyObject *> & PyType_Type));
   layer.def(py::init<>())
       .def("forward",
            [](imperative::Layer &self,

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1787,7 +1787,7 @@ void BindImperative(py::module *m_ptr) {
   // See details: https://github.com/pybind/pybind11/pull/679
   // https://github.com/pybind/pybind11/blob/028812ae7eee307dca5f8f69d467af7b92cc41c8/tests/test_methods_and_attributes.cpp#L284
   py::class_<imperative::Layer, Layer /* <--- trampoline*/> layer(
-      m, "Layer", py::metaclass(static_cast<PyObject *> & PyType_Type));
+      m, "Layer", py::metaclass((PyObject *)&PyType_Type));  // NOLINT
   layer.def(py::init<>())
       .def("forward",
            [](imperative::Layer &self,

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -841,6 +841,14 @@ class TestDygraphGuardWithError(unittest.TestCase):
             y = fluid.layers.matmul(x, x)
 
 
+class TestMetaclass(unittest.TestCase):
+    def test_metaclass(self):
+        self.assertEqual(type(MyLayer).__name__, 'type')
+        self.assertNotEqual(type(MyLayer).__name__, 'pybind11_type')
+        self.assertEqual(
+            type(paddle.fluid.core.VarBase).__name__, 'pybind11_type')
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
change metaclass of Layer from pybind11_builtins.pybind11_type to type

By default, the mateclass of `Layer` is `pybind11_builtins.pybind11_type`, and the mateclass of `pybind11_builtins.pybind11_type` is `type.` 
This PR changes mateclass of `Layer` to `type` directly to fix some problem.

For example,
```
import paddle
import cloudpickle
import os
import subprocess
import torch

class PaddleLayer(paddle.nn.Layer):
    def __init__(self):
        super(PaddleLayer, self).__init__()
        self.linear_1 = paddle.nn.Linear(784, 512)

class TorchModule(torch.nn.Module):
    def __init__(self):
        super(TorchModule, self).__init__()
        self.conv1 = torch.nn.Conv2d(1, 20, 5)

class OtherClass(object):
    def __init__(self):
        pass

def test_cloudpickle(cls):
    def to_str(byte):
        """ convert byte to string in pytohn2/3
        """
        return str(byte.decode())

    encoded = cloudpickle.dumps(cls)
    decoded_cls = cloudpickle.loads(encoded) # can be deserialized in the same process
    obj = decoded_cls()

    fname = "{}.cloudpickle".format(cls.__name__)
    with open(fname, 'wb') as f:
        f.write(encoded)

    command = """python -c '
import cloudpickle
with open("{}", "rb") as f:
    encoded = f.read()
    decoded_cls = cloudpickle.loads(encoded)
    obj = decoded_cls()
'
""".format(fname)
    # cannot be deserialized in another process
    try:
        subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
        print("load {} ok".format(fname))
    except subprocess.CalledProcessError as e:
        print("load {} failed".format(fname))
        print(str(e.output.decode()))

test_cloudpickle(OtherClass)
test_cloudpickle(TorchModule)
test_cloudpickle(PaddleLayer)
```

- before

```
load OtherClass.cloudpickle ok
load TorchModule.cloudpickle ok
load PaddleLayer.cloudpickle failed
Traceback (most recent call last):
  File "<string>", line 5, in <module>
  File "/usr/local/lib/python3.7/dist-packages/cloudpickle/cloudpickle.py", line 736, in _make_skeleton_class
    lambda ns: ns.update(type_kwargs)
  File "/usr/lib/python3.7/types.py", line 65, in new_class
    meta, ns, kwds = prepare_class(name, resolved_bases, kwds)
  File "/usr/lib/python3.7/types.py", line 118, in prepare_class
    meta = _calculate_meta(meta, bases)
  File "/usr/lib/python3.7/types.py", line 136, in _calculate_meta
    raise TypeError("metaclass conflict: "
TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```

- after

```
load OtherClass.cloudpickle ok
load TorchModule.cloudpickle ok
load PaddleLayer.cloudpickle ok
```