### PR TITLE
[hybrid performance] Optimize Pipeline Scheduler

### DIFF
--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -601,6 +601,10 @@ class SectionWorker : public DeviceWorker {
   std::vector<std::string> backward_send_vars_;
 
   std::vector<std::unique_ptr<OperatorBase>> ops_;
+  std::vector<std::unique_ptr<OperatorBase>> forward_first_ops_;
+  std::vector<std::unique_ptr<OperatorBase>> forward_other_ops_;
+  std::vector<std::unique_ptr<OperatorBase>> backward_ops_;
+  std::vector<std::unique_ptr<OperatorBase>> optimizer_ops_;
   std::shared_ptr<framework::ProgramDesc> program_;
   std::unordered_map<const OperatorBase*, std::vector<std::string>>
       unused_vars_;

--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -601,10 +601,10 @@ class SectionWorker : public DeviceWorker {
   std::vector<std::string> backward_send_vars_;
 
   std::vector<std::unique_ptr<OperatorBase>> ops_;
-  std::vector<std::unique_ptr<OperatorBase>> forward_first_ops_;
-  std::vector<std::unique_ptr<OperatorBase>> forward_other_ops_;
-  std::vector<std::unique_ptr<OperatorBase>> backward_ops_;
-  std::vector<std::unique_ptr<OperatorBase>> optimizer_ops_;
+  std::vector<OperatorBase*> forward_first_ops_;
+  std::vector<OperatorBase*> forward_other_ops_;
+  std::vector<OperatorBase*> backward_ops_;
+  std::vector<OperatorBase*> optimizer_ops_;
   std::shared_ptr<framework::ProgramDesc> program_;
   std::unordered_map<const OperatorBase*, std::vector<std::string>>
       unused_vars_;

--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -601,8 +601,8 @@ class SectionWorker : public DeviceWorker {
   std::vector<std::string> backward_send_vars_;
 
   std::vector<std::unique_ptr<OperatorBase>> ops_;
-  std::vector<OperatorBase*> forward_first_ops_;
-  std::vector<OperatorBase*> forward_other_ops_;
+  std::vector<OperatorBase*> forward_and_lr_ops_;
+  std::vector<OperatorBase*> forward_ops_;
   std::vector<OperatorBase*> backward_ops_;
   std::vector<OperatorBase*> optimizer_ops_;
   std::shared_ptr<framework::ProgramDesc> program_;

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -65,15 +65,18 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
                      static_cast<int>(OpRole::kLoss))) ||
         (op_role == static_cast<int>(OpRole::kLRSched))) {
       forward_first_ops_.push_back(op.get());
-    } else if ((op_role == static_cast<int>(OpRole::kForward)) ||
-               (op_role == (static_cast<int>(OpRole::kForward) |
-                            static_cast<int>(OpRole::kLoss)))) {
+    }
+    if ((op_role == static_cast<int>(OpRole::kForward)) ||
+        (op_role == (static_cast<int>(OpRole::kForward) |
+                     static_cast<int>(OpRole::kLoss)))) {
       forward_other_ops_.push_back(op.get());
-    } else if ((op_role == static_cast<int>(OpRole::kBackward)) ||
-               (op_role == (static_cast<int>(OpRole::kBackward) |
-                            static_cast<int>(OpRole::kLoss)))) {
+    }
+    if ((op_role == static_cast<int>(OpRole::kBackward)) ||
+        (op_role == (static_cast<int>(OpRole::kBackward) |
+                     static_cast<int>(OpRole::kLoss)))) {
       backward_ops_.push_back(op.get());
-    } else if (op_role == static_cast<int>(OpRole::kOptimize)) {
+    }
+    if (op_role == static_cast<int>(OpRole::kOptimize)) {
       optimizer_ops_.push_back(op.get());
     }
   }

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -33,7 +33,7 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
 
   for (auto &op : ops_) {
     // cache the op type during the init part
-    // reduce unnecessary op visit during 1F1B
+    // reduce unnecessary op visit during running
     int op_role = op->Attr<int>("op_role");
     if ((op_role == static_cast<int>(OpRole::kForward)) ||
         (op_role == (static_cast<int>(OpRole::kForward) |
@@ -53,7 +53,7 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
       optimizer_ops_.push_back(op.get());
     } else {
       PADDLE_THROW(platform::errors::PreconditionNotMet(
-          "The op %s is None of LRSchel, Forward, Backward or Optimize.",
+          "The op %s is None of LRSched, Forward, Backward or Optimize.",
           op->Type()));
     }
   }

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -57,22 +57,21 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
 
     // cache the op type during the init part
     // reduce unnecessary op visit during 1F1B
-    int op_role = op->Attr<int>(std::string("op_role"));
     if ((op_role == static_cast<int>(OpRole::kForward)) ||
         (op_role == (static_cast<int>(OpRole::kForward) |
                      static_cast<int>(OpRole::kLoss))) ||
         (op_role == static_cast<int>(OpRole::kLRSched))) {
-      forward_first_ops_.push_back(op);
+      forward_first_ops_.push_back(op.get());
     } else if ((op_role == static_cast<int>(OpRole::kForward)) ||
                (op_role == (static_cast<int>(OpRole::kForward) |
                             static_cast<int>(OpRole::kLoss)))) {
-      forward_other_ops_.push_back(op);
+      forward_other_ops_.push_back(op.get());
     } else if ((op_role == static_cast<int>(OpRole::kBackward)) ||
                (op_role == (static_cast<int>(OpRole::kBackward) |
                             static_cast<int>(OpRole::kLoss)))) {
-      backward_ops_.push_back(op);
+      backward_ops_.push_back(op.get());
     } else if (op_role == static_cast<int>(OpRole::kOptimize)) {
-      optimizer_ops_.push_back(op);
+      optimizer_ops_.push_back(op.get());
     }
   }
 }
