### PR TITLE
Optimize the subgraph generated by BuildCinnPass 

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
@@ -64,10 +64,86 @@ using framework::ir::Node;
 using GraphNodeVec = std::vector<Node*>;
 using GraphNodeSet = std::unordered_set<Node*>;
 
+// Deal with subgraph's feed input var node:
+// create a new input var node and it's feed op node
+void AddFeedOpAndVar(const std::unordered_set<Node*>& feed_vars,
+                     const GraphNodeSet& cluster,
+                     const std::unordered_map<Node*, Node*>& old_op2new_op,
+                     Graph* graph) {
+  for (auto* old_var : feed_vars) {
+    // create feed op
+    OpDesc desc;
+    desc.SetType("feed");
+    desc.SetOutput("Out", {old_var->Name()});
+    auto op = graph->CreateOpNode(&desc);
+
+    // create new feed var node (SSAGraph)
+    auto var = graph->CreateVarNode(old_var->Var());
+
+    // link feed op and feed var
+    op->outputs = {var};
+    var->inputs = {op};
+
+    // link feed var to cluster op
+    var->outputs.clear();
+    for (auto* old_op : old_var->outputs) {
+      if (cluster.count(old_op)) {
+        var->outputs.emplace_back(old_op2new_op.at(old_op));
+        old_op2new_op.at(old_op)->inputs.emplace_back(var);
+      }
+      // Do not need relink old op or old var here, they will be
+      // fixed in RemoveLinkFromCluster, here we just deal with
+      // new subgraph's node.
+    }
+  }
+}
+
+// Deal with subgraph's parameter var node:
+// create a new input var node, it's data will get by scope,
+// so it don't need feed op
+void AddParamVar(const std::unordered_set<Node*>& param_vars,
+                 const GraphNodeSet& cluster,
+                 const std::unordered_map<Node*, Node*>& old_op2new_op,
+                 Graph* graph) {
+  for (auto* old_var : param_vars) {
+    auto var = graph->CreateVarNode(old_var->Var());
+
+    var->inputs.clear();
+    var->outputs.clear();
+    for (auto* old_op : old_var->outputs) {
+      if (cluster.count(old_op)) {
+        var->outputs.emplace_back(old_op2new_op.at(old_op));
+        old_op2new_op.at(old_op)->inputs.emplace_back(var);
+      }
+    }
+  }
+}
+
+// Deal with subgraph's outputs var node:
+// create a new output var node and it's fetch op
+void AddOutputVar(const std::unordered_set<Node*>& output_vars,
+                  const GraphNodeSet& cluster,
+                  const std::unordered_map<Node*, Node*>& old_op2new_op,
+                  Graph* graph) {
+  for (auto* old_var : output_vars) {
+    auto var = graph->CreateVarNode(old_var->Var());
+
+    var->inputs.clear();
+    var->outputs.clear();
+    for (auto* old_op : old_var->inputs) {
+      if (cluster.count(old_op)) {
+        var->inputs.emplace_back(old_op2new_op.at(old_op));
+        old_op2new_op.at(old_op)->outputs.emplace_back(var);
+      }
+    }
+  }
+}
+
 // Create new subgraph with and op nodes are cluster nodes, and all
 // var node are from internal nodes
