### PR TITLE
[cherry-pick] fix bug of module 'paddle' has no attribute 'distributed' for py3.6

### DIFF
--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .spawn import spawn  # noqa: F401
-from paddle.distributed.fleet.launch import launch  # noqa: F401
+from .fleet.launch import launch  # noqa: F401
 
 from .parallel import init_parallel_env  # noqa: F401
 from .parallel import get_rank  # noqa: F401

--- a/python/paddle/distributed/fleet/elastic/collective.py
+++ b/python/paddle/distributed/fleet/elastic/collective.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 from paddle.distributed.fleet import launch_utils
-import paddle.distributed.fleet.cloud_utils as cloud_utils
-import paddle.distributed.fleet.ascend_utils as ascend_utils
+from paddle.distributed.fleet import cloud_utils
+from paddle.distributed.fleet import ascend_utils
 
 from paddle.distributed.fleet.launch_utils import *
 

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -72,8 +72,8 @@ from paddle.distributed.fleet import launch_utils
 
 # TODO(danleifeng): Don't import * from a module
 from paddle.distributed.fleet.launch_utils import *
-import paddle.distributed.fleet.cloud_utils as cloud_utils
-import paddle.distributed.fleet.ascend_utils as ascend_utils
+from paddle.distributed.fleet import cloud_utils
+from paddle.distributed.fleet import ascend_utils
 
 from paddle.distributed.fleet.elastic import enable_elastic, launch_elastic
 


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[cherry-pick] fix bug of module 'paddle' has no attribute 'distributed' for python3.6