### PR TITLE
[rc22] Remove linear v2 changes

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_fleet_static_mp_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_static_mp_layers.py
@@ -104,8 +104,7 @@ class TestDistTraning(unittest.TestCase):
             ops = main_program.global_block().ops
             ops = [op.type for op in ops]
             self.assertEqual(
-                ops,
-                ['c_identity', 'matmul_v2', 'elementwise_add', 'c_concat'])
+                ops, ['c_identity', 'matmul', 'elementwise_add', 'c_concat'])
 
             weight = model_a.parallel_linear.weight
             bias = model_a.parallel_linear.bias
@@ -128,7 +127,7 @@ class TestDistTraning(unittest.TestCase):
             ops = [op.type for op in ops]
             self.assertEqual(
                 ops,
-                ['c_split', 'matmul_v2', 'c_allreduce_sum', 'elementwise_add'])
+                ['c_split', 'matmul', 'c_allreduce_sum', 'elementwise_add'])
 
             weight = model_a.parallel_linear.weight
             bias = model_a.parallel_linear.bias

--- a/python/paddle/fluid/tests/unittests/test_linear.py
+++ b/python/paddle/fluid/tests/unittests/test_linear.py
@@ -74,7 +74,7 @@ class LinearTestCase(unittest.TestCase):
         np.testing.assert_array_almost_equal(res_nn, res_np)
 
     def test_error_dummy_input(self, place=paddle.CPUPlace()):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             x_arr = np.array([], dtype=np.float32)
             x = paddle.to_tensor(
                 np.reshape(x_arr, (0, 4, 4, 4)), dtype='float32')

--- a/python/paddle/fluid/tests/unittests/test_momentum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_momentum_op.py
@@ -664,7 +664,7 @@ class TestFusedMomentumWithDecayAPI(unittest.TestCase):
         self.assertEqual(ops[-3].type, 'sum')
         self.assertEqual(ops[-4].type, 'scale')
         self.assertEqual(ops[-5].type, 'sign')
-        self.assertEqual(ops[-6].type, 'matmul_v2_grad')
+        self.assertEqual(ops[-6].type, 'matmul_grad')
         if 'weight' in ops[-1].input('Param'):
             self.assertEqual(ops[-1].attr('regularization_method'), '')
             self.assertEqual(ops[-1].attr('regularization_coeff'), 0)

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -1469,8 +1469,9 @@ def linear(x, weight, bias=None, name=None):
           #     [2.1077576  2.1077576  2.1077576  2.1077576 ]]
     """
     if in_dygraph_mode():
-        pre_bias = _C_ops.matmul_v2(x, weight, 'trans_x', False, 'trans_y',
-                                    False)
+        pre_bias = _varbase_creator(dtype=x.dtype)
+        _C_ops.matmul(x, weight, pre_bias, 'transpose_X', False, 'transpose_Y',
+                      False, "alpha", 1)
 
         if bias is None:
             return pre_bias
@@ -1485,10 +1486,14 @@ def linear(x, weight, bias=None, name=None):
         check_dtype(dtype, 'dtype', ['float16', 'float32', 'float64'], 'linear')
 
         inputs = {'X': [x], 'Y': [weight]}
-        attrs = {'trans_x': False, 'trans_y': False}
+        attrs = {
+            'transpose_X': False,
+            'transpose_Y': False,
+            'alpha': 1,
+        }
         tmp = helper.create_variable_for_type_inference(dtype)
         helper.append_op(
-            type='matmul_v2', inputs=inputs, outputs={'Out': tmp}, attrs=attrs)
+            type='matmul', inputs=inputs, outputs={'Out': tmp}, attrs=attrs)
         if bias is not None:
             res = helper.create_variable_for_type_inference(dtype)
             helper.append_op(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
[rc22] Remove linear v2 changes. In Linear API, revert matmul_v2 back to matmul.