### PR TITLE
Fix persistable var is GC as unexpected

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -502,11 +502,11 @@ void InterpreterCore::CheckGC(const Instruction& instr) {
   for (auto var_id : instr.GCCheckVars()) {
     bool is_ready =
         atomic_var_ref[var_id]->fetch_sub(1, std::memory_order_relaxed) == 1;
-    if (is_ready && var_scope.VarDesc(var_id) &&
-        !var_scope.VarDesc(var_id)->Persistable()) {
-      gc_.Add(var_scope.Var(var_id), gc_event_.at(instr_id),
-              &instr.DeviceContext());
-    } else if (is_ready && var_scope.VarDesc(var_id) == nullptr) {
+    // ignore all persistable var while GC
+    if (var_scope.VarDesc(var_id) && var_scope.VarDesc(var_id)->Persistable()) {
+      continue;
+    }
+    if (is_ready) {
       gc_.Add(var_scope.Var(var_id), gc_event_.at(instr_id),
               &instr.DeviceContext());
     }

--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -146,7 +146,7 @@ void build_variable_scope(const framework::ProgramDesc& pdesc,
       if (nullptr == var_desc_tmp) {
         VLOG(3) << "update var:" << var_name << " desc from nullptr into "
                 << var_desc;
-        var_scope->VarMetaInfo(var_name).vardesc_ = var_desc;
+        var_scope->SetVarDesc(var_name, var_desc);
       }
     }
   }

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -564,6 +564,11 @@ class VariableScope : public ScopeBase {
     vec_meta_info_.push_back(info);
   }
 
+  void SetVarDescByName(const std::string& name, framework::VarDesc* var_desc) {
+    CheckExist(name);
+    vec_meta_info_[VarId(name)].vardesc_ = var_desc;
+  }
+
   paddle::framework::VarDesc* VarDesc(const std::string& name) const {
     return VarDesc(VarId(name));
   }

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -564,7 +564,7 @@ class VariableScope : public ScopeBase {
     vec_meta_info_.push_back(info);
   }
 
-  void SetVarDescByName(const std::string& name, framework::VarDesc* var_desc) {
+  void SetVarDesc(const std::string& name, framework::VarDesc* var_desc) {
     CheckExist(name);
     vec_meta_info_[VarId(name)].vardesc_ = var_desc;
   }
@@ -576,10 +576,6 @@ class VariableScope : public ScopeBase {
   paddle::framework::VarDesc* VarDesc(int id) const {
     CheckExist(id);
     return vec_meta_info_[id].vardesc_;
-  }
-
-  VariableMetaInfo& VarMetaInfo(const std::string& name) {
-    return vec_meta_info_[VarId(name)];
   }
 
   void CheckExist(int id) const {

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -29,14 +29,12 @@ StandaloneExecutor::StandaloneExecutor(const platform::Place& place,
   // init scope
   BuildVariableOuterScope(startup_prog, &global_scope_, scope);
 
-  auto& global_block = main_prog.Block(0);
   if (outer_scope_ != nullptr) {
     auto name_list = outer_scope_->LocalVarNames();
     for (auto name : name_list) {
       auto v = outer_scope_->Var(name);
       if (!global_scope_.HasVar(name)) {
         global_scope_.AddVar(name, *v);
-        global_scope_.SetVarDescByName(name, global_block.FindVar(name));
       }
     }
   }

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -29,12 +29,14 @@ StandaloneExecutor::StandaloneExecutor(const platform::Place& place,
   // init scope
   BuildVariableOuterScope(startup_prog, &global_scope_, scope);
 
+  auto& global_block = main_prog.Block(0);
   if (outer_scope_ != nullptr) {
     auto name_list = outer_scope_->LocalVarNames();
     for (auto name : name_list) {
       auto v = outer_scope_->Var(name);
       if (!global_scope_.HasVar(name)) {
         global_scope_.AddVar(name, *v);
+        global_scope_.SetVarDescByName(name, global_block.FindVar(name));
       }
     }
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

在`standalone_executor`中，会从outer_scope中构建VariableScope，但所有的vardesc均为空指针。导致在CheckGC函数中，persistable的变量可能会在第一个Batch被错误地GC掉。

此PR在构建VariableScope时，会从global_block中补充var_desc信息，以解决此问题


相关PR：https://github.com/PaddlePaddle/Paddle/pull/36888