### PR TITLE
fix random seed to avoid UT random failed

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
@@ -129,6 +129,7 @@ class TestGroupNormAPIV2_With_General_Dimensions(unittest.TestCase):
         paddle.disable_static()
         shapes = [(2, 6), (2, 6, 4), (2, 6, 4, 4), (2, 6, 6, 6, 2), (2, 6, 6, 6,
                                                                      2, 3)]
+        np.random.seed(10)
         places = [fluid.CPUPlace()]
         if core.is_compiled_with_cuda() and core.op_support_gpu("group_norm"):
             places.append(fluid.CUDAPlace(0))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
The unitest of group_norm_op_v2 will failed randomly in test_numerical_accuracy. fix the seed to ensure it will get the same results.