### PR TITLE
add det grad realize

### DIFF
--- a/paddle/fluid/operators/determinant_op.cc
+++ b/paddle/fluid/operators/determinant_op.cc
@@ -193,5 +193,5 @@ REGISTER_OP_CPU_KERNEL(slogdeterminant, ops::SlogDeterminantKernel<int>,
 
 REGISTER_OP_CPU_KERNEL(
     slogdeterminant_grad,
-    ops::DeterminantGradKernel<plat::CPUDeviceContext, float>,
-    ops::DeterminantGradKernel<plat::CPUDeviceContext, double>);
+    ops::SlogDeterminantGradKernel<plat::CPUDeviceContext, float>,
+    ops::SlogDeterminantGradKernel<plat::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/determinant_op.cc
+++ b/paddle/fluid/operators/determinant_op.cc
@@ -1,0 +1,197 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/determinant_op.h"
+
+namespace paddle {
+namespace operators {
+
+class DeterminantOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("Input"), "Input", "Input", "determinant");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "determinant");
+  }
+};
+
+class DeterminantOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput(
+        "Input",
+        "(Tensor) The input tensor, from which the determinant are taken.");
+    AddOutput("Out",
+              "(Tensor) The partial view of input with the its determinant "
+              "elements.");
+
+    AddComment(R"DOC(
+Determinant Operator.)DOC");
+  }
+};
+
+class DeterminantGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("Input"), "Input", "Input",
+                   "DeterminantGradOp");
+    OP_INOUT_CHECK(ctx->HasInput("Out"), "Input", "Out", "DeterminantGradOp");
+    OP_INOUT_CHECK(ctx->HasOutput(framework::GradVarName("Input")), "Output",
+                   framework::GradVarName("Input"), "DeterminantGradOp");
+
+    ctx->SetOutputDim(framework::GradVarName("Input"),
+                      ctx->GetInputDim("Input"));
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext &ctx) const override {
+    return framework::OpKernelType(OperatorWithKernel::IndicateVarDataType(
+                                       ctx, framework::GradVarName("Out")),
+                                   ctx.GetPlace());
+  }
+};
+
+template <typename T>
+class DeterminantGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> grad_op) const override {
+    grad_op->SetType("determinant_grad");
+    grad_op->SetInput("Input", this->Input("Input"));
+    grad_op->SetInput("Out", this->Output("Out"));
+    grad_op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    grad_op->SetOutput(framework::GradVarName("Input"),
+                       this->InputGrad("Input"));
+    grad_op->SetAttrMap(this->Attrs());
+  }
+};
+
+DECLARE_NO_NEED_BUFFER_VARS_INFERER(DeterminantGradNoNeedBufferVarsInferer,
+                                    "Input");
+
+class SlogDeterminantOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("Input"), "Input", "Input", "determinant");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "determinant");
+  }
+};
+
+class SlogDeterminantOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput(
+        "Input",
+        "(Tensor) The input tensor, from which the determinant are taken.");
+    AddOutput("Out",
+              "(Tensor) The partial view of input with the its slogdeterminant "
+              "elements.");
+
+    AddComment(R"DOC(
+SlogDeterminant Operator.)DOC");
+  }
+};
+
+class SlogDeterminantGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("Input"), "Input", "Input",
+                   "SlogDeterminantGradOp");
+    OP_INOUT_CHECK(ctx->HasInput("Out"), "Input", "Out",
+                   "SlogDeterminantGradOp");
+    OP_INOUT_CHECK(ctx->HasOutput(framework::GradVarName("Input")), "Output",
+                   framework::GradVarName("Input"), "SlogDeterminantGradOp");
+
+    ctx->SetOutputDim(framework::GradVarName("Input"),
+                      ctx->GetInputDim("Input"));
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext &ctx) const override {
+    return framework::OpKernelType(OperatorWithKernel::IndicateVarDataType(
+                                       ctx, framework::GradVarName("Out")),
+                                   ctx.GetPlace());
+  }
+};
+
+template <typename T>
+class SlogDeterminantGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> grad_op) const override {
+    grad_op->SetType("slogdeterminant_grad");
+    grad_op->SetInput("Input", this->Input("Input"));
+    grad_op->SetInput("Out", this->Output("Out"));
+    grad_op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    grad_op->SetOutput(framework::GradVarName("Input"),
+                       this->InputGrad("Input"));
+    grad_op->SetAttrMap(this->Attrs());
+  }
+};
+
+DECLARE_NO_NEED_BUFFER_VARS_INFERER(SlogDeterminantGradNoNeedBufferVarsInferer,
+                                    "Input");
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+REGISTER_OPERATOR(determinant, ops::DeterminantOp, ops::DeterminantOpMaker,
+                  ops::DeterminantGradOpMaker<paddle::framework::OpDesc>,
+                  ops::DeterminantGradOpMaker<paddle::imperative::OpBase>);
+
+REGISTER_OPERATOR(determinant_grad, ops::DeterminantGradOp)
+
+REGISTER_OP_CPU_KERNEL(determinant, ops::DeterminantKernel<int>,
+                       ops::DeterminantKernel<int64_t>,
+                       ops::DeterminantKernel<float>,
+                       ops::DeterminantKernel<double>,
+                       ops::DeterminantKernel<bool>);
+
+REGISTER_OP_CPU_KERNEL(
+    determinant_grad, ops::DeterminantGradKernel<plat::CPUDeviceContext, float>,
+    ops::DeterminantGradKernel<plat::CPUDeviceContext, double>);
+
+REGISTER_OPERATOR(slogdeterminant, ops::SlogDeterminantOp,
+                  ops::SlogDeterminantOpMaker,
+                  ops::SlogDeterminantGradOpMaker<paddle::framework::OpDesc>,
+                  ops::SlogDeterminantGradOpMaker<paddle::imperative::OpBase>);
+
+REGISTER_OPERATOR(slogdeterminant_grad,
+                  ops::DeterminantGradOp)  // reuse det grad op
+
+REGISTER_OP_CPU_KERNEL(slogdeterminant, ops::SlogDeterminantKernel<int>,
+                       ops::SlogDeterminantKernel<int64_t>,
+                       ops::SlogDeterminantKernel<float>,
+                       ops::SlogDeterminantKernel<double>,
+                       ops::SlogDeterminantKernel<bool>);
+
+REGISTER_OP_CPU_KERNEL(
+    slogdeterminant_grad,
+    ops::DeterminantGradKernel<plat::CPUDeviceContext, float>,
+    ops::DeterminantGradKernel<plat::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/determinant_op.cu
+++ b/paddle/fluid/operators/determinant_op.cu
@@ -1,0 +1,190 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/determinant_op.h"
+#include "paddle/fluid/operators/elementwise/elementwise_op_broadcast.cu.h"
+#include "paddle/fluid/platform/cuda_primitives.h"
+
+namespace paddle {
+namespace operators {
+
+using platform::PADDLE_CUDA_NUM_THREADS;
+using Tensor = framework::Tensor;
+
+template <typename T>
+struct CudaMulFunctor {
+  inline HOSTDEVICE T operator()(const T* args) const {
+    return args[0] * args[1];
+  }
+};
+
+template <typename T>
+struct ElementwiseMulFunctor<platform::CUDADeviceContext, T> {
+  void operator()(const framework::ExecutionContext& ctx,
+                  const framework::Tensor* x, const framework::Tensor* y,
+                  framework::Tensor* z) {
+    std::vector<const framework::Tensor*> ins = {x, y};
+    std::vector<framework::Tensor*> outs = {z};
+    const auto& cuda_ctx =
+        ctx.template device_context<platform::CUDADeviceContext>();
+    LaunchElementwiseCudaKernel<ElementwiseType::kBinary, T, T>(
+        cuda_ctx, ins, &outs, -1, CudaMulFunctor<T>());
+  }
+};
+
+template <typename T>
+__global__ void DeterminantGrad(const size_t numel, T* out) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  if (tid < numel) {
+    out[tid] = static_cast<T>(1);
+  }
+}
+template <typename T>
+class DeterminantCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* input = context.Input<framework::Tensor>("Input");
+    const auto* input_data = input->data<T>();
+    auto input_dim = input->dims().Get();
+    auto input_dim_size = input->dims().size();
+
+    std::vector<int64_t> res_in = vectorize(framework::stride(input->dims()));
+    paddle::framework::Tensor input_stride_tensor;
+    framework::TensorFromVector<int64_t>(res_in, context.device_context(),
+                                         &input_stride_tensor);
+
+    auto* output = context.Output<framework::Tensor>("Out");
+    auto* output_data = output->mutable_data<T>(context.GetPlace());
+    auto output_dim = output->dims().Get();
+    auto output_dim_size = output->dims().size();
+
+    int batch_count = 1;
+    for (int i = 0; i < input->dims().size() - 2; i++) {
+      batch_count *= input_dim[i];
+    }
+
+    auto rank = input_dim[input_dim_size - 1];
+    DeterminantFunctor<T>()(*input, context, rank, batch_count, output);
+    auto output_dims =
+        framework::slice_ddim(input->dims(), 0, input_dim_size - 2);
+    output->Resize(output_dims);
+  }
+};
+
+template <typename T>
+class DeterminantGradCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    const auto* dout =
+        context.Input<framework::Tensor>(framework::GradVarName("Out"));
+    const T* dout_data = dout->data<T>();
+    auto dout_dim = vectorize(dout->dims());
+
+    auto* dx =
+        context.Output<framework::Tensor>(framework::GradVarName("Input"));
+    T* dx_data = dx->mutable_data<T>(context.GetPlace());
+
+    int64_t numel = dx->numel();
+    for (int64_t idx = 0; idx < numel; idx++) {
+      dx_data[idx] = static_cast<T>(1);
+    }
+  }
+};
+
+template <typename T>
+class SlogDeterminantCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* input = context.Input<framework::Tensor>("Input");
+    const auto* input_data = input->data<T>();
+    auto input_dim = vectorize(input->dims());
+    auto input_dim_size = input->dims().size();
+
+    std::vector<int64_t> res_in = vectorize(framework::stride(input->dims()));
+    paddle::framework::Tensor input_stride_tensor;
+    framework::TensorFromVector<int64_t>(res_in, context.device_context(),
+                                         &input_stride_tensor);
+
+    auto* output = context.Output<framework::Tensor>("Out");
+    auto* output_data = output->mutable_data<T>(context.GetPlace());
+    auto output_dim = output->dims().Get();
+    auto output_dim_size = output->dims().size();
+
+    int batch_count = 1;
+    for (int i = 0; i < input->dims().size() - 2; i++) {
+      batch_count *= input_dim[i];
+    }
+
+    auto rank = input_dim[input_dim_size - 1];
+    SlogDeterminantFunctor<T>()(*input, context, rank, batch_count, output);
+    std::vector<int> output_dim_vec(input_dim.begin(), input_dim.end() - 2);
+    output_dim_vec.insert(output_dim_vec.begin(),
+                          2);  // make the output dims as same as numpy
+    auto output_dims = framework::make_ddim(output_dim_vec);
+    output->Resize(output_dims);
+    VLOG(2) << "output dim:" << output->dims();
+  }
+};
+
+template <typename T>
+class SlogDeterminantGradCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* input = context.Input<framework::Tensor>("Input");
+    const auto* input_data = input->data<T>();
+    auto input_dim = input->dims().Get();
+    auto input_dim_size = input->dims().size();
+
+    std::vector<int64_t> res_in = vectorize(framework::stride(input->dims()));
+    paddle::framework::Tensor input_stride_tensor;
+    framework::TensorFromVector<int64_t>(res_in, context.device_context(),
+                                         &input_stride_tensor);
+
+    auto* output = context.Output<framework::Tensor>("Out");
+    auto* output_data = output->mutable_data<T>(context.GetPlace());
+    auto output_dim = output->dims().Get();
+    auto output_dim_size = output->dims().size();
+
+    int threads = PADDLE_CUDA_NUM_THREADS;
+    auto numel = output->numel() / 2;
+    int blocks = (numel + threads - 1) / threads;
+
+    auto rank = input_dim[input_dim_size - 1];
+    DeterminantGrad<T><<<blocks, threads>>>(numel, output_data);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+REGISTER_OP_CUDA_KERNEL(determinant, ops::DeterminantCUDAKernel<float>,
+                        ops::DeterminantCUDAKernel<double>);
+
+REGISTER_OP_CUDA_KERNEL(
+    determinant_grad,
+    ops::DeterminantGradKernel<plat::CUDADeviceContext, float>,
+    ops::DeterminantGradKernel<plat::CUDADeviceContext, double>);
+
+REGISTER_OP_CUDA_KERNEL(slogdeterminant, ops::SlogDeterminantCUDAKernel<int>,
+                        ops::SlogDeterminantCUDAKernel<int64_t>,
+                        ops::SlogDeterminantCUDAKernel<float>,
+                        ops::SlogDeterminantCUDAKernel<double>,
+                        ops::SlogDeterminantCUDAKernel<bool>);
+
+REGISTER_OP_CUDA_KERNEL(slogdeterminant_grad,
+                        ops::SlogDeterminantGradCUDAKernel<float>,
+                        ops::SlogDeterminantGradCUDAKernel<double>);

