### PR TITLE
fix recurrent_grad tmp variable@GRAD don't exsit in VariableScope

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -174,7 +174,8 @@ std::vector<OperatorBase*> create_all_ops(const framework::BlockDesc& block) {
 }
 
 std::tuple<VariableValueMap, VariableIdMap> build_variable_map(
-    const VariableNameMap& var_name_map, VariableScope* var_scope) {
+    const VariableNameMap& var_name_map, VariableScope* var_scope,
+    bool enforce_exist = true) {
   VariableValueMap name2var;
   VariableIdMap name2id;
   for (auto& item : var_name_map) {
@@ -183,6 +184,11 @@ std::tuple<VariableValueMap, VariableIdMap> build_variable_map(
     vars.reserve(item.second.size());
 
     for (auto& var_name : item.second) {
+      if (!enforce_exist && !var_scope->HasVar(var_name)) {
+        // skip the non-exist variable: such as recurrent_grad
+        VLOG(4) << var_name << " don't exist in variable scope, skip it!";
+        continue;
+      }
       auto var_id = var_scope->VarId(var_name);
       auto* in_var = var_scope->Var(var_id);
       vars.push_back(in_var);
@@ -439,13 +445,15 @@ void build_op_func_list(const platform::Place& place,
 
     VariableValueMap ins_map;
     VariableIdMap ins_name2id;
+    bool enforce_exist = true;
+    if (op->Type() == "recurrent_grad") enforce_exist = false;
     std::tie(ins_map, ins_name2id) =
-        build_variable_map(inputs_names, var_scope);
+        build_variable_map(inputs_names, var_scope, enforce_exist);
 
     VariableValueMap outs_map;
     VariableIdMap outs_name2id;
     std::tie(outs_map, outs_name2id) =
-        build_variable_map(outputs_names, var_scope);
+        build_variable_map(outputs_names, var_scope, enforce_exist);
 
     // step 2: build OpFuncNode
     OpFuncNode op_func_node;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Fix recurrent_grad tmp variable@GRAD don't exsit in VariableScope

### 背景
在seq2seq模型上开启新执行器的时候，发现RNN的一个OP报了错误：一个临时变量不存在VariableScope中。最后定位到了recurrent_grad op出现了问题。recurrent_grad这个Op实现的时候支持输入的临时变量GRAD不存在scope中。如果不存在，那么就会进行特殊处理。但是新执行器在执行前进行变量check，同时进行id映射。就导致了Op里面的特殊判断没有作用。

修改方式，在新执行器的 build_variable_map 中进行了一个特判，如果是 enforce_exist，才是检测不存在直接报错。如果enforce_exist=False，那么不存在的话直接跳过这个变量。