### PR TITLE
【cherry-pick】Setitem support passing stop_gradient from value to tensor (#37023)

### DIFF
--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -985,6 +985,12 @@ void BindImperative(py::module *m_ptr) {
                 auto value_tensor =
                     value_obj.cast<std::shared_ptr<imperative::VarBase>>();
                 ins.insert({"ValueTensor", {value_tensor}});
+
+                // pass the stop_gradient from value to tensor
+                if (!value_tensor->OverridedStopGradient() &&
+                    self->OverridedStopGradient()) {
+                  self->SetOverridedStopGradient(false);
+                }
               } else if (py::isinstance<py::array>(value_obj)) {
                 auto value_tensor = std::shared_ptr<imperative::VarBase>(
                     new imperative::VarBase(false,

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -1154,6 +1154,18 @@ class TestGradientTruncated(unittest.TestCase):
             msg="The gradient of input should be \n{},\n but reveived {}".
             format(value_grad, value.grad.numpy()))
 
+        # case 6: pass stop_gradient from value to x
+        x = paddle.zeros([8, 8], dtype='float32')
+        value = paddle.to_tensor([10], dtype='float32', stop_gradient=False)
+
+        self.assertTrue(x.stop_gradient)
+        self.assertTrue(x.is_leaf)
+
+        x[0, :] = value
+
+        self.assertTrue(~x.stop_gradient)
+        self.assertTrue(~x.is_leaf)
+
     def test_static_graph(self):
         paddle.enable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Fix [issue:36902](https://github.com/PaddlePaddle/Paddle/issues/36902)

Before this PR:
```
a = paddle.rand(shape=[1,4])
b = paddle.rand(shape=[1,4])
a.stop_gradient = False
b.stop_gradient = False

d = paddle.zeros((4, 4))
print(d.stop_gradient)  # True
c = a/b
d[0, :] = a/b

print(c.stop_gradient)  # False
print('Is d requires grad: ', not d.stop_gradient)  # Is d requires grad:  False
```

Now:
```
a = paddle.rand(shape=[1,4])
b = paddle.rand(shape=[1,4])
a.stop_gradient = False
b.stop_gradient = False

d = paddle.zeros((4, 4))
print(d.stop_gradient)  # True
c = a/b
d[0, :] = a/b

print(c.stop_gradient)  # False
print('Is d requires grad: ', not d.stop_gradient)  # Is d requires grad:  True
```