### PR TITLE
[hybrid enhance] add flag to control the avg position for grad merge under pipeline mode

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -133,6 +133,10 @@ message GradientScaleConfig {
   // Else if sum, the gradient will accumulated among multiple
   // devices.
   optional string scale_strategy = 1 [ default = 'avg' ];
+  // The avg_loss flag is used to determine the position of average
+  // If avg_loss is True, it will avg the loss before grad merge.
+  // Otherwise, it will do grad merge firstly, then avg the grad after merging.
+  optional bool avg_loss = 2 [ default = false ];
 }
 
 message AsyncConfig {
@@ -162,7 +166,6 @@ message PipelineConfig {
   optional int32 accumulate_steps = 2 [ default = 1 ];
   optional string schedule_mode = 3 [ default = '1F1B' ];
   optional bool p2p_cache_shape = 4 [ default = true ];
-  optional bool grad_merge_avg_after_sum = 5 [ default = false ];
 }
 
 message TensorParallelConfig {

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -136,7 +136,7 @@ message GradientScaleConfig {
   // The avg_loss flag is used to determine the position of average
   // If avg_loss is True, it will avg the loss before grad merge.
   // Otherwise, it will do grad merge firstly, then avg the grad after merging.
-  optional bool avg_loss = 2 [ default = false ];
+  optional bool avg_loss = 2 [ default = true ];
 }
 
 message AsyncConfig {

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -162,6 +162,7 @@ message PipelineConfig {
   optional int32 accumulate_steps = 2 [ default = 1 ];
   optional string schedule_mode = 3 [ default = '1F1B' ];
   optional bool p2p_cache_shape = 4 [ default = true ];
+  optional bool grad_merge_avg_after_sum = 5 [ default = false ];
 }
 
 message TensorParallelConfig {

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -134,9 +134,9 @@ message GradientScaleConfig {
   // devices.
   optional string scale_strategy = 1 [ default = 'avg' ];
   // The avg_loss flag is used to determine the position of average
-  // If avg_loss is True, it will avg the loss before grad merge.
+  // If scale_gradient is False, it will avg the loss@Grad before grad merge.
   // Otherwise, it will do grad merge firstly, then avg the grad after merging.
-  optional bool avg_loss = 2 [ default = true ];
+  optional bool scale_gradient = 2 [ default = false ];
 }
 
 message AsyncConfig {

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
@@ -371,6 +371,8 @@ class ShardingOptimizer(MetaOptimizerBase):
             main_block, strategy=strategy, shard=shard)
 
         len_of_ops = len(main_block.ops)
+        if self.scale_gradient:
+            self._avg_grad_merge_after_sum(main_block, accumulated_grad_names)
         first_optimize_op_index = get_first_optimize_op_idx(main_block)
 
         if self.pp_allreduce_in_optimize:
@@ -435,8 +437,6 @@ class ShardingOptimizer(MetaOptimizerBase):
                 user_defined_strategy=strategy)
             first_optimize_op_index += (len(main_block.ops) - len_of_ops)
             len_of_ops = len(main_block.ops)
-
-        self._avg_grad_merge_after_sum(main_block, accumulated_grad_names)
 
         # FIXME(wangxi): if fp16_allreduce, put cast fp16->fp32 to there?
 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -5812,7 +5812,6 @@ class PipelineOptimizer(object):
             'use_sharding',
             'mp_degree',
             'mp_rank',
-            'avg_loss',
         ]
         for key in required_keys:
             assert key in pipeline_opt, \
@@ -5825,7 +5824,7 @@ class PipelineOptimizer(object):
         self.global_ring_id = pipeline_opt['global_ring_id']
         self.mp_degree = pipeline_opt['mp_degree']
         self.mp_rank = pipeline_opt['mp_rank']
-        self.avg_loss = pipeline_opt['avg_loss']
+        self.avg_loss = pipeline_opt.get('avg_loss', True)
         assert self.mp_degree >= 1
         assert 0 <= self.mp_rank < self.mp_degree
 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -5812,6 +5812,7 @@ class PipelineOptimizer(object):
             'use_sharding',
             'mp_degree',
             'mp_rank',
+            'grad_merge_avg_after_sum',
         ]
         for key in required_keys:
             assert key in pipeline_opt, \
@@ -5824,6 +5825,7 @@ class PipelineOptimizer(object):
         self.global_ring_id = pipeline_opt['global_ring_id']
         self.mp_degree = pipeline_opt['mp_degree']
         self.mp_rank = pipeline_opt['mp_rank']
+        self.grad_merge_avg_after_sum = pipeline_opt['grad_merge_avg_after_sum']
         assert self.mp_degree >= 1
         assert 0 <= self.mp_rank < self.mp_degree
 
@@ -5890,7 +5892,8 @@ class PipelineOptimizer(object):
             "startup_program": new_startup_program,
         }
         real_block = program_list[self.local_rank].global_block()
