### PR TITLE
Add invert support for bool/int Tensor

### DIFF
--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -111,6 +111,13 @@ def monkey_patch_math_varbase():
     def _neg_(var):
         return _scalar_elementwise_op_(var, -1.0, 0.0)
 
+    def _invert_(var):
+        var_dtype = var.dtype
+        if str(var_dtype) == "paddle.bool":
+            var_temp = core.ops.scale(var.astype("int"), 'scale', -1.0, 'bias', 1.0)
+            return var_temp.astype("bool")
+        return core.ops.scale(var, 'scale', -1.0, 'bias', -1.0)
+
     def _float_(var):
         numel = np.prod(var.shape)
         assert numel == 1, "only one element variable can be converted to float."
@@ -273,6 +280,7 @@ def monkey_patch_math_varbase():
 
     varbase_methods = [
         ('__neg__', _neg_),
+        ('__invert__', _invert_),
         ('__float__', _float_),
         ('__long__', _long_),
         ('__int__', _int_),

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -114,7 +114,8 @@ def monkey_patch_math_varbase():
     def _invert_(var):
         var_dtype = var.dtype
         if str(var_dtype) == "paddle.bool":
-            var_temp = core.ops.scale(var.astype("int"), 'scale', -1.0, 'bias', 1.0)
+            var_temp = core.ops.scale(
+                var.astype("int"), 'scale', -1.0, 'bias', 1.0)
             return var_temp.astype("bool")
         return core.ops.scale(var, 'scale', -1.0, 'bias', -1.0)
 

--- a/python/paddle/fluid/tests/test_python_operator_overriding.py
+++ b/python/paddle/fluid/tests/test_python_operator_overriding.py
@@ -49,7 +49,7 @@ class TestPythonOperatorOverride(unittest.TestCase):
                             fetch_list=[out])
 
         np.testing.assert_array_equal(python_out, fluid_out[0])
-    
+
     def check_result_unary(self, fn, place, dtype):
         shape = [9, 10]
 
@@ -76,9 +76,7 @@ class TestPythonOperatorOverride(unittest.TestCase):
             lambda _a, _b: _a >= _b,
         ]
 
-        unary_fns = [
-            lambda _a: ~_a,
-        ]
+        unary_fns = [lambda _a: ~_a, ]
 
         # places to check
         places = [fluid.CPUPlace()]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
1、支持bool以及int型Tensor的去反操作(https://github.com/PaddlePaddle/Paddle/issues/34905)
2、增加单测
对齐PyTorch，如下图所示
![7c0896dd84e20fcf653b0b038835b507](https://user-images.githubusercontent.com/19977378/135214925-2ded2c86-6fd6-4089-beb7-c961cd5d00e0.png)
