### PR TITLE
【PaddlePaddle Hackathon】16、在 Paddle 中新增 WideResNet

### DIFF
--- a/python/paddle/tests/test_vision_models.py
+++ b/python/paddle/tests/test_vision_models.py
@@ -70,6 +70,12 @@ class TestVisonModels(unittest.TestCase):
     def test_resnet152(self):
         self.models_infer('resnet152')
 
+    def test_wide_resnet50_2(self):
+        self.models_infer('wide_resnet50_2')
+
+    def test_wide_resnet101_2(self):
+        self.models_infer('wide_resnet101_2')
+
     def test_densenet121(self):
         self.models_infer('densenet121')
 

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -34,6 +34,8 @@ from .models import resnet34  # noqa: F401
 from .models import resnet50  # noqa: F401
 from .models import resnet101  # noqa: F401
 from .models import resnet152  # noqa: F401
+from .models import wide_resnet50_2  # noqa: F401
+from .models import wide_resnet101_2  # noqa: F401
 from .models import MobileNetV1  # noqa: F401
 from .models import mobilenet_v1  # noqa: F401
 from .models import MobileNetV2  # noqa: F401

--- a/python/paddle/vision/models/__init__.py
+++ b/python/paddle/vision/models/__init__.py
@@ -18,6 +18,8 @@ from .resnet import resnet34  # noqa: F401
 from .resnet import resnet50  # noqa: F401
 from .resnet import resnet101  # noqa: F401
 from .resnet import resnet152  # noqa: F401
+from .resnet import wide_resnet50_2  # noqa: F401
+from .resnet import wide_resnet101_2  # noqa: F401
 from .mobilenetv1 import MobileNetV1  # noqa: F401
 from .mobilenetv1 import mobilenet_v1  # noqa: F401
 from .mobilenetv2 import MobileNetV2  # noqa: F401
@@ -66,6 +68,8 @@ __all__ = [ #noqa
     'resnet50',
     'resnet101',
     'resnet152',
+    'wide_resnet50_2',
+    'wide_resnet101_2',
     'VGG',
     'vgg11',
     'vgg13',

--- a/python/paddle/vision/models/resnet.py
+++ b/python/paddle/vision/models/resnet.py
@@ -15,9 +15,10 @@
 from __future__ import division
 from __future__ import print_function
 
+from typing import Type, Any, Callable, Union, List, Optional
 import paddle
 import paddle.nn as nn
-
+from paddle import Tensor
 from paddle.utils.download import get_weights_path_from_url
 
 __all__ = []
@@ -36,36 +37,66 @@ model_urls = {
 }
 
 
+def conv3x3(in_planes: int,
+            out_planes: int,
+            stride: int = 1,
+            groups: int = 1,
+            dilation: int = 1) -> nn.Conv2D:
+    """3x3 convolution with padding."""
+    return nn.Conv2D(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=dilation,
+        groups=groups,
+        dilation=dilation,
+        bias_attr=False)
+
+
+def conv1x1(in_planes: int,
+            out_planes: int,
+            stride: int = 1) -> nn.Conv2D:
+    """1x1 convolution"""
+    return nn.Conv2D(
+        in_planes,
+        out_planes,
+        kernel_size=1,
+        stride=stride,
+        bias_attr=False)
+
+
 class BasicBlock(nn.Layer):
-    expansion = 1
+    expansion: int = 1
 
     def __init__(self,
-                 inplanes,
-                 planes,
-                 stride=1,
-                 downsample=None,
-                 groups=1,
-                 base_width=64,
-                 dilation=1,
-                 norm_layer=None):
+                 inplanes: int,
+                 planes: int,
+                 stride: int = 1,
+                 downsample: Optional[nn.Layer] = None,
+                 groups: int = 1,
+                 base_width: int = 64,
+                 dilation: int = 1,
+                 norm_layer: Optional[Callable[..., nn.Layer]] = None) -> None:
         super(BasicBlock, self).__init__()
         if norm_layer is None:
             norm_layer = nn.BatchNorm2D
-
+        if groups != 1 or base_width != 64:
+            raise ValueError(
+                'BasicBlock only supports groups=1 and base_width=64')
         if dilation > 1:
             raise NotImplementedError(
                 "Dilation > 1 not supported in BasicBlock")
