### PR TITLE
Modify H2D and D2H as kQueue::Sync and Polish Schedule logic

### DIFF
--- a/paddle/fluid/framework/new_executor/event_manager.h
+++ b/paddle/fluid/framework/new_executor/event_manager.h
@@ -24,10 +24,6 @@ class EventManager {
                    const platform::Place& place);
 
   void WaitEvent(const Instruction& instruction, const platform::Place& place);
-
- private:
-  void WaitOrSync(const std::vector<EventInter>& events,
-                  const platform::DeviceContext* dev_ctx);
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -183,8 +183,7 @@ void InterpreterCore::Convert() {
       }
     }
 
-    stream_analyzer_.Schedule(vec_func_list_, filter_next, i,
-                              &vec_instruction_);
+    stream_analyzer_.Schedule(filter_next, &vec_instruction_, i);
 
     for (auto inst_id : filter_next) {
       dependecy_count_[inst_id]++;

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -99,7 +99,6 @@ class InterpreterCore {
 
   InterpreterCoreGarbageCollector gc_;
   std::vector<paddle::platform::DeviceEvent> gc_event_;
-  std::unique_ptr<WorkQueueGroup> group_thread_pool_;
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -365,7 +365,9 @@ void build_op_func_list(const platform::Place& place,
               OpKernelComputeFunc(kernel_iter->second);
           copy_op_func_node.kernel_func_(copy_exec_ctx);
           VLOG(3) << "Run " << memcpy_op_type << " done.";
-          copy_op_func_node.type_ = OpFuncType::kQueueAsync;
+          // NOTE(Aurelius84): memcpy_op is expensive operation, so we tag them
+          // as kQueueSync and execute them in thread pool.
+          copy_op_func_node.type_ = OpFuncType::kQueueSync;
           copy_op_func_node.dev_ctx_ = dev_ctx;
           op_list->push_back(copy_op);
           vec_func_list->push_back(copy_op_func_node);

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -25,11 +25,6 @@
 namespace paddle {
 namespace framework {
 
-namespace interpretercore {
-static constexpr char kMemcpyH2D[] = "memcpy_h2d";
-static constexpr char kMemcpyD2H[] = "memcpy_d2h";
-}  // namespace interpretercore
-
 using OpKernelComputeFunc = std::function<void(const ExecutionContext&)>;
 using OpKernelMap =
     std::unordered_map<OpKernelType, OpKernelComputeFunc, OpKernelType::Hash>;
@@ -496,11 +491,11 @@ struct NextInstruction {
 struct EventInter {
   explicit EventInter(size_t var_id,
                       std::shared_ptr<platform::DeviceEvent> event,
-                      bool is_sync)
-      : var_id_(var_id), event_(event), is_sync_(is_sync) {}
+                      platform::DeviceType waiter_type)
+      : var_id_(var_id), event_(event), waiter_type_(waiter_type) {}
   size_t var_id_;
   std::shared_ptr<platform::DeviceEvent> event_;
-  bool is_sync_;
+  platform::DeviceType waiter_type_;
 };
 
 struct InstructionInfo {
@@ -542,6 +537,19 @@ struct OpFuncNode {
   platform::DeviceContext* dev_ctx_;  // not owned
   OpFuncType type_;
 };
+
+namespace interpretercore {
+static constexpr char kMemcpyH2D[] = "memcpy_h2d";
+static constexpr char kMemcpyD2H[] = "memcpy_d2h";
+
+static bool IsMemcpyH2D(const Instruction& instr) {
+  return instr.kernel_func_.operator_base_->Type() == kMemcpyH2D;
+}
+
+static bool IsMemcpyD2H(const Instruction& instr) {
+  return instr.kernel_func_.operator_base_->Type() == kMemcpyD2H;
+}
+}  // namespace interpretercore
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/stream_analyzer.h
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.h
@@ -29,9 +29,8 @@ class StreamAnalyzer {
 
   ~StreamAnalyzer() {}
 
-  void Schedule(const std::vector<OpFuncNode>& op_func_nodes,
-                const std::vector<size_t>& downstream_ops, size_t op_index,
-                std::vector<Instruction>* instructions);
+  void Schedule(const std::vector<size_t>& downstream_ops,
+                std::vector<Instruction>* instructions, size_t op_index);
 
   platform::DeviceContext* ParseDeviceContext(const OpFuncNode& op_func_node,
                                               const OperatorBase& op_base);
@@ -41,7 +40,14 @@ class StreamAnalyzer {
                                        const Instruction& next_instr);
 
   void AssociateInputWithEvents(const std::vector<size_t>& new_event_var_id,
-                                Instruction* next_instr, bool is_sync);
+                                Instruction* next_instr,
+                                platform::DeviceType waiter_type);
+
+  bool IsDirectRun(Instruction& cur_instr,  // NOLINT
+                   const Instruction& next_instr);
+
+  platform::DeviceType GetWaiterType(const Instruction& instr);
+
   platform::Place place_;
   platform::DeviceContextPool d2h_ctx_pool_;
   platform::DeviceContextPool h2d_ctx_pool_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Modify H2D and D2H as kQueue::Sync

### 1. Schedule 策略

StreamAanlyzer 模块的 Schedule 函数通过分析 Instruction 和 下游 Instruction 信息，得到后续 NextInstructions 的调度策略：

+ direct_run：表示可以在当前线程直接拉起，不需要切换线程。目前包含如下 4 种情况：
    + GPU -> GPU
    + CPU -> CPU
    + CPU -> H2D
    + D2H -> CPU
+ synchornize_run：表示此后续Intruction是个`昂贵的`同步等待操作，建议放到单独一个线程执行，如：
    + GPU -> D2H，因为 GPUKernel很快拉起后，可能在stream排队，下游D2H需要等待数据，且此操作是个sync操作
+ event_run：表示后续 Instruction 与当前Op不属于一个stream流，需要额外处理
    + H2D -> GPU


### 2. What's Next?

从上述分析可以，执行器的执行形式大概分为如下过程：
![image](https://user-images.githubusercontent.com/9301846/133884253-7fba1cef-4c70-4852-9ac6-72d6bc3cf074.png)


下一个PR，将充分利用direct_run等信息，减少AddTask带来的如下开销：

+ 多余的AddTask、入队、出队的时间