### PR TITLE
fix pass quickly for PR-CI-OP-Benchmark

### DIFF
--- a/tools/test_ci_op_benchmark.sh
+++ b/tools/test_ci_op_benchmark.sh
@@ -316,6 +316,21 @@ function gpu_op_benchmark {
   exit 0
 }
 
+# The PR will pass quickly when get approval from specific person.
+# Xreki 12538138, luotao1 6836917, Avin0323 16167147
+set +x
+approval_line=$(curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000)
+if [ -n "${approval_line}" ]; then
+  APPROVALS=$(echo ${approval_line} | python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 16167147 12538138 6836917)
+  LOG "[INFO] current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
+  if [ "${APPROVALS}" == "TRUE" ]; then
+    LOG "[INFO] ==================================="
+    LOG "[INFO] current pr ${GIT_PR_ID} has got approvals. So, Pass CI directly!"
+    LOG "[INFO] ==================================="
+    exit 0
+  fi
+fi
+set -x
 
 case $1 in
   cpu_op_benchmark)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Describe
<!-- Describe what this PR does -->
修复`PR-CI-OP-Benchmark`豁免机制。

未获得特定人员approval前：

![image](https://user-images.githubusercontent.com/23427135/133422712-010999ac-36b1-4a56-a026-c305238d5f8a.png)

获得特定人员approval后：

![image](https://user-images.githubusercontent.com/23427135/133422779-58e360b6-1619-4c17-a650-d3c06e88775a.png)
