### PR TITLE
fix pinv api explosure rule

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -106,7 +106,6 @@ from .tensor.linalg import slogdet  # noqa: F401
 from .tensor.linalg import multi_dot  # noqa: F401
 from .tensor.linalg import matrix_power  # noqa: F401
 from .tensor.linalg import svd  # noqa: F401
-from .tensor.linalg import pinv  # noqa: F401
 from .tensor.linalg import solve  # noqa: F401
 from .tensor.logic import equal  # noqa: F401
 from .tensor.logic import greater_equal  # noqa: F401


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix `linalg.pinv` api exposure rule
before modification：support `paddle.pinv` and `paddle.linalg.pinv`
after modification: only support `paddle.linalg.pinv`