### PR TITLE
[Dy2stat]remove no_value using var.name for ifelse

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -210,8 +210,7 @@ def convert_ifelse(pred, true_fn, false_fn, true_args, false_args, return_vars):
     else:
         out = _run_py_ifelse(pred, true_fn, false_fn, true_args, false_args)
 
-    out = _remove_no_value_return_var(out)
-    return out
+    return _remove_no_value_return_var(out)
 
 
 def _remove_no_value_return_var(out):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -20,6 +20,7 @@ from paddle.fluid.layers import array_length, array_read, array_write, create_ar
 from paddle.fluid.layers import assign, fill_constant, slice, reduce_all, reduce_any
 from paddle.fluid.layers import cast, control_flow, logical_and, logical_not, logical_or, nn
 from paddle.fluid.layers.control_flow import cond, while_loop, less_than, increment
+from paddle.fluid.dygraph.dygraph_to_static.return_transformer import RETURN_NO_VALUE_VAR_NAME
 
 
 def convert_while_loop(cond, body, loop_vars):
@@ -204,10 +205,46 @@ def convert_ifelse(pred, true_fn, false_fn, true_args, false_args, return_vars):
 
     """
     if isinstance(pred, Variable):
-        return _run_paddle_cond(pred, true_fn, false_fn, true_args, false_args,
-                                return_vars)
+        out = _run_paddle_cond(pred, true_fn, false_fn, true_args, false_args,
+                               return_vars)
     else:
-        return _run_py_ifelse(pred, true_fn, false_fn, true_args, false_args)
+        out = _run_py_ifelse(pred, true_fn, false_fn, true_args, false_args)
+
+    out = _remove_no_value_return_var(out)
+    return out
+
+
+def _remove_no_value_return_var(out):
+    if out and isinstance(out, tuple):
+        processed_out = out
+        align_ret = out[0]
+        if isinstance(align_ret, tuple):
+            for index, item in enumerate(align_ret):
+                if isinstance(item, Variable) and (
+                        RETURN_NO_VALUE_VAR_NAME in item.name):
+                    # return None
+                    if index == 0:
+                        processed_out = (None, ) + out[1:]
+                    elif index == 1:
+                        processed_out = align_ret[:1] + out[1:]
+                    else:
+                        processed_out = (align_ret[:index], ) + out[1:]
+                    break
+
+        for index, item in enumerate(processed_out):
+            if isinstance(item, Variable) and (
+                    RETURN_NO_VALUE_VAR_NAME in item.name):
+                processed_out = processed_out[:index]
+
+        if not processed_out:
+            return None
+        elif len(processed_out) == 1:
+            return processed_out[0]
+        else:
+            return processed_out
+
+    else:
+        return out
 
 
 def _run_paddle_cond(pred, true_fn, false_fn, true_args, false_args,

--- a/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
@@ -93,14 +93,14 @@ def create_fill_constant_node(name, value):
     func_code = "{} = paddle.fluid.layers.fill_constant(shape=[1], ".format(
         name)
     if isinstance(value, bool):
-        func_code += "dtype='bool', value={})".format(value)
+        func_code += "dtype='bool', value={}, name='{}')".format(value, name)
         return gast.parse(func_code).body[0]
     if isinstance(value, float):
-        func_code += "dtype='float64', value={})".format(value)
+        func_code += "dtype='float64', value={}, name='{}')".format(value, name)
         return gast.parse(func_code).body[0]
 
     if isinstance(value, int):
-        func_code += "dtype='int64', value={})".format(value)
+        func_code += "dtype='int64', value={}, name='{}')".format(value, name)
         return gast.parse(func_code).body[0]
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_operators.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_operators.py
@@ -276,7 +276,7 @@ class TestIfElseNoValue(unittest.TestCase):
                 z = x - 1
                 return None
 
-        out = func(input_x, True)
+        out = func(input_x, False)
         self.assertIsNone(out)
 
     def test_else_ret_c(self):
@@ -293,8 +293,8 @@ class TestIfElseNoValue(unittest.TestCase):
                 z = x - 1
                 return c
 
-        out = func(input_x, True)
-        self.assertEqual(out, input_x + 1)
+        out = func(input_x, False)
+        self.assertListEqual(paddle.tolist(out), paddle.tolist(input_x + 1))
 
     def test_else_ret_cz(self):
         input_x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
@@ -310,9 +310,9 @@ class TestIfElseNoValue(unittest.TestCase):
                 z = x - 1
                 return c, z
 
-        c, z = func(input_x, True)
-        self.assertEqual(c, input_x + 1)
-        self.assertEqual(z, input_x - 1)
+        c, z = func(input_x, False)
+        self.assertListEqual(paddle.tolist(c), paddle.tolist(input_x + 1))
+        self.assertListEqual(paddle.tolist(z), paddle.tolist(input_x - 1))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_operators.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_operators.py
@@ -261,5 +261,59 @@ class TestChooseShapeAttrOrApiWithLayer(unittest.TestCase):
         self.assertTrue(np.array_equal(out.numpy(), x.numpy()))
 
 
+class TestIfElseNoValue(unittest.TestCase):
+    def test_else_ret_none(self):
+        input_x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
+
+        @paddle.jit.to_static
+        def func(x, use_cache=False):
+            if use_cache:
+                y = x + 1
+                z = x + 2
+                return y, z
+            else:
+                c = x + 1
+                z = x - 1
+                return None
+
+        out = func(input_x, True)
+        self.assertIsNone(out)
+
+    def test_else_ret_c(self):
+        input_x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
+
+        @paddle.jit.to_static
+        def func(x, use_cache=False):
+            if use_cache:
+                y = x + 1
+                z = x + 2
+                return y, z
+            else:
+                c = x + 1
+                z = x - 1
+                return c
+
+        out = func(input_x, True)
+        self.assertEqual(out, input_x + 1)
+
+    def test_else_ret_cz(self):
+        input_x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
+
+        @paddle.jit.to_static
+        def func(x, use_cache=False):
+            if use_cache:
+                y = x + 1
+                z = x + 2
+                return y, z
+            else:
+                c = x + 1
+                z = x - 1
+                return c, z
+
+        c, z = func(input_x, True)
+        self.assertEqual(c, input_x + 1)
+        self.assertEqual(z, input_x - 1)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
@@ -64,7 +64,7 @@ def get_source_code(func):
 class StaticCode1():
     def dyfunc_with_if_else(x_v, label=None):
         __return_value_init_0 = paddle.fluid.layers.fill_constant(
-            shape=[1], dtype='float64', value=0.0)
+            shape=[1], dtype='float64', value=0.0, name='__return_value_init_0')
         __return_value_0 = __return_value_init_0
 
         def true_fn_0(x_v):
@@ -116,7 +116,7 @@ class StaticCode2():
     # TODO: Transform return statement
     def dyfunc_with_if_else(x_v, label=None):
         __return_value_init_1 = paddle.fluid.layers.fill_constant(
-            shape=[1], dtype='float64', value=0.0)
+            shape=[1], dtype='float64', value=0.0, name='__return_value_init_1')
         __return_value_1 = __return_value_init_1
 
         def true_fn_3(x_v):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_variable_trans_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_variable_trans_func.py
@@ -50,15 +50,15 @@ class TestDataLayerNotCheck(unittest.TestCase):
 class TestVariableTransFunc(unittest.TestCase):
     def test_create_fill_constant_node(self):
         node = create_fill_constant_node("a", 1.0)
-        source = "a = paddle.fluid.layers.fill_constant(shape=[1], dtype='float64', value=1.0)"
+        source = "a = paddle.fluid.layers.fill_constant(shape=[1], dtype='float64', value=1.0, name='a')"
         self.assertEqual(ast_to_source_code(node).strip(), source)
 
         node = create_fill_constant_node("b", True)
-        source = "b = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=True)"
+        source = "b = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=True, name='b')"
         self.assertEqual(ast_to_source_code(node).strip(), source)
 
         node = create_fill_constant_node("c", 4293)
-        source = "c = paddle.fluid.layers.fill_constant(shape=[1], dtype='int64', value=4293)"
+        source = "c = paddle.fluid.layers.fill_constant(shape=[1], dtype='int64', value=4293, name='c')"
         self.assertEqual(ast_to_source_code(node).strip(), source)
 
         self.assertIsNone(create_fill_constant_node("e", None))

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_variable_trans_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_variable_trans_func.py
@@ -51,15 +51,21 @@ class TestVariableTransFunc(unittest.TestCase):
     def test_create_fill_constant_node(self):
         node = create_fill_constant_node("a", 1.0)
         source = "a = paddle.fluid.layers.fill_constant(shape=[1], dtype='float64', value=1.0, name='a')"
-        self.assertEqual(ast_to_source_code(node).strip(), source)
+        self.assertEqual(
+            ast_to_source_code(node).replace('\n', '').replace(' ', ''),
+            source.replace(' ', ''))
 
         node = create_fill_constant_node("b", True)
         source = "b = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=True, name='b')"
-        self.assertEqual(ast_to_source_code(node).strip(), source)
+        self.assertEqual(
+            ast_to_source_code(node).replace('\n', '').replace(' ', ''),
+            source.replace(' ', ''))
 
         node = create_fill_constant_node("c", 4293)
         source = "c = paddle.fluid.layers.fill_constant(shape=[1], dtype='int64', value=4293, name='c')"
-        self.assertEqual(ast_to_source_code(node).strip(), source)
+        self.assertEqual(
+            ast_to_source_code(node).replace('\n', '').replace(' ', ''),
+            source.replace(' ', ''))
 
         self.assertIsNone(create_fill_constant_node("e", None))
         self.assertIsNone(create_fill_constant_node("e", []))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
使用下面代码对返回结果进行讨论，if分支中有两个变量y, z，else分支中有两个变量c, z
```python
import paddle
paddle.set_device('cpu')
def func(x, use_cache=False):
    if use_cache:
        y = x + 1
        z = x + 2
        return y,z
    else:
        c = x + 1
        z = x - 1
        # c = x - 1
        # d = x - 1
        # return c, z
        return c
        # return None
@paddle.jit.to_static
def run(x):
    out = func(x)
    # import pdb; pdb.set_trace()
    return out
x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
out = run(x)
print(run.code)
print(out)
print(type(out))
```
对于两个分支的ifelse，可以分为两种情况，一：两个分支有共有变量，二：两个分支无共有变量。下面的讨论中，else分支返回结果是指的动转静后静态图代码return语句的返回结果。

1 两个分支有共有变量，即else分支中有z变量

- else分支没有return语句， else分支返回结果return z

- else分支中return None，else分支返回结果((no_val_0, no_val_1), z)

- else分支有return语句 return c，else分支返回结果((c, no_val_0), z)

- else分支有return语句 return z， else分支返回结果((z, no_val_0), z)

- else分支有return语句 return c, z，else分支返回结果((c, z), z)

2 两个分支无共有变量，即else分支无z变量

- else分支没有return语句，else分支最后只有return，没有返回变量

- else分支return None，else分支返回结果(no_val_0, no_val_1)

- else分支return c，else分支返回结果(c, no_val_0)

- else分支return c, d，else分支返回结果(c, d)

上面的情况需要考虑，删除用于填充的no_val

NOTE：动转静转写时ifelse中对于`reutnr (a, b)`和`return [a, b]`动转静处理不同，tuple会被视为为两个变量；list被视为一个变量。