-
-        self.conv1 = nn.Conv2D(
-            inplanes, planes, 3, padding=1, stride=stride, bias_attr=False)
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv3x3(inplanes, planes, stride)
         self.bn1 = norm_layer(planes)
         self.relu = nn.ReLU()
-        self.conv2 = nn.Conv2D(planes, planes, 3, padding=1, bias_attr=False)
+        self.conv2 = conv3x3(planes, planes)
         self.bn2 = norm_layer(planes)
         self.downsample = downsample
-        self.stride = stride
+        self.stride = stride  # TODO: this line can be deleted
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         identity = x
 
         out = self.conv1(x)
@@ -85,45 +116,40 @@ class BasicBlock(nn.Layer):
 
 
 class BottleneckBlock(nn.Layer):
-
-    expansion = 4
+    """
+    BottleneckBlock places the stride for downsampling at 3x3 convolution(self.conv2)
+    while original implementation places the stride at the first 1x1 convolution(self.conv1)
+    according to "Deep residual learning for image recognition"https://arxiv.org/abs/1512.03385.
+    This variant is also known as ResNet V1.5 and improves accuracy according to
+    https://ngc.nvidia.com/catalog/model-scripts/nvidia:resnet_50_v1_5_for_pytorch.
+    """
+    expansion: int = 4
 
     def __init__(self,
-                 inplanes,
-                 planes,
-                 stride=1,
-                 downsample=None,
-                 groups=1,
-                 base_width=64,
-                 dilation=1,
-                 norm_layer=None):
+                 inplanes: int,
+                 planes: int,
+                 stride: int = 1,
+                 downsample: Optional[nn.Layer] = None,
+                 groups: int = 1,
+                 base_width: int = 64,
+                 dilation: int = 1,
+                 norm_layer: Optional[Callable[..., nn.Layer]] = None) -> None:
         super(BottleneckBlock, self).__init__()
         if norm_layer is None:
             norm_layer = nn.BatchNorm2D
         width = int(planes * (base_width / 64.)) * groups
-
-        self.conv1 = nn.Conv2D(inplanes, width, 1, bias_attr=False)
+        # Both self.conv2 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv1x1(inplanes, width)
         self.bn1 = norm_layer(width)
-
-        self.conv2 = nn.Conv2D(
-            width,
-            width,
-            3,
-            padding=dilation,
-            stride=stride,
-            groups=groups,
-            dilation=dilation,
-            bias_attr=False)
+        self.conv2 = conv3x3(width, width, stride, groups, dilation)
         self.bn2 = norm_layer(width)
-
-        self.conv3 = nn.Conv2D(
-            width, planes * self.expansion, 1, bias_attr=False)
+        self.conv3 = conv1x1(width, planes * self.expansion)
         self.bn3 = norm_layer(planes * self.expansion)
         self.relu = nn.ReLU()
         self.downsample = downsample
-        self.stride = stride
+        self.stride = stride  # TODO: this line can be deleted
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         identity = x
 
         out = self.conv1(x)
@@ -153,7 +179,7 @@ class ResNet(nn.Layer):
     Args:
         Block (BasicBlock|BottleneckBlock): block module of model.
         depth (int): layers of resnet, default: 50.
-        num_classes (int): output dim of last fc layer. If num_classes <=0, last fc layer 
+        num_classes (int): output dim of last fc layer. If num_classes <=0, last fc layer
                             will not be defined. Default: 1000.
         with_pool (bool): use pool before the last fc layer or not. Default: True.
 
