### PR TITLE
make unittest's allocator strategy to auto_growth

### DIFF
--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -188,7 +188,8 @@ long_time_test="^best_fit_allocator_test$|\
 ^test_strided_slice_op$"
 
 if [ ${WITH_GPU:-OFF} == "ON" ];then
-    export FLAGS_fraction_of_gpu_memory_to_use=0.92
+    export FLAGS_fraction_of_gpu_memory_to_use=0.0
+    export FLAGS_allocator_strategy=auto_growth
     export CUDA_VISIBLE_DEVICES=0
 
     UT_list=$(ctest -N | awk -F ': ' '{print $2}' | sed '/^$/d' | sed '$d')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
make unittest's allocator strategy to auto_growth instead of getting the most memory in the beginning