### PR TITLE
[cherry-pick]Verify the correctness of graph rewrited by GeneratePass

### DIFF
--- a/paddle/fluid/framework/ir/generate_pass.cc
+++ b/paddle/fluid/framework/ir/generate_pass.cc
@@ -70,8 +70,8 @@ void InitGeneratePattern(const proto::PassDesc& pass_desc, PDPattern* pattern) {
           });
         } else if (var_pdnode->IsInput()) {
           var_pdnode->AsIntermediate();
-          var_pdnode->assert_is_op_output(op.type());
         }
+        var_pdnode->assert_is_op_output(op.type());
         pattern->AddEdge(op_pdnode, var_pdnode);
       }
     }

--- a/paddle/fluid/framework/ir/generate_pass.cc
+++ b/paddle/fluid/framework/ir/generate_pass.cc
@@ -50,10 +50,28 @@ void InitGeneratePattern(const proto::PassDesc& pass_desc, PDPattern* pattern) {
         PDNode* var_pdnode = pattern->RetrieveNode(argument);
         if (nullptr == var_pdnode) {
           var_pdnode = pattern->NewNode(argument)->AsOutput();
+          var_pdnode->assert_is_var();
+          var_pdnode->assert_more([&](Node* x) {
+            for (Node* input : x->inputs) {
+              if (input && input->IsOp() && input->Op() &&
+                  input->Op()->Type() == op.type()) {
+                const auto& outputs = input->Op()->Outputs();
+                const auto& iter = outputs.find(var.parameter());
+                if (outputs.end() != iter) {
+                  if (iter->second.end() != std::find(iter->second.begin(),
+                                                      iter->second.end(),
+                                                      x->Name())) {
+                    return true;
+                  }
+                }
+              }
+            }
+            return false;
+          });
         } else if (var_pdnode->IsInput()) {
           var_pdnode->AsIntermediate();
+          var_pdnode->assert_is_op_output(op.type());
         }
-        var_pdnode->assert_is_op_output(op.type());
         pattern->AddEdge(op_pdnode, var_pdnode);
       }
     }
@@ -73,17 +91,63 @@ void InitGeneratePattern(const proto::PassDesc& pass_desc, PDPattern* pattern) {
   }
 }
 
