### PR TITLE
fix concat api to accept empty tensor to concat.

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -322,10 +322,13 @@ def concat(input, axis=0, name=None):
         if isinstance(axis, Variable):
             axis = axis.numpy()
             axis = axis.item(0)
+        if not isinstance(input, Variable):
+            input = [t for t in input if max(t.shape) > 0]
         return _C_ops.concat(input, 'axis', axis)
 
     check_type(input, 'input', (list, tuple, Variable), 'concat')
     if not isinstance(input, Variable):
+        input = [t for t in input if max(t.shape) > 0]
         for id, x in enumerate(input):
             check_variable_and_dtype(
                 x, 'input[' + str(id) + ']',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix concat api to accept empty tensor to concat.
![屏幕快照 2021-09-14 下午1 33 27](https://user-images.githubusercontent.com/77733235/133201115-b1e3ffdd-15d8-418e-9344-f98cb121a224.png)
![屏幕快照 2021-09-14 下午1 35 03](https://user-images.githubusercontent.com/77733235/133201133-09c0513d-8e4e-469a-9573-1e1527944aed.png)