--- a/paddle/fluid/operators/determinant_op.h
+++ b/paddle/fluid/operators/determinant_op.h
@@ -330,20 +330,18 @@ class SlogDeterminantGradKernel : public framework::OpKernel<T> {
     det_grad.Resize(det_grad.dims().reshape(det_grad_vec));
 
     // Fifth: unsqueeze(dslA, [-1, -2])
-    framework::Tensor unsqueeze_dA;
-    unsqueeze_dA.ShareDataWith(det_grad);
     auto unsqueeze_dims = UnsqueezeKernel<DeviceContext, T>::GetOutputShape(
         {-1, -2}, det_grad.dims());
-    unsqueeze_dA.Resize(unsqueeze_dims);
+    det_grad.Resize(unsqueeze_dims);
 
-    VLOG(3) << "unsqueezed(dslA) dims: " << unsqueeze_dA.dims();
+    VLOG(3) << "unsqueezed(dslA) dims: " << det_grad.dims();
 
     // Finally: unsqueeze(dslA) * inverse(A)
     dslogdet->Resize(transpose_inverse_A.dims());
     dslogdet->mutable_data<T>(context.GetPlace());
 
     ElementwiseMulFunctor<DeviceContext, T> elem_mul;
-    elem_mul(context, &unsqueeze_dA, &transpose_inverse_A, dslogdet);
+    elem_mul(context, &det_grad, &transpose_inverse_A, dslogdet);
 
     VLOG(3) << "dsl|A| dims: " << dslogdet->dims();
   }