-std::unique_ptr<Graph> CreateNewSubGraph(
-    const GraphNodeSet& cluster, const GraphNodeSet& cluster_internals) {
+std::unique_ptr<Graph> CreateNewSubGraph(const GraphNodeSet& cluster,
+                                         const GraphNodeSet& cluster_internals,
+                                         const GraphNodeSet& cluster_inputs) {
   // Graph's constructor must has one parameter, and in our code,
   // the ProgramDesc is useless, so here we pass a temporary object.
   auto sub_graph = std::make_unique<Graph>(framework::ProgramDesc());
@@ -75,15 +151,21 @@ std::unique_ptr<Graph> CreateNewSubGraph(
   std::unordered_map<Node*, Node*> old_op2new_op;
   for (auto* op : cluster) {
     auto sub_node = sub_graph->CreateOpNode(op->Op());
+    sub_node->inputs.clear();
+    sub_node->outputs.clear();
     old_op2new_op[op] = sub_node;
   }
 
   std::unordered_map<Node*, Node*> old_var2new_var;
   for (auto* var : cluster_internals) {
     auto sub_node = sub_graph->CreateVarNode(var->Var());
+    sub_node->inputs.clear();
+    sub_node->outputs.clear();
     old_var2new_var[var] = sub_node;
   }
 
+  std::unordered_set<Node*> need_feed_vars;
+  std::unordered_set<Node *> param_vars, output_vars;
   // the subgraph is independently, so here we only need link
   // to the node in new subgraph, and discard the link to
   // out-graph.
@@ -91,14 +173,35 @@ std::unique_ptr<Graph> CreateNewSubGraph(
     for (auto* var : op->inputs) {
       if (cluster_internals.count(var)) {
         old_op2new_op[op]->inputs.emplace_back(old_var2new_var[var]);
+      } else if (cluster_inputs.count(var)) {
+        if (var->Var()->IsParameter()) {
+          // Parameters have been preserved in scope, compared to feed var,
+          // param just need add new var and don't need add feed op.
+          // The var is used for check whether we need preserve the tensor
+          // when transform paddle scope to CINN scope.
+          param_vars.insert(var);
+        } else {
+          // When the var is subgraph input and the var is not parameter,
+          // we need add a new feed op to feed the var.
+          need_feed_vars.insert(var);
+        }
       }
     }
     for (auto* var : op->outputs) {
       if (cluster_internals.count(var)) {
         old_op2new_op[op]->outputs.emplace_back(old_var2new_var[var]);
+      } else {
+        // Create new output var node to guarantee the independency of
+        // subgraph. In other words, the subgraph has no connection with
+        // other graph, even the input graph.
+        output_vars.insert(var);
       }
     }
   }
+
+  AddFeedOpAndVar(need_feed_vars, cluster, old_op2new_op, sub_graph.get());
+  AddParamVar(param_vars, cluster, old_op2new_op, sub_graph.get());
+  AddOutputVar(param_vars, cluster, old_op2new_op, sub_graph.get());
 
   for (auto* var : cluster_internals) {
     for (auto* op : var->inputs) {
@@ -118,10 +221,12 @@ std::unique_ptr<Graph> CreateNewSubGraph(
 
 // This interface is used to classify all variables involved in a cluster into
 // three types: inputs, outputs, and internals.
-// Specially, the internal node is a node that only used by sub-graph, and
+// The input node is some subgraph op's input but not any subgraph op's output.
+// The output node is some subgraph op's output and some out-graph op's input.
+// Specially, the internal node is a node that only used by subgraph, and
 // out-graph should not using this node at all.
-// inputs & outputs & internals == NULL
-// inputs | outputs | internals == all graph node
+// cluster_inputs & cluster_outputs & cluster_internals == NULL
+// cluster_outputs | cluster_internals == all graph op's outputs node
 void AnalyseClusterVariables(const GraphNodeSet& cluster,
                              GraphNodeSet* cluster_inputs,
                              GraphNodeSet* cluster_outputs,
@@ -154,10 +259,6 @@ void AnalyseClusterVariables(const GraphNodeSet& cluster,
     }
   }
 
-  // if a output node also exists in input list, remove.
-  for (auto* var_node : *cluster_inputs) {
-    cluster_outputs->erase(var_node);
-  }
   // if a output node also exists in internal list, remove.
   for (auto* var_node : *cluster_internals) {
     cluster_outputs->erase(var_node);
@@ -206,14 +307,21 @@ void RemoveLinkFromCluster(const GraphNodeSet& cluster,
 
   // removing useless link from cluster_inputs to cluster
   for (auto* var_node : cluster_inputs) {
-    auto preserved_nodes = get_preserved_ops(var_node->outputs);
-    var_node->outputs.assign(preserved_nodes.begin(), preserved_nodes.end());
+    auto preserved_ops = get_preserved_ops(var_node->outputs);
+    var_node->outputs.assign(preserved_ops.begin(), preserved_ops.end());
+    // The cluster_inputs var nodes are not any subgraph op's output,
+    // so it's input op must be out-graph op.
   }
 
   // removing useless link from cluster to cluster_outputs
   for (auto* var_node : cluster_outputs) {
-    auto preserved_nodes = get_preserved_ops(var_node->inputs);
-    var_node->inputs.assign(preserved_nodes.begin(), preserved_nodes.end());
+    auto preserved_ops = get_preserved_ops(var_node->inputs);
+    var_node->inputs.assign(preserved_ops.begin(), preserved_ops.end());
+
+    // Note that cluster_outputs var node maybe some subgraph op's input,
+    // here we need remove them.
+    preserved_ops = get_preserved_ops(var_node->outputs);
+    var_node->outputs.assign(preserved_ops.begin(), preserved_ops.end());
   }
 }
 
@@ -272,7 +380,7 @@ void SearchAllSubgraphs(Graph* graph,
                             &cluster_internals);
 
     cinn_subgraphs->emplace_back(
-        CreateNewSubGraph(cluster_set, cluster_internals));
+        CreateNewSubGraph(cluster_set, cluster_internals, cluster_inputs));
 
     // replacing subgraph to a new special op node
     ReplaceSubGraphWithSpecialOpNode(cluster_set, cluster_inputs,

--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
@@ -201,7 +201,7 @@ std::unique_ptr<Graph> CreateNewSubGraph(const GraphNodeSet& cluster,
 
   AddFeedOpAndVar(need_feed_vars, cluster, old_op2new_op, sub_graph.get());
   AddParamVar(param_vars, cluster, old_op2new_op, sub_graph.get());
-  AddOutputVar(param_vars, cluster, old_op2new_op, sub_graph.get());
+  AddOutputVar(output_vars, cluster, old_op2new_op, sub_graph.get());
 
   for (auto* var : cluster_internals) {
     for (auto* op : var->inputs) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
如题， 基于 https://github.com/PaddlePaddle/Paddle/pull/36345 进一步优化`BuildCinnPass`生成的Cinn子图逻辑：

1. 对于非Parameter input，需要通过`feed` op来获取shape和dtype，因此需要额外添加一个`feed` node
2. 对于Parameter output，则是从`scope`中获取shape和dtype，无需增加一个`feed` node
3. 无论是input还是output，在子图中都需要新建一个node，以此来避免与其它图粘连，即保证子图是完全独立的

# 用例
其输入为一个`Graph`，输出为`std::vector<std::unique_ptr<Graph>>`，并通过`cinn_subgraphs`属性返回。

```
auto pass = paddle::framework::ir::PassRegistry::Instance().Get("build_cinn_pass");
std::vector<std::unique_ptr<Graph>> cinn_subgraphs;
pass->SetNotOwned<std::vector<std::unique_ptr<Graph>>>("cinn_subgraphs", &cinn_subgraphs);
pass->Apply(graph);
```
上述变量`cinn_subgraphs`即为我们筛选出的所有CINN支持的子图。

# 示例
详情示例请见单测文件：`build_cinn_pass_test.cc`， 具体而言，分为如下几种情况：

> 注：假定下述`var2`均为Parameter

## Graph中不含任何CINN支持的Op
  ```
  var1 --
         | --> fake1 --> var3 --> fake2 --> var4
  var2 --
  ```
  Pass前后Graph保持不变，且`cinn_subgraphs`为空。

## Graph由全为CINN支持的OP组成
```
v1 --
     | --> mul --> v3 --
v2 --                   | --> add --> v5 --> relu --> v6
                   v4 --
```
Pass后原Graph变为：
```
v1 --|
v2 --| --> kCinnLaunchOp --> v6
v4 --|
```
`cinn_subgraphs`包含一个子图，注意子图中的所有结点都是新创建的，并非原Graph的结点：
```
feed --> v1 --
              | --> mul --> v3 --
         v2 --                   | --> add --> v5 --> relu --> v6
                   feed --> v4 --
```

## Graph含一个CINN子图
```
fake1 --> v1 --
               | --> mul --> v3 --> relu --> v4 --> fake2
          v2 --
```
Pass后原Graph变为：
```
fake1 --> v1 --
               | --> kCinnLaunchOp --> v4 --> fake2
          v2 --
```
`cinn_subgraphs`包含一个子图，注意子图中的所有结点都是新创建的，并非原Graph的结点：
```
feed --> v1 --
              | --> mul --> v3 --> relu --> v4
         v2 --
```

## Graph包含多个分离的CINN子图
```
fake1 --> v1 --
               | --> mul --> v3 --> fake2 --> v4 --> relu --> v5 --> fake3
          v2 --
```
Pass后原Graph变为：
```
fake1 -> v1 -
             | -> CinnOp -> v3 -> fake2 -> v4 -> CinnOp ->v5 -> fake3
         v2 -
```
`cinn_subgraphs`包含2个单op子图，注意子图中的所有结点都是新创建的，并非原Graph的结点：
```
subgraph1:
feed --> v4 --> relu --> v5
subgraph2:
feed --> v1 --
              | --> mul --> v3
         v2 --
```
