### PR TITLE
Expose paddle.version.show API and add doc for it

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -118,6 +118,10 @@ def show():
         patch: the patch level version of paddle
         
         rc: whether it's rc version
+
+        cuda: the cuda version of package. It will return `False` if CPU version paddle package is installed
+
+        cudnn: the cudnn version of package. It will return `False` if CPU version paddle package is installed
     
     Examples:
         .. code-block:: python
@@ -131,10 +135,14 @@ def show():
             # minor: 2
             # patch: 0
             # rc: 0
+            # cuda: '10.2'
+            # cudnn: '7.6.5'
 
             # Case 2: paddle is not tagged
             paddle.version.show()
             # commit: cfa357e984bfd2ffa16820e354020529df434f7d
+            # cuda: '10.2'
+            # cudnn: '7.6.5'
     """
     if istaged:
         print('full_version:', full_version)
@@ -144,6 +152,8 @@ def show():
         print('rc:', rc)
     else:
         print('commit:', commit)
+    print('cuda:', cuda_version)
+    print('cudnn:', cudnn_version)
 
 def mkl():
     return with_mkl

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -108,10 +108,15 @@ def show():
     Returns:
         If paddle package is not tagged, the commit-id of paddle will be output.
         Otherwise, the following information will be output.
+
         full_version: version of paddle
+
         major: the major version of paddle
+
         minor: the minor version of paddle
+
         patch: the patch level version of paddle
+        
         rc: whether it's rc version
     
     Examples:

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -100,9 +100,37 @@ istaged         = %(istaged)s
 commit          = '%(commit)s'
 with_mkl        = '%(with_mkl)s'
 
-__all__ = ['cuda', 'cudnn']
+__all__ = ['cuda', 'cudnn', 'show']
 
 def show():
+    """Get the version of paddle if `paddle` package if tagged. Otherwise, output the corresponding commit id.
+    
+    Returns:
+        If paddle package is not tagged, the commit-id of paddle will be output.
+        Otherwise, the following information will be output.
+        full_version: version of paddle
+        major: the major version of paddle
+        minor: the minor version of paddle
+        patch: the patch level version of paddle
+        rc: whether it's rc version
+    
+    Examples:
+        .. code-block:: python
+
+            import paddle
+
+            # Case 1: paddle is tagged with 2.2.0
+            paddle.version.show()
+            # full_version: 2.2.0
+            # major: 2
+            # minor: 2
+            # patch: 0
+            # rc: 0
+
+            # Case 2: paddle is not tagged
+            paddle.version.show()
+            # commit: cfa357e984bfd2ffa16820e354020529df434f7d
+    """
     if istaged:
         print('full_version:', full_version)
         print('major:', major)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

As mentioned in PR https://github.com/PaddlePaddle/Paddle/pull/36556 , expose `paddle.version.show` API and add doc for it.

`paddle.version.show` will return the version of paddle package if it's tagged. Otherwise, `paddle.version.show` will return the commit-id.

link: http://10.136.157.23:8090/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc-review-1577

![图片](https://user-images.githubusercontent.com/26408901/139191380-6c4d0ed2-e909-401b-9fa9-8489c5155404.png)

![图片](https://user-images.githubusercontent.com/26408901/139191397-0f263c79-cf11-4410-a821-369c426a93fb.png)

