### PR TITLE
[Bug Fix]: "epsilon" attribute cannot parse into cpp code from python API

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -2068,6 +2068,7 @@ class LarsMomentumOptimizer(Optimizer):
             "lars_coeff": self._lars_coeff,
             "lars_weight_decay": [_lars_weight_decay],
             "multi_precision": find_master,
+            "epsilon": self._epsilon,
             "rescale_grad": self._rescale_grad
         }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
The `epsilon` attribute is not supported in parserd into cpp codes.