### PR TITLE
fix bug, make whl-build task only reuse local third_party cache

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -76,6 +76,7 @@ if not defined NIGHTLY_MODE set PRECISION_TEST=OFF
 if not defined retry_times set retry_times=3
 if not defined PYTHON_ROOT set PYTHON_ROOT=C:\Python37
 if not defined BUILD_DIR set BUILD_DIR=build
+set task_name=%1
 
 rem ------initialize the python environment------
 set PYTHON_EXECUTABLE=%PYTHON_ROOT%\python.exe
@@ -363,14 +364,22 @@ echo echo ${md5_content}^>md5.txt >> cache.sh
 %cache_dir%\tools\busybox64.exe bash cache.sh
 
 set /p md5=< md5.txt
+echo %task_name%|findstr build >nul && (
+    set THIRD_PARTY_HOME=%cache_dir:\=/%/third_party
+    set THIRD_PARTY_PATH=!THIRD_PARTY_HOME!/%md5%
+    echo %task_name% is a whl-build task, will only reuse local third_party cache.
+    goto :cmake_impl
+) || ( 
+    echo %task_name% is a PR-CI-Windows task, will try to reuse bos and local third_party cache both. 
+)
+
 if "%WITH_GPU%"=="ON" (
-    for /F "delims=" %%# in ('nvcc --version^|findstr V1') do set cuda_version=%%#
-    set cuda_version=!cuda_version:~-7,4!
+    for /F %%# in ('dir /b /d "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\"') do set cuda_version=%%#
+    set cuda_version=!cuda_version:~-4!
     set sub_dir=cuda!cuda_version:.=!
 ) else (
     set sub_dir=cpu
 )
-
 set THIRD_PARTY_HOME=%cache_dir:\=/%/third_party/%sub_dir%
 set THIRD_PARTY_PATH=%THIRD_PARTY_HOME%/%md5%
 set UPLOAD_TP_FILE=OFF
@@ -397,7 +406,7 @@ if not exist %THIRD_PARTY_PATH% (
     if not exist %THIRD_PARTY_PATH% ( set UPLOAD_TP_FILE=ON ) 
     cd %work_dir%\%BUILD_DIR%
 ) else (
-    echo Found reusable third_party cache locally, will reuse it.
+    echo Found reusable third_party cache in %THIRD_PARTY_PATH%, will reuse it.
 )
 
 :cmake_impl


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
make whl-build task only reuse local third_party cache, since ci and whl-build task can't share the same cache for different compile options. Besides, whl-build task is not sensitive to build time.
![image](https://user-images.githubusercontent.com/51314274/147067663-d30de7e7-a16c-439b-89b5-1a2e5270edcd.png)
