### PR TITLE
expose cuda stream to users

### DIFF
--- a/paddle/fluid/pybind/cuda_streams_py.cc
+++ b/paddle/fluid/pybind/cuda_streams_py.cc
@@ -202,6 +202,28 @@ void BindCudaStream(py::module *m_ptr) {
 
            )DOC",
            py::arg("event") = nullptr)
+      .def_property_readonly(
+          "cuda_stream",
+          [](paddle::platform::stream::CUDAStream &self) {
+            VLOG(10) << self.raw_stream();
+            return reinterpret_cast<std::uintptr_t>(self.raw_stream());
+          },
+          R"DOC(
+      retrun the raw cuda stream of type cudaStream_t as type int.
+
+      Examples:
+        .. code-block:: python
+
+            # required: gpu
+            import paddle
+            import ctypes
+            cuda_stream = paddle.device.cuda.current_stream().cuda_stream
+            print(cuda_stream)
+            
+            ptr = ctypes.c_void_p(cuda_stream)  # convert back to void*
+            print(ptr)
+
+           )DOC")
 #endif
       .def("__init__",
            [](paddle::platform::stream::CUDAStream &self,

--- a/python/paddle/fluid/tests/unittests/test_cuda_stream_event.py
+++ b/python/paddle/fluid/tests/unittests/test_cuda_stream_event.py
@@ -14,6 +14,7 @@
 
 from paddle.device import cuda
 import paddle
+import ctypes
 
 import unittest
 import numpy as np
@@ -154,6 +155,15 @@ class TestStreamGuard(unittest.TestCase):
                               np.zeros(5))
             self.assertRaises(TypeError, paddle.device.cuda._set_current_stream,
                               None)
+
+
+class TestRawStream(unittest.TestCase):
+    def test_cuda_stream(self):
+        if paddle.is_compiled_with_cuda():
+            cuda_stream = paddle.device.cuda.current_stream().cuda_stream
+            print(cuda_stream)
+            self.assertTrue(type(cuda_stream) is int)
+            ptr = ctypes.c_void_p(cuda_stream)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Related: #35555
expose cuda stream to users

usage:
```
import paddle
import ctypes
cuda_stream = paddle.device.cuda.current_stream().cuda_stream
print(cuda_stream)

ptr = ctypes.c_void_p(cuda_stream)  # convert back to void*
print(ptr)
```