### PR TITLE
fix extra op for expand, expand_as, tile, unstack

### DIFF
--- a/paddle/fluid/operators/expand_v2_op.cc
+++ b/paddle/fluid/operators/expand_v2_op.cc
@@ -129,8 +129,7 @@ class ExpandV2OpMaker : public framework::OpProtoAndCheckerMaker {
              "It has a higher priority than shape attribute, but a lower "
              "priority than the input Shape")
         .AsDuplicable()
-        .AsDispensable()
-        .AsExtra();
+        .AsDispensable();
     AddOutput("Out",
               "(Tensor, default Tensor<float>). A tensor with rank in [1, 6]."
               "The rank of Output(Out) have the same with Input(X). "

--- a/paddle/fluid/operators/expand_v2_op.cc
+++ b/paddle/fluid/operators/expand_v2_op.cc
@@ -129,7 +129,8 @@ class ExpandV2OpMaker : public framework::OpProtoAndCheckerMaker {
              "It has a higher priority than shape attribute, but a lower "
              "priority than the input Shape")
         .AsDuplicable()
-        .AsDispensable();
+        .AsDispensable()
+        .AsExtra();
     AddOutput("Out",
               "(Tensor, default Tensor<float>). A tensor with rank in [1, 6]."
               "The rank of Output(Out) have the same with Input(X). "
@@ -140,12 +141,14 @@ class ExpandV2OpMaker : public framework::OpProtoAndCheckerMaker {
         .SetDefault({});
     AddAttr<bool>("use_mkldnn",
                   "(bool, default false) Only used in mkldnn kernel")
-        .SetDefault(false);
+        .SetDefault(false)
+        .AsExtra();
     AddAttr<std::string>(
         "mkldnn_data_type",
         "(string, default \"float32\"). Data type of mkldnn kernel")
         .SetDefault("float32")
-        .InEnum({"float32", "bfloat16"});
+        .InEnum({"float32", "bfloat16"})
+        .AsExtra();
     AddComment(R"DOC(
 Expand the input to the given shape. The rank of X
 should be in [1, 6] and size of 'shape' must be in [1, 6] also.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- 修改expand_v2    
![image](https://user-images.githubusercontent.com/23625746/132544707-61e9858d-0a54-4a8a-b60d-16ffa48f2fa9.png)
应对Input： X，Shape，expand_shapes_tensor，Attr： shape 除外进行修改
![image](https://user-images.githubusercontent.com/23625746/132544982-08c22d9e-d4b5-4248-b68b-415e7c7ee052.png)
因此修改了 use_mkldnn和mkldnn_data_type

- 检查expand_as_v2，发现不用修改
![image](https://user-images.githubusercontent.com/23625746/132545255-783db73c-34a4-4ece-ad0c-79f7f23d6cd9.png)
应对Input： X, Attr: target_shape 除外进行修改。
![image](https://user-images.githubusercontent.com/23625746/132545443-9973bf37-672b-40bd-8240-a15a2d96598f.png)
发现目前已满足需求，没有需要Extra

- 检查unstack，发现不用修改
![image](https://user-images.githubusercontent.com/23625746/132545650-51970161-5ded-46d3-89ed-ed54d1429c6a.png)
应对 Input: X Attr: axis, num除外进行修改
![image](https://user-images.githubusercontent.com/23625746/132545760-bee52c05-d203-44ce-b4d1-182b58a65111.png)
发现目前已满足需求，没有需要Extra

- 检查tile，发现不用修改
![image](https://user-images.githubusercontent.com/23625746/132545974-d883c981-0087-4ffc-825c-80e88e00957f.png)
应对 Input: X RepeatedTimes repeated_times_tensor Attrs: repeated_times 除外进行修改
![image](https://user-images.githubusercontent.com/23625746/132546187-89a0eb80-cd17-4293-82c9-a03f38b50003.png)
发现目前已满足需求，没有需要Extra

