### PR TITLE
[cherry-pick]C++ support register pass via PassDesc

### DIFF
--- a/paddle/fluid/framework/ir/generate_pass.h
+++ b/paddle/fluid/framework/ir/generate_pass.h
@@ -173,9 +173,9 @@ class PassPairs {
 
 // Use function to register in CC.
 template <PassPairs (*Functor)(void)>
-class CXXGeneratePass : public GeneratePass {
+class MacroPassHelper : public GeneratePass {
  public:
-  CXXGeneratePass() : GeneratePass(Functor().MultiPassDesc()) {}
+  MacroPassHelper() : GeneratePass(Functor().MultiPassDesc()) {}
 };
 
 #define VAR_(name)                                         \
@@ -191,7 +191,7 @@ class CXXGeneratePass : public GeneratePass {
   paddle::framework::ir::PassPairs register_##pass_type();              \
   REGISTER_PASS(                                                        \
       pass_type,                                                        \
-      ::paddle::framework::ir::CXXGeneratePass<&register_##pass_type>); \
+      ::paddle::framework::ir::MacroPassHelper<&register_##pass_type>); \
   paddle::framework::ir::PassPairs register_##pass_type()
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/generate_pass_tester.cc
+++ b/paddle/fluid/framework/ir/generate_pass_tester.cc
@@ -16,226 +16,63 @@
 #include "gtest/gtest.h"
 #include "paddle/fluid/framework/ir/pass_tester_helper.h"
 
-namespace paddle {
-namespace framework {
-namespace ir {
-
-template <proto::MultiPassDesc (*Functor)(void)>
-class CXXGeneratePass : public GeneratePass {
- public:
-  CXXGeneratePass() : GeneratePass(Functor()) {}
-};
-
-#define REGISTER_GENERATE_PASS(pass_type, function) \
-  REGISTER_PASS(pass_type, ::paddle::framework::ir::CXXGeneratePass<&function>)
-
-proto::MultiPassDesc generate_fc_fuse() {
-  proto::MultiPassDesc multi_pass_desc;
+REGISTER_GENERATE_PASS(generate_fc_fuse) {
+  paddle::framework::ir::PassPairs pass_pairs;
   for (bool with_relu : {true, false}) {
-    proto::PassDesc* pass_desc = multi_pass_desc.add_pass_descs();
-    proto::BlockDesc* pattern = pass_desc->mutable_pattern()->add_blocks();
-    pattern->set_idx(0);
-    pattern->set_parent_idx(0);
-    proto::OpDesc* mul = pattern->add_ops();
-    mul->set_type("mul");
-    proto::OpDesc::Var* mul_x = mul->add_inputs();
-    mul_x->set_parameter("X");
-    mul_x->add_arguments()->assign("x");
-    proto::OpDesc::Var* mul_y = mul->add_inputs();
-    mul_y->set_parameter("Y");
-    mul_y->add_arguments()->assign("w");
-    proto::OpDesc::Var* mul_out = mul->add_outputs();
-    mul_out->set_parameter("Out");
-    mul_out->add_arguments()->assign("mul_out");
-    proto::OpDesc* ewadd = pattern->add_ops();
-    ewadd->set_type("elementwise_add");
-    proto::OpDesc::Var* ewadd_x = ewadd->add_inputs();
-    ewadd_x->set_parameter("X");
-    ewadd_x->add_arguments()->assign("mul_out");
-    proto::OpDesc::Var* ewadd_y = ewadd->add_inputs();
-    ewadd_y->set_parameter("Y");
-    ewadd_y->add_arguments()->assign("b");
-    proto::OpDesc::Var* ewadd_out = ewadd->add_outputs();
-    ewadd_out->set_parameter("Out");
-    ewadd_out->add_arguments()->assign("ewadd_out");
-    proto::OpDesc* relu = nullptr;
-    proto::BlockDesc* replace = pass_desc->mutable_replace()->add_blocks();
-    replace->set_idx(0);
-    replace->set_parent_idx(0);
-    proto::OpDesc* fc = replace->add_ops();
-    fc->set_type("fc");
-    proto::OpDesc::Var* fc_x = fc->add_inputs();
-    fc_x->set_parameter("Input");
-    fc_x->add_arguments()->assign("x");
-    proto::OpDesc::Var* fc_w = fc->add_inputs();
-    fc_w->set_parameter("W");
-    fc_w->add_arguments()->assign("w");
-    proto::OpDesc::Var* fc_b = fc->add_inputs();
-    fc_b->set_parameter("Bias");
-    fc_b->add_arguments()->assign("b");
-    proto::OpDesc::Var* fc_out = fc->add_outputs();
-    fc_out->set_parameter("Out");
-    fc_out->add_arguments()->assign("fc_out");
-    for (const char* var : {"x", "w", "b", "fc_out"}) {
-      proto::PassDesc::VarMap* var_map = pass_desc->add_var_maps();
-      var_map->set_pattern_var(var);
-      var_map->set_replace_var(var);
-    }
-    proto::PassDesc::AttrMap* attr_map = pass_desc->add_attr_maps();
-    attr_map->set_pattern_op_idx(0);
-    attr_map->set_pattern_name("x_num_col_dims");
-    attr_map->set_replace_op_idx(0);
-    attr_map->set_replace_name("in_num_col_dims");
-    if (with_relu) {
-      relu = pattern->add_ops();
-      relu->set_type("relu");
-      proto::OpDesc::Var* relu_x = relu->add_inputs();
-      relu_x->set_parameter("X");
-      relu_x->add_arguments()->assign("ewadd_out");
-      proto::OpDesc::Var* relu_out = relu->add_outputs();
-      relu_out->set_parameter("Out");
-      relu_out->add_arguments()->assign("relu_out");
-      pass_desc->mutable_var_maps(3)->set_pattern_var("relu_out");
-      proto::OpDesc::Attr* attr = fc->add_attrs();
-      attr->set_name("activation_type");
-      attr->set_type(proto::AttrType::STRING);
-      attr->set_s("relu");
-    } else {
-      pass_desc->mutable_var_maps(3)->set_pattern_var("ewadd_out");
-    }
+    // pattern
+    auto pattern = [with_relu](VAR_(x), VAR_(y), VAR_(z)) {
+      auto mul = OP_(mul)({{"X", x}, {"Y", y}});
+      auto ewadd = OP_(elementwise_add)({{"X", mul}, {"Y", z}});
+      if (with_relu) {
+        return OP_(relu)({{"X", ewadd}});
+      } else {
+        return ewadd;
+      }
+    };
+    // replace
+    auto replace = [with_relu](VAR_(x), VAR_(y), VAR_(z)) {
+      auto fc = OP_(fc)({{"Input", x}, {"W", y}, {"Bias", z}});
+      if (with_relu) {
+      } else {
+      }
+      return fc;
+    };
+    pass_pairs.push_back(std::make_pair(pattern, replace));
   }
-  return multi_pass_desc;
+  return pass_pairs;
 }
 
-proto::MultiPassDesc generate_multi_add_to_addn() {
-  proto::MultiPassDesc multi_pass_desc;
-  proto::PassDesc* pass_desc = multi_pass_desc.add_pass_descs();
-  proto::BlockDesc* pattern = pass_desc->mutable_pattern()->add_blocks();
-  proto::OpDesc* ewadd_0 = pattern->add_ops();
-  ewadd_0->set_type("elementwise_add");
-  proto::OpDesc::Var* ewadd_0_x = ewadd_0->add_inputs();
-  ewadd_0_x->set_parameter("X");
-  ewadd_0_x->add_arguments()->assign("a");
-  proto::OpDesc::Var* ewadd_0_y = ewadd_0->add_inputs();
-  ewadd_0_y->set_parameter("Y");
-  ewadd_0_y->add_arguments()->assign("b");
-  proto::OpDesc::Var* ewadd_0_out = ewadd_0->add_outputs();
-  ewadd_0_out->set_parameter("Out");
-  ewadd_0_out->add_arguments()->assign("ewadd_out_0");
-  proto::OpDesc* ewadd_1 = pattern->add_ops();
-  ewadd_1->set_type("elementwise_add");
-  proto::OpDesc::Var* ewadd_1_x = ewadd_1->add_inputs();
-  ewadd_1_x->set_parameter("X");
-  ewadd_1_x->add_arguments()->assign("ewadd_out_0");
-  proto::OpDesc::Var* ewadd_1_y = ewadd_1->add_inputs();
-  ewadd_1_y->set_parameter("Y");
-  ewadd_1_y->add_arguments()->assign("c");
-  proto::OpDesc::Var* ewadd_1_out = ewadd_1->add_outputs();
-  ewadd_1_out->set_parameter("Out");
-  ewadd_1_out->add_arguments()->assign("ewadd_out_1");
-  proto::BlockDesc* replace = pass_desc->mutable_replace()->add_blocks();
-  proto::OpDesc* addn = replace->add_ops();
-  addn->set_type("add_n");
-  proto::OpDesc::Var* addn_x = addn->add_inputs();
-  addn_x->set_parameter("X");
-  addn_x->add_arguments()->assign("a");
-  addn_x->add_arguments()->assign("b");
-  addn_x->add_arguments()->assign("c");
-  proto::OpDesc::Var* addn_out = addn->add_outputs();
-  addn_out->set_parameter("Out");
-  addn_out->add_arguments()->assign("addn_out");
-  for (const char* var : {"a", "b", "c", "ewadd_out_1"}) {
-    proto::PassDesc::VarMap* var_map = pass_desc->add_var_maps();
-    var_map->set_pattern_var(var);
-    var_map->set_replace_var(var);
-  }
-  pass_desc->mutable_var_maps(3)->set_replace_var("addn_out");
-  return multi_pass_desc;
+REGISTER_GENERATE_PASS(generate_multi_add_to_addn) {
+  // pattern
+  SUBGRAPH_(pattern) = [](VAR_(x), VAR_(y), VAR_(z)) {
+    auto ewadd1 = OP_(elementwise_add)({{"X", x}, {"Y", y}});
+    auto ewadd2 = OP_(elementwise_add)({{"X", ewadd1}, {"Y", z}});
+    return ewadd2;
+  };
+  // replace
+  auto replace = [](VAR_(x), VAR_(y), VAR_(z)) {
+    return OP_(sum)({"X", {x, y, z}});
+  };
+  return std::make_pair(pattern, replace);
 }
 
-proto::MultiPassDesc generate_combine_matmul() {
-  proto::MultiPassDesc multi_pass_desc;
-  proto::PassDesc* pass_desc = multi_pass_desc.add_pass_descs();
-  proto::BlockDesc* pattern = pass_desc->mutable_pattern()->add_blocks();
-  proto::OpDesc* matmul_0 = pattern->add_ops();
-  matmul_0->set_type("matmul");
-  proto::OpDesc::Var* matmul_0_x = matmul_0->add_inputs();
-  matmul_0_x->set_parameter("X");
-  matmul_0_x->add_arguments()->assign("a");
-  proto::OpDesc::Var* matmul_0_y = matmul_0->add_inputs();
-  matmul_0_y->set_parameter("Y");
-  matmul_0_y->add_arguments()->assign("b");
-  proto::OpDesc::Var* matmul_0_out = matmul_0->add_outputs();
-  matmul_0_out->set_parameter("Out");
-  matmul_0_out->add_arguments()->assign("matmul_out_0");
-  proto::OpDesc* matmul_1 = pattern->add_ops();
-  matmul_1->set_type("matmul");
-  proto::OpDesc::Var* matmul_1_x = matmul_1->add_inputs();
-  matmul_1_x->set_parameter("X");
-  matmul_1_x->add_arguments()->assign("a");
-  proto::OpDesc::Var* matmul_1_y = matmul_1->add_inputs();
-  matmul_1_y->set_parameter("Y");
-  matmul_1_y->add_arguments()->assign("c");
-  proto::OpDesc::Var* matmul_1_out = matmul_1->add_outputs();
-  matmul_1_out->set_parameter("Out");
-  matmul_1_out->add_arguments()->assign("matmul_out_1");
-  proto::BlockDesc* replace = pass_desc->mutable_replace()->add_blocks();
-  proto::OpDesc* concat = replace->add_ops();
-  concat->set_type("concat");
-  proto::OpDesc::Var* concat_x = concat->add_inputs();
-  concat_x->set_parameter("X");
-  concat_x->add_arguments()->assign("b");
-  concat_x->add_arguments()->assign("c");
-  proto::OpDesc::Var* concat_out = concat->add_outputs();
-  concat_out->set_parameter("Out");
-  concat_out->add_arguments()->assign("concat_out");
-  proto::OpDesc* matmul = replace->add_ops();
-  matmul->set_type("matmul");
-  proto::OpDesc::Var* matmul_x = matmul->add_inputs();
-  matmul_x->set_parameter("X");
-  matmul_x->add_arguments()->assign("a");
-  proto::OpDesc::Var* matmul_y = matmul->add_inputs();
-  matmul_y->set_parameter("Y");
-  matmul_y->add_arguments()->assign("concat_out");
-  proto::OpDesc::Var* matmul_out = matmul->add_outputs();
-  matmul_out->set_parameter("Out");
-  matmul_out->add_arguments()->assign("matmul_out");
-  proto::OpDesc* slice_0 = replace->add_ops();
-  slice_0->set_type("slice");
-  proto::OpDesc::Var* slice_0_x = slice_0->add_inputs();
-  slice_0_x->set_parameter("X");
-  slice_0_x->add_arguments()->assign("matmul_out");
-  proto::OpDesc::Var* slice_0_out = slice_0->add_outputs();
-  slice_0_out->set_parameter("Out");
-  slice_0_out->add_arguments()->assign("slice_out_0");
-  proto::OpDesc* slice_1 = replace->add_ops();
-  slice_1->set_type("slice");
-  proto::OpDesc::Var* slice_1_x = slice_1->add_inputs();
-  slice_1_x->set_parameter("X");
-  slice_1_x->add_arguments()->assign("matmul_out");
-  proto::OpDesc::Var* slice_1_out = slice_1->add_outputs();
-  slice_1_out->set_parameter("Out");
-  slice_1_out->add_arguments()->assign("slice_out_1");
-  for (const char* var : {"a", "b", "c", "matmul_out_0", "matmul_out_1"}) {
-    proto::PassDesc::VarMap* var_map = pass_desc->add_var_maps();
-    var_map->set_pattern_var(var);
-    var_map->set_replace_var(var);
-  }
-  pass_desc->mutable_var_maps(3)->set_replace_var("slice_out_0");
-  pass_desc->mutable_var_maps(4)->set_replace_var("slice_out_1");
-  return multi_pass_desc;
+REGISTER_GENERATE_PASS(generate_combine_matmul) {
+  // pattern
+  auto pattern = [](VAR_(x), VAR_(y), VAR_(z)) {
+    auto matmul1 = OP_(matmul)({{"X", x}, {"Y", y}});
+    auto matmul2 = OP_(matmul)({{"X", x}, {"Y", z}});
+    return std::make_tuple(matmul1, matmul2);
+  };
+  // replace
+  auto replace = [](VAR_(x), VAR_(y), VAR_(z)) {
+    auto concat = OP_(concat)({"X", {y, z}});
+    auto matmul = OP_(matmul)({{"X", x}, {"Y", concat}});
+    auto slice1 = OP_(slice)({"X", matmul});
+    auto slice2 = OP_(slice)({"X", matmul});
+    return std::make_tuple(slice1, slice2);
+  };
+  return std::make_pair(pattern, replace);
 }
-
-}  // namespace ir
-}  // namespace framework
-}  // namespace paddle
-
-REGISTER_GENERATE_PASS(generate_fc_fuse,
-                       paddle::framework::ir::generate_fc_fuse);
-REGISTER_GENERATE_PASS(generate_multi_add_to_addn,
-                       paddle::framework::ir::generate_multi_add_to_addn);
-REGISTER_GENERATE_PASS(generate_combine_matmul,
-                       paddle::framework::ir::generate_combine_matmul);
 
 namespace paddle {
 namespace framework {
@@ -243,7 +80,7 @@ namespace ir {
 
 TEST(GeneratePass, construct_with_string) {
   std::string binary_str;
-  generate_fc_fuse().SerializeToString(&binary_str);
+  register_generate_fc_fuse().ToMultiPassDesc().SerializeToString(&binary_str);
   GeneratePass generate_pass(binary_str);
 }
 

--- a/paddle/fluid/framework/ir/generate_pass_tester.cc
+++ b/paddle/fluid/framework/ir/generate_pass_tester.cc
@@ -155,20 +155,20 @@ TEST(GeneratePass, generate_multi_add_to_addn) {
 
   graph.reset(pass->Apply(graph.release()));
   int num_nodes_after = graph->Nodes().size();
-  int num_sum_nodes_after = GetNumOpNodes(graph, "sum");
+  int num_addn_nodes_after = GetNumOpNodes(graph, "sum");
   VLOG(3) << DebugString(graph);
 
   PADDLE_ENFORCE_EQ(num_nodes_before, num_nodes_after + 2,
                     platform::errors::InvalidArgument(
                         "num_nodes_before=%d, num_nodes_after=%d.",
                         num_nodes_before, num_nodes_after));
-  PADDLE_ENFORCE_EQ(num_sum_nodes_after, 1,
-                    platform::errors::InvalidArgument("num_sum_nodes_after=%d.",
-                                                      num_sum_nodes_after));
-  PADDLE_ENFORCE_EQ(num_add_nodes_before, num_sum_nodes_after + 1,
+  PADDLE_ENFORCE_EQ(num_addn_nodes_after, 1,
                     platform::errors::InvalidArgument(
-                        "num_add_nodes_before=%d, num_sum_nodes_after=%d.",
-                        num_add_nodes_before, num_sum_nodes_after));
+                        "num_addn_nodes_after=%d.", num_addn_nodes_after));
+  PADDLE_ENFORCE_EQ(num_add_nodes_before, num_addn_nodes_after + 1,
+                    platform::errors::InvalidArgument(
+                        "num_add_nodes_before=%d, num_addn_nodes_after=%d.",
+                        num_add_nodes_before, num_addn_nodes_after));
 }
 
 TEST(GeneratePass, generate_combine_matmul) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

(cherry picked from PR #36095)

**PR主要功能**：支持C++开发注册GeneratePass，简化针对fusion等子图优化场景开发方式。

# 背景

#35602 #35708 提供Python侧开发子图替换类Pass的方式：

- 利用Paddle Python API或者辅助类型定义子图program用来匹配/替换图；
- Python侧注册Pass时，将注册函数最终转换为protobuf定义的PassDesc数据形式，供C++侧进行解析完成Pass实例注册。

本PR在C++侧提供类似Python开发注册GeneratePass的API。

# 方案设计

## 定义匹配/替换子图

Python侧支持使用两种方式用于开发Pass，类似定义program的方式来定义匹配/替换子图：

1. 直接使用Paddle Python API；
2. 使用辅助类型；

Python侧定义子图通过定义一个函数（或lambda）完成，函数参数为子图的输入数据，返回值为输出数据，一个示例如下：

```
// 使用Paddle Python API方式
def pattern(x, y1, y2):
        mul1 = paddle.matmul(x, y1)
        mul2 = paddle.matmul(x, y2)
        return mul1, mul2

// 使用辅助类型方式
def pattern(x, y1, y2):
        mul1 = ir.PassDesc.OP.matmul_v2(X=x, Y=y1)
        mul2 = ir.PassDesc.OP.matmul_v2(X=x, Y=y2)
        return mul1, mul2
```

Python侧可以直接生成子图ProgramDesc，而C++中需要实现相同的功能使用的API较为复杂，因此方案采用如下方式实现类似Python侧的子图定义功能

- 使用`VarHelper`、`OpHelper`、`SubgraphHelper`三个辅助类型完成定义子图转换ProgramDesc功能；
- 使用`VAR_`、`OP_`、`SUBGRAPH_`宏创建对应上述三个辅助类型对象，从而尽可能简化代码量及内部细节；
- 使用lambda表达式定义子图，并捕获表达式需要绑定的子图对象。

C++上定义子图示例如下：

```
SUBGRAPH_(pattern) = [subgraph = &pattern](VAR_(x), VAR_(y), VAR_(z)) {
  auto ewadd1 = OP_(elementwise_add)({{"X", x}, {"Y", y}}).Out("Out");
  auto ewadd2 = OP_(elementwise_add)({{"X", ewadd1}, {"Y", z}}).Out("Out");
  return ewadd2;
};
SUBGRAPH_(replace) = [subgraph = &replace](VAR_(x), VAR_(y), VAR_(z)) {
  return OP_(sum)({"X", {x, y, z}}).Out("Out");
};
```

## 注册GeneratePass

Python侧Pass注册使用装饰器`RegisterPass`完成，将注册函数传递到C++中，在获取Pass实例时调用获取protobuf序列化数据，注册代码示例如下：

```
@ir.RegisterPass
def generate_add_n():
    def pattern(x, y, z):
        return paddle.add(paddle.add(x, y), z)
    def replace(x, y, z):
        return paddle.add_n([x, y, z])
    return pattern, replace
```

C++中使用类似的注册方式，使用宏`REGISTER_GENERATE_PASS`完成Pass的注册，其参数表示该pass的类型，代码示例如下：

```
REGISTER_GENERATE_PASS(generate_multi_add_to_addn) {
  // pattern
  SUBGRAPH_(pattern) = [subgraph = &pattern](VAR_(x), VAR_(y), VAR_(z)) {
    auto ewadd1 = OP_(elementwise_add)({{"X", x}, {"Y", y}}).Out("Out");
    auto ewadd2 = OP_(elementwise_add)({{"X", ewadd1}, {"Y", z}}).Out("Out");
    return ewadd2;
  };
  // replace
  SUBGRAPH_(replace) = [subgraph = &replace](VAR_(x), VAR_(y), VAR_(z)) {
    return OP_(sum)({"X", {x, y, z}}).Out("Out");
  };
  return {pattern, replace};
```