### PR TITLE
[hybrid] fix GradientClipByGlobalNorm in hybrid parallel

### DIFF
--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -522,7 +522,9 @@ class ClipGradByGlobalNorm(ClipGradBase):
                     # fp64
                     global_norm_var_other_dtype = layers.sums(sum_square_list)
                     global_norm_var.append(global_norm_var_other_dtype)
-                global_norm_var = layers.sums(global_norm_var)
+
+                global_norm_var = layers.sums(global_norm_var) if len(
+                    global_norm_var) > 1 else global_norm_var[0]
                 global_norm_var = layers.sqrt(x=global_norm_var)
                 max_global_norm = layers.fill_constant(
                     shape=[1],

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -266,10 +266,9 @@ class TestFleetShardingMetaOptimizer(TestFleetMetaOptimizer):
             'c_reduce_sum', 'c_reduce_sum', 'c_reduce_sum', 'c_reduce_sum',
             'c_reduce_sum', 'c_reduce_sum', 'c_sync_comm_stream',
             'squared_l2_norm', 'squared_l2_norm', 'squared_l2_norm', 'sum',
-            'c_allreduce_sum', 'sum', 'c_allreduce_sum', 'sqrt',
-            'fill_constant', 'elementwise_max', 'elementwise_div',
-            'elementwise_mul', 'elementwise_mul', 'elementwise_mul', 'momentum',
-            'momentum', 'momentum'
+            'c_allreduce_sum', 'sqrt', 'fill_constant', 'elementwise_max',
+            'elementwise_div', 'elementwise_mul', 'elementwise_mul',
+            'elementwise_mul', 'momentum', 'momentum', 'momentum'
         ])
 
     def test_sharding_clone_for_test(self):

--- a/python/paddle/fluid/tests/unittests/test_gradient_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_gradient_clip.py
@@ -216,7 +216,7 @@ class TestGradientClipByGlobalNorm(TestGradientClip):
     def test_none_grad_fp32(self):
         ops = self._test_none_grad_helper("float32")
         self.assertListEqual(ops, [
-            'squared_l2_norm', 'squared_l2_norm', 'sum', 'sum', 'sqrt',
+            'squared_l2_norm', 'squared_l2_norm', 'sum', 'sqrt',
             'fill_constant', 'elementwise_max', 'elementwise_div',
             'elementwise_mul', 'elementwise_mul'
         ])
@@ -225,9 +225,8 @@ class TestGradientClipByGlobalNorm(TestGradientClip):
         ops = self._test_none_grad_helper("float16")
         self.assertListEqual(ops, [
             'square', 'reduce_sum', 'square', 'reduce_sum', 'sum', 'cast',
-            'sum', 'sqrt', 'fill_constant', 'elementwise_max',
-            'elementwise_div', 'cast', 'elementwise_mul', 'cast',
-            'elementwise_mul'
+            'sqrt', 'fill_constant', 'elementwise_max', 'elementwise_div',
+            'cast', 'elementwise_mul', 'cast', 'elementwise_mul'
         ])
 
     def _test_none_grad_helper(self, dtype):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复 https://github.com/PaddlePaddle/Paddle/pull/33565 引入的精度bug。
#### 产生原因
上述PR在GradientClipByGlobalNorm里插入了两个sum op，导致混合并行中同样也会插入两个c_allreduce_sum。
原本global_norm = 9 = c_allreduce_sum(5, 4)，增加一个c_allreduce_sum后，global_norm = 18 = c_allreduce_sum(9, 9)，导致出错。
#### 修复方案
临时修复，判断global_norm_var_list的个数，为1则保持原始逻辑只有一个sum。