--- a/paddle/fluid/operators/determinant_op.h
+++ b/paddle/fluid/operators/determinant_op.h
@@ -1,0 +1,229 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <Eigen/Dense>
+#include <Eigen/LU>
+#include <algorithm>
+#include <cmath>
+#include <vector>
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/elementwise/elementwise_mul_op.h"
+#include "paddle/fluid/operators/math/matrix_inverse.h"
+#include "paddle/fluid/operators/transpose_op.h"
+#include "paddle/fluid/operators/unsqueeze_op.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+template <typename T>
+struct DeterminantFunctor {
+  void operator()(const Tensor& input, const framework::ExecutionContext ctx,
+                  int rank, int batch_count, Tensor* output) {
+    std::vector<T> input_vec;
+    std::vector<float> output_vec;
+    framework::TensorToVector(input, ctx.device_context(), &input_vec);
+    for (int i = 0; i < batch_count; ++i) {  // maybe can be parallel
+      auto begin_idx = input_vec.begin() + i * rank * rank;
+      auto end_idx = input_vec.begin() + (i + 1) * rank * rank;
+      std::vector<T> sub_vec(begin_idx,
+                             end_idx);  // get every square matrix data
+      Eigen::MatrixXf matrix(rank, rank);
+      for (int i = 0; i < rank; ++i) {
+        for (int j = 0; j < rank; ++j) {
+          matrix(i, j) = sub_vec[rank * i + j];
+        }
+      }
+      output_vec.push_back(matrix.determinant());
+    }
+    framework::TensorFromVector(output_vec, output);
+  }
+};
+template <typename T>
+class DeterminantKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* input = context.Input<framework::Tensor>("Input");
+    auto input_dim = vectorize(input->dims());
+    auto input_dim_size = input_dim.size();
+    auto* output = context.Output<framework::Tensor>("Out");
+
+    int batch_count = 1;
+    for (int i = 0; i < input->dims().size() - 2; i++) {
+      batch_count *= input_dim[i];
+    }
+
+    VLOG(2) << "input dim:" << input->dims();
+    auto rank = input_dim[input_dim_size - 1];  // square matrix length
+    DeterminantFunctor<T>()(*input, context, rank, batch_count, output);
+    auto output_dims =
+        framework::slice_ddim(input->dims(), 0, input_dim_size - 2);
+    output->Resize(output_dims);
+    VLOG(2) << "output dim:" << output->dims();
+  }
+};
+
+template <typename DeviceContext, typename T>
+struct ElementwiseMulFunctor {
+  void operator()(const framework::ExecutionContext& ctx,
+                  const framework::Tensor* x, const framework::Tensor* y,
+                  framework::Tensor* z) {
+    default_elementwise_mul<DeviceContext, T>(ctx, x, y, z);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class DeterminantGradKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto& dev_ctx = context.template device_context<DeviceContext>();
+    const auto* input = context.Input<framework::Tensor>("Input");
+    const auto* det = context.Input<framework::Tensor>("Out");
+    const auto* grad =
+        context.Input<framework::Tensor>(framework::GradVarName("Out"));
+    auto* ddet =
+        context.Output<framework::Tensor>(framework::GradVarName("Input"));
+
+    // let |A| = Determinant(A)
+    // In pytorch:
+    // d|A| = det(A).unsqueeze(-1).unsqueeze(-2) * inverse(A).transpose(-2, -1)
+    // In tensorflow:
+    // d|A| = det(A).reshape(tf.concat([det(A).shape, [1, 1]], 0)) * inv(A,
+    // adjoint=True)
+    // And ref to https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf
+    // we set d|A| = unsqueeze(dA * |A|, [-1, -2]) * inverse(A).transpose(-2,
+    // -1)
+
+    // First: inverse(A)
+    framework::Tensor inverse_A;
+    // A must be square matrices!
+    inverse_A.Resize(input->dims());
+    inverse_A.mutable_data<T>(context.GetPlace());
+
+    math::MatrixInverseFunctor<DeviceContext, T> mat_inv;
+    mat_inv(dev_ctx, *input, &inverse_A);
+
+    VLOG(3) << "inverse(A) dims: " << inverse_A.dims();
+
+    // Second: inverse(A).transpose(-2, -1)
+    framework::Tensor transpose_inverse_A;
+    // A must be square matrix! Transpose the last two dimension not change
+    // the shape
+    transpose_inverse_A.Resize(inverse_A.dims());
+    transpose_inverse_A.mutable_data<T>(context.GetPlace());
+
+    auto inverse_A_rank = inverse_A.dims().size();
+    std::vector<int> trans_axis(inverse_A_rank);
+    for (int i = 0; i < inverse_A_rank; ++i) {
+      trans_axis[i] = i;
+    }
+    // Transpose the last two dimension
+    trans_axis[inverse_A_rank - 1] = inverse_A_rank - 2;
+    trans_axis[inverse_A_rank - 2] = inverse_A_rank - 1;
+    TransCompute<DeviceContext, T>(inverse_A_rank, dev_ctx, inverse_A,
+                                   &transpose_inverse_A, trans_axis);
+
+    // Third: dA * |A|
+    ElementwiseMulFunctor<DeviceContext, T> elem_mul;
+    framework::Tensor mul_dA_detA;
+    mul_dA_detA.Resize(grad->dims());
+    mul_dA_detA.mutable_data<T>(context.GetPlace());
+    elem_mul(context, grad, det, &mul_dA_detA);
+
+    // Fourth: unsqueeze(dA * |A|, [-1, -2])
+    auto unsqueeze_dims = UnsqueezeKernel<DeviceContext, T>::GetOutputShape(
+        {-1, -2}, mul_dA_detA.dims());
+    mul_dA_detA.Resize(unsqueeze_dims);
+
+    VLOG(3) << "unsqueezed(dA * |A|) dims: " << mul_dA_detA.dims();
+
+    // Finally: unsqueeze(dA * |A|) * inverse(A)
+    ddet->Resize(transpose_inverse_A.dims());
+    ddet->mutable_data<T>(context.GetPlace());
+    elem_mul(context, &mul_dA_detA, &transpose_inverse_A, ddet);
+
+    VLOG(3) << "d|A| dims: " << ddet->dims();
+  }
+};
+
+template <typename T>
+T sign(T val) {
+  return static_cast<T>(T(0) < val) - (val < T(0));
+}
+template <typename T>
+struct SlogDeterminantFunctor {
+  void operator()(const Tensor& input, const framework::ExecutionContext ctx,
+                  int rank, int batch_count, Tensor* output) {
+    std::vector<T> input_vec;
+    std::vector<float> sign_vec;
+    std::vector<float> log_vec;
+    std::vector<float> output_vec;
+    framework::TensorToVector(input, ctx.device_context(), &input_vec);
+    for (int i = 0; i < batch_count; ++i) {  // maybe can be parallel
+      auto begin_idx = input_vec.begin() + i * rank * rank;
+      auto end_idx = input_vec.begin() + (i + 1) * rank * rank;
+      std::vector<T> sub_vec(begin_idx,
+                             end_idx);  // get every square matrix data
+      Eigen::MatrixXf matrix(rank, rank);
+      for (int i = 0; i < rank; ++i) {
+        for (int j = 0; j < rank; ++j) {
+          matrix(i, j) = sub_vec[rank * i + j];
+        }
+      }
+      VLOG(2) << "det value: " << matrix.determinant();
+      VLOG(2) << "matrix val: " << matrix;
+      auto det_val = matrix.determinant();
+      sign_vec.push_back(sign(det_val));
+      det_val >= 0
+          ? log_vec.push_back(log(det_val))
+          : log_vec.push_back(
+                -1.0 *
+                log(abs(
+                    det_val)));  // for computing log value of a negative value.
+    }
+    // merge sign_vec and log_vec as final output_vec
+    output_vec.insert(output_vec.end(), sign_vec.begin(), sign_vec.end());
+    output_vec.insert(output_vec.end(), log_vec.begin(), log_vec.end());
+    framework::TensorFromVector(output_vec, output);
+  }
+};
+
+template <typename T>
+class SlogDeterminantKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* input = context.Input<framework::Tensor>("Input");
+    auto input_dim = vectorize(input->dims());
+    auto input_dim_size = input_dim.size();
+    auto* output = context.Output<framework::Tensor>("Out");
+
+    int batch_count = 1;
+    for (int i = 0; i < input->dims().size() - 2; i++) {
+      batch_count *= input_dim[i];
+    }
+    VLOG(2) << "input dim:" << input->dims();
+    auto rank = input_dim[input_dim_size - 1];  // square matrix length
+    SlogDeterminantFunctor<T>()(*input, context, rank, batch_count, output);
+    std::vector<int> output_dim_vec(input_dim.begin(), input_dim.end() - 2);
+    output_dim_vec.insert(output_dim_vec.begin(),
+                          2);  // make the output dims as same as numpy
+    auto output_dims = framework::make_ddim(output_dim_vec);
+    output->Resize(output_dims);
+    VLOG(2) << "output dim:" << output->dims();
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -99,6 +99,8 @@ from .tensor.linalg import cholesky  # noqa: F401
 from .tensor.linalg import bmm  # noqa: F401
 from .tensor.linalg import histogram  # noqa: F401
 from .tensor.linalg import mv  # noqa: F401
