### PR TITLE
add the extra for OP rnn/sequence_pool/sequence_softmax

### DIFF
--- a/paddle/fluid/operators/rnn_op.cc
+++ b/paddle/fluid/operators/rnn_op.cc
@@ -162,8 +162,10 @@ class RNNOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::string>(
         "mode",
         "(string) rnn types, including: LSTM, GRU, RNN_RELU, RNN_TANH.");
-    AddAttr<bool>("is_test", "True if in test phase.").SetDefault(false);
     AddAttr<int>("seed", "seed to used if fix_seed is True").SetDefault(0);
+    AddAttr<bool>("is_test", "True if in test phase.")
+        .SetDefault(false)
+        .AsExtra();
     AddComment(R"DOC(
 )DOC");
   }

--- a/paddle/fluid/operators/rnn_op.h
+++ b/paddle/fluid/operators/rnn_op.h
@@ -230,7 +230,7 @@ template <typename T>
 void dropout_cpu_function_inplace(const framework::ExecutionContext& context,
                                   Tensor* x, Tensor* y, Tensor* mask,
                                   const float& dropout_prob,
-                                  const int& seed_number, const bool& is_test,
+                                  const int& seed_number, bool is_test,
                                   bool* is_has_reset) {
   if (is_test) {
     return;
@@ -816,7 +816,7 @@ void RnnFunc(const framework::ExecutionContext& ctx, const Tensor* input,
              Tensor* dropout_mask, const int& num_layers, const int& gate_num,
              const int& input_size, const int& hidden_size,
              const bool& is_bidirec, const std::string& cell_type,
-             const float& dropout_prob, const bool& is_test, const int& seed,
+             const float& dropout_prob, bool is_test, const int& seed,
              Tensor* reserve_data) {
   const int& direction_num = is_bidirec ? 2 : 1;
   const auto& init_h_dims = init_h->dims();
@@ -952,8 +952,8 @@ class RNNCPUKernel : public framework::OpKernel<T> {
     const int& hidden_size = ctx.Attr<int>("hidden_size");
     const float& dropout_prob = ctx.Attr<float>("dropout_prob");
     const std::string& mode = ctx.Attr<std::string>("mode");
-    const bool& is_test = ctx.Attr<bool>("is_test");
     const int& seed = ctx.Attr<int>("seed");
+    bool is_test = ctx.HasAttr("is_test") ? ctx.Attr<bool>("is_test") : false;
 
     bool has_seq_length = ctx.HasInput("SequenceLength");
     const Tensor* sequence_length = nullptr;
@@ -1809,7 +1809,8 @@ void RnnGradFunc(const framework::ExecutionContext& context,
   const int& num_layers = context.Attr<int>("num_layers");
   const bool& is_bidirec = context.Attr<bool>("is_bidirec");
   const float& dropout_prob = context.Attr<float>("dropout_prob");
-  const bool& is_test = context.Attr<bool>("is_test");
+  bool is_test =
+      context.HasAttr("is_test") ? context.Attr<bool>("is_test") : false;
 
   // get the input_size, batch_size, time_step, hidden_size
   const int& time_step = input->dims()[0];

--- a/paddle/fluid/operators/sequence_ops/sequence_pool_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_pool_op.cc
@@ -61,7 +61,8 @@ class SequencePoolOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
                   "for training. Some layers may run faster when this is true.")
-        .SetDefault(false);
+        .SetDefault(false)
+        .AsExtra();
     AddAttr<std::string>(
         "pooltype",
         "(string, default 'AVERAGE') the pooling pooltype of SequencePoolOp.")

--- a/paddle/fluid/operators/sequence_ops/sequence_pool_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_pool_op.h
@@ -67,7 +67,8 @@ class SequencePoolKernel : public framework::OpKernel<T> {
     out->mutable_data<T>(context.GetPlace());
     Tensor* index = nullptr;
 
-    const bool is_test = context.Attr<bool>("is_test");
+    bool is_test =
+        context.HasAttr("is_test") ? context.Attr<bool>("is_test") : false;
 
     // Do not create index buffer for inference (is_test) mode
     // TODO(jczaja): Skip index buffer creation for other devices eg. GPU

--- a/paddle/fluid/operators/sequence_ops/sequence_softmax_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_softmax_op.cc
@@ -34,7 +34,8 @@ class SequenceSoftmaxOp : public framework::OperatorWithKernel {
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override {
     // choose cudnn kernel if the runtime supported.
-    bool use_cudnn = ctx.Attr<bool>("use_cudnn");
+    bool use_cudnn =
+        ctx.HasAttr("use_cudnn") ? ctx.Attr<bool>("use_cudnn") : false;
     bool runtime_cudnn_support = false;
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     if (platform::is_gpu_place(ctx.GetPlace())) {
@@ -47,7 +48,9 @@ class SequenceSoftmaxOp : public framework::OperatorWithKernel {
     if (use_cudnn && runtime_cudnn_support) {
       library_ = framework::LibraryType::kCUDNN;
     }
-    std::string data_format = ctx.Attr<std::string>("data_format");
+    std::string data_format = ctx.HasAttr("data_format")
+                                  ? ctx.Attr<std::string>("data_format")
+                                  : "AnyLayout";
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace(),
         framework::StringToDataLayout(data_format), library_);
@@ -66,14 +69,16 @@ class SequenceSoftmaxOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>(
         "use_cudnn",
         "(bool, default false) Only used in cudnn kernel, need install cudnn")
-        .SetDefault(false);
+        .SetDefault(false)
+        .AsExtra();
     AddAttr<std::string>(
         "data_format",
         "(string, default NCHW) Only used in "
         "An optional string from: \"NHWC\", \"NCHW\". "
         "Defaults to \"NHWC\". Specify the data format of the output data, "
         "the input will be transformed automatically. ")
-        .SetDefault("AnyLayout");
+        .SetDefault("AnyLayout")
+        .AsExtra();
     AddComment(R"DOC(
 Sequence Softmax Operator.
 
@@ -130,7 +135,8 @@ class SequenceSoftmaxGradOp : public framework::OperatorWithKernel {
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override {
     // choose cudnn kernel if the runtime supported.
-    bool use_cudnn = ctx.Attr<bool>("use_cudnn");
+    bool use_cudnn =
+        ctx.HasAttr("use_cudnn") ? ctx.Attr<bool>("use_cudnn") : false;
     bool runtime_cudnn_support = false;
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     if (platform::is_gpu_place(ctx.GetPlace())) {
@@ -143,7 +149,9 @@ class SequenceSoftmaxGradOp : public framework::OperatorWithKernel {
     if (use_cudnn && runtime_cudnn_support) {
       library_ = framework::LibraryType::kCUDNN;
     }
-    std::string data_format = ctx.Attr<std::string>("data_format");
+    std::string data_format = ctx.HasAttr("data_format")
+                                  ? ctx.Attr<std::string>("data_format")
+                                  : "AnyLayout";
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "Out"), ctx.GetPlace(),
         framework::StringToDataLayout(data_format), library_);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

给 OP `rnn/sequence_pool/sequence_softmax` 添加extra标记信息
------

1. **rnn_op**：is_test是非原生属性，系统自动判断；
2. **sequence_pool_op**：is_test，判断是否建立反向的index var，对前向无影响，默认值为false，虽然用户可以指定，但将其裁剪对前向无影响；
3. **sequence_softmax_op**：use_cudnn，设备相关的属性；data_format，在Python API中无对应接口，用户无需指定的属性；
