### PR TITLE
[PaddlePaddle Hackathon] add WideResNet

### DIFF
--- a/python/paddle/tests/test_pretrained_model.py
+++ b/python/paddle/tests/test_pretrained_model.py
@@ -56,7 +56,7 @@ class TestPretrainedModel(unittest.TestCase):
             'mobilenet_v1', 'mobilenet_v2', 'resnet18', 'vgg16', 'alexnet',
             'resnext50_32x4d', 'inception_v3', 'densenet121', 'squeezenet1_0',
             'squeezenet1_1', 'googlenet', 'shufflenet_v2_x0_25',
-            'shufflenet_v2_swish'
+            'shufflenet_v2_swish', 'wide_resnet50_2', 'wide_resnet101_2'
         ]
         for arch in arches:
             self.infer(arch)

--- a/python/paddle/tests/test_vision_models.py
+++ b/python/paddle/tests/test_vision_models.py
@@ -70,6 +70,12 @@ class TestVisonModels(unittest.TestCase):
     def test_resnet152(self):
         self.models_infer('resnet152')
 
+    def test_wide_resnet50_2(self):
+        self.models_infer('wide_resnet50_2')
+
+    def test_wide_resnet101_2(self):
+        self.models_infer('wide_resnet101_2')
+
     def test_densenet121(self):
         self.models_infer('densenet121')
 

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -34,6 +34,8 @@ from .models import resnet34  # noqa: F401
 from .models import resnet50  # noqa: F401
 from .models import resnet101  # noqa: F401
 from .models import resnet152  # noqa: F401
+from .models import wide_resnet50_2  # noqa: F401
+from .models import wide_resnet101_2  # noqa: F401
 from .models import MobileNetV1  # noqa: F401
 from .models import mobilenet_v1  # noqa: F401
 from .models import MobileNetV2  # noqa: F401

--- a/python/paddle/vision/models/__init__.py
+++ b/python/paddle/vision/models/__init__.py
@@ -18,6 +18,8 @@ from .resnet import resnet34  # noqa: F401
 from .resnet import resnet50  # noqa: F401
 from .resnet import resnet101  # noqa: F401
 from .resnet import resnet152  # noqa: F401
+from .resnet import wide_resnet50_2  # noqa: F401
+from .resnet import wide_resnet101_2  # noqa: F401
 from .mobilenetv1 import MobileNetV1  # noqa: F401
 from .mobilenetv1 import mobilenet_v1  # noqa: F401
 from .mobilenetv2 import MobileNetV2  # noqa: F401
