### PR TITLE
allow user to export parameters defined in model

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5074,11 +5074,7 @@ class Program(object):
                         else:
                             target_op = op
 
-                if target_op is None:
-                    raise ValueError(
-                        "The target variable used for pruning should have an "
-                        "associated operator that generates it.")
-                else:
+                if target_op is not None:
                     targets_idx.append([target_op.block.idx, target_op.idx])
             else:
                 targets_idx.append([t.block.idx, t.idx])

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1426,7 +1426,8 @@ def save_inference_model(dirname,
                 main_program.global_block().create_var(
                     name=target_v.name,
                     shape=target_v.shape,
-                    dtype=target_v.dtype)
+                    dtype=target_v.dtype,
+                    persistable=target_v.persistable)
 
         prepend_feed_ops(main_program, feeded_var_names)
         append_fetch_ops(main_program, fetch_var_names)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
allow user to export parameters defined in model.
```python
import paddle
import math
import numpy as np

class ONNXModel(paddle.nn.Layer):
    def __init__(self):
        super(ONNXModel, self).__init__()
        self.x2paddle_transitions_0 = self.create_parameter(shape=[12, 12], attr='x2paddle_transitions_0', dtype='float32', default_initializer=paddle.nn.initializer.Constant(value=0.0))
        self.conv0 = paddle.nn.Conv2D(in_channels=512, out_channels=256, kernel_size=[3, 3], padding=[1, 1, 1, 1], bias_attr=True)

    def forward(self, input_tensor):
        x2paddle_transitions_0 = self.x2paddle_transitions_0
        output = self.conv0(input_tensor)
        return x2paddle_transitions_0, output

model = ONNXModel()
model.eval()

sepc_list = list()
sepc_list.append(paddle.static.InputSpec(shape=[1, 512, 256, 256], dtype="float32", name="x2paddle_input_mask_0"))
static_model = paddle.jit.to_static(model, input_spec=sepc_list)

print("static fininsed!")

paddle.jit.save(static_model,"inference_model/model")

print("save fininsed!")
```