### PR TITLE
reduce calls to SizeOfType

### DIFF
--- a/paddle/fluid/framework/tensor.cc
+++ b/paddle/fluid/framework/tensor.cc
@@ -29,14 +29,16 @@ void Tensor::check_memory_size() const {
   PADDLE_ENFORCE_NOT_NULL(holder_, platform::errors::PreconditionNotMet(
                                        "Tensor holds no memory. "
                                        "Call Tensor::mutable_data firstly."));
+  size_t size = numel() * SizeOfType(type());
+
   PADDLE_ENFORCE_LE(
-      numel() * SizeOfType(type()), memory_size(),
+      size, memory_size(),
       platform::errors::PreconditionNotMet(
           "Tensor's dimension is out of bound."
           "Tensor's dimension must be equal or less than the size of its "
           "memory."
           "But received  Tensor's dimension is d%, memory's size is %d.",
-          numel() * SizeOfType(type()), memory_size()));
+          size, memory_size()));
 }
 
 Tensor::Tensor(const proto::VarType::Type& dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
reduce calls to SizeOfType

`paddle::framework:: SizeOfType` is an expensive operation, `check_memory_size` calls it twice, and this PR reduces to only once.

- before
<img width="871" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/6888866/134801497-11e8b9a6-1b6b-4ad7-8190-ab4cbfdcad46.png">

- after
<img width="1071" alt="5a4e3e9d16b52eeb30d5d34af4274fbd" src="https://user-images.githubusercontent.com/6888866/135199518-7b1f0a33-11ff-4b95-a9e1-dca2ca8174d7.png">