### PR TITLE
[Paddle-Inference]Add MatmulV2ToMatmul convert Pass, fix (matmul_v2, matmul, mul) convert pass, fix (matmul, mul) op_teller

### DIFF
--- a/paddle/fluid/framework/ir/delete_quant_dequant_filter_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_quant_dequant_filter_op_pass.cc
@@ -181,7 +181,7 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
                               "Weight scale should be nonzero, but get zero."));
         weight_scale[i] = weight_scale[i] / range;
       }
-    } else {
+    } else if (dequant_type == "fake_quantize_dequantize_abs_max") {
       // Implement quantize_dequantize_abs_max quantization algorithm
       float abs_max_weight = 0.;
       for (int j = 0; j < weight_tensor->numel(); j++) {
@@ -192,6 +192,9 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
                         platform::errors::InvalidArgument(
                             "Weight scale should be nonzero, but get zero"));
       weight_scale.push_back(abs_max_weight / range);
+    } else {
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "Unsupported quantize_dequantize op type: %s", dequant_type));
     }
 
     nodes2rm.insert(quant_dequant_op_outscale);

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1606,6 +1606,7 @@ PDNode *patterns::Matmul::operator()() {
                          ->assert_is_op_input("matmul", "X");
   auto matmul_in_y = pattern->NewNode(matmul_in_y_repr())
                          ->AsInput()
+                         ->assert_is_persistable_var()
                          ->assert_is_op_input("matmul", "Y");
   auto matmul_out = pattern->NewNode(matmul_out_repr())
                         ->AsOutput()
@@ -1616,22 +1617,21 @@ PDNode *patterns::Matmul::operator()() {
 }
 
 PDNode *patterns::MatmulV2::operator()() {
-  auto matmul_op =
-      pattern->NewNode(matmul_op_repr())->assert_is_op("matmul_v2");
+  auto matmul_v2_op =
+      pattern->NewNode(matmul_v2_op_repr())->assert_is_op("matmul_v2");
 
-  auto matmul_in_x = pattern->NewNode(matmul_in_x_repr())
+  auto matmul_v2_in_x = pattern->NewNode(matmul_v2_in_x_repr())
                          ->AsInput()
                          ->assert_is_op_input("matmul_v2", "X");
-  auto matmul_in_y = pattern->NewNode(matmul_in_y_repr())
-                         ->assert_is_persistable_var()
+  auto matmul_v2_in_y = pattern->NewNode(matmul_v2_in_y_repr())
                          ->AsInput()
                          ->assert_is_op_input("matmul_v2", "Y");
-  auto matmul_out = pattern->NewNode(matmul_out_repr())
+  auto matmul_v2_out = pattern->NewNode(matmul_v2_out_repr())
                         ->AsOutput()
                         ->assert_is_op_output("matmul_v2", "Out");
 
-  matmul_op->LinksFrom({matmul_in_x, matmul_in_y}).LinksTo({matmul_out});
-  return matmul_out;
+  matmul_v2_op->LinksFrom({matmul_v2_in_x, matmul_v2_in_y}).LinksTo({matmul_v2_out});
+  return matmul_v2_out;
 }
 
 PDNode *patterns::Squeeze2Matmul::operator()() {

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -983,10 +983,10 @@ struct MatmulV2 : public PatternBase {
       : PatternBase(pattern, name_scope, "matmul_v2") {}
 
   PDNode* operator()();
-  PATTERN_DECL_NODE(matmul_in_x);
-  PATTERN_DECL_NODE(matmul_in_y);
-  PATTERN_DECL_NODE(matmul_op);
-  PATTERN_DECL_NODE(matmul_out);
+  PATTERN_DECL_NODE(matmul_v2_in_x);
+  PATTERN_DECL_NODE(matmul_v2_in_y);
+  PATTERN_DECL_NODE(matmul_v2_op);
+  PATTERN_DECL_NODE(matmul_v2_out);
 };
 
 // Squeeze2 + Matmul

--- a/paddle/fluid/framework/ir/map_matmul_to_mul_pass.cc
+++ b/paddle/fluid/framework/ir/map_matmul_to_mul_pass.cc
@@ -307,8 +307,8 @@ void MapMatmulV2ToMatmulPass::ApplyImpl(ir::Graph* graph) const {
     desc.SetInput("X", {matmul_v2_in_x->Name()});
     desc.SetInput("Y", {matmul_v2_in_y->Name()});
     desc.SetOutput("Out", {matmul_v2_out->Name()});
-    desc.SetAttr("transpose_X", matmul_v2_op->Op()->GetAttr("transpose_X"));
-    desc.SetAttr("transpose_Y", matmul_v2_op->Op()->GetAttr("transpose_Y"));
+    desc.SetAttr("transpose_X", matmul_v2_op->Op()->GetAttr("trans_x"));
+    desc.SetAttr("transpose_Y", matmul_v2_op->Op()->GetAttr("trans_y"));
     if (matmul_v2_op->Op()->HasAttr("enable_int8")) {
       desc.SetAttr("enable_int8", matmul_v2_op->Op()->GetAttr("enable_int8"));
       desc.SetAttr("X_scale", matmul_v2_op->Op()->GetAttr("X_scale"));

--- a/paddle/fluid/framework/ir/map_matmul_to_mul_pass.cc
+++ b/paddle/fluid/framework/ir/map_matmul_to_mul_pass.cc
@@ -42,6 +42,7 @@ MapMatmul2MulPass::MapMatmul2MulPass() {
       .AddAttr("alpha")
       .IsNumGE(0.99f)
       .IsNumLE(1.01f)
+      .IsOptional()
       .End()
       .AddAttr("transpose_X")
       .IsBoolEQ(false)
@@ -68,7 +69,7 @@ MapMatmul2MulPass::MapMatmul2MulPass() {
       .End();
 }
 
-MapMatmulv2ToMulPass::MapMatmulv2ToMulPass() {
+MapMatmulV2ToMatmulPass::MapMatmulV2ToMatmulPass() {
   AddOpCompat(OpCompat("matmul_v2"))
       .AddInput("X")
       .IsTensor()
@@ -79,14 +80,8 @@ MapMatmulv2ToMulPass::MapMatmulv2ToMulPass() {
       .AddOutput("Out")
       .IsTensor()
       .End()
-      .AddAttr("trans_x")
-      .IsBoolEQ(false)
-      .End()
-      .AddAttr("trans_y")
-      .IsBoolEQ(false)
-      .End();
 
-  AddOpCompat(OpCompat("mul"))
+  AddOpCompat(OpCompat("matmul"))
       .AddInput("X")
       .IsTensor()
       .End()
@@ -96,12 +91,6 @@ MapMatmulv2ToMulPass::MapMatmulv2ToMulPass() {
       .AddOutput("Out")
       .IsTensor()
       .End()
-      .AddAttr("x_num_col_dims")
-      .IsNumGE(1)
-      .End()
-      .AddAttr("y_num_col_dims")
-      .IsNumEQ(1)
-      .End();
 }
 
 Flatten2MatmulFusePass::Flatten2MatmulFusePass() {
@@ -239,22 +228,21 @@ void MapMatmul2MulPass::ApplyImpl(ir::Graph* graph) const {
         BOOST_GET_CONST(bool, matmul_op->Op()->GetAttr("transpose_X"));
     bool transpose_Y =
         BOOST_GET_CONST(bool, matmul_op->Op()->GetAttr("transpose_Y"));
-    float alpha = BOOST_GET_CONST(float, matmul_op->Op()->GetAttr("alpha"));
+    float alpha = 1;
+    if (matmul_op->Op()->HasAttr("alpha")) {
+      alpha = BOOST_GET_CONST(float, matmul_op->Op()->GetAttr("alpha"));
+    }
     flag = flag && !transpose_X && !transpose_Y && std::abs(alpha - 1.0) < 1e-5;
 
     std::vector<int64_t> x_shape = matmul_in_x->Var()->GetShape();
     std::vector<int64_t> y_shape = matmul_in_y->Var()->GetShape();
     size_t x_rank = x_shape.size();
     size_t y_rank = y_shape.size();
-    flag = flag && (x_rank == 2 || x_rank == 3) && y_rank == 2;
-
-    std::vector<Node*>& next_ops = matmul_out->outputs;
-    flag = flag && next_ops.size() == 1 &&
-           next_ops[0]->Name() == "elementwise_add";
+    flag = flag && x_rank >= 2 && y_rank == 2;
 
     if (flag) {
       if (!IsCompat(subgraph, g)) {
-        LOG(WARNING) << "Pass in op compat failed.";
+        LOG(WARNING) << "MapMatmul2MulPass in op compat failed.";
         return;
       }
       OpDesc desc(matmul_op->Op()->Block());
@@ -268,6 +256,7 @@ void MapMatmul2MulPass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
+        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
       }
       auto mul_node = g->CreateOpNode(&desc);
       IR_NODE_LINK_TO(matmul_in_x, mul_node);
@@ -287,68 +276,52 @@ void MapMatmul2MulPass::ApplyImpl(ir::Graph* graph) const {
   AddStatis(found_count);
 }
 
-void MapMatmulv2ToMulPass::ApplyImpl(ir::Graph* graph) const {
+void MapMatmulV2ToMatmulPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph, platform::errors::InvalidArgument("Graph cannot be nullptr."));
-  std::string name_scope = "map_matmul_v2_to_mul_pass";
+  std::string name_scope = "map_matmul_v2_to_matmul_pass";
   FusePassBase::Init(name_scope, graph);
 
   GraphPatternDetector gpd;
-  patterns::MatmulV2 matmul_pattern(gpd.mutable_pattern(), name_scope);
-  matmul_pattern();
+  patterns::MatmulV2 matmul_v2_pattern(gpd.mutable_pattern(), name_scope);
+  matmul_v2_pattern();
 
   int found_count = 0;
   auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
                      Graph* g) {
-    VLOG(4) << "map matmul_v2 to mul";
-    GET_IR_NODE_FROM_SUBGRAPH(matmul_in_x, matmul_in_x, matmul_pattern);
-    GET_IR_NODE_FROM_SUBGRAPH(matmul_in_y, matmul_in_y, matmul_pattern);
-    GET_IR_NODE_FROM_SUBGRAPH(matmul_op, matmul_op, matmul_pattern);
-    GET_IR_NODE_FROM_SUBGRAPH(matmul_out, matmul_out, matmul_pattern);
-    bool flag = true;
+    VLOG(4) << "map matmul_v2 to matmul";
+    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_in_x, matmul_v2_in_x, matmul_v2_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_in_y, matmul_v2_in_y, matmul_v2_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_op, matmul_v2_op, matmul_v2_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_out, matmul_v2_out, matmul_v2_pattern);
 
-    bool trans_x = BOOST_GET_CONST(bool, matmul_op->Op()->GetAttr("trans_x"));
-    bool trans_y = BOOST_GET_CONST(bool, matmul_op->Op()->GetAttr("trans_y"));
-    flag = flag && !trans_x && !trans_y;
+    if (!IsCompat(subgraph, g)) {
+      LOG(WARNING) << "MapMatmulV2ToMatmulPass in op compat failed.";
+      return;
+    }
+    OpDesc desc(matmul_v2_op->Op()->Block());
+    desc.SetType("matmul");
+    desc.SetInput("X", {matmul_v2_in_x->Name()});
+    desc.SetInput("Y", {matmul_v2_in_y->Name()});
+    desc.SetOutput("Out", {matmul_v2_out->Name()});
+    desc.SetAttr("transpose_X", matmul_v2_op->Op()->GetAttr("transpose_X"));
+    desc.SetAttr("transpose_Y", matmul_v2_op->Op()->GetAttr("transpose_Y"));
+    if (matmul_v2_op->Op()->HasAttr("enable_int8")) {
+      desc.SetAttr("enable_int8", matmul_v2_op->Op()->GetAttr("enable_int8"));
+      desc.SetAttr("X_scale", matmul_v2_op->Op()->GetAttr("X_scale"));
+      desc.SetAttr("weight_scale", matmul_v2_op->Op()->GetAttr("weight_scale"));
+      desc.SetAttr("out_threshold", matmul_v2_op->Op()->GetAttr("out_threshold"));
+    }
+    auto matmul_node = g->CreateOpNode(&desc);
+    IR_NODE_LINK_TO(matmul_v2_in_x, matmul_node);
+    IR_NODE_LINK_TO(matmul_v2_in_y, matmul_node);
+    IR_NODE_LINK_TO(matmul_node, matmul_v2_out);
+    GraphSafeRemoveNodes(graph, {matmul_v2_op});
+    ++found_count;
 
-    std::vector<int64_t> x_shape = matmul_in_x->Var()->GetShape();
-    std::vector<int64_t> y_shape = matmul_in_y->Var()->GetShape();
-    size_t x_rank = x_shape.size();
-    size_t y_rank = y_shape.size();
-    flag = flag && (x_rank == 2 || x_rank == 3) && y_rank == 2;
-
-    std::vector<Node*>& next_ops = matmul_out->outputs;
-    flag = flag && next_ops.size() == 1 &&
-           next_ops[0]->Name() == "elementwise_add";
-
-    if (flag) {
-      if (!IsCompat(subgraph, g)) {
-        LOG(WARNING) << "Pass in op compat failed.";
-        return;
-      }
-      OpDesc desc(matmul_op->Op()->Block());
-      desc.SetType("mul");
-      desc.SetInput("X", {matmul_in_x->Name()});
-      desc.SetInput("Y", {matmul_in_y->Name()});
-      desc.SetOutput("Out", {matmul_out->Name()});
-      desc.SetAttr("x_num_col_dims", static_cast<int>(x_rank - 1));
-      desc.SetAttr("y_num_col_dims", 1);
-      if (matmul_op->Op()->HasAttr("enable_int8")) {
-        desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
-        desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
-        desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
-      }
-      auto mul_node = g->CreateOpNode(&desc);
-      IR_NODE_LINK_TO(matmul_in_x, mul_node);
-      IR_NODE_LINK_TO(matmul_in_y, mul_node);
-      IR_NODE_LINK_TO(mul_node, matmul_out);
-      GraphSafeRemoveNodes(graph, {matmul_op});
-      ++found_count;
-
-      if (!IsCompat(desc)) {
-        LOG(WARNING) << "MapMatmulv2ToMulPass in out mul op compat failed.";
-        return;
-      }
+    if (!IsCompat(desc)) {
+      LOG(WARNING) << "MapMatmulV2ToMatmulPass in out matmul op compat failed.";
+      return;
     }
   };
 
@@ -402,7 +375,7 @@ void Squeeze2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
 
     if (flag) {
       if (!IsCompat(subgraph, g)) {
-        LOG(WARNING) << "Pass in op compat failed.";
+        LOG(WARNING) << "Squeeze2MatmulFusePass in op compat failed.";
         return;
       }
       OpDesc desc(matmul_op->Op()->Block());
@@ -416,6 +389,7 @@ void Squeeze2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
+        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
       }
       auto mul_node = g->CreateOpNode(&desc);
       IR_NODE_LINK_TO(squeeze2_in_x, mul_node);
@@ -544,7 +518,7 @@ void Reshape2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
 
     if (flag) {
       if (!IsCompat(subgraph, g)) {
-        LOG(WARNING) << "Pass in op compat failed.";
+        LOG(WARNING) << "Reshape2MatmulFusePass in op compat failed.";
         return;
       }
       OpDesc desc(matmul_op->Op()->Block());
@@ -558,9 +532,10 @@ void Reshape2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
+        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
       }
       if (!IsCompat(desc)) {
-        LOG(WARNING) << "reshape2 matmul pass in out mul op compat failed.";
+        LOG(WARNING) << "Reshape2MatmulFusePass in out mul op compat failed.";
         return;
       }
       auto mul_node = g->CreateOpNode(&desc);
@@ -629,7 +604,7 @@ void Flatten2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
 
     if (pattern_found) {
       if (!IsCompat(subgraph, g)) {
-        LOG(WARNING) << "Pass in op compat failed.";
+        LOG(WARNING) << "Flatten2MatmulFusePass in op compat failed.";
         return;
       }
       OpDesc desc(matmul_op->Op()->Block());
@@ -643,6 +618,7 @@ void Flatten2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
+        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
       }
       auto mul_node = g->CreateOpNode(&desc);
       IR_NODE_LINK_TO(flatten2_in_x, mul_node);
@@ -673,13 +649,13 @@ REGISTER_PASS_CAPABILITY(map_matmul_to_mul_pass)
             .LE("matmul", 1)
             .EQ("mul", 0));
 
-REGISTER_PASS(map_matmul_v2_to_mul_pass,
-              paddle::framework::ir::MapMatmulv2ToMulPass);
-REGISTER_PASS_CAPABILITY(map_matmul_v2_to_mul_pass)
+REGISTER_PASS(map_matmul_v2_to_matmul_pass,
+              paddle::framework::ir::MapMatmulV2ToMatmulPass);
+REGISTER_PASS_CAPABILITY(map_matmul_v2_to_matmul_pass)
     .AddCombination(
         paddle::framework::compatible::OpVersionComparatorCombination()
             .EQ("matmul_v2", 0)
-            .EQ("mul", 0));
+            .GE("matmul", 0));
 
 REGISTER_PASS(squeeze2_matmul_fuse_pass,
               paddle::framework::ir::Squeeze2MatmulFusePass);

--- a/paddle/fluid/framework/ir/map_matmul_to_mul_pass.cc
+++ b/paddle/fluid/framework/ir/map_matmul_to_mul_pass.cc
@@ -79,7 +79,7 @@ MapMatmulV2ToMatmulPass::MapMatmulV2ToMatmulPass() {
       .End()
       .AddOutput("Out")
       .IsTensor()
-      .End()
+      .End();
 
   AddOpCompat(OpCompat("matmul"))
       .AddInput("X")
@@ -90,7 +90,7 @@ MapMatmulV2ToMatmulPass::MapMatmulV2ToMatmulPass() {
       .End()
       .AddOutput("Out")
       .IsTensor()
-      .End()
+      .End();
 }
 
 Flatten2MatmulFusePass::Flatten2MatmulFusePass() {
@@ -256,7 +256,8 @@ void MapMatmul2MulPass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
-        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
+        desc.SetAttr("out_threshold",
+                     matmul_op->Op()->GetAttr("out_threshold"));
       }
       auto mul_node = g->CreateOpNode(&desc);
       IR_NODE_LINK_TO(matmul_in_x, mul_node);
@@ -290,8 +291,10 @@ void MapMatmulV2ToMatmulPass::ApplyImpl(ir::Graph* graph) const {
   auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
                      Graph* g) {
     VLOG(4) << "map matmul_v2 to matmul";
-    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_in_x, matmul_v2_in_x, matmul_v2_pattern);
-    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_in_y, matmul_v2_in_y, matmul_v2_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_in_x, matmul_v2_in_x,
+                              matmul_v2_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_in_y, matmul_v2_in_y,
+                              matmul_v2_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_op, matmul_v2_op, matmul_v2_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(matmul_v2_out, matmul_v2_out, matmul_v2_pattern);
 
@@ -310,7 +313,8 @@ void MapMatmulV2ToMatmulPass::ApplyImpl(ir::Graph* graph) const {
       desc.SetAttr("enable_int8", matmul_v2_op->Op()->GetAttr("enable_int8"));
       desc.SetAttr("X_scale", matmul_v2_op->Op()->GetAttr("X_scale"));
       desc.SetAttr("weight_scale", matmul_v2_op->Op()->GetAttr("weight_scale"));
-      desc.SetAttr("out_threshold", matmul_v2_op->Op()->GetAttr("out_threshold"));
+      desc.SetAttr("out_threshold",
+                   matmul_v2_op->Op()->GetAttr("out_threshold"));
     }
     auto matmul_node = g->CreateOpNode(&desc);
     IR_NODE_LINK_TO(matmul_v2_in_x, matmul_node);
@@ -389,7 +393,8 @@ void Squeeze2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
-        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
+        desc.SetAttr("out_threshold",
+                     matmul_op->Op()->GetAttr("out_threshold"));
       }
       auto mul_node = g->CreateOpNode(&desc);
       IR_NODE_LINK_TO(squeeze2_in_x, mul_node);
@@ -532,7 +537,8 @@ void Reshape2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
-        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
+        desc.SetAttr("out_threshold",
+                     matmul_op->Op()->GetAttr("out_threshold"));
       }
       if (!IsCompat(desc)) {
         LOG(WARNING) << "Reshape2MatmulFusePass in out mul op compat failed.";
@@ -618,7 +624,8 @@ void Flatten2MatmulFusePass::ApplyImpl(ir::Graph* graph) const {
         desc.SetAttr("enable_int8", matmul_op->Op()->GetAttr("enable_int8"));
         desc.SetAttr("X_scale", matmul_op->Op()->GetAttr("X_scale"));
         desc.SetAttr("weight_scale", matmul_op->Op()->GetAttr("weight_scale"));
-        desc.SetAttr("out_threshold", matmul_op->Op()->GetAttr("out_threshold"));
+        desc.SetAttr("out_threshold",
+                     matmul_op->Op()->GetAttr("out_threshold"));
       }
       auto mul_node = g->CreateOpNode(&desc);
       IR_NODE_LINK_TO(flatten2_in_x, mul_node);

--- a/paddle/fluid/framework/ir/map_matmul_to_mul_pass.h
+++ b/paddle/fluid/framework/ir/map_matmul_to_mul_pass.h
@@ -47,12 +47,12 @@ class MapMatmul2MulPass : public FusePassBase {
 };
 
 /*
- * Map matmul_v2 to mul, the same as MapMatmul2MulPass.
+ * Map matmul_v2 to matmul. 
  */
-class MapMatmulv2ToMulPass : public FusePassBase {
+class MapMatmulV2ToMatmulPass : public FusePassBase {
  public:
-  MapMatmulv2ToMulPass();
-  virtual ~MapMatmulv2ToMulPass() {}
+  MapMatmulV2ToMatmulPass();
+  virtual ~MapMatmulV2ToMatmulPass() {}
 
  protected:
   void ApplyImpl(Graph* graph) const override;

--- a/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
@@ -1174,6 +1174,23 @@ MultiHeadMatmulV3FusePass::MultiHeadMatmulV3FusePass() {
       .IsType<bool>()
       .End();
 
+  AddOpCompat(OpCompat("matmul_v2"))
+      .AddInput("X")
+      .IsTensor()
+      .End()
+      .AddInput("Y")
+      .IsTensor()
+      .End()
+      .AddOutput("Out")
+      .IsTensor()
+      .End()
+      .AddAttr("trans_x")
+      .IsBoolEQ(false)
+      .End()
+      .AddAttr("trans_y")  // QK(true) QKV(false)
+      .IsType<bool>()
+      .End();
+
   AddOpCompat(OpCompat("softmax"))
       .AddInput("X")
       .IsTensor()

--- a/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
@@ -461,7 +461,7 @@ PDNode* MultiHeadMatmulV3Pattern::operator()() {
       pattern->NewNode(transpose2_0_repr())->assert_is_op("transpose2");
   auto* transpose2_0_out_var = pattern->NewNode(transpose2_0_out_repr())
                                    ->assert_is_op_output("transpose2");
-  transpose2_0_out_var->AsIntermediate()->assert_is_ops_input(matmul_ops);
+  transpose2_0_out_var->AsIntermediate()->assert_is_ops_input(matmul_ops, "X");
 
   auto* matmul_qk =
       pattern->NewNode(matmul_qk_repr())->assert_is_ops(matmul_ops);

--- a/paddle/fluid/framework/ir/quant_conv2d_dequant_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/quant_conv2d_dequant_fuse_pass.cc
@@ -223,6 +223,7 @@ QuantDequantFusePass::QuantDequantFusePass() {
       .AddAttr("alpha")
       .IsNumGE(0.99f)
       .IsNumLE(1.01f)
+      .IsOptional()
       .End()
       .AddAttr("transpose_X")
       .IsBoolEQ(false)

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -93,8 +93,8 @@ const std::vector<std::string> kTRTSubgraphPasses({
       "squeeze2_matmul_fuse_pass",              //
       "reshape2_matmul_fuse_pass",              //
       "flatten2_matmul_fuse_pass",              //
+      "map_matmul_v2_to_matmul_pass",           //
       "map_matmul_to_mul_pass",                 //
-      "map_matmul_v2_to_mul_pass",              //
       "fc_fuse_pass",                           //
       "conv_elementwise_add_fuse_pass",         //
       "add_support_int8_pass",
@@ -142,8 +142,8 @@ GpuPassStrategy::GpuPassStrategy() : PassStrategy({}) {
         "squeeze2_matmul_fuse_pass",                 //
         "reshape2_matmul_fuse_pass",                 //
         "flatten2_matmul_fuse_pass",                 //
+        "map_matmul_v2_to_matmul_pass",              //
         "map_matmul_to_mul_pass",                    //
-        "map_matmul_v2_to_mul_pass",                 //
         "fc_fuse_pass",                              //
         "fc_elementwise_layernorm_fuse_pass",        //
 #if CUDNN_VERSION >= 7100  // To run conv_fusion, the version of cudnn must be
@@ -203,8 +203,8 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
                   "squeeze2_matmul_fuse_pass",               //
                   "reshape2_matmul_fuse_pass",               //
                   "flatten2_matmul_fuse_pass",               //
+                  "map_matmul_v2_to_matmul_pass",            //
                   "map_matmul_to_mul_pass",                  //
-                  "map_matmul_v2_to_mul_pass",               //
                   "fc_fuse_pass",                            //
                   "repeated_fc_relu_fuse_pass",              //
                   "squared_mat_sub_fuse_pass",               //

--- a/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/inference/tensorrt/convert/op_converter.h"
+#include "paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.h"
 
 namespace paddle {
 namespace framework {
@@ -35,58 +36,92 @@ class MatMulOpConverter : public OpConverter {
  public:
   void operator()(const framework::proto::OpDesc& op,
                   const framework::Scope& scope, bool test_mode) override {
-    VLOG(3) << "convert a fluid matmul op to tensorrt mul layer without bias";
+    VLOG(3)
+        << "convert a fluid matmul op to tensorrt matmul layer without bias";
 
     framework::OpDesc op_desc(op, nullptr);
+    nvinfer1::ILayer* layer = nullptr;
+
     // Declare inputs
     auto* input1 = engine_->GetITensor(op_desc.Input("X")[0]);
     auto* input2 = engine_->GetITensor(op_desc.Input("Y")[0]);
 
+    nvinfer1::Dims dims_x = input1->getDimensions();
+    nvinfer1::Dims dims_y = input2->getDimensions();
+
     bool transpose_X = BOOST_GET_CONST(bool, op_desc.GetAttr("transpose_X"));
     bool transpose_Y = BOOST_GET_CONST(bool, op_desc.GetAttr("transpose_Y"));
-
+    auto output_name = op_desc.Output("Out")[0];
+    float alpha = 1;
+    if (op_desc.HasAttr("alpha")) {
+      float alpha_tem = BOOST_GET_CONST(float, op_desc.GetAttr("alpha"));
+      if (fabs(alpha_tem - 1.0) > std::numeric_limits<float>::epsilon()) {
+        alpha = alpha_tem;
+      }
+    }
     nvinfer1::MatrixOperation matrix_operation_X =
         transpose_X ? nvinfer1::MatrixOperation::kTRANSPOSE
                     : nvinfer1::MatrixOperation::kNONE;
     nvinfer1::MatrixOperation matrix_operation_Y =
         transpose_Y ? nvinfer1::MatrixOperation::kTRANSPOSE
                     : nvinfer1::MatrixOperation::kNONE;
-
-    auto* layer =
-        TRT_ENGINE_ADD_LAYER(engine_, MatrixMultiply, *input1,
-                             matrix_operation_X, *input2, matrix_operation_Y);
-
-    float alpha = BOOST_GET_CONST(float, op_desc.GetAttr("alpha"));
-    auto output_name = op_desc.Output("Out")[0];
-    if (fabs(alpha - 1.0) < std::numeric_limits<float>::epsilon()) {
-      engine_->SetITensor(output_name, layer->getOutput(0));
+    if (op_desc.HasAttr("support_int8") &&
+        engine_->precision() == AnalysisConfig::Precision::kInt8) {
+      if (engine_->with_dynamic_shape()) {
+        VLOG(3) << "Convert a fluid matmul_op_int8_dynamic to TensorRT "
+                   "MatmulPluginLayer";
+        plugin::MatmulPluginDynamic* plugin =
+            new plugin::MatmulPluginDynamic(transpose_X, transpose_Y, alpha);
+        std::vector<nvinfer1::ITensor*> inputs{input1, input2};
+        layer = engine_->AddDynamicPlugin(inputs.data(), inputs.size(), plugin);
+        RreplenishLayerAndOutput(layer, "matmul_op_int8_dynamic", {output_name},
+                                 test_mode);
+      } else {
+        VLOG(3) << "Convert a fluid matmul_op_int8_static to TensorRT "
+                   "MatmulPluginLayer";
+        plugin::MatmulPlugin* plugin = new plugin::MatmulPlugin(
+            dims_x, dims_y, transpose_X, transpose_Y, alpha);
+        std::vector<nvinfer1::ITensor*> inputs{input1, input2};
+        layer = engine_->AddPluginV2IOExt(inputs.data(), inputs.size(), plugin);
+        RreplenishLayerAndOutput(layer, "matmul_op_int8_static", {output_name},
+                                 test_mode);
+      }
     } else {
-      auto create_weights = [&](float data, const std::string& type) -> float* {
-        std::unique_ptr<framework::Tensor> tmp_tensor(new framework::Tensor());
-        tmp_tensor->Resize({1});
-        auto* tmp_data = tmp_tensor->mutable_data<float>(platform::CPUPlace());
-        tmp_data[0] = data;
-        engine_->SetWeights(output_name + "_add_scale_op_" + type,
-                            std::move(tmp_tensor));
-        return tmp_data;
-      };
-      float* alpha_data = create_weights(alpha, "alpha");
-      float* shift_data = create_weights(0.0, "shift");
-      float* power_data = create_weights(1.0, "power");
-      TensorRTEngine::Weight nv_alpha{nvinfer1::DataType::kFLOAT,
-                                      static_cast<void*>(alpha_data), 1};
-      TensorRTEngine::Weight nv_shift{nvinfer1::DataType::kFLOAT,
-                                      static_cast<void*>(shift_data), 1};
-      TensorRTEngine::Weight nv_power{nvinfer1::DataType::kFLOAT,
-                                      static_cast<void*>(power_data), 1};
-      auto* scale_layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Scale, *layer->getOutput(0), nvinfer1::ScaleMode::kUNIFORM,
-          nv_shift.get(), nv_alpha.get(), nv_power.get());
-      engine_->SetITensor(output_name, scale_layer->getOutput(0));
-    }
-    if (test_mode) {  // the test framework can not determine which is the
-                      // output, so place the declaration inside.
-      engine_->DeclareOutput(output_name);
+      VLOG(3) << "Convert a fluid matmul_op_float to TensorRT ";
+      layer =
+          TRT_ENGINE_ADD_LAYER(engine_, MatrixMultiply, *input1,
+                               matrix_operation_X, *input2, matrix_operation_Y);
+      if (alpha == 1) {
+        RreplenishLayerAndOutput(layer, "matmul_op_float_no_alpha",
+                                 {output_name}, test_mode);
+      } else {
+        auto create_weights = [&](float data,
+                                  const std::string& type) -> float* {
+          std::unique_ptr<framework::Tensor> tmp_tensor(
+              new framework::Tensor());
+          tmp_tensor->Resize({1});
+          auto* tmp_data =
+              tmp_tensor->mutable_data<float>(platform::CPUPlace());
+          tmp_data[0] = data;
+          engine_->SetWeights(output_name + "_add_scale_op_" + type,
+                              std::move(tmp_tensor));
+          return tmp_data;
+        };
+        float* alpha_data = create_weights(alpha, "alpha");
+        float* shift_data = create_weights(0.0, "shift");
+        float* power_data = create_weights(1.0, "power");
+        TensorRTEngine::Weight nv_alpha{nvinfer1::DataType::kFLOAT,
+                                        static_cast<void*>(alpha_data), 1};
+        TensorRTEngine::Weight nv_shift{nvinfer1::DataType::kFLOAT,
+                                        static_cast<void*>(shift_data), 1};
+        TensorRTEngine::Weight nv_power{nvinfer1::DataType::kFLOAT,
+                                        static_cast<void*>(power_data), 1};
+        auto* scale_layer = TRT_ENGINE_ADD_LAYER(
+            engine_, Scale, *layer->getOutput(0), nvinfer1::ScaleMode::kUNIFORM,
+            nv_shift.get(), nv_alpha.get(), nv_power.get());
+        RreplenishLayerAndOutput(scale_layer, "matmul_op_float_has_alpha",
+                                 {output_name}, test_mode);
+      }
     }
   }
 };

--- a/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
@@ -93,9 +93,9 @@ class MatMulOpConverter : public OpConverter {
         RreplenishLayerAndOutput(layer, "matmul_op_float_no_alpha",
                                  {output_name}, test_mode);
       } else {
-        RreplenishLayerAndOutput(layer,
-                                 "matmul_op_float_has_alpha: MatrixMultiply",
-                                 {output_name}, test_mode);
+        layer->setName(("matmul_op_float_has_alpha: MatrixMultiplyLayer" +
+                        " (Output: " + {output_name}[0] + ")")
+                           .c_str());
         auto create_weights = [&](float data,
                                   const std::string& type) -> float* {
           std::unique_ptr<framework::Tensor> tmp_tensor(
@@ -121,7 +121,7 @@ class MatMulOpConverter : public OpConverter {
             engine_, Scale, *layer->getOutput(0), nvinfer1::ScaleMode::kUNIFORM,
             nv_shift.get(), nv_alpha.get(), nv_power.get());
         RreplenishLayerAndOutput(scale_layer,
-                                 "matmul_op_float_has_alpha: Scale",
+                                 "matmul_op_float_has_alpha: ScaleLayer",
                                  {output_name}, test_mode);
       }
     }

--- a/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
@@ -55,9 +55,7 @@ class MatMulOpConverter : public OpConverter {
     float alpha = 1;
     if (op_desc.HasAttr("alpha")) {
       float alpha_tem = BOOST_GET_CONST(float, op_desc.GetAttr("alpha"));
-      if (fabs(alpha_tem - 1.0) > std::numeric_limits<float>::epsilon()) {
-        alpha = alpha_tem;
-      }
+      alpha = alpha_tem;
     }
     nvinfer1::MatrixOperation matrix_operation_X =
         transpose_X ? nvinfer1::MatrixOperation::kTRANSPOSE
@@ -95,6 +93,9 @@ class MatMulOpConverter : public OpConverter {
         RreplenishLayerAndOutput(layer, "matmul_op_float_no_alpha",
                                  {output_name}, test_mode);
       } else {
+        RreplenishLayerAndOutput(layer,
+                                 "matmul_op_float_has_alpha: MatrixMultiply",
+                                 {output_name}, test_mode);
         auto create_weights = [&](float data,
                                   const std::string& type) -> float* {
           std::unique_ptr<framework::Tensor> tmp_tensor(
@@ -119,7 +120,8 @@ class MatMulOpConverter : public OpConverter {
         auto* scale_layer = TRT_ENGINE_ADD_LAYER(
             engine_, Scale, *layer->getOutput(0), nvinfer1::ScaleMode::kUNIFORM,
             nv_shift.get(), nv_alpha.get(), nv_power.get());
-        RreplenishLayerAndOutput(scale_layer, "matmul_op_float_has_alpha",
+        RreplenishLayerAndOutput(scale_layer,
+                                 "matmul_op_float_has_alpha: Scale",
                                  {output_name}, test_mode);
       }
     }

--- a/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
@@ -93,9 +93,10 @@ class MatMulOpConverter : public OpConverter {
         RreplenishLayerAndOutput(layer, "matmul_op_float_no_alpha",
                                  {output_name}, test_mode);
       } else {
-        layer->setName(("matmul_op_float_has_alpha: MatrixMultiplyLayer" +
-                        " (Output: " + output_name + ")")
-                           .c_str());
+        layer->setName(
+            ("matmul_op_float_has_alpha: MatrixMultiplyLayer (Output: " +
+             output_name + ")")
+                .c_str());
         auto create_weights = [&](float data,
                                   const std::string& type) -> float* {
           std::unique_ptr<framework::Tensor> tmp_tensor(

--- a/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
@@ -94,7 +94,7 @@ class MatMulOpConverter : public OpConverter {
                                  {output_name}, test_mode);
       } else {
         layer->setName(("matmul_op_float_has_alpha: MatrixMultiplyLayer" +
-                        " (Output: " + {output_name}[0] + ")")
+                        " (Output: " + output_name + ")")
                            .c_str());
         auto create_weights = [&](float data,
                                   const std::string& type) -> float* {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -363,7 +363,8 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
             << "matmul op not support broadcast, please check inputs'shape. ";
         return false;
       }
-      for (int i = 0; i < x_shape.size() - 2; i++) {
+      uint64_t dims = 2;
+      for (size_t i = 0; i < x_shape.size() - dims; ++i) {
         if (x_shape[i] != y_shape[i] && (x_shape[i] == 1 || y_shape[i] == 1)) {
           VLOG(3) << "matmul op not support broadcast, please check "
                      "inputs'shape[i]. ";

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -359,12 +359,14 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
       const auto x_shape = x_var_desc->GetShape();
       const auto y_shape = y_var_desc->GetShape();
       if (x_shape.size() != y_shape.size()) {
-        VLOG(3) << "matmul op not support broadcast, please check inputs'shape. ";
+        VLOG(3)
+            << "matmul op not support broadcast, please check inputs'shape. ";
         return false;
       }
-      for(int i = 0;i<x_shape.size()-2;i++){
-        if(x_shape[i]!=y_shape[i] && (x_shape[i] ==1 || y_shape[i]==1)){
-          VLOG(3) << "matmul op not support broadcast, please check inputs'shape[i]. ";
+      for (int i = 0; i < x_shape.size() - 2; i++) {
+        if (x_shape[i] != y_shape[i] && (x_shape[i] == 1 || y_shape[i] == 1)) {
+          VLOG(3) << "matmul op not support broadcast, please check "
+                     "inputs'shape[i]. ";
           return false;
         }
       }
@@ -1358,15 +1360,19 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
       auto* y_var_desc = block->FindVar(desc.Input("Y")[0]);
       const auto y_shape = y_var_desc->GetShape();
       if (y_shape.size() != 2) {
-        VLOG(3) << " input_y(fc_op)'shapes must be 2, but input_y(fc_op)'shapes = %d. ",y_shape.size();
+        VLOG(3)
+            << " input_y(fc_op)'shapes must be 2, but input_y(fc_op)'shapes = "
+            << y_shape.size();
         return false;
       }
 
       // y_num_col_dims ==1
-      if(desc.HasAttr("y_num_col_dims")){
-        int y_num_col_dims = BOOST_GET_CONST(int, desc.GetAttr("y_num_col_dims"));
-        if(y_num_col_dims != 1){
-          VLOG(3) << " fc_op'y_num_col_dims must be 1, but y_num_col_dims = %d. ",y_num_col_dims;
+      if (desc.HasAttr("y_num_col_dims")) {
+        int y_num_col_dims =
+            BOOST_GET_CONST(int, desc.GetAttr("y_num_col_dims"));
+        if (y_num_col_dims != 1) {
+          VLOG(3) << " fc_op'y_num_col_dims must be 1, but y_num_col_dims = "
+                  << y_num_col_dims;
           return false;
         }
       }
@@ -1378,7 +1384,8 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
                      : 1);
       if (x_num_col_dims < 1) {
         VLOG(3) << "fc_op expects x_num_col_dims >= 1, "
-                   "but x_num_col_dims = %d. ", x_num_col_dims;
+                   "but x_num_col_dims = "
+                << x_num_col_dims;
         return false;
       }
     }

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -339,6 +339,7 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
                    "the pass.";
         return false;
       }
+
       for (auto& param_name : desc.Inputs()) {
         for (auto& var_name : param_name.second) {
           auto* var_desc = block->FindVar(var_name);
@@ -349,6 +350,22 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
                 << shape.size() << ", so jump it.";
             return false;
           }
+        }
+      }
+
+      // not support broadcast
+      auto* x_var_desc = block->FindVar(desc.Input("X")[0]);
+      auto* y_var_desc = block->FindVar(desc.Input("Y")[0]);
+      const auto x_shape = x_var_desc->GetShape();
+      const auto y_shape = y_var_desc->GetShape();
+      if (x_shape.size() != y_shape.size()) {
+        VLOG(3) << "matmul op not support broadcast, please check inputs'shape. ";
+        return false;
+      }
+      for(int i = 0;i<x_shape.size()-2;i++){
+        if(x_shape[i]!=y_shape[i] && (x_shape[i] ==1 || y_shape[i]==1)){
+          VLOG(3) << "matmul op not support broadcast, please check inputs'shape[i]. ";
+          return false;
         }
       }
     }
@@ -1329,6 +1346,30 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
     }
 
     if (op_type == "fc") {
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
+
+      // y'shapes == 2
+      auto* y_var_desc = block->FindVar(desc.Input("Y")[0]);
+      const auto y_shape = y_var_desc->GetShape();
+      if (y_shape.size() != 2) {
+        VLOG(3) << " input_y(fc_op)'shapes must be 2, but input_y(fc_op)'shapes = %d. ",y_shape.size();
+        return false;
+      }
+
+      // y_num_col_dims ==1
+      if(desc.HasAttr("y_num_col_dims")){
+        int y_num_col_dims = BOOST_GET_CONST(int, desc.GetAttr("y_num_col_dims"));
+        if(y_num_col_dims != 1){
+          VLOG(3) << " fc_op'y_num_col_dims must be 1, but y_num_col_dims = %d. ",y_num_col_dims;
+          return false;
+        }
+      }
       int x_num_col_dims =
           desc.HasAttr("x_num_col_dims")
               ? BOOST_GET_CONST(int, desc.GetAttr("x_num_col_dims"))
@@ -1336,8 +1377,8 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
                      ? BOOST_GET_CONST(int, desc.GetAttr("in_num_col_dims"))
                      : 1);
       if (x_num_col_dims < 1) {
-        VLOG(3) << "converter expects x_num_col_dims >= 1, "
-                   "but x_num_col_dims = %d.";
+        VLOG(3) << "fc_op expects x_num_col_dims >= 1, "
+                   "but x_num_col_dims = %d. ", x_num_col_dims;
         return false;
       }
     }

--- a/paddle/fluid/inference/tensorrt/plugin/CMakeLists.txt
+++ b/paddle/fluid/inference/tensorrt/plugin/CMakeLists.txt
@@ -10,6 +10,7 @@ nv_library(tensorrt_plugin
            roi_align_op_plugin.cu
            gather_nd_op_plugin.cu
            mish_op_plugin.cu
+           matmul_op_int8_plugin.cu
            DEPS enforce tensorrt_engine prelu tensor bert_encoder_functor)
 
 nv_test(test_split_plugin SRCS test_split_plugin.cc DEPS

--- a/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
@@ -169,7 +169,11 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
   if (type_ == nvinfer1::DataType::kINT8) {
     cudaDataType_t cudadataTypeIO = CUDA_R_8I;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+#if CUBLAS_VER_MAJOR < 11
+    cudaDataType_t cudaComputeType = CUBLAS_R_32I;
+#else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32I;
+#endif
     cublasLtOrder_t COL32 = CUBLASLT_ORDER_COL32;
     cublasLtOrder_t COL4_4R2_8C = CUBLASLT_ORDER_COL4_4R2_8C;
 
@@ -274,8 +278,14 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
     cublasOperation_t ATranspose = CUBLAS_OP_N, BTranspose = CUBLAS_OP_T;
     cublasLtPointerMode_t matmul_model =
         CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO;
+
+#if CUBLAS_VER_MAJOR < 11
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType));
+#else
     CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType,
                                                cudaDataTypeS));
+#endif
+
     CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
         matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSA, &ATranspose,
         sizeof(ATranspose)));
@@ -304,8 +314,11 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
   } else if (type_ == nvinfer1::DataType::kHALF) {
     cudaDataType_t cudadataTypeIO = CUDA_R_16F;
     cudaDataType_t cudaDataTypeS = CUDA_R_16F;
+#if CUBLAS_VER_MAJOR < 11
+    cudaDataType_t cudaComputeType = CUBLAS_R_16F;
+#else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_16F;
-
+#endif
     CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
         &Adesc_, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n_ : k_,
         AopTranspose == CUBLAS_OP_N ? k_ : n_,
@@ -344,8 +357,14 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
         sizeof(stridec)));
 
     cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+
+#if CUBLAS_VER_MAJOR < 11
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType));
+#else
     CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType,
                                                cudaDataTypeS));
+#endif
+
     CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
         matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
         sizeof(AopTranspose)));
@@ -367,8 +386,11 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
   } else {
     cudaDataType_t cudadataTypeIO = CUDA_R_32F;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+#if CUBLAS_VER_MAJOR < 11
+    cudaDataType_t cudaComputeType = CUBLAS_R_32F;
+#else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32F_FAST_16F;
-
+#endif
     CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
         &Adesc_, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n_ : k_,
         AopTranspose == CUBLAS_OP_N ? k_ : n_,
@@ -407,8 +429,14 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
         sizeof(stridec)));
 
     cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+
+#if CUBLAS_VER_MAJOR < 11
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType));
+#else
     CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType,
                                                cudaDataTypeS));
+#endif
+
     CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
         matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
         sizeof(AopTranspose)));
@@ -710,7 +738,11 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
   if (type_ == nvinfer1::DataType::kINT8) {
     cudaDataType_t cudadataTypeIO = CUDA_R_8I;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+#if CUBLAS_VER_MAJOR < 11
+    cudaDataType_t cudaComputeType = CUBLAS_R_32I;
+#else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32I;
+#endif
     cublasLtOrder_t COL32 = CUBLASLT_ORDER_COL32;
     cublasLtOrder_t COL4_4R2_8C = CUBLASLT_ORDER_COL4_4R2_8C;
 
@@ -802,8 +834,14 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
     cublasOperation_t ATranspose = CUBLAS_OP_N, BTranspose = CUBLAS_OP_T;
     cublasLtPointerMode_t matmul_model =
         CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO;
+
+#if CUBLAS_VER_MAJOR < 11
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType));
+#else
     CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType,
                                                cudaDataTypeS));
+#endif
+
     CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
         matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA, &ATranspose,
         sizeof(ATranspose)));
