### PR TITLE
Refine param name in layer.to

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1477,6 +1477,7 @@ class Layer(core.Layer):
                     param_applied.stop_gradient = param.stop_gradient
                     if hasattr(param_applied, 'is_distributed'):
                         param_applied.is_distributed = param.is_distributed
+                    param_applied.name = param.name + param_applied.name
                     self._parameters[key] = param_applied
 
                 if param.grad is not None:

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1482,7 +1482,7 @@ class Layer(core.Layer):
                         param_applied.name = param_applied.name + "_" + self._device_to_str(
                             device)
                     if dtype is not None:
-                        param_applied.name = param_applied.name + "_" + paddle.fluid.data_feeder.convert_dtype(
+                        param_applied.name = param_applied.name + "_" + self._dtype_to_str(
                             dtype)
                     self._parameters[key] = param_applied
 
@@ -1613,3 +1613,9 @@ class Layer(core.Layer):
             return 'xpu'
         else:
             return device
+
+    def _dtype_to_str(self, dtype):
+        if isinstance(dtype, core.VarDesc.VarType):
+            return paddle.fluid.data_feeder.convert_dtype(dtype)
+        else:
+            return dtype

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1477,7 +1477,13 @@ class Layer(core.Layer):
                     param_applied.stop_gradient = param.stop_gradient
                     if hasattr(param_applied, 'is_distributed'):
                         param_applied.is_distributed = param.is_distributed
-                    param_applied.name = param.name + param_applied.name
+                    param_applied.name = param.name + ".to"
+                    if device is not None:
+                        param_applied.name = param_applied.name + "_" + self._device_to_str(
+                            device)
+                    if dtype is not None:
+                        param_applied.name = param_applied.name + "_" + paddle.fluid.data_feeder.convert_dtype(
+                            dtype)
                     self._parameters[key] = param_applied
 
                 if param.grad is not None:
@@ -1597,3 +1603,13 @@ class Layer(core.Layer):
     # [aliases] Compatible with old method names
     set_dict = set_state_dict
     load_dict = set_state_dict
+
+    def _device_to_str(self, device):
+        if isinstance(device, core.CPUPlace):
+            return 'cpu'
+        elif isinstance(device, (core.CUDAPlace, core.CUDAPinnedPlace)):
+            return 'cuda'
+        elif isinstance(device, core.XPUPlace):
+            return 'xpu'
+        else:
+            return device

--- a/python/paddle/fluid/tests/unittests/test_base_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_base_layer.py
@@ -389,6 +389,13 @@ class TestLayerTo(unittest.TestCase):
             for p in self.linear.parameters():
                 self.assertTrue(isinstance(p, paddle.fluid.framework.ParamBase))
 
+        if paddle.fluid.is_compiled_with_xpu():
+            self.linear.to(device=paddle.XPUPlace(0))
+            self.assertTrue(self.linear.weight.place.is_xpu_place())
+            self.assertTrue(self.linear.buf_name.place.is_xpu_place())
+            self.assertTrue(self.linear.weight._grad_ivar().place.is_xpu_place(
+            ))
+
         self.linear.to(device=paddle.CPUPlace())
         self.assertTrue(self.linear.weight.place.is_cpu_place())
         self.assertTrue(self.linear.buf_name.place.is_cpu_place())


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
layer.to will create new param, new param name is origin_param_name+auto_create_name.
Example:
```python
import paddle
linear = paddle.nn.Linear(2, 2)
# linear's param name：linear_0.w_0 &  linear_0.b_0
linear.to(device=paddle.CPUPlace(), dtype='float16')
# linear's param name：linear_0.w_0.to_cpu_float16 &  linear_0.b_0.to_cpu_float16
```
