### PR TITLE
Fix scatter_nd_add doc

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -8590,7 +8590,7 @@ def scatter_nd_add(ref, index, updates, name=None):
             output = [[67, 19], [-16, -27]]
 
     Args:
-        ref (Variable): The ref input. Its dtype should be float32, float64.
+        ref (Variable): The ref input. Its dtype should be int32, int64, float32, float64.
         index (Variable): The index input with rank > 1 and index.shape[-1] <= ref.rank.
                           Its dtype should be int32 or int64 as it is used as indexes.
         updates (Variable): The updated value of scatter_nd_add op, and it must have the same dtype

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1348,7 +1348,7 @@ def scatter_nd_add(x, index, updates, name=None):
             output = [[67, 19], [-16, -27]]
 
     Args:
-        x (Tensor): The x input. Its dtype should be float32, float64.
+        x (Tensor): The x input. Its dtype should be int32, int64, float32, float64.
         index (Tensor): The index input with ndim > 1 and index.shape[-1] <= x.ndim.
                           Its dtype should be int32 or int64 as it is used as indexes.
         updates (Tensor): The updated value of scatter_nd_add op, and it must have the same dtype


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Docs

### Describe
Add `int32` and `int64` type for `scatter_nd_add` doc.

Related to cn doc PR: https://github.com/PaddlePaddle/docs/pull/3855

![image](https://user-images.githubusercontent.com/32832641/132336923-aae67c2a-bcb1-46ac-b93e-e4bd1b75c1bc.png)


![image](https://user-images.githubusercontent.com/32832641/132336847-5c1170fa-0db4-4e39-abdd-0e5b505ea42d.png)
