### PR TITLE
fix windows bug that virtual env can't find python executable

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -39,10 +39,12 @@ import numpy as np
 if six.PY3:
     import subprocess
     import sys
-    if sys.platform == 'win32':
-        interpreter = sys.exec_prefix + "\\" + "python.exe"
-    else:
-        interpreter = sys.executable
+    import os
+    interpreter = sys.executable
+    # Note(zhouwei): if use Python/C 'PyRun_SimpleString', 'sys.executable'
+    # will be the C++ execubable on Windows
+    if sys.platform == 'win32' and 'python.exe' not in interpreter:
+        interpreter = sys.exec_prefix + os.sep + 'python.exe'
     import_cv2_proc = subprocess.Popen(
         [interpreter, "-c", "import cv2"],
         stdout=subprocess.PIPE,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

修复https://github.com/PaddlePaddle/Paddle/pull/34312 导致的bug，Windows Python虚环境下无法找到python解释器，导致 `import paddle` 时挂掉的问题。

![infoflow 2021-09-29 22-50-02](https://user-images.githubusercontent.com/52485244/135293269-9e1717d0-0890-454e-a5c5-a704ef14fc61.png)

原因是由于Python虚环境下 ``sys.exec_prefix`` 在解释器python.exe的上一级目录；而Python裸机环境下``sys.exec_prefix`` 在解释器python.exe的同一级目录。

该PR修复了这个问题。