-        self._insert_loss_scale(real_block)
+        if not self.grad_merge_avg_after_sum:
+            self._insert_loss_scale(real_block)
         if not self.use_sharding:
             # Step7: clear gradients before each mini-batch and 
             # accumulate gradients during backward

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -5824,7 +5824,7 @@ class PipelineOptimizer(object):
         self.global_ring_id = pipeline_opt['global_ring_id']
         self.mp_degree = pipeline_opt['mp_degree']
         self.mp_rank = pipeline_opt['mp_rank']
-        self.scale_gradient = pipeline_opt.get('scale_gradient', True)
+        self.scale_gradient = pipeline_opt.get('scale_gradient', False)
         assert self.mp_degree >= 1
         assert 0 <= self.mp_rank < self.mp_degree
 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -5824,7 +5824,7 @@ class PipelineOptimizer(object):
         self.global_ring_id = pipeline_opt['global_ring_id']
         self.mp_degree = pipeline_opt['mp_degree']
         self.mp_rank = pipeline_opt['mp_rank']
-        self.avg_loss = pipeline_opt.get('avg_loss', True)
+        self.scale_gradient = pipeline_opt.get('scale_gradient', True)
         assert self.mp_degree >= 1
         assert 0 <= self.mp_rank < self.mp_degree
 
@@ -5891,7 +5891,7 @@ class PipelineOptimizer(object):
             "startup_program": new_startup_program,
         }
         real_block = program_list[self.local_rank].global_block()
-        if self.avg_loss:
+        if not self.scale_gradient:
             self._insert_loss_scale(real_block)
         if not self.use_sharding:
             # Step7: clear gradients before each mini-batch and 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -5812,7 +5812,7 @@ class PipelineOptimizer(object):
             'use_sharding',
             'mp_degree',
             'mp_rank',
-            'grad_merge_avg_after_sum',
+            'avg_loss',
         ]
         for key in required_keys:
             assert key in pipeline_opt, \
@@ -5825,7 +5825,7 @@ class PipelineOptimizer(object):
         self.global_ring_id = pipeline_opt['global_ring_id']
         self.mp_degree = pipeline_opt['mp_degree']
         self.mp_rank = pipeline_opt['mp_rank']
-        self.grad_merge_avg_after_sum = pipeline_opt['grad_merge_avg_after_sum']
+        self.avg_loss = pipeline_opt['avg_loss']
         assert self.mp_degree >= 1
         assert 0 <= self.mp_rank < self.mp_degree
 
@@ -5892,7 +5892,7 @@ class PipelineOptimizer(object):
             "startup_program": new_startup_program,
         }
         real_block = program_list[self.local_rank].global_block()
-        if not self.grad_merge_avg_after_sum:
+        if self.avg_loss:
             self._insert_loss_scale(real_block)
         if not self.use_sharding:
             # Step7: clear gradients before each mini-batch and 

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1393,7 +1393,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
             'mul_grad', 'tanh_grad', 'elementwise_add_grad', 'mul_grad',
             'tanh_grad', 'elementwise_add_grad', 'mul_grad', 'tanh_grad',
             'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream', 'send_v2',
