### PR TITLE
mp grad clip by norm fix

### DIFF
--- a/paddle/fluid/operators/clip_by_norm_op.cu
+++ b/paddle/fluid/operators/clip_by_norm_op.cu
@@ -13,34 +13,12 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/clip_by_norm_op.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_functor_op.h"
 #include "paddle/fluid/operators/reduce_ops/reduce_op.cu.h"
 
 namespace paddle {
 namespace operators {
 using Tensor = framework::Tensor;
-template <typename Tx, typename Ty = Tx>
-struct SquareTransformer {
-  HOSTDEVICE explicit inline SquareTransformer(int n) {}
-
-  HOSTDEVICE inline Ty operator()(const Tx& x) const {
-    return static_cast<Ty>(x) * static_cast<Ty>(x);
-  }
-
-  HOSTDEVICE inline Ty operator()(const Tx* x) const {
-    return static_cast<Ty>(x[0]) * static_cast<Ty>(x[0]);
-  }
-};
-
-template <typename Tx, typename Ty = Tx>
-struct SquareSum {
-  using Transformer = SquareTransformer<Tx, Ty>;
-
-  inline Ty initial() { return static_cast<Ty>(0.0f); }
-
-  __device__ __forceinline__ Ty operator()(const Ty& a, const Ty& b) const {
-    return b + a;
-  }
-};
 
 template <>
 class ClipByNormKernel<platform::CUDADeviceContext, platform::float16>

--- a/paddle/fluid/operators/collective/c_clip_by_norm_op.cc
+++ b/paddle/fluid/operators/collective/c_clip_by_norm_op.cc
@@ -1,0 +1,105 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#include "paddle/fluid/operators/collective/c_clip_by_norm_op.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+
+class CollectiveClipByNormOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+ protected:
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInputs("X"), true,
+        platform::errors::InvalidArgument(
+            "Input(X) of CollectiveClipByNormOp should not be null. "
+            "Please check if it is created correctly."));
+    PADDLE_ENFORCE_EQ(
+        ctx->HasOutputs("Out"), true,
+        platform::errors::InvalidArgument(
+            "Output(Out) of CollectiveClipByNormOp should not be null. "
+            "Please check if it is created correctly."));
+    auto max_norm = ctx->Attrs().Get<float>("max_norm");
+    PADDLE_ENFORCE_GT(max_norm, 0, platform::errors::InvalidArgument(
+                                       "max_norm should be greater than 0. "
+                                       "Received max_norm is %f.",
+                                       max_norm));
+
+    PADDLE_ENFORCE_GT(ctx->Inputs("X").size(), static_cast<size_t>(0),
+                      platform::errors::InvalidArgument(
+                          "The CollectiveClipByNormOp operator has no input."));
+    PADDLE_ENFORCE_EQ(
+        ctx->Inputs("X").size(), ctx->Outputs("Out").size(),
+        platform::errors::InvalidArgument(
+            "The input(X) and output(Out) should have same size in "
+            "Operator(c_clip_by_norm), size of input(X) is %d "
+            "and size of output(Out) is %d.",
+            ctx->Inputs("X").size(), ctx->Outputs("Out").size()));
+    auto x_dims = ctx->GetInputsDim("X");
+    ctx->SetOutputsDim("Out", x_dims);
+    ctx->ShareLoD("X", "Out");
+  }
+};
+
+class CollectiveClipByNormOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput(
+        "X",
+        "(Tensors) The inputs of c_clip_by_norm op and data type is float32."
+        "The number of dimensions must be between [1, 9].")
+        .AsDuplicable();
+    AddOutput("Out",
+              "(Tensors) The output of c_clip_by_norm op with shape as input(X)"
+              "The data type is float32.")
+        .AsDuplicable();
+    AddAttr<float>("max_norm", "(float) The maximum norm value.");
+    AddAttr<int>("ring_id", "(int) The ring id for allreduce.");
+    AddAttr<bool>("use_calc_stream",
+                  "(bool) whether use calc stream for "
+                  "allreduce")
+        .SetDefault(false);
+    AddComment(R"DOC(
+CollectiveClipByNorm Operator.
+
+This operator is used under model-parallel circumstance.
+The math equation for this op is same with the equation
+of ClipByNorm.
+During the MP, some vars will be split into each rank.
+When calc the norm of the split vars, all values from
+every parts should be counted.
+In this op, we first calc the square_sum value for values
+in current mp rank. Then do a c_allreduce_sum operation to
+get the final square_sum value for all values from each
+parts. Then do the sqrt operations.
+)DOC");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+REGISTER_OP_WITHOUT_GRADIENT(c_clip_by_norm, ops::CollectiveClipByNormOp,
+                             ops::CollectiveClipByNormOpMaker);
+
+REGISTER_OP_CPU_KERNEL(
+    c_clip_by_norm,
+    ops::CollectiveClipByNormCPUKernel<plat::CPUDeviceContext, float>,
+    ops::CollectiveClipByNormCPUKernel<plat::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/collective/c_clip_by_norm_op.cu
+++ b/paddle/fluid/operators/collective/c_clip_by_norm_op.cu
@@ -1,0 +1,126 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#ifdef PADDLE_WITH_HIP
+#include <hipcub/hipcub.hpp>
+namespace cub = hipcub;
+#else
+#include <cub/cub.cuh>
+#endif
+#include <math.h>
+
+#include "paddle/fluid/framework/data_type.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/collective/c_clip_by_norm_op.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_functor_op.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_op.cu.h"
+#include "paddle/fluid/platform/collective_helper.h"
+#include "paddle/fluid/platform/float16.h"
+#include "paddle/fluid/platform/gpu_launch_config.h"
+#include "paddle/fluid/platform/nccl_helper.h"
+
+namespace paddle {
+namespace operators {
+using Tensor = framework::Tensor;
+
+template <typename T>
+__global__ void ClipByNormCUDACalcKernel(const T* src,
+                                         const float* x_norm_square,
+                                         const float max_norm, const int N,
+                                         T* dst) {
+  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+  float x_norm = sqrt(*x_norm_square);
+  for (; idx < N; idx += blockDim.x * gridDim.x) {
+    const float src_tmp = static_cast<const float>(src[idx]);
+    if (src_tmp <= max_norm) {
+      dst[idx] = src[idx];
+    } else {
+      dst[idx] = static_cast<T>((src_tmp * max_norm) / x_norm);
+    }
+  }
+}
+
+template <typename Place, typename T>
+class CollectiveClipByNormCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto max_norm = context.Attr<float>("max_norm");
+    auto ring_id = context.Attr<int>("ring_id");
+    auto in_tensors = context.MultiInput<Tensor>("X");
+    auto out_tensors = context.MultiOutput<Tensor>("Out");
+    auto& dev_ctx =
+        context.template device_context<platform::CUDADeviceContext>();
+
+    // var for allreduce
+    const auto& place = context.GetPlace();
+    auto comm = platform::NCCLCommContext::Instance().Get(ring_id, place);
+    gpuStream_t stream = nullptr;
+    if (context.Attr<bool>("use_calc_stream")) {
+      auto stream_ctx = platform::DeviceContextPool::Instance().Get(place);
+      stream = static_cast<platform::CUDADeviceContext*>(stream_ctx)->stream();
+    } else {
+      stream = comm->stream();
+    }
+
+    for (size_t i = 0; i < in_tensors.size(); ++i) {
+      // calculate the squared_l2_norm value
+      const Tensor* input = in_tensors[i];
+      const int data_size = input->numel();
+
+      std::vector<int> reduce_dims;
+      reduce_dims.resize(input->dims().size());
+      for (int i = 0; i < reduce_dims.size(); ++i) {
+        reduce_dims[i] = i;
+      }
+      Tensor tmp =
+          context.AllocateTmpTensor<float, platform::CUDADeviceContext>(
+              {1}, dev_ctx);
+      TensorReduceFunctorImpl<T, float, SquareSum>(*input, &tmp, reduce_dims,
+                                                   dev_ctx.stream());
+      float* tmp_data = tmp.data<float>();
+      PADDLE_ENFORCE_CUDA_SUCCESS(platform::dynload::ncclAllReduce(
+          tmp_data, tmp_data, 1, platform::ToNCCLDataType(tmp.type()), ncclSum,
+          comm->comm(), stream));
+      if (!context.Attr<bool>("use_calc_stream")) {
+#ifdef PADDLE_WITH_HIP
+        PADDLE_ENFORCE_CUDA_SUCCESS(hipStreamSynchronize(stream));
+        PADDLE_ENFORCE_CUDA_SUCCESS(hipGetLastError());
+#else
+        PADDLE_ENFORCE_CUDA_SUCCESS(cudaStreamSynchronize(stream));
+        PADDLE_ENFORCE_CUDA_SUCCESS(cudaGetLastError());
+#endif
+      }
+      const T* input_data = input->data<T>();
+      Tensor* output = out_tensors[i];
+      T* output_data = output->mutable_data<T>(context.GetPlace());
+      platform::GpuLaunchConfig config =
+          platform::GetGpuLaunchConfig1D(dev_ctx, data_size);
+      ClipByNormCUDACalcKernel<
+          T><<<config.block_per_grid, config.thread_per_block, 0,
+               dev_ctx.stream()>>>(input_data, tmp_data, max_norm, data_size,
+                                   output_data);
+    }
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+REGISTER_OP_CUDA_KERNEL(
+    c_clip_by_norm,
+    ops::CollectiveClipByNormCUDAKernel<plat::CUDADeviceContext, float>,
+    ops::CollectiveClipByNormCUDAKernel<plat::CUDADeviceContext,
+                                        plat::float16>);

--- a/paddle/fluid/operators/collective/c_clip_by_norm_op.h
+++ b/paddle/fluid/operators/collective/c_clip_by_norm_op.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+template <typename DeviceContext, typename T>
+class CollectiveClipByNormCPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    PADDLE_ENFORCE_EQ(platform::is_gpu_place(ctx.GetPlace()), true,
+                      platform::errors::Unimplemented(
+                          "c_clip_by_norm only supports GPU now."));
+  }
+};
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/kernel_primitives/helper_primitives.h
+++ b/paddle/fluid/operators/kernel_primitives/helper_primitives.h
@@ -74,6 +74,19 @@ struct DivideFunctor {
   T n_inv;
 };
 
+template <typename Tx, typename Ty = Tx>
+struct SquareTransformer {
+  HOSTDEVICE explicit inline SquareTransformer(int n) {}
+
+  HOSTDEVICE inline Ty operator()(const Tx& x) const {
+    return static_cast<Ty>(x) * static_cast<Ty>(x);
+  }
+
+  HOSTDEVICE inline Ty operator()(const Tx* x) const {
+    return static_cast<Ty>(x[0]) * static_cast<Ty>(x[0]);
+  }
+};
+
 }  // namespace details
 }  // namespace kernel_primitives
 }  // namespace operators

