### PR TITLE
fix bugs when build in windows with_inference_api_test=on

### DIFF
--- a/cmake/external/dirent.cmake
+++ b/cmake/external/dirent.cmake
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note(chenxin33): dirent.h is only exist in Linux, so get it from github when build in windows.
+# use dirent tag v1.23.2 on 09/05//2018 https://github.com/tronkko/dirent.git
+
+INCLUDE (ExternalProject)
+
+SET(DIRENT_PREFIX_DIR       ${THIRD_PARTY_PATH}/dirent)
+SET(DIRENT_SOURCE_DIR       ${THIRD_PARTY_PATH}/dirent/src/extern_dirent)
+SET(DIRENT_INCLUDE_DIR      ${DIRENT_SOURCE_DIR}/include)
+
+include_directories(${DIRENT_INCLUDE_DIR})
+
+set(DIRENT_REPOSITORY  ${GIT_URL}/tronkko/dirent)
+set(DIRENT_TAG         1.23.2)
+
+ExternalProject_Add(
+  extern_dirent
+  ${EXTERNAL_PROJECT_LOG_ARGS}
+  ${SHALLOW_CLONE}
+  GIT_REPOSITORY  ${DIRENT_REPOSITORY}
+  GIT_TAG         ${DIRENT_TAG}
+  PREFIX          ${DIRENT_PREFIX_DIR}
+  UPDATE_COMMAND    ""
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
+)
+
+add_library(dirent INTERFACE)
+
+add_dependencies(dirent extern_dirent)

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -378,4 +378,9 @@ if (WITH_POCKETFFT)
     add_definitions(-DPADDLE_WITH_POCKETFFT)
 endif (WITH_POCKETFFT)
 
+if (WIN32)
+    include(external/dirent)
+    list(APPEND third_party_deps extern_dirent)
+endif (WIN32)
+
 add_custom_target(third_party ALL DEPENDS ${third_party_deps})

--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -465,7 +465,8 @@ void PredictionWarmUp(PaddlePredictor *predictor,
   }
   int iterations = 1;
   if (FLAGS_warmup_iters > 1)
-    iterations = std::min(FLAGS_warmup_iters, static_cast<int>(inputs.size()));
+    iterations =
+        (std::min)(FLAGS_warmup_iters, static_cast<int>(inputs.size()));
   outputs->resize(iterations);
   Timer warmup_timer;
   double elapsed_time = 0;

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_fp16_serialize_deserialize_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_fp16_serialize_deserialize_test.cc
@@ -13,9 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include <dirent.h>
+#ifndef _WIN32
+#include <unistd.h>
+#else  // headers below are substitute of unistd.h in windows
+#include <io.h>
+#include <process.h>
+#endif
+#define GLOG_NO_ABBREVIATED_SEVERITIES
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <unistd.h>
 #include "gflags/gflags.h"
 
 #include "paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h"

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.cc
@@ -13,9 +13,15 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include <dirent.h>
+#ifndef _WIN32
+#include <unistd.h>
+#else  // headers below are substitute of unistd.h in windows
+#include <io.h>
+#include <process.h>
+#endif
+#define GLOG_NO_ABBREVIATED_SEVERITIES
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <unistd.h>
 #include "gflags/gflags.h"
 
 #include "paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h"

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h
@@ -14,7 +14,12 @@ limitations under the License. */
 #pragma once
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#ifndef _WIN32
 #include <unistd.h>
+#else  // headers below are substitute of unistd.h in windows
+#include <io.h>
+#include <process.h>
+#endif
 #include <functional>
 #include <map>
 #include <string>

--- a/paddle/fluid/platform/complex.h
+++ b/paddle/fluid/platform/complex.h
@@ -352,12 +352,12 @@ HOSTDEVICE inline bool operator>=(const complex<T>& a, const complex<T>& b) {
 }
 
 template <typename T>
-HOSTDEVICE inline complex<T> max(const complex<T>& a, const complex<T>& b) {
+HOSTDEVICE inline complex<T>(max)(const complex<T>& a, const complex<T>& b) {
   return (a.real >= b.real) ? a : b;
 }
 
 template <typename T>
-HOSTDEVICE inline complex<T> min(const complex<T>& a, const complex<T>& b) {
+HOSTDEVICE inline complex<T>(min)(const complex<T>& a, const complex<T>& b) {
   return (a.real < b.real) ? a : b;
 }
 
@@ -507,13 +507,13 @@ struct numeric_limits<paddle::platform::complex<T>> {
   static const bool traps = false;
   static const bool tinyness_before = false;
 
-  static paddle::platform::complex<T> min() {
+  static paddle::platform::complex<T>(min)() {
     return paddle::platform::complex<T>(0.0, 0.0);
   }
   static paddle::platform::complex<T> lowest() {
     return paddle::platform::complex<T>(0.0, 0.0);
   }
-  static paddle::platform::complex<T> max() {
+  static paddle::platform::complex<T>(max)() {
     return paddle::platform::complex<T>(0.0, 0.0);
   }
   static paddle::platform::complex<T> epsilon() {

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -37,6 +37,9 @@ limitations under the License. */
 #ifdef WITH_WIN_DUMP_DBG
 #include <stdio.h>
 #include <time.h>
+#ifndef NOMINMAX
+#define NOMINMAX  // msvc max/min macro conflict with std::min/max
+#endif
 #include <windows.h>
 
 #include "DbgHelp.h"

--- a/paddle/fluid/platform/port.h
+++ b/paddle/fluid/platform/port.h
@@ -30,13 +30,16 @@
 #include <sys/time.h>
 #include <algorithm>  // std::accumulate
 #else
+#ifndef NOMINMAX
 #define NOMINMAX  // msvc max/min macro conflict with std::min/max
+#endif
 // solve static linking error in windows
 // https://github.com/google/glog/issues/301
 #define GOOGLE_GLOG_DLL_DECL
 #include <io.h>  // _popen, _pclose
 #include <stdio.h>
 #include <windows.h>
+#include <winsock.h>
 #include <numeric>  // std::accumulate in msvc
 #ifndef S_ISDIR     // windows port for sys/stat.h
 #define S_ISDIR(mode) (((mode)&S_IFMT) == S_IFDIR)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

-  <dirent.h> included by files only exist in Linux system, So I add [dirent.h](https://github.com/tronkko/dirent) compatible with Windows as third party
- include <io.h> and <process.h> instead of <unistd.h> when defined _WIN32 macro
- include <winsock.h> to avoid error of undefined type timeval 
- add tokens to min and max function name in complex.h to avoid macro expand, so that compiler can resolve function definition rightly.
<img width="1201" alt="1e ot Ov  Lanes1e Spe Ce gavat For PA BAe11" src="https://user-images.githubusercontent.com/51314274/140699091-b70962a3-ebd9-4a18-b057-1971d92bec69.png">
<img width="1005" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/51314274/140698861-79b5368b-24ac-4f8f-828a-63bcb4ea3adc.png">



