### PR TITLE
fix the bug that use _pipeline_opt attribute for CompiledProgram

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1626,7 +1626,7 @@ class Executor(object):
                           fetch_info=None,
                           print_period=100,
                           fetch_handler=None):
-        if program._pipeline_opt is not None:
+        if isinstance(program, Program) and program._pipeline_opt is not None:
             import paddle
             if dataset is not None:
                 raise RuntimeError("dataset should be None for pipeline mode")

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1652,7 +1652,7 @@ class Executor(object):
 
         dataset._prepare_to_run()
         real_fetch_list = []
-        if program._pipeline_opt:
+        if isinstance(program, Program) and program._pipeline_opt:
             real_program = program._pipeline_opt["section_program"]
             for fetch_var in fetch_list:
                 if isinstance(fetch_var, Variable):
@@ -1691,7 +1691,7 @@ class Executor(object):
         trainer._set_infer(is_infer)
         trainer._gen_trainer_desc()
 
-        if program._pipeline_opt is None:
+        if isinstance(program, Program) and program._pipeline_opt is None:
             self._dump_debug_info(program=program, trainer=trainer)
         # in case of calling _set_use_ps_gpu explicitly
         if dataset.use_ps_gpu is False:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix the bug that use _pipeline_opt attribute for CompiledProgram. For the api exe.train_from_dataset, the passed program maybe an instance of CompliedProgram which has no attribute "_pipeline_opt".