### PR TITLE
[Dy2stat]delete remove_static_file() function in error.py

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -57,23 +57,6 @@ def attach_error_data(error, in_runtime=False):
     return error
 
 
-def remove_static_file():
-    """
-    Removes temporary files created during the transformation of dygraph to static graph.
-    """
-    del_files = set()
-    for loc in global_origin_info_map:
-        static_filepath = loc[0]
-        del_files.add(static_filepath)
-
-        filename, extension = os.path.splitext(static_filepath)
-        del_files.add(filename + ".pyc")
-
-    for filepath in del_files:
-        if os.path.exists(filepath):
-            os.remove(filepath)
-
-
 class TraceBackFrame(OriginInfo):
     """
     Traceback frame information.
@@ -172,9 +155,6 @@ class ErrorData(object):
         self.origin_info_map = origin_info_map
         self.in_runtime = False
         self.suggestion_dict = SuggestionDict()
-
-    def __del__(self):
-        remove_static_file()
 
     def create_exception(self):
         message = self.create_message()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -54,7 +54,6 @@ def attach_error_data(error, in_runtime=False):
 
     setattr(error, ERROR_DATA, error_data)
 
-    remove_static_file()
     return error
 
 
@@ -173,6 +172,9 @@ class ErrorData(object):
         self.origin_info_map = origin_info_map
         self.in_runtime = False
         self.suggestion_dict = SuggestionDict()
+
+    def __del__(self):
+        remove_static_file()
 
     def create_exception(self):
         message = self.create_message()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
动转静的临时文件已经通过atexit.register注册了删除函数，不需要在error.py中重复进行删除。