-            'sum', 'scale', 'c_allreduce_sum', 'c_sync_comm_stream', 'momentum',
+            'sum', 'c_allreduce_sum', 'scale', 'c_sync_comm_stream', 'momentum',
             'momentum', 'momentum', 'momentum', 'momentum', 'momentum',
             'momentum', 'momentum'
         ])

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1293,7 +1293,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         }
         strategy.gradient_scale_configs = {
             'scale_strategy': 'avg',
-            'avg_loss': False
+            'scale_gradient': True
         }
         strategy.fuse_grad_merge = True
         self.optimizer(avg_cost, strategy, train_prog, startup_prog)
@@ -1358,7 +1358,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         }
         strategy.gradient_scale_configs = {
             'scale_strategy': 'avg',
-            'avg_loss': False
+            'scale_gradient': True
         }
         strategy.fuse_grad_merge = True
         self.optimizer(avg_cost, strategy, train_prog, startup_prog)

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1289,8 +1289,11 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
         strategy.pipeline_configs = {
             "schedule_mode": "1F1B",
             "micro_batch_size": 2,
-            "accumulate_steps": 4,
-            "grad_merge_avg_after_sum": True,
+            "accumulate_steps": 4
+        }
+        strategy.gradient_scale_configs = {
+            'scale_strategy': 'avg',
+            'avg_loss': False
         }
         strategy.fuse_grad_merge = True
         self.optimizer(avg_cost, strategy, train_prog, startup_prog)

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1272,6 +1272,70 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
 
         self.assertEqual(dp_group_waiting_ports, ['127.0.0.1:36002'])
 
+    def test_hybrid_with_pp_dp_amp_with_gradient_fuse_and_avg_after_sum(self):
+        train_prog, startup_prog = paddle.fluid.Program(), paddle.fluid.Program(
+        )
+        avg_cost, strategy = self.pp_net(train_prog, startup_prog)
+        strategy.amp = True
+        strategy.amp_configs = {'custom_black_varnames': ['fc_6.b_0'], }
+        strategy.sharding = True
+        strategy.sharding_configs = {
+            "sharding_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 2,
+            "dp_degree": 2,
+        }
+        strategy.pipeline = True
+        strategy.pipeline_configs = {
+            "schedule_mode": "1F1B",
+            "micro_batch_size": 2,
+            "accumulate_steps": 4,
+            "grad_merge_avg_after_sum": True,
+        }
+        strategy.fuse_grad_merge = True
+        self.optimizer(avg_cost, strategy, train_prog, startup_prog)
+        train_prog = train_prog._pipeline_opt['section_program']
+        startup_prog = startup_prog._pipeline_opt['startup_program']
+
+        startup_prog_ops = startup_prog.global_block().ops
+        main_prog_ops = train_prog.global_block().ops
+
+        # check program
+        startup_prog_op_types = [op.type for op in startup_prog_ops]
+        main_prog_op_types = [op.type for op in main_prog_ops]
+
+        self.assertEqual(startup_prog_op_types, [
+            'uniform_random', 'fill_constant', 'uniform_random',
+            'fill_constant', 'uniform_random', 'fill_constant',
+            'uniform_random', 'fill_constant', 'fill_constant', 'fill_constant',
+            'fill_constant', 'fill_constant', 'fill_constant', 'fill_constant',
+            'fill_constant', 'fill_constant', 'fill_constant', 'fill_constant',
+            'fill_constant', 'fill_constant', 'c_gen_nccl_id', 'c_comm_init',
+            'c_gen_nccl_id', 'c_comm_init', 'c_gen_nccl_id', 'c_comm_init',
+            'c_gen_nccl_id', 'c_comm_init', 'c_broadcast', 'c_broadcast',
+            'c_broadcast', 'c_broadcast', 'c_broadcast', 'c_broadcast',
+            'c_broadcast', 'c_broadcast'
+        ])
+
+        self.assertEqual(main_prog_op_types, [
+            'recv_v2', 'cast', 'mul', 'cast', 'elementwise_add', 'tanh', 'cast',
+            'mul', 'cast', 'elementwise_add', 'tanh', 'cast', 'mul', 'cast',
+            'elementwise_add', 'tanh', 'cast', 'mul', 'cast', 'elementwise_add',
+            'softmax', 'cross_entropy2', 'mean', 'elementwise_mul',
+            'coalesce_tensor', 'coalesce_tensor', 'coalesce_tensor',
+            'coalesce_tensor', 'fill_constant', 'elementwise_mul_grad',
+            'mean_grad', 'cross_entropy_grad2', 'softmax_grad',
+            'elementwise_add_grad', 'cast', 'mul_grad', 'tanh_grad',
+            'elementwise_add_grad', 'mul_grad', 'tanh_grad',
+            'elementwise_add_grad', 'mul_grad', 'tanh_grad',
+            'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream', 'send_v2',
+            'cast', 'sum', 'sum', 'scale', 'scale', 'c_allreduce_sum',
+            'c_allreduce_sum', 'c_sync_comm_stream', 'check_finite_and_unscale',
+            'cast', 'c_allreduce_max', 'cast', 'update_loss_scaling',
+            'momentum', 'momentum', 'momentum', 'momentum', 'momentum',
+            'momentum', 'momentum', 'momentum'
+        ])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1332,11 +1332,11 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
             'elementwise_add_grad', 'mul_grad', 'tanh_grad',
             'elementwise_add_grad', 'mul_grad', 'tanh_grad',
             'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream', 'send_v2',
