### PR TITLE
[cherry-pick] fix nullptr block in op_teller

### DIFF
--- a/paddle/fluid/framework/ir/quant_conv2d_dequant_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/quant_conv2d_dequant_fuse_pass.cc
@@ -548,7 +548,8 @@ void QuantDequantFusePass::FuseDequant(ir::Graph* graph, Scope* scope,
     std::string new_input = quantized_op_input_node->Name();
     std::string new_output = dequant_op_out_node->Name();
 
-    framework::OpDesc new_op_desc(base_op_desc, nullptr);
+    framework::OpDesc new_op_desc(base_op_desc,
+                                  quantized_op_node->Op()->Block());
     new_op_desc.SetType(quantized_op_type);
     new_op_desc.SetAttr("enable_int8", true);
     if (quantized_op_type == "conv2d" || quantized_op_type == "conv2d_fusion" ||


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
修复op_teller中量化场景获取不到block的情况，develop分支pr：https://github.com/PaddlePaddle/Paddle/pull/36197

问题卡片序号：37682
根本原因是：在op_teller中添加了multihad_matmul的broadcast的限制条件，这个条件需要在opDesc里获取block后进行判断，但ernie量化场景中quant_conv2d_dequant_fuse_pass里创建opDesc时没有传入block，从而导致op_teller判断失败multihad_matmul没有进入tensorrt，在动态shape情况下后面的算子报没有设置动态shape的错误。

<!-- Describe what this PR does -->
