### PR TITLE
lower cpu_parallel_job's parallel num

### DIFF
--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -354,7 +354,7 @@ if [ "${WITH_GPU:-OFF}" == "ON" ];then
             exit 8;
         fi
     fi
-    run_unittest_gpu $cpu_parallel_job 12
+    run_unittest_gpu $cpu_parallel_job 10
     run_unittest_gpu $tetrad_parallel_job 4
     run_unittest_gpu $two_parallel_job 2
     run_unittest_gpu $non_parallel_job


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
lower cpu_parallel_job's parallel num to 10 to avoiding timeout
![image](https://user-images.githubusercontent.com/51314274/139204838-5b8fd342-f680-4793-85b8-41c54eb6fded.png)