### PR TITLE
disable tests for fft on windows with gpu

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -702,7 +702,10 @@ endif()
 add_subdirectory(sequence)
 add_subdirectory(dygraph_to_static)
 add_subdirectory(rnn)
-add_subdirectory(fft)
+
+if (NOT WIN32 OR NOT WITH_GPU)
+    add_subdirectory(fft)
+endif()
 
 if (WITH_XPU)
     add_subdirectory(xpu)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
disable tests for fft on windows with gpu to avoid stochastic failure.