### PR TITLE
experimental feature: error status, test=develop

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SHARED_INFERENCE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/api/api.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/api_impl.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/analysis_predictor.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/api/paddle_infer_contrib.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/details/zero_copy_tensor.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/io_utils.cc
     ${PADDLE_CUSTOM_OP_SRCS})

--- a/paddle/fluid/inference/api/paddle_infer_contrib.h
+++ b/paddle/fluid/inference/api/paddle_infer_contrib.h
@@ -112,7 +112,7 @@ class Status {
 /// \return State result of calling function.
 ///
 template <typename Func, typename... Args>
-Status status_wrapper(Func func, Args&&... args) noexcept(
+Status get_status(Func func, Args&&... args) noexcept(
     noexcept(Status(std::declval<Status>()))) {
   try {
     func(std::forward<Args>(args)...);

--- a/paddle/fluid/inference/api/paddle_infer_contrib.h
+++ b/paddle/fluid/inference/api/paddle_infer_contrib.h
@@ -36,42 +36,90 @@ class TensorUtils {
                              void* cb_params);
 };
 
+/// \brief A status class, used to intercept exceptions and convert
+/// them into a status number.
 class Status {
  public:
   using Code = int;
+  struct Impl;
+
   Status() noexcept;
   explicit Status(std::exception_ptr e) noexcept;
 
   Status(const Status&) noexcept;
   Status& operator=(const Status&) noexcept;
+  Status& operator=(Status&&) = default;
+  Status(Status&&) = default;
 
-  Status& operator=(Status&&) noexcept(
-      noexcept(std::declval<std::shared_ptr<Status>>().operator=(
-          std::declval<std::shared_ptr<Status>>()))) = default;
-
-  Status(Status&&) noexcept(noexcept(std::shared_ptr<Status>(
-      std::declval<std::shared_ptr<Status>>()))) = default;
-
+  ///
+  /// \brief Construct a status which indicate ok.
+  ///
+  /// \return A status which indicate ok.
+  ///
   static Status OK() noexcept;
+
+  ///
+  /// \brief Determine whether the status is ok.
+  ///
+  /// \return Whether the status is ok.
+  ///
   bool ok() const noexcept;
+
+  ///
+  /// \brief Return the error code.
+  /// The meaning corresponds to the following.
+  ///
+  /// CODE    IMPLICATION
+  ///  -1      UNKNOWN
+  ///  0        NORMAL
+  ///  1        LEGACY
+  ///  2    INVALID_ARGUMENT
+  ///  3       NOT_FOUND
+  ///  4     OUT_OF_RANGE
+  ///  5    ALREADY_EXISTS
+  ///  6   RESOURCE_EXHAUSTED
+  ///  7  PRECONDITION_NOT_MET
+  ///  8   PERMISSION_DENIED
+  ///  9   EXECUTION_TIMEOUT
+  ///  10    UNIMPLEMENTED
+  ///  11     UNAVAILABLE
+  ///  12        FATAL
+  ///  13       EXTERNAL
+  ///
+  /// \return The error code.
+  ///
   Code code() const noexcept;
+
+  ///
+  /// \brief Return the error message.
+  ///
+  /// \return The error message.
+  ///
   const std::string& error_message() const noexcept;
+
   bool operator==(const Status& x) const noexcept;
   bool operator!=(const Status& x) const noexcept;
 
  private:
-  struct Impl;
   std::shared_ptr<Impl> impl_;
 };
 
+///
+/// \brief A wrapper used to provide exception safety.
+///
+/// \param func Wrapped function.
+/// \param args Parameters of the wrapped function.
+/// \return State result of calling function.
+///
 template <typename Func, typename... Args>
-Status status_wrapper(Func func, Args&&... args) noexcept {
+Status status_wrapper(Func func, Args&&... args) noexcept(
+    noexcept(Status(std::declval<Status>()))) {
   try {
     func(std::forward<Args>(args)...);
   } catch (...) {
     return Status(std::current_exception());
   }
-  return {};
+  return Status::OK();
 }
 
 }  // namespace contrib

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -708,6 +708,8 @@ if(WITH_GPU)
     set_tests_properties(paddle_infer_api_copy_tensor_tester PROPERTIES TIMEOUT 30)
 endif()
 
+cc_test(paddle_infer_api_errors_tester SRCS paddle_infer_api_errors_tester.cc DEPS paddle_infer_contrib)
+
 if("$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
     return()
 endif()

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -708,7 +708,7 @@ if(WITH_GPU)
     set_tests_properties(paddle_infer_api_copy_tensor_tester PROPERTIES TIMEOUT 30)
 endif()
 
-cc_test(paddle_infer_api_errors_tester SRCS paddle_infer_api_errors_tester.cc DEPS paddle_infer_contrib)
+cc_test(paddle_infer_api_errors_test SRCS paddle_infer_api_errors_tester.cc DEPS paddle_inference_api)
 
 if("$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
     return()

--- a/paddle/fluid/inference/tests/api/paddle_infer_api_errors_tester.cc
+++ b/paddle/fluid/inference/tests/api/paddle_infer_api_errors_tester.cc
@@ -38,8 +38,10 @@ struct FakeException {
 
 TEST(Status, pd_exception) {
   FakeException e;
-  Status status = status_wrapper([&]() { e.pd_exception(1); });
+  Status status = get_status([&]() { e.pd_exception(1); });
   CHECK(!status.ok());
+  CHECK(status == status);
+  CHECK(!(status != status));
   CHECK_EQ(status.code(), paddle::platform::error::INVALID_ARGUMENT + 1);
   LOG(INFO) << status.error_message();
 }
@@ -47,7 +49,7 @@ TEST(Status, pd_exception) {
 TEST(Status, basic_exception) {
   FakeException e;
   Status status;
-  status = status_wrapper([&]() { e.base_exception(); });
+  status = get_status([&]() { e.base_exception(); });
   CHECK(!status.ok());
   LOG(INFO) << status.error_message();
 }
@@ -55,8 +57,14 @@ TEST(Status, basic_exception) {
 TEST(Status, no_exception) {
   FakeException e;
   Status status;
-  status = status_wrapper([&]() { e.no_exception(); });
+  status = get_status([&]() { e.no_exception(); });
   CHECK(status.ok());
+}
+
+TEST(Status, copy) {
+  Status status;
+  Status status_1(status);
+  status_1 = status;
 }
 
 }  // namespace contrib

--- a/paddle/fluid/inference/tests/api/paddle_infer_api_errors_tester.cc
+++ b/paddle/fluid/inference/tests/api/paddle_infer_api_errors_tester.cc
@@ -25,15 +25,19 @@ namespace contrib {
 TEST(Status, ctor) { CHECK(Status::OK().ok()); }
 
 struct FakeException {
-  void pd_exception(int a, const std::string& msg) const {
-    PADDLE_ENFORCE_NE(a, a, paddle::platform::errors::InvalidArgument(msg));
+  void pd_exception(int a) const {
+    PADDLE_ENFORCE_NE(a, a,
+                      paddle::platform::errors::InvalidArgument(
+                          "This is a preset error message used to verify "
+                          "whether the exception meets expectations: %d, %d.",
+                          a, a));
   }
   void base_exception() const { throw std::exception(); }
 };
 
 TEST(Status, pd_exception) {
   FakeException e;
-  Status status = status_wrapper([&]() { e.pd_exception(1, "test"); });
+  Status status = status_wrapper([&]() { e.pd_exception(1); });
   CHECK(!status.ok());
   CHECK_NE(status.code(), 0);
 }

--- a/paddle/fluid/inference/tests/api/paddle_infer_api_errors_tester.cc
+++ b/paddle/fluid/inference/tests/api/paddle_infer_api_errors_tester.cc
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+#include "paddle/fluid/inference/api/paddle_infer_contrib.h"
+#include "paddle/fluid/platform/enforce.h"
+
+namespace paddle_infer {
+namespace contrib {
+
+TEST(Status, ctor) { CHECK(Status::OK().ok()); }
+
+struct FakeException {
+  void pd_exception(int a, const std::string& msg) const {
+    PADDLE_ENFORCE_NE(a, a, paddle::platform::errors::InvalidArgument(msg));
+  }
+  void base_exception() const { throw std::exception(); }
+};
+
+TEST(Status, pd_exception) {
+  FakeException e;
+  Status status = status_wrapper([&]() { e.pd_exception(1, "test"); });
+  CHECK(!status.ok());
+  CHECK_NE(status.code(), 0);
+}
+
+TEST(Status, basic_exception) {
+  FakeException e;
+  Status status;
+  status = status_wrapper([&]() { e.base_exception(); });
+  CHECK(!status.ok());
+}
+
+}  // namespace contrib
+}  // namespace paddle_infer


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
应业务需求，提供了辅助接口将异常转换为错误状态码。

使用示例：
```
#include "paddle_api.h"
#include "paddle_infer_contrib.h"

using paddle_infer::contrib::Status;

int main() {
  paddle_infer::Config config;
  auto pred = paddle_infer::CreatePredictor(config);
  Status status = paddle_infer::contrib::get_status([&](){predictor->Run();});
  return status.code();
}
```