--- a/paddle/fluid/operators/reduce_ops/reduce_functor_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_functor_op.h
@@ -108,5 +108,16 @@ struct CustomLogicalAnd {
   }
 };
 
+template <typename Tx, typename Ty = Tx>
+struct SquareSum {
+  using Transformer = kpds::SquareTransformer<Tx, Ty>;
+
+  inline Ty initial() { return static_cast<Ty>(0.0f); }
+
+  __device__ __forceinline__ Ty operator()(const Ty &a, const Ty &b) const {
+    return b + a;
+  }
+};
+
 }  // namespace operators
 }  // namespace paddle

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -165,6 +165,8 @@ if(NOT WITH_DISTRIBUTE OR WIN32)
     LIST(REMOVE_ITEM TEST_OPS test_fleet_rolemaker_2)
     LIST(REMOVE_ITEM TEST_OPS test_fleet_utils)
     LIST(REMOVE_ITEM TEST_OPS test_collective_cpu_barrier_with_gloo)
+    LIST(REMOVE_ITEM TEST_OPS test_collective_clip_by_norm_op)
+    LIST(REMOVE_ITEM TEST_OPS test_collective_clip_by_norm_op_cpu)
 
     # TODO: Fix these unittests failed on Windows
     list(REMOVE_ITEM TEST_OPS test_fake_init_op)

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -817,6 +817,7 @@ if (WITH_DISTRIBUTE)
     set_tests_properties(test_dist_fleet_infer PROPERTIES TIMEOUT 200)
     set_tests_properties(test_dist_fleet_raw_program_optimizer PROPERTIES TIMEOUT 120)
     set_tests_properties(test_dist_fleet_raw_program_optimizer_fuse_allreduce PROPERTIES TIMEOUT 60)
