### PR TITLE
fix 2 bug: 1.skip lodtensorarray; 2.delete feed op

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -373,6 +373,9 @@ std::vector<OpFuncNode> apply_data_transform(
   for (auto& var_name_item : *ins_map_temp) {
     for (size_t i = 0; i < var_name_item.second.size(); ++i) {
       auto var = var_name_item.second[i];
+      if (!(var->IsType<LoDTensor>() || var->IsType<SelectedRows>())) {
+        continue;
+      }
       auto& var_name = inputs_names[var_name_item.first].at(i);
       auto tensor_in = GetLoDTensorOrSelectedRowsValueFromVar(*var);
       if (!tensor_in->IsInitialized()) {

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -599,7 +599,7 @@ class _ExecutorCache(object):
             program, Program), "Required type(Program), but received {}".format(
                 type(program).__name__)
         if program not in self._cached_executors:
-            new_program = program
+            new_program = program.clone()
             _prune_feed_ops(new_program)
             new_exe = _StandaloneExecutor(self._place, new_program, scope)
             self._cached_executors[program] = new_exe

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -34,6 +34,7 @@ from .trainer_factory import FetchHandlerMonitor
 import copy
 from . import framework
 from .incubate.checkpoint import auto_checkpoint as acp
+from .compiler import _prune_feed_ops
 
 __all__ = ['Executor', 'global_scope', 'scope_guard']
 
@@ -598,7 +599,9 @@ class _ExecutorCache(object):
             program, Program), "Required type(Program), but received {}".format(
                 type(program).__name__)
         if program not in self._cached_executors:
-            new_exe = _StandaloneExecutor(self._place, program, scope)
+            new_program = program
+            _prune_feed_ops(new_program)
+            new_exe = _StandaloneExecutor(self._place, new_program, scope)
             self._cached_executors[program] = new_exe
 
         return self._cached_executors[program]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
修改了新执行器两处bug： 

1. transformdata不处理LoDTensorArray类型
2. 有些save的模型保存了feedop，在python端将feedop删除掉