### PR TITLE
Update acc func using topk v2

### DIFF
--- a/python/paddle/metric/metrics.py
+++ b/python/paddle/metric/metrics.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from ..fluid.data_feeder import check_variable_and_dtype
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.layers.nn import topk
 from ..fluid.framework import core, _varbase_creator, in_dygraph_mode
 import paddle
 from paddle import _C_ops
@@ -798,7 +797,7 @@ def accuracy(input, label, k=1, correct=None, total=None, name=None):
         if total is None:
             total = _varbase_creator(dtype="int32")
 
-        topk_out, topk_indices = topk(input, k=k)
+        topk_out, topk_indices = paddle.topk(input, k=k)
         _acc, _, _ = _C_ops.accuracy(topk_out, topk_indices, label, correct,
                                      total)
         return _acc
@@ -806,7 +805,7 @@ def accuracy(input, label, k=1, correct=None, total=None, name=None):
     helper = LayerHelper("accuracy", **locals())
     check_variable_and_dtype(input, 'input', ['float16', 'float32', 'float64'],
                              'accuracy')
-    topk_out, topk_indices = topk(input, k=k)
+    topk_out, topk_indices = paddle.topk(input, k=k)
     acc_out = helper.create_variable_for_type_inference(dtype="float32")
     if correct is None:
         correct = helper.create_variable_for_type_inference(dtype="int32")


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Update `paddle.metrci.accuracy` func using `top_k_v2` operator

## 精度测试
```python
import numpy as np

import paddle

paddle.seed(42)
input = paddle.rand((10,10))
label = paddle.randint( 0,2, [10,1])

acc = paddle.metric.accuracy(input, label, k=1)
np.save("/1", acc.numpy()) # 修改API之后，再测一遍保存到"/2"
```
上面脚本在修改API前后测试两次精度

```python
import numpy as np
pa = np.load("/1.npy")
pt = np.load("/2.npy")

# 绝对误差最大
diff = abs(pa-pt)
max_index = np.unravel_index(np.argmax(diff), diff.shape)

print("abs diff max: ", pa[max_index], pt[max_index], pa[max_index]-pt[max_index])

# 相对误差最大
max_index = np.unravel_index(np.argmax(abs(pa-pt) / pt), diff.shape)

print("relative diff max: ", pa[max_index], pt[max_index], (pa[max_index]-pt[max_index])/pt[max_index])


np.testing.assert_allclose(pa, pt)#, rtol=1e-14, atol=1e-14)

```

输出
```shell
abs diff max:  0.2 0.2 0.0
relative diff max:  0.2 0.2 0.0
```

## 性能测试

```python
import time
import numpy as np

import paddle

paddle.seed(42)
time1 = time.time()
for i in range(10000):
    input = paddle.rand((10,10))
    label = paddle.randint(0, 2, [10,1])
    acc = paddle.metric.accuracy(input, label, k=1)

print(time.time()-time1)
```

改之前：6.86283278465271s
改之后：6.733795881271362s