### PR TITLE
fix cusparse compile bug in windows CUDA11.2, test=develop

### DIFF
--- a/paddle/fluid/platform/dynload/cusparse.h
+++ b/paddle/fluid/platform/dynload/cusparse.h
@@ -41,6 +41,7 @@ extern void *cusparse_dso_handle;
   };                                                                 \
   extern DynLoad__##__name __name
 
+#ifndef(_WIN32)
 #if CUDA_VERSION >= 11020
 #define CUSPARSE_ROUTINE_EACH(__macro) \
   __macro(cusparseCreate);             \
@@ -56,6 +57,7 @@ extern void *cusparse_dso_handle;
   __macro(cusparseSDDMM);
 
 CUSPARSE_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP);
+#endif
 #endif
 
 #undef DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP

--- a/paddle/fluid/platform/dynload/cusparse.h
+++ b/paddle/fluid/platform/dynload/cusparse.h
@@ -41,7 +41,7 @@ extern void *cusparse_dso_handle;
   };                                                                 \
   extern DynLoad__##__name __name
 
-#ifndef(_WIN32)
+#ifndef _WIN32
 #if CUDA_VERSION >= 11020
 #define CUSPARSE_ROUTINE_EACH(__macro) \
   __macro(cusparseCreate);             \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Currently, CUDA 11.2 of Windows does not support the SDDMM function in cusparse. It is restricted on Windows.