### PR TITLE
Fix for swin_transformer(matmul+transpose+reshape)

### DIFF
--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -358,6 +358,8 @@ inline MKLDNNMemoryFormat MKLDNNFormatForSize(size_t dims_size,
     } else if (data_format == MKLDNNMemoryFormat::nhwc) {
       return MKLDNNMemoryFormat::ndhwc;
     }
+  } else if (dims_size == 6) {
+    return MKLDNNMemoryFormat::abcdef;
   }
   return data_format;
 }


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix for #35719. Problem was caused because matmul+transpose+reshape was not handling dim inference which is used by reshape op. Other problem was caused because we weren't handling 6 dim tensors, but now we do.
