### PR TITLE
[PTen] Add lock to kernel signature map init

### DIFF
--- a/paddle/fluid/framework/pten_utils.cc
+++ b/paddle/fluid/framework/pten_utils.cc
@@ -59,6 +59,19 @@ pten::KernelKey TransOpKernelTypeToPtenKernelKey(
   return pten::KernelKey(backend, layout, dtype);
 }
 
+KernelSignatureMap* KernelSignatureMap::kernel_signature_map_ = nullptr;
+std::mutex KernelSignatureMap::mutex_;
+
+KernelSignatureMap& KernelSignatureMap::Instance() {
+  if (kernel_signature_map_ == nullptr) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (kernel_signature_map_ == nullptr) {
+      kernel_signature_map_ = new KernelSignatureMap;
+    }
+  }
+  return *kernel_signature_map_;
+}
+
 const paddle::SmallVector<std::string>&
 KernelArgsNameMakerByOpProto::GetInputArgsNames() {
   for (int i = 0; i < op_proto_->inputs_size(); ++i) {

--- a/paddle/fluid/framework/pten_utils.cc
+++ b/paddle/fluid/framework/pten_utils.cc
@@ -72,6 +72,30 @@ KernelSignatureMap& KernelSignatureMap::Instance() {
   return *kernel_signature_map_;
 }
 
+bool KernelSignatureMap::Has(const std::string& op_type) const {
+  return map_.find(op_type) != map_.end();
+}
+
+void KernelSignatureMap::Emplace(const std::string& op_type,
+                                 KernelSignature&& signature) {
+  if (!Has(op_type)) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!Has(op_type)) {
+      map_.emplace(op_type, signature);
+    }
+  }
+}
+
+const KernelSignature& KernelSignatureMap::Get(
+    const std::string& op_type) const {
+  auto it = map_.find(op_type);
+  PADDLE_ENFORCE_NE(
+      it, map_.end(),
+      platform::errors::NotFound(
+          "Operator `%s`'s kernel signature is not registered.", op_type));
+  return it->second;
+}
+
 const paddle::SmallVector<std::string>&
 KernelArgsNameMakerByOpProto::GetInputArgsNames() {
   for (int i = 0; i < op_proto_->inputs_size(); ++i) {

--- a/paddle/fluid/framework/pten_utils.h
+++ b/paddle/fluid/framework/pten_utils.h
@@ -65,24 +65,11 @@ class KernelSignatureMap {
  public:
   static KernelSignatureMap& Instance();
 
-  bool Has(const std::string& op_type) const {
-    return map_.find(op_type) != map_.end();
-  }
+  bool Has(const std::string& op_type) const;
 
-  void Emplace(const std::string& op_type, KernelSignature&& signature) {
-    if (!Has(op_type)) {
-      map_.emplace(op_type, signature);
-    }
-  }
+  void Emplace(const std::string& op_type, KernelSignature&& signature);
 
-  const KernelSignature& Get(const std::string& op_type) const {
-    auto it = map_.find(op_type);
-    PADDLE_ENFORCE_NE(
-        it, map_.end(),
-        platform::errors::NotFound(
-            "Operator `%s`'s kernel signature is not registered.", op_type));
-    return it->second;
-  }
+  const KernelSignature& Get(const std::string& op_type) const;
 
  private:
   KernelSignatureMap() = default;

--- a/paddle/fluid/framework/pten_utils.h
+++ b/paddle/fluid/framework/pten_utils.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -62,10 +63,7 @@ struct KernelSignature {
 // TODO(chenweihang): we can generate this map by proto info in compile time
 class KernelSignatureMap {
  public:
-  static KernelSignatureMap& Instance() {
-    static KernelSignatureMap g_kernel_signature_map;
-    return g_kernel_signature_map;
-  }
+  static KernelSignatureMap& Instance();
 
   bool Has(const std::string& op_type) const {
     return map_.find(op_type) != map_.end();
@@ -88,9 +86,13 @@ class KernelSignatureMap {
 
  private:
   KernelSignatureMap() = default;
-  paddle::flat_hash_map<std::string, KernelSignature> map_;
-
   DISABLE_COPY_AND_ASSIGN(KernelSignatureMap);
+
+ private:
+  static KernelSignatureMap* kernel_signature_map_;
+  static std::mutex mutex_;
+
+  paddle::flat_hash_map<std::string, KernelSignature> map_;
 };
 
 class KernelArgsNameMaker {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[PTen] Add lock to kernel signature map init, the singleton construct may be not thread safe 