### PR TITLE
the result may be nan when trt_fp16 is used in ernie

### DIFF
--- a/paddle/fluid/operators/math/bert_encoder_functor.cu
+++ b/paddle/fluid/operators/math/bert_encoder_functor.cu
@@ -97,7 +97,8 @@ __device__ inline void LayerNorm2(const kvp<T> &thread_data, const int ld,
 
   if (threadIdx.x == 0) {
     mu = sum_kv.key;
-    rsigma = local_rsqrt(sum_kv.value - mu * mu + eps);
+    rsigma =
+        (T)local_rsqrt(abs(static_cast<float>(sum_kv.value - mu * mu + eps)));
   }
   __syncthreads();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
the result may be nan when trt_fp16 is used in ernie
