### PR TITLE
Correct conv2d int8 mkldnn UT

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -226,6 +226,17 @@ bool SupportsBfloat16FastPerformance() {
 #endif
 }
 
+bool SupportsVNNI() {
+#ifndef PADDLE_WITH_MKLDNN
+  return false;
+#else
+  if (platform::MayIUse(platform::cpu_isa_t::avx512_core_vnni))
+    return true;
+  else
+    return false;
+#endif
+}
+
 // According to the input `place` and `dtype`, this function returns a tuple
 // consists of three sets:
 // 1) All operators registered in the Paddle framework.
@@ -2113,6 +2124,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("_is_compiled_with_heterps", IsCompiledWithHETERPS);
   m.def("supports_bfloat16", SupportsBfloat16);
   m.def("supports_bfloat16_fast_performance", SupportsBfloat16FastPerformance);
+  m.def("supports_vnni", SupportsVNNI);
   m.def("op_supported_infos", OpSupportedInfos);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);
   m.def("is_compiled_with_dist", IsCompiledWithDIST);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -226,14 +226,20 @@ bool SupportsBfloat16FastPerformance() {
 #endif
 }
 
+bool SupportsInt8() {
+#ifndef PADDLE_WITH_MKLDNN
+  return false;
+#else
+  return (platform::MayIUse(platform::cpu_isa_t::avx2) ||
+          platform::MayIUse(platform::cpu_isa_t::avx512f));
+#endif
+}
+
 bool SupportsVNNI() {
 #ifndef PADDLE_WITH_MKLDNN
   return false;
 #else
-  if (platform::MayIUse(platform::cpu_isa_t::avx512_core_vnni))
-    return true;
-  else
-    return false;
+  return platform::MayIUse(platform::cpu_isa_t::avx512_core_vnni);
 #endif
 }
 
@@ -2124,6 +2130,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("_is_compiled_with_heterps", IsCompiledWithHETERPS);
   m.def("supports_bfloat16", SupportsBfloat16);
   m.def("supports_bfloat16_fast_performance", SupportsBfloat16FastPerformance);
+  m.def("supports_int8", SupportsInt8);
   m.def("supports_vnni", SupportsVNNI);
   m.def("op_supported_infos", OpSupportedInfos);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
In this PR the unit test of the covolution has been fixed:
- There was an error in the test that in the calculation of the reference convolution the `input` and `input_shift` were multiplied by `Scale_in`, and for the tested OneDNN, the input was not multiplied. This caused this test to not work properly when `Scale_in` was other than 1.0. Therefore, multiplication was removed, so we assume that input is already quantized.
- In the test, the weight scale was multiplied by 0.5. However, this situation should only occur when using Intel AVX2 or Intel AVX512 to avoid a potential overflow. If the processor supports VNNI instructions, the weight scales should remain unchanged.

The changes were adjusted based on documentation https://docs.oneapi.io/versions/latest/onednn/dev_guide_int8_computations.html#doxid-dev-guide-int8-computations