### PR TITLE
[cherry-pick] fix cusparse compile bug in windows CUDA11.2

### DIFF
--- a/paddle/fluid/platform/dynload/cusparse.h
+++ b/paddle/fluid/platform/dynload/cusparse.h
@@ -41,6 +41,7 @@ extern void *cusparse_dso_handle;
   };                                                                 \
   extern DynLoad__##__name __name
 
+#ifndef _WIN32
 #if CUDA_VERSION >= 11020
 #define CUSPARSE_ROUTINE_EACH(__macro) \
   __macro(cusparseCreate);             \
@@ -56,6 +57,7 @@ extern void *cusparse_dso_handle;
   __macro(cusparseSDDMM);
 
 CUSPARSE_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP);
+#endif
 #endif
 
 #undef DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
解决Windows中CUDA11.2编译出错的问题。
cherry-pick [#35941](https://github.com/PaddlePaddle/Paddle/pull/35941)