### PR TITLE
Update scales when variable is unsigned

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -71,7 +71,7 @@ function(inference_quant2_int8_image_classification_test target quant_model_dir 
             ARGS --quant_model ${quant_model_dir}
                  --fp32_model ${fp32_model_dir}
                  --infer_data ${dataset_path}
-                 --batch_size 10
+                 --batch_size 50
                  --batch_num 2
                  --acc_diff_threshold 0.1)
 endfunction()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
This PR:
- fixes updating scales in the quant-aware training quantization process. In this process we tag vars which are after relu op, to `unsigned`. But if this var was before tagged as `signed`, it means that the scales for this var were already computed for signed data. To resolve that, scales for this var must be multiplied by 2 to fill the entire range of uint8. This change should improve accuracy in QAT models.
- changes batch size in `inference_quant2_int8_image_classification_test` because the above fix improve acc in resnet50 test and acc comparison QAT with PTQ  int8 failed. 

Graph showing the change:
![Scales](https://user-images.githubusercontent.com/33838455/132678846-72391297-eea7-45e9-8e1b-7cebcc3a3bd2.jpg)

 