@@ -169,7 +195,15 @@ class ResNet(nn.Layer):
 
     """
 
-    def __init__(self, block, depth, num_classes=1000, with_pool=True):
+    def __init__(self,
+                 block: Type[Union[BasicBlock, BottleneckBlock]],
+                 depth: int,
+                 num_classes: int = 1000,
+                 groups: int = 1,
+                 width_per_group: int = 64,
+                 replace_stride_with_dilation: Optional[List[bool]] = None,
+                 norm_layer: Optional[Callable[..., nn.Layer]] = None,
+                 with_pool: bool = True) -> None:
         super(ResNet, self).__init__()
         layer_cfg = {
             18: [2, 2, 2, 2],
@@ -181,11 +215,23 @@ class ResNet(nn.Layer):
         layers = layer_cfg[depth]
         self.num_classes = num_classes
         self.with_pool = with_pool
-        self._norm_layer = nn.BatchNorm2D
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2D
+        self._norm_layer = norm_layer
 
         self.inplanes = 64
         self.dilation = 1
-
+        if replace_stride_with_dilation is None:
+            # each element in the tuple indicates if we should replace
+            # the 2x2 stride with a dilated convolution instead
+            replace_stride_with_dilation = [False, False, False]
+        if not isinstance(replace_stride_with_dilation, (
+                tuple, list)) or len(replace_stride_with_dilation) != 3:
+            raise ValueError("replace_stride_with_dilation should be None "
+                             "or a 3-element tuple/list, got {}".format(
+                replace_stride_with_dilation))
+        self.groups = groups
+        self.base_width = width_per_group
         self.conv1 = nn.Conv2D(
             3,
             self.inplanes,
@@ -197,16 +243,35 @@ class ResNet(nn.Layer):
         self.relu = nn.ReLU()
         self.maxpool = nn.MaxPool2D(kernel_size=3, stride=2, padding=1)
         self.layer1 = self._make_layer(block, 64, layers[0])
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+        self.layer2 = self._make_layer(
+            block,
+            128,
+            layers[1],
+            stride=2,
+            dilate=replace_stride_with_dilation[0])
+        self.layer3 = self._make_layer(
+            block,
+            256,
+            layers[2],
+            stride=2,
+            dilate=replace_stride_with_dilation[1])
+        self.layer4 = self._make_layer(
+            block,
+            512,
+            layers[3],
+            stride=2,
+            dilate=replace_stride_with_dilation[2])
         if with_pool:
             self.avgpool = nn.AdaptiveAvgPool2D((1, 1))
-
         if num_classes > 0:
             self.fc = nn.Linear(512 * block.expansion, num_classes)
 
-    def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
+    def _make_layer(self,
+                    block: Type[Union[BasicBlock, BottleneckBlock]],
+                    planes: int,
+                    blocks: int,
+                    stride: int = 1,
+                    dilate: bool = False) -> nn.Sequential:
         norm_layer = self._norm_layer
         downsample = None
         previous_dilation = self.dilation
@@ -215,25 +280,27 @@ class ResNet(nn.Layer):
             stride = 1
         if stride != 1 or self.inplanes != planes * block.expansion:
             downsample = nn.Sequential(
-                nn.Conv2D(
-                    self.inplanes,
-                    planes * block.expansion,
-                    1,
-                    stride=stride,
-                    bias_attr=False),
+                conv1x1(self.inplanes, planes * block.expansion, stride),
                 norm_layer(planes * block.expansion), )
 
         layers = []
         layers.append(
-            block(self.inplanes, planes, stride, downsample, 1, 64,
-                  previous_dilation, norm_layer))
+            block(self.inplanes, planes, stride, downsample, self.groups,
+                  self.base_width, previous_dilation, norm_layer))
         self.inplanes = planes * block.expansion
         for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes, norm_layer=norm_layer))
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=self.dilation,
+                    norm_layer=norm_layer))
 
         return nn.Sequential(*layers)
 
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         x = self.conv1(x)
         x = self.bn1(x)
         x = self.relu(x)
@@ -253,27 +320,31 @@ class ResNet(nn.Layer):
         return x
 
 
-def _resnet(arch, Block, depth, pretrained, **kwargs):
-    model = ResNet(Block, depth, **kwargs)
+def _resnet(arch: str,
+            block: Type[Union[BasicBlock, BottleneckBlock]],
+            depth: int,
+            pretrained: bool,
+            **kwargs: Any) -> ResNet:
+    model = ResNet(block, depth, **kwargs)
     if pretrained:
         assert arch in model_urls, "{} model do not have a pretrained model now, you should set pretrained=False".format(
             arch)
-        weight_path = get_weights_path_from_url(model_urls[arch][0],
-                                                model_urls[arch][1])
-
-        param = paddle.load(weight_path)
+        weights_path = get_weights_path_from_url(model_urls[arch][0],
+                                                 model_urls[arch][1])
+        param = paddle.load(weights_path)
         model.set_dict(param)
 
     return model
 
 
-def resnet18(pretrained=False, **kwargs):
-    """ResNet 18-layer model
-    
+def resnet18(pretrained: bool = False, **kwargs: Any) -> ResNet:
+    r"""ResNet-18 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
-    Examples:
+        Examples:
         .. code-block:: python
 
             from paddle.vision.models import resnet18
@@ -287,12 +358,13 @@ def resnet18(pretrained=False, **kwargs):
     return _resnet('resnet18', BasicBlock, 18, pretrained, **kwargs)
 
 
-def resnet34(pretrained=False, **kwargs):
-    """ResNet 34-layer model
-    
+def resnet34(pretrained: bool = False, **kwargs: Any) -> ResNet:
+    r"""ResNet-34 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
-    
+
     Examples:
         .. code-block:: python
 
@@ -307,9 +379,10 @@ def resnet34(pretrained=False, **kwargs):
     return _resnet('resnet34', BasicBlock, 34, pretrained, **kwargs)
 
 
-def resnet50(pretrained=False, **kwargs):
-    """ResNet 50-layer model
-    
+def resnet50(pretrained: bool = False, **kwargs: Any) -> ResNet:
+    r"""ResNet-50 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
@@ -327,9 +400,10 @@ def resnet50(pretrained=False, **kwargs):
     return _resnet('resnet50', BottleneckBlock, 50, pretrained, **kwargs)
 
 
-def resnet101(pretrained=False, **kwargs):
-    """ResNet 101-layer model
-    
+def resnet101(pretrained: bool = False, **kwargs: Any) -> ResNet:
+    r"""ResNet-101 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
@@ -342,14 +416,15 @@ def resnet101(pretrained=False, **kwargs):
             model = resnet101()
 
             # build model and load imagenet pretrained weight
-            # model = resnet101(pretrained=True)
+            model = resnet101(pretrained=True)
     """
     return _resnet('resnet101', BottleneckBlock, 101, pretrained, **kwargs)
 
 