@@ -86,14 +85,14 @@ void SectionWorker::RunForward(
     int micro_id, std::unique_ptr<GarbageCollector> &gc,
     std::unordered_map<const OperatorBase *, std::vector<std::string>>
         &unused_vars_) {
-  std::vector<std::unique_ptr<OperatorBase>> &forward_tmp =
+  std::vector<OperatorBase *> &forward_tmp =
       micro_id == 0 ? forward_first_ops_ : forward_other_ops_;
   for (auto &op : forward_tmp) {
     VLOG(3) << "Forward: running op " << op->Type() << " for micro-batch "
             << micro_id;
     op->Run(*microbatch_scopes_[micro_id], place_);
     if (gc) {
-      DeleteUnusedTensors(*microbatch_scopes_[micro_id], op.get(), unused_vars_,
+      DeleteUnusedTensors(*microbatch_scopes_[micro_id], op, unused_vars_,
                           gc.get());
     }
   }
@@ -108,7 +107,7 @@ void SectionWorker::RunBackward(
             << micro_id;
     op->Run(*microbatch_scopes_[micro_id], place_);
     if (gc) {
-      DeleteUnusedTensors(*microbatch_scopes_[micro_id], op.get(), unused_vars_,
+      DeleteUnusedTensors(*microbatch_scopes_[micro_id], op, unused_vars_,
                           gc.get());
     }
   }
@@ -122,7 +121,7 @@ void SectionWorker::RunUpdate(
     VLOG(3) << "Update: running op " << op->Type();
     op->Run(*microbatch_scopes_[num_microbatches_ - 1], place_);
     if (gc) {
-      DeleteUnusedTensors(*microbatch_scopes_[num_microbatches_ - 1], op.get(),
+      DeleteUnusedTensors(*microbatch_scopes_[num_microbatches_ - 1], op,
                           unused_vars_, gc.get());
     }
   }

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -39,8 +39,10 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
         (op_role == (static_cast<int>(OpRole::kForward) |
                      static_cast<int>(OpRole::kLoss))) ||
         (op_role == static_cast<int>(OpRole::kLRSched))) {
+      // forward ops and lr schedule ops, used for first micro step
       forward_and_lr_ops_.push_back(op.get());
       if ((op_role != static_cast<int>(OpRole::kLRSched))) {
+        // only forward ops, used for second and later micro steps
         forward_ops_.push_back(op.get());
       }
     } else if ((op_role == static_cast<int>(OpRole::kBackward)) ||

--- a/paddle/fluid/framework/section_worker.cc
+++ b/paddle/fluid/framework/section_worker.cc
@@ -54,9 +54,12 @@ void SectionWorker::Initialize(const TrainerDesc &desc) {
 
     backward_send_vars_.push_back(var_name);
     skip_vars_.push_back(var_name);
+  }
 
+  for (auto &op : ops_) {
     // cache the op type during the init part
     // reduce unnecessary op visit during 1F1B
+    int op_role = op->Attr<int>("op_role");
     if ((op_role == static_cast<int>(OpRole::kForward)) ||
         (op_role == (static_cast<int>(OpRole::kForward) |
                      static_cast<int>(OpRole::kLoss))) ||


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
Update the pipeline scheduler, move the forward/backward/optimize op decision logic to init function of SectionWorker.

Loss compare on GPU with Ernie3.0:
![image](https://user-images.githubusercontent.com/25279174/133044752-560d1c19-468c-4e69-823b-24bf2483f26f.png)

Speed:
|Before | After | Gain |
|:-:|:-:|:-:|
| 35358 | 36032 | +1.9% |

