### PR TITLE
remove distributed attributes at the last stage for auto parallel

### DIFF
--- a/python/paddle/distributed/auto_parallel/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/parallelizer.py
@@ -42,13 +42,10 @@ class AutoParallelizer:
     def _remove_distributed_attrs(self, main_program):
         suffix = core.kAutoParallelSuffix()
         for block in main_program.blocks:
-            for var_name in block.vars:
-                var = block.var(var_name)
-                for attr_name in var.attr_names:
-                    if suffix in attr_name: var._remove_attr(attr_name)
             for op in block.ops:
                 for attr_name in op.attr_names:
-                    if suffix in attr_name: op._remove_attr(attr_name)
+                    if suffix in attr_name:
+                        op._remove_attr(attr_name)
 
     def parallelize(self,
                     loss,

--- a/python/paddle/distributed/auto_parallel/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/parallelizer.py
@@ -38,6 +38,16 @@ class AutoParallelizer:
         # self._dist_context = DistributedContext()
         self._dist_context = get_default_distributed_context()
 
+    def _remove_distributed_attrs(self, main_program):
+        suffix = core.kAutoParallelSuffix()
+        for block in main_program.blocks:
+            for var in block.vars:
+                for attr_name in var.attr_names:
+                    if suffix in attr_name: var._remove_attr(attr_name)
+            for op in block.ops:
+                for attr_name in op.attr_names:
+                    if suffix in attr_name: op._remove_attr(attr_name)
+
     def parallelize(self,
                     loss,
                     startup_program=None,
@@ -75,5 +85,9 @@ class AutoParallelizer:
         all_process_groups = get_all_process_groups()
         for process_group in all_process_groups:
             process_group.instantiate()
+
+        # The last step: remove all distributed attributes to be compatiable
+        # with inference.
+        self._remove_distributed_attrs(partitioned_main_prog)
 
         return dist_optimize_ops, dist_params_grads, partitioned_startup_prog, partitioned_main_prog

--- a/python/paddle/distributed/auto_parallel/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/parallelizer.py
@@ -41,6 +41,8 @@ class AutoParallelizer:
 
     def _remove_distributed_attrs(self, main_program):
         suffix = core.kAutoParallelSuffix()
+        # distributed attributes for variable have been removed
+        # in previous process.
         for block in main_program.blocks:
             for op in block.ops:
                 for attr_name in op.attr_names:

--- a/python/paddle/distributed/auto_parallel/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/parallelizer.py
@@ -14,7 +14,7 @@
 
 import paddle
 from paddle.distributed.fleet import cloud_utils
-import paddle.core as core
+import paddle.fluid.core as core
 from .context import DistributedContext
 from .context import get_default_distributed_context
 from .completion import complete_annotation
@@ -42,7 +42,8 @@ class AutoParallelizer:
     def _remove_distributed_attrs(self, main_program):
         suffix = core.kAutoParallelSuffix()
         for block in main_program.blocks:
-            for var in block.vars:
+            for var_name in block.vars:
+                var = block.var(var_name)
                 for attr_name in var.attr_names:
                     if suffix in attr_name: var._remove_attr(attr_name)
             for op in block.ops:

--- a/python/paddle/distributed/auto_parallel/parallelizer.py
+++ b/python/paddle/distributed/auto_parallel/parallelizer.py
@@ -14,6 +14,7 @@
 
 import paddle
 from paddle.distributed.fleet import cloud_utils
+import paddle.core as core
 from .context import DistributedContext
 from .context import get_default_distributed_context
 from .completion import complete_annotation

--- a/python/paddle/fluid/tests/unittests/test_auto_parallel_parallelizer.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_parallel_parallelizer.py
@@ -30,6 +30,7 @@ from paddle.fluid import layers
 from paddle.distributed import fleet
 import paddle.distributed.auto_parallel as auto
 from paddle.distributed.auto_parallel.utils import print_program_with_distributed_attr
+import paddle.fluid.core as core
 
 paddle.enable_static()
 _global_parallel_strategy = None
@@ -130,6 +131,11 @@ class TestMLPAutoParallelizer(unittest.TestCase):
         optimizer = fleet.distributed_optimizer(optimizer)
         _, _, distributed_startup_program, distributed_main_program = optimizer.minimize(
             loss, start_program)
+        suffix = core.kAutoParallelSuffix()
+        for block in distributed_main_program.blocks:
+            for op in block.ops:
+                for attr_name in op.attr_names:
+                    self.assertTrue(suffix not in attr_name)
         # print_program_with_distributed_attr(distributed_main_program)
         self.assertIsNotNone(distributed_startup_program)
         self.assertIsNotNone(distributed_main_program)

--- a/python/paddle/fluid/tests/unittests/test_auto_parallel_parallelizer.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_parallel_parallelizer.py
@@ -83,6 +83,7 @@ def mlp_pretrain_forward(train_program, start_program):
             name="label", shape=[batch_size, sequence_len, 1], dtype='float32')
 
         auto.shard_tensor(input, _global_process_mesh, dim_mapping=[-1, -1, -1])
+        auto.set_pipeline_stage(1)
 
         mlp = MLPLayer(
             hidden_size=hidden_size,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
remove distributed attributes of all ops at the last stage for auto parallel