### PR TITLE
Refine FLAGS approval

### DIFF
--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -88,7 +88,7 @@ function run_tools_test() {
     cd ${CUR_PWD}
 }
 
-changed_env_var_count=`git diff -U0 upstream/$BRANCH ${PADDLE_ROOT}/paddle | grep -E 'DEFINE_EXPORTED|DEFINE_bool|DEFINE_int32|DEFINE_int64|DEFINE_uint64|DEFINE_double|DEFINE_string' | wc -l`
+changed_env_var_count=`git diff -U0 upstream/$BRANCH ${PADDLE_ROOT}/paddle | grep 'DEFINE_EXPORTED' | wc -l`
 if [[ $changed_env_var_count -gt 0 ]]; then
     echo_line="You must have one RD (lanxianghit (Recommend), phlrain or luotao1) approval for changing the FLAGS, which manages the environment variables.\n"
     check_approval 1 6836917 47554610 43953930


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
优化FLAGS approve条件。预测的单测有些场景只会定义一些单测里采用的FLAGS。如https://github.com/PaddlePaddle/Paddle/pull/35890 。这些FLAGS不需要暴露在Python。

只有通过`PADDLE_DEFINE_EXPORTED_xxx`定义的FLAGS，以及修改了`python/paddle/fluid/__init__.py`文件的FLAGS才需要approve。