### PR TITLE
set proxy off when download vis_demo

### DIFF
--- a/paddle/fluid/inference/api/demo_ci/run.sh
+++ b/paddle/fluid/inference/api/demo_ci/run.sh
@@ -23,6 +23,7 @@ TENSORRT_INCLUDE_DIR=$5 # TensorRT header file dir, default to /usr/local/Tensor
 TENSORRT_LIB_DIR=$6 # TensorRT lib file dir, default to /usr/local/TensorRT/lib
 MSVC_STATIC_CRT=$7
 inference_install_dir=${PADDLE_ROOT}/build/paddle_inference_install_dir
+WIN_DETECT=$(echo `uname` | grep "Win") # detect current platform
 
 cd `dirname $0`
 current_dir=`pwd`
@@ -53,7 +54,11 @@ function download() {
   if [[ -e "${PREFIX}${dir_name}.tar.gz" ]]; then
     echo "${PREFIX}${dir_name}.tar.gz has been downloaded."
   else
-      wget -q ${URL_ROOT}$dir_name.tar.gz
+      if [ $WIN_DETECT != "" ]; then
+        wget -q -Y off ${URL_ROOT}$dir_name.tar.gz
+      else
+        wget -q --no-proxy ${URL_ROOT}$dir_name.tar.gz
+      fi
       tar xzf *.tar.gz
   fi
   cd ..


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
set proxy off when download vis_demo, so that download will be faster and more stable
![image](https://user-images.githubusercontent.com/51314274/133384680-e9500fe6-6327-49ca-b306-975bd5b9b989.png)