+// There are some duplicate patterns.
+bool IsDuplicatePattern(const GraphPatternDetector::subgraph_t& subgraph,
+                        Graph* graph) {
+  for (auto iter : subgraph) {
+    if (nullptr == graph->RetrieveNode(iter.second->id())) {
+      VLOG(3) << "Node [" << iter.second->Name()
+              << "] of subgraph has been removed. So skip this optimize.";
+      return true;
+    }
+  }
+  return false;
+}
+
+GraphPatternDetector::handle_t GetGenerateDelete(
+    const PDPattern& pattern, const proto::PassDesc& pass_desc) {
+  GraphPatternDetector::handle_t handler = [&](
+      const GraphPatternDetector::subgraph_t& subgraph, Graph* graph) {
+    if (IsDuplicatePattern(subgraph, graph)) {
+      return;
+    }
+    // `var_node_maps` record the mapping of variable to the pattern subgraph.
+    std::map<std::string, Node*> var_node_maps;
+    for (const proto::PassDesc::VarMap& var_map : pass_desc.var_maps()) {
+      Node* node = subgraph.at(pattern.RetrieveNode(var_map.pattern_var()));
+      const auto& iter = var_node_maps.find(var_map.replace_var());
+      if (var_node_maps.end() == iter) {
+        // first node is input
+        var_node_maps.insert({var_map.replace_var(), node});
+      } else {
+        // output node
+        for (Node* s_node : node->outputs) {
+          iter->second->outputs.push_back(s_node);
+          std::replace(s_node->inputs.begin(), s_node->inputs.end(), node,
+                       iter->second);
+          s_node->Op()->RenameInput(node->Name(), iter->second->Name());
+        }
+      }
+    }
+    // Remove nodes that are intermediate.
+    std::unordered_set<const Node*> remove_nodes;
+    for (const std::unique_ptr<PDNode>& pdnode : pattern.nodes()) {
+      remove_nodes.emplace(subgraph.at(pdnode.get()));
+    }
+    for (auto iter : var_node_maps) {
+      remove_nodes.erase(iter.second);
+    }
+    GraphSafeRemoveNodes(graph, remove_nodes);
+  };
+  return handler;
+}
+
 GraphPatternDetector::handle_t GetGenerateRewrite(
     const PDPattern& pattern, const proto::PassDesc& pass_desc) {
   GraphPatternDetector::handle_t handler = [&](
-      const GraphPatternDetector::subgraph_t subgraph, Graph* graph) {
-    // There are some duplicate patterns.
-    for (auto iter : subgraph) {
-      if (nullptr == graph->RetrieveNode(iter.second->id())) {
-        VLOG(3) << "Node [" << iter.second->Name()
-                << "] of subgraph has been removed. So skip this optimize.";
-        return;
-      }
+      const GraphPatternDetector::subgraph_t& subgraph, Graph* graph) {
+    if (IsDuplicatePattern(subgraph, graph)) {
+      return;
     }
     const proto::BlockDesc& block = pass_desc.replace().blocks(0);
     // `var_node_maps` record the mapping of variable to the pattern subgraph.
@@ -175,7 +239,11 @@ void GeneratePass::ApplyImpl(Graph* graph) const {
   for (const proto::PassDesc& pass_desc : multi_pass_desc_.pass_descs()) {
     GraphPatternDetector detector;
     InitGeneratePattern(pass_desc, detector.mutable_pattern());
-    detector(graph, GetGenerateRewrite(detector.pattern(), pass_desc));
+    if (pass_desc.replace().blocks(0).ops_size() == 0) {
+      detector(graph, GetGenerateDelete(detector.pattern(), pass_desc));
+    } else {
+      detector(graph, GetGenerateRewrite(detector.pattern(), pass_desc));
+    }
     // The rewrited graph needs to be verified. Current Pass should be skipped
     // if validation failed. Rewrite based on the original graph cannot
     // implement rollback operation.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Describe
<!-- Describe what this PR does -->

(cherry picked from PR #36116)

验证GeneratePass在计算子图替换后计算结果正确性，并对相关问题进行修复。

# 验证场景

- [x] 1. 完整的Python注册Pass到完成获取Pass实例对Graph进行子图替换；
- [x] 2. 简单的fusion场景：
  - [x] 2.1 Paddle Python API开发时无需指定：input_specs、算子属性；
  - [x] 2.2 辅助类型开发时无需指定：匹配/替换子图中的属性限制；
  - [x] 2.3 替换子图可以为仅有输入输出情况，意味着该Pass将删除匹配子图；
  - [x] 2.4 匹配图与替换图可任意使用一种方式开发；
- [ ] 3. 较为复杂的fusion场景：
  - [x] 3.1 Paddle Python API开发时指定且参与匹配替换限制：input_specs、算子属性；
  - [ ] 3.2 辅助类型开发时指定：匹配子图中属性限制、替换子图算子在匹配子图中的属性映射；
  - [ ] 3.3 匹配/替换子图中存在需要推导的算子属性，如concat、slice等；

**本PR中验证其中1、2、3.1场景，对于3.2、3.3于后续PR支持及验证**

# PR涉及功能验证及问题修复

## 1. 完整的Python注册Pass到完成获取Pass实例对Graph进行子图替换

**功能验证点**：`RegisterPass`注册的Pass，通过`core.get_pass`可以获取到实例且能对Graph进行操作。

**存在问题及解决方案**：

- 问题：获取Pass实例存在异常，无法正确在C++中调用Python侧函数；
- 解决方案：`RegisterPassHelper`类成员中保存每个实例，用以确保Python侧对象的生命周期。

## 2. 简单的fusion场景

### 2.1 Paddle Python API开发时无需指定：input_specs、算子属性

以融合两个add算子为例，简单的示意图如下：

![image](https://user-images.githubusercontent.com/23427135/136531128-855f207f-fe12-4973-8f4a-f0c484212e93.png)

使用Paddle API创建该Pass代码如下：

```
@ir.RegisterPass
def multi_add_to_sum():
    pattern = lambda x, y, z: paddle.add(paddle.add(x, y), z)
    replace = lambda x, y, z: paddle.add_n([x, y, z])
    return pattern, replace
```

为验证该Pass可以正确替换子图并得到相同的计算结果，使用如下图中的计算图来验证：

![image](https://user-images.githubusercontent.com/23427135/136542846-898f2851-c387-4a4f-ab96-bf8b16b4c028.png)

对于上面的计算图验证点如下：

- 仅匹配到一个子图；
- 替换子图之后，计算图中的节点数目减少2；
- 替换前后计算结果相同；

### 2.2 辅助类型开发时无需指定：匹配/替换子图中的属性限制

仍使用2.1中示例的Pass及测试方式，不同的是使用辅助类型注册Pass，代码如下：

```
@ir.RegisterPass
def multi_add_to_sum():
    def pattern(x, y, z):
        ewadd1 = ir.PassDesc.OP.elementwise_add(X=x, Y=y)
        ewadd2 = ir.PassDesc.OP.elementwise_add(X=ewadd1, Y=z)
        return ewadd2
    replace = lambda x, y, z: ir.PassDesc.OP.sum(X=[x, y, z])
    return pattern, replace
```

### 2.3 替换子图可以为仅有输入输出情况，意味着该Pass将删除匹配子图

以删除连续两个`transpose`算子为例，简单的示意图如下：

![image](https://user-images.githubusercontent.com/23427135/136547283-50e81e89-3204-415f-92b6-a939303267c7.png)

使用辅助类型注册该Pass代码如下：

```
@ir.RegisterPass
def simplify_inference():
    def pattern(x):
        transpose = ir.PassDesc.OP.transpose2(X=x)
        return ir.PassDesc.OP.transpose2(X=transpose)
    replace = lambda x: x
    return pattern, replace
```

为验证该Pass可以正确替换子图并得到相同的计算结果，使用如下图中的计算图来验证：

![image](https://user-images.githubusercontent.com/23427135/136554203-aaccc2e1-719a-4f13-9e3f-62005649974a.png)

对于上面的计算图验证点如下：

- 仅匹配到一个子图；
- 替换子图之后，计算图中的节点数目减少6；
- 替换前后计算结果相同；

### 2.4 匹配图与替换图可任意使用一种方式开发

仍使用2.1中示例的Pass及测试方式，不同的是使用辅助类型注册Pass，代码如下：

```
@ir.RegitserPass
def multi_add_to_sum():
    pattern = lambda x, y, z: paddle.add(paddle.add(x, y), z)
    replace = lambda x, y, z: ir.PassDesc.OP.sum(X=[x, y, z])
    return pattern, replace
```

### 3.1 Paddle Python API开发时指定且参与匹配替换限制：input_specs、算子属性

#### 3.1.1 示例1：融合多个matmul算子

该示例Pass的简单示意图如下：

![image](https://user-images.githubusercontent.com/23427135/137094161-5a7e3206-8734-459f-8d33-2a2b397cc50a.png)

```
@ir.RegisterPass(input_specs={
    'x': InputSpec([16, 32]),
    'y1': InputSpec([32, 12]),
    'y2': InputSpec([32, 48])
})
def combine_multi_matmul():
    def pattern(x, y1, y2):
        mul1 = paddle.matmul(x, y1)
        mul2 = paddle.matmul(x, y2)
        return mul1, mul2
    def replace(x, y1, y2):
        concat_out = paddle.concat([y1, y2], axis=-1)
        mul_out = paddle.matmul(x, concat_out)
        out1 = paddle.slice(mul_out, axes=[1], starts=[0], ends=[12])
        out2 = paddle.slice(mul_out, axes=[1], starts=[12], ends=[60])
        return out1, out2
    return pattern, replace
```

#### 3.1.2 示例2：融合连续的transpose算子

与2.3中示例类似，改用Paddle Python API定义子图，并且指定输入的shape及transpose算子的参数设置。

```
@ir.RegisterPass(input_specs={'x': InputSpec([10, 16, 16])})
def generate_simplify_inference_v1():
    def pattern(x):
        transpose = paddle.transpose(x, [0, 2, 1])
        return paddle.transpose(transpose, [0, 2, 1])
    return pattern, lambda x: x
```