@@ -66,6 +68,8 @@ __all__ = [ #noqa
     'resnet50',
     'resnet101',
     'resnet152',
+    'wide_resnet50_2',
+    'wide_resnet101_2',
     'VGG',
     'vgg11',
     'vgg13',

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -166,6 +166,7 @@ class ResNet(nn.Layer):
 
     Examples:
         .. code-block:: python
+
             import paddle
             from paddle.vision.models import ResNet
             from paddle.vision.models.resnet import BottleneckBlock, BasicBlock
@@ -303,6 +304,7 @@ def resnet18(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
+
             import paddle
             from paddle.vision.models import resnet18
 
@@ -329,6 +331,7 @@ def resnet34(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
+
             import paddle
             from paddle.vision.models import resnet34
 
@@ -355,6 +358,7 @@ def resnet50(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
+
             import paddle
             from paddle.vision.models import resnet50
 
@@ -381,6 +385,7 @@ def resnet101(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
+
             import paddle
             from paddle.vision.models import resnet101
 
@@ -407,6 +412,7 @@ def resnet152(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
+
             import paddle
             from paddle.vision.models import resnet152
 
@@ -433,6 +439,7 @@ def wide_resnet50_2(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
+
             import paddle
             from paddle.vision.models import wide_resnet50_2
 
@@ -460,6 +467,7 @@ def wide_resnet101_2(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
+        
             import paddle
             from paddle.vision.models import wide_resnet101_2
 

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -33,6 +33,12 @@ model_urls = {
                   '02f35f034ca3858e1e54d4036443c92d'),
     'resnet152': ('https://paddle-hapi.bj.bcebos.com/models/resnet152.pdparams',
                   '7ad16a2f1e7333859ff986138630fd7a'),
+    'wide_resnet50_2':
+    ('https://bj.bcebos.com/v1/ai-studio-online/93f78b51775a4434bde046e765a206c51b1aa05797c64f96aff33f7791b3de45',
+     '0282f804d73debdab289bd9fea3fa6dc'),
+    'wide_resnet101_2':
+    ('https://bj.bcebos.com/v1/ai-studio-online/cfb1df23c8604dbfa0c52aacdc841810901fa064ff104abda62bfb112b022245',
+     'd4360a2d23657f059216f5d5a1a9ac93')
 }
 
 
@@ -153,23 +159,36 @@ class ResNet(nn.Layer):
     Args:
         Block (BasicBlock|BottleneckBlock): block module of model.
         depth (int): layers of resnet, default: 50.
-        num_classes (int): output dim of last fc layer. If num_classes <=0, last fc layer 
+        width (int): base width of resnet, default: 64.
+        num_classes (int): output dim of last fc layer. If num_classes <=0, last fc layer
                             will not be defined. Default: 1000.
         with_pool (bool): use pool before the last fc layer or not. Default: True.
 
     Examples:
         .. code-block:: python
-
+            import paddle
             from paddle.vision.models import ResNet
             from paddle.vision.models.resnet import BottleneckBlock, BasicBlock
 
             resnet50 = ResNet(BottleneckBlock, 50)
 
+            wide_resnet50_2 = ResNet(BottleneckBlock, 50, width=64*2)
+
             resnet18 = ResNet(BasicBlock, 18)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = resnet18(x)
+
+            print(out.shape)
 
     """
 
-    def __init__(self, block, depth, num_classes=1000, with_pool=True):
+    def __init__(self,
+                 block,
+                 depth=50,
+                 width=64,
+                 num_classes=1000,
+                 with_pool=True):
         super(ResNet, self).__init__()
         layer_cfg = {
             18: [2, 2, 2, 2],
@@ -179,6 +198,8 @@ class ResNet(nn.Layer):
             152: [3, 8, 36, 3]
         }
         layers = layer_cfg[depth]
+        self.groups = 1
+        self.base_width = width
         self.num_classes = num_classes
         self.with_pool = with_pool
         self._norm_layer = nn.BatchNorm2D
@@ -225,11 +246,17 @@ class ResNet(nn.Layer):
 
         layers = []
         layers.append(
-            block(self.inplanes, planes, stride, downsample, 1, 64,
-                  previous_dilation, norm_layer))
+            block(self.inplanes, planes, stride, downsample, self.groups,
+                  self.base_width, previous_dilation, norm_layer))
         self.inplanes = planes * block.expansion
         for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes, norm_layer=norm_layer))
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    norm_layer=norm_layer))
 
         return nn.Sequential(*layers)
 
@@ -268,14 +295,15 @@ def _resnet(arch, Block, depth, pretrained, **kwargs):
 
 
 def resnet18(pretrained=False, **kwargs):
-    """ResNet 18-layer model
-    
+    """ResNet 18-layer model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
     Examples:
         .. code-block:: python
-
+            import paddle
             from paddle.vision.models import resnet18
 
             # build model
@@ -283,19 +311,25 @@ def resnet18(pretrained=False, **kwargs):
 
             # build model and load imagenet pretrained weight
             # model = resnet18(pretrained=True)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
     return _resnet('resnet18', BasicBlock, 18, pretrained, **kwargs)
 
 
 def resnet34(pretrained=False, **kwargs):
-    """ResNet 34-layer model
-    
+    """ResNet 34-layer model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
-    
+
     Examples:
         .. code-block:: python
-
+            import paddle
             from paddle.vision.models import resnet34
 
             # build model
@@ -303,19 +337,25 @@ def resnet34(pretrained=False, **kwargs):
 
             # build model and load imagenet pretrained weight
             # model = resnet34(pretrained=True)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
     return _resnet('resnet34', BasicBlock, 34, pretrained, **kwargs)
 
 
 def resnet50(pretrained=False, **kwargs):
-    """ResNet 50-layer model
-    
+    """ResNet 50-layer model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
     Examples:
         .. code-block:: python
-
+            import paddle
             from paddle.vision.models import resnet50
 
             # build model
@@ -323,19 +363,25 @@ def resnet50(pretrained=False, **kwargs):
 
             # build model and load imagenet pretrained weight
             # model = resnet50(pretrained=True)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
     return _resnet('resnet50', BottleneckBlock, 50, pretrained, **kwargs)
 
 
 def resnet101(pretrained=False, **kwargs):
-    """ResNet 101-layer model
-    
+    """ResNet 101-layer model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
     Examples:
         .. code-block:: python
-
+            import paddle
             from paddle.vision.models import resnet101
 
             # build model
@@ -343,19 +389,25 @@ def resnet101(pretrained=False, **kwargs):
 
             # build model and load imagenet pretrained weight
             # model = resnet101(pretrained=True)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
     return _resnet('resnet101', BottleneckBlock, 101, pretrained, **kwargs)
 
 
 def resnet152(pretrained=False, **kwargs):
-    """ResNet 152-layer model
-    
+    """ResNet 152-layer model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
     Examples:
         .. code-block:: python
-
+            import paddle
             from paddle.vision.models import resnet152
 
             # build model
@@ -363,5 +415,65 @@ def resnet152(pretrained=False, **kwargs):
 
             # build model and load imagenet pretrained weight
             # model = resnet152(pretrained=True)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
     return _resnet('resnet152', BottleneckBlock, 152, pretrained, **kwargs)
+
+
+def wide_resnet50_2(pretrained=False, **kwargs):
+    """Wide ResNet-50-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+
+    Examples:
+        .. code-block:: python
+            import paddle
+            from paddle.vision.models import wide_resnet50_2
+
+            # build model
+            model = wide_resnet50_2()
+
+            # build model and load imagenet pretrained weight
+            # model = wide_resnet50_2(pretrained=True)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
+    """
+    kwargs['width'] = 64 * 2
+    return _resnet('wide_resnet50_2', BottleneckBlock, 50, pretrained, **kwargs)
+
+
+def wide_resnet101_2(pretrained=False, **kwargs):
+    """Wide ResNet-101-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+
+    Examples:
+        .. code-block:: python
+            import paddle
+            from paddle.vision.models import wide_resnet101_2
+
+            # build model
+            model = wide_resnet101_2()
+
+            # build model and load imagenet pretrained weight
+            # model = wide_resnet101_2(pretrained=True)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
+    """
+    kwargs['width'] = 64 * 2
+    return _resnet('wide_resnet101_2', BottleneckBlock, 101, pretrained,
+                   **kwargs)

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -34,11 +34,11 @@ model_urls = {
     'resnet152': ('https://paddle-hapi.bj.bcebos.com/models/resnet152.pdparams',
                   '7ad16a2f1e7333859ff986138630fd7a'),
     'wide_resnet50_2':
-    ('https://bj.bcebos.com/v1/ai-studio-online/93f78b51775a4434bde046e765a206c51b1aa05797c64f96aff33f7791b3de45',
+    ('https://paddle-hapi.bj.bcebos.com/models/wide_resnet50_2.pdparams',
      '0282f804d73debdab289bd9fea3fa6dc'),
     'wide_resnet101_2':
-    ('https://bj.bcebos.com/v1/ai-studio-online/cfb1df23c8604dbfa0c52aacdc841810901fa064ff104abda62bfb112b022245',
-     'd4360a2d23657f059216f5d5a1a9ac93')
+    ('https://paddle-hapi.bj.bcebos.com/models/wide_resnet101_2.pdparams',
+     'd4360a2d23657f059216f5d5a1a9ac93'),
 }
 
 
@@ -467,7 +467,7 @@ def wide_resnet101_2(pretrained=False, **kwargs):
 
     Examples:
         .. code-block:: python
-        
+
             import paddle
             from paddle.vision.models import wide_resnet101_2
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

APIs

### Describe
<!-- Describe what this PR does -->

- Task: https://github.com/PaddlePaddle/Paddle/issues/35994
- 向 paddle.vision.models 添加 WideResNet 系列模型（同 torchvision）
   - wide_resnet50_2（BottleneckBlock 的宽度为 resnet50 的 2倍）
   - wide_resnet101_2（BottleneckBlock 的宽度为 resnet101 的 2倍）

status: Pending Review

- [x] 预训练参数支持
- [x] 单元测试
- [x] 文档 https://github.com/PaddlePaddle/docs/pull/4034
- [x] 精度自测 如下：

### Performance

AI Studio 测试详情：<https://aistudio.baidu.com/aistudio/projectdetail/2561949>
基准参考（torchvision）：<https://pytorch.org/vision/stable/models.html>

|Model|Top-1|Top-5|
|-|-|-|
|wide_resnet50_2|0.78468<span style="color:blue;"><sub>(=)</sub></span>|0.94086<span style="color:blue;"><sub>(=)</sub></span>|
|wide_resnet101_2|0.78846<span style="color:green;"><sub>(-0.00002)</sub></span>|0.94284<span style="color:blue;"><sub>(=)</sub></span>|

> 括号中为以 torchvision 性能基准为参考的偏差值

由于题目要求中给出的预训练权重貌似是 CIFAR10 上预训练得到的，这与 paddle.vision 中其他模型均为 imagenet 预训练得到不同，因此本 PR 所使用的预训练权重为自行从 torchvision 转换得来（存储在 AI Studio 中），~~不过转换后的模型经自测精度损失相对于前几次高一点~~由于 OpenCV 与 Pillow 在 Resize 预处理时效果不一致，会导致精度降低，将预处理统一改成 Pillow 后精度与基准基本完全一致～

同时还对 ResNet 英文文档进行了一定的修改，以保持与中文文档一致～