### PR TITLE
Change __init__.py to adapt the new FLAGS coding style and update CI to monitor FLAGS changing

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -50,6 +50,8 @@ DECLARE_bool(enable_unused_var_check);
 PADDLE_DEFINE_EXPORTED_int32(inner_op_parallelism, 0,
                              "number of threads for inner op");
 
+PADDLE_DEFINE_EXPORTED_bool(for_test_paddle_ci, false, "Test Paddle CI");
+
 namespace paddle {
 namespace framework {
 

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -50,8 +50,6 @@ DECLARE_bool(enable_unused_var_check);
 PADDLE_DEFINE_EXPORTED_int32(inner_op_parallelism, 0,
                              "number of threads for inner op");
 
-PADDLE_DEFINE_EXPORTED_bool(for_test_paddle_ci, false, "Test Paddle CI");
-
 namespace paddle {
 namespace framework {
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -176,83 +176,23 @@ def __bootstrap__():
         print('PLEASE USE OMP_NUM_THREADS WISELY.', file=sys.stderr)
 
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
-    sysstr = platform.system()
+
+    flag_prefix = "FLAGS_"
     read_env_flags = [
-        'check_nan_inf',
-        'convert_all_blocks',
-        'benchmark',
-        'eager_delete_scope',
-        'fraction_of_cpu_memory_to_use',
-        'initial_cpu_memory_in_mb',
-        'init_allocated_mem',
-        'paddle_num_threads',
-        'dist_threadpool_size',
-        'eager_delete_tensor_gb',
-        'fast_eager_deletion_mode',
-        'memory_fraction_of_eager_deletion',
-        'allocator_strategy',
-        'reader_queue_speed_test_mode',
-        'print_sub_graph_dir',
-        'pe_profile_fname',
-        'inner_op_parallelism',
-        'enable_parallel_graph',
-        'fuse_parameter_groups_size',
-        'multiple_of_cupti_buffer_size',
-        'fuse_parameter_memory_size',
-        'tracer_profile_fname',
-        'dygraph_debug',
-        'use_system_allocator',
-        'enable_unused_var_check',
-        'free_idle_chunk',
-        'free_when_no_cache_hit',
-        'call_stack_level',
-        'sort_sum_gradient',
-        'max_inplace_grad_add',
-        'apply_pass_to_program',
-        'new_executor_use_inplace',
+        key[len(flag_prefix):] for key in core.globals().keys()
+        if key.startswith(flag_prefix)
     ]
-    if 'Darwin' not in sysstr:
-        read_env_flags.append('use_pinned_memory')
 
-    if os.name != 'nt':
-        read_env_flags.append('cpu_deterministic')
+    def remove_flag_if_exists(name):
+        if name in read_env_flags:
+            read_env_flags.remove(name)
 
-    if core.is_compiled_with_mkldnn():
-        read_env_flags.append('use_mkldnn')
-        read_env_flags.append('tracer_mkldnn_ops_on')
-        read_env_flags.append('tracer_mkldnn_ops_off')
+    sysstr = platform.system()
+    if 'Darwin' in sysstr:
+        remove_flag_if_exists('use_pinned_memory')
 
-    if core.is_compiled_with_cuda():
-        read_env_flags += [
-            'fraction_of_gpu_memory_to_use',
-            'initial_gpu_memory_in_mb',
-            'reallocate_gpu_memory_in_mb',
-            'cudnn_deterministic',
-            'enable_cublas_tensor_op_math',
-            'conv_workspace_size_limit',
-            'cudnn_exhaustive_search',
-            'selected_gpus',
-            'sync_nccl_allreduce',
-            'cudnn_batchnorm_spatial_persistent',
-            'gpu_allocator_retry_time',
-            'local_exe_sub_scope_limit',
-            'gpu_memory_limit_mb',
-            'conv2d_disable_cudnn',
-            'get_host_by_name_time',
-        ]
-
-    if core.is_compiled_with_npu():
-        read_env_flags += [
-            'selected_npus',
-            'fraction_of_gpu_memory_to_use',
-            'initial_gpu_memory_in_mb',
-            'reallocate_gpu_memory_in_mb',
-            'gpu_memory_limit_mb',
-            'npu_config_path',
-            'get_host_by_name_time',
-            'hccl_check_nan',
-            'min_loss_scaling',
-        ]
+    if os.name == 'nt':
+        remove_flag_if_exists('cpu_deterministic')
 
     core.init_gflags(["--tryfromenv=" + ",".join(read_env_flags)])
     # Note(zhouwei25): sys may not have argv in some cases, 

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -88,6 +88,16 @@ function run_tools_test() {
     cd ${CUR_PWD}
 }
 
+function check_env_var_diff_approval() {
+    echo_line="You must have one RD (lanxianghit (Recommend), phlrain or luotao1) approval for changing the FLAGS or python/paddle/fluid/__init__.py, which manage the environment variables.\n"
+    check_approval 1 6836917 47554610 43953930
+}
+
+changed_env_var_count=`git diff -U0 upstream/$BRANCH ${PADDLE_ROOT}/paddle | grep -E 'DEFINE_EXPORTED|DEFINE_bool|DEFINE_int32|DEFINE_int64|DEFINE_uint64|DEFINE_double|DEFINE_string' | wc -l`
+if [[ $changed_env_var_count -gt 0 ]]; then
+    check_env_var_diff_approval 
+fi
+
 if [[ $git_files -gt 19 || $git_count -gt 999 ]];then
     echo_line="You must have Dianhai approval for change 20+ files or add than 1000+ lines of content.\n"
     check_approval 1 38231817
@@ -103,8 +113,7 @@ for API_FILE in ${API_FILES[*]}; do
           echo_line="You must have one RD (wanghuancoder, luotao1 or XiaoguangHu01) approval for CMakeLists.txt, which manages the compilation parameter.\n"
           check_approval 1 6836917 46782768 26922892
       elif [ "${API_FILE}" == "python/paddle/fluid/__init__.py" ];then
-          echo_line="You must have one RD (lanxianghit (Recommend), phlrain or luotao1) approval for the python/paddle/fluid/init.py, which manages the environment variables.\n"
-          check_approval 1 6836917 47554610 43953930
+          check_env_var_diff_approval
       elif [ "${API_FILE}" == "python/requirements.txt" ];then
           echo_line="You must have one RD (phlrain) and one TPM (dingjiaweiww) and one QA (kolinwei) approval for python/requirements.txt, which manages the third-party python package.\n"
           check_approval 3 43953930 23093488 22165420

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -88,14 +88,10 @@ function run_tools_test() {
     cd ${CUR_PWD}
 }
 
-function check_env_var_diff_approval() {
-    echo_line="You must have one RD (lanxianghit (Recommend), phlrain or luotao1) approval for changing the FLAGS or python/paddle/fluid/__init__.py, which manage the environment variables.\n"
-    check_approval 1 6836917 47554610 43953930
-}
-
 changed_env_var_count=`git diff -U0 upstream/$BRANCH ${PADDLE_ROOT}/paddle | grep -E 'DEFINE_EXPORTED|DEFINE_bool|DEFINE_int32|DEFINE_int64|DEFINE_uint64|DEFINE_double|DEFINE_string' | wc -l`
 if [[ $changed_env_var_count -gt 0 ]]; then
-    check_env_var_diff_approval 
+    echo_line="You must have one RD (lanxianghit (Recommend), phlrain or luotao1) approval for changing the FLAGS, which manages the environment variables.\n"
+    check_approval 1 6836917 47554610 43953930
 fi
 
 if [[ $git_files -gt 19 || $git_count -gt 999 ]];then
@@ -113,7 +109,8 @@ for API_FILE in ${API_FILES[*]}; do
           echo_line="You must have one RD (wanghuancoder, luotao1 or XiaoguangHu01) approval for CMakeLists.txt, which manages the compilation parameter.\n"
           check_approval 1 6836917 46782768 26922892
       elif [ "${API_FILE}" == "python/paddle/fluid/__init__.py" ];then
-          check_env_var_diff_approval
+          echo_line="You must have one RD (lanxianghit (Recommend), phlrain or luotao1) approval for the python/paddle/fluid/init.py, which manages the environment variables.\n"
+          check_approval 1 6836917 47554610 43953930
       elif [ "${API_FILE}" == "python/requirements.txt" ];then
           echo_line="You must have one RD (phlrain) and one TPM (dingjiaweiww) and one QA (kolinwei) approval for python/requirements.txt, which manages the third-party python package.\n"
           check_approval 3 43953930 23093488 22165420


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe

以往加一个FLAG需要改三处地方：
- 在所需的`.cc`文件里加`DEFINE_xxx`。
- 在`global_value_getter_setter.cc`里加`DECLARE_xxx`和`REGISTER_PUBLIC_GLOBAL_VAR`。这个目的是为了可以在Python端使用`set_flags` API来设置FLAG的值。
- 在`python/paddle/fluid/__init__.py`的`read_env_flags`里加一行。这个目的是为了可以通过环境变量来设置FLAG的值。

同时需要改3个文件才能添加一个FLAG，开发起来太复杂了。

https://github.com/PaddlePaddle/Paddle/pull/35823 和 https://github.com/PaddlePaddle/Paddle/pull/35841 简化了FLAG 的开发流程。以后开发人员只需要使用`PADDLE_DEFINE_EXPORTED_bool/int32/int64/uint64/string`即可自动实现以上前2处的修改。至于第3处的自动化修改（即`python/paddle/fluid/__init__.py`的修改），则在本PR中实现了。以后开发人员只需要写一处`PADDLE_DEFINE_EXPORTED_xxx`即可自动实现上述3个修改，极大简化了FLAG的开发流程。

本PR同时修改了CI检查方法，CI会自动检测PR是否包含了`DEFINE_EXPORTED/DEFINE_xxx`这些地方的修改。若发现有修改，则CI approval规则与原先的`python/paddle/fluid/__init__.py`文件的CI approval规则相同。

- 通过手动在本PR中添加了一个测试FLAGS，测试了CI确实能检测到FLAGS的修改。
![image](https://user-images.githubusercontent.com/32832641/133805028-1bda9f25-2e2d-4064-8222-9ab1dbe9b1ec.png)

- 删除本PR中添加的测试FLAGS，CI关于FLAGS修改的检查结果消失，进一步验证了CI的可靠性。
![image](https://user-images.githubusercontent.com/32832641/133806721-1f678c66-8b97-4e18-933b-d3db729e9db3.png)
