### PR TITLE
fix reduce op out_dtype check in op_teller

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1550,7 +1550,7 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
             !BOOST_GET_CONST(bool, desc.GetAttr("keep_dim")))
           return false;
       }
-      if (desc.HasAttr("reduce_all")) {
+      if (desc.HasAttr("out_dtype")) {
         int out_dtype = BOOST_GET_CONST(int32_t, desc.GetAttr("out_dtype"));
         if (out_dtype != -1) {
           return false;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
1、out_dtype属性与reduce_all无关。该属性在ReduceOpMaker中定义为必填项，但业务模型现在有该属性为空的情况。
2、如果有out_dtype属性则只支持输入和输出为相同数据类型，也就是-1，tensorrt的IReduceLayer没有转换数据类型的功能；如果没有该属性，则默认相同，能进trt。

<!-- Describe what this PR does -->
