### PR TITLE
Rename ScaleLossGradOpHandle::Name() return value for better log analysis

### DIFF
--- a/paddle/fluid/framework/details/scale_loss_grad_op_handle.cc
+++ b/paddle/fluid/framework/details/scale_loss_grad_op_handle.cc
@@ -105,7 +105,7 @@ void ScaleLossGradOpHandle::RunImpl() {
 #endif
 }
 
-std::string ScaleLossGradOpHandle::Name() const { return "Scale LossGrad"; }
+std::string ScaleLossGradOpHandle::Name() const { return "ScaleLossGrad"; }
 }  // namespace details
 }  // namespace framework
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
The `ScaleLossGradOpHandle::Name()` returns a name with blank, which makes log analysis difficult (for example using `awk`).