### PR TITLE
Set gradient_merge_cond persistable to false

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -6884,7 +6884,7 @@ class GradientMergeOptimizer(object):
             shape=[1],
             value=bool(0),
             dtype='bool',
-            persistable=True,
+            persistable=False,
             force_cpu=True)
 
         with device_guard("cpu"):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. gradient_merge_cond is not need to save as persistable.
2. save op is not supported to save bool type

Old PR tries to fix this issue: https://github.com/PaddlePaddle/Paddle/pull/31752