### PR TITLE
Disable pool&conv_transpose&quantize caching

### DIFF
--- a/paddle/fluid/operators/fused/mkldnn/fusion_gru_mkldnn_op.cc
+++ b/paddle/fluid/operators/fused/mkldnn/fusion_gru_mkldnn_op.cc
@@ -21,7 +21,6 @@ namespace operators {
 using paddle::framework::LoDTensor;
 using paddle::framework::Tensor;
 using paddle::platform::CPUDeviceContext;
-using paddle::platform::CreateKey;
 using paddle::platform::MKLDNNGetDataType;
 using paddle::platform::MKLDNNMemDesc;
 using platform::to_void_cast;

--- a/paddle/fluid/operators/fused/mkldnn/fusion_lstm_mkldnn_op.cc
+++ b/paddle/fluid/operators/fused/mkldnn/fusion_lstm_mkldnn_op.cc
@@ -21,7 +21,6 @@ namespace operators {
 using paddle::framework::LoDTensor;
 using paddle::framework::Tensor;
 using paddle::platform::CPUDeviceContext;
-using paddle::platform::CreateKey;
 using paddle::platform::MKLDNNGetDataType;
 using paddle::platform::MKLDNNMemDesc;
 using platform::to_void_cast;

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -63,306 +63,330 @@ static mkldnn::memory::data_type GetDstType(bool is_int8, bool is_bfloat16,
 
 template <typename T, typename K, typename T_out>
 class ConvMKLDNNHandlerT
-    : public platform::MKLDNNHandlerNoCachingT<
-          T, mkldnn::convolution_forward, mkldnn::convolution_backward_data,
-          mkldnn::convolution_backward_weights> {
+    : public platform::MKLDNNHandlerT<T, mkldnn::convolution_forward,
+                                      mkldnn::convolution_backward_data,
+                                      mkldnn::convolution_backward_weights> {
  public:
   ConvMKLDNNHandlerT(const framework::ExecutionContext& ctx,
-                     const mkldnn::engine mkldnn_engine, const Tensor* input,
-                     const Tensor* filter, const Tensor* bias, Tensor* output)
-      : platform::MKLDNNHandlerNoCachingT<T, mkldnn::convolution_forward,
-                                          mkldnn::convolution_backward_data,
-                                          mkldnn::convolution_backward_weights>(
-            mkldnn_engine, ctx.GetPlace()),
-        is_test_(ctx.Attr<bool>("is_test")) {
-    PADDLE_ENFORCE_EQ(input->layout(), framework::DataLayout::kMKLDNN,
-                      platform::errors::InvalidArgument(
-                          "The input tensor's layout should be %d, but got %d.",
-                          framework::DataLayout::kMKLDNN, input->layout()));
-    PADDLE_ENFORCE_NE(
-        input->format(), MKLDNNMemoryFormat::undef,
-        platform::errors::InvalidArgument("Wrong format set for Input tensor"));
-
-    PADDLE_ENFORCE_EQ(
-        filter->layout(), framework::DataLayout::kMKLDNN,
-        platform::errors::InvalidArgument(
-            "The Filter tensor's layout should be %d, but got %d.",
-            framework::DataLayout::kMKLDNN, filter->layout()));
-    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
-                      platform::errors::InvalidArgument(
-                          "Wrong format set for Filter tensor"));
-
-    PADDLE_ENFORCE_GE(input->dims().size(), 4,
-                      platform::errors::InvalidArgument(
-                          "Input must be with 4 or 5 dimensions, i.e. NCHW or "
-                          "NCDHW, but got dimension = %d .",
-                          input->dims().size()));
-    PADDLE_ENFORCE_LE(input->dims().size(), 5,
-                      platform::errors::InvalidArgument(
-                          "Input must be with 4 or 5 dimensions, i.e. NCHW or "
-                          "NCDHW, but got dimension = %d .",
-                          input->dims().size()));
-
-    PADDLE_ENFORCE_GE(filter->dims().size(), 4,
-                      platform::errors::InvalidArgument(
-                          "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
-                          "OIDHW, but got dimension = %d .",
-                          filter->dims().size()));
-    PADDLE_ENFORCE_LE(filter->dims().size(), 5,
-                      platform::errors::InvalidArgument(
-                          "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
-                          "OIDHW, but got dimension = %d .",
-                          filter->dims().size()));
-
-    if (bias) {
+                     const platform::MKLDNNDeviceContext& dev_ctx,
+                     const mkldnn::engine mkldnn_engine,
+                     platform::Place cpu_place, const Tensor* input,
+                     const Tensor* filter, const Tensor* bias, Tensor* output,
+                     const std::string& unique_name)
+      : platform::MKLDNNHandlerT<T, mkldnn::convolution_forward,
+                                 mkldnn::convolution_backward_data,
+                                 mkldnn::convolution_backward_weights>(
+            dev_ctx, mkldnn_engine, cpu_place,
+            platform::CreateKey(dev_ctx, framework::vectorize(input->dims()),
+                                unique_name)) {
+    if (!this->isCached()) {
       PADDLE_ENFORCE_EQ(
-          bias->layout(), framework::DataLayout::kMKLDNN,
+          input->layout(), framework::DataLayout::kMKLDNN,
           platform::errors::InvalidArgument(
-              "The Bias tensor's layout should be %d, but got %d.",
-              framework::DataLayout::kMKLDNN, bias->layout()));
-      PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::undef,
+              "The input tensor's layout should be %d, but got %d.",
+              framework::DataLayout::kMKLDNN, input->layout()));
+      PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::undef,
                         platform::errors::InvalidArgument(
-                            "Got wrong format for Bias tensor."));
+                            "Wrong format set for Input tensor"));
 
       PADDLE_ENFORCE_EQ(
-          bias->dims().size(), 1,
-          platform::errors::InvalidArgument("Bias must only have 1 dimension, "
-                                            "i.e. X, but got dimension = %d .",
-                                            bias->dims().size()));
-    }
+          filter->layout(), framework::DataLayout::kMKLDNN,
+          platform::errors::InvalidArgument(
+              "The Filter tensor's layout should be %d, but got %d.",
+              framework::DataLayout::kMKLDNN, filter->layout()));
+      PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
+                        platform::errors::InvalidArgument(
+                            "Wrong format set for Filter tensor"));
 
-    const std::string fuse_activation =
-        ctx.Attr<std::string>("fuse_activation");
-    const float fuse_alpha = ctx.Attr<float>("fuse_alpha");
-    const float fuse_beta = ctx.Attr<float>("fuse_beta");
-    const bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
-    const int groups = ctx.Attr<int>("groups");
-    const std::string padding_algorithm =
-        ctx.Attr<std::string>("padding_algorithm");
+      PADDLE_ENFORCE_GE(
+          input->dims().size(), 4,
+          platform::errors::InvalidArgument(
+              "Input must be with 4 or 5 dimensions, i.e. NCHW or "
+              "NCDHW, but got dimension = %d .",
+              input->dims().size()));
+      PADDLE_ENFORCE_LE(
+          input->dims().size(), 5,
+          platform::errors::InvalidArgument(
+              "Input must be with 4 or 5 dimensions, i.e. NCHW or "
+              "NCDHW, but got dimension = %d .",
+              input->dims().size()));
 
-    const auto input_dims = input->dims();
-    const auto data_dims =
-        framework::slice_ddim(input_dims, 2, input_dims.size());
-    const auto filter_dims = filter->dims();
-    const auto filter_data_dims =
-        framework::slice_ddim(filter_dims, 2, filter_dims.size());
+      PADDLE_ENFORCE_GE(
+          filter->dims().size(), 4,
+          platform::errors::InvalidArgument(
+              "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
+              "OIDHW, but got dimension = %d .",
+              filter->dims().size()));
+      PADDLE_ENFORCE_LE(
+          filter->dims().size(), 5,
+          platform::errors::InvalidArgument(
+              "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
+              "OIDHW, but got dimension = %d .",
+              filter->dims().size()));
 
-    const auto ksize = framework::vectorize(filter_data_dims);
+      if (bias) {
+        PADDLE_ENFORCE_EQ(
+            bias->layout(), framework::DataLayout::kMKLDNN,
+            platform::errors::InvalidArgument(
+                "The Bias tensor's layout should be %d, but got %d.",
+                framework::DataLayout::kMKLDNN, bias->layout()));
+        PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::undef,
+                          platform::errors::InvalidArgument(
+                              "Got wrong format for Bias tensor."));
 
-    auto strides_temp = ctx.Attr<std::vector<int>>("strides");
-    std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
-
-    auto paddings_temp = ctx.Attr<std::vector<int>>("paddings");
-    std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
-
-    auto dilations_temp = ctx.Attr<std::vector<int>>("dilations");
-    std::vector<int64_t> dilations(begin(dilations_temp), end(dilations_temp));
-
-    UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
-                             data_dims, strides, ksize);
-
-    std::transform(dilations.begin(), dilations.end(), dilations.begin(),
-                   [](int64_t i) { return i - 1; });
-
-    const auto src_tz = framework::vectorize(input->dims());
-
-    auto weights_tz = framework::vectorize(filter->dims());
-    platform::GetGroupConvWeightsTz(weights_tz, groups);
-
-    const auto dst_tz = framework::vectorize(output->dims());
-
-    const mkldnn::memory::dims stride_dims = strides;
-    const auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
-    const mkldnn::memory::dims dilations_dims = dilations;
-
-    /* create memory descriptor for convolution without specified format
-     * ('any') which lets a primitive (convolution in this case) choose
-     * the memory format preferred for best performance
-     */
-    auto chosen_memory_format = MKLDNNMemoryFormat::any;
-    auto data_type = mkldnn::memory::data_type::f32;
-    if (ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16" ||
-        std::is_same<T_out, platform::bfloat16>::value)
-      data_type = mkldnn::memory::data_type::bf16;
-
-    mkldnn::memory::desc src_md, weights_md;
-    if (platform::is_int8<T>()) {
-      src_md = platform::MKLDNNMemDesc(
-          src_tz, framework::ToMKLDNNDataType(input->type()),
-          chosen_memory_format);
-      weights_md = platform::MKLDNNMemDesc(
-          weights_tz, mkldnn::memory::data_type::s8, chosen_memory_format);
-    } else {
-      src_md = platform::MKLDNNMemDesc(src_tz, data_type, chosen_memory_format);
-      weights_md = platform::MKLDNNMemDesc(weights_tz, data_type,
-                                           MKLDNNMemoryFormat::any);
-    }
-
-    const auto dst_md = platform::MKLDNNMemDesc(
-        dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
-    const auto fwd_prop_kind = is_test_ ? mkldnn::prop_kind::forward_inference
-                                        : mkldnn::prop_kind::forward_training;
-    float sum_scale = 1.0f;
-    std::vector<float> output_shift_scale;
-    if (platform::is_int8<T>())
-      std::tie(sum_scale, output_shift_scale) = get_int8_scales(ctx);
-
-    const mkldnn::primitive_attr conv_attr = CreatePostOps(
-        fuse_activation, fuse_alpha, fuse_beta, fuse_residual_conn,
-        output_shift_scale, sum_scale);  // for INT8 only!
-
-    if (bias) {
-      auto bias_tz = framework::vectorize(bias->dims());
-      mkldnn::memory::desc bias_md;
-      if (platform::is_int8<T>()) {
-        bias_md = platform::MKLDNNMemDesc(
-            bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
-      } else {
-        bias_md =
-            platform::MKLDNNMemDesc(bias_tz, data_type, MKLDNNMemoryFormat::x);
+        PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
+                          platform::errors::InvalidArgument(
+                              "Bias must only have 1 dimension, "
+                              "i.e. X, but got dimension = %d .",
+                              bias->dims().size()));
       }
 
-      this->AcquireForwardPrimitiveDescriptor(
-          conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct, src_md,
-          weights_md, bias_md, dst_md, stride_dims, dilations_dims,
-          mkldnn_paddings[0], mkldnn_paddings[1]);
-    } else {
-      this->AcquireForwardPrimitiveDescriptor(
-          conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct, src_md,
-          weights_md, dst_md, stride_dims, dilations_dims, mkldnn_paddings[0],
-          mkldnn_paddings[1]);
+      const std::string fuse_activation =
+          ctx.Attr<std::string>("fuse_activation");
+      const float fuse_alpha = ctx.Attr<float>("fuse_alpha");
+      const float fuse_beta = ctx.Attr<float>("fuse_beta");
+      const bool fuse_residual_conn =
+          ctx.Attr<bool>("fuse_residual_connection");
+      const int groups = ctx.Attr<int>("groups");
+      const std::string padding_algorithm =
+          ctx.Attr<std::string>("padding_algorithm");
+
+      const auto input_dims = input->dims();
+      const auto data_dims =
+          framework::slice_ddim(input_dims, 2, input_dims.size());
+      const auto filter_dims = filter->dims();
+      const auto filter_data_dims =
+          framework::slice_ddim(filter_dims, 2, filter_dims.size());
+
+      const auto ksize = framework::vectorize(filter_data_dims);
+      const bool is_test = ctx.Attr<bool>("is_test");
+
+      auto strides_temp = ctx.Attr<std::vector<int>>("strides");
+      std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
+
+      auto paddings_temp = ctx.Attr<std::vector<int>>("paddings");
+      std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
+
+      auto dilations_temp = ctx.Attr<std::vector<int>>("dilations");
+      std::vector<int64_t> dilations(begin(dilations_temp),
+                                     end(dilations_temp));
+
+      UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
+                               data_dims, strides, ksize);
+
+      std::transform(dilations.begin(), dilations.end(), dilations.begin(),
+                     [](int64_t i) { return i - 1; });
+
+      const auto src_tz = framework::vectorize(input->dims());
+
+      auto weights_tz = framework::vectorize(filter->dims());
+      platform::GetGroupConvWeightsTz(weights_tz, groups);
+
+      const auto dst_tz = framework::vectorize(output->dims());
+
+      const mkldnn::memory::dims stride_dims = strides;
+      const auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
+      const mkldnn::memory::dims dilations_dims = dilations;
+
+      /* create memory descriptor for convolution without specified format
+       * ('any') which lets a primitive (convolution in this case) choose
+       * the memory format preferred for best performance
+       */
+      auto chosen_memory_format = MKLDNNMemoryFormat::any;
+      auto data_type = mkldnn::memory::data_type::f32;
+      if (ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16" ||
+          std::is_same<T_out, platform::bfloat16>::value)
+        data_type = mkldnn::memory::data_type::bf16;
+
+      mkldnn::memory::desc src_md, weights_md;
+      if (platform::is_int8<T>()) {
+        src_md = platform::MKLDNNMemDesc(
+            src_tz, framework::ToMKLDNNDataType(input->type()),
+            chosen_memory_format);
+        weights_md = platform::MKLDNNMemDesc(
+            weights_tz, mkldnn::memory::data_type::s8, chosen_memory_format);
+      } else {
+        src_md =
+            platform::MKLDNNMemDesc(src_tz, data_type, chosen_memory_format);
+        weights_md = platform::MKLDNNMemDesc(weights_tz, data_type,
+                                             MKLDNNMemoryFormat::any);
+      }
+
+      const auto dst_md = platform::MKLDNNMemDesc(
+          dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
+      const auto fwd_prop_kind = is_test ? mkldnn::prop_kind::forward_inference
+                                         : mkldnn::prop_kind::forward_training;
+
+      float sum_scale = 1.0f;
+      std::vector<float> output_shift_scale;
+      if (platform::is_int8<T>())
+        std::tie(sum_scale, output_shift_scale) = get_int8_scales(ctx);
+
+      const mkldnn::primitive_attr conv_attr = CreatePostOps(
+          fuse_activation, fuse_alpha, fuse_beta, fuse_residual_conn,
+          output_shift_scale, sum_scale);  // for INT8 only!
+
+      if (bias) {
+        auto bias_tz = framework::vectorize(bias->dims());
+        mkldnn::memory::desc bias_md;
+        if (platform::is_int8<T>()) {
+          bias_md = platform::MKLDNNMemDesc(
+              bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
+        } else {
+          bias_md = platform::MKLDNNMemDesc(bias_tz, data_type,
+                                            MKLDNNMemoryFormat::x);
+        }
+
+        this->AcquireForwardPrimitiveDescriptor(
+            conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct,
+            src_md, weights_md, bias_md, dst_md, stride_dims, dilations_dims,
+            mkldnn_paddings[0], mkldnn_paddings[1]);
+      } else {
+        this->AcquireForwardPrimitiveDescriptor(
+            conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct,
+            src_md, weights_md, dst_md, stride_dims, dilations_dims,
+            mkldnn_paddings[0], mkldnn_paddings[1]);
+      }
     }
   }
 
   ConvMKLDNNHandlerT(const framework::ExecutionContext& ctx,
-                     const mkldnn::engine mkldnn_engine, const Tensor* in,
+                     const platform::MKLDNNDeviceContext& dev_ctx,
+                     platform::Place cpu_place, const Tensor* in,
                      const Tensor* filter, const Tensor* bias,
                      const Tensor* out_grad, Tensor* filter_grad,
-                     Tensor* in_x_grad)
-      : platform::MKLDNNHandlerNoCachingT<T, mkldnn::convolution_forward,
-                                          mkldnn::convolution_backward_data,
-                                          mkldnn::convolution_backward_weights>(
-            mkldnn_engine, ctx.GetPlace()),
-        is_test_(false) {
-    PADDLE_ENFORCE_EQ(in->layout(), framework::DataLayout::kMKLDNN,
-                      platform::errors::InvalidArgument(
-                          "The input tensor's layout should be %d, but got %d.",
-                          framework::DataLayout::kMKLDNN, in->layout()));
-    PADDLE_ENFORCE_NE(in->format(), MKLDNNMemoryFormat::undef,
-                      platform::errors::InvalidArgument(
-                          "Got wrong format for Input tensor."));
+                     Tensor* in_x_grad, const std::string& unique_name)
+      : platform::MKLDNNHandlerT<T, mkldnn::convolution_forward,
+                                 mkldnn::convolution_backward_data,
+                                 mkldnn::convolution_backward_weights>(
+            dev_ctx, dev_ctx.GetEngine(), cpu_place,
+            platform::CreateKey(dev_ctx, framework::vectorize(in->dims()),
+                                unique_name)) {
+    if (!this->isBwdCached()) {
+      PADDLE_ENFORCE_EQ(
+          in->layout(), framework::DataLayout::kMKLDNN,
+          platform::errors::InvalidArgument(
+              "The input tensor's layout should be %d, but got %d.",
+              framework::DataLayout::kMKLDNN, in->layout()));
+      PADDLE_ENFORCE_NE(in->format(), MKLDNNMemoryFormat::undef,
+                        platform::errors::InvalidArgument(
+                            "Got wrong format for Input tensor."));
 
-    PADDLE_ENFORCE_EQ(
-        filter->layout(), framework::DataLayout::kMKLDNN,
-        platform::errors::InvalidArgument(
-            "The filter tensor's layout should be %d, but got %d.",
-            framework::DataLayout::kMKLDNN, filter->layout()));
-    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
-                      platform::errors::InvalidArgument(
-                          "Got wrong format for Filter tensor."));
+      PADDLE_ENFORCE_EQ(
+          filter->layout(), framework::DataLayout::kMKLDNN,
+          platform::errors::InvalidArgument(
+              "The filter tensor's layout should be %d, but got %d.",
+              framework::DataLayout::kMKLDNN, filter->layout()));
+      PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
+                        platform::errors::InvalidArgument(
+                            "Got wrong format for Filter tensor."));
 
-    PADDLE_ENFORCE_EQ(
-        out_grad->layout(), framework::DataLayout::kMKLDNN,
-        platform::errors::InvalidArgument(
-            "The output_grad tensor's layout should be %d, but got %d.",
-            framework::DataLayout::kMKLDNN, out_grad->layout()));
-    PADDLE_ENFORCE_NE(out_grad->format(), MKLDNNMemoryFormat::undef,
-                      platform::errors::InvalidArgument(
-                          "Wrong format set for output_grad tensor"));
+      PADDLE_ENFORCE_EQ(
+          out_grad->layout(), framework::DataLayout::kMKLDNN,
+          platform::errors::InvalidArgument(
+              "The output_grad tensor's layout should be %d, but got %d.",
+              framework::DataLayout::kMKLDNN, out_grad->layout()));
+      PADDLE_ENFORCE_NE(out_grad->format(), MKLDNNMemoryFormat::undef,
+                        platform::errors::InvalidArgument(
+                            "Wrong format set for output_grad tensor"));
 
-    PADDLE_ENFORCE_EQ(
-        is_test_, false,
-        platform::errors::InvalidArgument(
-            "is_test attribute should be set to False in training phase."));
+      PADDLE_ENFORCE_EQ(
+          ctx.Attr<bool>("is_test"), false,
+          platform::errors::InvalidArgument(
+              "is_test attribute should be set to False in training phase."));
 
-    std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
-    std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
+      std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
+      std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
 
-    std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
-    std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
+      std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
+      std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
 
-    std::vector<int> dilations_temp = ctx.Attr<std::vector<int>>("dilations");
-    std::vector<int64_t> dilations(begin(dilations_temp), end(dilations_temp));
+      std::vector<int> dilations_temp = ctx.Attr<std::vector<int>>("dilations");
+      std::vector<int64_t> dilations(begin(dilations_temp),
+                                     end(dilations_temp));
 
-    auto input_dims = in->dims();
-    auto data_dims = framework::slice_ddim(input_dims, 2, input_dims.size());
-    auto filter_dims = filter->dims();
-    auto filter_data_dims =
-        framework::slice_ddim(filter_dims, 2, filter_dims.size());
-    auto ksize = framework::vectorize(filter_data_dims);
+      auto input_dims = in->dims();
+      auto data_dims = framework::slice_ddim(input_dims, 2, input_dims.size());
+      auto filter_dims = filter->dims();
+      auto filter_data_dims =
+          framework::slice_ddim(filter_dims, 2, filter_dims.size());
+      auto ksize = framework::vectorize(filter_data_dims);
 
-    std::string padding_algorithm = ctx.Attr<std::string>("padding_algorithm");
-    UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
-                             data_dims, strides, ksize);
+      std::string padding_algorithm =
+          ctx.Attr<std::string>("padding_algorithm");
+      UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
+                               data_dims, strides, ksize);
 
