### PR TITLE
Fix fused_attention_op and fused_feedforward_op bug when pre_layer_norm is false.

### DIFF
--- a/paddle/fluid/operators/fused/fused_feedforward_op.cu
+++ b/paddle/fluid/operators/fused/fused_feedforward_op.cu
@@ -113,26 +113,40 @@ class FusedFeedForwardKernel : public framework::OpKernel<T> {
     auto* linear1_bias = context.Input<framework::Tensor>("Linear1Bias");
     auto* linear2_weight = context.Input<framework::Tensor>("Linear2Weight");
     auto* linear2_bias = context.Input<framework::Tensor>("Linear2Bias");
-    auto* ln1_scale = context.Input<framework::Tensor>("Ln1Scale");
-    auto* ln1_bias = context.Input<framework::Tensor>("Ln1Bias");
-    auto* ln2_scale = context.Input<framework::Tensor>("Ln2Scale");
-    auto* ln2_bias = context.Input<framework::Tensor>("Ln2Bias");
+    const bool pre_layer_norm = context.Attr<bool>("pre_layer_norm");
 
-    auto* ln1_mean = context.Output<framework::Tensor>("Ln1Mean");
-    auto* ln1_variance = context.Output<framework::Tensor>("Ln1Variance");
-    auto* ln2_mean = context.Output<framework::Tensor>("Ln2Mean");
-    auto* ln2_variance = context.Output<framework::Tensor>("Ln2Variance");
+    auto* ln1_scale =
+        pre_layer_norm ? context.Input<framework::Tensor>("Ln1Scale") : nullptr;
+    auto* ln1_bias =
+        pre_layer_norm ? context.Input<framework::Tensor>("Ln1Bias") : nullptr;
+    auto* ln2_scale = !pre_layer_norm
+                          ? context.Input<framework::Tensor>("Ln2Scale")
+                          : nullptr;
+    auto* ln2_bias =
+        !pre_layer_norm ? context.Input<framework::Tensor>("Ln2Bias") : nullptr;
+
+    auto* ln1_mean =
+        pre_layer_norm ? context.Output<framework::Tensor>("Ln1Mean") : nullptr;
+    auto* ln1_variance = pre_layer_norm
+                             ? context.Output<framework::Tensor>("Ln1Variance")
+                             : nullptr;
+    auto* ln2_mean = !pre_layer_norm
+                         ? context.Output<framework::Tensor>("Ln2Mean")
+                         : nullptr;
+    auto* ln2_variance = !pre_layer_norm
+                             ? context.Output<framework::Tensor>("Ln2Variance")
+                             : nullptr;
     auto* out = context.Output<framework::Tensor>("Out");
     auto* dropout1_mask = context.Output<framework::Tensor>("Dropout1Mask");
     auto* dropout2_mask = context.Output<framework::Tensor>("Dropout2Mask");
     auto* linear1_out = context.Output<framework::Tensor>("Linear1Out");
-    auto* ln1_out = context.Output<framework::Tensor>("Ln1Out");
+    auto* ln1_out =
+        pre_layer_norm ? context.Output<framework::Tensor>("Ln1Out") : nullptr;
     auto* dropout1_out = context.Output<framework::Tensor>("Dropout1Out");
     auto* dropout2_out = context.Output<framework::Tensor>("Dropout2Out");
 
     const std::string act_method = context.Attr<std::string>("act_method");
 
-    const bool pre_layer_norm = context.Attr<bool>("pre_layer_norm");
     const float epsilon1 = context.Attr<float>("ln1_epsilon");
     const float epsilon2 = context.Attr<float>("ln2_epsilon");
 
@@ -144,12 +158,16 @@ class FusedFeedForwardKernel : public framework::OpKernel<T> {
     out->mutable_data<T>(place);
     dropout1_mask->mutable_data<uint8_t>(place);
     dropout2_mask->mutable_data<uint8_t>(place);
-    ln1_mean->mutable_data<U>(place);
-    ln1_variance->mutable_data<U>(place);
-    ln2_mean->mutable_data<U>(place);
-    ln2_variance->mutable_data<U>(place);
+    if (pre_layer_norm) {
+      ln1_mean->mutable_data<U>(place);
+      ln1_variance->mutable_data<U>(place);
+      ln1_out->mutable_data<T>(place);
+    } else {
+      ln2_mean->mutable_data<U>(place);
+      ln2_variance->mutable_data<U>(place);
+    }
+
     linear1_out->mutable_data<T>(place);
-    ln1_out->mutable_data<T>(place);
     dropout1_out->mutable_data<T>(place);
     dropout2_out->mutable_data<T>(place);
 
@@ -193,16 +211,16 @@ class FusedFeedForwardGradKernel : public framework::OpKernel<T> {
       const framework::Tensor& d_out, const framework::Tensor& x,
       const framework::Tensor& dropout1_mask,
       const framework::Tensor& dropout2_mask,
-      const framework::Tensor& linear1_out, const framework::Tensor& ln1_out,
+      const framework::Tensor& linear1_out, const framework::Tensor* ln1_out,
       const framework::Tensor& dropout1_out,
       const framework::Tensor& dropout2_out,
       const framework::Tensor& linear1_weight,
       const framework::Tensor* linear1_bias,
       const framework::Tensor& linear2_weight,
       const framework::Tensor* ln1_gamma, const framework::Tensor* ln1_beta,
-      const framework::Tensor& ln1_mean, const framework::Tensor& ln1_variance,
+      const framework::Tensor* ln1_mean, const framework::Tensor* ln1_variance,
       const framework::Tensor* ln2_gamma, const framework::Tensor* ln2_beta,
-      const framework::Tensor& ln2_mean, const framework::Tensor& ln2_variance,
+      const framework::Tensor* ln2_mean, const framework::Tensor* ln2_variance,
       framework::Tensor* d_x, framework::Tensor* d_linear1_weight,
       framework::Tensor* d_linear1_bias, framework::Tensor* d_linear2_weight,
       framework::Tensor* d_linear2_bias, framework::Tensor* d_ln1_gamma,
@@ -252,8 +270,8 @@ class FusedFeedForwardGradKernel : public framework::OpKernel<T> {
     } else {
       fused_dropout_layernorm_helper.LayernormResidualDropoutBiasGrad(
           ctx, d_out.data<T>(), dropout2_out.data<T>(),
-          dropout2_mask.data<uint8_t>(), ln2_gamma_ptr, ln2_mean.data<U>(),
-          ln2_variance.data<U>(), d_dropout2_out.data<T>(), d_ln2_gamma_ptr,
+          dropout2_mask.data<uint8_t>(), ln2_gamma_ptr, ln2_mean->data<U>(),
+          ln2_variance->data<U>(), d_dropout2_out.data<T>(), d_ln2_gamma_ptr,
           d_ln2_beta_ptr, d_linear2_out.data<T>(), d_linear2_bias_ptr,
           d_residual.data<T>());
     }
@@ -273,13 +291,13 @@ class FusedFeedForwardGradKernel : public framework::OpKernel<T> {
     if (pre_layer_norm) {
       framework::Tensor d_ln1_out;
       d_ln1_out.mutable_data<T>({bsz_seq, d_model}, place);
-      MatMulGrad(ctx, d_linear1_out, ln1_out, linear1_weight, &d_ln1_out,
+      MatMulGrad(ctx, d_linear1_out, *ln1_out, linear1_weight, &d_ln1_out,
                  d_linear1_weight);
 
-      pre_layernorm_helper.LayerNormGrad(ctx, d_ln1_out.data<T>(), x.data<T>(),
-                                         ln1_gamma_ptr, ln1_mean.data<U>(),
-                                         ln1_variance.data<U>(), d_x->data<T>(),
-                                         d_ln1_gamma_ptr, d_ln1_beta_ptr);
+      pre_layernorm_helper.LayerNormGrad(
+          ctx, d_ln1_out.data<T>(), x.data<T>(), ln1_gamma_ptr,
+          ln1_mean->data<U>(), ln1_variance->data<U>(), d_x->data<T>(),
+          d_ln1_gamma_ptr, d_ln1_beta_ptr);
     } else {
       MatMulGrad(ctx, d_linear1_out, x, linear1_weight, d_x, d_linear1_weight);
     }
@@ -290,33 +308,52 @@ class FusedFeedForwardGradKernel : public framework::OpKernel<T> {
     auto d_out =
         *context.Input<framework::Tensor>(framework::GradVarName("Out"));
     auto x = *context.Input<framework::Tensor>("X");
+    const bool pre_layer_norm = context.Attr<bool>("pre_layer_norm");
     auto dropout1_mask = *context.Input<framework::Tensor>("Dropout1Mask");
     auto dropout2_mask = *context.Input<framework::Tensor>("Dropout2Mask");
     auto linear1_out = *context.Input<framework::Tensor>("Linear1Out");
-    auto ln1_out = *context.Input<framework::Tensor>("Ln1Out");
+    auto* ln1_out =
+        pre_layer_norm ? context.Input<framework::Tensor>("Ln1Out") : nullptr;
     auto dropout1_out = *context.Input<framework::Tensor>("Dropout1Out");
     auto dropout2_out = *context.Input<framework::Tensor>("Dropout2Out");
     auto linear1_weight = *context.Input<framework::Tensor>("Linear1Weight");
     auto* linear1_bias = context.Input<framework::Tensor>("Linear1Bias");
     auto linear2_weight = *context.Input<framework::Tensor>("Linear2Weight");
-    auto ln1_mean = *context.Input<framework::Tensor>("Ln1Mean");
-    auto ln1_variance = *context.Input<framework::Tensor>("Ln1Variance");
-    auto* ln1_scale = context.Input<framework::Tensor>("Ln1Scale");
-    auto* ln1_bias = context.Input<framework::Tensor>("Ln1Bias");
-    auto ln2_mean = *context.Input<framework::Tensor>("Ln2Mean");
-    auto ln2_variance = *context.Input<framework::Tensor>("Ln2Variance");
-    auto* ln2_scale = context.Input<framework::Tensor>("Ln2Scale");
-    auto* ln2_bias = context.Input<framework::Tensor>("Ln2Bias");
+    auto* ln1_mean =
+        pre_layer_norm ? context.Input<framework::Tensor>("Ln1Mean") : nullptr;
+    auto* ln1_variance = pre_layer_norm
+                             ? context.Input<framework::Tensor>("Ln1Variance")
+                             : nullptr;
+    auto* ln1_scale =
+        pre_layer_norm ? context.Input<framework::Tensor>("Ln1Scale") : nullptr;
+    auto* ln1_bias =
+        pre_layer_norm ? context.Input<framework::Tensor>("Ln1Bias") : nullptr;
+    auto* ln2_mean =
+        !pre_layer_norm ? context.Input<framework::Tensor>("Ln2Mean") : nullptr;
+    auto* ln2_variance = !pre_layer_norm
+                             ? context.Input<framework::Tensor>("Ln2Variance")
+                             : nullptr;
+    auto* ln2_scale = !pre_layer_norm
+                          ? context.Input<framework::Tensor>("Ln2Scale")
+                          : nullptr;
+    auto* ln2_bias =
+        !pre_layer_norm ? context.Input<framework::Tensor>("Ln2Bias") : nullptr;
 
     auto* d_x = context.Output<framework::Tensor>(framework::GradVarName("X"));
-    auto* d_ln1_scale =
-        context.Output<framework::Tensor>(framework::GradVarName("Ln1Scale"));
-    auto* d_ln1_bias =
-        context.Output<framework::Tensor>(framework::GradVarName("Ln1Bias"));
+    auto* d_ln1_scale = pre_layer_norm
+                            ? context.Output<framework::Tensor>(
+                                  framework::GradVarName("Ln1Scale"))
+                            : nullptr;
+    auto* d_ln1_bias = pre_layer_norm
+                           ? context.Output<framework::Tensor>(
+                                 framework::GradVarName("Ln1Bias"))
+                           : nullptr;
     auto* d_ln2_scale =
-        context.Output<framework::Tensor>(framework::GradVarName("Ln2Scale"));
+        pre_layer_norm ? nullptr : context.Output<framework::Tensor>(
+                                       framework::GradVarName("Ln2Scale"));
     auto* d_ln2_bias =
-        context.Output<framework::Tensor>(framework::GradVarName("Ln2Bias"));
+        pre_layer_norm ? nullptr : context.Output<framework::Tensor>(
+                                       framework::GradVarName("Ln2Bias"));
     auto* d_linear1_weight = context.Output<framework::Tensor>(
         framework::GradVarName("Linear1Weight"));
     auto* d_linear1_bias = context.Output<framework::Tensor>(
@@ -328,7 +365,6 @@ class FusedFeedForwardGradKernel : public framework::OpKernel<T> {
 
     const float epsilon1 = context.Attr<float>("ln1_epsilon");
     const float epsilon2 = context.Attr<float>("ln2_epsilon");
-    const bool pre_layer_norm = context.Attr<bool>("pre_layer_norm");
     const std::string act_method = context.Attr<std::string>("act_method");
     DropoutParam dropout_param1(context, 1);
     DropoutParam dropout_param2(context, 2);

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
@@ -65,7 +65,7 @@ class TestFusedAttentionOp(OpTest):
     def config(self):
         self.x_type = np.float32
         self.attn_mask_type = np.float64
-        self.pre_layer_norm = True
+        self.pre_layer_norm = False
         self.training = True
 
         self.batch_size = 8
@@ -213,11 +213,40 @@ class TestFusedAttentionOp(OpTest):
             x_grad_ref, x_grad.numpy(), rtol=1e-5, atol=1e-5)
 
 
+class TestFusedAttentionOpPreLn(TestFusedAttentionOp):
+    def config(self):
+        self.x_type = np.float32
+        self.attn_mask_type = np.float64
+        self.pre_layer_norm = True
+        self.training = True
+
+        self.batch_size = 8
+        self.query_length = 128
+        self.head_dim = 64
+        self.num_heads = 16
+        self.embed_dim = self.head_dim * self.num_heads
+
+        self.dropout_prob = 0.0
+        self.attn_dropout_prob = 0.0
+        self.weight_attr = None
+        self.bias_attr = None
+        self.kdim, self.vdim = self.embed_dim, self.embed_dim
+        self.key_length, self.value_length = self.query_length, self.query_length
+
+    def test_fused_attention_op(self):
+        final_out_ref, x_grad_ref = self.GetBaselineOut()
+        final_out, x_grad = self.GetFusedAttentionOut()
+        np.testing.assert_allclose(
+            final_out_ref, final_out.numpy(), rtol=1e-5, atol=1e-1)
+        np.testing.assert_allclose(
+            x_grad_ref, x_grad.numpy(), rtol=1e-5, atol=1e-1)
+
+
 class TestFusedAttentionOpFp16(TestFusedAttentionOp):
     def config(self):
         self.x_type = np.float16
         self.attn_mask_type = np.float64
-        self.pre_layer_norm = True
+        self.pre_layer_norm = False
         self.training = True
 
         self.batch_size = 8


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
问题描述：
fused_attention_op中，当pre_layer_norm为false时，fused_attention_op.cc的GradOpMaker将与pre layer_norm相关的张量也作为了输入和输出（比如，将d_scale，d_bias和d_ln_out作为输出）。此时，模型中调用该op时，梯度更新阶段会更新d_scale, d_bias和d_ln_out。由于这几个张量的值是没有初始化的，会偶发性的引发nan，inf的错误。
同理，fused_feedforwad_op也有类似的问题。

解决：
1.当pre_layer_norm为false时，反向的输入输出中去掉与pre layer_norm相关的张量；
2.为fused_attention_op增加单测，测试pre_layer_norm为true和false的情形。