@@ -825,8 +863,11 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
   } else if (type_ == nvinfer1::DataType::kHALF) {
     cudaDataType_t cudadataTypeIO = CUDA_R_16F;
     cudaDataType_t cudaDataTypeS = CUDA_R_16F;
+#if CUBLAS_VER_MAJOR < 11
+    cudaDataType_t cudaComputeType = CUBLAS_R_16F;
+#else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_16F;
-
+#endif
     CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
         &Adesc, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n : k,
         AopTranspose == CUBLAS_OP_N ? k : n,
@@ -865,8 +906,14 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
         sizeof(stridec)));
 
     cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+
+#if CUBLAS_VER_MAJOR < 11
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType));
+#else
     CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType,
                                                cudaDataTypeS));
+#endif
+
     CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
         matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
         sizeof(AopTranspose)));
@@ -885,8 +932,11 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
   } else {
     cudaDataType_t cudadataTypeIO = CUDA_R_32F;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+#if CUBLAS_VER_MAJOR < 11
+    cudaDataType_t cudaComputeType = CUBLAS_R_32F;
+#else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32F_FAST_16F;
-
+#endif
     CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
         &Adesc, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n : k,
         AopTranspose == CUBLAS_OP_N ? k : n,
@@ -925,8 +975,14 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
         sizeof(stridec)));
 
     cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+