-    auto src_tz = framework::vectorize(in->dims());
-    auto weights_tz = framework::vectorize(filter->dims());
+      auto src_tz = framework::vectorize(in->dims());
+      auto weights_tz = framework::vectorize(filter->dims());
 
-    int groups = ctx.Attr<int>("groups");
-    int g = std::max(groups, 1);
-    platform::GetGroupConvWeightsTz(weights_tz, g);
-    auto dst_tz = framework::vectorize(out_grad->dims());
+      int groups = ctx.Attr<int>("groups");
+      int g = std::max(groups, 1);
+      platform::GetGroupConvWeightsTz(weights_tz, g);
+      auto dst_tz = framework::vectorize(out_grad->dims());
 
-    /* create memory descriptor for conv backward without specified format
-     * ('any') which lets a primitive (conv backward in this case) choose
-     * the memory format preferred for best performance
-     */
-    const auto chosen_memory_format = MKLDNNMemoryFormat::any;
-    const auto weights_format = MKLDNNMemoryFormat::any;
+      /* create memory descriptor for conv backward without specified format
+       * ('any') which lets a primitive (conv backward in this case) choose
+       * the memory format preferred for best performance
+       */
+      const auto chosen_memory_format = MKLDNNMemoryFormat::any;
+      const auto weights_format = MKLDNNMemoryFormat::any;
 
