### PR TITLE
[cherry-pick]concat api support empty tensor. (#35845)

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -322,6 +322,8 @@ def concat(input, axis=0, name=None):
         if isinstance(axis, Variable):
             axis = axis.numpy()
             axis = axis.item(0)
+        if not isinstance(input, Variable):
+            input = [t for t in input if t.shape.count(0) == 0]
         return _C_ops.concat(input, 'axis', axis)
 
     check_type(input, 'input', (list, tuple, Variable), 'concat')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
concat api support empty tensor in dygraph mode.
<img width="670" alt="aaa" src="https://user-images.githubusercontent.com/77733235/134797422-e53bbe26-96b3-4b52-9e3c-261ebade1b35.png">
<img width="715" alt="bbb" src="https://user-images.githubusercontent.com/77733235/134797428-dd9af600-2497-4959-9f98-676096679fec.png">