+    set_tests_properties(test_collective_clip_by_norm_op PROPERTIES TIMEOUT 60)
 endif()
 
 if (WITH_DISTRIBUTE AND NOT APPLE)

--- a/python/paddle/fluid/tests/unittests/collective_clip_by_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_clip_by_norm_op.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
+import paddle.fluid.layers as layers
+from test_collective_base import TestCollectiveRunnerBase, runtime_main
+
+paddle.enable_static()
+
+
+class TestCollectiveClipByNorm(TestCollectiveRunnerBase):
+    def __init__(self):
+        self.global_ring_id = 0
+
+    def get_model(self, main_prog, startup_program):
+        ring_id = 0
+        max_norm = 1e-3
+        with fluid.program_guard(main_prog, startup_program):
+            tindata = layers.data(
+                name="tindata", shape=[10, 1000], dtype='float32')
+            x = main_prog.current_block().create_var(
+                name="x",
+                dtype='float32',
+                shape=[10, 1000],
+                type=core.VarDesc.VarType.LOD_TENSOR,
+                persistable=False,
+                stop_gradient=False)
+            main_prog.global_block().append_op(
+                type='fill_constant',
+                inputs={},
+                outputs={'Out': x},
+                attrs={
+                    'shape': x.shape,
+                    'dtype': x.dtype,
+                    'value': 0.5,
+                })
+            toutdata = main_prog.current_block().create_var(
+                name="outofallreduce",
+                dtype='float32',
+                type=core.VarDesc.VarType.LOD_TENSOR,
+                persistable=False,
+                stop_gradient=False)
+            main_prog.global_block().append_op(
+                type="c_clip_by_norm",
+                inputs={'X': [x]},
+                attrs={
+                    'max_norm': max_norm,
+                    'use_calc_stream': True,
+                    'ring_id': ring_id
+                },
+                outputs={'Out': [toutdata]})
+            return toutdata
+
+
+if __name__ == "__main__":
+    runtime_main(TestCollectiveClipByNorm, "c_clip_by_norm", 0)

