### PR TITLE
Enable FC int8

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
@@ -47,6 +47,10 @@ TEST(Analyzer_int8_image_classification, quantization) {
     std::shared_ptr<std::vector<PaddleTensor>> warmup_data =
         paddle::inference::GetWarmupData(input_slots_all);
 
+    // INT8 implies FC oneDNN passes to be used
+    q_cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
+    q_cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+
     // configure quantizer
     q_cfg.EnableMkldnnQuantizer();
     q_cfg.mkldnn_quantizer_config()->SetWarmupData(warmup_data);


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
It does enable mkldnn FC functionality be default for int8 classification workloads (internal tests)