-            'cast', 'sum', 'sum', 'scale', 'scale', 'c_allreduce_sum',
-            'c_allreduce_sum', 'c_sync_comm_stream', 'check_finite_and_unscale',
-            'cast', 'c_allreduce_max', 'cast', 'update_loss_scaling',
+            'cast', 'sum', 'sum', 'c_allreduce_sum', 'c_allreduce_sum',
+            'c_sync_comm_stream', 'scale', 'check_finite_and_unscale', 'cast',
+            'c_allreduce_max', 'cast', 'update_loss_scaling', 'momentum',
             'momentum', 'momentum', 'momentum', 'momentum', 'momentum',
-            'momentum', 'momentum', 'momentum'
+            'momentum', 'momentum'
         ])
 
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1339,6 +1339,65 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
             'momentum', 'momentum'
         ])
 
+    def test_hybrid_with_pp_dp_with_gradient_fuse_and_avg_after_sum(self):
+        train_prog, startup_prog = paddle.fluid.Program(), paddle.fluid.Program(
+        )
+        avg_cost, strategy = self.pp_net(train_prog, startup_prog)
+        strategy.sharding = True
+        strategy.sharding_configs = {
+            "sharding_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 2,
+            "dp_degree": 2,
+        }
+        strategy.pipeline = True
+        strategy.pipeline_configs = {
+            "schedule_mode": "1F1B",
+            "micro_batch_size": 2,
+            "accumulate_steps": 4
+        }
+        strategy.gradient_scale_configs = {
+            'scale_strategy': 'avg',
+            'avg_loss': False
+        }
+        strategy.fuse_grad_merge = True
+        self.optimizer(avg_cost, strategy, train_prog, startup_prog)
+        train_prog = train_prog._pipeline_opt['section_program']
+        startup_prog = startup_prog._pipeline_opt['startup_program']
+
+        startup_prog_ops = startup_prog.global_block().ops
+        main_prog_ops = train_prog.global_block().ops
+
+        # check program
+        startup_prog_op_types = [op.type for op in startup_prog_ops]
+        main_prog_op_types = [op.type for op in main_prog_ops]
+
+        self.assertEqual(startup_prog_op_types, [
+            'uniform_random', 'fill_constant', 'uniform_random',
+            'fill_constant', 'uniform_random', 'fill_constant',
+            'uniform_random', 'fill_constant', 'fill_constant', 'fill_constant',
+            'fill_constant', 'fill_constant', 'fill_constant', 'fill_constant',
+            'fill_constant', 'fill_constant', 'fill_constant', 'c_gen_nccl_id',
+            'c_comm_init', 'c_gen_nccl_id', 'c_comm_init', 'c_gen_nccl_id',
+            'c_comm_init', 'c_gen_nccl_id', 'c_comm_init', 'c_broadcast',
+            'c_broadcast', 'c_broadcast', 'c_broadcast', 'c_broadcast',
+            'c_broadcast', 'c_broadcast', 'c_broadcast'
+        ])
+
+        self.assertEqual(main_prog_op_types, [
+            'recv_v2', 'mul', 'elementwise_add', 'tanh', 'mul',
+            'elementwise_add', 'tanh', 'mul', 'elementwise_add', 'tanh', 'mul',
+            'elementwise_add', 'softmax', 'cross_entropy2', 'mean',
+            'coalesce_tensor', 'coalesce_tensor', 'fill_constant', 'mean_grad',
+            'cross_entropy_grad2', 'softmax_grad', 'elementwise_add_grad',
+            'mul_grad', 'tanh_grad', 'elementwise_add_grad', 'mul_grad',
+            'tanh_grad', 'elementwise_add_grad', 'mul_grad', 'tanh_grad',
+            'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream', 'send_v2',
+            'sum', 'scale', 'c_allreduce_sum', 'c_sync_comm_stream', 'momentum',
+            'momentum', 'momentum', 'momentum', 'momentum', 'momentum',
+            'momentum', 'momentum'
+        ])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1393,7 +1393,7 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
             'mul_grad', 'tanh_grad', 'elementwise_add_grad', 'mul_grad',
             'tanh_grad', 'elementwise_add_grad', 'mul_grad', 'tanh_grad',
             'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream', 'send_v2',
