### PR TITLE
rename the auto parallel suffix

### DIFF
--- a/paddle/fluid/framework/proto_desc.h
+++ b/paddle/fluid/framework/proto_desc.h
@@ -27,8 +27,8 @@ constexpr int kNoneProcessMeshIndex = -1;
 
 // If a attribute name has a certain suffix, it means that the
 // atrribute is a distributed-related attribute for auto parallel.
-// e.g., "mesh_id@PARALLEL".
-constexpr char kAutoParallelSuffix[] = "@PARALLEL";
+// e.g., "mesh_id@AUTO_PARALLEL".
+constexpr char kAutoParallelSuffix[] = "@AUTO_PARALLEL";
 
 }  // namespace framework
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
rename the auto parallel suffix from '@PARALLEL' to '@AUTO_PARALLEL' to avoid being used by others.