+#if CUBLAS_VER_MAJOR < 11
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType));
+#else
     CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType,
                                                cudaDataTypeS));
+#endif
+
     CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
         matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
         sizeof(AopTranspose)));

--- a/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
@@ -1,0 +1,952 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.h"
+#include "paddle/fluid/platform/dynload/cublasLt.h"
+
+namespace plf = paddle::platform;
+namespace dyl = paddle::platform::dynload;
+namespace paddle {
+namespace inference {
+namespace tensorrt {
+namespace plugin {
+float zero = 0;
+void Ltgemm_int8_linear(
+    cublasLtHandle_t ltHandle, const int8_t* A, cublasLtMatrixLayout_t Adesc,
+    int8_t* Atransform, cublasLtMatrixLayout_t AtransformDesc, bool transA_,
+    const int8_t* B, cublasLtMatrixLayout_t Bdesc, int8_t* Btransform,
+    cublasLtMatrixLayout_t BtransformDesc, bool transB_, int8_t* C,
+    cublasLtMatrixLayout_t Cdesc, int8_t* Ctransform,
+    cublasLtMatrixLayout_t CtransformDesc,
+    cublasLtMatrixTransformDesc_t transformDescT,
+    cublasLtMatrixTransformDesc_t transformDescN,
+    cublasLtMatmulDesc_t matmulDesc, void* alpha_scale, void* alpha_zero,
+    void* alpha_one, void* workspace, cudaStream_t stream) {
+  if (transA_) {
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransform(
+        ltHandle, transformDescT, alpha_one, A, Adesc, alpha_zero, nullptr,
+        nullptr, Atransform, AtransformDesc, stream));
+  } else {
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransform(
+        ltHandle, transformDescN, alpha_one, A, Adesc, alpha_zero, nullptr,
+        nullptr, Atransform, AtransformDesc, stream));
+  }
+
+  if (transB_) {
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransform(
+        ltHandle, transformDescN, alpha_one, B, Bdesc, alpha_zero, nullptr,
+        nullptr, Btransform, BtransformDesc, stream));
+  } else {
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransform(
+        ltHandle, transformDescT, alpha_one, B, Bdesc, alpha_zero, nullptr,
+        nullptr, Btransform, BtransformDesc, stream));
+  }
+
+  CUDA_RT_CALL(dyl::cublasLtMatmul(
+      ltHandle, matmulDesc, alpha_scale, Atransform, AtransformDesc, Btransform,
+      BtransformDesc, nullptr, Ctransform, CtransformDesc, Ctransform,
+      CtransformDesc, nullptr, workspace, 0, stream));
+
+  CUDA_RT_CALL(dyl::cublasLtMatrixTransform(
+      ltHandle, transformDescN, alpha_one, Ctransform, CtransformDesc,
+      alpha_zero, nullptr, nullptr, C, Cdesc, stream));
+}
+
+void Ltgemm_fp32_linear(cublasLtHandle_t ltHandle, const float* A,
+                        cublasLtMatrixLayout_t Adesc, const float* B,
+                        cublasLtMatrixLayout_t Bdesc, float* C,
+                        cublasLtMatrixLayout_t Cdesc,
+                        cublasLtMatmulDesc_t matmulDesc, void* alpha_scale,
+                        void* alpha_zero, void* workspace,
+                        cudaStream_t stream) {
+  CUDA_RT_CALL(dyl::cublasLtMatmul(ltHandle, matmulDesc, alpha_scale, A, Adesc,
+                                   B, Bdesc, alpha_zero, C, Cdesc, C, Cdesc,
+                                   nullptr, workspace, 0, stream));
+}
+
+void Ltgemm_fp16_linear(cublasLtHandle_t ltHandle, const half* A,
+                        cublasLtMatrixLayout_t Adesc, const half* B,
+                        cublasLtMatrixLayout_t Bdesc, half* C,
+                        cublasLtMatrixLayout_t Cdesc,
+                        cublasLtMatmulDesc_t matmulDesc, void* alpha_scale,
+                        void* alpha_zero, void* workspace,
+                        cudaStream_t stream) {
+  CUDA_RT_CALL(dyl::cublasLtMatmul(ltHandle, matmulDesc, alpha_scale, A, Adesc,
+                                   B, Bdesc, alpha_zero, C, Cdesc, C, Cdesc,
+                                   nullptr, workspace, 0, stream));
+}
+
+nvinfer1::DataType MatmulPlugin::getOutputDataType(
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
+  return input_types[0];
+}
+
+nvinfer1::Dims MatmulPlugin::getOutputDimensions(
+    int index, const nvinfer1::Dims* input_dims, int num_inputs) TRT_NOEXCEPT {
+  if (transB_) {
+    m_ = dims_x_.d[dims_x_.nbDims - 1];
+    k_ = dims_x_.d[dims_x_.nbDims - 2];
+  } else {
+    m_ = dims_x_.d[dims_x_.nbDims - 2];
+    k_ = dims_x_.d[dims_x_.nbDims - 1];
+  }
+  if (transA_) {
+    n_ = dims_y_.d[dims_y_.nbDims - 2];
+  } else {
+    n_ = dims_y_.d[dims_y_.nbDims - 1];
+  }
+
+  batch_ = 1;
+  for (int i = 0; i < dims_x_.nbDims - 2; i++) {
+    batch_ *= dims_x_.d[i];
+  }
+  nvinfer1::Dims output_dims;
+  output_dims.nbDims = dims_x_.nbDims;
+  for (int i = 0; i < output_dims.nbDims - 2; i++) {
+    output_dims.d[i] = dims_x_.d[i];
+  }
+  output_dims.d[output_dims.nbDims - 2] = m_;
+  output_dims.d[output_dims.nbDims - 1] = n_;
+
+  return output_dims;
+}
+
+bool MatmulPlugin::supportsFormatCombination(
+    int32_t pos, nvinfer1::PluginTensorDesc const* inOut, int32_t nbInputs,
+    int32_t nbOutputs) const TRT_NOEXCEPT {
+  PADDLE_ENFORCE_EQ(nbInputs, 2, platform::errors::InvalidArgument("......."
+                                                                   ",,,,,,,"));
+  PADDLE_ENFORCE_EQ(nbOutputs, getNbOutputs(),
+                    platform::errors::InvalidArgument("......."
+                                                      ",,,,,,,"));
+  if (pos == 0) {
+    return (inOut[pos].type == nvinfer1::DataType::kHALF ||
+            inOut[pos].type == nvinfer1::DataType::kFLOAT ||
+            inOut[pos].type == nvinfer1::DataType::kINT8) &&
+           inOut[pos].format == nvinfer1::TensorFormat::kLINEAR;
+  } else {
+    return inOut[pos].type == inOut[0].type &&
+           inOut[pos].format == inOut[0].format;
+  }
+}
+
+void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
+                                   int32_t nbInputs,
+                                   const nvinfer1::PluginTensorDesc* out,
+                                   int32_t nbOutputs) TRT_NOEXCEPT {
+  float inscale_0 = inputs[0].scale;
+  float inscale_1 = inputs[1].scale;
+  float outscale = out[0].scale;
+  type_ = inputs[0].type;
+  int64_t stridea = k_ * n_;
+  int64_t strideb = k_ * m_;
+  int64_t stridec = m_ * n_;
+
+  cublasOperation_t AopTranspose, BopTranspose;
+  if (transA_) {
+    AopTranspose = CUBLAS_OP_T;
+  } else {
+    AopTranspose = CUBLAS_OP_N;
+  }
+  if (transB_) {
+    BopTranspose = CUBLAS_OP_T;
+  } else {
+    BopTranspose = CUBLAS_OP_N;
+  }
+
+  if (type_ == nvinfer1::DataType::kINT8) {
+    cudaDataType_t cudadataTypeIO = CUDA_R_8I;
+    cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+    cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32I;
+    cublasLtOrder_t COL32 = CUBLASLT_ORDER_COL32;
+    cublasLtOrder_t COL4_4R2_8C = CUBLASLT_ORDER_COL4_4R2_8C;
+
+    int const ldatransform = 32 * n_;
+    int const ldbtransform = 32 * ((m_ + 8 - 1) / 8 * 8);
+    int const ldctransform = 32 * n_;
+    CUDA_RT_CALL(cudaMalloc(
+        (void**)&Atransform_,
+        sizeof(int8_t) * ((k_ + 32 - 1) / 32 * 32) / 32 * ldatransform));
+    CUDA_RT_CALL(cudaMalloc(
+        (void**)&Btransform_,
+        sizeof(int8_t) * ((k_ + 32 - 1) / 32 * 32) / 32 * ldbtransform));
+    CUDA_RT_CALL(cudaMalloc(
+        (void**)&Ctransform_,
+        sizeof(int8_t) * ((m_ + 32 - 1) / 32 * 32) / 32 * ldctransform));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Adesc_, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n_ : k_,
+        AopTranspose == CUBLAS_OP_N ? k_ : n_,
+        AopTranspose == CUBLAS_OP_N ? n_ : k_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridea),
+        sizeof(stridea)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Bdesc_, cudadataTypeIO, BopTranspose == CUBLAS_OP_N ? k_ : m_,
+        BopTranspose == CUBLAS_OP_N ? m_ : k_,
+        BopTranspose == CUBLAS_OP_N ? k_ : m_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(strideb),
+        sizeof(strideb)));
+
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixLayoutCreate(&Cdesc_, cudadataTypeIO, n_, m_, n_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridec),
+        sizeof(stridec)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &AtransformDesc_, cudadataTypeIO, n_, k_, ldatransform));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc_, CUBLASLT_MATRIX_LAYOUT_ORDER, &COL32, sizeof(COL32)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &BtransformDesc_, cudadataTypeIO, m_, k_, ldbtransform));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc_, CUBLASLT_MATRIX_LAYOUT_ORDER, &COL4_4R2_8C,
+        sizeof(COL4_4R2_8C)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &CtransformDesc_, cudadataTypeIO, n_, m_, ldctransform));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc_, CUBLASLT_MATRIX_LAYOUT_ORDER, &COL32, sizeof(COL32)));
+
+    cublasOperation_t Transpose = CUBLAS_OP_T;
+    cublasLtPointerMode_t transform_model = CUBLASLT_POINTER_MODE_DEVICE;
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescCreate(&transformDescT_,
+                                                        cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescT_, CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE,
+        &cudaDataTypeS, sizeof(cudaDataTypeS)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescT_, CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA, &Transpose,
+        sizeof(Transpose)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescT_, CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE,
+        &transform_model, sizeof(transform_model)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescCreate(&transformDescN_,
+                                                        cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescN_, CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE,
+        &cudaDataTypeS, sizeof(cudaDataTypeS)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescN_, CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE,
+        &transform_model, sizeof(transform_model)));
+
+    cublasOperation_t ATranspose = CUBLAS_OP_N, BTranspose = CUBLAS_OP_T;
+    cublasLtPointerMode_t matmul_model =
+        CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO;
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType,
+                                               cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSA, &ATranspose,
+        sizeof(ATranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSB, &BTranspose,
+        sizeof(BTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_POINTER_MODE, &matmul_model,
+        sizeof(matmul_model)));
+
+    float alpha_tem[n_];
+    for (int i = 0; i < n_; i++) {
+      alpha_tem[i] = alpha_ * inscale_0 * inscale_1 / outscale;
+    }
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_scale_, n_ * sizeof(float)));
+    cudaMemcpyAsync(alpha_scale_, alpha_tem, n_ * sizeof(float),
+                    cudaMemcpyHostToDevice);
+    float zero_tem = zero;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_zero_, sizeof(float)));
+    cudaMemcpyAsync(alpha_zero_, &zero_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+    float one_tem = 1;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_one_, sizeof(float)));
+    cudaMemcpyAsync(alpha_one_, &one_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+  } else if (type_ == nvinfer1::DataType::kHALF) {
+    cudaDataType_t cudadataTypeIO = CUDA_R_16F;
+    cudaDataType_t cudaDataTypeS = CUDA_R_16F;
+    cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_16F;
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Adesc_, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n_ : k_,
+        AopTranspose == CUBLAS_OP_N ? k_ : n_,
+        AopTranspose == CUBLAS_OP_N ? n_ : k_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridea),
+        sizeof(stridea)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Bdesc_, cudadataTypeIO, BopTranspose == CUBLAS_OP_N ? k_ : m_,
+        BopTranspose == CUBLAS_OP_N ? m_ : k_,
+        BopTranspose == CUBLAS_OP_N ? k_ : m_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(strideb),
+        sizeof(strideb)));
+
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixLayoutCreate(&Cdesc_, cudadataTypeIO, n_, m_, n_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridec),
+        sizeof(stridec)));
+
+    cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType,
+                                               cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
+        sizeof(AopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSB, &BopTranspose,
+        sizeof(BopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_POINTER_MODE, &matmul_model,
+        sizeof(matmul_model)));
+
+    half alpha_tem = static_cast<half>(alpha_);
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_scale_, sizeof(half)));
+    cudaMemcpyAsync(alpha_scale_, &alpha_tem, sizeof(half),
+                    cudaMemcpyHostToDevice);
+    half zero_tem = static_cast<half>(zero);
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_zero_, sizeof(half)));
+    cudaMemcpyAsync(alpha_zero_, &zero_tem, sizeof(half),
+                    cudaMemcpyHostToDevice);
+  } else {
+    cudaDataType_t cudadataTypeIO = CUDA_R_32F;
+    cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+    cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32F_FAST_16F;
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Adesc_, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n_ : k_,
+        AopTranspose == CUBLAS_OP_N ? k_ : n_,
+        AopTranspose == CUBLAS_OP_N ? n_ : k_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridea),
+        sizeof(stridea)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Bdesc_, cudadataTypeIO, BopTranspose == CUBLAS_OP_N ? k_ : m_,
+        BopTranspose == CUBLAS_OP_N ? m_ : k_,
+        BopTranspose == CUBLAS_OP_N ? k_ : m_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(strideb),
+        sizeof(strideb)));
+
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixLayoutCreate(&Cdesc_, cudadataTypeIO, n_, m_, n_));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch_), sizeof(batch_)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc_, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridec),
+        sizeof(stridec)));
+
+    cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc_, cudaComputeType,
+                                               cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
+        sizeof(AopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_TRANSB, &BopTranspose,
+        sizeof(BopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc_, CUBLASLT_MATMUL_DESC_POINTER_MODE, &matmul_model,
+        sizeof(matmul_model)));
+
+    float alpha_tem = alpha_;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_scale_, sizeof(float)));
+    cudaMemcpyAsync(alpha_scale_, &alpha_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+    float zero_tem = zero;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_zero_, sizeof(float)));
+    cudaMemcpyAsync(alpha_zero_, &zero_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+  }
+}
+
+void MatmulPlugin::attachToContext(
+    cudnnContext* cudnnContext, cublasContext* cublasContext,
+    nvinfer1::IGpuAllocator* gpuAllocator) TRT_NOEXCEPT {
+  dyl::cublasLtCreate(&cublas_);
+}
+
+void MatmulPlugin::detachFromContext() TRT_NOEXCEPT {
+  dyl::cublasLtDestroy(cublas_);
+}
+
+void MatmulPlugin::terminate() TRT_NOEXCEPT {
+  /*
+   if(alpha_scale_){
+     cudaFree((void *)alpha_scale_);
+     alpha_scale_ = nullptr;
+   }
+   if(alpha_zero_){
+     cudaFree((void *)alpha_zero_);
+     alpha_zero_ = nullptr;
+   }
+   if(alpha_one_){
+     cudaFree((void *)alpha_one_);
+     alpha_one_ = nullptr;
+   }
+   if(Atransform_){
+     cudaFree((void *)Atransform_);
+     Atransform_ = nullptr;
+   }
+   if(Btransform_){
+     cudaFree((void *)Btransform_);
+     Btransform_ = nullptr;
+   }
+   if(Ctransform_){
+     cudaFree((void *)Ctransform_);
+     Ctransform_ = nullptr;
+   }   */
+}
+
+int MatmulPlugin::enqueue(int batchSize, const void* const* inputs,
+#if IS_TRT_VERSION_LT(8000)
+                          void** outputs, void* workspace,
+                          cudaStream_t stream) {
+#else
+                          void* const* outputs, void* workspace,
+                          cudaStream_t stream) TRT_NOEXCEPT {
+#endif
+  if (type_ == nvinfer1::DataType::kINT8) {
+    const int8_t* B = static_cast<const int8_t*>(inputs[0]);
+    const int8_t* A = static_cast<const int8_t*>(inputs[1]);
+    int8_t* C = static_cast<int8_t*>(outputs[0]);
+    Ltgemm_int8_linear(
+        cublas_, A, Adesc_, Atransform_, AtransformDesc_, transA_, B, Bdesc_,
+        Btransform_, BtransformDesc_, transB_, C, Cdesc_, Ctransform_,
+        CtransformDesc_, transformDescT_, transformDescN_, matmulDesc_,
+        alpha_scale_, alpha_zero_, alpha_one_, workspace, stream);
+  } else if (type_ == nvinfer1::DataType::kFLOAT) {
+    const float* B = static_cast<const float*>(inputs[0]);
+    const float* A = static_cast<const float*>(inputs[1]);
+    float* C = static_cast<float*>(outputs[0]);
+    Ltgemm_fp32_linear(cublas_, A, Adesc_, B, Bdesc_, C, Cdesc_, matmulDesc_,
+                       alpha_scale_, alpha_zero_, workspace, stream);
+  } else if (type_ == nvinfer1::DataType::kHALF) {
+    const half* B = static_cast<const half*>(inputs[0]);
+    const half* A = static_cast<const half*>(inputs[1]);
+    half* C = static_cast<half*>(outputs[0]);
+    Ltgemm_fp16_linear(cublas_, A, Adesc_, B, Bdesc_, C, Cdesc_, matmulDesc_,
+                       alpha_scale_, alpha_zero_, workspace, stream);
+  } else {
+    PADDLE_THROW(platform::errors::InvalidArgument(
+        "VarMessageToVarType:Unsupported type"));
+  }
+  return cudaGetLastError() != cudaSuccess;
+}
+
+nvinfer1::DataType MatmulPluginDynamic::getOutputDataType(
+    int index, const nvinfer1::DataType* input_types,
+    int nb_inputs) const TRT_NOEXCEPT {
+  return input_types[0];
+}
+
+nvinfer1::DimsExprs MatmulPluginDynamic::getOutputDimensions(
+    int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
+    nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT {
+  nvinfer1::DimsExprs output_dims(inputs[0]);
+  if (transB_) {
+    output_dims.d[output_dims.nbDims - 2] = inputs[0].d[inputs[0].nbDims - 1];
+  } else {
+    output_dims.d[output_dims.nbDims - 2] = inputs[0].d[inputs[0].nbDims - 2];
+  }
+  if (transA_) {
+    output_dims.d[output_dims.nbDims - 1] = inputs[1].d[inputs[1].nbDims - 2];
+  } else {
+    output_dims.d[output_dims.nbDims - 1] = inputs[1].d[inputs[1].nbDims - 1];
+  }
+  return output_dims;
+}
+
+bool MatmulPluginDynamic::supportsFormatCombination(
+    int pos, const nvinfer1::PluginTensorDesc* inOut, int nbInputs,
+    int nbOutputs) TRT_NOEXCEPT {
+  PADDLE_ENFORCE_EQ(nbInputs, 2, platform::errors::InvalidArgument("......."
+                                                                   ",,,,,,,"));
+  PADDLE_ENFORCE_EQ(nbOutputs, getNbOutputs(),
+                    platform::errors::InvalidArgument("......."
+                                                      ",,,,,,,"));
+  if (pos == 0) {
+    return (inOut[pos].type == nvinfer1::DataType::kHALF ||
+            inOut[pos].type == nvinfer1::DataType::kFLOAT ||
+            inOut[pos].type == nvinfer1::DataType::kINT8) &&
+           inOut[pos].format == nvinfer1::TensorFormat::kLINEAR;
+  } else {
+    return inOut[pos].type == inOut[0].type &&
+           inOut[pos].format == nvinfer1::TensorFormat::kLINEAR;
+  }
+}
+
+void MatmulPluginDynamic::configurePlugin(
+    const nvinfer1::DynamicPluginTensorDesc* inputs, int nbInputs,
+    const nvinfer1::DynamicPluginTensorDesc* outputs,
+    int nbOutputs) TRT_NOEXCEPT {
+  float inscale_0 = inputs[0].desc.scale;
+  float inscale_1 = inputs[1].desc.scale;
+  float outscale = outputs[0].desc.scale;
+  type_ = inputs[0].desc.type;
+  uint64_t m_max, n_max, k_max;
+  if (transB_) {
+    m_max = inputs[0].max.d[inputs[0].max.nbDims - 1];
+    k_max = inputs[0].max.d[inputs[0].max.nbDims - 2];
+  } else {
+    m_max = inputs[0].max.d[inputs[0].max.nbDims - 2];
+    k_max = inputs[0].max.d[inputs[0].max.nbDims - 1];
+  }
+  if (transA_) {
+    n_max = inputs[1].max.d[inputs[1].max.nbDims - 2];
+  } else {
+    n_max = inputs[1].max.d[inputs[1].max.nbDims - 1];
+  }
+
+  int const ldatransform = 32 * n_max;
+  int const ldbtransform = 32 * ((m_max + 8 - 1) / 8 * 8);
+  int const ldctransform = 32 * n_max;
+  CUDA_RT_CALL(cudaMalloc(
+      (void**)&Atransform_,
+      sizeof(int8_t) * ((k_max + 32 - 1) / 32 * 32) / 32 * ldatransform));
+  CUDA_RT_CALL(cudaMalloc(
+      (void**)&Btransform_,
+      sizeof(int8_t) * ((k_max + 32 - 1) / 32 * 32) / 32 * ldbtransform));
+  CUDA_RT_CALL(cudaMalloc(
+      (void**)&Ctransform_,
+      sizeof(int8_t) * ((m_max + 32 - 1) / 32 * 32) / 32 * ldctransform));
+
+  if (type_ == nvinfer1::DataType::kINT8) {
+    float alpha_tem[n_max];
+    for (int i = 0; i < n_max; i++) {
+      alpha_tem[i] = alpha_ * inscale_0 * inscale_1 / outscale;
+    }
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_scale_, n_max * sizeof(float)));
+    cudaMemcpyAsync(alpha_scale_, alpha_tem, n_max * sizeof(float),
+                    cudaMemcpyHostToDevice);
+    float zero_tem = zero;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_zero_, sizeof(float)));
+    cudaMemcpyAsync(alpha_zero_, &zero_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+    float one_tem = 1;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_one_, sizeof(float)));
+    cudaMemcpyAsync(alpha_one_, &one_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+  } else if (type_ == nvinfer1::DataType::kHALF) {
+    half alpha_tem = static_cast<half>(alpha_);
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_scale_, sizeof(half)));
+    cudaMemcpyAsync(alpha_scale_, &alpha_tem, sizeof(half),
+                    cudaMemcpyHostToDevice);
+    half zero_tem = static_cast<half>(zero);
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_zero_, sizeof(half)));
+    cudaMemcpyAsync(alpha_zero_, &zero_tem, sizeof(half),
+                    cudaMemcpyHostToDevice);
+  } else {
+    float alpha_tem = alpha_;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_scale_, sizeof(float)));
+    cudaMemcpyAsync(alpha_scale_, &alpha_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+    float zero_tem = zero;
+    CUDA_RT_CALL(cudaMalloc((void**)&alpha_zero_, sizeof(float)));
+    cudaMemcpyAsync(alpha_zero_, &zero_tem, sizeof(float),
+                    cudaMemcpyHostToDevice);
+  }
+}
+
+void MatmulPluginDynamic::attachToContext(
+    cudnnContext* cudnnContext, cublasContext* cublasContext,
+    nvinfer1::IGpuAllocator* gpuAllocator) TRT_NOEXCEPT {
+  dyl::cublasLtCreate(&cublas_);
+}
+
+void MatmulPluginDynamic::detachFromContext() TRT_NOEXCEPT {
+  dyl::cublasLtDestroy(cublas_);
+}
+
+void MatmulPluginDynamic::terminate() TRT_NOEXCEPT {
+  /*if(alpha_scale_){
+    cudaFree((void *)alpha_scale_);
+    alpha_scale_ = nullptr;
+  }
+  if(alpha_zero_){
+    cudaFree((void *)alpha_zero_);
+    alpha_zero_ = nullptr;
+  }
+  if(alpha_one_){
+    cudaFree((void *)alpha_one_);
+    alpha_one_ = nullptr;
+  }
+  if(Atransform_){
+    cudaFree((void *)Atransform_);
+    Atransform_ = nullptr;
+  }
+  if(Btransform_){
+    cudaFree((void *)Btransform_);
+    Btransform_ = nullptr;
+  }
+  if(Ctransform_){
+    cudaFree((void *)Ctransform_);
+    Ctransform_ = nullptr;
+  } */
+}
+
+int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
+                                 const nvinfer1::PluginTensorDesc* outputDesc,
+                                 const void* const* inputs,
+                                 void* const* outputs, void* workspace,
+                                 cudaStream_t stream) TRT_NOEXCEPT {
+  const auto Input0Desc = inputDesc[0];
+  const auto Input1Desc = inputDesc[1];
+  uint64_t m, n, k;
+  if (transB_) {
+    m = Input0Desc.dims.d[Input0Desc.dims.nbDims - 1];
+    k = Input0Desc.dims.d[Input0Desc.dims.nbDims - 2];
+  } else {
+    m = Input0Desc.dims.d[Input0Desc.dims.nbDims - 2];
+    k = Input0Desc.dims.d[Input0Desc.dims.nbDims - 1];
+  }
+  if (transA_) {
+    n = Input1Desc.dims.d[Input1Desc.dims.nbDims - 2];
+  } else {
+    n = Input1Desc.dims.d[Input1Desc.dims.nbDims - 1];
+  }
+
+  int batch = 1;
+  for (int i = 0; i < Input0Desc.dims.nbDims - 2; i++) {
+    batch *= Input0Desc.dims.d[i];
+  }
+  int const ldatransform = 32 * n;
+  int const ldbtransform = 32 * ((m + 8 - 1) / 8 * 8);
+  int const ldctransform = 32 * n;
+
+  int64_t stridea = k * n;
+  int64_t strideb = k * m;
+  int64_t stridec = m * n;
+
+  cublasOperation_t AopTranspose, BopTranspose;
+  if (transA_) {
+    AopTranspose = CUBLAS_OP_T;
+  } else {
+    AopTranspose = CUBLAS_OP_N;
+  }
+  if (transB_) {
+    BopTranspose = CUBLAS_OP_T;
+  } else {
+    BopTranspose = CUBLAS_OP_N;
+  }
+
+  cublasLtMatrixLayout_t Adesc{nullptr}, Bdesc{nullptr}, Cdesc{nullptr};
+  cublasLtMatmulDesc_t matmulDesc{nullptr};
+  cublasLtMatrixLayout_t AtransformDesc{nullptr}, BtransformDesc{nullptr},
+      CtransformDesc{nullptr};
+  int8_t *Atransform{nullptr}, *Btransform{nullptr}, *Ctransform{nullptr};
+  cublasLtMatrixTransformDesc_t transformDescT{nullptr},
+      transformDescN{nullptr};
+  if (type_ == nvinfer1::DataType::kINT8) {
+    cudaDataType_t cudadataTypeIO = CUDA_R_8I;
+    cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+    cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32I;
+    cublasLtOrder_t COL32 = CUBLASLT_ORDER_COL32;
+    cublasLtOrder_t COL4_4R2_8C = CUBLASLT_ORDER_COL4_4R2_8C;
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Adesc, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n : k,
+        AopTranspose == CUBLAS_OP_N ? k : n,
+        AopTranspose == CUBLAS_OP_N ? n : k));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridea),
+        sizeof(stridea)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Bdesc, cudadataTypeIO, BopTranspose == CUBLAS_OP_N ? k : m,
+        BopTranspose == CUBLAS_OP_N ? m : k,
+        BopTranspose == CUBLAS_OP_N ? k : m));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(strideb),
+        sizeof(strideb)));
+
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixLayoutCreate(&Cdesc, cudadataTypeIO, n, m, n));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridec),
+        sizeof(stridec)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &AtransformDesc, cudadataTypeIO, n, k, ldatransform));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        AtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER, &COL32, sizeof(COL32)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &BtransformDesc, cudadataTypeIO, m, k, ldbtransform));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        BtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER, &COL4_4R2_8C,
+        sizeof(COL4_4R2_8C)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &CtransformDesc, cudadataTypeIO, n, m, ldctransform));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        CtransformDesc, CUBLASLT_MATRIX_LAYOUT_ORDER, &COL32, sizeof(COL32)));
+
+    cublasOperation_t Transpose = CUBLAS_OP_T;
+    cublasLtPointerMode_t transform_model = CUBLASLT_POINTER_MODE_DEVICE;
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixTransformDescCreate(&transformDescT, cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescT, CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE,
+        &cudaDataTypeS, sizeof(cudaDataTypeS)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescT, CUBLASLT_MATRIX_TRANSFORM_DESC_TRANSA, &Transpose,
+        sizeof(Transpose)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescT, CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE,
+        &transform_model, sizeof(transform_model)));
+
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixTransformDescCreate(&transformDescN, cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescN, CUBLASLT_MATRIX_TRANSFORM_DESC_SCALE_TYPE,
+        &cudaDataTypeS, sizeof(cudaDataTypeS)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixTransformDescSetAttribute(
+        transformDescN, CUBLASLT_MATRIX_TRANSFORM_DESC_POINTER_MODE,
+        &transform_model, sizeof(transform_model)));
+
+    cublasOperation_t ATranspose = CUBLAS_OP_N, BTranspose = CUBLAS_OP_T;
+    cublasLtPointerMode_t matmul_model =
+        CUBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_ZERO;
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType,
+                                               cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA, &ATranspose,
+        sizeof(ATranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB, &BTranspose,
+        sizeof(BTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_POINTER_MODE, &matmul_model,
+        sizeof(matmul_model)));
+
+    const int8_t* B = static_cast<const int8_t*>(inputs[0]);
+    const int8_t* A = static_cast<const int8_t*>(inputs[1]);
+    int8_t* C = static_cast<int8_t*>(outputs[0]);
+    Ltgemm_int8_linear(cublas_, A, Adesc, Atransform_, AtransformDesc, transA_,
+                       B, Bdesc, Btransform_, BtransformDesc, transB_, C, Cdesc,
+                       Ctransform_, CtransformDesc, transformDescT,
+                       transformDescN, matmulDesc, alpha_scale_, alpha_zero_,
+                       alpha_one_, workspace, stream);
+  } else if (type_ == nvinfer1::DataType::kHALF) {
+    cudaDataType_t cudadataTypeIO = CUDA_R_16F;
+    cudaDataType_t cudaDataTypeS = CUDA_R_16F;
+    cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_16F;
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Adesc, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n : k,
+        AopTranspose == CUBLAS_OP_N ? k : n,
+        AopTranspose == CUBLAS_OP_N ? n : k));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridea),
+        sizeof(stridea)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Bdesc, cudadataTypeIO, BopTranspose == CUBLAS_OP_N ? k : m,
+        BopTranspose == CUBLAS_OP_N ? m : k,
+        BopTranspose == CUBLAS_OP_N ? k : m));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(strideb),
+        sizeof(strideb)));
+
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixLayoutCreate(&Cdesc, cudadataTypeIO, n, m, n));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridec),
+        sizeof(stridec)));
+
+    cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType,
+                                               cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
+        sizeof(AopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB, &BopTranspose,
+        sizeof(BopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_POINTER_MODE, &matmul_model,
+        sizeof(matmul_model)));
+
+    const half* B = static_cast<const half*>(inputs[0]);
+    const half* A = static_cast<const half*>(inputs[1]);
+    half* C = static_cast<half*>(outputs[0]);
+    Ltgemm_fp16_linear(cublas_, A, Adesc, B, Bdesc, C, Cdesc, matmulDesc,
+                       alpha_scale_, alpha_zero_, workspace, stream);
+  } else {
+    cudaDataType_t cudadataTypeIO = CUDA_R_32F;
+    cudaDataType_t cudaDataTypeS = CUDA_R_32F;
+    cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32F_FAST_16F;
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Adesc, cudadataTypeIO, AopTranspose == CUBLAS_OP_N ? n : k,
+        AopTranspose == CUBLAS_OP_N ? k : n,
+        AopTranspose == CUBLAS_OP_N ? n : k));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Adesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridea),
+        sizeof(stridea)));
+
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutCreate(
+        &Bdesc, cudadataTypeIO, BopTranspose == CUBLAS_OP_N ? k : m,
+        BopTranspose == CUBLAS_OP_N ? m : k,
+        BopTranspose == CUBLAS_OP_N ? k : m));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Bdesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(strideb),
+        sizeof(strideb)));
+
+    CUDA_RT_CALL(
+        dyl::cublasLtMatrixLayoutCreate(&Cdesc, cudadataTypeIO, n, m, n));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_TYPE, &cudadataTypeIO,
+        sizeof(cudadataTypeIO)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &(batch), sizeof(batch)));
+    CUDA_RT_CALL(dyl::cublasLtMatrixLayoutSetAttribute(
+        Cdesc, CUBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &(stridec),
+        sizeof(stridec)));
+
+    cublasLtPointerMode_t matmul_model = CUBLASLT_POINTER_MODE_DEVICE;
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescCreate(&matmulDesc, cudaComputeType,
+                                               cudaDataTypeS));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA, &AopTranspose,
+        sizeof(AopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB, &BopTranspose,
+        sizeof(BopTranspose)));
+    CUDA_RT_CALL(dyl::cublasLtMatmulDescSetAttribute(
+        matmulDesc, CUBLASLT_MATMUL_DESC_POINTER_MODE, &matmul_model,
+        sizeof(matmul_model)));
+
+    const float* B = static_cast<const float*>(inputs[0]);
+    const float* A = static_cast<const float*>(inputs[1]);
+    float* C = static_cast<float*>(outputs[0]);
+    Ltgemm_fp32_linear(cublas_, A, Adesc, B, Bdesc, C, Cdesc, matmulDesc,
+                       alpha_scale_, alpha_zero_, workspace, stream);
+  }
+  return cudaGetLastError() != cudaSuccess;
+}
+
+}  // namespace plugin
+}  // namespace tensorrt
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.cu
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.h"
-#include "paddle/fluid/platform/dynload/cublasLt.h"
 
 namespace plf = paddle::platform;
 namespace dyl = paddle::platform::dynload;
