### PR TITLE
Fix flags compilation dependency

### DIFF
--- a/paddle/fluid/imperative/CMakeLists.txt
+++ b/paddle/fluid/imperative/CMakeLists.txt
@@ -1,4 +1,4 @@
-cc_library(imperative_flag SRCS flags.cc DEPS gflags)
+cc_library(imperative_flag SRCS flags.cc DEPS gflags flags)
 
 IF(WITH_XPU)
 cc_library(prepared_operator SRCS prepared_operator.cc DEPS xpu_op_list proto_desc operator device_context lod_tensor selected_rows var_type_traits op_kernel_type data_transform nan_inf_utils)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
Fix `imperative_flags` compilation dependency error.
<img width="1124" alt="535681b671d3bfc0d3b925360e3bfe90" src="https://user-images.githubusercontent.com/32832641/133877582-a8b3e630-0bf9-47ce-9c28-bf42e5649520.png">
