### PR TITLE
Added conv + hard_sigmoid oneDNN fuse pass

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
@@ -228,12 +228,14 @@ Conv2DHardSigmoidFusePass::Conv2DHardSigmoidFusePass() {
       .AddOutput("Out")
       .IsTensor()
       .End()
-      // default=0.2
+      // optional, default=0.2
       .AddAttr("slope")
+      .IsOptional()
       .IsType<float>()
       .End()
-      // default=0.5
+      // optional, default=0.5
       .AddAttr("offset")
+      .IsOptional()
       .IsType<float>()
       .End();
 }

--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
@@ -228,14 +228,12 @@ Conv2DHardSigmoidFusePass::Conv2DHardSigmoidFusePass() {
       .AddOutput("Out")
       .IsTensor()
       .End()
-      // optional, default=0.2
+      // default=0.2
       .AddAttr("slope")
-      .IsOptional()
       .IsType<float>()
       .End()
-      // optional, default=0.5
+      // default=0.5
       .AddAttr("offset")
-      .IsOptional()
       .IsType<float>()
       .End();
 }

--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.h
@@ -72,6 +72,15 @@ class Conv2DHardSwishFusePass : public ConvActivationFusePass {
   Conv2DHardSwishFusePass();
   std::string activation_type() const { return "hard_swish"; }
 };
+/*
+ * Fuse Conv and HardSigmoid class
+ */
+class Conv2DHardSigmoidFusePass : public ConvActivationFusePass {
+ public:
+  Conv2DHardSigmoidFusePass();
+  std::string activation_type() const { return "hard_sigmoid"; }
+};
+
 }  // namespace ir
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass_tester.cc
@@ -148,6 +148,9 @@ TEST(ConvActivationFusePass, conv_swish_fuse_pass) { MainTest("swish"); }
 TEST(ConvActivationFusePass, conv_hard_swish_fuse_pass) {
   MainTest("hard_swish");
 }
+TEST(ConvActivationFusePass, conv_hard_sigmoid_fuse_pass) {
+  MainTest("hard_sigmoid");
+}
 
 }  // namespace ir
 }  // namespace framework

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -249,6 +249,7 @@ void CpuPassStrategy::EnableMKLDNN() {
              "conv_relu6_mkldnn_fuse_pass",                //
              "conv_swish_mkldnn_fuse_pass",                //
              "conv_hard_swish_mkldnn_fuse_pass",           //
+             "conv_hard_sigmoid_mkldnn_fuse_pass",         //
              "scale_matmul_fuse_pass",                     //
              "reshape_transpose_matmul_mkldnn_fuse_pass",  //
              "matmul_transpose_reshape_fuse_pass",         //

--- a/paddle/fluid/operators/compat/hard_sigmoid.pbtxt
+++ b/paddle/fluid/operators/compat/hard_sigmoid.pbtxt
@@ -1,0 +1,17 @@
+type: "hard_sigmoid"
+def {
+  inputs {
+    name: "X"
+  }
+  outputs {
+    name: "Out"
+  }
+  attrs {
+    name: "slope"
+    type: FLOAT
+  }
+  attrs {
+    name: "offset"
+    type: FLOAT
+  }
+}

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -475,23 +475,25 @@ class ConvMKLDNNHandlerT
     }
     // Fusion with ReLU layer is executed through the PostOps feature. Create a
     // PostOps object and configure it to execute an eltwise relu operation.
+    constexpr float scale = 1.0f;
     if (fuse_activation == "relu" || fuse_activation == "leaky_relu") {
-      constexpr float scale = 1.0f;
       post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_relu,
                                      fuse_alpha, fuse_beta);
     } else if (fuse_activation == "relu6") {
-      constexpr float scale = 1.0f;
       post_operations.append_eltwise(scale,
                                      mkldnn::algorithm::eltwise_bounded_relu,
                                      fuse_alpha, fuse_beta);
     } else if (fuse_activation == "swish") {
-      constexpr float scale = 1.0f;
       post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_swish,
                                      fuse_alpha, fuse_beta);
     } else if (fuse_activation == "hard_swish") {
-      constexpr float scale = 1.0f;
       post_operations.append_eltwise(
           scale, mkldnn::algorithm::eltwise_hardswish, fuse_alpha, fuse_beta);
+    } else if (fuse_activation == "hard_sigmoid") {
+      post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_linear,
+                                     fuse_alpha, fuse_beta);
+      post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_clip,
+                                     0.0f, 1.0f);
     }
     conv_attr.set_post_ops(post_operations);
     return conv_attr;

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_conv_activation_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_conv_activation_fuse_pass.py
@@ -102,5 +102,14 @@ class ConvActivationMkldnnFusePassTest_5(ConvActivationMkldnnFusePassTest):
         self.pass_name = 'conv_hard_swish_mkldnn_fuse_pass'
 
 
+class ConvHardSigmoidOneDNNFusePassTest(ConvActivationMkldnnFusePassTest):
+    def set_params(self):
+        self.conv_num_filters = 5
+        self.conv_filter_size = 5
+        self.conv_bias_attr = True
+        self.act = "hard_sigmoid"
+        self.pass_name = 'conv_hard_sigmoid_mkldnn_fuse_pass'
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
Added conv + hard_sigmoid oneDNN fuse pass. It is designed mainly for PPLCNets architectures. This fuse pass improves PPLCNet_x0_25 model performance by 3% and PPLCNet_x1_0 performance by 1.4%
OneDNN does not have pure hard_sigmoid activation, that's why 2 eltwise postops are needed.

`
hard_sigmoid(x, slope, offset) = max(0, min(1, slope * x + offset))
`
With oneDNN, we can get the inner equation by
`
eltwise_linear(x, slope, offset) = slope * x + offset
`
And adding clip after that would give us the exact equation as pure hard_sigmoid
`
eltwise_clip(eltwise_linear(x, slope, offset), 0, 1) = max(0, min(1, slope * x + offset))
`