@@ -170,7 +169,7 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
     cudaDataType_t cudadataTypeIO = CUDA_R_8I;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
 #if CUBLAS_VER_MAJOR < 11
-    cudaDataType_t cudaComputeType = CUBLAS_R_32I;
+    cudaDataType_t cudaComputeType = CUDA_R_32I;
 #else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32I;
 #endif
@@ -315,7 +314,7 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
     cudaDataType_t cudadataTypeIO = CUDA_R_16F;
     cudaDataType_t cudaDataTypeS = CUDA_R_16F;
 #if CUBLAS_VER_MAJOR < 11
-    cudaDataType_t cudaComputeType = CUBLAS_R_16F;
+    cudaDataType_t cudaComputeType = CUDA_R_16F;
 #else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_16F;
 #endif
@@ -387,7 +386,7 @@ void MatmulPlugin::configurePlugin(const nvinfer1::PluginTensorDesc* inputs,
     cudaDataType_t cudadataTypeIO = CUDA_R_32F;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
 #if CUBLAS_VER_MAJOR < 11
-    cudaDataType_t cudaComputeType = CUBLAS_R_32F;
+    cudaDataType_t cudaComputeType = CUDA_R_32F;
 #else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32F_FAST_16F;
 #endif
@@ -739,7 +738,7 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
     cudaDataType_t cudadataTypeIO = CUDA_R_8I;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
 #if CUBLAS_VER_MAJOR < 11
-    cudaDataType_t cudaComputeType = CUBLAS_R_32I;
+    cudaDataType_t cudaComputeType = CUDA_R_32I;
 #else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32I;
 #endif
@@ -864,7 +863,7 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
     cudaDataType_t cudadataTypeIO = CUDA_R_16F;
     cudaDataType_t cudaDataTypeS = CUDA_R_16F;
 #if CUBLAS_VER_MAJOR < 11
-    cudaDataType_t cudaComputeType = CUBLAS_R_16F;
+    cudaDataType_t cudaComputeType = CUDA_R_16F;
 #else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_16F;
 #endif
@@ -933,7 +932,7 @@ int MatmulPluginDynamic::enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
     cudaDataType_t cudadataTypeIO = CUDA_R_32F;
     cudaDataType_t cudaDataTypeS = CUDA_R_32F;
 #if CUBLAS_VER_MAJOR < 11
-    cudaDataType_t cudaComputeType = CUBLAS_R_32F;
+    cudaDataType_t cudaComputeType = CUDA_R_32F;
 #else
     cublasComputeType_t cudaComputeType = CUBLAS_COMPUTE_32F_FAST_16F;
 #endif

--- a/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/matmul_op_int8_plugin.h
@@ -1,0 +1,445 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+#include <cassert>
+
+#include <string>
+#include <vector>
+#include "paddle/fluid/inference/tensorrt/plugin/trt_plugin.h"
+#include "paddle/fluid/platform/dynload/cublasLt.h"
+
+namespace paddle {
+namespace inference {
+namespace tensorrt {
+namespace plugin {
+
+#ifndef CUDA_RT_CALL
+#define CUDA_RT_CALL(call)                                                    \
+  {                                                                           \
+    auto status = static_cast<cudaError_t>(call);                             \
+    if (status != cudaSuccess)                                                \
+      fprintf(stderr,                                                         \
+              "ERROR: CUDA RT call \"%s\" in line %d of file %s failed "      \
+              "with "                                                         \
+              "%s (%d).\n",                                                   \
+              #call, __LINE__, __FILE__, cudaGetErrorString(status), status); \
+  }
+#endif  // CUDA_RT_CALL
+// *************** FOR ERROR CHECKING *******************
+
+class MatmulPlugin : public nvinfer1::IPluginV2IOExt {
+ public:
+  MatmulPlugin(nvinfer1::Dims const& dims_x, nvinfer1::Dims const& dims_y,
+               bool transA, bool transB, float alpha)
+      : dims_x_(dims_x),
+        dims_y_(dims_y),
+        transB_(transA),
+        transA_(transB),
+        alpha_(alpha) {}
+
+  MatmulPlugin(void const* serial_data, size_t serial_length) {
+    DeserializeValue(&serial_data, &serial_length, &dims_x_);
+    DeserializeValue(&serial_data, &serial_length, &dims_y_);
+    DeserializeValue(&serial_data, &serial_length, &transB_);
+    DeserializeValue(&serial_data, &serial_length, &transA_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_scale_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_one_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_zero_);
+    DeserializeValue(&serial_data, &serial_length, &batch_);
+    DeserializeValue(&serial_data, &serial_length, &k_);
+    DeserializeValue(&serial_data, &serial_length, &m_);
+    DeserializeValue(&serial_data, &serial_length, &n_);
+    DeserializeValue(&serial_data, &serial_length, &cublas_);
+    DeserializeValue(&serial_data, &serial_length, &type_);
+    DeserializeValue(&serial_data, &serial_length, &Adesc_);
+    DeserializeValue(&serial_data, &serial_length, &Bdesc_);
+    DeserializeValue(&serial_data, &serial_length, &Cdesc_);
+    DeserializeValue(&serial_data, &serial_length, &AtransformDesc_);
+    DeserializeValue(&serial_data, &serial_length, &BtransformDesc_);
+    DeserializeValue(&serial_data, &serial_length, &CtransformDesc_);
+    DeserializeValue(&serial_data, &serial_length, &Atransform_);
+    DeserializeValue(&serial_data, &serial_length, &Btransform_);
+    DeserializeValue(&serial_data, &serial_length, &Ctransform_);
+    DeserializeValue(&serial_data, &serial_length, &transformDescT_);
+    DeserializeValue(&serial_data, &serial_length, &transformDescN_);
+    DeserializeValue(&serial_data, &serial_length, &matmulDesc_);
+  }
+
+  virtual bool isOutputBroadcastAcrossBatch(
+      int32_t output_index, const bool* input_is_broadcasted,
+      int32_t nb_inputs) const TRT_NOEXCEPT {
+    return false;
+  }
+
+  virtual bool canBroadcastInputAcrossBatch(int32_t input_index) const
+      TRT_NOEXCEPT {
+    return false;
+  }
+
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
+
+  size_t getWorkspaceSize(int) const TRT_NOEXCEPT override { return 0; }
+
+  void setPluginNamespace(const char* plugin_namespace) TRT_NOEXCEPT override {
+    name_space_ = plugin_namespace;
+  }
+
+  nvinfer1::IPluginV2IOExt* clone() const TRT_NOEXCEPT override {
+    MatmulPlugin* ptr =
+        new MatmulPlugin(dims_x_, dims_y_, transB_, transA_, alpha_);
+    ptr->setPluginNamespace(this->getPluginNamespace());
+    ptr->batch_ = batch_;
+    ptr->k_ = k_;
+    ptr->m_ = m_;
+    ptr->n_ = n_;
+    ptr->alpha_scale_ = alpha_scale_;
+    ptr->alpha_one_ = alpha_one_;
+    ptr->alpha_zero_ = alpha_zero_;
+    ptr->cublas_ = cublas_;
+    ptr->type_ = type_;
+    ptr->Adesc_ = Adesc_;
+    ptr->Bdesc_ = Bdesc_;
+    ptr->Cdesc_ = Cdesc_;
+    ptr->AtransformDesc_ = AtransformDesc_;
+    ptr->BtransformDesc_ = BtransformDesc_;
+    ptr->CtransformDesc_ = CtransformDesc_;
+    ptr->Atransform_ = Atransform_;
+    ptr->Btransform_ = Btransform_;
+    ptr->Ctransform_ = Ctransform_;
+    ptr->transformDescT_ = transformDescT_;
+    ptr->transformDescN_ = transformDescN_;
+    ptr->matmulDesc_ = matmulDesc_;
+    return ptr;
+  }
+
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
+    return name_space_.c_str();
+  }
+
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "matmul_int8_plugin";
+  }
+
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* input_types,
+      int nb_inputs) const TRT_NOEXCEPT override;
+
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+
+  nvinfer1::Dims getOutputDimensions(int index,
+                                     const nvinfer1::Dims* input_dims,
+                                     int num_inputs) TRT_NOEXCEPT override;
+
+  bool supportsFormatCombination(int32_t pos,
+                                 nvinfer1::PluginTensorDesc const* inOut,
+                                 int32_t nbInputs,
+                                 int32_t nbOutputs) const TRT_NOEXCEPT override;
+
+  void configurePlugin(const nvinfer1::PluginTensorDesc* in, int32_t nbInputs,
+                       const nvinfer1::PluginTensorDesc* out,
+                       int32_t nbOutputs) TRT_NOEXCEPT override;
+
+  /*
+    bool supportsFormat(nvinfer1::DataType type, nvinfer1::PluginFormat format)
+        const TRT_NOEXCEPT override;
+  */
+  int initialize() TRT_NOEXCEPT { return 0; }
+  void terminate() TRT_NOEXCEPT;
+
+#if IS_TRT_VERSION_LT(8000)
+  int enqueue(int batch_size, const void* const* inputs, void** outputs,
+#else
+  int enqueue(int batch_size, const void* const* inputs, void* const* outputs,
+#endif
+              void* workspace, cudaStream_t stream) TRT_NOEXCEPT override;
+
+  void destroy() TRT_NOEXCEPT override { delete this; }
+  void attachToContext(cudnnContext* cudnnContext, cublasContext* cublasContext,
+                       nvinfer1::IGpuAllocator* gpuAllocator)
+      TRT_NOEXCEPT override;
+  void detachFromContext() TRT_NOEXCEPT override;
+
+ protected:
+  nvinfer1::Dims dims_x_;
+  nvinfer1::Dims dims_y_;
+  bool transB_;
+  bool transA_;
+  float alpha_;
+  void *alpha_scale_{nullptr}, *alpha_one_{nullptr}, *alpha_zero_{nullptr};
+  int batch_;
+  uint64_t k_;
+  uint64_t m_;
+  uint64_t n_;
+  cublasLtHandle_t cublas_{nullptr};
+  nvinfer1::DataType type_;
+  cublasLtMatrixLayout_t Adesc_{nullptr}, Bdesc_{nullptr}, Cdesc_{nullptr};
+  cublasLtMatrixLayout_t AtransformDesc_{nullptr}, BtransformDesc_{nullptr},
+      CtransformDesc_{nullptr};
+  int8_t *Atransform_{nullptr}, *Btransform_{nullptr}, *Ctransform_{nullptr};
+  cublasLtMatrixTransformDesc_t transformDescT_{nullptr},
+      transformDescN_{nullptr};
+  cublasLtMatmulDesc_t matmulDesc_{nullptr};
+  std::string name_space_;
+
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
+    return SerializedSize(dims_x_) + SerializedSize(dims_y_) +
+           SerializedSize(transB_) + SerializedSize(transA_) +
+           SerializedSize(alpha_) + SerializedSize(alpha_scale_) +
+           SerializedSize(alpha_one_) + SerializedSize(alpha_zero_) +
+           SerializedSize(batch_) + SerializedSize(k_) + SerializedSize(m_) +
+           SerializedSize(n_) + SerializedSize(cublas_) +
+           SerializedSize(type_) + SerializedSize(Adesc_) +
+           SerializedSize(Bdesc_) + SerializedSize(Cdesc_) +
+           SerializedSize(AtransformDesc_) + SerializedSize(BtransformDesc_) +
+           SerializedSize(CtransformDesc_) + SerializedSize(Atransform_) +
+           SerializedSize(Btransform_) + SerializedSize(Ctransform_) +
+           SerializedSize(transformDescT_) + SerializedSize(transformDescN_) +
+           SerializedSize(matmulDesc_);
+  }
+
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
+    SerializeValue(&buffer, dims_x_);
+    SerializeValue(&buffer, dims_y_);
+    SerializeValue(&buffer, transB_);
+    SerializeValue(&buffer, transA_);
+    SerializeValue(&buffer, alpha_);
+    SerializeValue(&buffer, alpha_scale_);
+    SerializeValue(&buffer, alpha_one_);
+    SerializeValue(&buffer, alpha_zero_);
+    SerializeValue(&buffer, batch_);
+    SerializeValue(&buffer, k_);
+    SerializeValue(&buffer, m_);
+    SerializeValue(&buffer, n_);
+    SerializeValue(&buffer, cublas_);
+    SerializeValue(&buffer, type_);
+    SerializeValue(&buffer, Adesc_);
+    SerializeValue(&buffer, Bdesc_);
+    SerializeValue(&buffer, Cdesc_);
+    SerializeValue(&buffer, AtransformDesc_);
+    SerializeValue(&buffer, BtransformDesc_);
+    SerializeValue(&buffer, CtransformDesc_);
+    SerializeValue(&buffer, Atransform_);
+    SerializeValue(&buffer, Btransform_);
+    SerializeValue(&buffer, Ctransform_);
+    SerializeValue(&buffer, transformDescT_);
+    SerializeValue(&buffer, transformDescN_);
+    SerializeValue(&buffer, matmulDesc_);
+  }
+};
+
+class MatmulPluginCreator : public nvinfer1::IPluginCreator {
+ public:
+  MatmulPluginCreator() {}
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "matmul_int8_plugin";
+  }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
+
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
+    return &field_collection_;
+  }
+
+  nvinfer1::IPluginV2IOExt* createPlugin(
+      const char* name,
+      const nvinfer1::PluginFieldCollection* fc) TRT_NOEXCEPT override {
+    return nullptr;
+  }
+
+  nvinfer1::IPluginV2IOExt* deserializePlugin(
+      const char* name, void const* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
+    MatmulPlugin* obj = new MatmulPlugin(serial_data, serial_length);
+    obj->setPluginNamespace(name);
+    return obj;
+  }
+
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
+    plugin_namespace_ = lib_namespace;
+  }
+
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
+    return plugin_namespace_.c_str();
+  }
+
+ private:
+  std::string plugin_namespace_;
+  std::string plugin_name_;
+  nvinfer1::PluginFieldCollection field_collection_{0, nullptr};
+  std::vector<nvinfer1::PluginField> plugin_attributes_;
+};
+REGISTER_TRT_PLUGIN_V2(MatmulPluginCreator);
+
+#if IS_TRT_VERSION_GE(6000)
+class MatmulPluginDynamic : public DynamicPluginTensorRT {
+ public:
+  MatmulPluginDynamic(bool transA, bool transB, float alpha)
+      : transB_(transA), transA_(transB), alpha_(alpha) {}
+
+  MatmulPluginDynamic(void const* serial_data, size_t serial_length) {
+    DeserializeValue(&serial_data, &serial_length, &transB_);
+    DeserializeValue(&serial_data, &serial_length, &transA_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_scale_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_one_);
+    DeserializeValue(&serial_data, &serial_length, &alpha_zero_);
+    DeserializeValue(&serial_data, &serial_length, &cublas_);
+    DeserializeValue(&serial_data, &serial_length, &Atransform_);
+    DeserializeValue(&serial_data, &serial_length, &Btransform_);
+    DeserializeValue(&serial_data, &serial_length, &Ctransform_);
+    DeserializeValue(&serial_data, &serial_length, &type_);
+  }
+
+  nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
+    MatmulPluginDynamic* ptr =
+        new MatmulPluginDynamic(transB_, transA_, alpha_);
+    ptr->setPluginNamespace(this->getPluginNamespace());
+    ptr->alpha_scale_ = alpha_scale_;
+    ptr->alpha_one_ = alpha_one_;
+    ptr->alpha_zero_ = alpha_zero_;
+    ptr->cublas_ = cublas_;
+    ptr->Atransform_ = Atransform_;
+    ptr->Btransform_ = Btransform_;
+    ptr->Ctransform_ = Ctransform_;
+    ptr->type_ = type_;
+    return ptr;
+  }
+
+  const char* getPluginType() const TRT_NOEXCEPT override {
+    return "matmul_int8_dynamic_plugin";
+  }
+
+  int getNbOutputs() const TRT_NOEXCEPT override { return 1; }
+
+  int initialize() TRT_NOEXCEPT { return 0; }
+  void terminate() TRT_NOEXCEPT;
+  nvinfer1::DimsExprs getOutputDimensions(
+      int outputIndex, const nvinfer1::DimsExprs* inputs, int nbInputs,
+      nvinfer1::IExprBuilder& exprBuilder) TRT_NOEXCEPT override;
+
+  bool supportsFormatCombination(int pos,
+                                 const nvinfer1::PluginTensorDesc* inOut,
+                                 int nbInputs,
+                                 int nbOutputs) TRT_NOEXCEPT override;
+
+  void configurePlugin(const nvinfer1::DynamicPluginTensorDesc* inputs,
+                       int nbInputs,
+                       const nvinfer1::DynamicPluginTensorDesc* outputs,
+                       int nbOutputs) TRT_NOEXCEPT override;
+
+  size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs,
+                          int nbInputs,
+                          const nvinfer1::PluginTensorDesc* outputs,
+                          int nbOutputs) const TRT_NOEXCEPT override {
+    return 0;
+  }
+
+  void attachToContext(cudnnContext* cudnnContext, cublasContext* cublasContext,
+                       nvinfer1::IGpuAllocator* gpuAllocator)
+      TRT_NOEXCEPT override;
+
+  void detachFromContext() TRT_NOEXCEPT override;
+
+  int enqueue(const nvinfer1::PluginTensorDesc* inputDesc,
+              const nvinfer1::PluginTensorDesc* outputDesc,
+              const void* const* inputs, void* const* outputs, void* workspace,
+              cudaStream_t stream) TRT_NOEXCEPT override;
+  nvinfer1::DataType getOutputDataType(
+      int index, const nvinfer1::DataType* inputTypes,
+      int nbInputs) const TRT_NOEXCEPT override;
+
+  void destroy() TRT_NOEXCEPT override { delete this; }
+
+ protected:
+  bool transB_;
+  bool transA_;
+  float alpha_;
+  void *alpha_scale_{nullptr}, *alpha_one_{nullptr}, *alpha_zero_{nullptr};
+  cublasLtHandle_t cublas_{nullptr};
+  nvinfer1::DataType type_;
+  int8_t *Atransform_{nullptr}, *Btransform_{nullptr}, *Ctransform_{nullptr};
+  std::string name_space_;
+
+  size_t getSerializationSize() const TRT_NOEXCEPT override {
+    return SerializedSize(transB_) + SerializedSize(transA_) +
+           SerializedSize(alpha_) + SerializedSize(alpha_scale_) +
+           SerializedSize(alpha_one_) + SerializedSize(alpha_zero_) +
+           SerializedSize(Atransform_) + SerializedSize(Btransform_) +
+           SerializedSize(Ctransform_) + SerializedSize(cublas_) +
+           SerializedSize(type_);
+  }
+
+  void serialize(void* buffer) const TRT_NOEXCEPT override {
+    SerializeValue(&buffer, transB_);
+    SerializeValue(&buffer, transA_);
+    SerializeValue(&buffer, alpha_);
+    SerializeValue(&buffer, alpha_scale_);
+    SerializeValue(&buffer, alpha_one_);
+    SerializeValue(&buffer, alpha_zero_);
+    SerializeValue(&buffer, Atransform_);
+    SerializeValue(&buffer, Btransform_);
+    SerializeValue(&buffer, Ctransform_);
+    SerializeValue(&buffer, cublas_);
+    SerializeValue(&buffer, type_);
+  }
+};
+
+class MatmulPluginDynamicCreator : public nvinfer1::IPluginCreator {
+ public:
+  MatmulPluginDynamicCreator() {}
+  const char* getPluginName() const TRT_NOEXCEPT override {
+    return "matmul_int8_dynamic_plugin";
+  }
+  const char* getPluginVersion() const TRT_NOEXCEPT override { return "1"; }
+
+  const nvinfer1::PluginFieldCollection* getFieldNames() TRT_NOEXCEPT override {
+    return &field_collection_;
+  }
+
+  nvinfer1::IPluginV2* createPlugin(const char* name,
+                                    const nvinfer1::PluginFieldCollection* fc)
+      TRT_NOEXCEPT override {
+    return nullptr;
+  }
+
+  nvinfer1::IPluginV2* deserializePlugin(
+      const char* name, void const* serial_data,
+      size_t serial_length) TRT_NOEXCEPT override {
+    MatmulPluginDynamic* obj =
+        new MatmulPluginDynamic(serial_data, serial_length);
+    obj->setPluginNamespace(name);
+    return obj;
+  }
+
+  void setPluginNamespace(const char* lib_namespace) TRT_NOEXCEPT override {
+    plugin_namespace_ = lib_namespace;
+  }
+
+  const char* getPluginNamespace() const TRT_NOEXCEPT override {
+    return plugin_namespace_.c_str();
+  }
+
+ private:
+  std::string plugin_namespace_;
+  std::string plugin_name_;
+  nvinfer1::PluginFieldCollection field_collection_{0, nullptr};
+  std::vector<nvinfer1::PluginField> plugin_attributes_;
+};
+REGISTER_TRT_PLUGIN_V2(MatmulPluginDynamicCreator);
+#endif
+}  // namespace plugin
+}  // namespace tensorrt
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/platform/dynload/CMakeLists.txt
+++ b/paddle/fluid/platform/dynload/CMakeLists.txt
@@ -1,6 +1,6 @@
 cc_library(dynamic_loader SRCS dynamic_loader.cc DEPS glog gflags enforce)
 
