### PR TITLE
Added requirements_first

### DIFF
--- a/python/requirements_first.txt
+++ b/python/requirements_first.txt
@@ -1,0 +1,3 @@
+numpy>=1.13 ; python_version>="3.5" and platform_system != "Windows"
+numpy>=1.13, <=1.19.3 ; python_version>="3.5" and platform_system == "Windows"
+

--- a/python/requirements_first.txt
+++ b/python/requirements_first.txt
@@ -1,3 +1,2 @@
 numpy>=1.13 ; python_version>="3.5" and platform_system != "Windows"
 numpy>=1.13, <=1.19.3 ; python_version>="3.5" and platform_system == "Windows"
-


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Added requirements_first to fix dependency of bfloat16 package. It is needed as a seperate PR because CI-Coverage would fail without it as it resets itself to paddle/develop at the end of CI.
