### PR TITLE
[NPU] fix lookup_table_v2_grad ACL error for model BoW

### DIFF
--- a/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
@@ -38,7 +38,7 @@ class TestLookupTableV2(OpTest):
         np.random.seed(SEED)
         w = np.random.random([self.vocab, self.dim]).astype(self.dtype)
         x = np.random.randint(
-            0, self.vocab, size=(self.bsz, self.seqlen)).astype(np.int32)
+            0, self.vocab, size=(self.bsz, self.seqlen)).astype(self.ids_dtype)
         out = w[x]
         if self.padding_idx != -1:
             out[np.squeeze(x == self.padding_idx)] = np.zeros(self.dim)
@@ -60,6 +60,7 @@ class TestLookupTableV2(OpTest):
 
     def init_dtype(self):
         self.dtype = np.float32
+        self.ids_dtype = np.int32
 
     def init_dims(self):
         self.bsz = 6
@@ -85,6 +86,7 @@ class TestLookupTableV2FP16(TestLookupTableV2):
 
     def init_dtype(self):
         self.dtype = np.float16
+        self.ids_dtype = np.int32
 
     def set_npu(self):
         self.__class__.use_npu = True
@@ -105,6 +107,7 @@ class TestLookupTableV2Dim32FP16(TestLookupTableV2):
 
     def init_dtype(self):
         self.dtype = np.float16
+        self.ids_dtype = np.int64
 
     def init_dims(self):
         self.bsz = 6
@@ -120,6 +123,15 @@ class TestLookupTableV2Dim32FP16(TestLookupTableV2):
 class TestLookupTableV2WithPadding(TestLookupTableV2):
     def init_padding_idx(self):
         self.padding_idx = np.random.randint(0, self.vocab)
+
+
+class TestLookupTableV2WithPadding1(TestLookupTableV2):
+    def init_padding_idx(self):
+        self.padding_idx = np.random.randint(0, self.vocab)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+        self.ids_dtype = np.int64
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
OPs

### Describe
lookup_table_v2_grad fails in text_classification model BoW because of ACL error, UnsortedSegmentSum works well.
<img width="1433" alt="e5c77b300b86dba629286bcf100fade8" src="https://user-images.githubusercontent.com/5997715/139422854-3756f43e-00fa-4005-a452-528a79e3ae6e.png">

![image](https://user-images.githubusercontent.com/5997715/139423307-50f78f84-858b-44bf-8d99-df2a7f9d32eb.png)