-    auto src_md = platform::MKLDNNMemDesc(
-        src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
-    const auto dst_md = platform::MKLDNNMemDesc(
-        dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
-    auto diff_src_md = platform::MKLDNNMemDesc(
-        src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
-    auto weights_md = platform::MKLDNNMemDesc(
-        weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
-    auto diff_weights_md = platform::MKLDNNMemDesc(
-        weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
-    auto diff_dst_md = platform::MKLDNNMemDesc(
-        dst_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
+      auto src_md = platform::MKLDNNMemDesc(
+          src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
+      const auto dst_md = platform::MKLDNNMemDesc(
+          dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
+      auto diff_src_md = platform::MKLDNNMemDesc(
+          src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
+      auto weights_md = platform::MKLDNNMemDesc(
+          weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
+      auto diff_weights_md = platform::MKLDNNMemDesc(
+          weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
+      auto diff_dst_md = platform::MKLDNNMemDesc(
+          dst_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
 
-    auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
-    std::transform(dilations.begin(), dilations.end(), dilations.begin(),
-                   [](int64_t i) { return i - 1; });
-    const mkldnn::memory::dims dilations_dims = dilations;
+      auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
+      std::transform(dilations.begin(), dilations.end(), dilations.begin(),
+                     [](int64_t i) { return i - 1; });
+      const mkldnn::memory::dims dilations_dims = dilations;
 
-    const mkldnn::memory::dims stride_dims = strides;
-    // Recreating FWD PD. For training there are no post ops in convolution
-    mkldnn::primitive_attr conv_attr;
-    if (bias) {
-      auto bias_tz = framework::vectorize(bias->dims());
-      mkldnn::memory::desc bias_md;
-      if (platform::is_int8<T>()) {
-        bias_md = platform::MKLDNNMemDesc(
-            bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
+      const mkldnn::memory::dims stride_dims = strides;
+      // Recreating FWD PD. For training there are no post ops in convolution
+      mkldnn::primitive_attr conv_attr;
+      if (bias) {
+        auto bias_tz = framework::vectorize(bias->dims());
+        mkldnn::memory::desc bias_md;
+        if (platform::is_int8<T>()) {
+          bias_md = platform::MKLDNNMemDesc(
+              bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
+        } else {
+          bias_md = platform::MKLDNNMemDesc(
+              bias_tz, mkldnn::memory::data_type::f32, MKLDNNMemoryFormat::x);
+        }
+
+        this->AcquireForwardPrimitiveDescriptor(
+            conv_attr, mkldnn::prop_kind::forward_training,
+            dnnl::algorithm::convolution_direct, src_md, weights_md, bias_md,
+            dst_md, stride_dims, dilations_dims, mkldnn_paddings[0],
+            mkldnn_paddings[1]);
       } else {
-        bias_md = platform::MKLDNNMemDesc(
-            bias_tz, mkldnn::memory::data_type::f32, MKLDNNMemoryFormat::x);
+        this->AcquireForwardPrimitiveDescriptor(
+            conv_attr, mkldnn::prop_kind::forward_training,
+            dnnl::algorithm::convolution_direct, src_md, weights_md, dst_md,
+            stride_dims, dilations_dims, mkldnn_paddings[0],
+            mkldnn_paddings[1]);
       }
 
-      this->AcquireForwardPrimitiveDescriptor(
-          conv_attr, mkldnn::prop_kind::forward_training,
-          dnnl::algorithm::convolution_direct, src_md, weights_md, bias_md,
-          dst_md, stride_dims, dilations_dims, mkldnn_paddings[0],
+      this->AcquireBackwardPrimitiveDescriptor(
+          mkldnn::algorithm::convolution_direct, diff_src_md, weights_md,
+          diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
           mkldnn_paddings[1]);
-    } else {
-      this->AcquireForwardPrimitiveDescriptor(
-          conv_attr, mkldnn::prop_kind::forward_training,
-          dnnl::algorithm::convolution_direct, src_md, weights_md, dst_md,
-          stride_dims, dilations_dims, mkldnn_paddings[0], mkldnn_paddings[1]);
+
+      this->AcquireBackwardWeightsPrimitiveDescriptor(
+          mkldnn::algorithm::convolution_direct, src_md, diff_weights_md,
+          diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
+          mkldnn_paddings[1]);
     }
-
-    this->AcquireBackwardPrimitiveDescriptor(
-        mkldnn::algorithm::convolution_direct, diff_src_md, weights_md,
-        diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
-        mkldnn_paddings[1]);
-
-    this->AcquireBackwardWeightsPrimitiveDescriptor(
-        mkldnn::algorithm::convolution_direct, src_md, diff_weights_md,
-        diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
-        mkldnn_paddings[1]);
   }
 
   std::tuple<float, std::vector<float>> get_int8_scales(
@@ -477,7 +501,6 @@ class ConvMKLDNNHandlerT
 
   std::shared_ptr<mkldnn::memory>
   AcquireWeightsMemoryWithReorderFromDataPrimitive(
-      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
       const framework::Tensor* filter, const int groups, const bool is_conv3d) {
     const K* filter_data = filter->data<K>();
     auto weights_tz = framework::vectorize(filter->dims());
@@ -488,157 +511,108 @@ class ConvMKLDNNHandlerT
         GetWeightsFormat(filter->format(), groups, is_conv3d));
 
     return this->AcquireMemoryWithReorder(
-        dev_ctx, user_src_md, this->bwd_pd_->weights_desc(),
-        platform::to_void_cast<K>(filter_data), key, "@weights_mem_d_p", false);
+        user_src_md, this->bwd_pd_->weights_desc(),
+        platform::to_void_cast<K>(filter_data), "@weights_mem_d_p", false);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireSrcMemoryWithReorder(
       const framework::Tensor* input) {
-    return this->AcquireMemoryWithReorderPrimitive(input,
-                                                   this->fwd_pd_->src_desc());
+    return this->AcquireMemoryWithReorderPrimitive(
+        input, "@src_mem_p_user", "@src_mem_p_target", "@src_mem_p",
+        this->fwd_pd_->src_desc());
   }
 
   std::shared_ptr<mkldnn::memory>
   AcquireSrcMemoryWithReorderFromWeightsPrimitive(
       const framework::Tensor* input) {
-    return this->AcquireMemoryWithReorderPrimitive(input,
-                                                   this->bwd_w_pd_->src_desc());
+    return this->AcquireMemoryWithReorderPrimitive(
+        input, "@src_mem_w_p_user", "@src_mem_w_p_target", "@src_mem_w_p",
+        this->bwd_w_pd_->src_desc());
   }
 
   std::shared_ptr<mkldnn::memory>
   AcquireDiffDstMemoryWithReorderFromWeightsPrimitive(
       const framework::Tensor* out_grad) {
     return this->AcquireMemoryWithReorderPrimitive(
-        out_grad, this->bwd_w_pd_->diff_dst_desc());
+        out_grad, "@diff_dst_mem_w_p_user", "@diff_dst_mem_w_p_target",
+        "@diff_dst_mem_w_p", this->bwd_w_pd_->diff_dst_desc());
   }
 
   std::shared_ptr<mkldnn::memory>
   AcquireDiffDstMemoryWithReorderMemoryFromDataPrimitive(
       const framework::Tensor* out_grad) {
     return this->AcquireMemoryWithReorderPrimitive(
-        out_grad, this->bwd_pd_->diff_dst_desc());
+        out_grad, "@diff_dst_mem_p_user", "@diff_dst_mem_p_target",
+        "@diff_dst_mem_p", this->bwd_pd_->diff_dst_desc());
   }
 
   std::shared_ptr<mkldnn::memory> AcquireMemoryWithReorderPrimitive(
-      const framework::Tensor* in_mem, const mkldnn::memory::desc& mem_md) {
+      const framework::Tensor* in_mem, const char* key_mem_user,
+      const char* key_mem_target, const char* key_mem,
+      const mkldnn::memory::desc& mem_md) {
     const T* in_mem_data = in_mem->data<T>();
+    const std::string user_key_suffix{key_mem_user};
+    auto user_mem_p = this->AcquireMemory(user_key_suffix);
 
-    auto user_mem_md = platform::MKLDNNMemDesc(
-        framework::vectorize(in_mem->dims()), platform::MKLDNNGetDataType<T>(),
-        in_mem->format());
-
-    return platform::MKLDNNHandlerNoCachingT<
-        T, mkldnn::convolution_forward, mkldnn::convolution_backward_data,
-        mkldnn::convolution_backward_weights>::
-        AcquireMemoryWithReorder(user_mem_md, mem_md,
-                                 platform::to_void_cast<T>(in_mem_data),
-                                 is_test_);
+    if (!user_mem_p) {
+      auto user_mem_md = platform::MKLDNNMemDesc(
+          framework::vectorize(in_mem->dims()),
+          platform::MKLDNNGetDataType<T>(), in_mem->format());
+      return this->AcquireMemoryWithReorder(
+          user_mem_md, mem_md, platform::to_void_cast<T>(in_mem_data), key_mem);
+    } else {
+      const std::string target_key_suffix{key_mem_target};
+      const auto target_mem_p = this->AcquireMemory(target_key_suffix);
+      user_mem_p->set_data_handle(platform::to_void_cast<T>(in_mem_data));
+      if (user_mem_p != target_mem_p) {
+        this->AcquireReorder(user_mem_p, target_mem_p, key_mem);
+      }
+      return target_mem_p;
+    }
   }
 
   std::shared_ptr<mkldnn::memory> AcquireWeightsMemoryWithReorder(
-      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
       const framework::Tensor* filter, const int groups, const bool is_conv3d,
-      const std::vector<float>& scale_data = {1.0f}, int mask = 0) {
-    const K* filter_data = filter->data<K>();
-    auto weights_tz = framework::vectorize(filter->dims());
-    platform::GetGroupConvWeightsTz(weights_tz, groups);
+      const bool is_test, const std::vector<float>& scale_data = {1.0f},
+      int mask = 0) {
+    // This is workaround to make execution faster, delete
+    // if statement after including md inside Tensor
+    auto weights_mem_p = this->AcquireMemory("@weights_mem_p_target");
+    if (is_test && weights_mem_p) {
+      return weights_mem_p;
+    } else {
+      const K* filter_data = filter->data<K>();
+      auto weights_tz = framework::vectorize(filter->dims());
+      platform::GetGroupConvWeightsTz(weights_tz, groups);
 
-    auto user_src_md = platform::MKLDNNMemDesc(
-        weights_tz, platform::MKLDNNGetDataType<K>(),
-        GetWeightsFormat(filter->format(), groups, is_conv3d));
+      auto user_src_md = platform::MKLDNNMemDesc(
+          weights_tz, platform::MKLDNNGetDataType<K>(),
+          GetWeightsFormat(filter->format(), groups, is_conv3d));
 
-    return this->AcquireMemoryWithReorder(
-        dev_ctx, user_src_md, this->fwd_pd_->weights_desc(),
-        platform::to_void_cast<K>(filter_data), key, "@weights_mem_p", is_test_,
-        {}, scale_data, mask);
-  }
-
-  template <typename F = T>
-  std::shared_ptr<mkldnn::memory> AcquireMemoryWithReorder(
-      const platform::MKLDNNDeviceContext& dev_ctx,
-      const mkldnn::memory::desc& user_md,
-      const mkldnn::memory::desc& target_md, void* ptr, const std::string& key,
-      const std::string& suffix, bool is_persistent = false,
-      std::function<std::shared_ptr<F>(const F*)> custom_reorder_func = {},
-      const std::vector<float>& scale_data = {1.0f}, int mask = 0) {
-    const auto target_key = key + suffix + "_target";
-    const auto key_reorder_p = key + suffix + "reorder_p";
-    const auto user_key = key + suffix + "_user";
-
-    auto target_memory_p =
-        std::static_pointer_cast<dnnl::memory>(dev_ctx.GetBlob(target_key));
-
-    if (target_memory_p == nullptr) {
-      if (custom_reorder_func) {
-        auto reordered_data =
-            custom_reorder_func(reinterpret_cast<const F*>(ptr));
-        dev_ctx.SetBlob(key_reorder_p + "-custom_reorder", reordered_data);
-        ptr = reinterpret_cast<void*>(reordered_data.get());
-      }
-      auto user_memory_p =
-          std::make_shared<dnnl::memory>(user_md, this->engine_, ptr);
-      if (user_md != target_md) {
-        target_memory_p =
-            std::make_shared<mkldnn::memory>(target_md, this->engine_);
-        dnnl::reorder::primitive_desc reorder_pdesc;
-        if (platform::is_int8<T>()) {
-          dnnl::primitive_attr attr;
-          attr.set_output_scales(mask, scale_data);
-          reorder_pdesc = dnnl::reorder::primitive_desc(*user_memory_p,
-                                                        *target_memory_p, attr);
-        } else {
-          reorder_pdesc =
-              dnnl::reorder::primitive_desc(*user_memory_p, *target_memory_p);
-        }
-        auto reorder_p = std::make_shared<dnnl::reorder>(reorder_pdesc);
-        dev_ctx.SetBlob(key_reorder_p, reorder_p);
-
-        auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
-        platform::RecordEvent record_reorder("int_reorder",
-                                             platform::EventRole::kUniqueOp);
-        reorder_p->execute(astream, {{MKLDNN_ARG_FROM, *user_memory_p},
-                                     {MKLDNN_ARG_TO, *target_memory_p}});
-        astream.wait();
-      } else {
-        target_memory_p = user_memory_p;
-      }
-      dev_ctx.SetBlob(user_key, user_memory_p);
-      dev_ctx.SetBlob(target_key, target_memory_p);
-    } else if (!is_persistent) {
-      auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
-
-      auto user_memory_p =
-          std::static_pointer_cast<dnnl::memory>(dev_ctx.GetBlob(user_key));
-      user_memory_p->set_data_handle(ptr);
-
-      // TODO(jczaja): Here we detect if reorder is cached it means it is needed
-      // need to change this to get rid of keys
-      auto reorder_p = std::static_pointer_cast<mkldnn::reorder>(
-          dev_ctx.GetBlob(key_reorder_p));
-      if (reorder_p != nullptr) {
-        platform::RecordEvent record_reorder("int_reorder",
-                                             platform::EventRole::kUniqueOp);
-        reorder_p->execute(astream, {{MKLDNN_ARG_FROM, *user_memory_p},
-                                     {MKLDNN_ARG_TO, *target_memory_p}});
-        astream.wait();
-      }
+      return this->AcquireMemoryWithReorder(
+          user_src_md, this->fwd_pd_->weights_desc(),
+          platform::to_void_cast<K>(filter_data), "@weights_mem_p", is_test, {},
+          scale_data, mask);
     }
-    return target_memory_p;
   }
 
   std::shared_ptr<mkldnn::memory> AcquireBiasMemoryWithReorder(
-      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
-      const framework::Tensor* bias,
+      const framework::Tensor* bias, const bool is_test,
       const std::vector<float>& scale_data = {1.0f}, int mask = 0) {
-    const K* bias_data = bias->data<K>();
-    auto user_bias_md = platform::MKLDNNMemDesc(
-        framework::vectorize(bias->dims()), platform::MKLDNNGetDataType<K>(),
-        MKLDNNMemoryFormat::x);
+    auto bias_mem_p = this->AcquireMemory("@bias_mem_p_target");
+    if (is_test && bias_mem_p) {
+      return bias_mem_p;
+    } else {
+      const K* bias_data = bias->data<K>();
+      auto user_bias_md = platform::MKLDNNMemDesc(
+          framework::vectorize(bias->dims()), platform::MKLDNNGetDataType<K>(),
+          MKLDNNMemoryFormat::x);
 
-    return this->AcquireMemoryWithReorder(
-        dev_ctx, user_bias_md, this->fwd_pd_->bias_desc(),
-        platform::to_void_cast<K>(bias_data), key, "@bias_mem_p", is_test_, {},
-        scale_data, mask);
+      return this->AcquireMemoryWithReorder(
+          user_bias_md, this->fwd_pd_->bias_desc(),
+          platform::to_void_cast<K>(bias_data), "@bias_mem_p", is_test, {},
+          scale_data, mask);
+    }
   }
 
   std::shared_ptr<mkldnn::memory> AcquireResidualMemory(
@@ -647,11 +621,19 @@ class ConvMKLDNNHandlerT
         residual_param->type() == framework::DataTypeTrait<T_out>::DataType()
             ? platform::to_void_cast<T_out>(residual_param->data<T_out>())
             : platform::to_void_cast<T>(residual_param->data<T>());
-    auto user_residual_md = platform::MKLDNNMemDesc(
-        framework::vectorize(residual_param->dims()),
-        framework::ToMKLDNNDataType(residual_param->type()),
-        residual_param->format());
-    return this->AcquireMemoryFromPrimitive(user_residual_md, residual_data);
+    auto residual_mem_p = this->AcquireMemory("@user_residual_data_mem_p");
+    if (residual_mem_p) {
+      residual_mem_p->set_data_handle(residual_data);
+      return residual_mem_p;
+    } else {
+      auto user_residual_md = platform::MKLDNNMemDesc(
+          framework::vectorize(residual_param->dims()),
+          framework::ToMKLDNNDataType(residual_param->type()),
+          residual_param->format());
+
+      return this->AcquireMemoryFromPrimitive(user_residual_md, residual_data,
+                                              "@user_residual_data_mem_p");
+    }
   }
 
   std::shared_ptr<mkldnn::memory> AcquireDstMemoryWithResidual(
@@ -661,7 +643,7 @@ class ConvMKLDNNHandlerT
         platform::GetMKLDNNFormat(this->fwd_pd_->dst_desc())) {
       auto residual_memory_p = this->AcquireResidualMemory(residual_param);
       dst_memory_p = this->template AcquireDstMemory<T_out>(output);
-      this->AcquireReorder(residual_memory_p, dst_memory_p);
+      this->AcquireReorder(residual_memory_p, dst_memory_p, "@residual_dst");
     } else {
       // Changing ShareDataWith to TensorCopy results in performance drop
       // on ResNet architectures
@@ -671,9 +653,6 @@ class ConvMKLDNNHandlerT
     }
     return dst_memory_p;
   }
-
- private:
-  const bool is_test_;
 };
 
 }  // anonymous namespace
@@ -718,6 +697,7 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         ctx.template device_context<platform::MKLDNNDeviceContext>();
     const auto& mkldnn_engine = dev_ctx.GetEngine();
 
+    const bool is_test = ctx.Attr<bool>("is_test");
     const bool is_conv3d = ctx.Attr<std::vector<int>>("strides").size() == 3U;
     const bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
 
@@ -727,19 +707,15 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
-    ConvMKLDNNHandlerT<T, K, T_out> handler(ctx, mkldnn_engine, input, filter,
-                                            bias, output);
+    ConvMKLDNNHandlerT<T, K, T_out> handler(
+        ctx, dev_ctx, mkldnn_engine, ctx.GetPlace(), input, filter, bias,
+        output, ctx.InputName("Input") + ctx.InputName("Filter"));
 
     auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
 
-    // Key is needed for params (weights and biases) to have reordered weights
-    // cached
-    std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
-                                          ctx.InputName("Filter"));
-    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
-
     auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
-        dev_ctx, key, filter, ctx.Attr<int>("groups"), is_conv3d);
+        filter, ctx.Attr<int>("groups"), is_conv3d, is_test);
+
     std::shared_ptr<dnnl::memory> dst_memory_p;
     if (fuse_residual_conn) {
       auto* residual_param = ctx.Input<Tensor>("ResidualData");
@@ -757,8 +733,7 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         {MKLDNN_ARG_DST, *dst_memory_p}};
 
     if (bias) {
-      auto bias_memory_p =
-          handler.AcquireBiasMemoryWithReorder(dev_ctx, key, bias);
+      auto bias_memory_p = handler.AcquireBiasMemoryWithReorder(bias, is_test);
       args.insert({MKLDNN_ARG_BIAS, *bias_memory_p});
     }
 
@@ -800,8 +775,9 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
     auto* bias = ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
-    ConvMKLDNNHandlerT<T, K, T_out> handler(ctx, mkldnn_engine, input, filter,
-                                            bias, output);
+    ConvMKLDNNHandlerT<T, K, T_out> handler(
+        ctx, dev_ctx, mkldnn_engine, ctx.GetPlace(), input, filter, bias,
+        output, ctx.InputName("Input") + ctx.InputName("Filter"));
 
     auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
 
@@ -809,17 +785,11 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         ctx.Attr<std::vector<float>>("Scale_weights");
     const bool is_multi_channel = scale_weights_data.size() > 1;
     const int& groups = ctx.Attr<int>("groups");
+    const bool& is_test = ctx.Attr<bool>("is_test");
     int mask_reorder =
         is_multi_channel ? ((groups != 1) ? (1 << 1) + (1 << 0) : 1 << 0) : 0;
-
-    // Key is needed for params (weights and biases) to have reordered weights
-    // cached
-    std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
-                                          ctx.InputName("Filter"));
-    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
-
     auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
-        dev_ctx, key, filter, groups, false, scale_weights_data, mask_reorder);
+        filter, groups, false, is_test, scale_weights_data, mask_reorder);
 
     std::shared_ptr<dnnl::memory> dst_memory_p;
     if (fuse_residual_conn) {
@@ -854,7 +824,7 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
           handler.get_int8_bias_scales(ctx);
 
       auto bias_memory_p = handler.AcquireBiasMemoryWithReorder(
-          dev_ctx, key, bias, scale_bias_data, mask_reorder);
+          bias, is_test, scale_bias_data, mask_reorder);
       args.insert({MKLDNN_ARG_BIAS, *bias_memory_p});
     }
 
@@ -894,15 +864,10 @@ class ConvMKLDNNGradOpKernel : public framework::OpKernel<T> {
     if (!input_grad && !filter_grad) return;
 
     // TODO(jczaja): Are all tensors really needed?
-    ConvMKLDNNHandlerT<T, K, T> handler(ctx, dev_ctx.GetEngine(), input, filter,
-                                        bias, output_grad, filter_grad,
-                                        input_grad);
-
-    // Key is needed for params (weights and biases) to have reordered weights
-    // cached
-    std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
-                                          ctx.InputName("Filter"));
-    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
+    ConvMKLDNNHandlerT<T, K, T> handler(
+        ctx, dev_ctx, ctx.GetPlace(), input, filter, bias, output_grad,
+        filter_grad, input_grad,
+        ctx.InputName("Input") + ctx.InputName("Filter"));
 
     // create mkldnn memory from input tensors (data/weights)
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
@@ -978,7 +943,7 @@ class ConvMKLDNNGradOpKernel : public framework::OpKernel<T> {
     if (input_grad) {
       auto weights_memory_p =
           handler.AcquireWeightsMemoryWithReorderFromDataPrimitive(
-              dev_ctx, key, filter, ctx.Attr<int>("groups"),
+              filter, ctx.Attr<int>("groups"),
               ctx.Attr<std::vector<int>>("strides").size() == 3U);
 
       auto diff_dst_memory_p =

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -565,7 +565,7 @@ class ConvMKLDNNHandlerT
       const auto target_mem_p = this->AcquireMemory(target_key_suffix);
       user_mem_p->set_data_handle(platform::to_void_cast<T>(in_mem_data));
       if (user_mem_p != target_mem_p) {
-        this->AcquireReorder(user_mem_p, target_mem_p, key_mem);
+        this->AcquireReorder(user_mem_p, target_mem_p);
       }
       return target_mem_p;
     }
@@ -643,7 +643,7 @@ class ConvMKLDNNHandlerT
         platform::GetMKLDNNFormat(this->fwd_pd_->dst_desc())) {
       auto residual_memory_p = this->AcquireResidualMemory(residual_param);
       dst_memory_p = this->template AcquireDstMemory<T_out>(output);
-      this->AcquireReorder(residual_memory_p, dst_memory_p, "@residual_dst");
+      this->AcquireReorder(residual_memory_p, dst_memory_p);
     } else {
       // Changing ShareDataWith to TensorCopy results in performance drop
       // on ResNet architectures

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -63,330 +63,306 @@ static mkldnn::memory::data_type GetDstType(bool is_int8, bool is_bfloat16,
 
 template <typename T, typename K, typename T_out>
 class ConvMKLDNNHandlerT
-    : public platform::MKLDNNHandlerT<T, mkldnn::convolution_forward,
-                                      mkldnn::convolution_backward_data,
-                                      mkldnn::convolution_backward_weights> {
+    : public platform::MKLDNNHandlerNoCachingT<
+          T, mkldnn::convolution_forward, mkldnn::convolution_backward_data,
+          mkldnn::convolution_backward_weights> {
  public:
   ConvMKLDNNHandlerT(const framework::ExecutionContext& ctx,
-                     const platform::MKLDNNDeviceContext& dev_ctx,
-                     const mkldnn::engine mkldnn_engine,
-                     platform::Place cpu_place, const Tensor* input,
-                     const Tensor* filter, const Tensor* bias, Tensor* output,
-                     const std::string& unique_name)
-      : platform::MKLDNNHandlerT<T, mkldnn::convolution_forward,
-                                 mkldnn::convolution_backward_data,
-                                 mkldnn::convolution_backward_weights>(
-            dev_ctx, mkldnn_engine, cpu_place,
-            platform::CreateKey(dev_ctx, framework::vectorize(input->dims()),
-                                unique_name)) {
-    if (!this->isCached()) {
+                     const mkldnn::engine mkldnn_engine, const Tensor* input,
+                     const Tensor* filter, const Tensor* bias, Tensor* output)
+      : platform::MKLDNNHandlerNoCachingT<T, mkldnn::convolution_forward,
+                                          mkldnn::convolution_backward_data,
+                                          mkldnn::convolution_backward_weights>(
+            mkldnn_engine, ctx.GetPlace()),
+        is_test_(ctx.Attr<bool>("is_test")) {
+    PADDLE_ENFORCE_EQ(input->layout(), framework::DataLayout::kMKLDNN,
+                      platform::errors::InvalidArgument(
+                          "The input tensor's layout should be %d, but got %d.",
+                          framework::DataLayout::kMKLDNN, input->layout()));
+    PADDLE_ENFORCE_NE(
+        input->format(), MKLDNNMemoryFormat::undef,
+        platform::errors::InvalidArgument("Wrong format set for Input tensor"));
+
+    PADDLE_ENFORCE_EQ(
+        filter->layout(), framework::DataLayout::kMKLDNN,
+        platform::errors::InvalidArgument(
+            "The Filter tensor's layout should be %d, but got %d.",
+            framework::DataLayout::kMKLDNN, filter->layout()));
+    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Wrong format set for Filter tensor"));
+
+    PADDLE_ENFORCE_GE(input->dims().size(), 4,
+                      platform::errors::InvalidArgument(
+                          "Input must be with 4 or 5 dimensions, i.e. NCHW or "
+                          "NCDHW, but got dimension = %d .",
+                          input->dims().size()));
+    PADDLE_ENFORCE_LE(input->dims().size(), 5,
+                      platform::errors::InvalidArgument(
+                          "Input must be with 4 or 5 dimensions, i.e. NCHW or "
+                          "NCDHW, but got dimension = %d .",
+                          input->dims().size()));
+
+    PADDLE_ENFORCE_GE(filter->dims().size(), 4,
+                      platform::errors::InvalidArgument(
+                          "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
+                          "OIDHW, but got dimension = %d .",
+                          filter->dims().size()));
+    PADDLE_ENFORCE_LE(filter->dims().size(), 5,
+                      platform::errors::InvalidArgument(
+                          "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
+                          "OIDHW, but got dimension = %d .",
+                          filter->dims().size()));
+
+    if (bias) {
       PADDLE_ENFORCE_EQ(
-          input->layout(), framework::DataLayout::kMKLDNN,
+          bias->layout(), framework::DataLayout::kMKLDNN,
           platform::errors::InvalidArgument(
-              "The input tensor's layout should be %d, but got %d.",
-              framework::DataLayout::kMKLDNN, input->layout()));
-      PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::undef,
+              "The Bias tensor's layout should be %d, but got %d.",
+              framework::DataLayout::kMKLDNN, bias->layout()));
+      PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::undef,
                         platform::errors::InvalidArgument(
-                            "Wrong format set for Input tensor"));
+                            "Got wrong format for Bias tensor."));
 
       PADDLE_ENFORCE_EQ(
-          filter->layout(), framework::DataLayout::kMKLDNN,
-          platform::errors::InvalidArgument(
-              "The Filter tensor's layout should be %d, but got %d.",
-              framework::DataLayout::kMKLDNN, filter->layout()));
-      PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Wrong format set for Filter tensor"));
+          bias->dims().size(), 1,
+          platform::errors::InvalidArgument("Bias must only have 1 dimension, "
+                                            "i.e. X, but got dimension = %d .",
+                                            bias->dims().size()));
+    }
 
-      PADDLE_ENFORCE_GE(
-          input->dims().size(), 4,
-          platform::errors::InvalidArgument(
-              "Input must be with 4 or 5 dimensions, i.e. NCHW or "
-              "NCDHW, but got dimension = %d .",
-              input->dims().size()));
-      PADDLE_ENFORCE_LE(
-          input->dims().size(), 5,
-          platform::errors::InvalidArgument(
-              "Input must be with 4 or 5 dimensions, i.e. NCHW or "
-              "NCDHW, but got dimension = %d .",
-              input->dims().size()));
+    const std::string fuse_activation =
+        ctx.Attr<std::string>("fuse_activation");
+    const float fuse_alpha = ctx.Attr<float>("fuse_alpha");
+    const float fuse_beta = ctx.Attr<float>("fuse_beta");
+    const bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
+    const int groups = ctx.Attr<int>("groups");
+    const std::string padding_algorithm =
+        ctx.Attr<std::string>("padding_algorithm");
 
-      PADDLE_ENFORCE_GE(
-          filter->dims().size(), 4,
-          platform::errors::InvalidArgument(
-              "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
-              "OIDHW, but got dimension = %d .",
-              filter->dims().size()));
-      PADDLE_ENFORCE_LE(
-          filter->dims().size(), 5,
-          platform::errors::InvalidArgument(
-              "Filter must be with 4 or 5 dimensions, i.e. OIHW or "
-              "OIDHW, but got dimension = %d .",
-              filter->dims().size()));
+    const auto input_dims = input->dims();
+    const auto data_dims =
+        framework::slice_ddim(input_dims, 2, input_dims.size());
+    const auto filter_dims = filter->dims();
+    const auto filter_data_dims =
+        framework::slice_ddim(filter_dims, 2, filter_dims.size());
 
-      if (bias) {
-        PADDLE_ENFORCE_EQ(
-            bias->layout(), framework::DataLayout::kMKLDNN,
-            platform::errors::InvalidArgument(
-                "The Bias tensor's layout should be %d, but got %d.",
-                framework::DataLayout::kMKLDNN, bias->layout()));
-        PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::undef,
-                          platform::errors::InvalidArgument(
-                              "Got wrong format for Bias tensor."));
+    const auto ksize = framework::vectorize(filter_data_dims);
 
-        PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
-                          platform::errors::InvalidArgument(
-                              "Bias must only have 1 dimension, "
-                              "i.e. X, but got dimension = %d .",
-                              bias->dims().size()));
-      }
+    auto strides_temp = ctx.Attr<std::vector<int>>("strides");
+    std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
 
-      const std::string fuse_activation =
-          ctx.Attr<std::string>("fuse_activation");
-      const float fuse_alpha = ctx.Attr<float>("fuse_alpha");
-      const float fuse_beta = ctx.Attr<float>("fuse_beta");
-      const bool fuse_residual_conn =
-          ctx.Attr<bool>("fuse_residual_connection");
-      const int groups = ctx.Attr<int>("groups");
-      const std::string padding_algorithm =
-          ctx.Attr<std::string>("padding_algorithm");
+    auto paddings_temp = ctx.Attr<std::vector<int>>("paddings");
+    std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
 
-      const auto input_dims = input->dims();
-      const auto data_dims =
-          framework::slice_ddim(input_dims, 2, input_dims.size());
-      const auto filter_dims = filter->dims();
-      const auto filter_data_dims =
-          framework::slice_ddim(filter_dims, 2, filter_dims.size());
+    auto dilations_temp = ctx.Attr<std::vector<int>>("dilations");
+    std::vector<int64_t> dilations(begin(dilations_temp), end(dilations_temp));
 
-      const auto ksize = framework::vectorize(filter_data_dims);
-      const bool is_test = ctx.Attr<bool>("is_test");
+    UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
+                             data_dims, strides, ksize);
 
-      auto strides_temp = ctx.Attr<std::vector<int>>("strides");
-      std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
+    std::transform(dilations.begin(), dilations.end(), dilations.begin(),
+                   [](int64_t i) { return i - 1; });
 
-      auto paddings_temp = ctx.Attr<std::vector<int>>("paddings");
-      std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
+    const auto src_tz = framework::vectorize(input->dims());
 
-      auto dilations_temp = ctx.Attr<std::vector<int>>("dilations");
-      std::vector<int64_t> dilations(begin(dilations_temp),
-                                     end(dilations_temp));
+    auto weights_tz = framework::vectorize(filter->dims());
+    platform::GetGroupConvWeightsTz(weights_tz, groups);
 
-      UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
-                               data_dims, strides, ksize);
+    const auto dst_tz = framework::vectorize(output->dims());
 
-      std::transform(dilations.begin(), dilations.end(), dilations.begin(),
-                     [](int64_t i) { return i - 1; });
+    const mkldnn::memory::dims stride_dims = strides;
+    const auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
+    const mkldnn::memory::dims dilations_dims = dilations;
 
