### PR TITLE
[cherry-pick]fix hasattr(paddle.fluid.ir.PassDesc.OP, '__name__') error

### DIFF
--- a/python/paddle/fluid/ir.py
+++ b/python/paddle/fluid/ir.py
@@ -230,9 +230,6 @@ class PassDesc(object):
             self._type = type
 
         def __getattr__(self, name):
-            if self._type is not None:
-                raise AttributeError(
-                    "type object 'OpHelper' has no attribute '{}'".format(name))
             op = PassDesc.OpHelper(name)
             op.Init()
             return op
@@ -261,7 +258,12 @@ class PassDesc(object):
             self._op_idx = len(block.ops)
             self._op_desc = block.desc.append_op()
             self._op_desc.set_type(self._type)
-            self._op_proto = OpProtoHolder.instance().get_op_proto(self._type)
+            self._op_proto = OpProtoHolder.instance().op_proto_map.get(
+                self._type)
+            if self._op_proto is None:
+                raise AttributeError(
+                    "type object 'OpHelper' has no attribute '{}'".format(
+                        self._type))
             block.ops.append(self)
 
         def Attr(self, name):

--- a/python/paddle/fluid/tests/unittests/ir/test_ir_generate_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_ir_generate_pass.py
@@ -123,6 +123,9 @@ class TestGeneratePass(unittest.TestCase):
                 op_dicts[op.type] = [op]
         return op_dicts
 
+    def test_has_attr(self):
+        self.assertFalse(hasattr(ir.PassDesc.OP, '__name__'))
+
     def test_generate_fc_fuse(self):
         def _check_fc_fuse_pass(pass_desc, with_relu):
             pattern_op_dicts = self.convert_ops_to_op_dicts(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

修复如下图所示问题：

![image](https://user-images.githubusercontent.com/23427135/135374510-84c4018e-519c-487a-8780-e27e817f1ad8.png)

对于`__getattr__`重载后不满足条件的参数，全部抛出`AttributeError`异常，达到与未重载版本一致。

(cherry picked from PR #36229)