### PR TITLE
[hapi] support dygraph amp O2

### DIFF
--- a/paddle/fluid/framework/data_type_transform.cc
+++ b/paddle/fluid/framework/data_type_transform.cc
@@ -65,11 +65,24 @@ struct CastDataType {
 void TransDataType(const OpKernelType& kernel_type_for_var,
                    const OpKernelType& expected_kernel_type, const Tensor& in,
                    Tensor* out) {
+  PADDLE_ENFORCE_EQ(in.type(), kernel_type_for_var.data_type_,
+                    platform::errors::InvalidArgument(
+                        "The src dtype(%s) of input tensor and kernel_type(%s) "
+                        "are not conststent.",
+                        DataTypeToString(in.type()),
+                        DataTypeToString(kernel_type_for_var.data_type_)));
+  auto dst_type = expected_kernel_type.data_type_;
+  TransDataType(in, dst_type, out);
+}
+
+void TransDataType(const Tensor& in,
+                   const paddle::framework::proto::VarType::Type& type,
+                   Tensor* out) {
   platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
 
   out->Resize(in.dims());
-  auto src_type = kernel_type_for_var.data_type_;
-  auto dst_type = expected_kernel_type.data_type_;
+  auto src_type = in.type();
+  auto dst_type = type;
   auto ctx = pool.Get(in.place());
 
   switch (src_type) {

--- a/paddle/fluid/framework/data_type_transform.h
+++ b/paddle/fluid/framework/data_type_transform.h
@@ -32,6 +32,9 @@ using KernelTypePair = std::pair<OpKernelType, OpKernelType>;
 void TransDataType(const OpKernelType& kernel_type_for_var,
                    const OpKernelType& expected_kernel_type, const Tensor& in,
                    Tensor* out);
+void TransDataType(const Tensor& in,
+                   const paddle::framework::proto::VarType::Type& type,
+                   Tensor* out);
 
 /**
  * Transform complex gradient to real data type.

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -108,7 +108,10 @@ class Tracer {
 
   void SetHasGrad(bool has_grad) { has_grad_ = has_grad; }
 
-  void SetAmpLevel(AmpLevel level) { amp_level_ = level; }
+  void SetAmpLevel(AmpLevel level) {
+    VLOG(4) << "set amp_level to " << static_cast<unsigned int>(level);
+    amp_level_ = level;
+  }
 
   AmpLevel GetAmpLevel() const { return amp_level_; }
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -30,6 +30,7 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/custom_operator.h"
 #include "paddle/fluid/framework/data_layout.h"
+#include "paddle/fluid/framework/data_type_transform.h"
 #include "paddle/fluid/framework/executor.h"
 #include "paddle/fluid/framework/executor_cache.h"
 #include "paddle/fluid/framework/executor_gc_helper.h"
@@ -1115,6 +1116,15 @@ PYBIND11_MODULE(core_noavx, m) {
              std::stringstream ostr;
              ostr << self;
              return ostr.str();
+           })
+      .def("_as_type",
+           [](const LoDTensor &self,
+              paddle::framework::proto::VarType::Type type) {
+             LoDTensor dst;
+             if (self.IsInitialized() && self.numel() > 0) {
+               TransDataType(self, type, &dst);
+             }
+             return dst;
            })
       .def("_copy", [](const LoDTensor &self, const platform::Place &place) {
         // follow fetch_op's inplementation

--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -235,9 +235,9 @@ def amp_guard(enable=True,
                 print(conv.dtype) # FP32
 
     """
-    if not (level in ['O1', 'O2']):
+    if not (level in ['O0', 'O1', 'O2']):
         raise ValueError(
-            "level should be O1 or O2, O1 represent AMP train mode, O2 represent Pure fp16 train mode."
+            "level should be O0, O1 or O2. O0 represents fp32 train mode, O1 represents AMP train mode, O2 represents pure fp16 train mode."
         )
 
     tracer = _dygraph_tracer()
@@ -256,10 +256,14 @@ def amp_guard(enable=True,
         amp_level = AMP_LEVEL.O1
         _white_list = WHITE_LIST
         _black_list = BLACK_LIST
-    else:
+    elif level == 'O2':
         amp_level = AMP_LEVEL.O2
         _white_list = PURE_FP16_WHITE_LIST
         _black_list = PURE_FP16_BLACK_LIST
+    elif level == 'O0':
+        amp_level = AMP_LEVEL.O0
+        _white_list = WHITE_LIST
+        _black_list = BLACK_LIST
 
     if custom_white_list or custom_black_list:
         _white_list, _black_list = _update_list(custom_white_list,

--- a/python/paddle/fluid/tests/test_lod_tensor.py
+++ b/python/paddle/fluid/tests/test_lod_tensor.py
@@ -149,6 +149,13 @@ class TestLoDTensor(unittest.TestCase):
                     np.array(gtensor_from_dlpack),
                     np.array([[1], [2], [3], [4]]).astype('int')))
 
+    def test_as_type(self):
+        tensor = fluid.create_lod_tensor(
+            np.array([[1], [2], [3], [4]]).astype('int'), [[1, 3]],
+            fluid.CPUPlace())
+        fp32_tensor = tensor._as_type(core.VarDesc.VarType.FP32)
+        print(fp32_tensor)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1691,7 +1691,6 @@ class Model(object):
                         epochs=2,
                         save_dir='mnist_checkpoint')
         """
-
         assert train_data is not None, \
                 "train_data must be given!"
 

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1362,18 +1362,18 @@ class Model(object):
 
         optim_state = None if reset_optimizer else _load_state_from_path(
             path + ".pdopt")
-        
+
         # TODO: support save/load scaler state in static graph
         if in_dygraph_mode():
             scaler_state = None
             if hasattr(self, '_scaler') and self._scaler is not None:
                 if os.path.exists(path + '.pdscaler'):
                     scaler_state = paddle.load(path + '.pdscaler')
-        
+
             return self._adapter.load(matched_param_state, optim_state,
-                                    scaler_state)
+                                      scaler_state)
         else:
-            return self._adapter.load(matched_param_state, optim_state)            
+            return self._adapter.load(matched_param_state, optim_state)
 
     def parameters(self, *args, **kwargs):
         """

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -823,7 +823,7 @@ class DynamicGraphAdapter(object):
             if self.model._optimizer.state_dict():
                 optim = self.model._optimizer.state_dict()
                 fluid.save_dygraph(optim, path)
-        if self.model._scaler is not None:
+        if hasattr(self.model, '_scaler') and self.model._scaler is not None:
             if self.model._scaler.state_dict():
                 scaler = self.model._scaler.state_dict()
                 fluid.save_dygraph(scaler, path)
@@ -833,8 +833,9 @@ class DynamicGraphAdapter(object):
         for param, state in param_state_pairs:
             param.set_value(state)
 
-        if self.model._scaler and scaler_state:
-            self.model._scaler.set_state_dict(scaler_state)
+        if hasattr(self.model, '_scaler') and self.model._scaler is not None:
+            if scaler_state:
+                self.model._scaler.set_state_dict(scaler_state)
 
         # resotre optimizer states
         if not self.model._optimizer or not optim_state:

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -723,10 +723,10 @@ class DynamicGraphAdapter(object):
                 level=self._amp_level):
             if self._nranks > 1:
                 outputs = self.ddp_model.forward(
-                    * [to_variable(x) for x in inputs])
+                    *[to_variable(x) for x in inputs])
             else:
                 outputs = self.model.network.forward(
-                    * [to_variable(x) for x in inputs])
+                    *[to_variable(x) for x in inputs])
 
             losses = self.model._loss(*(to_list(outputs) + labels))
             losses = to_list(losses)
@@ -747,7 +747,7 @@ class DynamicGraphAdapter(object):
         metrics = []
         for metric in self.model._metrics:
             metric_outs = metric.compute(*(to_list(outputs) + labels))
-            m = metric.update(* [to_numpy(m) for m in to_list(metric_outs)])
+            m = metric.update(*[to_numpy(m) for m in to_list(metric_outs)])
             metrics.append(m)
 
         return ([to_numpy(l) for l in losses], metrics) \
@@ -761,7 +761,7 @@ class DynamicGraphAdapter(object):
         labels = labels or []
         labels = [to_variable(l) for l in to_list(labels)]
 
-        outputs = self.model.network.forward(* [to_variable(x) for x in inputs])
+        outputs = self.model.network.forward(*[to_variable(x) for x in inputs])
         if self.model._loss:
             losses = self.model._loss(*(to_list(outputs) + labels))
             losses = to_list(losses)
@@ -792,7 +792,7 @@ class DynamicGraphAdapter(object):
                     self._merge_count[self.mode + '_batch'] = samples
 
             metric_outs = metric.compute(*(to_list(outputs) + labels))
-            m = metric.update(* [to_numpy(m) for m in to_list(metric_outs)])
+            m = metric.update(*[to_numpy(m) for m in to_list(metric_outs)])
             metrics.append(m)
 
         if self.model._loss and len(metrics):

--- a/python/paddle/tests/test_hapi_amp.py
+++ b/python/paddle/tests/test_hapi_amp.py
@@ -50,7 +50,6 @@ class TestHapiWithAmp(unittest.TestCase):
         return model
 
     def run_model(self, model):
-
         transform = T.Compose([T.Transpose(), T.Normalize([127.5], [127.5])])
         train_dataset = MNIST(mode='train', transform=transform)
         model.fit(train_dataset,
@@ -61,9 +60,12 @@ class TestHapiWithAmp(unittest.TestCase):
 
     def run_amp(self, amp_level):
         for dynamic in [True, False]:
+            if not dynamic and amp_level['level'] == 'O2':
+                amp_level['use_fp16_guard'] = False
             print('dynamic' if dynamic else 'static', amp_level)
+
             paddle.seed(2021)
-            paddle.enable_static() if not dynamic else None
+            paddle.enable_static() if not dynamic else paddle.disable_static()
             paddle.set_device('gpu')
             model = self.get_model(amp_level)
             self.run_model(model)

--- a/python/paddle/tests/test_hapi_amp.py
+++ b/python/paddle/tests/test_hapi_amp.py
@@ -61,7 +61,7 @@ class TestHapiWithAmp(unittest.TestCase):
 
     def run_amp(self, amp_level):
         for dynamic in [True, False]:
-            print(dynamic, amp_level)
+            print('dynamic' if dynamic else 'static', amp_level)
             paddle.seed(2021)
             paddle.enable_static() if not dynamic else None
             paddle.set_device('gpu')

--- a/python/paddle/tests/test_hapi_amp.py
+++ b/python/paddle/tests/test_hapi_amp.py
@@ -15,6 +15,9 @@
 from __future__ import division
 from __future__ import print_function
 
+import os
+os.environ['FLAGS_cudnn_deterministic'] = '1'
+
 import unittest
 
 import numpy as np
@@ -26,34 +29,59 @@ from paddle import Model
 from paddle.static import InputSpec
 from paddle.nn.layer.loss import CrossEntropyLoss
 from paddle.vision.models import LeNet
+from paddle.vision.datasets import MNIST
+import paddle.vision.transforms as T
 
 
 @unittest.skipIf(not fluid.is_compiled_with_cuda(),
                  'CPU testing is not supported')
-class TestDistTraningUsingAMP(unittest.TestCase):
-    def test_amp_training(self):
-        if not fluid.is_compiled_with_cuda():
-            self.skipTest('module not tested when ONLY_CPU compling')
-        data = np.random.random(size=(4, 1, 28, 28)).astype(np.float32)
-        label = np.random.randint(0, 10, size=(4, 1)).astype(np.int64)
-        amp_level = "O1"
+class TestHapiWithAmp(unittest.TestCase):
+    def get_model(self, amp_config):
+        net = LeNet()
+        inputs = InputSpec([None, 1, 28, 28], "float32", 'x')
+        labels = InputSpec([None, 1], "int64", "y")
+        model = Model(net, inputs, labels)
+        optim = paddle.optimizer.Adam(
+            learning_rate=0.001, parameters=model.parameters())
+        model.prepare(
+            optimizer=optim,
+            loss=CrossEntropyLoss(reduction="sum"),
+            amp_configs=amp_config)
+        return model
+
+    def run_model(self, model):
+
+        transform = T.Compose([T.Transpose(), T.Normalize([127.5], [127.5])])
+        train_dataset = MNIST(mode='train', transform=transform)
+        model.fit(train_dataset,
+                  epochs=1,
+                  batch_size=64,
+                  num_iters=2,
+                  log_freq=1)
+
+    def run_amp(self, amp_level):
         for dynamic in [True, False]:
-            if not fluid.is_compiled_with_cuda():
-                self.skipTest('module not tested when ONLY_CPU compling')
+            print(dynamic, amp_level)
+            paddle.seed(2021)
             paddle.enable_static() if not dynamic else None
             paddle.set_device('gpu')
-            net = LeNet()
-            inputs = InputSpec([None, 1, 28, 28], "float32", 'x')
-            labels = InputSpec([None, 1], "int64", "y")
-            model = Model(net, inputs, labels)
-            optim = paddle.optimizer.Adam(
-                learning_rate=0.001, parameters=model.parameters())
-            amp_configs = {"level": amp_level}
-            model.prepare(
-                optimizer=optim,
-                loss=CrossEntropyLoss(reduction="sum"),
-                amp_configs=amp_configs)
-            model.train_batch([data], [label])
+            model = self.get_model(amp_level)
+            self.run_model(model)
+
+    def test_pure_fp16(self):
+        amp_config = {
+            "level": "O2",
+            "init_loss_scaling": 128,
+        }
+        self.run_amp(amp_config)
+
+    def test_amp(self):
+        amp_config = {"level": "O1", "init_loss_scaling": 128}
+        self.run_amp(amp_config)
+
+    def test_fp32(self):
+        amp_config = {"level": "O0", }
+        self.run_amp(amp_config)
 
     def test_dynamic_check_input(self):
         paddle.disable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[hapi] support dygrapg amp O2

result of test_hapi_amp.py [since the loss can not get and check from model.fit()]

```
dynamic {'level': 'O1', 'init_loss_scaling': 128}
step 1/2 - loss: 314.2420
step 2/2 - loss: 286.8351
static {'level': 'O1', 'init_loss_scaling': 128}
step 1/2 - loss: 314.2420
step 2/2 - loss: 286.8125

dynamic {'level': 'O0'}
step 1/2 - loss: 314.2520 
step 2/2 - loss: 286.7574 
static {'level': 'O0'}
step 1/2 - loss: 314.2520 
step 2/2 - loss: 286.7574 

dynamic {'level': 'O2', 'init_loss_scaling': 128}
step 1/2 - loss: 314.2 
step 2/2 - loss: 285.8
static {'level': 'O2', 'init_loss_scaling': 128}
step 1/2 - loss: 314.2
step 2/2 - loss: 285.8
```

1. Model.fit() runs ok with Amp_level =  O0, O1 and O2 both in dynamic mode and static mode
2. The results in dynamic mode and static mode with Amp_level =  O0/O2 are equal, but slightly differs with Amp_level =  O1 since the O1 implementation in dynamic mode and static mode are not exactly equal.
3. The results with Amp_level =  O0, O1 and O2 are close (285.6282~286.8351), max diff is 0.4%