-      const auto src_tz = framework::vectorize(input->dims());
+    /* create memory descriptor for convolution without specified format
+     * ('any') which lets a primitive (convolution in this case) choose
+     * the memory format preferred for best performance
+     */
+    auto chosen_memory_format = MKLDNNMemoryFormat::any;
+    auto data_type = mkldnn::memory::data_type::f32;
+    if (ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16" ||
+        std::is_same<T_out, platform::bfloat16>::value)
+      data_type = mkldnn::memory::data_type::bf16;
 
-      auto weights_tz = framework::vectorize(filter->dims());
-      platform::GetGroupConvWeightsTz(weights_tz, groups);
+    mkldnn::memory::desc src_md, weights_md;
+    if (platform::is_int8<T>()) {
+      src_md = platform::MKLDNNMemDesc(
+          src_tz, framework::ToMKLDNNDataType(input->type()),
+          chosen_memory_format);
+      weights_md = platform::MKLDNNMemDesc(
+          weights_tz, mkldnn::memory::data_type::s8, chosen_memory_format);
+    } else {
+      src_md = platform::MKLDNNMemDesc(src_tz, data_type, chosen_memory_format);
+      weights_md = platform::MKLDNNMemDesc(weights_tz, data_type,
+                                           MKLDNNMemoryFormat::any);
+    }
 
