### PR TITLE
add no need buffer check for inplace

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -204,6 +204,23 @@ void InterpreterCore::Convert() {
   }
 }
 
+bool InterpreterCore::BuildInplaceCheckVarIsOnlyInput(size_t var_index) {
+  if (!global_scope_->vec_meta_info_[var_index].vardesc_) {
+    return input_var2op_info_[var_index].size() == 1;
+  } else {
+    int is_input_cnt = 0;
+    for (auto inst_id : input_var2op_info_[var_index]) {
+      OpInOutInfo info;
+      info.Build(vec_instruction_[inst_id].kernel_func_.operator_base_);
+      if (info.IsInArgBufferNeeded(
+              global_scope_->vec_meta_info_[var_index].vardesc_->Name())) {
+        is_input_cnt++;
+      }
+    }
+    return is_input_cnt == 1;
+  }
+}
+
 void InterpreterCore::BuildInplace() {
   for (size_t i = 0; i < vec_instruction_.size(); ++i) {
     if (!vec_instruction_[i]
@@ -219,7 +236,7 @@ void InterpreterCore::BuildInplace() {
     for (auto& pair : in_to_outs) {
       auto iter = vec_instruction_[i].input_index_.find(pair.first);
       if (iter != vec_instruction_[i].input_index_.end()) {
-        if (input_var2op_info_[iter->second[0]].size() == 1) {
+        if (BuildInplaceCheckVarIsOnlyInput(iter->second[0])) {
           auto iterout = vec_instruction_[i].output_index_.find(pair.second);
           if (iterout != vec_instruction_[i].output_index_.end()) {
             auto invar = global_scope_->var_list[iter->second[0]];
@@ -227,6 +244,15 @@ void InterpreterCore::BuildInplace() {
             if (invar && outvar) {
               vec_instruction_[i].vec_inplace_in_to_out_.emplace_back(invar,
                                                                       outvar);
+              VLOG(3) << "inplace "
+                      << vec_instruction_[i].kernel_func_.operator_base_->Type()
+                      << " "
+                      << global_scope_->vec_meta_info_[iter->second[0]]
+                             .vardesc_->Name()
+                      << " -> "
+                      << global_scope_->vec_meta_info_[iterout->second[0]]
+                             .vardesc_->Name()
+                      << std::endl;
             }
           }
         }

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -55,6 +55,8 @@ class InterpreterCore {
 
   void BuildInplace();
 
+  bool BuildInplaceCheckVarIsOnlyInput(size_t var_index);
+
   void RunInstruction(const Instruction& instr_node);
 
   void ExecuteInstructionList(const std::vector<Instruction>& vec_instr,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
在Inplace时，如果1个Var作为N个OP的输入，但其中N-1个都为NoNeedBuffer的。此时，可以看错这个Var只被另外一个OP使用，可以做Inplace。
