### PR TITLE
fix interpolate mkldnn op error

### DIFF
--- a/paddle/fluid/operators/mkldnn/interpolate_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/interpolate_mkldnn_op.cc
@@ -104,8 +104,10 @@ class InterpolateMKLDNNKernel : public framework::OpKernel<T> {
           scale.push_back(scale[0]);
         } else {  // v2
           std::vector<float> scale_attr = ctx.Attr<std::vector<float>>("scale");
-          scale.resize(3, scale_attr[0]);
-          std::copy(scale_attr.begin(), scale_attr.end(), scale.begin());
+          if (scale_attr.size() > 0) {
+            scale.resize(3, scale_attr[0]);
+            std::copy(scale_attr.begin(), scale_attr.end(), scale.begin());
+          }
         }
       }
       if (scale[0] > 0.0f && scale[1] > 0.0f && scale[2] > 0.0f) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
OPs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
Fix the problem that the interpolate_v2 mkldnn op reports an error when the scale attribute is empty.

修复interpolate_v2 mkldnn 算子在scale属性为空时报错问题
<!-- Describe what this PR does -->