### PR TITLE
Fix PTen thread safety error

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -399,7 +399,7 @@ cc_library(save_load_util SRCS save_load_util.cc DEPS tensor scope layer)
 cc_test(save_load_util_test SRCS save_load_util_test.cc DEPS save_load_util tensor scope layer)
 cc_library(generator SRCS generator.cc DEPS enforce place)
 
-cc_library(pten_utils SRCS pten_utils.cc DEPS lod_tensor selected_rows place pten var_type_traits pten_hapi_utils)
+cc_library(pten_utils SRCS pten_utils.cc DEPS lod_tensor selected_rows place pten var_type_traits pten_hapi_utils op_info)
 
 # Get the current working branch
 execute_process(

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1762,12 +1762,6 @@ OpKernelType OperatorWithKernel::GetKernelTypeForVar(
 
 KernelSignature OperatorWithKernel::GetExpectedPtenKernelArgs(
     const ExecutionContext& ctx) const {
-  if (!KernelSignatureMap::Instance().Has(Type())) {
-    // TODO(chenweihang): we can generate this map by proto info in compile time
-    KernelArgsNameMakerByOpProto maker(Info().proto_);
-    KernelSignatureMap::Instance().Emplace(
-        Type(), std::move(maker.GetKernelSignature()));
-  }
   return KernelSignatureMap::Instance().Get(Type());
 }
 

--- a/paddle/fluid/framework/pten_utils.cc
+++ b/paddle/fluid/framework/pten_utils.cc
@@ -117,7 +117,7 @@ KernelSignatureMap& KernelSignatureMap::Instance() {
 }
 
 bool KernelSignatureMap::Has(const std::string& op_type) const {
-  return map_.count(op_type) > 0;
+  return map_.find(op_type) != map_.end();
 }
 
 const KernelSignature& KernelSignatureMap::Get(

--- a/paddle/fluid/framework/pten_utils.cc
+++ b/paddle/fluid/framework/pten_utils.cc
@@ -15,14 +15,44 @@ limitations under the License. */
 #include <sstream>
 
 #include "paddle/fluid/framework/pten_utils.h"
+#include "paddle/pten/core/kernel_factory.h"
 
 #include "paddle/fluid/framework/lod_tensor.h"
+#include "paddle/fluid/framework/op_info.h"
 #include "paddle/fluid/framework/selected_rows.h"
 #include "paddle/fluid/framework/variable.h"
 #include "paddle/fluid/string/string_helper.h"
 
 namespace paddle {
 namespace framework {
+
+class KernelArgsNameMakerByOpProto : public KernelArgsNameMaker {
+ public:
+  explicit KernelArgsNameMakerByOpProto(
+      const framework::proto::OpProto* op_proto)
+      : op_proto_(op_proto) {
+    PADDLE_ENFORCE_NOT_NULL(op_proto_, platform::errors::InvalidArgument(
+                                           "Op proto cannot be nullptr."));
+  }
+
+  ~KernelArgsNameMakerByOpProto() {}
+
+  const paddle::SmallVector<std::string>& GetInputArgsNames() override;
+  const paddle::SmallVector<std::string>& GetOutputArgsNames() override;
+  const paddle::SmallVector<std::string>& GetAttrsArgsNames() override;
+
+  KernelSignature GetKernelSignature();
+
+ private:
+  DISABLE_COPY_AND_ASSIGN(KernelArgsNameMakerByOpProto);
+
+ private:
+  const framework::proto::OpProto* op_proto_;
+
+  paddle::SmallVector<std::string> input_names_;
+  paddle::SmallVector<std::string> output_names_;
+  paddle::SmallVector<std::string> attr_names_;
+};
 
 OpKernelType TransPtenKernelKeyToOpKernelType(
     const pten::KernelKey& kernel_key) {
@@ -60,30 +90,34 @@ pten::KernelKey TransOpKernelTypeToPtenKernelKey(
 }
 
 KernelSignatureMap* KernelSignatureMap::kernel_signature_map_ = nullptr;
-std::mutex KernelSignatureMap::mutex_;
+std::once_flag KernelSignatureMap::init_flag_;
 
 KernelSignatureMap& KernelSignatureMap::Instance() {
-  if (kernel_signature_map_ == nullptr) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    if (kernel_signature_map_ == nullptr) {
-      kernel_signature_map_ = new KernelSignatureMap;
+  std::call_once(init_flag_, [] {
+    kernel_signature_map_ = new KernelSignatureMap();
+    for (const auto& pair : OpInfoMap::Instance().map()) {
+      const auto& op_type = pair.first;
+      const auto* op_proto = pair.second.proto_;
+      if (pten::KernelFactory::Instance().HasCompatiblePtenKernel(op_type)) {
+        KernelArgsNameMakerByOpProto maker(op_proto);
+        VLOG(10) << "Register kernel signature for " << op_type;
+        auto success =
+            kernel_signature_map_->map_
+                .emplace(op_type, std::move(maker.GetKernelSignature()))
+                .second;
+        PADDLE_ENFORCE_EQ(
+            success, true,
+            platform::errors::PermissionDenied(
+                "Kernel signature of the operator %s has been registered.",
+                op_type));
+      }
     }
-  }
+  });
   return *kernel_signature_map_;
 }
 
 bool KernelSignatureMap::Has(const std::string& op_type) const {
-  return map_.find(op_type) != map_.end();
-}
-
-void KernelSignatureMap::Emplace(const std::string& op_type,
-                                 KernelSignature&& signature) {
-  if (!Has(op_type)) {
-    std::unique_lock<std::mutex> lock(mutex_);
-    if (!Has(op_type)) {
-      map_.emplace(op_type, signature);
-    }
-  }
+  return map_.count(op_type) > 0;
 }
 
 const KernelSignature& KernelSignatureMap::Get(

--- a/paddle/fluid/framework/pten_utils.h
+++ b/paddle/fluid/framework/pten_utils.h
@@ -67,8 +67,6 @@ class KernelSignatureMap {
 
   bool Has(const std::string& op_type) const;
 
-  void Emplace(const std::string& op_type, KernelSignature&& signature);
-
   const KernelSignature& Get(const std::string& op_type) const;
 
  private:
@@ -77,7 +75,7 @@ class KernelSignatureMap {
 
  private:
   static KernelSignatureMap* kernel_signature_map_;
-  static std::mutex mutex_;
+  static std::once_flag init_flag_;
 
   paddle::flat_hash_map<std::string, KernelSignature> map_;
 };
@@ -88,27 +86,6 @@ class KernelArgsNameMaker {
   virtual const paddle::SmallVector<std::string>& GetInputArgsNames() = 0;
   virtual const paddle::SmallVector<std::string>& GetOutputArgsNames() = 0;
   virtual const paddle::SmallVector<std::string>& GetAttrsArgsNames() = 0;
-};
-
-class KernelArgsNameMakerByOpProto : public KernelArgsNameMaker {
- public:
-  explicit KernelArgsNameMakerByOpProto(framework::proto::OpProto* op_proto)
-      : op_proto_(op_proto) {}
-
-  ~KernelArgsNameMakerByOpProto() {}
-
-  const paddle::SmallVector<std::string>& GetInputArgsNames() override;
-  const paddle::SmallVector<std::string>& GetOutputArgsNames() override;
-  const paddle::SmallVector<std::string>& GetAttrsArgsNames() override;
-
-  KernelSignature GetKernelSignature();
-
- private:
-  framework::proto::OpProto* op_proto_;
-
-  paddle::SmallVector<std::string> input_names_;
-  paddle::SmallVector<std::string> output_names_;
-  paddle::SmallVector<std::string> attr_names_;
 };
 
 std::string KernelSignatureToString(const KernelSignature& signature);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
The double checking does not work! The PaddleNLP BERT model hangs because of core dump. The double checking does not guarantee:
- thread safety.
- thread visibility.

Considering the following codes:

```C++
void KernelSignatureMap::Emplace(const std::string& op_type,
                                 KernelSignature&& signature) {
  if (!Has(op_type)) { // code C1
    std::unique_lock<std::mutex> lock(mutex_);
    if (!Has(op_type)) {
      map_.emplace(op_type, signature); // code C2
    }
  }
}
```

The problems would be:
- thread safety: when C1 and C2 are executed concurrently, the data structure of the `map_` may be corrupted when C2 is running (C2 is not an atomic operation). Therefore, C1 (C1 is not an atomic operation) may occur core dump.
- thread visibility: even though C1 and C2 are not executed concurrently, the side-effect after L2 is executed (i.e., a new key-value pair is inserted) may not be seen when C1 is executed in another thread. It is because: (1) the compiler/CPU may reorder the CPU instruction. The actual execution order of the codes may not be the same as what we expect. (2) the CPU has cache for memory. Only when memory barrier is used (for example, use `std::mutex`), we would get the right value (which is changed in another thread) in the current thread.