### PR TITLE
fix  _run_from_dataset

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1667,6 +1667,7 @@ class Executor(object):
                         'op_role',
                         core.op_proto_and_checker_maker.OpRole.Optimize)
             fetch_list = None
+            fetch_info = None
 
         scope, trainer = self._prepare_trainer(
             program=program,

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1667,8 +1667,7 @@ class Executor(object):
                         'op_role',
                         core.op_proto_and_checker_maker.OpRole.Optimize)
             fetch_list = None
-            fetch_info = None # fix in pipeline mode
-            
+            fetch_info = None
         scope, trainer = self._prepare_trainer(
             program=program,
             dataset=dataset,

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1668,6 +1668,7 @@ class Executor(object):
                         core.op_proto_and_checker_maker.OpRole.Optimize)
             fetch_list = None
             fetch_info = None
+            
         scope, trainer = self._prepare_trainer(
             program=program,
             dataset=dataset,

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1668,7 +1668,6 @@ class Executor(object):
                         core.op_proto_and_checker_maker.OpRole.Optimize)
             fetch_list = None
             fetch_info = None
-            
         scope, trainer = self._prepare_trainer(
             program=program,
             dataset=dataset,

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1667,8 +1667,8 @@ class Executor(object):
                         'op_role',
                         core.op_proto_and_checker_maker.OpRole.Optimize)
             fetch_list = None
-            fetch_info = None
-
+            fetch_info = None # fix in pipeline mode
+            
         scope, trainer = self._prepare_trainer(
             program=program,
             dataset=dataset,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
set fetch_info = None in _run_from_dataset with pipeline mode
in_prepare_trainer API, it will assert len(fetch_list) == len(fetch_info)