### PR TITLE
add set-xpu-device-id function for inference config.

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -115,6 +115,9 @@ void AnalysisConfig::EnableXpu(int l3_workspace_size, bool locked,
 }
 
 void AnalysisConfig::SetXpuDeviceId(int device_id) {
+  PADDLE_ENFORCE_EQ(use_xpu_, true,
+                    platform::errors::PreconditionNotMet(
+                        "Should call EnableXpu before SetXpuDeviceId."));
   xpu_device_id_ = device_id;
   Update();
 }

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -114,6 +114,11 @@ void AnalysisConfig::EnableXpu(int l3_workspace_size, bool locked,
   Update();
 }
 
+void AnalysisConfig::SetXpuDeviceId(int device_id) {
+  xpu_device_id_ = device_id;
+  Update();
+}
+
 void AnalysisConfig::EnableNpu(int device_id) {
 #ifdef PADDLE_WITH_ASCEND_CL
   use_npu_ = true;

--- a/paddle/fluid/inference/api/analysis_predictor_tester.cc
+++ b/paddle/fluid/inference/api/analysis_predictor_tester.cc
@@ -275,6 +275,17 @@ TEST(AnalysisPredictor, bf16_pass_strategy) {
   passStrategy.EnableMkldnnBfloat16();
 }
 
+#ifdef PADDLE_WITH_XPU
+TEST(AnalysisPredictor, set_xpu_device_id) {
+  AnalysisConfig config;
+  config.EnableXpu();
+  config.SetXpuDeviceId(0);
+  ASSERT_EQ(config.xpu_device_id(), 0);
+  config.SetXpuDeviceId(1);
+  ASSERT_EQ(config.xpu_device_id(), 1);
+}
+#endif
+
 }  // namespace paddle
 
 namespace paddle_infer {

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -203,6 +203,12 @@ struct PD_INFER_DECL AnalysisConfig {
                  const std::string& precision = "int16",
                  bool adaptive_seqlen = false);
   ///
+  /// \brief Set XPU device id.
+  ///
+  /// \param device_id the XPU card to use (default is 0).
+  ///
+  void SetXpuDeviceId(int device_id = 0);
+  ///
   /// \brief Turn on NPU.
   ///
   /// \param device_id device_id the NPU card to use (default is 0).

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -523,6 +523,8 @@ void BindAnalysisConfig(py::module *m) {
            py::arg("locked") = false, py::arg("autotune") = true,
            py::arg("autotune_file") = "", py::arg("precision") = "int16",
            py::arg("adaptive_seqlen") = false)
+      .def("set_xpu_device_id", &AnalysisConfig::SetXpuDeviceId,
+           py::arg("device_id") = 0)
       .def("enable_npu", &AnalysisConfig::EnableNpu, py::arg("device_id") = 0)
       .def("disable_gpu", &AnalysisConfig::DisableGpu)
       .def("use_gpu", &AnalysisConfig::use_gpu)


### PR DESCRIPTION
### PR types
New features

### PR changes
APIs

### Describe
在预测的时候，如果是用xpu，是不支持设置设备号的。其实xpu_device_id_这个成员变量已经存在，只不过没有赋值的代码。
所以追加了个函数，可以指定xpu的设备号了。

python端的用法示例：

``` python
from paddle.inference import Config
config = Config("infer_model0.pdmodel", "infer_model0.pdiparams")
config.enable_xpu(100)
config.set_xpu_device_id(device_id=0)
```