-      const auto dst_tz = framework::vectorize(output->dims());
+    const auto dst_md = platform::MKLDNNMemDesc(
+        dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
+    const auto fwd_prop_kind = is_test_ ? mkldnn::prop_kind::forward_inference
+                                        : mkldnn::prop_kind::forward_training;
+    float sum_scale = 1.0f;
+    std::vector<float> output_shift_scale;
+    if (platform::is_int8<T>())
+      std::tie(sum_scale, output_shift_scale) = get_int8_scales(ctx);
 
-      const mkldnn::memory::dims stride_dims = strides;
-      const auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
-      const mkldnn::memory::dims dilations_dims = dilations;
+    const mkldnn::primitive_attr conv_attr = CreatePostOps(
+        fuse_activation, fuse_alpha, fuse_beta, fuse_residual_conn,
+        output_shift_scale, sum_scale);  // for INT8 only!
 
-      /* create memory descriptor for convolution without specified format
-       * ('any') which lets a primitive (convolution in this case) choose
-       * the memory format preferred for best performance
-       */
-      auto chosen_memory_format = MKLDNNMemoryFormat::any;
-      auto data_type = mkldnn::memory::data_type::f32;
-      if (ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16" ||
-          std::is_same<T_out, platform::bfloat16>::value)
-        data_type = mkldnn::memory::data_type::bf16;
-
-      mkldnn::memory::desc src_md, weights_md;
+    if (bias) {
+      auto bias_tz = framework::vectorize(bias->dims());
+      mkldnn::memory::desc bias_md;
       if (platform::is_int8<T>()) {
-        src_md = platform::MKLDNNMemDesc(
-            src_tz, framework::ToMKLDNNDataType(input->type()),
-            chosen_memory_format);
-        weights_md = platform::MKLDNNMemDesc(
-            weights_tz, mkldnn::memory::data_type::s8, chosen_memory_format);
+        bias_md = platform::MKLDNNMemDesc(
+            bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
       } else {
-        src_md =
-            platform::MKLDNNMemDesc(src_tz, data_type, chosen_memory_format);
-        weights_md = platform::MKLDNNMemDesc(weights_tz, data_type,
-                                             MKLDNNMemoryFormat::any);
+        bias_md =
+            platform::MKLDNNMemDesc(bias_tz, data_type, MKLDNNMemoryFormat::x);
       }
 
-      const auto dst_md = platform::MKLDNNMemDesc(
-          dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
-      const auto fwd_prop_kind = is_test ? mkldnn::prop_kind::forward_inference
-                                         : mkldnn::prop_kind::forward_training;
-
-      float sum_scale = 1.0f;
-      std::vector<float> output_shift_scale;
-      if (platform::is_int8<T>())
-        std::tie(sum_scale, output_shift_scale) = get_int8_scales(ctx);
-
-      const mkldnn::primitive_attr conv_attr = CreatePostOps(
-          fuse_activation, fuse_alpha, fuse_beta, fuse_residual_conn,
-          output_shift_scale, sum_scale);  // for INT8 only!
-
-      if (bias) {
-        auto bias_tz = framework::vectorize(bias->dims());
-        mkldnn::memory::desc bias_md;
-        if (platform::is_int8<T>()) {
-          bias_md = platform::MKLDNNMemDesc(
-              bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
-        } else {
-          bias_md = platform::MKLDNNMemDesc(bias_tz, data_type,
-                                            MKLDNNMemoryFormat::x);
-        }
-
-        this->AcquireForwardPrimitiveDescriptor(
-            conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct,
-            src_md, weights_md, bias_md, dst_md, stride_dims, dilations_dims,
-            mkldnn_paddings[0], mkldnn_paddings[1]);
-      } else {
-        this->AcquireForwardPrimitiveDescriptor(
-            conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct,
-            src_md, weights_md, dst_md, stride_dims, dilations_dims,
-            mkldnn_paddings[0], mkldnn_paddings[1]);
-      }
+      this->AcquireForwardPrimitiveDescriptor(
+          conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct, src_md,
+          weights_md, bias_md, dst_md, stride_dims, dilations_dims,
+          mkldnn_paddings[0], mkldnn_paddings[1]);
+    } else {
+      this->AcquireForwardPrimitiveDescriptor(
+          conv_attr, fwd_prop_kind, dnnl::algorithm::convolution_direct, src_md,
+          weights_md, dst_md, stride_dims, dilations_dims, mkldnn_paddings[0],
+          mkldnn_paddings[1]);
     }
   }
 
   ConvMKLDNNHandlerT(const framework::ExecutionContext& ctx,
-                     const platform::MKLDNNDeviceContext& dev_ctx,
-                     platform::Place cpu_place, const Tensor* in,
+                     const mkldnn::engine mkldnn_engine, const Tensor* in,
                      const Tensor* filter, const Tensor* bias,
                      const Tensor* out_grad, Tensor* filter_grad,
-                     Tensor* in_x_grad, const std::string& unique_name)
-      : platform::MKLDNNHandlerT<T, mkldnn::convolution_forward,
-                                 mkldnn::convolution_backward_data,
-                                 mkldnn::convolution_backward_weights>(
-            dev_ctx, dev_ctx.GetEngine(), cpu_place,
-            platform::CreateKey(dev_ctx, framework::vectorize(in->dims()),
-                                unique_name)) {
-    if (!this->isBwdCached()) {
-      PADDLE_ENFORCE_EQ(
-          in->layout(), framework::DataLayout::kMKLDNN,
-          platform::errors::InvalidArgument(
-              "The input tensor's layout should be %d, but got %d.",
-              framework::DataLayout::kMKLDNN, in->layout()));
-      PADDLE_ENFORCE_NE(in->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Got wrong format for Input tensor."));
+                     Tensor* in_x_grad)
+      : platform::MKLDNNHandlerNoCachingT<T, mkldnn::convolution_forward,
+                                          mkldnn::convolution_backward_data,
+                                          mkldnn::convolution_backward_weights>(
+            mkldnn_engine, ctx.GetPlace()),
+        is_test_(false) {
+    PADDLE_ENFORCE_EQ(in->layout(), framework::DataLayout::kMKLDNN,
+                      platform::errors::InvalidArgument(
+                          "The input tensor's layout should be %d, but got %d.",
+                          framework::DataLayout::kMKLDNN, in->layout()));
+    PADDLE_ENFORCE_NE(in->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Got wrong format for Input tensor."));
 
-      PADDLE_ENFORCE_EQ(
-          filter->layout(), framework::DataLayout::kMKLDNN,
-          platform::errors::InvalidArgument(
-              "The filter tensor's layout should be %d, but got %d.",
-              framework::DataLayout::kMKLDNN, filter->layout()));
-      PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Got wrong format for Filter tensor."));
+    PADDLE_ENFORCE_EQ(
+        filter->layout(), framework::DataLayout::kMKLDNN,
+        platform::errors::InvalidArgument(
+            "The filter tensor's layout should be %d, but got %d.",
+            framework::DataLayout::kMKLDNN, filter->layout()));
+    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Got wrong format for Filter tensor."));
 
-      PADDLE_ENFORCE_EQ(
-          out_grad->layout(), framework::DataLayout::kMKLDNN,
-          platform::errors::InvalidArgument(
-              "The output_grad tensor's layout should be %d, but got %d.",
-              framework::DataLayout::kMKLDNN, out_grad->layout()));
-      PADDLE_ENFORCE_NE(out_grad->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Wrong format set for output_grad tensor"));
+    PADDLE_ENFORCE_EQ(
+        out_grad->layout(), framework::DataLayout::kMKLDNN,
+        platform::errors::InvalidArgument(
+            "The output_grad tensor's layout should be %d, but got %d.",
+            framework::DataLayout::kMKLDNN, out_grad->layout()));
+    PADDLE_ENFORCE_NE(out_grad->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Wrong format set for output_grad tensor"));
 
-      PADDLE_ENFORCE_EQ(
-          ctx.Attr<bool>("is_test"), false,
-          platform::errors::InvalidArgument(
-              "is_test attribute should be set to False in training phase."));
+    PADDLE_ENFORCE_EQ(
+        is_test_, false,
+        platform::errors::InvalidArgument(
+            "is_test attribute should be set to False in training phase."));
 
-      std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
-      std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
+    std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
+    std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
 
-      std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
-      std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
+    std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
+    std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
 
-      std::vector<int> dilations_temp = ctx.Attr<std::vector<int>>("dilations");
-      std::vector<int64_t> dilations(begin(dilations_temp),
-                                     end(dilations_temp));
+    std::vector<int> dilations_temp = ctx.Attr<std::vector<int>>("dilations");
+    std::vector<int64_t> dilations(begin(dilations_temp), end(dilations_temp));
 
-      auto input_dims = in->dims();
-      auto data_dims = framework::slice_ddim(input_dims, 2, input_dims.size());
-      auto filter_dims = filter->dims();
-      auto filter_data_dims =
-          framework::slice_ddim(filter_dims, 2, filter_dims.size());
-      auto ksize = framework::vectorize(filter_data_dims);
+    auto input_dims = in->dims();
+    auto data_dims = framework::slice_ddim(input_dims, 2, input_dims.size());
+    auto filter_dims = filter->dims();
+    auto filter_data_dims =
+        framework::slice_ddim(filter_dims, 2, filter_dims.size());
+    auto ksize = framework::vectorize(filter_data_dims);
 
-      std::string padding_algorithm =
-          ctx.Attr<std::string>("padding_algorithm");
-      UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
-                               data_dims, strides, ksize);
+    std::string padding_algorithm = ctx.Attr<std::string>("padding_algorithm");
+    UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
+                             data_dims, strides, ksize);
 
-      auto src_tz = framework::vectorize(in->dims());
-      auto weights_tz = framework::vectorize(filter->dims());
+    auto src_tz = framework::vectorize(in->dims());
+    auto weights_tz = framework::vectorize(filter->dims());
 
-      int groups = ctx.Attr<int>("groups");
-      int g = std::max(groups, 1);
-      platform::GetGroupConvWeightsTz(weights_tz, g);
-      auto dst_tz = framework::vectorize(out_grad->dims());
+    int groups = ctx.Attr<int>("groups");
+    int g = std::max(groups, 1);
+    platform::GetGroupConvWeightsTz(weights_tz, g);
+    auto dst_tz = framework::vectorize(out_grad->dims());
 
-      /* create memory descriptor for conv backward without specified format
-       * ('any') which lets a primitive (conv backward in this case) choose
-       * the memory format preferred for best performance
-       */
-      const auto chosen_memory_format = MKLDNNMemoryFormat::any;
-      const auto weights_format = MKLDNNMemoryFormat::any;
+    /* create memory descriptor for conv backward without specified format
+     * ('any') which lets a primitive (conv backward in this case) choose
+     * the memory format preferred for best performance
+     */
+    const auto chosen_memory_format = MKLDNNMemoryFormat::any;
+    const auto weights_format = MKLDNNMemoryFormat::any;
 
-      auto src_md = platform::MKLDNNMemDesc(
-          src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
-      const auto dst_md = platform::MKLDNNMemDesc(
-          dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
-      auto diff_src_md = platform::MKLDNNMemDesc(
-          src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
-      auto weights_md = platform::MKLDNNMemDesc(
-          weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
-      auto diff_weights_md = platform::MKLDNNMemDesc(
-          weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
-      auto diff_dst_md = platform::MKLDNNMemDesc(
-          dst_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
+    auto src_md = platform::MKLDNNMemDesc(
+        src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
+    const auto dst_md = platform::MKLDNNMemDesc(
+        dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
+    auto diff_src_md = platform::MKLDNNMemDesc(
+        src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
+    auto weights_md = platform::MKLDNNMemDesc(
+        weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
+    auto diff_weights_md = platform::MKLDNNMemDesc(
+        weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
+    auto diff_dst_md = platform::MKLDNNMemDesc(
+        dst_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
 
-      auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
-      std::transform(dilations.begin(), dilations.end(), dilations.begin(),
-                     [](int64_t i) { return i - 1; });
-      const mkldnn::memory::dims dilations_dims = dilations;
+    auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
+    std::transform(dilations.begin(), dilations.end(), dilations.begin(),
+                   [](int64_t i) { return i - 1; });
+    const mkldnn::memory::dims dilations_dims = dilations;
 
-      const mkldnn::memory::dims stride_dims = strides;
-      // Recreating FWD PD. For training there are no post ops in convolution
-      mkldnn::primitive_attr conv_attr;
-      if (bias) {
-        auto bias_tz = framework::vectorize(bias->dims());
-        mkldnn::memory::desc bias_md;
-        if (platform::is_int8<T>()) {
-          bias_md = platform::MKLDNNMemDesc(
-              bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
-        } else {
-          bias_md = platform::MKLDNNMemDesc(
-              bias_tz, mkldnn::memory::data_type::f32, MKLDNNMemoryFormat::x);
-        }
-
-        this->AcquireForwardPrimitiveDescriptor(
-            conv_attr, mkldnn::prop_kind::forward_training,
-            dnnl::algorithm::convolution_direct, src_md, weights_md, bias_md,
-            dst_md, stride_dims, dilations_dims, mkldnn_paddings[0],
-            mkldnn_paddings[1]);
+    const mkldnn::memory::dims stride_dims = strides;
+    // Recreating FWD PD. For training there are no post ops in convolution
+    mkldnn::primitive_attr conv_attr;
+    if (bias) {
+      auto bias_tz = framework::vectorize(bias->dims());
+      mkldnn::memory::desc bias_md;
+      if (platform::is_int8<T>()) {
+        bias_md = platform::MKLDNNMemDesc(
+            bias_tz, mkldnn::memory::data_type::s32, MKLDNNMemoryFormat::x);
       } else {
-        this->AcquireForwardPrimitiveDescriptor(
-            conv_attr, mkldnn::prop_kind::forward_training,
-            dnnl::algorithm::convolution_direct, src_md, weights_md, dst_md,
-            stride_dims, dilations_dims, mkldnn_paddings[0],
-            mkldnn_paddings[1]);
+        bias_md = platform::MKLDNNMemDesc(
+            bias_tz, mkldnn::memory::data_type::f32, MKLDNNMemoryFormat::x);
       }
 
-      this->AcquireBackwardPrimitiveDescriptor(
-          mkldnn::algorithm::convolution_direct, diff_src_md, weights_md,
-          diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
+      this->AcquireForwardPrimitiveDescriptor(
+          conv_attr, mkldnn::prop_kind::forward_training,
+          dnnl::algorithm::convolution_direct, src_md, weights_md, bias_md,
+          dst_md, stride_dims, dilations_dims, mkldnn_paddings[0],
           mkldnn_paddings[1]);
-
-      this->AcquireBackwardWeightsPrimitiveDescriptor(
-          mkldnn::algorithm::convolution_direct, src_md, diff_weights_md,
-          diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
-          mkldnn_paddings[1]);
+    } else {
+      this->AcquireForwardPrimitiveDescriptor(
+          conv_attr, mkldnn::prop_kind::forward_training,
+          dnnl::algorithm::convolution_direct, src_md, weights_md, dst_md,
+          stride_dims, dilations_dims, mkldnn_paddings[0], mkldnn_paddings[1]);
     }
+
+    this->AcquireBackwardPrimitiveDescriptor(
+        mkldnn::algorithm::convolution_direct, diff_src_md, weights_md,
+        diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
+        mkldnn_paddings[1]);
+
+    this->AcquireBackwardWeightsPrimitiveDescriptor(
+        mkldnn::algorithm::convolution_direct, src_md, diff_weights_md,
+        diff_dst_md, strides, dilations_dims, mkldnn_paddings[0],
+        mkldnn_paddings[1]);
   }
 
   std::tuple<float, std::vector<float>> get_int8_scales(
@@ -501,6 +477,7 @@ class ConvMKLDNNHandlerT
 
   std::shared_ptr<mkldnn::memory>
   AcquireWeightsMemoryWithReorderFromDataPrimitive(
+      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
       const framework::Tensor* filter, const int groups, const bool is_conv3d) {
     const K* filter_data = filter->data<K>();
     auto weights_tz = framework::vectorize(filter->dims());
@@ -511,108 +488,157 @@ class ConvMKLDNNHandlerT
         GetWeightsFormat(filter->format(), groups, is_conv3d));
 
     return this->AcquireMemoryWithReorder(
-        user_src_md, this->bwd_pd_->weights_desc(),
-        platform::to_void_cast<K>(filter_data), "@weights_mem_d_p", false);
+        dev_ctx, user_src_md, this->bwd_pd_->weights_desc(),
+        platform::to_void_cast<K>(filter_data), key, "@weights_mem_d_p", false);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireSrcMemoryWithReorder(
       const framework::Tensor* input) {
-    return this->AcquireMemoryWithReorderPrimitive(
-        input, "@src_mem_p_user", "@src_mem_p_target", "@src_mem_p",
-        this->fwd_pd_->src_desc());
+    return this->AcquireMemoryWithReorderPrimitive(input,
+                                                   this->fwd_pd_->src_desc());
   }
 
   std::shared_ptr<mkldnn::memory>
   AcquireSrcMemoryWithReorderFromWeightsPrimitive(
       const framework::Tensor* input) {
-    return this->AcquireMemoryWithReorderPrimitive(
-        input, "@src_mem_w_p_user", "@src_mem_w_p_target", "@src_mem_w_p",
-        this->bwd_w_pd_->src_desc());
+    return this->AcquireMemoryWithReorderPrimitive(input,
+                                                   this->bwd_w_pd_->src_desc());
   }
 
   std::shared_ptr<mkldnn::memory>
   AcquireDiffDstMemoryWithReorderFromWeightsPrimitive(
       const framework::Tensor* out_grad) {
     return this->AcquireMemoryWithReorderPrimitive(
-        out_grad, "@diff_dst_mem_w_p_user", "@diff_dst_mem_w_p_target",
-        "@diff_dst_mem_w_p", this->bwd_w_pd_->diff_dst_desc());
+        out_grad, this->bwd_w_pd_->diff_dst_desc());
   }
 
   std::shared_ptr<mkldnn::memory>
   AcquireDiffDstMemoryWithReorderMemoryFromDataPrimitive(
       const framework::Tensor* out_grad) {
     return this->AcquireMemoryWithReorderPrimitive(
-        out_grad, "@diff_dst_mem_p_user", "@diff_dst_mem_p_target",
-        "@diff_dst_mem_p", this->bwd_pd_->diff_dst_desc());
+        out_grad, this->bwd_pd_->diff_dst_desc());
   }
 
   std::shared_ptr<mkldnn::memory> AcquireMemoryWithReorderPrimitive(
-      const framework::Tensor* in_mem, const char* key_mem_user,
-      const char* key_mem_target, const char* key_mem,
-      const mkldnn::memory::desc& mem_md) {
+      const framework::Tensor* in_mem, const mkldnn::memory::desc& mem_md) {
     const T* in_mem_data = in_mem->data<T>();
-    const std::string user_key_suffix{key_mem_user};
-    auto user_mem_p = this->AcquireMemory(user_key_suffix);
 
-    if (!user_mem_p) {
-      auto user_mem_md = platform::MKLDNNMemDesc(
-          framework::vectorize(in_mem->dims()),
-          platform::MKLDNNGetDataType<T>(), in_mem->format());
-      return this->AcquireMemoryWithReorder(
-          user_mem_md, mem_md, platform::to_void_cast<T>(in_mem_data), key_mem);
-    } else {
-      const std::string target_key_suffix{key_mem_target};
-      const auto target_mem_p = this->AcquireMemory(target_key_suffix);
-      user_mem_p->set_data_handle(platform::to_void_cast<T>(in_mem_data));
-      if (user_mem_p != target_mem_p) {
-        this->AcquireReorder(user_mem_p, target_mem_p, key_mem);
-      }
-      return target_mem_p;
-    }
+    auto user_mem_md = platform::MKLDNNMemDesc(
+        framework::vectorize(in_mem->dims()), platform::MKLDNNGetDataType<T>(),
+        in_mem->format());
+
+    return platform::MKLDNNHandlerNoCachingT<
+        T, mkldnn::convolution_forward, mkldnn::convolution_backward_data,
+        mkldnn::convolution_backward_weights>::
+        AcquireMemoryWithReorder(user_mem_md, mem_md,
+                                 platform::to_void_cast<T>(in_mem_data),
+                                 is_test_);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireWeightsMemoryWithReorder(
+      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
       const framework::Tensor* filter, const int groups, const bool is_conv3d,
-      const bool is_test, const std::vector<float>& scale_data = {1.0f},
-      int mask = 0) {
-    // This is workaround to make execution faster, delete
-    // if statement after including md inside Tensor
-    auto weights_mem_p = this->AcquireMemory("@weights_mem_p_target");
-    if (is_test && weights_mem_p) {
-      return weights_mem_p;
-    } else {
-      const K* filter_data = filter->data<K>();
-      auto weights_tz = framework::vectorize(filter->dims());
-      platform::GetGroupConvWeightsTz(weights_tz, groups);
+      const std::vector<float>& scale_data = {1.0f}, int mask = 0) {
+    const K* filter_data = filter->data<K>();
+    auto weights_tz = framework::vectorize(filter->dims());
+    platform::GetGroupConvWeightsTz(weights_tz, groups);
 
-      auto user_src_md = platform::MKLDNNMemDesc(
-          weights_tz, platform::MKLDNNGetDataType<K>(),
-          GetWeightsFormat(filter->format(), groups, is_conv3d));
+    auto user_src_md = platform::MKLDNNMemDesc(
+        weights_tz, platform::MKLDNNGetDataType<K>(),
+        GetWeightsFormat(filter->format(), groups, is_conv3d));
 
-      return this->AcquireMemoryWithReorder(
-          user_src_md, this->fwd_pd_->weights_desc(),
-          platform::to_void_cast<K>(filter_data), "@weights_mem_p", is_test, {},
-          scale_data, mask);
+    return this->AcquireMemoryWithReorder(
+        dev_ctx, user_src_md, this->fwd_pd_->weights_desc(),
+        platform::to_void_cast<K>(filter_data), key, "@weights_mem_p", is_test_,
+        {}, scale_data, mask);
+  }
+
+  template <typename F = T>
+  std::shared_ptr<mkldnn::memory> AcquireMemoryWithReorder(
+      const platform::MKLDNNDeviceContext& dev_ctx,
+      const mkldnn::memory::desc& user_md,
+      const mkldnn::memory::desc& target_md, void* ptr, const std::string& key,
+      const std::string& suffix, bool is_persistent = false,
+      std::function<std::shared_ptr<F>(const F*)> custom_reorder_func = {},
+      const std::vector<float>& scale_data = {1.0f}, int mask = 0) {
+    const auto target_key = key + suffix + "_target";
+    const auto key_reorder_p = key + suffix + "reorder_p";
+    const auto user_key = key + suffix + "_user";
+
+    auto target_memory_p =
+        std::static_pointer_cast<dnnl::memory>(dev_ctx.GetBlob(target_key));
+
+    if (target_memory_p == nullptr) {
+      if (custom_reorder_func) {
+        auto reordered_data =
+            custom_reorder_func(reinterpret_cast<const F*>(ptr));
+        dev_ctx.SetBlob(key_reorder_p + "-custom_reorder", reordered_data);
+        ptr = reinterpret_cast<void*>(reordered_data.get());
+      }
+      auto user_memory_p =
+          std::make_shared<dnnl::memory>(user_md, this->engine_, ptr);
+      if (user_md != target_md) {
+        target_memory_p =
+            std::make_shared<mkldnn::memory>(target_md, this->engine_);
+        dnnl::reorder::primitive_desc reorder_pdesc;
+        if (platform::is_int8<T>()) {
+          dnnl::primitive_attr attr;
+          attr.set_output_scales(mask, scale_data);
+          reorder_pdesc = dnnl::reorder::primitive_desc(*user_memory_p,
+                                                        *target_memory_p, attr);
+        } else {
+          reorder_pdesc =
+              dnnl::reorder::primitive_desc(*user_memory_p, *target_memory_p);
+        }
+        auto reorder_p = std::make_shared<dnnl::reorder>(reorder_pdesc);
+        dev_ctx.SetBlob(key_reorder_p, reorder_p);
+
+        auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
+        platform::RecordEvent record_reorder("int_reorder",
+                                             platform::EventRole::kUniqueOp);
+        reorder_p->execute(astream, {{MKLDNN_ARG_FROM, *user_memory_p},
+                                     {MKLDNN_ARG_TO, *target_memory_p}});
+        astream.wait();
+      } else {
+        target_memory_p = user_memory_p;
+      }
+      dev_ctx.SetBlob(user_key, user_memory_p);
+      dev_ctx.SetBlob(target_key, target_memory_p);
+    } else if (!is_persistent) {
+      auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
+
+      auto user_memory_p =
+          std::static_pointer_cast<dnnl::memory>(dev_ctx.GetBlob(user_key));
+      user_memory_p->set_data_handle(ptr);
+
+      // TODO(jczaja): Here we detect if reorder is cached it means it is needed
+      // need to change this to get rid of keys
+      auto reorder_p = std::static_pointer_cast<mkldnn::reorder>(
+          dev_ctx.GetBlob(key_reorder_p));
+      if (reorder_p != nullptr) {
+        platform::RecordEvent record_reorder("int_reorder",
+                                             platform::EventRole::kUniqueOp);
+        reorder_p->execute(astream, {{MKLDNN_ARG_FROM, *user_memory_p},
+                                     {MKLDNN_ARG_TO, *target_memory_p}});
+        astream.wait();
+      }
     }
+    return target_memory_p;
   }
 
   std::shared_ptr<mkldnn::memory> AcquireBiasMemoryWithReorder(
-      const framework::Tensor* bias, const bool is_test,
+      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
+      const framework::Tensor* bias,
       const std::vector<float>& scale_data = {1.0f}, int mask = 0) {
-    auto bias_mem_p = this->AcquireMemory("@bias_mem_p_target");
-    if (is_test && bias_mem_p) {
-      return bias_mem_p;
-    } else {
-      const K* bias_data = bias->data<K>();
-      auto user_bias_md = platform::MKLDNNMemDesc(
-          framework::vectorize(bias->dims()), platform::MKLDNNGetDataType<K>(),
-          MKLDNNMemoryFormat::x);
+    const K* bias_data = bias->data<K>();
+    auto user_bias_md = platform::MKLDNNMemDesc(
+        framework::vectorize(bias->dims()), platform::MKLDNNGetDataType<K>(),
+        MKLDNNMemoryFormat::x);
 
-      return this->AcquireMemoryWithReorder(
-          user_bias_md, this->fwd_pd_->bias_desc(),
-          platform::to_void_cast<K>(bias_data), "@bias_mem_p", is_test, {},
-          scale_data, mask);
-    }
+    return this->AcquireMemoryWithReorder(
+        dev_ctx, user_bias_md, this->fwd_pd_->bias_desc(),
+        platform::to_void_cast<K>(bias_data), key, "@bias_mem_p", is_test_, {},
+        scale_data, mask);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireResidualMemory(
@@ -621,19 +647,11 @@ class ConvMKLDNNHandlerT
         residual_param->type() == framework::DataTypeTrait<T_out>::DataType()
             ? platform::to_void_cast<T_out>(residual_param->data<T_out>())
             : platform::to_void_cast<T>(residual_param->data<T>());
-    auto residual_mem_p = this->AcquireMemory("@user_residual_data_mem_p");
-    if (residual_mem_p) {
-      residual_mem_p->set_data_handle(residual_data);
-      return residual_mem_p;
-    } else {
-      auto user_residual_md = platform::MKLDNNMemDesc(
-          framework::vectorize(residual_param->dims()),
-          framework::ToMKLDNNDataType(residual_param->type()),
-          residual_param->format());
-
-      return this->AcquireMemoryFromPrimitive(user_residual_md, residual_data,
-                                              "@user_residual_data_mem_p");
-    }
+    auto user_residual_md = platform::MKLDNNMemDesc(
+        framework::vectorize(residual_param->dims()),
+        framework::ToMKLDNNDataType(residual_param->type()),
+        residual_param->format());
+    return this->AcquireMemoryFromPrimitive(user_residual_md, residual_data);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireDstMemoryWithResidual(
@@ -643,7 +661,7 @@ class ConvMKLDNNHandlerT
         platform::GetMKLDNNFormat(this->fwd_pd_->dst_desc())) {
       auto residual_memory_p = this->AcquireResidualMemory(residual_param);
       dst_memory_p = this->template AcquireDstMemory<T_out>(output);
-      this->AcquireReorder(residual_memory_p, dst_memory_p, "@residual_dst");
+      this->AcquireReorder(residual_memory_p, dst_memory_p);
     } else {
       // Changing ShareDataWith to TensorCopy results in performance drop
       // on ResNet architectures
@@ -653,6 +671,9 @@ class ConvMKLDNNHandlerT
     }
     return dst_memory_p;
   }
+
+ private:
+  const bool is_test_;
 };
 
 }  // anonymous namespace
@@ -697,7 +718,6 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         ctx.template device_context<platform::MKLDNNDeviceContext>();
     const auto& mkldnn_engine = dev_ctx.GetEngine();
 
-    const bool is_test = ctx.Attr<bool>("is_test");
     const bool is_conv3d = ctx.Attr<std::vector<int>>("strides").size() == 3U;
     const bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
 
@@ -707,15 +727,19 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
-    ConvMKLDNNHandlerT<T, K, T_out> handler(
-        ctx, dev_ctx, mkldnn_engine, ctx.GetPlace(), input, filter, bias,
-        output, ctx.InputName("Input") + ctx.InputName("Filter"));
+    ConvMKLDNNHandlerT<T, K, T_out> handler(ctx, mkldnn_engine, input, filter,
+                                            bias, output);
 
     auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
 
-    auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
-        filter, ctx.Attr<int>("groups"), is_conv3d, is_test);
+    // Key is needed for params (weights and biases) to have reordered weights
+    // cached
+    std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
+                                          ctx.InputName("Filter"));
+    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
 
+    auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
+        dev_ctx, key, filter, ctx.Attr<int>("groups"), is_conv3d);
     std::shared_ptr<dnnl::memory> dst_memory_p;
     if (fuse_residual_conn) {
       auto* residual_param = ctx.Input<Tensor>("ResidualData");
@@ -733,7 +757,8 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         {MKLDNN_ARG_DST, *dst_memory_p}};
 
     if (bias) {
-      auto bias_memory_p = handler.AcquireBiasMemoryWithReorder(bias, is_test);
+      auto bias_memory_p =
+          handler.AcquireBiasMemoryWithReorder(dev_ctx, key, bias);
       args.insert({MKLDNN_ARG_BIAS, *bias_memory_p});
     }
 
@@ -775,9 +800,8 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
     auto* bias = ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
-    ConvMKLDNNHandlerT<T, K, T_out> handler(
-        ctx, dev_ctx, mkldnn_engine, ctx.GetPlace(), input, filter, bias,
-        output, ctx.InputName("Input") + ctx.InputName("Filter"));
+    ConvMKLDNNHandlerT<T, K, T_out> handler(ctx, mkldnn_engine, input, filter,
+                                            bias, output);
 
     auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
 
@@ -785,11 +809,17 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
         ctx.Attr<std::vector<float>>("Scale_weights");
     const bool is_multi_channel = scale_weights_data.size() > 1;
     const int& groups = ctx.Attr<int>("groups");
-    const bool& is_test = ctx.Attr<bool>("is_test");
     int mask_reorder =
         is_multi_channel ? ((groups != 1) ? (1 << 1) + (1 << 0) : 1 << 0) : 0;
+
+    // Key is needed for params (weights and biases) to have reordered weights
+    // cached
+    std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
+                                          ctx.InputName("Filter"));
+    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
+
     auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
-        filter, groups, false, is_test, scale_weights_data, mask_reorder);
+        dev_ctx, key, filter, groups, false, scale_weights_data, mask_reorder);
 
     std::shared_ptr<dnnl::memory> dst_memory_p;
     if (fuse_residual_conn) {
@@ -824,7 +854,7 @@ class ConvMKLDNNOpKernel : public framework::OpKernel<T> {
           handler.get_int8_bias_scales(ctx);
 
       auto bias_memory_p = handler.AcquireBiasMemoryWithReorder(
-          bias, is_test, scale_bias_data, mask_reorder);
+          dev_ctx, key, bias, scale_bias_data, mask_reorder);
       args.insert({MKLDNN_ARG_BIAS, *bias_memory_p});
     }
 
@@ -864,10 +894,15 @@ class ConvMKLDNNGradOpKernel : public framework::OpKernel<T> {
     if (!input_grad && !filter_grad) return;
 
     // TODO(jczaja): Are all tensors really needed?
-    ConvMKLDNNHandlerT<T, K, T> handler(
-        ctx, dev_ctx, ctx.GetPlace(), input, filter, bias, output_grad,
-        filter_grad, input_grad,
-        ctx.InputName("Input") + ctx.InputName("Filter"));
+    ConvMKLDNNHandlerT<T, K, T> handler(ctx, dev_ctx.GetEngine(), input, filter,
+                                        bias, output_grad, filter_grad,
+                                        input_grad);
+
+    // Key is needed for params (weights and biases) to have reordered weights
+    // cached
+    std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
+                                          ctx.InputName("Filter"));
+    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
 
     // create mkldnn memory from input tensors (data/weights)
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
@@ -943,7 +978,7 @@ class ConvMKLDNNGradOpKernel : public framework::OpKernel<T> {
     if (input_grad) {
       auto weights_memory_p =
           handler.AcquireWeightsMemoryWithReorderFromDataPrimitive(
-              filter, ctx.Attr<int>("groups"),
+              dev_ctx, key, filter, ctx.Attr<int>("groups"),
               ctx.Attr<std::vector<int>>("strides").size() == 3U);
 
       auto diff_dst_memory_p =

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -213,9 +213,9 @@ class ConvTransposeMKLDNNHandlerT
     auto user_src_md = platform::MKLDNNMemDesc(
         framework::vectorize(input->dims()), platform::MKLDNNGetDataType<T>(),
         input->format());
-    return this->AcquireMemoryWithReorder(
-        user_src_md, this->fwd_pd_->src_desc(),
-        platform::to_void_cast<T>(input_data));
+    return platform::MKLDNNHandlerNoCachingT<T, mkldnn::deconvolution_forward>::
+        AcquireMemoryWithReorder(user_src_md, this->fwd_pd_->src_desc(),
+                                 platform::to_void_cast<T>(input_data));
   }
 
   std::shared_ptr<mkldnn::memory> AcquireWeightsMemoryWithReorder(
@@ -386,7 +386,8 @@ class ConvTransposeMKLDNNOpKernel : public framework::OpKernel<T> {
     auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
     // Caching Key for weights is needed
     std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
-                                          ctx.InputName("Filter"), (bias ? ctx.InputName("Bias") : ""));
+                                          ctx.InputName("Filter"),
+                                          (bias ? ctx.InputName("Bias") : ""));
     key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
     auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
         dev_ctx, key, filter, ctx.Attr<int>("groups"));

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -399,7 +399,7 @@ class ConvTransposeMKLDNNOpKernel : public framework::OpKernel<T> {
 
     if (bias) {
       auto bias_memory_p =
-          handler.AcquireBiasMemoryWithReorder(dev_Ctx, key, bias);
+          handler.AcquireBiasMemoryWithReorder(dev_ctx, key, bias);
       args.insert({MKLDNN_ARG_BIAS, *bias_memory_p});
     }
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -40,151 +40,144 @@ inline mkldnn::memory::dims GetWeightsTz(const Tensor* filter,
 
 template <typename T, typename K, typename T_out>
 class ConvTransposeMKLDNNHandlerT
-    : public platform::MKLDNNHandlerT<T, mkldnn::deconvolution_forward> {
+    : public platform::MKLDNNHandlerNoCachingT<T,
+                                               mkldnn::deconvolution_forward> {
  public:
   ConvTransposeMKLDNNHandlerT(const framework::ExecutionContext& ctx,
-                              const platform::MKLDNNDeviceContext& dev_ctx,
                               const mkldnn::engine mkldnn_engine,
-                              platform::Place cpu_place, const Tensor* input,
-                              const Tensor* filter, const Tensor* bias,
-                              Tensor* output, const std::string& unique_name)
-      : platform::MKLDNNHandlerT<T, mkldnn::deconvolution_forward>(
-            dev_ctx, mkldnn_engine, cpu_place,
-            platform::CreateKey(dev_ctx, framework::vectorize(input->dims()),
-                                unique_name)),
+                              const Tensor* input, const Tensor* filter,
+                              const Tensor* bias, Tensor* output)
+      : platform::MKLDNNHandlerNoCachingT<T, mkldnn::deconvolution_forward>(
+            mkldnn_engine, ctx.GetPlace()),
         is_test_(ctx.Attr<bool>("is_test")) {
-    if (!this->isCached()) {
-      PADDLE_ENFORCE_EQ(is_test_, true,
-                        platform::errors::InvalidArgument(
-                            "ConvTransposeMKLDNN works only for inference. "
-                            "The attribute \'is_test\' value should be set to "
-                            "True, but got is_test=False."));
+    PADDLE_ENFORCE_EQ(is_test_, true,
+                      platform::errors::InvalidArgument(
+                          "ConvTransposeMKLDNN works only for inference. "
+                          "The attribute \'is_test\' value should be set to "
+                          "True, but got is_test=False."));
 
+    PADDLE_ENFORCE_EQ(
+        input->layout(), DataLayout::kMKLDNN,
+        platform::errors::InvalidArgument(
+            "Got wrong layout = %d for Input tensor.", input->layout()));
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Got wrong format for Input tensor. The input "
+                          "format is undefined."));
+
+    PADDLE_ENFORCE_EQ(
+        filter->layout(), DataLayout::kMKLDNN,
+        platform::errors::InvalidArgument(
+            "The filter tensor's laytout should be %d, but got %d.",
+            DataLayout::kMKLDNN, filter->layout()));
+    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Got wrong formats for Filter tensor."));
+
+    PADDLE_ENFORCE_EQ(
+        input->dims().size(), 4,
+        platform::errors::InvalidArgument("Input must be with 4 dimensions, "
+                                          "i.e. NCHW. but got dimension =%d",
+                                          input->dims().size()));
+    PADDLE_ENFORCE_EQ(
+        filter->dims().size(), 4,
+        platform::errors::InvalidArgument("Filter must be with 4 dimensions, "
+                                          "i.e. OIHW, but got dimension =%d",
+                                          filter->dims().size()));
+
+    if (bias) {
       PADDLE_ENFORCE_EQ(
-          input->layout(), DataLayout::kMKLDNN,
+          bias->layout(), DataLayout::kMKLDNN,
           platform::errors::InvalidArgument(
-              "Got wrong layout = %d for Input tensor.", input->layout()));
-      PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::undef,
+              "The bias tensor's laytout should be %d, but got %d.",
+              DataLayout::kMKLDNN, bias->layout()));
+      PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::undef,
                         platform::errors::InvalidArgument(
-                            "Got wrong format for Input tensor. The input "
-                            "format is undefined."));
+                            "Got wrong format for Bias tensor."));
 
       PADDLE_ENFORCE_EQ(
-          filter->layout(), DataLayout::kMKLDNN,
-          platform::errors::InvalidArgument(
-              "The filter tensor's laytout should be %d, but got %d.",
-              DataLayout::kMKLDNN, filter->layout()));
-      PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Got wrong formats for Filter tensor."));
+          bias->dims().size(), 1,
+          platform::errors::InvalidArgument("Bias must only have 1 dimension, "
+                                            "i.e. X, but got dimension = %d .",
+                                            bias->dims().size()));
+    }
 
-      PADDLE_ENFORCE_EQ(
-          input->dims().size(), 4,
-          platform::errors::InvalidArgument("Input must be with 4 dimensions, "
-                                            "i.e. NCHW. but got dimension =%d",
-                                            input->dims().size()));
-      PADDLE_ENFORCE_EQ(
-          filter->dims().size(), 4,
-          platform::errors::InvalidArgument("Filter must be with 4 dimensions, "
-                                            "i.e. OIHW, but got dimension =%d",
-                                            filter->dims().size()));
+    std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
+    mkldnn::memory::dims strides(begin(strides_temp), end(strides_temp));
 
-      if (bias) {
-        PADDLE_ENFORCE_EQ(
-            bias->layout(), DataLayout::kMKLDNN,
-            platform::errors::InvalidArgument(
-                "The bias tensor's laytout should be %d, but got %d.",
-                DataLayout::kMKLDNN, bias->layout()));
-        PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::undef,
-                          platform::errors::InvalidArgument(
-                              "Got wrong format for Bias tensor."));
+    std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
+    mkldnn::memory::dims paddings(begin(paddings_temp), end(paddings_temp));
 
-        PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
-                          platform::errors::InvalidArgument(
-                              "Bias must only have 1 dimension, "
-                              "i.e. X, but got dimension = %d .",
-                              bias->dims().size()));
-      }
+    std::vector<int> dilations_temp = ctx.Attr<std::vector<int>>("dilations");
+    mkldnn::memory::dims dilations(begin(dilations_temp), end(dilations_temp));
 
-      std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
-      mkldnn::memory::dims strides(begin(strides_temp), end(strides_temp));
+    int groups = ctx.Attr<int>("groups");
+    std::string padding_algorithm = ctx.Attr<std::string>("padding_algorithm");
 
-      std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
-      mkldnn::memory::dims paddings(begin(paddings_temp), end(paddings_temp));
+    PADDLE_ENFORCE_EQ(
+        strides.size(), 2,
+        platform::errors::Unimplemented(
+            "Now we only support 2d oneDNN convolution transpose op"));
 
-      std::vector<int> dilations_temp = ctx.Attr<std::vector<int>>("dilations");
-      mkldnn::memory::dims dilations(begin(dilations_temp),
-                                     end(dilations_temp));
+    const auto& input_dims = input->dims();
+    const auto data_dims =
+        framework::slice_ddim(input_dims, 2, input_dims.size());
+    const auto& filter_dims = filter->dims();
+    const auto filter_data_dims =
+        framework::slice_ddim(filter_dims, 2, filter_dims.size());
 
-      int groups = ctx.Attr<int>("groups");
-      std::string padding_algorithm =
-          ctx.Attr<std::string>("padding_algorithm");
+    const auto ksize = framework::vectorize(filter_data_dims);
 
-      PADDLE_ENFORCE_EQ(
-          strides.size(), 2,
-          platform::errors::Unimplemented(
-              "Now we only support 2d oneDNN convolution transpose op"));
+    UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
+                             data_dims, strides, ksize);
 
-      const auto& input_dims = input->dims();
-      const auto data_dims =
-          framework::slice_ddim(input_dims, 2, input_dims.size());
-      const auto& filter_dims = filter->dims();
-      const auto filter_data_dims =
-          framework::slice_ddim(filter_dims, 2, filter_dims.size());
+    std::transform(dilations.begin(), dilations.end(), dilations.begin(),
+                   [](int64_t i) { return i - 1; });
 
-      const auto ksize = framework::vectorize(filter_data_dims);
+    const auto src_tz = framework::vectorize(input->dims());
+    const auto weights_tz = GetWeightsTz(filter, groups);
+    const auto dst_tz = framework::vectorize(output->dims());
+    const auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
 
-      UpdatePaddingAndDilation(&paddings, &dilations, padding_algorithm,
-                               data_dims, strides, ksize);
+    /* create memory descriptor for convolution without specified format
+     * ('any') which lets a primitive (convolution in this case) choose
+     * the memory format preferred for best performance
+     */
+    const auto chosen_memory_format = MKLDNNMemoryFormat::any;
+    const std::string fuse_activation =
+        ctx.Attr<std::string>("fuse_activation");
+    const float fuse_alpha = ctx.Attr<float>("fuse_alpha");
+    const float fuse_beta = ctx.Attr<float>("fuse_beta");
 
-      std::transform(dilations.begin(), dilations.end(), dilations.begin(),
-                     [](int64_t i) { return i - 1; });
+    auto data_type = mkldnn::memory::data_type::f32;
+    if (ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16" ||
+        std::is_same<T_out, platform::bfloat16>::value)
+      data_type = mkldnn::memory::data_type::bf16;
 
-      const auto src_tz = framework::vectorize(input->dims());
-      const auto weights_tz = GetWeightsTz(filter, groups);
-      const auto dst_tz = framework::vectorize(output->dims());
-      const auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
+    const auto src_md =
+        platform::MKLDNNMemDesc(src_tz, data_type, chosen_memory_format);
+    const auto weights_md =
+        platform::MKLDNNMemDesc(weights_tz, data_type, chosen_memory_format);
+    const auto dst_md = platform::MKLDNNMemDesc(
+        dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
 
-      /* create memory descriptor for convolution without specified format
-       * ('any') which lets a primitive (convolution in this case) choose
-       * the memory format preferred for best performance
-       */
-      const auto chosen_memory_format = MKLDNNMemoryFormat::any;
-      const std::string fuse_activation =
-          ctx.Attr<std::string>("fuse_activation");
-      const float fuse_alpha = ctx.Attr<float>("fuse_alpha");
-      const float fuse_beta = ctx.Attr<float>("fuse_beta");
-
-      auto data_type = mkldnn::memory::data_type::f32;
-      if (ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16" ||
-          std::is_same<T_out, platform::bfloat16>::value)
-        data_type = mkldnn::memory::data_type::bf16;
-
-      const auto src_md =
-          platform::MKLDNNMemDesc(src_tz, data_type, chosen_memory_format);
-      const auto weights_md =
-          platform::MKLDNNMemDesc(weights_tz, data_type, chosen_memory_format);
-      const auto dst_md = platform::MKLDNNMemDesc(
-          dst_tz, platform::MKLDNNGetDataType<T_out>(), chosen_memory_format);
-
-      const mkldnn::primitive_attr conv_trans_attr =
-          CreatePostOps(fuse_activation, fuse_alpha, fuse_beta);
-      auto fwd_prop_kind = is_test_ ? mkldnn::prop_kind::forward_inference
-                                    : mkldnn::prop_kind::forward_training;
-      if (bias) {
-        std::vector<int64_t> bias_tz = framework::vectorize(bias->dims());
-        const auto bias_md =
-            platform::MKLDNNMemDesc(bias_tz, data_type, MKLDNNMemoryFormat::x);
-        this->AcquireForwardPrimitiveDescriptor(
-            conv_trans_attr, fwd_prop_kind,
-            dnnl::algorithm::deconvolution_direct, src_md, weights_md, bias_md,
-            dst_md, strides, dilations, mkldnn_paddings[0], mkldnn_paddings[1]);
-      } else {
-        this->AcquireForwardPrimitiveDescriptor(
-            conv_trans_attr, fwd_prop_kind,
-            dnnl::algorithm::deconvolution_direct, src_md, weights_md, dst_md,
-            strides, dilations, mkldnn_paddings[0], mkldnn_paddings[1]);
-      }
+    const mkldnn::primitive_attr conv_trans_attr =
+        CreatePostOps(fuse_activation, fuse_alpha, fuse_beta);
+    auto fwd_prop_kind = is_test_ ? mkldnn::prop_kind::forward_inference
+                                  : mkldnn::prop_kind::forward_training;
+    if (bias) {
+      std::vector<int64_t> bias_tz = framework::vectorize(bias->dims());
+      const auto bias_md =
+          platform::MKLDNNMemDesc(bias_tz, data_type, MKLDNNMemoryFormat::x);
+      this->AcquireForwardPrimitiveDescriptor(
+          conv_trans_attr, fwd_prop_kind, dnnl::algorithm::deconvolution_direct,
+          src_md, weights_md, bias_md, dst_md, strides, dilations,
+          mkldnn_paddings[0], mkldnn_paddings[1]);
+    } else {
+      this->AcquireForwardPrimitiveDescriptor(
+          conv_trans_attr, fwd_prop_kind, dnnl::algorithm::deconvolution_direct,
+          src_md, weights_md, dst_md, strides, dilations, mkldnn_paddings[0],
+          mkldnn_paddings[1]);
     }
   }
 
@@ -217,69 +210,124 @@ class ConvTransposeMKLDNNHandlerT
   std::shared_ptr<mkldnn::memory> AcquireSrcMemoryWithReorder(
       const framework::Tensor* input) {
     const T* input_data = input->data<T>();
-    const std::string user_key_suffix{"@src_mem_p_user"};
-    auto user_src_mem_p = this->AcquireMemory(user_key_suffix);
-    if (!user_src_mem_p) {
-      auto user_src_md = platform::MKLDNNMemDesc(
-          framework::vectorize(input->dims()), platform::MKLDNNGetDataType<T>(),
-          input->format());
-      return this->AcquireMemoryWithReorder(
-          user_src_md, this->fwd_pd_->src_desc(),
-          platform::to_void_cast<T>(input_data), "@src_mem_p");
-    } else {
-      const std::string target_key_suffix{"@src_mem_p_target"};
-      const auto target_src_mem_p = this->AcquireMemory(target_key_suffix);
-      user_src_mem_p->set_data_handle(platform::to_void_cast<T>(input_data));
-      if (user_src_mem_p != target_src_mem_p) {
-        this->AcquireReorder(user_src_mem_p, target_src_mem_p);
-      }
-      return target_src_mem_p;
-    }
+    auto user_src_md = platform::MKLDNNMemDesc(
+        framework::vectorize(input->dims()), platform::MKLDNNGetDataType<T>(),
+        input->format());
+    return this->AcquireMemoryWithReorder(
+        user_src_md, this->fwd_pd_->src_desc(),
+        platform::to_void_cast<T>(input_data));
   }
 
   std::shared_ptr<mkldnn::memory> AcquireWeightsMemoryWithReorder(
+      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
       const framework::Tensor* filter, const int& groups) {
-    // This is workaround to make execution faster, delete
-    // if statement after including md inside Tensor
-    auto weights_mem_p = this->AcquireMemory("@weights_mem_p_target");
-    if (is_test_ && weights_mem_p) {
-      return weights_mem_p;
-    } else {
-      const K* filter_data = filter->data<K>();
-      auto weights_tz = GetWeightsTz(filter, groups);
-      int g = std::max(groups, 1);
+    const K* filter_data = filter->data<K>();
+    auto weights_tz = GetWeightsTz(filter, groups);
+    int g = std::max(groups, 1);
 
-      auto user_src_md = platform::MKLDNNMemDesc(
-          weights_tz, platform::MKLDNNGetDataType<K>(),
-          (g == 1) ? filter->format() : MKLDNNMemoryFormat::goihw);
+    auto user_src_md = platform::MKLDNNMemDesc(
+        weights_tz, platform::MKLDNNGetDataType<K>(),
+        (g == 1) ? filter->format() : MKLDNNMemoryFormat::goihw);
 
-      auto iohw_weights_tz = framework::vectorize(filter->dims());
-      // Custom Reorder from IOHW to OIHW
-      auto iohw2oihw_reorder =
-          [&iohw_weights_tz](const K* filter_data) -> std::shared_ptr<K> {
-        int o = iohw_weights_tz[1];
-        int c = iohw_weights_tz[0];
-        int h = iohw_weights_tz[2];
-        int w = iohw_weights_tz[3];
-        std::shared_ptr<K> reordered_filter_data(new K[o * c * h * w](),
-                                                 std::default_delete<K[]>());
-        for (int i = 0; i < c; ++i) {
-          for (int j = 0; j < o; ++j) {
-            int in_offset = j * h * w + i * o * h * w;
-            int out_offset = j * c * h * w + i * h * w;
-            std::memcpy(&(reordered_filter_data.get())[out_offset],
-                        &filter_data[in_offset], h * w * sizeof(K));
-          }
+    auto iohw_weights_tz = framework::vectorize(filter->dims());
+    // Custom Reorder from IOHW to OIHW
+    auto iohw2oihw_reorder =
+        [&iohw_weights_tz](const K* filter_data) -> std::shared_ptr<K> {
+      int o = iohw_weights_tz[1];
+      int c = iohw_weights_tz[0];
+      int h = iohw_weights_tz[2];
+      int w = iohw_weights_tz[3];
+      std::shared_ptr<K> reordered_filter_data(new K[o * c * h * w](),
+                                               std::default_delete<K[]>());
+      for (int i = 0; i < c; ++i) {
+        for (int j = 0; j < o; ++j) {
+          int in_offset = j * h * w + i * o * h * w;
+          int out_offset = j * c * h * w + i * h * w;
+          std::memcpy(&(reordered_filter_data.get())[out_offset],
+                      &filter_data[in_offset], h * w * sizeof(K));
         }
+      }
 
-        return reordered_filter_data;
-      };
+      return reordered_filter_data;
+    };
 
-      return this->template AcquireMemoryWithReorder<K>(
-          user_src_md, this->fwd_pd_->weights_desc(),
-          platform::to_void_cast<K>(filter_data), "@weights_mem_p", is_test_,
-          iohw2oihw_reorder);
+    return this->template AcquireMemoryWithReorder<K>(
+        dev_ctx, user_src_md, this->fwd_pd_->weights_desc(),
+        platform::to_void_cast<K>(filter_data), key, "@weights_mem_p", is_test_,
+        iohw2oihw_reorder);
+  }
+
+  template <typename F = T>
+  std::shared_ptr<mkldnn::memory> AcquireMemoryWithReorder(
+      const platform::MKLDNNDeviceContext& dev_ctx,
+      const mkldnn::memory::desc& user_md,
+      const mkldnn::memory::desc& target_md, void* ptr, const std::string& key,
+      const std::string& suffix, bool is_persistent = false,
+      std::function<std::shared_ptr<F>(const F*)> custom_reorder_func = {},
+      const std::vector<float>& scale_data = {1.0f}, int mask = 0) {
+    const auto target_key = key + suffix + "_target";
+    const auto key_reorder_p = key + suffix + "reorder_p";
+    const auto user_key = key + suffix + "_user";
+
+    auto target_memory_p =
+        std::static_pointer_cast<dnnl::memory>(dev_ctx.GetBlob(target_key));
+
+    if (target_memory_p == nullptr) {
+      if (custom_reorder_func) {
+        auto reordered_data =
+            custom_reorder_func(reinterpret_cast<const F*>(ptr));
+        dev_ctx.SetBlob(key_reorder_p + "-custom_reorder", reordered_data);
+        ptr = reinterpret_cast<void*>(reordered_data.get());
+      }
+      auto user_memory_p =
+          std::make_shared<dnnl::memory>(user_md, this->engine_, ptr);
+      if (user_md != target_md) {
+        target_memory_p =
+            std::make_shared<mkldnn::memory>(target_md, this->engine_);
+        dnnl::reorder::primitive_desc reorder_pdesc;
+        if (platform::is_int8<T>()) {
+          dnnl::primitive_attr attr;
+          attr.set_output_scales(mask, scale_data);
+          reorder_pdesc = dnnl::reorder::primitive_desc(*user_memory_p,
+                                                        *target_memory_p, attr);
+        } else {
+          reorder_pdesc =
+              dnnl::reorder::primitive_desc(*user_memory_p, *target_memory_p);
+        }
+        auto reorder_p = std::make_shared<dnnl::reorder>(reorder_pdesc);
+        dev_ctx.SetBlob(key_reorder_p, reorder_p);
+
+        auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
+        platform::RecordEvent record_reorder("int_reorder",
+                                             platform::EventRole::kUniqueOp);
+        reorder_p->execute(astream, {{MKLDNN_ARG_FROM, *user_memory_p},
+                                     {MKLDNN_ARG_TO, *target_memory_p}});
+        astream.wait();
+      } else {
+        target_memory_p = user_memory_p;
+      }
+      dev_ctx.SetBlob(user_key, user_memory_p);
+      dev_ctx.SetBlob(target_key, target_memory_p);
+    } else if (!is_persistent) {
+      auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
+
+      auto user_memory_p =
+          std::static_pointer_cast<dnnl::memory>(dev_ctx.GetBlob(user_key));
+      user_memory_p->set_data_handle(ptr);
+
+      // TODO(jczaja): Here we detect if reorder is cached it means it is needed
+      // need to change this to get rid of keys
+      auto reorder_p = std::static_pointer_cast<mkldnn::reorder>(
+          dev_ctx.GetBlob(key_reorder_p));
+      if (reorder_p != nullptr) {
+        platform::RecordEvent record_reorder("int_reorder",
+                                             platform::EventRole::kUniqueOp);
+        reorder_p->execute(astream, {{MKLDNN_ARG_FROM, *user_memory_p},
+                                     {MKLDNN_ARG_TO, *target_memory_p}});
+        astream.wait();
+      }
     }
+    return target_memory_p;
   }
 
   std::shared_ptr<mkldnn::memory> AcquireBiasMemoryWithReorder(
@@ -333,15 +381,15 @@ class ConvTransposeMKLDNNOpKernel : public framework::OpKernel<T> {
     const auto* bias =
         ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
-    const std::string unique_name = ctx.InputName("Input") +
-                                    ctx.InputName("Filter") +
-                                    (bias ? ctx.InputName("Bias") : "");
-    ConvTransposeMKLDNNHandlerT<T, K, T_out> handler(
-        ctx, dev_ctx, mkldnn_engine, ctx.GetPlace(), input, filter, bias,
-        output, unique_name);
+    ConvTransposeMKLDNNHandlerT<T, K, T_out> handler(ctx, mkldnn_engine, input,
+                                                     filter, bias, output);
     auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
+    // Caching Key for weights is needed
+    std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
+                                          ctx.InputName("Filter"), (bias ? ctx.InputName("Bias") : "");
+    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
     auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
-        filter, ctx.Attr<int>("groups"));
+        dev_ctx, key, filter, ctx.Attr<int>("groups"));
 
     std::shared_ptr<dnnl::memory> dst_memory_p =
         handler.template AcquireDstMemory<T_out>(output);

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -331,19 +331,15 @@ class ConvTransposeMKLDNNHandlerT
   }
 
   std::shared_ptr<mkldnn::memory> AcquireBiasMemoryWithReorder(
+      const platform::MKLDNNDeviceContext& dev_ctx, const std::string& key,
       const framework::Tensor* bias) {
-    auto bias_mem_p = this->AcquireMemory("@bias_mem_p_target");
-    if (is_test_ && bias_mem_p) {
-      return bias_mem_p;
-    } else {
-      const K* bias_data = bias->data<K>();
-      auto user_bias_md = platform::MKLDNNMemDesc(
-          framework::vectorize(bias->dims()), platform::MKLDNNGetDataType<K>(),
-          MKLDNNMemoryFormat::x);
-      return this->AcquireMemoryWithReorder(
-          user_bias_md, this->fwd_pd_->bias_desc(),
-          platform::to_void_cast<K>(bias_data), "@bias_mem_p", is_test_);
-    }
+    const K* bias_data = bias->data<K>();
+    auto user_bias_md = platform::MKLDNNMemDesc(
+        framework::vectorize(bias->dims()), platform::MKLDNNGetDataType<K>(),
+        MKLDNNMemoryFormat::x);
+    return this->AcquireMemoryWithReorder(
+        dev_ctx, user_bias_md, this->fwd_pd_->bias_desc(),
+        platform::to_void_cast<K>(bias_data), key, "@bias_mem_p", is_test_);
   }
 
  private:

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -398,7 +398,8 @@ class ConvTransposeMKLDNNOpKernel : public framework::OpKernel<T> {
         {MKLDNN_ARG_DST, *dst_memory_p}};
 
     if (bias) {
-      auto bias_memory_p = handler.AcquireBiasMemoryWithReorder(bias);
+      auto bias_memory_p =
+          handler.AcquireBiasMemoryWithReorder(dev_Ctx, key, bias);
       args.insert({MKLDNN_ARG_BIAS, *bias_memory_p});
     }
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -386,7 +386,7 @@ class ConvTransposeMKLDNNOpKernel : public framework::OpKernel<T> {
     auto src_memory_p = handler.AcquireSrcMemoryWithReorder(input);
     // Caching Key for weights is needed
     std::string key = platform::CreateKey(dev_ctx, ctx.InputName("Input"),
-                                          ctx.InputName("Filter"), (bias ? ctx.InputName("Bias") : "");
+                                          ctx.InputName("Filter"), (bias ? ctx.InputName("Bias") : ""));
     key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
     auto weights_memory_p = handler.AcquireWeightsMemoryWithReorder(
         dev_ctx, key, filter, ctx.Attr<int>("groups"));

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -234,16 +234,16 @@ class PoolingMKLDNNHandler
         platform::CreateKey(dev_ctx, workspace_md.dims(),
                             workspace_md.data_type(), unique_name, "@wrk");
     auto mem_p = std::static_pointer_cast<mkldnn::memory>(
-        this->dev_ctx_.GetBlob(workspace_key));
+        dev_ctx.GetBlob(workspace_key));
     if (mem_p == nullptr) {
       static std::mutex acquire_barrier;
       std::lock_guard<std::mutex> block_threads_until_finish_this_job(
           acquire_barrier);
       mem_p = std::static_pointer_cast<mkldnn::memory>(
-          this->dev_ctx_.GetBlob(workspace_key));
+          dev_ctx.GetBlob(workspace_key));
       if (mem_p == nullptr) {
         mem_p = std::make_shared<mkldnn::memory>(workspace_md, this->engine_);
-        this->dev_ctx_.SetBlob(workspace_key, mem_p);
+        dev_ctx.SetBlob(workspace_key, mem_p);
       }
     }
     return mem_p;

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -30,234 +30,219 @@ using platform::to_void_cast;
 
 template <typename T>
 class PoolingMKLDNNHandler
-    : public platform::MKLDNNHandlerT<T, mkldnn::pooling_forward,
-                                      mkldnn::pooling_backward> {
+    : public platform::MKLDNNHandlerNoCachingT<T, mkldnn::pooling_forward,
+                                               mkldnn::pooling_backward> {
  public:
   PoolingMKLDNNHandler(const paddle::framework::ExecutionContext& ctx,
-                       const platform::MKLDNNDeviceContext& dev_ctx,
-                       platform::Place cpu_place, const Tensor* input,
-                       Tensor* output, const std::string& unique_name)
-      : platform::MKLDNNHandlerT<T, mkldnn::pooling_forward,
-                                 mkldnn::pooling_backward>(
-            dev_ctx, dev_ctx.GetEngine(), cpu_place,
-            platform::CreateKey(dev_ctx, framework::vectorize(input->dims()),
-                                framework::ToMKLDNNDataType(input->type()),
-                                unique_name)) {
-    if (!this->isCached()) {
-      PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
-                        platform::errors::InvalidArgument(
-                            "Wrong layout set for Input tensor."));
-      PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Wrong format set for Input tensor."));
+                       const mkldnn::engine mkldnn_engine, const Tensor* input,
+                       Tensor* output)
+      : platform::MKLDNNHandlerNoCachingT<T, mkldnn::pooling_forward,
+                                          mkldnn::pooling_backward>(
+            mkldnn_engine, ctx.GetPlace()) {
+    PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
+                      platform::errors::InvalidArgument(
+                          "Wrong layout set for Input tensor."));
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Wrong format set for Input tensor."));
 
-      const std::string pooling_type = ctx.Attr<std::string>("pooling_type");
+    const std::string pooling_type = ctx.Attr<std::string>("pooling_type");
 
-      std::vector<int> ksize_temp = ctx.Attr<std::vector<int>>("ksize");
-      std::vector<int64_t> ksize(begin(ksize_temp), end(ksize_temp));
+    std::vector<int> ksize_temp = ctx.Attr<std::vector<int>>("ksize");
+    std::vector<int64_t> ksize(begin(ksize_temp), end(ksize_temp));
 
-      std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
-      std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
+    std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
+    std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
 
-      std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
-      std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
+    std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
+    std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
 
-      const bool global_pooling = ctx.Attr<bool>("global_pooling");
-      const std::string padding_algorithm =
-          ctx.Attr<std::string>("padding_algorithm");
+    const bool global_pooling = ctx.Attr<bool>("global_pooling");
+    const std::string padding_algorithm =
+        ctx.Attr<std::string>("padding_algorithm");
 
-      // Only 2D pooling is supported now
-      PADDLE_ENFORCE_EQ(
-          ksize.size(), 2,
-          platform::errors::InvalidArgument(
-              "The ksize must be 2D, i.e. 2D pooling, but received %dD.",
-              ksize.size()));
-      PADDLE_ENFORCE_EQ(
-          pooling_type == "max" || pooling_type == "avg", true,
-          platform::errors::InvalidArgument(
-              "The pooling_type must be 'max' or 'avg', but received %s.",
-              pooling_type));
-      PADDLE_ENFORCE_EQ(
-          input->dims().size(), 4,
-          platform::errors::InvalidArgument(
-              "Input dim must be with 4, i.e. NCHW, but received %d.",
-              input->dims().size()));
+    // Only 2D pooling is supported now
+    PADDLE_ENFORCE_EQ(
+        ksize.size(), 2,
+        platform::errors::InvalidArgument(
+            "The ksize must be 2D, i.e. 2D pooling, but received %dD.",
+            ksize.size()));
+    PADDLE_ENFORCE_EQ(
+        pooling_type == "max" || pooling_type == "avg", true,
+        platform::errors::InvalidArgument(
+            "The pooling_type must be 'max' or 'avg', but received %s.",
+            pooling_type));
+    PADDLE_ENFORCE_EQ(
+        input->dims().size(), 4,
+        platform::errors::InvalidArgument(
+            "Input dim must be with 4, i.e. NCHW, but received %d.",
+            input->dims().size()));
 
-      const auto input_dims = input->dims();
-      framework::DDim data_dims =
-          framework::slice_ddim(input_dims, 2, input_dims.size());
+    const auto input_dims = input->dims();
+    framework::DDim data_dims =
+        framework::slice_ddim(input_dims, 2, input_dims.size());
 
-      if (global_pooling) {
-        operators::UpdateKsize(&ksize, data_dims);
-      }
-
-      operators::UpdatePadding(&paddings, global_pooling, 0, padding_algorithm,
-                               data_dims, strides, ksize);
-
-      const auto src_tz = paddle::framework::vectorize(input->dims());
-      const auto dst_tz = paddle::framework::vectorize(output->dims());
-
-      const auto is_test = ctx.Attr<bool>("is_test");
-
-      const auto dt = framework::ToMKLDNNDataType(input->type());
-
-      const auto exclude_padding = ctx.Attr<bool>("exclusive");
-
-      const auto src_md = mkldnn::memory::desc(src_tz, dt, input->format());
-      /* create memory descriptor for pooling without specified format
-       * ('any') which lets a primitive (pooling in this case) choose
-       * the memory format preferred for best performance
-       */
-
-      const auto dst_md =
-          platform::MKLDNNMemDesc(dst_tz, dt, MKLDNNMemoryFormat::any);
-
-      auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
-
-      const bool ceil_mode = ctx.Attr<bool>("ceil_mode");
-
-      if (ceil_mode) {
-        CorrectOutputSize(src_tz, dst_tz, ksize, paddings, strides,
-                          mkldnn_paddings[1]);
-      }
-
-      ComputeAdaptivePoolParameters(ctx, src_tz, &ksize, &strides);
-
-      this->AcquireForwardPrimitiveDescriptor(
-          is_test ? mkldnn::prop_kind::forward_inference
-                  : mkldnn::prop_kind::forward_training,
-          pooling_type == "max"
-              ? mkldnn::algorithm::pooling_max
-              : (exclude_padding
-                     ? mkldnn::algorithm::pooling_avg_exclude_padding
-                     : mkldnn::algorithm::pooling_avg_include_padding),
-          src_md, dst_md, strides, ksize, mkldnn_paddings[0],
-          mkldnn_paddings[1]);
+    if (global_pooling) {
+      operators::UpdateKsize(&ksize, data_dims);
     }
+
+    operators::UpdatePadding(&paddings, global_pooling, 0, padding_algorithm,
+                             data_dims, strides, ksize);
+
+    const auto src_tz = paddle::framework::vectorize(input->dims());
+    const auto dst_tz = paddle::framework::vectorize(output->dims());
+
+    const auto is_test = ctx.Attr<bool>("is_test");
+
+    const auto dt = framework::ToMKLDNNDataType(input->type());
+
+    const auto exclude_padding = ctx.Attr<bool>("exclusive");
+
+    const auto src_md = mkldnn::memory::desc(src_tz, dt, input->format());
+    /* create memory descriptor for pooling without specified format
+     * ('any') which lets a primitive (pooling in this case) choose
+     * the memory format preferred for best performance
+     */
+
+    const auto dst_md =
+        platform::MKLDNNMemDesc(dst_tz, dt, MKLDNNMemoryFormat::any);
+
+    auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
+
+    const bool ceil_mode = ctx.Attr<bool>("ceil_mode");
+
+    if (ceil_mode) {
+      CorrectOutputSize(src_tz, dst_tz, ksize, paddings, strides,
+                        mkldnn_paddings[1]);
+    }
+
+    ComputeAdaptivePoolParameters(ctx, src_tz, &ksize, &strides);
+
+    this->AcquireForwardPrimitiveDescriptor(
+        is_test ? mkldnn::prop_kind::forward_inference
+                : mkldnn::prop_kind::forward_training,
+        pooling_type == "max"
+            ? mkldnn::algorithm::pooling_max
+            : (exclude_padding
+                   ? mkldnn::algorithm::pooling_avg_exclude_padding
+                   : mkldnn::algorithm::pooling_avg_include_padding),
+        src_md, dst_md, strides, ksize, mkldnn_paddings[0], mkldnn_paddings[1]);
   }
 
   PoolingMKLDNNHandler(const paddle::framework::ExecutionContext& ctx,
-                       const platform::MKLDNNDeviceContext& dev_ctx,
-                       platform::Place cpu_place, const Tensor* in_x,
-                       const Tensor* out_grad, Tensor* in_x_grad,
-                       const std::string& unique_name)
-      : platform::MKLDNNHandlerT<T, mkldnn::pooling_forward,
-                                 mkldnn::pooling_backward>(
-            dev_ctx, dev_ctx.GetEngine(), cpu_place,
-            platform::CreateKey(dev_ctx, framework::vectorize(in_x->dims()),
-                                framework::ToMKLDNNDataType(in_x->type()),
-                                unique_name)) {
-    if (!this->isBwdCached()) {
-      PADDLE_ENFORCE_EQ(in_x->layout(), DataLayout::kMKLDNN,
-                        platform::errors::InvalidArgument(
-                            "Wrong layout set for Input tensor"));
-      PADDLE_ENFORCE_NE(in_x->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Wrong format set for Input tensor"));
+                       const mkldnn::engine mkldnn_engine, const Tensor* in_x,
+                       const Tensor* out_grad, Tensor* in_x_grad)
 
-      PADDLE_ENFORCE_EQ(out_grad->layout(), DataLayout::kMKLDNN,
-                        platform::errors::InvalidArgument(
-                            "Wrong layout set for Input output_grad tensor"));
-      PADDLE_ENFORCE_NE(out_grad->format(), MKLDNNMemoryFormat::undef,
-                        platform::errors::InvalidArgument(
-                            "Wrong format set for Input output_grad tensor"));
+      : platform::MKLDNNHandlerNoCachingT<T, mkldnn::pooling_forward,
+                                          mkldnn::pooling_backward>(
+            mkldnn_engine, ctx.GetPlace()) {
+    PADDLE_ENFORCE_EQ(
+        in_x->layout(), DataLayout::kMKLDNN,
+        platform::errors::InvalidArgument("Wrong layout set for Input tensor"));
+    PADDLE_ENFORCE_NE(
+        in_x->format(), MKLDNNMemoryFormat::undef,
+        platform::errors::InvalidArgument("Wrong format set for Input tensor"));
 
-      PADDLE_ENFORCE_EQ(
-          ctx.Attr<bool>("is_test"), false,
-          platform::errors::InvalidArgument(
-              "is_test attribute should be set to False in training phase."));
+    PADDLE_ENFORCE_EQ(out_grad->layout(), DataLayout::kMKLDNN,
+                      platform::errors::InvalidArgument(
+                          "Wrong layout set for Input output_grad tensor"));
+    PADDLE_ENFORCE_NE(out_grad->format(), MKLDNNMemoryFormat::undef,
+                      platform::errors::InvalidArgument(
+                          "Wrong format set for Input output_grad tensor"));
 
-      std::string pooling_type = ctx.Attr<std::string>("pooling_type");
+    PADDLE_ENFORCE_EQ(
+        ctx.Attr<bool>("is_test"), false,
+        platform::errors::InvalidArgument(
+            "is_test attribute should be set to False in training phase."));
 
-      std::vector<int> ksize_temp = ctx.Attr<std::vector<int>>("ksize");
-      std::vector<int64_t> ksize(begin(ksize_temp), end(ksize_temp));
+    std::string pooling_type = ctx.Attr<std::string>("pooling_type");
 
-      std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
-      std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
+    std::vector<int> ksize_temp = ctx.Attr<std::vector<int>>("ksize");
+    std::vector<int64_t> ksize(begin(ksize_temp), end(ksize_temp));
 
-      std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
-      std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
+    std::vector<int> strides_temp = ctx.Attr<std::vector<int>>("strides");
+    std::vector<int64_t> strides(begin(strides_temp), end(strides_temp));
 
-      bool global_pooling = ctx.Attr<bool>("global_pooling");
-      std::string padding_algorithm =
-          ctx.Attr<std::string>("padding_algorithm");
+    std::vector<int> paddings_temp = ctx.Attr<std::vector<int>>("paddings");
+    std::vector<int64_t> paddings(begin(paddings_temp), end(paddings_temp));
 
-      auto in_x_dims = in_x->dims();
-      framework::DDim data_dims =
-          framework::slice_ddim(in_x_dims, 2, in_x_dims.size());
+    bool global_pooling = ctx.Attr<bool>("global_pooling");
+    std::string padding_algorithm = ctx.Attr<std::string>("padding_algorithm");
 
-      if (global_pooling) {
-        operators::UpdateKsize(&ksize, data_dims);
-      }
+    auto in_x_dims = in_x->dims();
+    framework::DDim data_dims =
+        framework::slice_ddim(in_x_dims, 2, in_x_dims.size());
 
-      operators::UpdatePadding(&paddings, global_pooling, 0, padding_algorithm,
-                               data_dims, strides, ksize);
-
-      auto src_tz = paddle::framework::vectorize<int64_t>(in_x->dims());
-      auto diff_src_tz =
-          paddle::framework::vectorize<int64_t>(in_x_grad->dims());
-      auto diff_dst_tz =
-          paddle::framework::vectorize<int64_t>(out_grad->dims());
-
-      const auto dt = framework::ToMKLDNNDataType(in_x->type());
-      auto src_md = mkldnn::memory::desc(src_tz, dt, in_x->format());
-      auto dst_md =
-          mkldnn::memory::desc(diff_dst_tz, dt, MKLDNNMemoryFormat::any);
-      auto diff_dst_md = mkldnn::memory::desc(
-          diff_dst_tz, platform::MKLDNNGetDataType<T>(), out_grad->format());
-      auto diff_src_md =
-          mkldnn::memory::desc(diff_src_tz, platform::MKLDNNGetDataType<T>(),
-                               MKLDNNMemoryFormat::any);
-
-      auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
-      const bool ceil_mode = ctx.Attr<bool>("ceil_mode");
-
-      if (ceil_mode) {
-        CorrectOutputSize(src_tz, diff_dst_tz, ksize, paddings, strides,
-                          mkldnn_paddings[1]);
-      }
-      ComputeAdaptivePoolParameters(ctx, diff_src_tz, &ksize, &strides);
-
-      const auto exclude_padding = ctx.Attr<bool>("exclusive");
-
-      this->AcquireForwardPrimitiveDescriptor(
-          mkldnn::prop_kind::forward_training,
-          pooling_type == "max"
-              ? mkldnn::algorithm::pooling_max
-              : (exclude_padding
-                     ? mkldnn::algorithm::pooling_avg_exclude_padding
-                     : mkldnn::algorithm::pooling_avg_include_padding),
-          src_md, dst_md, strides, ksize, mkldnn_paddings[0],
-          mkldnn_paddings[1]);
-
-      this->AcquireBackwardPrimitiveDescriptor(
-          pooling_type == "max"
-              ? mkldnn::algorithm::pooling_max
-              : (exclude_padding
-                     ? mkldnn::algorithm::pooling_avg_exclude_padding
-                     : mkldnn::algorithm::pooling_avg_include_padding),
-          diff_src_md, diff_dst_md, strides, ksize, mkldnn_paddings[0],
-          mkldnn_paddings[1]);
+    if (global_pooling) {
+      operators::UpdateKsize(&ksize, data_dims);
     }
+
+    operators::UpdatePadding(&paddings, global_pooling, 0, padding_algorithm,
+                             data_dims, strides, ksize);
+
+    auto src_tz = paddle::framework::vectorize<int64_t>(in_x->dims());
+    auto diff_src_tz = paddle::framework::vectorize<int64_t>(in_x_grad->dims());
+    auto diff_dst_tz = paddle::framework::vectorize<int64_t>(out_grad->dims());
+
+    const auto dt = framework::ToMKLDNNDataType(in_x->type());
+    auto src_md = mkldnn::memory::desc(src_tz, dt, in_x->format());
+    auto dst_md =
+        mkldnn::memory::desc(diff_dst_tz, dt, MKLDNNMemoryFormat::any);
+    auto diff_dst_md = mkldnn::memory::desc(
+        diff_dst_tz, platform::MKLDNNGetDataType<T>(), out_grad->format());
+    auto diff_src_md = mkldnn::memory::desc(
+        diff_src_tz, platform::MKLDNNGetDataType<T>(), MKLDNNMemoryFormat::any);
+
+    auto mkldnn_paddings = platform::ToMkldnnPadding(paddings);
+    const bool ceil_mode = ctx.Attr<bool>("ceil_mode");
+
+    if (ceil_mode) {
+      CorrectOutputSize(src_tz, diff_dst_tz, ksize, paddings, strides,
+                        mkldnn_paddings[1]);
+    }
+    ComputeAdaptivePoolParameters(ctx, diff_src_tz, &ksize, &strides);
+
+    const auto exclude_padding = ctx.Attr<bool>("exclusive");
+
+    this->AcquireForwardPrimitiveDescriptor(
+        mkldnn::prop_kind::forward_training,
+        pooling_type == "max"
+            ? mkldnn::algorithm::pooling_max
+            : (exclude_padding
+                   ? mkldnn::algorithm::pooling_avg_exclude_padding
+                   : mkldnn::algorithm::pooling_avg_include_padding),
+        src_md, dst_md, strides, ksize, mkldnn_paddings[0], mkldnn_paddings[1]);
+
+    this->AcquireBackwardPrimitiveDescriptor(
+        pooling_type == "max"
+            ? mkldnn::algorithm::pooling_max
+            : (exclude_padding
+                   ? mkldnn::algorithm::pooling_avg_exclude_padding
+                   : mkldnn::algorithm::pooling_avg_include_padding),
+        diff_src_md, diff_dst_md, strides, ksize, mkldnn_paddings[0],
+        mkldnn_paddings[1]);
   }
 
-  std::shared_ptr<mkldnn::memory> AcquireWorkspaceMemory(void) {
+  std::shared_ptr<mkldnn::memory> AcquireWorkspaceMemory(
+      const platform::MKLDNNDeviceContext& dev_ctx, std::string& unique_name) {
     mkldnn::memory::desc workspace_md = this->fwd_pd_->workspace_desc();
-    // Pooling PD has to be passed to Grad op that
+    // Pooling Workspace has to be passed to Grad op that
     // may be executed by diffrent thread, hence
     // for that one we use key that does not contain TID
-    auto local_key = this->key_common_ + "@workspace";
+    std::string workspace_key =
+        platform::CreateKey(dev_ctx, workspace_md.dims(),
+                            workspace_md.data_type(), unique_name, "@wrk");
     auto mem_p = std::static_pointer_cast<mkldnn::memory>(
-        this->dev_ctx_.GetBlob(local_key));
+        this->dev_ctx_.GetBlob(workspace_key));
     if (mem_p == nullptr) {
       static std::mutex acquire_barrier;
       std::lock_guard<std::mutex> block_threads_until_finish_this_job(
           acquire_barrier);
       mem_p = std::static_pointer_cast<mkldnn::memory>(
-          this->dev_ctx_.GetBlob(local_key));
+          this->dev_ctx_.GetBlob(workspace_key));
       if (mem_p == nullptr) {
         mem_p = std::make_shared<mkldnn::memory>(workspace_md, this->engine_);
-        this->dev_ctx_.SetBlob(local_key, mem_p);
+        this->dev_ctx_.SetBlob(workspace_key, mem_p);
       }
     }
     return mem_p;
@@ -319,8 +304,7 @@ class PoolMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     const Tensor* input = ctx.Input<Tensor>("X");
     Tensor* output = ctx.Output<Tensor>("Out");
 
-    PoolingMKLDNNHandler<T> handler(ctx, dev_ctx, ctx.GetPlace(), input, output,
-                                    ctx.OutputName("Out"));
+    PoolingMKLDNNHandler<T> handler(ctx, dev_ctx.GetEngine(), input, output);
 
     auto src_memory = handler.AcquireSrcMemory(input);
     auto dst_memory = handler.AcquireDstMemory(output);
@@ -331,7 +315,8 @@ class PoolMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     if ((ctx.Attr<bool>("is_test") == false) &&
         (ctx.Attr<std::string>("pooling_type") == "max")) {
       // Training
-      auto workspace_memory = handler.AcquireWorkspaceMemory();
+      auto workspace_memory =
+          handler.AcquireWorkspaceMemory(dev_ctx, ctx.OutputName("Out"));
       pool_p->execute(astream, {{MKLDNN_ARG_SRC, *src_memory},
                                 {MKLDNN_ARG_DST, *dst_memory},
                                 {MKLDNN_ARG_WORKSPACE, *workspace_memory}});
@@ -361,8 +346,8 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     auto& dev_ctx =
         ctx.template device_context<platform::MKLDNNDeviceContext>();
 
-    PoolingMKLDNNHandler<T> handler(ctx, dev_ctx, ctx.GetPlace(), in_x,
-                                    out_grad, in_x_grad, ctx.InputName("Out"));
+    PoolingMKLDNNHandler<T> handler(ctx, dev_ctx.GetEngine(), in_x, out_grad,
+                                    in_x_grad);
 
     auto diff_dst_memory = handler.AcquireDiffDstMemory(out_grad);
     auto diff_src_memory = handler.AcquireDiffSrcMemory(in_x_grad);
@@ -372,7 +357,8 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
     if (ctx.Attr<std::string>("pooling_type") == "max") {
       // Max - pooling needs Workspace
-      auto workspace_memory = handler.AcquireWorkspaceMemory();
+      auto workspace_memory =
+          handler.AcquireWorkspaceMemory(dev_ctx, ctx.InputName("Out"));
       pool_bwd_p->execute(astream, {{MKLDNN_ARG_DIFF_SRC, *diff_src_memory},
                                     {MKLDNN_ARG_DIFF_DST, *diff_dst_memory},
                                     {MKLDNN_ARG_WORKSPACE, *workspace_memory}});

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -224,7 +224,8 @@ class PoolingMKLDNNHandler
   }
 
   std::shared_ptr<mkldnn::memory> AcquireWorkspaceMemory(
-      const platform::MKLDNNDeviceContext& dev_ctx, std::string& unique_name) {
+      const platform::MKLDNNDeviceContext& dev_ctx,
+      const std::string& unique_name) {
     mkldnn::memory::desc workspace_md = this->fwd_pd_->workspace_desc();
     // Pooling Workspace has to be passed to Grad op that
     // may be executed by diffrent thread, hence

--- a/paddle/fluid/operators/mkldnn/quantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/quantize_mkldnn_op.cc
@@ -64,81 +64,46 @@ class QuantOpKernel : public framework::OpKernel<T> {
     bool is_negative_input = ctx.Attr<bool>("is_negative_input");
     bool bfloat16 = ctx.Attr<bool>("bfloat16");
 
-    std::string key =
-        platform::CreateKey(dev_ctx, src_tz, scale_data, scale_shift,
-                            is_negative_input, ctx.OutputName("Output"));
-    key = platform::ExtendKeyWithThreadInfoIfNeeded(dev_ctx, key);
-
-    const std::string key_prim = key + "@r";
-    const std::string key_src_mem = key + "@s";
-    const std::string key_dst_mem = key + "@d";
-
+    // TODO(jczaja): Refactor with Acquire API
     std::shared_ptr<mkldnn::memory> src_memory;
     std::shared_ptr<mkldnn::memory> dst_memory;
     std::shared_ptr<reorder> reorder_p;
-    reorder_p = std::static_pointer_cast<reorder>(dev_ctx.GetBlob(key_prim));
 
-    if (reorder_p == nullptr) {
-      std::string out_layout = ctx.Attr<std::string>("output_format");
-      MKLDNNMemoryFormat out_format =
-          platform::data_format_to_memory_format(out_layout);
-      mkldnn::primitive_attr attri;
-      int mask = 0;
-      attri.set_output_scales(mask, {scale_data});
+    std::string out_layout = ctx.Attr<std::string>("output_format");
+    MKLDNNMemoryFormat out_format =
+        platform::data_format_to_memory_format(out_layout);
+    mkldnn::primitive_attr attri;
+    int mask = 0;
+    attri.set_output_scales(mask, {scale_data});
 
-      if (with_shift) {
-        mkldnn::post_ops post_operations;
-        post_operations.append_sum();
-        attri.set_post_ops(post_operations);
-        uint8_t* output_data = output->mutable_data<uint8_t>(ctx.GetPlace());
-        // memset casts scale_shift to unsigned char (uint8_t) internally
-        std::memset(output_data, scale_shift, output->numel());
-      }
-
-      auto src_md = platform::MKLDNNMemDesc({src_tz}, memory::data_type::f32,
-                                            input->format());
-      src_memory = std::make_shared<mkldnn::memory>(
-          src_md, engine, to_void_cast<T>(input_data));
-
-      std::shared_ptr<mkldnn::memory::desc> dst_md;
-      if (bfloat16) {
-        platform::SetDstMemoryQuantized<paddle::platform::bfloat16>(
-            ctx, output, dst_tz, engine, dst_md, dst_memory, out_format);
-      } else if (is_negative_input && !with_shift) {
-        platform::SetDstMemoryQuantized<int8_t>(ctx, output, dst_tz, engine,
-                                                dst_md, dst_memory, out_format);
-      } else {
-        platform::SetDstMemoryQuantized<uint8_t>(
-            ctx, output, dst_tz, engine, dst_md, dst_memory, out_format);
-      }
-      auto reorder_pd = std::shared_ptr<reorder::primitive_desc>(
-          new reorder::primitive_desc(*src_memory, *dst_memory, attri));
-      reorder_p = std::shared_ptr<reorder>(new reorder(*reorder_pd));
-
-      dev_ctx.SetBlob(key_prim, reorder_p);
-      dev_ctx.SetBlob(key_src_mem, src_memory);
-      dev_ctx.SetBlob(key_dst_mem, dst_memory);
-    } else {
-      src_memory = std::static_pointer_cast<mkldnn::memory>(
-          dev_ctx.GetBlob(key_src_mem));
-      src_memory->set_data_handle(to_void_cast<T>(input_data));
-
-      dst_memory = std::static_pointer_cast<mkldnn::memory>(
-          dev_ctx.GetBlob(key_dst_mem));
-      auto place = ctx.GetPlace();
-
-      if (bfloat16) {
-        dst_memory->set_data_handle(
-            output->mutable_data<paddle::platform::bfloat16>(place));
-      } else if (with_shift || !is_negative_input) {
-        uint8_t* output_data = output->mutable_data<uint8_t>(ctx.GetPlace());
-        if (with_shift) std::memset(output_data, scale_shift, output->numel());
-        dst_memory->set_data_handle(output_data);
-      } else {
-        dst_memory->set_data_handle(
-            output->mutable_data<int8_t>(ctx.GetPlace()));
-      }
+    if (with_shift) {
+      mkldnn::post_ops post_operations;
+      post_operations.append_sum();
+      attri.set_post_ops(post_operations);
+      uint8_t* output_data = output->mutable_data<uint8_t>(ctx.GetPlace());
+      // memset casts scale_shift to unsigned char (uint8_t) internally
+      std::memset(output_data, scale_shift, output->numel());
     }
+
+    auto src_md = platform::MKLDNNMemDesc({src_tz}, memory::data_type::f32,
+                                          input->format());
+    src_memory = std::make_shared<mkldnn::memory>(src_md, engine,
+                                                  to_void_cast<T>(input_data));
+
+    std::shared_ptr<mkldnn::memory::desc> dst_md;
+    if (bfloat16) {
+      platform::SetDstMemoryQuantized<paddle::platform::bfloat16>(
+          ctx, output, dst_tz, engine, dst_md, dst_memory, out_format);
+    } else if (is_negative_input && !with_shift) {
+      platform::SetDstMemoryQuantized<int8_t>(ctx, output, dst_tz, engine,
+                                              dst_md, dst_memory, out_format);
+    } else {
+      platform::SetDstMemoryQuantized<uint8_t>(ctx, output, dst_tz, engine,
+                                               dst_md, dst_memory, out_format);
+    }
+    auto reorder_pd = std::shared_ptr<reorder::primitive_desc>(
+        new reorder::primitive_desc(*src_memory, *dst_memory, attri));
+    reorder_p = std::shared_ptr<reorder>(new reorder(*reorder_pd));
 
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
     {

--- a/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
+++ b/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
@@ -138,7 +138,8 @@ TEST(test_conv2d_reuse_cache, cpu_place) {
   CacheTester ct;
   RunOperator<float>(p, "conv2d", dims, "input_signal");
   RunOperator<float>(p, "conv2d", dims, "input_signal");
-  PADDLE_ENFORCE_EQ(ct.Analyze(9), true,
+  // 3 cached objects are: user_weights, reordered_weights, reorder primitive
+  PADDLE_ENFORCE_EQ(ct.Analyze(3), true,
                     platform::errors::InvalidArgument(
                         "Invalid number of cached oneDNN objects"));
 }
@@ -149,7 +150,7 @@ TEST(test_conv2d_noreuse_cache, cpu_place) {
   CacheTester ct;
   RunOperator<float>(p, "conv2d", dims, "input_signal");
   RunOperator<float>(p, "conv2d", dims, "input_signal2");
-  PADDLE_ENFORCE_EQ(ct.Analyze(18), true,
+  PADDLE_ENFORCE_EQ(ct.Analyze(6), true,
                     platform::errors::InvalidArgument(
                         "Invalid number of cached oneDNN objects"));
 }

--- a/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
+++ b/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
@@ -138,8 +138,7 @@ TEST(test_conv2d_reuse_cache, cpu_place) {
   CacheTester ct;
   RunOperator<float>(p, "conv2d", dims, "input_signal");
   RunOperator<float>(p, "conv2d", dims, "input_signal");
-  // 3 cached objects are: user_weights, reordered_weights, reorder primitive
-  PADDLE_ENFORCE_EQ(ct.Analyze(3), true,
+  PADDLE_ENFORCE_EQ(ct.Analyze(9), true,
                     platform::errors::InvalidArgument(
                         "Invalid number of cached oneDNN objects"));
 }
@@ -150,7 +149,7 @@ TEST(test_conv2d_noreuse_cache, cpu_place) {
   CacheTester ct;
   RunOperator<float>(p, "conv2d", dims, "input_signal");
   RunOperator<float>(p, "conv2d", dims, "input_signal2");
-  PADDLE_ENFORCE_EQ(ct.Analyze(6), true,
+  PADDLE_ENFORCE_EQ(ct.Analyze(18), true,
                     platform::errors::InvalidArgument(
                         "Invalid number of cached oneDNN objects"));
 }

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -207,7 +207,7 @@ class MKLDNNHandlerNoCachingT {
   std::shared_ptr<mkldnn::memory> AcquireMemoryWithReorder(
       const mkldnn::memory::desc& user_md,
       const mkldnn::memory::desc& target_md, void* ptr,
-      const std::string& suffix, bool is_persistent = false,
+      bool is_persistent = false,
       std::function<std::shared_ptr<F>(const F*)> custom_reorder_func = {}) {
     std::shared_ptr<mkldnn::memory> target_memory_p;
     if (custom_reorder_func) {
@@ -500,18 +500,9 @@ class MKLDNNHandlerT {
   }
 
   void AcquireReorder(const std::shared_ptr<mkldnn::memory>& user_memory_p,
-                      const std::shared_ptr<mkldnn::memory>& target_memory_p,
-                      const std::string& suffix) {
-    const auto key_reorder_p = key_ + suffix + "reorder_p";
-
-    auto reorder_p = std::static_pointer_cast<mkldnn::reorder>(
-        dev_ctx_.GetBlob(key_reorder_p));
-
-    if (reorder_p == nullptr) {
-      reorder_p =
-          std::make_shared<mkldnn::reorder>(*user_memory_p, *target_memory_p);
-      dev_ctx_.SetBlob(key_reorder_p, reorder_p);
-    }
+                      const std::shared_ptr<mkldnn::memory>& target_memory_p) {
+    auto reorder_p =
+        std::make_shared<mkldnn::reorder>(*user_memory_p, *target_memory_p);
 
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
 
@@ -578,6 +569,8 @@ class MKLDNNHandlerT {
           std::static_pointer_cast<dnnl::memory>(dev_ctx_.GetBlob(user_key));
       user_memory_p->set_data_handle(ptr);
 
+      // TODO(jczaja): Here we detect if reorder is cached it means it is needed
+      // need to change this to get rid of keys
       auto reorder_p = std::static_pointer_cast<mkldnn::reorder>(
           dev_ctx_.GetBlob(key_reorder_p));
       if (reorder_p != nullptr) {

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
@@ -95,4 +95,6 @@ class TestConv3DOp_Valid_MKLDNN(TestConv3DOp_AsyPadding_MKLDNN):
 
 
 if __name__ == '__main__':
+    from paddle import enable_static
+    enable_static()
     unittest.main()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
PaddlePaddle is caching oneDNN objects and this PR is to disable this for pool2d and conv_transpose. Reason is that oneDNN is caching some of its objects itself
