### PR TITLE
negative label in softmax cross entropy

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -73,17 +73,21 @@ __global__ void CrossEntropyHardLabel(T* loss, const T* softmax,
 
   // thread ids compute loss[ids] using softmax[idx]
   if (ids < n * d) {
-    int64_t idx = idx_n * dim * d + labels[ids] * d + idx_d;
-    if (IgnoreIndex == true) {
-      // IgnoreIndex is true
-      if (labels[ids] == ignore_idx) {
-        loss[ids] = static_cast<T>(0.0);
+    if (labels[ids] < 0) {  // label is negative
+      loss[ids] = static_cast<T>(0.0);
+    } else {  // label is positive of zero
+      int64_t idx = idx_n * dim * d + labels[ids] * d + idx_d;
+      if (IgnoreIndex == true) {
+        // IgnoreIndex is true
+        if (labels[ids] == ignore_idx) {
+          loss[ids] = static_cast<T>(0.0);
+        } else {
+          loss[ids] = -Log(softmax[idx]);
+        }
       } else {
+        // IgnoreIndex is false
         loss[ids] = -Log(softmax[idx]);
       }
-    } else {
-      // IgnoreIndex is false
-      loss[ids] = -Log(softmax[idx]);
     }
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
OPs

### Describe
Op softmax_with_cross_entropy, "labels" is one input. In doc, this should be zero or positive integer. This PR enforce the behavior when labels is negative. In previous code, the address is computed using labels, when it is negative, the address idx could be out of bound. 

The behavior is as following in this PR.
- labels is not negative: no modifications compared to previous code
- labels is negative: return loss[ids] as zero

In code, firstly check if label is zero, if yes, return 0.