-            'sum', 'c_allreduce_sum', 'scale', 'c_sync_comm_stream', 'momentum',
+            'sum', 'c_allreduce_sum', 'c_sync_comm_stream', 'scale', 'momentum',
             'momentum', 'momentum', 'momentum', 'momentum', 'momentum',
             'momentum', 'momentum'
         ])
@@ -1461,8 +1461,8 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
             'elementwise_add_grad', 'mul_grad', 'tanh_grad',
             'elementwise_add_grad', 'mul_grad', 'tanh_grad',
             'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream', 'send_v2',
-            'cast', 'sum', 'sum', 'c_allreduce_sum', 'c_allreduce_sum', 'scale',
-            'scale', 'c_sync_comm_stream', 'check_finite_and_unscale',
+            'cast', 'sum', 'sum', 'c_allreduce_sum', 'c_allreduce_sum',
+            'c_sync_comm_stream', 'scale', 'scale', 'check_finite_and_unscale',
             'momentum', 'momentum', 'momentum', 'momentum', 'momentum',
             'momentum', 'momentum', 'momentum'
         ])

--- a/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_sharding_meta_optimizer.py
@@ -1398,6 +1398,75 @@ class TestFleetShardingHybridOptimizer(TestFleetMetaOptimizer):
             'momentum', 'momentum'
         ])
 
