### PR TITLE
fix matmul dim error when fused_reshape_Out contains 0 and -1

### DIFF
--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -695,12 +695,26 @@ class MatMulOp : public framework::OperatorWithKernel {
                                             "received %d",
                                             reshape_out_size));
 
-      auto it = std::find(reshape_out.begin(), reshape_out.end(), -1);
+      auto it_zero = std::find(reshape_out.begin(), reshape_out.end(), 0);
+      if (it_zero != reshape_out.end()) {
+        for (uint64_t i = 0; i < reshape_out.size(); i++) {
+          if (reshape_out[i] == 0) {
+            PADDLE_ENFORCE_LT(
+                i, ddim_out.size(),
+                platform::errors::InvalidArgument(
+                    "The index of 0 in fused_reshape_Out ",
+                    "should be less than output dim size, ",
+                    "but the index is %d and output dim size is %d", i,
+                    ddim_out.size()));
+            reshape_out[i] = ddim_out.at(i);
+          }
+        }
+      }
 
       // if "-1" is present then one of reshape dims must be infered
+      auto it = std::find(reshape_out.begin(), reshape_out.end(), -1);
       if (it != reshape_out.end()) {
         int index = std::distance(reshape_out.begin(), it);
-
         auto ddim_out_vec = framework::vectorize(ddim_out);
 
         int ddim_out_product =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
OPs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe

使用mkldnn推理时会根据fused_reshape_Out的值reshape matmul的输出，在判断是否含有-1之前要判断fused_reshape_Out中有0的情况，并将0替换为输入的真实维度，否则无法自动推导值为-1的维度。

<!-- Describe what this PR does -->
