### PR TITLE
[Paddle-Inference] fix_qkv_plugin: fix half scale

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
@@ -347,8 +347,8 @@ int QkvToContextPluginDynamic::enqueue(
             platform::CUDAPlace(device_id)));
 
     int n_q = seq_len * head_number_ * head_size_ * batch;
-    constexpr int threads = 128;
-    int blocks = (n_q + threads - 1) / threads;
+    int threads = head_number_ * head_size_ * batch;
+    int blocks = seq_len;
 
     apply_scale<<<blocks, threads, 0, stream>>>(tptr, static_cast<half>(scale_),
                                                 n_q);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复 half 的 scale 的核函数中 block 和 thread 的设置错误