### PR TITLE
Remove RunFromCinn in PE because We Will Call CinnRunner in Compute of SubgraphOp 

### DIFF
--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -14,7 +14,6 @@ limitations under the License. */
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -92,10 +91,6 @@ class ParallelExecutor {
                       bool return_merged = true);
 
   void RunWithoutFetch(const std::vector<std::string> &skip_eager_vars);
-
-  FetchResultType RunFromCinn(
-      const std::unordered_map<std::string, LoDTensor> &feed_tensors,
-      const std::vector<std::string> &fetch_names);
 
   void ResetOpHandleScopeMapOfGraphs(
       const std::unordered_map<Scope *, Scope *> &scope_map);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3293,18 +3293,6 @@ All parameter, weight, gradient are variables in Paddle.
                    BOOST_GET(paddle::framework::FetchUnmergedList, ret)));
              }
            })
-      .def("run_from_cinn",
-           [](ParallelExecutor &self,
-              const std::unordered_map<std::string, LoDTensor> &feed_tensors,
-              const std::vector<std::string> &fetch_names) -> py::object {
-             paddle::framework::FetchResultType ret;
-             {
-               pybind11::gil_scoped_release release;
-               ret = self.RunFromCinn(feed_tensors, fetch_names);
-             }
-             return py::cast(
-                 std::move(BOOST_GET(paddle::framework::FetchList, ret)));
-           })
       .def("device_count", &ParallelExecutor::DeviceCount);
 
   BindFleetWrapper(&m);

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -24,7 +24,7 @@ from .wrapped_decorator import signature_safe_contextmanager
 import six
 from .data_feeder import convert_dtype
 from .framework import Program, default_main_program, Variable, Operator
-from .framework import convert_np_dtype_to_dtype_, get_flags
+from .framework import convert_np_dtype_to_dtype_
 from . import core
 from . import unique_name
 from . import compiler
@@ -1017,16 +1017,6 @@ class Executor(object):
                     check_feed_shape_type(var, feed_tensor, exe.device_count())
                 feed_tensor_dict[feed_name] = feed_tensor
 
-            #TODO(zhhsplendid): handle other feed data format case for CINN
-            use_cinn = get_flags("FLAGS_use_cinn")["FLAGS_use_cinn"]
-            if use_cinn:
-                fetch_var_names = list(map(_to_name_str, fetch_list))
-                fetch_tensors = exe.run_from_cinn(
-                    feed_tensor_dict, fetch_var_names)._move_to_list()
-                return as_numpy(
-                    fetch_tensors) if return_numpy else fetch_tensors
-            else:
-                exe.feed_and_split_tensor_into_local_scopes(feed_tensor_dict)
         elif isinstance(feed, list) or isinstance(feed, tuple):
             res = list()
             for i, each in enumerate(feed):
@@ -1047,7 +1037,6 @@ class Executor(object):
                     res_dict[feed_name] = tensor
                 res.append(res_dict)
 
-            use_cinn = get_flags("FLAGS_use_cinn")["FLAGS_use_cinn"]
             exe.feed_tensors_into_local_scopes(res)
 
         if hasattr(program._program, 'lr_sheduler'):

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1016,6 +1016,7 @@ class Executor(object):
                 if need_check_feed:
                     check_feed_shape_type(var, feed_tensor, exe.device_count())
                 feed_tensor_dict[feed_name] = feed_tensor
+            exe.feed_and_split_tensor_into_local_scopes(feed_tensor_dict)
 
         elif isinstance(feed, list) or isinstance(feed, tuple):
             res = list()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Remove `RunFromCinn` method in PE because We Will Call `CinnRunner` in `Compute` method of SubgraphOp 