### PR TITLE
Refine LarsMomentumOp rescale_grad

### DIFF
--- a/paddle/fluid/operators/optimizers/lars_momentum_op.cu
+++ b/paddle/fluid/operators/optimizers/lars_momentum_op.cu
@@ -160,7 +160,6 @@ __global__ void L2NormKernel(
   __shared__ MT s_buffer[2];
   int tid = threadIdx.x + blockDim.x * blockIdx.x;
   int grid_stride = LARS_BLOCK_SIZE * gridDim.x;
-  const MT rescale_pow = rescale_grad * rescale_grad;
 
   MT p_tmp = static_cast<MT>(0);
   MT g_tmp = static_cast<MT>(0);
@@ -190,7 +189,7 @@ __global__ void L2NormKernel(
   }
   __syncthreads();
   *p_n = Sqrt(s_buffer[0]);
-  *g_n = Sqrt(rescale_pow * s_buffer[1]);
+  *g_n = rescale_grad * Sqrt(s_buffer[1]);
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization 

### PR changes
OPs

### Describe
当`rescale_grad`很小且训练轮数较大的时候（梯度很小），原来计算方法精度可能会比较低。换了一种计算方法提高LARS的精度。

原来的方式：
`*g_n = Sqrt(rescale_grad * rescale_grad * s_buffer[1]);`

现在的方式：
`*g_n = rescale_grad * Sqrt(s_buffer[1]);`