-def resnet152(pretrained=False, **kwargs):
-    """ResNet 152-layer model
-    
+def resnet152(pretrained: bool = False, **kwargs: Any) -> ResNet:
+    r"""ResNet-152 model from
+    `"Deep Residual Learning for Image Recognition" <https://arxiv.org/pdf/1512.03385.pdf>`_.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
 
@@ -362,6 +437,54 @@ def resnet152(pretrained=False, **kwargs):
             model = resnet152()
 
             # build model and load imagenet pretrained weight
-            # model = resnet152(pretrained=True)
+            model = resnet152(pretrained=True)
     """
     return _resnet('resnet152', BottleneckBlock, 152, pretrained, **kwargs)
+
+
+def wide_resnet50_2(pretrained: bool = False, **kwargs: Any) -> ResNet:
+    r"""Wide ResNet-50-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_.
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+
+    Examples:
+        .. code-block:: python
+
+            from paddle.vision.models import wide_resnet50_2
+
+            # build model
+            model = wide_resnet50_2()
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet50_2', BottleneckBlock, 50, pretrained, **kwargs)
+
+
+def wide_resnet101_2(pretrained: bool = False, **kwargs: Any) -> ResNet:
+    r"""Wide ResNet-101-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_.
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+
+    Examples:
+        .. code-block:: python
+
+            from paddle.vision.models import wide_resnet101_2
+
+            # build model
+            model = wide_resnet101_2()
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet101_2', BottleneckBlock, 101, pretrained, **kwargs)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
APIs

### Describe
add wide resnet
task 16: #35994
改写自 torchvision.models.resnet

1.torchvision.models中的wide resnet预训练模型被转化为paddle预训练模型，纯手工完成，代码地址如下:
https://github.com/SmirnovKol/some-useful-code/blob/main/pytorch_to_paddle.ipynb

2.转化后的paddle预训练模型地址如下:
https://aistudio.baidu.com/aistudio/datasetdetail/115082/0

3.验证转化后的paddle模型在Imagenet-1k验证集上的精度(请查看v0.1版):
https://aistudio.baidu.com/aistudio/projectdetail/2557824

wide_resnet50_2: {'acc_top1': 0.78468, 'acc_top5': 0.94086}
wide_resnet101_2: {'acc_top1': 0.78846, 'acc_top5': 0.94284}
