### PR TITLE
Simplify constructor of InterpreterCore

### DIFF
--- a/paddle/fluid/framework/new_executor/event_manager.cc
+++ b/paddle/fluid/framework/new_executor/event_manager.cc
@@ -16,9 +16,8 @@
 
 namespace paddle {
 namespace framework {
-
-void EventManager::WaitEvent(const Instruction& instruction,
-                             const platform::Place& place) {
+namespace interpreter {
+void WaitEvent(const Instruction& instruction, const platform::Place& place) {
   // If InterpreterCore in on CPUPlace, do nothing.
   if (platform::is_cpu_place(place)) return;
 
@@ -32,8 +31,7 @@ void EventManager::WaitEvent(const Instruction& instruction,
   }
 }
 
-void EventManager::RecordEvent(const Instruction& instruction,
-                               const platform::Place& place) {
+void RecordEvent(const Instruction& instruction, const platform::Place& place) {
   // If InterpreterCore in on CPUPlace, do nothing.
   if (platform::is_cpu_place(place)) return;
 
@@ -43,5 +41,6 @@ void EventManager::RecordEvent(const Instruction& instruction,
   }
 }
 
+}  // namespace interpreter
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/event_manager.h
+++ b/paddle/fluid/framework/new_executor/event_manager.h
@@ -17,14 +17,11 @@
 
 namespace paddle {
 namespace framework {
+namespace interpreter {
+void RecordEvent(const Instruction& instruction, const platform::Place& place);
 
-class EventManager {
- public:
-  void RecordEvent(const Instruction& instruction,
-                   const platform::Place& place);
+void WaitEvent(const Instruction& instruction, const platform::Place& place);
 
-  void WaitEvent(const Instruction& instruction, const platform::Place& place);
-};
-
+}  // namespace interpreter
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -33,17 +33,15 @@ namespace framework {
 // NOTE(Aurelius84): Need a better strategy to determine it.
 static constexpr size_t kHostNumThreads = 4;
 
-InterpreterCore::InterpreterCore(const platform::Place& place, BlockDesc* block,
-                                 VariableScope* global_scope,
-                                 const std::vector<std::string>& feed_names)
+InterpreterCore::InterpreterCore(const platform::Place& place,
+                                 const BlockDesc& block,
+                                 VariableScope* global_scope)
     : place_(place),
       block_(block),
       global_scope_(global_scope),
       stream_analyzer_(place),
       async_work_queue_(kHostNumThreads, &main_thread_blocker_) {
   is_build_ = false;
-
-  feed_names_ = feed_names;
 
   exception_notifier_ = main_thread_blocker_.RegisterEvent(
       kExceptionCaught, [this]() { return exception_holder_.IsCaught(); });
@@ -56,27 +54,12 @@ InterpreterCore::InterpreterCore(const platform::Place& place, BlockDesc* block,
 }
 
 paddle::framework::FetchList InterpreterCore::Run(
+    const std::vector<std::string>& feed_names,
     const std::vector<framework::LoDTensor>& feed_tensors) {
-  auto FeedInput = [&] {
-    for (size_t i = 0; i < feed_names_.size(); ++i) {
-      auto* feed_var = global_scope_->Var(feed_names_[i]);
-      auto feed_tensor = feed_var->GetMutable<framework::LoDTensor>();
-      feed_tensor->ShareDataWith(feed_tensors[i]);
-      feed_tensor->set_lod(feed_tensors[i].lod());
-    }
-  };
+  bool is_build = is_build_;
+  Prepare(feed_names, feed_tensors, is_build);
 
-  if (is_build_ == false) {
-    paddle::framework::interpreter::build_variable_scope(*block_,
-                                                         global_scope_);
-    FeedInput();
-    paddle::framework::interpreter::build_op_func_list(
-        place_, *block_, &vec_func_list_, global_scope_);
-    is_build_ = true;
-    // convert vec func_list to graph
-    Convert();
-  } else {
-    FeedInput();
+  if (is_build) {
     ExecuteInstructionList(vec_instruction_);
   }
 
@@ -86,9 +69,9 @@ paddle::framework::FetchList InterpreterCore::Run(
 }
 
 void InterpreterCore::Convert() {
+  auto& vec_meta_info = global_scope_->MutableVecMetaInfo();
   auto var_nums = global_scope_->VarSize();
   input_var2op_info_.resize(var_nums);
-  vec_meta_info_.resize(var_nums);
 
   auto op_nums = vec_func_list_.size();
   vec_instruction_.reserve(op_nums);
@@ -127,7 +110,7 @@ void InterpreterCore::Convert() {
     gc_check_input_list.erase(last, gc_check_input_list.end());
 
     for (auto var_id : gc_check_input_list) {
-      vec_meta_info_[var_id].var_ref_count_++;
+      vec_meta_info[var_id].var_ref_count_++;
       instr.AddGCCheckVar(var_id);
     }
   }
@@ -139,7 +122,7 @@ void InterpreterCore::Convert() {
         if (input_var2op_info_.at(id).size() == 0) {
           // output var not be used by any kernel
           vec_instruction_[i].AddGCCheckVar(id);
-          vec_meta_info_[id].var_ref_count_++;
+          vec_meta_info[id].var_ref_count_++;
         }
       }
     }
@@ -171,7 +154,7 @@ void InterpreterCore::Convert() {
   }
 
   for (size_t i = 0; i < vec_instruction_.size(); ++i) {
-    BuildAndCacheInstructionCtx(&vec_instruction_[i], *global_scope_, place_);
+    BuildAndCacheInstructionCtx(&vec_instruction_[i]);
   }
 
   BuildSkipShareLoDInfo();
@@ -239,16 +222,14 @@ void InterpreterCore::BuildInplace() {
   }
 }
 
-void InterpreterCore::BuildAndCacheInstructionCtx(
-    Instruction* instr_node, const VariableScope& var_scope,
-    const platform::Place& place) {
+void InterpreterCore::BuildAndCacheInstructionCtx(Instruction* instr_node) {
   VariableValueMap ins_map;
   for (auto& var_name_item : instr_node->Inputs()) {
     std::vector<Variable*> input_vars;
 
     input_vars.reserve(var_name_item.second.size());
     for (auto& id : var_name_item.second) {
-      input_vars.emplace_back(var_scope.Var(id));
+      input_vars.emplace_back(global_scope_->Var(id));
     }
     ins_map.emplace(var_name_item.first, std::move(input_vars));
   }
@@ -259,7 +240,7 @@ void InterpreterCore::BuildAndCacheInstructionCtx(
 
     out_vars.reserve(var_name_item.second.size());
     for (auto& id : var_name_item.second) {
-      out_vars.emplace_back(var_scope.Var(id));
+      out_vars.emplace_back(global_scope_->Var(id));
     }
     outs_map.emplace(var_name_item.first, std::move(out_vars));
   }
@@ -350,7 +331,7 @@ void InterpreterCore::RunInstruction(const Instruction& instr_node) {
 void InterpreterCore::ExecuteInstructionList(
     const std::vector<Instruction>& vec_instr) {
   async_work_queue_.PrepareAtomicDeps(dependecy_count_);
-  async_work_queue_.PrepareAtomicVarRef(vec_meta_info_);
+  async_work_queue_.PrepareAtomicVarRef(global_scope_->VecMetaInfo());
   op_run_number_ = 0;
 
   exception_holder_.Clear();
@@ -443,7 +424,7 @@ void InterpreterCore::RunInstructionAsync(size_t instr_id) {
     auto& instr_node = vec_instruction_.at(instr_id);
     auto* op = instr_node.OpBase();
     platform::RecordEvent instruction_event(op->Type());
-    event_manager_.WaitEvent(instr_node, place_);
+    interpreter::WaitEvent(instr_node, place_);
 
     try {
       RunInstruction(instr_node);
@@ -470,7 +451,7 @@ void InterpreterCore::RunInstructionAsync(size_t instr_id) {
       return;
     }
 
-    event_manager_.RecordEvent(instr_node, place_);
+    interpreter::RecordEvent(instr_node, place_);
     op_run_number_.fetch_add(1, std::memory_order_relaxed);
 
     // GC infomation
@@ -499,11 +480,18 @@ void InterpreterCore::CheckGC(const Instruction& instr) {
   }
 }
 
-void InterpreterCore::DryRunPrepare(
-    const std::vector<framework::LoDTensor>& feed_tensors) {
+void InterpreterCore::Prepare(
+    const std::vector<std::string>& feed_names,
+    const std::vector<framework::LoDTensor>& feed_tensors, bool prepare_feed) {
+  PADDLE_ENFORCE_EQ(feed_names.size(), feed_tensors.size(),
+                    platform::errors::PreconditionNotMet(
+                        "Required feed_names.size() == feed_tensors.size(), "
+                        "but received %d != %d",
+                        feed_names.size(), feed_tensors.size()));
+
   auto FeedInput = [&] {
-    for (size_t i = 0; i < feed_names_.size(); ++i) {
-      auto* feed_var = global_scope_->FindVar(feed_names_[i]);
+    for (size_t i = 0; i < feed_names.size(); ++i) {
+      auto* feed_var = global_scope_->FindVar(feed_names[i]);
       PADDLE_ENFORCE_NOT_NULL(feed_var, platform::errors::NotFound(
                                             "feed_var shall not be nullptr."));
 
@@ -513,35 +501,33 @@ void InterpreterCore::DryRunPrepare(
     }
   };
 
-  if (is_build_ == false) {
-    paddle::framework::interpreter::build_variable_scope(*block_,
-                                                         global_scope_);
+  if (is_build_) {
+    paddle::framework::interpreter::build_variable_scope(block_, global_scope_);
     FeedInput();
     paddle::framework::interpreter::build_op_func_list(
-        place_, *block_, &vec_func_list_, global_scope_);
+        place_, block_, &vec_func_list_, global_scope_);
     is_build_ = true;
     // convert vec func_list to graph
     Convert();
   }
   // NOTE: Because feed_tensor will be GC after
   // paddle::framework::build_op_func_list, so we should
-  // call
-  // FeedInput again.
-  FeedInput();
+  // call FeedInput again.
+  if (prepare_feed) FeedInput();
 }
 
-const CostInfo& InterpreterCore::DryRun(
+interpreter::CostInfo InterpreterCore::DryRun(
+    const std::vector<std::string>& feed_names,
     const std::vector<framework::LoDTensor>& feed_tensors) {
-  DryRunPrepare(feed_tensors);
-  // DryRun may be called many times.
-  dry_run_profiler_.Reset();
-  dry_run_profiler_.Start();
-  ExecuteInstructionList(vec_instruction_);
-  platform::DeviceContextPool::Instance().Get(place_)->Wait();
+  Prepare(feed_names, feed_tensors, true);
+  interpreter::CostInfo cost_info;
+  {
+    interpreter::ProfilerGuard(place_, &cost_info);
+    ExecuteInstructionList(vec_instruction_);
+    platform::DeviceContextPool::Instance().Get(place_)->Wait();
+  }
 
-  dry_run_profiler_.Pause();
-  dry_run_profiler_.TotalCUDAAllocatedMemorySize(place_);
-  return dry_run_profiler_.GetCostInfo();
+  return cost_info;
 }
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -501,7 +501,7 @@ void InterpreterCore::Prepare(
     }
   };
 
-  if (is_build_) {
+  if (!is_build_) {
     paddle::framework::interpreter::build_variable_scope(block_, global_scope_);
     FeedInput();
     paddle::framework::interpreter::build_op_func_list(

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -40,21 +40,21 @@ using AtomicVectorSizeT = std::vector<std::unique_ptr<std::atomic<size_t>>>;
 
 class InterpreterCore {
  public:
-  InterpreterCore(const platform::Place& place, BlockDesc* block,
-                  VariableScope* global_scope,
-                  const std::vector<std::string>& feed_names);
+  InterpreterCore(const platform::Place& place, const BlockDesc& block,
+                  VariableScope* global_scope);
 
   paddle::framework::FetchList Run(
+      const std::vector<std::string>& feed_names,
       const std::vector<framework::LoDTensor>& feed_tensors);
 
-  const CostInfo& DryRun(const std::vector<framework::LoDTensor>& feed_tensors);
+  interpreter::CostInfo DryRun(
+      const std::vector<std::string>& feed_names,
+      const std::vector<framework::LoDTensor>& feed_tensors);
 
  private:
   void Convert();
 
-  void BuildAndCacheInstructionCtx(Instruction* instr_node,
-                                   const VariableScope& var_scope,
-                                   const platform::Place& place);
+  void BuildAndCacheInstructionCtx(Instruction* instr_node);
 
   void BuildInplace();
 
@@ -64,7 +64,9 @@ class InterpreterCore {
 
   void ExecuteInstructionList(const std::vector<Instruction>& vec_instr);
 
-  void DryRunPrepare(const std::vector<framework::LoDTensor>& feed_tensors);
+  void Prepare(const std::vector<std::string>& feed_names,
+               const std::vector<framework::LoDTensor>& feed_tensors,
+               bool prepare_feed);
 
   void CheckGC(const Instruction& instr);
 
@@ -77,22 +79,17 @@ class InterpreterCore {
   bool is_build_;
 
   const platform::Place& place_;
-  BlockDesc* block_;             // not owned
+  const BlockDesc& block_;       // not owned
   VariableScope* global_scope_;  // not owned
 
   std::vector<paddle::framework::OpFuncNode> vec_func_list_;
   std::vector<Instruction> vec_instruction_;  // deconstruct before OpFuncNode
 
-  InstructionInfo instruction_info_;
   std::vector<size_t> dependecy_count_;
+  std::atomic<size_t> op_run_number_{0};
   std::vector<std::vector<size_t>> input_var2op_info_;
-  std::vector<VariableMetaInfo> vec_meta_info_;
 
-  std::vector<std::string> feed_names_;
-
-  InterpreterProfiler dry_run_profiler_;
   StreamAnalyzer stream_analyzer_;
-  EventManager event_manager_;
   EventsWaiter main_thread_blocker_;
   interpreter::AsyncWorkQueue async_work_queue_;
   details::ExceptionHolder exception_holder_;
@@ -100,7 +97,6 @@ class InterpreterCore {
 
   InterpreterCoreGarbageCollector gc_;
   std::vector<paddle::platform::DeviceEvent> gc_event_;
-  std::atomic<size_t> op_run_number_{0};
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -650,22 +650,8 @@ struct EventInter {
   platform::DeviceType waiter_type_;
 };
 
-/*
- * An utility class containing base information to help convert OpFuncNode
- * into Instruction.
- */
 struct InstructionInfo {
-  void Resize(size_t num) {
-    dependecy_count_.resize(num);
-    input_var2op_info_.resize(num);
-    vec_meta_info_.resize(num);
-  }
-
-  const std::vector<size_t> DependecyCount() const { return dependecy_count_; }
-
   std::vector<size_t> dependecy_count_;
-  std::vector<std::vector<size_t>> input_var2op_info_;
-  std::vector<VariableMetaInfo> vec_meta_info_;
 };
 
 enum class OpFuncType {

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -607,6 +607,12 @@ class VariableScope : public ScopeBase {
         platform::errors::NotFound("%s not in VariableScope.", name));
   }
 
+  std::vector<VariableMetaInfo>& MutableVecMetaInfo() { return vec_meta_info_; }
+
+  const std::vector<VariableMetaInfo>& VecMetaInfo() const {
+    return vec_meta_info_;
+  }
+
  private:
   std::vector<Variable*> var_list_;
   std::map<std::string, int> name2id_;
@@ -644,8 +650,22 @@ struct EventInter {
   platform::DeviceType waiter_type_;
 };
 
+/*
+ * An utility class containing base information to help convert OpFuncNode
+ * into Instruction.
+ */
 struct InstructionInfo {
+  void Resize(size_t num) {
+    dependecy_count_.resize(num);
+    input_var2op_info_.resize(num);
+    vec_meta_info_.resize(num);
+  }
+
+  const std::vector<size_t> DependecyCount() const { return dependecy_count_; }
+
   std::vector<size_t> dependecy_count_;
+  std::vector<std::vector<size_t>> input_var2op_info_;
+  std::vector<VariableMetaInfo> vec_meta_info_;
 };
 
 enum class OpFuncType {

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -51,16 +51,15 @@ paddle::framework::FetchList StandaloneExecutor::Run(
     const std::vector<std::string>& fetch_names) {
   auto core = GetInterpreterCore(feed_names, fetch_names);
 
-  return core->Run(feed_tensors);
+  return core->Run(feed_names, feed_tensors);
 }
 
-const CostInfo& StandaloneExecutor::DryRun(
+framework::interpreter::CostInfo StandaloneExecutor::DryRun(
     const std::vector<std::string>& feed_names,
     const std::vector<framework::LoDTensor>& feed_tensors) {
   auto core = GetInterpreterCore(feed_names, {});
 
-  auto& cost_info = core->DryRun(feed_tensors);
-  return cost_info;
+  return core->DryRun(feed_names, feed_tensors);
 }
 
 void StandaloneExecutor::BuildVariableOuterScope(
@@ -102,8 +101,8 @@ std::shared_ptr<InterpreterCore> StandaloneExecutor::GetInterpreterCore(
     auto* block = new_prog->MutableBlock(0);
     interpreter::add_fetch(fetch_names, block);
 
-    auto core = std::make_shared<InterpreterCore>(place_, block, &global_scope_,
-                                                  feed_names);
+    auto core =
+        std::make_shared<InterpreterCore>(place_, *block, &global_scope_);
     programs_.emplace(oss.str(), new_prog);
     interpretercores_.emplace(oss.str(), core);
     return core;

--- a/paddle/fluid/framework/new_executor/standalone_executor.h
+++ b/paddle/fluid/framework/new_executor/standalone_executor.h
@@ -45,8 +45,9 @@ class StandaloneExecutor : public ExecutorBase {
       const std::vector<framework::LoDTensor>& feed_tensors,
       const std::vector<std::string>& fetch_names);
 
-  const CostInfo& DryRun(const std::vector<std::string>& feed_names,
-                         const std::vector<framework::LoDTensor>& feed_tensors);
+  framework::interpreter::CostInfo DryRun(
+      const std::vector<std::string>& feed_names,
+      const std::vector<framework::LoDTensor>& feed_tensors);
 
  private:
   void BuildVariableOuterScope(const framework::ProgramDesc& pdesc,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2069,11 +2069,13 @@ All parameter, weight, gradient are variables in Paddle.
                  fetch_vars);
       });
 
-  py::class_<framework::CostInfo>(m, "CostInfo")
+  py::class_<framework::interpreter::CostInfo>(m, "CostInfo")
       .def(py::init<>())
-      .def("total_time", [](CostInfo &self) { return self.total_time; })
-      .def("device_memory_bytes",
-           [](CostInfo &self) { return self.device_memory_bytes; });
+      .def("total_time",
+           [](interpreter::CostInfo &self) { return self.total_time; })
+      .def("device_memory_bytes", [](interpreter::CostInfo &self) {
+        return self.device_memory_bytes;
+      });
 
   py::class_<framework::StandaloneExecutor>(m, "StandaloneExecutor")
       .def(py::init<const platform::Place &, const ProgramDesc &,
@@ -2134,7 +2136,7 @@ All parameter, weight, gradient are variables in Paddle.
                feed_tensors.push_back(t);
              }
 
-             CostInfo cost_info;
+             framework::interpreter::CostInfo cost_info;
              {
                pybind11::gil_scoped_release release;
                cost_info = self.DryRun(feed_names, feed_tensors);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->


+ 简化构造函数的参数，仅保留`place_`,`block`、`global_scope`三个必要参数
+ BlockDesc 标记为const，确保执行器会的职责只负责执行，与block相关的预处理逻辑交给上层
+ 抽离公用的`Prepare`逻辑，提升代码可维护性
+ 重构 Profiler 类，修改为 `Guard` 逻辑，简化接口调用方式
+ 删除`event_manager_`、`feed_names_`、`vec_meta_info_`等多余的成员变量
