### PR TITLE
remove max_relative_error for float64 of l2_normalize unittest

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -5061,7 +5061,7 @@ def l2_normalize(x, axis, epsilon=1e-12, name=None):
         
         X = paddle.randn(shape=[3, 5], dtype='float64')
         out = paddle.fluid.layers.l2_normalize(X, axis=-1)
-        print(out.numpy())
+        print(out)
 
         # [[ 0.21558504  0.56360189  0.47466096  0.46269539 -0.44326736]
         #  [-0.70602414 -0.52745777  0.37771788 -0.2804768  -0.04449922]

--- a/python/paddle/fluid/tests/unittests/test_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_norm_op.py
@@ -41,10 +41,10 @@ class TestNormOp(OpTest):
         self.outputs = {'Out': y, 'Norm': norm}
 
     def test_check_output(self):
-        self.check_output(atol=1e-5)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', max_relative_error=0.008)
+        self.check_grad(['X'], 'Out')
 
     def init_test_case(self):
         self.shape = [2, 3, 4, 5]
@@ -96,6 +96,9 @@ class TestNormOp5(TestNormOp):
 class TestNormOp6(TestNormOp):
     def init_dtype(self):
         self.dtype = "float32"
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out', max_relative_error=0.008)
 
 
 @unittest.skipIf(not fluid.core.is_compiled_with_cuda(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
remove max_relative_error for float64 of l2_normalize unittest [#35776](https://github.com/PaddlePaddle/Paddle/pull/35776)