### PR TITLE
no necessary to add scale_op to stop inplace op from being pruned. fix prune instead.

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5031,12 +5031,6 @@ class Program(object):
                         "All targets of Program._prune_with_input() can only be "
                         "Variable or Operator, but received %s." % type(t))
 
-                # NOTEZ(zhiqiu): For variable to be fed in fetch_list, there two cases:
-                # (1) the variable is leaf, it has no op that generates it;
-                # (2) the variable is not leaf, and we need to prune the op that generates it.
-                # In both cases, wo can just skip target_op of that it.
-                if name in feeded_var_names:
-                    continue
 
                 # After transpiler processing, the op that output this
                 # variable maybe has been changed, so t.op is not reliable
@@ -5053,11 +5047,16 @@ class Program(object):
                             continue
                         else:
                             target_op = op
-                            break
+
                 if target_op is None:
-                    raise ValueError(
-                        "The target variable used for pruning should have an "
-                        "associated operator that generates it.")
+                    # NOTEZ(zhiqiu): For variable to be fed in fetch_list, there two cases:
+                    # (1) the variable is leaf, it has no op that generates it;
+                    # (2) the variable is not leaf, and we need to prune the op that generates it.
+                    # In both cases, wo can just skip target_op of that it.
+                    if name in feeded_var_names:
+                        raise ValueError(
+                            "The target variable used for pruning should have an "
+                            "associated operator that generates it.")
                 else:
                     targets_idx.append([target_op.block.idx, target_op.idx])
             else:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5031,12 +5031,6 @@ class Program(object):
                         "All targets of Program._prune_with_input() can only be "
                         "Variable or Operator, but received %s." % type(t))
 
-                # NOTEZ(zhiqiu): For variable to be fed in fetch_list, there two cases:
-                # (1) the variable is leaf, it has no op that generates it;
-                # (2) the variable is not leaf, and we need to prune the op that generates it.
-                # In both cases, wo can just skip target_op of that it.
-                if name in feeded_var_names:
-                    continue
 
                 # After transpiler processing, the op that output this
                 # variable maybe has been changed, so t.op is not reliable
@@ -5053,11 +5047,16 @@ class Program(object):
                             continue
                         else:
                             target_op = op
-                            break
+
                 if target_op is None:
-                    raise ValueError(
-                        "The target variable used for pruning should have an "
-                        "associated operator that generates it.")
+                    # NOTEZ(zhiqiu): For variable to be fed in fetch_list, there two cases:
+                    # (1) the variable is leaf, it has no op that generates it;
+                    # (2) the variable is not leaf, and we need to prune the op that generates it.
+                    # In both cases, wo can just skip target_op of that it.
+                    if name not in feeded_var_names:
+                        raise ValueError(
+                            "The target variable used for pruning should have an "
+                            "associated operator that generates it.")
                 else:
                     targets_idx.append([target_op.block.idx, target_op.idx])
             else:

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1372,15 +1372,9 @@ def save_inference_model(dirname,
             )
             break
 
-    # fix the bug that the activation op's output as target will be pruned.
-    # will affect the inference performance.
-    # TODO(Superjomn) add an IR pass to remove 1-scale op.
     with program_guard(main_program):
         uniq_target_vars = []
         for i, var in enumerate(target_vars):
-            if isinstance(var, Variable) and var.dtype != paddle.bool:
-                var = layers.scale(
-                    var, 1., name="save_infer_model/scale_{}".format(i))
             uniq_target_vars.append(var)
         target_vars = uniq_target_vars
     target_var_name_list = [var.name for var in target_vars]


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
when the _prune_with_input method (python/paddle/fluid/framework.py) is implemented, there is no static graph and no inplace op. after inplace op is introduced, some graph will not save, cause the inplace op will be pruned. to stop this, a scale_op is added to each output var. this is a trick, it works sometime, but not always, cause scale_op doesn't support all the datatypes. another problem introduced by inplace op is when a var is both feedvar and fetchvar, prune will also prune it. 

this PR just fix the prune method to support inplace op, so there will be no necessary to add scale_op after output var. this PR just remove the tricks.