--- a/python/paddle/fluid/tests/unittests/test_collective_base.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_base.py
@@ -309,5 +309,7 @@ class TestDistBase(unittest.TestCase):
             self.assertTrue(
                 np.allclose(
                     tr1_out[0][1], need_result2, rtol=1e-05, atol=1e-05))
+        elif col_type == 'c_clip_by_norm':
+            self.assertTrue(np.allclose(tr0_out[0][1], tr1_out[0][1]))
         else:
             pass

--- a/python/paddle/fluid/tests/unittests/test_collective_clip_by_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_clip_by_norm_op.py
@@ -1,0 +1,34 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import paddle
+from test_collective_base import TestDistBase
+import paddle.fluid.core as core
+
+paddle.enable_static()
+
+
+class TestCollectiveClipByNormOp(TestDistBase):
+    def _setup_config(self):
+        pass
+
+    def test_c_clip_by_norm(self, col_type="c_clip_by_norm"):
+        self.check_with_place("collective_clip_by_norm_op.py", col_type)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_collective_clip_by_norm_op_cpu.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_clip_by_norm_op_cpu.py
@@ -1,0 +1,52 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+from op_test import OpTest
+import paddle.fluid.core as core
+
+
+@unittest.skipIf(not core.is_compiled_with_cuda(),
+                 "core is not compiled with CUDA")
+class TestClipByNormOp(OpTest):
+    def setUp(self):
+        self.dtype = np.float32
+        self.shape = (10, 20)
+        self.max_relative_error = 0.006
+        input = np.random.random((10, 20)).astype(np.float32)
+        input[np.abs(input) < self.max_relative_error] = 0.5
+        self.op_type = "c_clip_by_norm"
+        self.inputs = {'X': [('X', input)]}
+        self.attrs = {'max_norm': 0.5, 'ring_id': 0}
+        norm = np.sqrt(np.sum(np.square(input)))
+        if norm > 0.5:
+            output = 0.5 * input / norm
+        else:
+            output = input
+        self.outputs = {'Out': [('Out', output)]}
+
+    def test_check_output(self):
+        if core.is_compiled_with_cuda():
+            place = core.CPUPlace()
+            try:
+                self.check_output_with_place(place)
+            except NotImplementedError:
+                pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix ClipGradByNorm error under mp configuration.
Currently, the norm only computed based on the value on that mp_rank. However, the norm should be calculated by all value through all mp_ranks instead of only focusing on current mp_rank. 
This PR fix this problem by adding a new op named: c_clip_grad_by_norm, which first calculated local norm for current mp_rank, then, do an allreduce_sum operation between all other mp_ranks to get the 'GLOBAL' norm. Then, use the global norm to do the gradient clip.
Besides fixing the bug, this PR also restructure some codes to bring reusability of codes.