### PR TITLE
change boost url to avoid uselese warn

### DIFF
--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -23,7 +23,10 @@ set(BOOST_PROJECT       "extern_boost")
 # checked that the devtools package of CentOS 6 installs boost 1.41.0.
 # So we use 1.41.0 here.
 set(BOOST_VER   "1.41.0")
-set(BOOST_TAR   "boost_1_41_0" CACHE STRING "" FORCE)
+# boost_1_41_0_2021_10.tar.gz is almost the same with boost_1_41_0.tar.gz,
+# except in visualc.hpp i comment a warning of "unknown compiler version",
+# so if you need to change boost, you may need to block the warning similarly.
+set(BOOST_TAR   "boost_1_41_0_2021_10" CACHE STRING "" FORCE)
 set(BOOST_URL   "http://paddlepaddledeps.bj.bcebos.com/${BOOST_TAR}.tar.gz" CACHE STRING "" FORCE)
 
 MESSAGE(STATUS "BOOST_VERSION: ${BOOST_VER}, BOOST_URL: ${BOOST_URL}")
@@ -46,7 +49,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               f891e8c2c9424f0565f0129ad9ab4aff
+    URL_MD5               51be7cc203628dc0848e97eee32d79e3
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
 The version of boost that paddle is using is 1.41.0, whose last known and checked version is 1600 (VC10, aka 2010). While paddle is using visual studio 2017, so there are a lot warning of unkown compiler version when compiling. I just comment the warn and upload new tar to bos named boost_1_41_0_2021_10.tar.gz.
![image](https://user-images.githubusercontent.com/51314274/139397804-f712dd02-8100-4d76-9441-5f0ab11e5961.png)
![image](https://user-images.githubusercontent.com/51314274/139398475-c01c4b00-0f0a-45d2-ab56-41e9b4e31c76.png)
