### PR TITLE
[cherrypick] change paddle.mm api  to matmul v2 op

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -950,7 +950,7 @@ def mm(input, mat2, name=None):
     """
     if in_dygraph_mode():
         out = _varbase_creator(dtype=input.dtype)
-        _C_ops.matmul(input, mat2, out)
+        _C_ops.matmul_v2(input, mat2, out)
         return out
 
     def __check_input(x, y):
@@ -991,7 +991,7 @@ def mm(input, mat2, name=None):
     helper = LayerHelper('mm', **locals())
     out = helper.create_variable_for_type_inference(dtype=input.dtype)
     helper.append_op(
-        type='matmul', inputs={'X': input,
+        type='matmul_v2', inputs={'X': input,
                                'Y': mat2}, outputs={'Out': out})
     return out
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -923,8 +923,6 @@ def mm(input, mat2, name=None):
     nontransposed, the prepended or appended dimension :math:`1` will be
     removed after matrix multiplication.
 
-    This op does not support broadcasting. See paddle.matmul.
-
     Args:
         input (Tensor): The input tensor which is a Tensor.
         mat2 (Tensor): The input tensor which is a Tensor.

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -949,9 +949,7 @@ def mm(input, mat2, name=None):
 
     """
     if in_dygraph_mode():
-        out = _varbase_creator(dtype=input.dtype)
-        _C_ops.matmul_v2(input, mat2, out)
-        return out
+        return _C_ops.matmul_v2(input, mat2)
 
     def __check_input(x, y):
         var_names = {'x': x, 'y': y}


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
APIs 

### Describe
[cherrypick] change paddle.mm api  to matmul v2 op [#35770](https://github.com/PaddlePaddle/Paddle/pull/35770 )
