### PR TITLE
re-submit softmax_with_cross_entropy hard label (#35283)

### DIFF
--- a/python/paddle/fluid/tests/unittests/parallel_margin_cross_entropy.py
+++ b/python/paddle/fluid/tests/unittests/parallel_margin_cross_entropy.py
@@ -142,7 +142,10 @@ class TestParallelMarginSoftmaxCrossEntropyOp(unittest.TestCase):
                             return_softmax=True)
 
                         np.testing.assert_allclose(
-                            loss_a.numpy(), loss_b.numpy(), rtol=1e-5)
+                            loss_a.numpy(),
+                            loss_b.numpy(),
+                            rtol=1e-5,
+                            atol=1e-7)
 
                         integral_prob = np.zeros(
                             (batch_size, num_class), dtype=dtype)
@@ -181,7 +184,8 @@ class TestParallelMarginSoftmaxCrossEntropyOp(unittest.TestCase):
                         np.testing.assert_allclose(
                             integral_data.grad.numpy(),
                             integral_grad.numpy(),
-                            rtol=1e-5)
+                            rtol=1e-5,
+                            atol=1e-7)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Ops

### Describe
Op softmax_with_cross_entropy optimization hard label. This PR includes:

hard label forward kernel: use same idea of softmax's implementation: SoftmaxWithCrossEntropyHardLabel
hard label backward kernel: merge multiple kernels to one kernel: SoftmaxWithCrossEntropyGradHardLabel

This PR re-submit PR 32290, which was reverted by PR 33340. The difference is from manual written kernel and cudnn implementation (log softmax)
- Current  implementation: L636 - L649
- PR implementation: L450 - L468

This PR also modifies the absolute error check of "parallel_margin_cross_entropy". The owner (Guoxia Wang) is approved.