### PR TITLE
Fix fleet executor cmake dependence error

### DIFF
--- a/paddle/fluid/distributed/fleet_executor/CMakeLists.txt
+++ b/paddle/fluid/distributed/fleet_executor/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 cc_library(fleet_executor SRCS fleet_executor.cc carrier.cc
         interceptor.cc interceptor_message_service.cc message_bus.cc
-        DEPS fleet_executor_desc_proto interceptor_message_proto ${BRPC_DEPS})
+        DEPS proto_desc fleet_executor_desc_proto interceptor_message_proto ${BRPC_DEPS})
 
 if(WITH_DISTRIBUTE)
   set(DISTRIBUTE_COMPILE_FLAGS "-Wno-non-virtual-dtor -Wno-error=non-virtual-dtor -Wno-error=delete-non-virtual-dtor")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix fleet executor cmake dependence error.

The fleet_executor.cc include the program_desc.h, but not dep the proto_desc target, which cause random compile error in musl ci like

<img width="874" alt="5b6e1951b61380ddec627b11e23093b2" src="https://user-images.githubusercontent.com/22561442/140674577-7a69c22d-a39e-4640-992c-5edccc12c575.png">

