### PR TITLE
Support No DataTransform From GetKernelTypeForVar

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -118,6 +118,8 @@ void InterpreterCore::Convert() {
     temp_inst.input_index_ = vec_func_list_[i].input_index;
     temp_inst.output_index_ = vec_func_list_[i].output_index;
     temp_inst.type_ = vec_func_list_[i].type_;
+    temp_inst.no_data_transform_index_ =
+        vec_func_list_[i].no_data_transform_index;
 
     OpInOutInfo info;
 

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -511,6 +511,8 @@ struct Instruction {
   std::map<std::string, std::vector<int>> input_index_;
   std::map<std::string, std::vector<int>> output_index_;
 
+  std::unordered_set<int> no_data_transform_index_;
+
   std::vector<size_t> gc_check_var_list;
   NextInstruction next_instruction_;
 
@@ -527,6 +529,7 @@ struct OpFuncNode {
   // int unsed;
   std::map<std::string, std::vector<int>> input_index;
   std::map<std::string, std::vector<int>> output_index;
+  std::unordered_set<int> no_data_transform_index;
 
   OpKernelComputeFunc kernel_func_;
   platform::DeviceContext* dev_ctx_;  // not owned

--- a/paddle/fluid/framework/new_executor/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.cc
@@ -38,7 +38,8 @@ std::vector<size_t> StreamAnalyzer::ParseEventVarIds(
   std::vector<size_t> new_event_var_ids;
   for (auto& item : next_instr.input_index_) {
     for (auto var_id : item.second) {
-      if (unique_var_ids.count(var_id) > 0) {
+      if (unique_var_ids.count(var_id) > 0 &&
+          next_instr.no_data_transform_index_.count(var_id) == 0) {
         new_event_var_ids.push_back(var_id);
       }
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Support No DataTransform From GetKernelTypeForVar

框架存在部分Op（如range、fill_constant、slice等）的一些输入是不需要进行DataTransform的，即GetKernelTypeForVar总是返回ExpectedKernelType。对于此类的Tensor，是不需要关联一个跨Stream的Event的，也需要进行Event->Record()