### PR TITLE
skip sharelod

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -94,6 +94,7 @@ class InterpreterCore {
 
   std::vector<paddle::framework::OpFuncNode> vec_func_list_;
   std::vector<paddle::framework::OperatorBase*> op_list_;
+  std::vector<bool> vec_skip_lod_;
 
   std::vector<std::string> feed_names_;
 

--- a/paddle/fluid/framework/new_executor/interpretercore_util.h
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.h
@@ -240,6 +240,9 @@ class RuntimeInferShapeContext : public InferShapeContext {
 
   void ShareLoD(const std::string& in, const std::string& out, size_t i = 0,
                 size_t j = 0) const override {
+    if (can_skip_lod_) {
+      return;
+    }
     auto in_it = ctx_.inputs.find(in);
     auto out_it = ctx_.outputs.find(out);
     PADDLE_ENFORCE_NE(
@@ -368,6 +371,8 @@ class RuntimeInferShapeContext : public InferShapeContext {
     SetDims(vars, dims);
   }
 
+  void SetSkipLoD(bool skip) { can_skip_lod_ = skip; }
+
  protected:
   DDim GetDim(Variable* var) const {
     PADDLE_ENFORCE_NOT_NULL(
@@ -468,6 +473,7 @@ class RuntimeInferShapeContext : public InferShapeContext {
 
   const OperatorBase& op_;
   const RuntimeContext& ctx_;
+  bool can_skip_lod_;
 };
 
 namespace interpretercore {
@@ -485,6 +491,7 @@ void build_op_func_list(const platform::Place& place,
                         const framework::ProgramDesc& pdesc,
                         std::vector<OperatorBase*>* op_list,
                         std::vector<OpFuncNode>* vec_func_list,
+                        std::vector<bool>* vec_skip_lod,
                         VariableScope* var_scope);
 
 std::vector<size_t> merge_vector(const std::vector<size_t>& first,

--- a/paddle/fluid/framework/new_executor/interpretercore_util.h
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.h
@@ -49,7 +49,7 @@ namespace framework {
 class RuntimeInferShapeContext : public InferShapeContext {
  public:
   RuntimeInferShapeContext(const OperatorBase& op, const RuntimeContext& ctx)
-      : op_(op), ctx_(ctx) {}
+      : op_(op), ctx_(ctx), can_skip_lod_(false) {}
 
   bool HasInput(const std::string& name) const override {
     // has only one input

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -87,6 +87,8 @@ struct Instruction {
   std::vector<EventInter> output_events_;
 
   platform::DeviceContext* dev_ctx_;  // not owned
+
+  bool can_skip_lod_;
 };
 
 enum class OpFuncType {

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -49,8 +49,10 @@ StandaloneExecutor::StandaloneExecutor(const platform::Place& place,
   // run startup program
   std::vector<paddle::framework::OpFuncNode> vec_func_list;
   std::vector<paddle::framework::OperatorBase*> op_list;
+  std::vector<bool> vec_skip_lod;
   paddle::framework::interpretercore::build_op_func_list(
-      place_, startup_prog, &op_list, &vec_func_list, &global_scope_);
+      place_, startup_prog, &op_list, &vec_func_list, &vec_skip_lod,
+      &global_scope_);
 }
 
 paddle::framework::FetchList StandaloneExecutor::Run(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
如果某个OP的所有输入的LOD level=0，那么在InferShape时可以跳过ShareLoD。
在PTB模型中ShareLoD占总时间的1.17%：
![1631101257(1)](https://user-images.githubusercontent.com/26922892/132503079-9bbc4a18-bbac-4266-a2ae-d57c80d70cfa.png)
