### PR TITLE
[Bug fixes] Add default arg to enhance varbase ClearGradient func

### DIFF
--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -28,7 +28,7 @@
 #endif
 
 DECLARE_bool(use_mkldnn);
-
+DECLARE_bool(use_release);
 namespace paddle {
 namespace imperative {
 
@@ -186,7 +186,7 @@ size_t VarBase::GradOpNum() const {
   return grad_node_ ? grad_node_->size() : 0;
 }
 
-void VarBase::ClearGradient(bool release) {
+void VarBase::ClearGradient() {
   VLOG(4) << "ClearGradient " << Name();
   if (grad_var_) {
     if (grad_var_->Var().IsType<framework::SelectedRows>()) {
@@ -204,7 +204,7 @@ void VarBase::ClearGradient(bool release) {
       auto* grad_t =
           grad_var_->MutableVar()->GetMutable<framework::LoDTensor>();
       if (grad_t->IsInitialized()) {
-        if (!release) {
+        if (!FLAGS_use_release) {
           auto* dev_ctx =
               platform::DeviceContextPool::Instance().Get(grad_t->place());
           operators::math::set_constant(*dev_ctx, grad_t, 0.0);

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -28,7 +28,6 @@
 #endif
 
 DECLARE_bool(use_mkldnn);
-DECLARE_bool(real_release);
 namespace paddle {
 namespace imperative {
 

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -222,19 +222,24 @@ void VarBase::ClearGradient(bool set_to_zero) {
   }
 }
 
-void VarBase::_GradientSetEmpty(bool set_is_empty) {
-  VLOG(4) << "Gradient " << Name() << " SetIsEmpty " << set_is_empty;
+void VarBase::_GradientSetEmpty(bool is_empty) {
+  VLOG(4) << "Set gradient " << Name() << " is_empty:" << is_empty;
   if (grad_var_) {
-    grad_var_->SharedVar()->SetIsEmpty(set_is_empty);
+    auto share_var = grad_var_->SharedVar();
+    if (share_var) {
+      share_var->SetIsEmpty(is_empty);
+    }
   }
 }
 
 bool VarBase::_IsGradientSetEmpty() {
   bool res = true;
   if (grad_var_) {
-    res = grad_var_->SharedVar()->is_empty_;
-    VLOG(4) << "Check gradient " << Name() << "is empty:" << res;
-    return res;
+    auto share_var = grad_var_->SharedVar();
+    if (share_var) {
+      res = share_var->is_empty_;
+      VLOG(4) << "Check gradient " << Name() << " is empty:" << res;
+    }
   }
   return res;
 }

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -28,7 +28,7 @@
 #endif
 
 DECLARE_bool(use_mkldnn);
-DECLARE_bool(use_release);
+DECLARE_bool(real_release);
 namespace paddle {
 namespace imperative {
 
@@ -204,7 +204,7 @@ void VarBase::ClearGradient() {
       auto* grad_t =
           grad_var_->MutableVar()->GetMutable<framework::LoDTensor>();
       if (grad_t->IsInitialized()) {
-        if (!FLAGS_use_release) {
+        if (!FLAGS_real_release) {
           auto* dev_ctx =
               platform::DeviceContextPool::Instance().Get(grad_t->place());
           operators::math::set_constant(*dev_ctx, grad_t, 0.0);

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -221,7 +221,10 @@ class VarBase {
 
   const platform::Place Place() const { return var_->Place(); }
 
-  void ClearGradient();
+  void ClearGradient(bool set_to_zero = true);
+
+  void _GradientSetEmpty(bool set_is_empty = true);
+  bool _IsGradientSetEmpty();
 
   std::shared_ptr<VarBase> NewVarBase(const platform::Place& dst_place,
                                       const bool blocking) const;

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -221,7 +221,7 @@ class VarBase {
 
   const platform::Place Place() const { return var_->Place(); }
 
-  void ClearGradient();
+  void ClearGradient(bool release = false);
 
   std::shared_ptr<VarBase> NewVarBase(const platform::Place& dst_place,
                                       const bool blocking) const;

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -221,7 +221,7 @@ class VarBase {
 
   const platform::Place Place() const { return var_->Place(); }
 
-  void ClearGradient(bool release = false);
+  void ClearGradient();
 
   std::shared_ptr<VarBase> NewVarBase(const platform::Place& dst_place,
                                       const bool blocking) const;

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -223,7 +223,7 @@ class VarBase {
 
   void ClearGradient(bool set_to_zero = true);
 
-  void _GradientSetEmpty(bool set_is_empty = true);
+  void _GradientSetEmpty(bool is_empty = true);
   bool _IsGradientSetEmpty();
 
   std::shared_ptr<VarBase> NewVarBase(const platform::Place& dst_place,

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -722,12 +722,12 @@ DEFINE_bool(enable_ins_parser_file, false,
 
 /**
  * ClearGradient related FLAG
- * Name: use_release
+ * Name: real_release
  * Since Version:
  * Value Range: bool, default=false
  * Example:
  * Note: if true, it means to use real ClearGradient to clear grad_var_ instead
  * of setting 0.0
  */
-PADDLE_DEFINE_EXPORTED_bool(use_release, false,
-                            "Use release to clear gradient");
+PADDLE_DEFINE_EXPORTED_bool(real_release, false,
+                            "release gradient, default false");

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -719,15 +719,3 @@ DEFINE_bool(enable_slotrecord_reset_shrink, false,
             "enable slotrecord obejct reset shrink memory, default false");
 DEFINE_bool(enable_ins_parser_file, false,
             "enable parser ins file , default false");
-
-/**
- * ClearGradient related FLAG
- * Name: real_release
- * Since Version:
- * Value Range: bool, default=false
- * Example:
- * Note: if true, it means to use real ClearGradient to clear grad_var_ instead
- * of setting 0.0
- */
-PADDLE_DEFINE_EXPORTED_bool(real_release, false,
-                            "release gradient, default false");

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -719,3 +719,15 @@ DEFINE_bool(enable_slotrecord_reset_shrink, false,
             "enable slotrecord obejct reset shrink memory, default false");
 DEFINE_bool(enable_ins_parser_file, false,
             "enable parser ins file , default false");
+
+/**
+ * ClearGradient related FLAG
+ * Name: use_release
+ * Since Version:
+ * Value Range: bool, default=false
+ * Example:
+ * Note: if true, it means to use real ClearGradient to clear grad_var_ instead
+ * of setting 0.0
+ */
+PADDLE_DEFINE_EXPORTED_bool(use_release, false,
+                            "Use release to clear gradient");

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1443,7 +1443,8 @@ void BindImperative(py::module *m_ptr) {
                 #   one of the variables needed for gradient computation has been modified by an inplace operation.
              
        )DOC")
-      .def("clear_gradient", &imperative::VarBase::ClearGradient, R"DOC(
+      .def("clear_gradient", &imperative::VarBase::ClearGradient,
+           py::arg("set_to_zero") = true, R"DOC(
 
         Only for Tensor that has gradient, normally we use this for Parameters since other temporary Tensor doesen't has gradient.
 
@@ -1463,6 +1464,9 @@ void BindImperative(py::module *m_ptr) {
                 linear.weight.clear_gradient()
                 print("After clear_gradient, linear.weight.grad: {}".format(linear.weight.grad))
       )DOC")
+      .def("_gradient_set_empty", &imperative::VarBase::_GradientSetEmpty,
+           py::arg("set_is_empty") = true)
+      .def("_is_gradient_set_empty", &imperative::VarBase::_IsGradientSetEmpty)
       .def("clone",
            [](std::shared_ptr<imperative::VarBase> &self) {
              const auto &tensor = self->Var().Get<framework::LoDTensor>();

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1443,7 +1443,8 @@ void BindImperative(py::module *m_ptr) {
                 #   one of the variables needed for gradient computation has been modified by an inplace operation.
              
        )DOC")
-      .def("clear_gradient", &imperative::VarBase::ClearGradient, R"DOC(
+      .def("clear_gradient", &imperative::VarBase::ClearGradient,
+           py::arg("release") = false, R"DOC(
 
         Only for Tensor that has gradient, normally we use this for Parameters since other temporary Tensor doesen't has gradient.
 

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1443,8 +1443,7 @@ void BindImperative(py::module *m_ptr) {
                 #   one of the variables needed for gradient computation has been modified by an inplace operation.
              
        )DOC")
-      .def("clear_gradient", &imperative::VarBase::ClearGradient,
-           py::arg("release") = false, R"DOC(
+      .def("clear_gradient", &imperative::VarBase::ClearGradient, R"DOC(
 
         Only for Tensor that has gradient, normally we use this for Parameters since other temporary Tensor doesen't has gradient.
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
@@ -58,7 +58,7 @@ class TestDygraphClearGradient(TestCase):
         linear = paddle.nn.Linear(2, 3)
         out = linear(input)
         out.backward()
-        fluid.set_flags({"FLAGS_use_release": True})
+        fluid.set_flags({"FLAGS_real_release": True})
         linear.weight.clear_gradient()
 
         # actual result

--- a/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
@@ -58,7 +58,8 @@ class TestDygraphClearGradient(TestCase):
         linear = paddle.nn.Linear(2, 3)
         out = linear(input)
         out.backward()
-        linear.weight.clear_gradient(True)
+        fluid.set_flags({"FLAGS_use_release": True})
+        linear.weight.clear_gradient()
 
         # actual result
         gradient_actual = linear.weight.grad

--- a/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+import paddle
+from paddle.fluid.wrapped_decorator import wrap_decorator
+import unittest
+from unittest import TestCase
+import numpy as np
+
+
+def _dygraph_guard_(func):
+    def __impl__(*args, **kwargs):
+        if fluid.in_dygraph_mode():
+            return func(*args, **kwargs)
+        else:
+            with fluid.dygraph.guard():
+                return func(*args, **kwargs)
+
+    return __impl__
+
+
+dygraph_guard = wrap_decorator(_dygraph_guard_)
+
+
+class TestDygraphClearGradient(TestCase):
+    def setUp(self):
+        self.input_shape = [10, 2]
+
+    @dygraph_guard
+    def test_tensor_method_clear_gradient_case1(self):
+        input = paddle.uniform(self.input_shape)
+        linear = paddle.nn.Linear(2, 3)
+        out = linear(input)
+        out.backward()
+        linear.weight.clear_gradient()
+
+        # actual result
+        gradient_actual = linear.weight.grad
+        # expected result
+        gradient_expected = np.zeros([2, 3]).astype('float64')
+        self.assertTrue(np.allclose(gradient_actual.numpy(), gradient_expected))
+
+    @dygraph_guard
+    def test_tensor_method_clear_gradient_case2(self):
+        input = paddle.uniform(self.input_shape)
+        linear = paddle.nn.Linear(2, 3)
+        out = linear(input)
+        out.backward()
+        linear.weight.clear_gradient(True)
+
+        # actual result
+        gradient_actual = linear.weight.grad
+        # expected result
+        self.assertTrue(np.empty(gradient_actual))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_tensor_clear_gradient.py
@@ -58,8 +58,19 @@ class TestDygraphClearGradient(TestCase):
         linear = paddle.nn.Linear(2, 3)
         out = linear(input)
         out.backward()
-        fluid.set_flags({"FLAGS_real_release": True})
-        linear.weight.clear_gradient()
+        # default arg set_to_zero is true
+        # so, False means real clear gradient
+        linear.weight.clear_gradient(False)
+
+        # before ._gradient_set_empty(False), 
+        # the return of ._is_gradient_set_empty() should be True
+        self.assertTrue(linear.weight._is_gradient_set_empty())
+
+        # reset, because ClearGradient will call SetIsEmpty(True), but this is not our expectation.
+        linear.weight._gradient_set_empty(False)
+        # after ._gradient_set_empty(False), 
+        # the return of ._is_gradient_set_empty() should be False
+        self.assertFalse(linear.weight._is_gradient_set_empty())
 
         # actual result
         gradient_actual = linear.weight.grad


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
APIs 

### Describe
#### 1. Add arg to enhance varbase ClearGradient func,
use case: 1
```
 linear.weight.clear_gradient() #  same as the original version.
```
use case: 2
```
 linear.weight.clear_gradient(False)   # False means to real clear gradient
 # default args: set_to_zero = True
```

#### 2. Expose two func to set and get the " is_empty_ " attribute of grad_var_
- _is_gradient_set_empty()
- _gradient_set_empty(is_empty = False) or _gradient_set_empty(is_empty = True) , default=True
```
@dygraph_guard
    def test_tensor_method_clear_gradient_case2(self):
        input = paddle.uniform(self.input_shape)
        linear = paddle.nn.Linear(2, 3)
        out = linear(input)
        out.backward()
        # default arg set_to_zero is true
        # so, False means real clear gradient
        linear.weight.clear_gradient(False)

        # before ._gradient_set_empty(False), 
        # the return of ._is_gradient_set_empty() should be True
        self.assertTrue(linear.weight._is_gradient_set_empty())

        # reset, because ClearGradient will call SetIsEmpty(True), but this is not our expectation.
        linear.weight._gradient_set_empty(False)
        # after ._gradient_set_empty(False), 
        # the return of ._is_gradient_set_empty() should be False
        self.assertFalse(linear.weight._is_gradient_set_empty())

        # actual result
        gradient_actual = linear.weight.grad
        # expected result
        self.assertTrue(np.empty(gradient_actual))

```