### PR TITLE
fix hdfs download_dir

### DIFF
--- a/python/paddle/distributed/fleet/utils/fs.py
+++ b/python/paddle/distributed/fleet/utils/fs.py
@@ -842,8 +842,8 @@ class HDFSClient(FS):
         if self.is_file(fs_path):
             return self._try_download(fs_path, local_path)
         # download dir
-        _, all_files = self.ls_dir(fs_path)
-
+        _, all_filenames = self.ls_dir(fs_path)
+        all_files = [fs_path + i for i in all_filenames]
         procs = []
         for i in range(multi_processes):
             process_datas = self._split_files(all_files, i, multi_processes)

--- a/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
+++ b/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
@@ -128,6 +128,25 @@ class FSTestBase(unittest.TestCase):
         fs.delete(dst_file)
         local.delete(src_file)
 
+    def _test_download_dir(self, fs):
+        # upload dir
+        src_file = os.path.abspath("./fs_download_dir")
+        dst_file = os.path.abspath("./local_download_dir")
+        file1 = os.path.abspath("./fs_download_dir/file1")
+        file2 = os.path.abspath("./fs_download_dir/file2")
+
+        local = LocalFS()
+        local.mkdirs(src_file)
+        fs.mkdirs(src_file)
+        fs.touch(file1)
+        fs.touch(file2)
+
+        fs.download(src_file, dst_file)
+
+        self.assertTrue(local.is_exist(file1))
+        fs.delete(src_file)
+        local.delete(dst_file)
+
     def _test_try_download(self, fs):
         src_file = os.path.abspath("./test_try_download.src")
         dst_file = os.path.abspath("./test_try_download.dst")

--- a/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
+++ b/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
@@ -128,25 +128,6 @@ class FSTestBase(unittest.TestCase):
         fs.delete(dst_file)
         local.delete(src_file)
 
-    def _test_download_dir(self, fs):
-        # upload dir
-        src_file = os.path.abspath("./fs_download_dir")
-        dst_file = os.path.abspath("./local_download_dir")
-        file1 = os.path.abspath("./fs_download_dir/file1")
-        file2 = os.path.abspath("./fs_download_dir/file2")
-
-        local = LocalFS()
-        local.mkdirs(src_file)
-        fs.mkdirs(src_file)
-        fs.touch(file1)
-        fs.touch(file2)
-
-        fs.download(src_file, dst_file)
-
-        self.assertTrue(local.is_exist(file1))
-        fs.delete(src_file)
-        local.delete(dst_file)
-
     def _test_try_download(self, fs):
         src_file = os.path.abspath("./test_try_download.src")
         dst_file = os.path.abspath("./test_try_download.dst")
@@ -214,7 +195,7 @@ class FSTestBase(unittest.TestCase):
 
         fs.download(src_file, dst_file)
         local = LocalFS()
-        self.assertTrue(local.is_exist(dst_file))
+        self.assertTrue(local.is_exist(file1))
         local.delete(dst_file)
         fs.delete(src_file)
 

--- a/python/paddle/fluid/tests/unittests/test_hdfs3.py
+++ b/python/paddle/fluid/tests/unittests/test_hdfs3.py
@@ -35,6 +35,7 @@ class FSTest3(FSTestBase):
         self._test_mkdirs(fs)
         self._test_list_dir(fs)
         self._test_try_upload(fs)
+        self._test_download_dir(fs)
         self._test_try_download(fs)
 
         self._test_upload(fs)

--- a/python/paddle/fluid/tests/unittests/test_hdfs3.py
+++ b/python/paddle/fluid/tests/unittests/test_hdfs3.py
@@ -35,12 +35,12 @@ class FSTest3(FSTestBase):
         self._test_mkdirs(fs)
         self._test_list_dir(fs)
         self._test_try_upload(fs)
-        self._test_download_dir(fs)
         self._test_try_download(fs)
 
         self._test_upload(fs)
         self._test_upload_dir(fs)
         self._test_download(fs)
+        self._test_download_dir(fs)
 
     def test_local(self):
         fs = LocalFS()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix hdfs download dir：`ls_dir` only get filename without whole path