+from .tensor.linalg import det  # noqa: F401
+from .tensor.linalg import slogdet  # noqa: F401
 from .tensor.linalg import matrix_power  # noqa: F401
 from .tensor.linalg import svd  # noqa: F401
 from .tensor.logic import equal  # noqa: F401
@@ -519,5 +521,7 @@ __all__ = [  # noqa
            'standard_normal',
            'diagonal',
            'broadcast_tensors',
+           'det',
+           'slogdet',
            'einsum'
 ]

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -38,7 +38,6 @@ from paddle.fluid.tests.unittests.testsuite import (
     set_input,
     append_input_output,
     append_loss_ops, )
-from paddle.fluid import unique_name
 from paddle.fluid.tests.unittests.white_list import (
     op_accuracy_white_list,
     check_shape_white_list,

--- a/python/paddle/fluid/tests/unittests/test_determinant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_determinant_op.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+from op_test import OpTest
+import paddle
+import paddle.nn.functional as F
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+import paddle.tensor as tensor
+
+paddle.enable_static()
+
+
+class TestDeterminantOp(OpTest):
+    def setUp(self):
+        self.op_type = "determinant"
+        self.init_config()
+        self.outputs = {'Out': self.target}
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        self.check_grad(['Input'], 'Out')
+
+    def init_config(self):
+        self.case = np.random.randn(3, 3, 3, 3).astype('float64')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.inputs['Input'])
+
+
+class TestDeterminantOpCase1(TestDeterminantOp):
+    def init_config(self):
+        self.case = np.random.randn(3, 3, 3, 3).astype('float32')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.inputs['Input'])
+
+
+class TestDeterminantOpCase2(TestDeterminantOp):
+    def init_config(self):
+        self.case = np.random.randint(0, 2, (4, 2, 4, 4)).astype('float64')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.det(self.inputs['Input'])
+        self.grad_x = np.eye(100).astype('int64')
+        self.grad_out = np.ones(100).astype('int64')
+
+    def test_check_grad(self):
+        self.check_grad(['Input'], 'Out')
+
+
+class TestDeterminantAPI(unittest.TestCase):
+    def setUp(self):
+        self.shape = [3, 3, 3, 3]
+        self.x = np.random.random((3, 3, 3, 3)).astype(np.float32)
+        self.place = paddle.CPUPlace()
+
+    def test_api_static(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.fluid.data('X', self.shape)
+            out = paddle.linalg.det(x)
+            exe = paddle.static.Executor(self.place)
+            res = exe.run(feed={'X': self.x}, fetch_list=[out])
+        out_ref = np.linalg.det(self.x)
+
+        for out in res:
+            self.assertEqual(np.allclose(out, out_ref, rtol=1e-03), True)
+
+    def test_api_dygraph(self):
+        paddle.disable_static(self.place)
+        x_tensor = paddle.to_tensor(self.x)
+        out = paddle.linalg.det(x_tensor)
+        out_ref = np.linalg.det(self.x)
+        self.assertEqual(np.allclose(out.numpy(), out_ref, rtol=1e-03), True)
+        paddle.enable_static()
+
+
+class TestSlogDeterminantOp(OpTest):
+    def setUp(self):
+        self.op_type = "slogdeterminant"
+        self.init_config()
+        self.outputs = {'Out': self.target}
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['Input'],
+            'Out',
+            user_defined_grads=[self.grad_x],
+            user_defined_grad_outputs=[self.grad_out])
+
+    def init_config(self):
+        self.case = np.random.randn(3, 3, 3, 3).astype('float64')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.slogdet(self.inputs['Input'])
+
+
+class TestSlogDeterminantOpCase1(TestSlogDeterminantOp):
+    def init_config(self):
+        self.case = np.random.randn(3, 3, 3, 3).astype('float32')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.slogdet(self.inputs['Input'])
+        print(">>>>>>>>")
+        print(self.target)
+        self.grad_x = np.eye(100).astype('int64')
+        self.grad_out = np.ones(100).astype('int64')
+
+
+class TestSlogDeterminantOpCase2(TestSlogDeterminantOp):
+    def init_config(self):
+        self.case = np.random.randint(0, 2, (4, 2, 4, 4)).astype('int')
+        self.inputs = {'Input': self.case}
+        self.target = np.linalg.slogdet(self.inputs['Input'])
+
+    def test_check_grad(self):
+        self.check_grad(
+            ['Input'],
+            'Out',
+            user_defined_grads=[self.grad_x],
+            user_defined_grad_outputs=[self.grad_out])
+
+
+class TestSlogDeterminantAPI(unittest.TestCase):
+    def setUp(self):
+        self.shape = [3, 3, 3, 3]
+        self.x = np.random.random((3, 3, 3, 3)).astype(np.float32)
+        self.place = paddle.CPUPlace()
+
+    def test_api_static(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.fluid.data('X', self.shape)
+            out = paddle.linalg.slogdet(x)
+            exe = paddle.static.Executor(self.place)
+            res = exe.run(feed={'X': self.x}, fetch_list=[out])
+        out_ref = np.linalg.slogdet(self.x)
+        for out in res:
+            self.assertEqual(np.allclose(out, out_ref, rtol=1e-03), True)
+
+    def test_api_dygraph(self):
+        paddle.disable_static(self.place)
+        x_tensor = paddle.to_tensor(self.x)
+        out = paddle.linalg.slogdet(x_tensor)
+        out_ref = np.linalg.slogdet(self.x)
+        self.assertEqual(np.allclose(out.numpy(), out_ref, rtol=1e-03), True)
+        paddle.enable_static()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/linalg.py
+++ b/python/paddle/linalg.py
@@ -17,7 +17,7 @@ from .tensor.linalg import norm  # noqa: F401
 from .tensor.linalg import matrix_power  # noqa: F401
 from .tensor import inverse as inv  # noqa: F401
 from .tensor.linalg import matrix_rank
-from .tensor.linalg import svd
+from .tensor.linalg import svd, det, slogdet
 
 __all__ = [
     'cholesky',  #noqa
@@ -25,5 +25,7 @@ __all__ = [
     'inv',
     'matrix_rank',
     'svd',
-    'matrix_power'
+    'matrix_power',
+    'det',
+    'slogdet'
 ]

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.data_feeder import check_variable_and_dtype, check_type
+from ..fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype
 from ..fluid.framework import in_dygraph_mode, _varbase_creator, Variable
 
 from ..fluid.layers import transpose, cast  # noqa: F401
@@ -1029,6 +1029,95 @@ def mv(x, vec, name=None):
         type='mv', inputs={'X': x,
                            'Vec': vec}, outputs={'Out': out})
     return out
+
+
+def det(x):
+    """
+    Calculates determinant value of a square matrix or batches of square matrices.
+    Args:
+        x (Tensor): input (Tensor): the input matrix of size `(n, n)` or the batch of matrices of size
+                    `(*, n, n)` where `*` is one or more batch dimensions.
+    Returns:
+        y (Tensor):the determinant value of a square matrix or batches of square matrices.
+
+    Returns:
+    
+    """
+    if in_dygraph_mode():
+        return core.ops.determinant(x)
+
+    def __check_input(input):
+        check_dtype(
+            x.dtype, 'Input',
+            ['bool', 'int32', 'int64', 'float16', 'float32', 'float64'], 'det')
+
+        input_shape = list(x.shape)
+        assert len(input_shape) >= 2,                     \
+                "The x must be at least 2-dimensional, "   \
+                "but received Input x's dimensional: %s.\n" %  \
+                len(input_shape)
+
+        assert (input_shape[-1] == input_shape[-2]),    \
+                "Expect squared input," \
+                "but received %s by %s matrix.\n" \
+                %(input_shape[-2], input_shape[-1]) \
+
+    __check_input(input)
+    helper = LayerHelper('determinant', **locals())
+    out = helper.create_variable_for_type_inference(dtype=x.dtype)
+
+    helper.append_op(
+        type='determinant', inputs={'Input': [x]}, outputs={'Out': [out]})
+    return out
+
+
+def slogdet(x):
+    """
+    Calculates the sign and natural logarithm of the absolute value of a square matrix's or batches square matrices' determinant.
+    The determinant can be computed with ``sign * exp(logabsdet)
+    
+    Supports input of bool, int32, int64, float16, float, double
+
+    Note that for matrices that have zero determinant, this returns ``(0, -inf)``
+    Args:
+        x (Tensor): the batch of matrices of size :math:`(*, n, n)`
+            where math:`*` is one or more batch dimensions.
+
+    Returns:
+        y (Tensor): A namedtuple (sign, logabsdet) containing the sign of the determinant and the natural logarithm
+        of the absolute value of determinant, respectively.
+
+    Example::
+
+ 
+
+    """
+    if in_dygraph_mode():
+        return core.ops.slogdeterminant(x)
+
+    def __check_input(input):
+        check_dtype(
+            x.dtype, 'Input',
+            ['bool', 'int32', 'int64', 'float16', 'float32', 'float64'],
+            'slogdet')
+
+        input_shape = list(x.shape)
+        assert len(input_shape) >= 2,                     \
+                "The x must be at least 2-dimensional, "   \
+                "but received Input x's dimensional: %s.\n" %  \
+                len(input_shape)
+
+        assert (input_shape[-1] == input_shape[-2]),    \
+                "Expect squared input," \
+                "but received %s by %s matrix.\n" \
+                %(input_shape[-2], input_shape[-1]) \
+
+    __check_input(input)
+    helper = LayerHelper('slogdeterminant', **locals())
+    out = helper.create_variable_for_type_inference(dtype=x.dtype)
+
+    helper.append_op(
+        type='slogdeterminant', inputs={'Input': [x]}, outputs={'Out': [out]})
 
 
 def svd(x, full_matrices=False, name=None):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
增加`paddle.linalg.det`的反向代码实现。

参考论文：https://people.maths.ox.ac.uk/gilesm/files/NA-08-01.pdf

# 主要竞品实现
`det_grad`：
tensorflow：`det_grad = tf.reshape( grad * det, tf.concat([det.shape, [1, 1]], 0)) * tf.linalg.inv(x, adjoint=True)`
pytorch：`det_grad = (grad * det).unsqueeze(-1).unsqueeze(-2) * x.inverse().transpose(-2, -1)`

`slog_grad`：
tensorflow：`slogdet_grad = tf.reshape(grad, tf.concat([grad.shape, [1, 1]], 0)) * tf.linalg.inv(x, adjoint=True)`
pytorch：`slogdet_grad = grad.unsqueeze(-1).unsqueeze(-2) * x.inverse().conj().transpose(-2, -1)`

这里我们参考pytorch的方法实现反向。