### PR TITLE
fix op_flops not define

### DIFF
--- a/python/paddle/hapi/static_flops.py
+++ b/python/paddle/hapi/static_flops.py
@@ -176,6 +176,7 @@ def count_element_op(op):
 def _graph_flops(graph, detail=False):
     assert isinstance(graph, GraphWrapper)
     flops = 0
+    op_flops = 0
     table = Table(["OP Type", 'Param name', "Flops"])
     for op in graph.ops():
         param_name = ''


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
fix `op_flops` not defined when the 1st op not in table
