### PR TITLE
[Cherry-pick][Dy2stat]remove no_value using var.name for ifelse (#36513)

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
@@ -93,14 +93,14 @@ def create_fill_constant_node(name, value):
     func_code = "{} = paddle.fluid.layers.fill_constant(shape=[1], ".format(
         name)
     if isinstance(value, bool):
-        func_code += "dtype='bool', value={})".format(value)
+        func_code += "dtype='bool', value={}, name='{}')".format(value, name)
         return gast.parse(func_code).body[0]
     if isinstance(value, float):
-        func_code += "dtype='float64', value={})".format(value)
+        func_code += "dtype='float64', value={}, name='{}')".format(value, name)
         return gast.parse(func_code).body[0]
 
     if isinstance(value, int):
-        func_code += "dtype='int64', value={})".format(value)
+        func_code += "dtype='int64', value={}, name='{}')".format(value, name)
         return gast.parse(func_code).body[0]
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
@@ -64,7 +64,7 @@ def get_source_code(func):
 class StaticCode1():
     def dyfunc_with_if_else(x_v, label=None):
         __return_value_init_0 = paddle.fluid.layers.fill_constant(
-            shape=[1], dtype='float64', value=0.0)
+            shape=[1], dtype='float64', value=0.0, name='__return_value_init_0')
         __return_value_0 = __return_value_init_0
 
         def true_fn_0(x_v):
@@ -116,7 +116,7 @@ class StaticCode2():
     # TODO: Transform return statement
     def dyfunc_with_if_else(x_v, label=None):
         __return_value_init_1 = paddle.fluid.layers.fill_constant(
-            shape=[1], dtype='float64', value=0.0)
+            shape=[1], dtype='float64', value=0.0, name='__return_value_init_1')
         __return_value_1 = __return_value_init_1
 
         def true_fn_3(x_v):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_variable_trans_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_variable_trans_func.py
@@ -50,16 +50,22 @@ class TestDataLayerNotCheck(unittest.TestCase):
 class TestVariableTransFunc(unittest.TestCase):
     def test_create_fill_constant_node(self):
         node = create_fill_constant_node("a", 1.0)
-        source = "a = paddle.fluid.layers.fill_constant(shape=[1], dtype='float64', value=1.0)"
-        self.assertEqual(ast_to_source_code(node).strip(), source)
+        source = "a = paddle.fluid.layers.fill_constant(shape=[1], dtype='float64', value=1.0, name='a')"
+        self.assertEqual(
+            ast_to_source_code(node).replace('\n', '').replace(' ', ''),
+            source.replace(' ', ''))
 
         node = create_fill_constant_node("b", True)
-        source = "b = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=True)"
-        self.assertEqual(ast_to_source_code(node).strip(), source)
+        source = "b = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=True, name='b')"
+        self.assertEqual(
+            ast_to_source_code(node).replace('\n', '').replace(' ', ''),
+            source.replace(' ', ''))
 
         node = create_fill_constant_node("c", 4293)
-        source = "c = paddle.fluid.layers.fill_constant(shape=[1], dtype='int64', value=4293)"
-        self.assertEqual(ast_to_source_code(node).strip(), source)
+        source = "c = paddle.fluid.layers.fill_constant(shape=[1], dtype='int64', value=4293, name='c')"
+        self.assertEqual(
+            ast_to_source_code(node).replace('\n', '').replace(' ', ''),
+            source.replace(' ', ''))
 
         self.assertIsNone(create_fill_constant_node("e", None))
         self.assertIsNone(create_fill_constant_node("e", []))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
使用下面代码对返回结果进行讨论，if分支中有两个变量y, z，else分支中有两个变量c, z。
```python
import paddle
paddle.set_device('cpu')
def func(x, use_cache=False):
    if use_cache:
        y = x + 1
        z = x + 2
        return [y,z]
    else:
        c = x + 1
        z = x - 1
        # c = x - 1
        # d = x - 1
        # return c, z
        return c
        # return None
@paddle.jit.to_static
def run(x):
    out = func(x)
    # import pdb; pdb.set_trace()
    return out
x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
out = run(x)
print(run.code)
print(out)
print(type(out))
```
对于两个分支的ifelse，可以分为两种情况，一：两个分支有共有变量，二：两个分支无共有变量。下面的讨论中，else分支返回结果是指的动转静后静态图代码return语句的返回结果。

1 两个分支有共有变量，即else分支中有z变量

- else分支没有return语句， else分支返回结果return z

- else分支中return None，else分支返回结果((no_val_0, no_val_1), z)

- else分支有return语句 return c，else分支返回结果((c, no_val_0), z)

- else分支有return语句 return z， else分支返回结果((z, no_val_0), z)

- else分支有return语句 return c, z，else分支返回结果((c, z), z)

2 两个分支无共有变量，即else分支无z变量

- else分支没有return语句，else分支最后只有return，没有返回变量

- else分支return None，else分支返回结果(no_val_0, no_val_1)

- else分支return c，else分支返回结果(c, no_val_0)

- else分支return c, d，else分支返回结果(c, d)

上面的情况需要考虑，删除用于填充的no_val