### PR TITLE
Refine FastThreadedSSAGraphExecutor::Run when thread_num = 1

### DIFF
--- a/paddle/fluid/framework/details/fast_threaded_ssa_graph_executor.cc
+++ b/paddle/fluid/framework/details/fast_threaded_ssa_graph_executor.cc
@@ -47,7 +47,16 @@ FastThreadedSSAGraphExecutor::FastThreadedSSAGraphExecutor(
         << "Change thread number to 1 because the toposort order is unique";
     strategy_.num_threads_ = 1;
   }
-  pool_.reset(new ::ThreadPool(strategy.num_threads_));
+  if (strategy_.num_threads_ > 1) {
+    pool_.reset(new ::ThreadPool(strategy.num_threads_));
+  } else {
+    auto nodes = ir::TopologySortOperations(*graph_);
+    traced_ops_.clear();
+    traced_ops_.reserve(nodes.size());
+    for (auto *node : nodes) {
+      traced_ops_.push_back(&node->Wrapper<OpHandleBase>());
+    }
+  }
   for (auto &op : ir::FilterByNodeWrapper<OpHandleBase>(*graph_)) {
     int dep = static_cast<int>(op->NotReadyInputSize());
     op_deps_.emplace(op, dep);
@@ -228,7 +237,7 @@ void FastThreadedSSAGraphExecutor::RunOpAsync(
     OpHandleBase *op,
     const std::shared_ptr<BlockingQueue<size_t>> &complete_q) {
   ++remaining_;
-  this->pool_->enqueue([=] {
+  auto func = [=] {
     std::deque<OpHandleBase *> op_queue;
     op_queue.push_front(op);
 
@@ -287,7 +296,12 @@ void FastThreadedSSAGraphExecutor::RunOpAsync(
     }
     --remaining_;
     complete_q->Push(complete);
-  });
+  };
+  if (pool_) {
+    pool_->enqueue(func);
+  } else {
+    func();
+  }
 }
 
 void FastThreadedSSAGraphExecutor::PrepareAtomicOpDeps() {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Prepare `traced_ops_` beforehand if thread number is 1.
This PR is prepared for CUDA Graph.