### PR TITLE
cinn_launch_op: remove the check on extracting temporary variables

### DIFF
--- a/paddle/fluid/operators/cinn_launch_op.cc
+++ b/paddle/fluid/operators/cinn_launch_op.cc
@@ -137,9 +137,7 @@ std::vector<std::string> SeperateTempVar(
       [](const auto& name_view) { return std::string(name_view.data()); });
 
   auto exclude_fn = [&all_cinn_names](const auto& cinn_name) {
-    PADDLE_ENFORCE_EQ(all_cinn_names.erase(cinn_name), 1,
-                      platform::errors::NotFound(
-                          "Variable(%s) not found in cinn scope", cinn_name));
+    all_cinn_names.erase(cinn_name);
   };
 
   std::for_each(input_cinn_names.begin(), input_cinn_names.end(), exclude_fn);

--- a/paddle/fluid/operators/cinn_launch_op.h
+++ b/paddle/fluid/operators/cinn_launch_op.h
@@ -179,7 +179,7 @@ class CinnLaunchOpKernel : public framework::OpKernel<T> {
                                                tensor);
       }
 
-      VLOG(4) << "Prepare outnput argument-" << i << ":"
+      VLOG(4) << "Prepare output argument-" << i << ":"
               << "name(" << var_name << "->" << cinn_name << "), "
               << "tensor(type:" << tensor->type() << ","
               << "dims:" << tensor->dims() << ").";
@@ -188,9 +188,12 @@ class CinnLaunchOpKernel : public framework::OpKernel<T> {
       hold_buffers.emplace_back(std::move(buffer));
     }
 
-    // 3.3 Prepare temporary variables: Create a temporary scope
-    //     to keep temporary variables needed by compiled runtime program
-    //     in addition, they directly use the names from CinnScope.
+    // 3.3 Prepare internal or temporary variables: Create a temporary
+    //     scope to keep internal variables within graph or temporary
+    //     variables needed by the compiled runtime program in addition.
+    //     Here we directly use the names from CinnScope as Paddle variable
+    //     names, because they will not be used outside the graph
+    //     and should be destructed after computation finished.
     auto temp_variable_names = details::SeperateTempVar(
         cinn_scope, input_cinn_names, output_cinn_names);
     auto temp_scope = scope.NewTmpScope();

--- a/paddle/fluid/operators/cinn_launch_op_test.cc
+++ b/paddle/fluid/operators/cinn_launch_op_test.cc
@@ -263,9 +263,6 @@ TEST(CinnLaunchOpHelperTest, TestSeperateTempVar) {
       SeperateTempVar(cinn_scope, {"cinn_var1", "cinn_var2"}, {"cinn_var4"});
   ASSERT_EQ(temp_names.size(), 1);
   EXPECT_EQ(temp_names.front(), "cinn_var3");
-  ASSERT_THROW(
-      SeperateTempVar(cinn_scope, {"cinn_var1", "not_exist"}, {"cinn_var4"}),
-      paddle::platform::EnforceNotMet);
 }
 
 TEST(CinnLaunchOpHelperTest, TestShareTensorWithCinnBuffer) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
cinn_launch_op: remove the check on extracting temporary variables