### PR TITLE
[Cherry-pick][Dy2stat]fix no_grad context error in train mode when using save/load (#36434)

### DIFF
--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -844,11 +844,19 @@ def _run_dygraph(instance, input, program_holder):
             continue
         persistable_var._set_grad_type(grad_var.type())
 
+    drop_scope_if_no_grad(instance, tmp_scope_vec)
+
     # 3. prepare output, keep same form with inputs
     outs = output_vars
     if len(output_vars) == 1:
         outs = output_vars[0]
     return outs
+
+
+def drop_scope_if_no_grad(instance, scope_vec):
+    tracer = framework._dygraph_tracer()
+    if (not instance._is_test) and (not tracer._has_grad):
+        scope_vec.value().get_scope().drop_kids()
 
 
 def _run_static_graph(input, program_holder, trace_program):

--- a/python/paddle/fluid/tests/unittests/test_io_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_io_save_load.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import unittest
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
 
@@ -67,6 +68,23 @@ class TestSaveInferenceModelAPIError(unittest.TestCase):
                 target_vars=[z],
                 executor=exe,
                 main_program=main_prog)
+
+
+class TestWhenTrainWithNoGrad(unittest.TestCase):
+    def test_when_train_with_no_grad(self):
+        paddle.disable_static()
+        net = paddle.nn.Linear(1024, 1)
+        net = paddle.jit.to_static(net)
+        x = paddle.rand([1024], 'float32')
+        net(x)
+        save_path = './train_with_no_grad'
+        paddle.jit.save(net, save_path)
+        net = paddle.jit.load(save_path)
+        net.train()
+
+        with paddle.no_grad():
+            x = paddle.rand([1024], 'float32')
+            net(x)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复使用jit.save/load接口加载模型后，在train模式和no_grad上下文中，显存会一直增长的问题

使用了一个简单的线性层网络进行测试
![image](https://user-images.githubusercontent.com/23097963/137440341-cc45832c-222b-47d5-8b14-3557693c02fd.png)

修改之前使用jit.load加载模型，在train模式和no_grad上下文中，每次forward后显存都会增长。
![image](https://user-images.githubusercontent.com/23097963/137440183-c7da5b8c-ca96-459f-9434-4b777212477b.png)
在修改后显存占用会稳定在1126M
![image](https://user-images.githubusercontent.com/23097963/137440311-2fcd9762-edd3-4cfc-9132-b9c89c25b1e9.png)
