### PR TITLE
[NPU] fix fill_constant and test_memcpy_op_npu

### DIFF
--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -87,6 +87,9 @@ class FillConstantOp : public framework::OperatorWithKernel {
         case 3:
           kt.place_ = platform::XPUPlace();
           break;
+        case 4:
+          kt.place_ = platform::NPUPlace();
+          break;
         default:
           PADDLE_THROW(platform::errors::Unimplemented(
               "Could NOT determine the place of variable, place_type = %d .",
@@ -164,7 +167,8 @@ class FillConstantOpMaker : public framework::OpProtoAndCheckerMaker {
                  "0: CPUPlace. "
                  "1: CUDAPlace. "
                  "2: CUDAPinnedPlace. "
-                 "3: XPUPlace. ")
+                 "3: XPUPlace. "
+                 "4: NPUPlace. ")
         .SetDefault(-1);
     AddOutput("Out",
               "(Tensor) Tensor of specified shape will be filled "

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
@@ -144,5 +144,26 @@ class TestFillConstantBool(OpTest):
         self.check_output_with_place(self.place)
 
 
+class TestFillConstantWithPlaceType(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.place = paddle.NPUPlace(0)
+        self.op_type = "fill_constant"
+        self.init_dtype()
+
+        self.inputs = {}
+        self.attrs = {'shape': [123, 92], 'value': 3.8, 'place_type': 4}
+        self.outputs = {'Out': np.full((123, 92), 3.8)}
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
@@ -54,7 +54,7 @@ class TestMemcpy_FillConstant(unittest.TestCase):
                     "shape": [10, 10],
                     "dtype": npu_var.dtype,
                     "value": 1.0,
-                    "place_type": 1
+                    "place_type": 4
                 })
             main_program.global_block().append_op(
                 type="fill_constant",
@@ -63,7 +63,7 @@ class TestMemcpy_FillConstant(unittest.TestCase):
                     "shape": [10, 10],
                     "dtype": cpu_var.dtype,
                     "value": 0.0,
-                    "place_type": 2
+                    "place_type": 0
                 })
         return main_program, npu_var, cpu_var
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
1. fill_constant new GetExpectedKernelType logic can not deal with NPUPlace, then may give wrong kernel_key, fix it;
2. test_memcpy_op_npu set wrong place_type in using of fill_constant, fix it;
<img width="808" alt="3c9e88fc9256658b54b2cba56ce3e296" src="https://user-images.githubusercontent.com/5997715/141394647-fbd8b79d-a749-42e3-b676-f29131e47976.png">
<img width="793" alt="70bc01fe0050f7a8cc8757de8cc30132" src="https://user-images.githubusercontent.com/5997715/141394657-244300ef-c527-4c26-8758-8a91441af177.png">