-list(APPEND CUDA_SRCS cublas.cc cudnn.cc curand.cc cusolver.cc cusparse.cc  nvtx.cc cufft.cc)
+list(APPEND CUDA_SRCS cublas.cc cublasLt.cc cudnn.cc curand.cc cusolver.cc cusparse.cc  nvtx.cc cufft.cc)
 
 if (NOT WITH_NV_JETSON)
     list(APPEND CUDA_SRCS nvjpeg.cc)

--- a/paddle/fluid/platform/dynload/cublasLt.cc
+++ b/paddle/fluid/platform/dynload/cublasLt.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/platform/dynload/cublasLt.h"
+
+namespace paddle {
+namespace platform {
+namespace dynload {
+std::once_flag cublasLt_dso_flag;
+void *cublasLt_dso_handle = nullptr;
+
+#define DEFINE_WRAP(__name) DynLoad__##__name __name
+
+CUBLASLT_BLAS_ROUTINE_EACH(DEFINE_WRAP);
+
+}  // namespace dynload
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/dynload/cublasLt.h
+++ b/paddle/fluid/platform/dynload/cublasLt.h
@@ -1,0 +1,78 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <cublasLt.h>
+#include <cuda.h>
+#include <mutex>  // NOLINT
+#include <type_traits>
+
+#include "paddle/fluid/platform/dynload/dynamic_loader.h"
+#include "paddle/fluid/platform/port.h"
+
+namespace paddle {
+namespace platform {
+namespace dynload {
+
+extern std::once_flag cublasLt_dso_flag;
+extern void *cublasLt_dso_handle;
+
+/**
+ * The following macro definition can generate structs
+ * (for each function) to dynamic load cublasLt routine
+ * via operator overloading.
+ *
+ * note: default dynamic linked libs
+ */
+#define DECLARE_DYNAMIC_LOAD_CUBLASLT_WRAP(__name)                          \
+  struct DynLoad__##__name {                                                \
+    template <typename... Args>                                             \
+    inline auto operator()(Args... args) -> DECLARE_TYPE(__name, args...) { \
+      using cublasLt_func =                                                 \
+          decltype(::__name(std::declval<Args>()...)) (*)(Args...);         \
+      std::call_once(cublasLt_dso_flag, []() {                              \
+        cublasLt_dso_handle =                                               \
+            paddle::platform::dynload::GetCublasLtDsoHandle();              \
+      });                                                                   \
+      static void *p_##__name = dlsym(cublasLt_dso_handle, #__name);        \
+      return reinterpret_cast<cublasLt_func>(p_##__name)(args...);          \
+    }                                                                       \
+  };                                                                        \
+  extern DynLoad__##__name __name
+
+// APIs available after CUDA 10.1
+// #if CUDA_VERSION >= 10100
+#define CUBLASLT_BLAS_ROUTINE_EACH(__macro)    \
+  __macro(cublasLtCreate);                     \
+  __macro(cublasLtDestroy);                    \
+  __macro(cublasLtMatmul);                     \
+  __macro(cublasLtMatmulDescCreate);           \
+  __macro(cublasLtMatmulDescDestroy);          \
+  __macro(cublasLtMatmulDescSetAttribute);     \
+  __macro(cublasLtMatrixLayoutCreate);         \
+  __macro(cublasLtMatrixLayoutDestroy);        \
+  __macro(cublasLtMatrixLayoutSetAttribute);   \
+  __macro(cublasLtMatrixTransform);            \
+  __macro(cublasLtMatrixTransformDescCreate);  \
+  __macro(cublasLtMatrixTransformDescDestroy); \
+  __macro(cublasLtMatrixTransformDescSetAttribute);
+
+CUBLASLT_BLAS_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUBLASLT_WRAP)
+// #endif
+
+#undef DECLARE_DYNAMIC_LOAD_CUBLASLT_WRAP
+}  // namespace dynload
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -211,16 +211,8 @@ static inline void* GetDsoHandleFromDefaultPath(const std::string& dso_path,
     dso_handle =
         dlopen(join("/usr/local/cuda/lib/", dso_path).c_str(), dynload_flags);
   }
-#elif defined(PADDLE_WITH_CUDA)
-  if (nullptr == dso_handle) {
-    dso_handle =
-        dlopen(join("/usr/local/cuda/lib64/", dso_path).c_str(), dynload_flags);
-  }
-  if (nullptr == dso_handle) {
-    dso_handle = dlopen(join("/usr/lib/x86_64-linux-gnu/", dso_path).c_str(),
-                        dynload_flags);
-  }
 #endif
+
   return dso_handle;
 }
 

--- a/paddle/fluid/platform/dynload/dynamic_loader.h
+++ b/paddle/fluid/platform/dynload/dynamic_loader.h
@@ -26,6 +26,7 @@ namespace dynload {
 #endif
 
 void* GetCublasDsoHandle();
+void* GetCublasLtDsoHandle();
 void* GetCUDNNDsoHandle();
 void* GetCUPTIDsoHandle();
 void* GetCurandDsoHandle();

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1965,10 +1965,12 @@ function gen_dockerfile() {
     DOCKERFILE_GPU_ENV=""
     DOCKERFILE_CUDNN_DSO=""
     DOCKERFILE_CUBLAS_DSO=""
+    DOCKERFILE_CUBLASLT_DSO=""
     if [[ ${WITH_GPU:-OFF} == 'ON' ]]; then
         DOCKERFILE_GPU_ENV="ENV LD_LIBRARY_PATH /usr/lib/x86_64-linux-gnu:\${LD_LIBRARY_PATH}"
         DOCKERFILE_CUDNN_DSO="RUN ln -sf /usr/lib/x86_64-linux-gnu/libcudnn.so.${CUDNN_MAJOR} /usr/lib/x86_64-linux-gnu/libcudnn.so"
         DOCKERFILE_CUBLAS_DSO="RUN ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libcublas.so.${CUDA_MAJOR} /usr/lib/x86_64-linux-gnu/libcublas.so"
+        DOCKERFILE_CUBLASLT_DSO="RUN ln -sf /usr/local/cuda/targets/x86_64-linux/lib/libcublasLt.so /usr/lib/x86_64-linux-gnu/libcublasLt.so"
     fi
 
     cat <<EOF
@@ -2058,6 +2060,7 @@ EOF
         ldconfig
     ${DOCKERFILE_CUDNN_DSO}
     ${DOCKERFILE_CUBLAS_DSO}
+    ${DOCKERFILE_CUBLASLT_DSO}
     ${DOCKERFILE_GPU_ENV}
 EOF
     cat >> ${PADDLE_ROOT}/build/Dockerfile <<EOF


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
增加 MatmulV2ToMatmul 的 Pass，重新限定 (matmul_v2, matmul, mul) 映射的 Pass，修改 (matmul, mul) 的 op_teller 映射条件：
1、 MapMatmulV2ToMatmulPass：原生 op 完整无条件映射（matmul_v2 无 scales 的参数，其它行为完全一样）；
2、MapMatmul2MulPass：限制matmul 映射到 mul 的条件（当 alpha 存在时 ==1、transpose_X==false、transpose_Y==false、y.dims==2、等），移除之前过度的限制（很多无用落后版本的限制，x.dims）；
3、修复之前 pass 映射导致的 op 中量化信息（out_threshold）的丢失；
4、增加matmul 的op_teller映射条件：不支持广播的限制；
5、增加mul 的op_teller映射条件：y.dims ==2、y_num_col_dims ==1；
6、动态图量化增加限制：只支持fake_quantize_dequantize_abs_max、fake_channel_wise_quantize_dequantize_abs_max