+    def test_hybrid_with_pp_dp_with_amp_no_dynamic_gradient_fuse_and_avg_after_sum(
+            self):
+        train_prog, startup_prog = paddle.fluid.Program(), paddle.fluid.Program(
+        )
+        avg_cost, strategy = self.pp_net(train_prog, startup_prog)
+        strategy.sharding = True
+        strategy.sharding_configs = {
+            "sharding_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 2,
+            "dp_degree": 2,
+        }
+        strategy.amp = True
+        strategy.amp_configs = {
+            'custom_black_varnames': ['fc_6.b_0'],
+            'use_dynamic_loss_scaling': False
+        }
+        strategy.pipeline = True
+        strategy.pipeline_configs = {
+            "schedule_mode": "1F1B",
+            "micro_batch_size": 2,
+            "accumulate_steps": 4
+        }
+        strategy.gradient_scale_configs = {
+            'scale_strategy': 'avg',
+            'scale_gradient': True
+        }
+        strategy.fuse_grad_merge = True
+        self.optimizer(avg_cost, strategy, train_prog, startup_prog)
+        train_prog = train_prog._pipeline_opt['section_program']
+        startup_prog = startup_prog._pipeline_opt['startup_program']
+
+        startup_prog_ops = startup_prog.global_block().ops
+        main_prog_ops = train_prog.global_block().ops
+
+        # check program
+        startup_prog_op_types = [op.type for op in startup_prog_ops]
+        main_prog_op_types = [op.type for op in main_prog_ops]
+
+        self.assertEqual(startup_prog_op_types, [
+            'uniform_random', 'fill_constant', 'uniform_random',
+            'fill_constant', 'uniform_random', 'fill_constant',
+            'uniform_random', 'fill_constant', 'fill_constant', 'fill_constant',
+            'fill_constant', 'fill_constant', 'fill_constant', 'fill_constant',
+            'fill_constant', 'fill_constant', 'fill_constant', 'fill_constant',
+            'c_gen_nccl_id', 'c_comm_init', 'c_gen_nccl_id', 'c_comm_init',
+            'c_gen_nccl_id', 'c_comm_init', 'c_gen_nccl_id', 'c_comm_init',
+            'c_broadcast', 'c_broadcast', 'c_broadcast', 'c_broadcast',
+            'c_broadcast', 'c_broadcast', 'c_broadcast', 'c_broadcast'
+        ])
+
+        self.assertEqual(main_prog_op_types, [
+            'recv_v2', 'cast', 'mul', 'cast', 'elementwise_add', 'tanh', 'cast',
+            'mul', 'cast', 'elementwise_add', 'tanh', 'cast', 'mul', 'cast',
+            'elementwise_add', 'tanh', 'cast', 'mul', 'cast', 'elementwise_add',
+            'softmax', 'cross_entropy2', 'mean', 'elementwise_mul',
+            'coalesce_tensor', 'coalesce_tensor', 'coalesce_tensor',
+            'coalesce_tensor', 'fill_constant', 'elementwise_mul_grad',
+            'mean_grad', 'cross_entropy_grad2', 'softmax_grad',
+            'elementwise_add_grad', 'cast', 'mul_grad', 'tanh_grad',
+            'elementwise_add_grad', 'mul_grad', 'tanh_grad',
+            'elementwise_add_grad', 'mul_grad', 'tanh_grad',
+            'elementwise_add_grad', 'mul_grad', 'c_sync_calc_stream', 'send_v2',
+            'cast', 'sum', 'sum', 'c_allreduce_sum', 'c_allreduce_sum', 'scale',
+            'scale', 'c_sync_comm_stream', 'check_finite_and_unscale',
+            'momentum', 'momentum', 'momentum', 'momentum', 'momentum',
+            'momentum', 'momentum', 'momentum'
+        ])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Describe
Support pure dp kind 'average for gradient merge after merging' operation for pp mode.
Add a new flag inside gradient_scale_configs: `scale_gradient`, which default value is False, to control where to do the average operation for gradient merge.
If `gradient_scale_configs['scale_gradient'] = False`, the pipeline will scale the loss@Grad (divide by number of micro steps) for each micro step, then do the gradient merge. It does the gradient merge avg op before sum.
Otherwise, if `gradient_scale_configs['scale_gradient'] = True`, the pipeline will do the gradient merge firstly. Then, during the optimize stage, the merged gradient will be divided by the number of micro steps. It does the gradient merge avg op after sum.

Hot to use:
```python
strategy = paddle.distributed.fleet.DistributedStrategy()
strategy.gradient_scale_configs = {
    'scale_strategy': 'avg',
    'scale_gradient': True
}
```

Loss compared under fp16_allreduce
![image](https://user-images.githubusercontent.com/25279174/137091909-bed6f266-f628-45a4-a85b-78e04d4909b8.png)
