### PR TITLE
[new-exec] fix stream analysis

### DIFF
--- a/paddle/fluid/framework/new_executor/event_manager.cc
+++ b/paddle/fluid/framework/new_executor/event_manager.cc
@@ -41,6 +41,16 @@ void RecordEvent(const Instruction& instruction, const platform::Place& place) {
   }
 }
 
+void RecordEvent(const Instruction& instruction) {
+  // If InterpreterCore in on CPUPlace, do nothing.
+  if (platform::is_cpu_place(instruction.DeviceContext().GetPlace())) return;
+
+  for (auto& event : instruction.OutputEvents()) {
+    VLOG(3) << "Record event in out_var_id: " << event.var_id_;
+    event.event_->Record(&instruction.DeviceContext());
+  }
+}
+
 }  // namespace interpreter
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/event_manager.h
+++ b/paddle/fluid/framework/new_executor/event_manager.h
@@ -20,6 +20,8 @@ namespace framework {
 namespace interpreter {
 void RecordEvent(const Instruction& instruction, const platform::Place& place);
 
+void RecordEvent(const Instruction& instruction);
+
 void WaitEvent(const Instruction& instruction, const platform::Place& place);
 
 }  // namespace interpreter

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -466,7 +466,7 @@ void InterpreterCore::RunInstructionAsync(size_t instr_id) {
       return;
     }
 
-    interpreter::RecordEvent(instr_node, place_);
+    interpreter::RecordEvent(instr_node);
     op_run_number_.fetch_add(1, std::memory_order_relaxed);
 
     RunNextInstructions(instr_node, &ready_ops);

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -468,7 +468,7 @@ void InterpreterCore::RunInstructionAsync(size_t instr_id) {
       return;
     }
 
-    interpreter::RecordEvent(instr_node);
+    interpreter::RecordEvent(instr_node, place_);
     op_run_number_.fetch_add(1, std::memory_order_relaxed);
 
     RunNextInstructions(instr_node, &ready_ops);

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -77,20 +77,22 @@ paddle::framework::FetchList InterpreterCore::Run(
   return *(fetch_var->GetMutable<framework::FetchList>());
 }
 
-void InterpreterCore::Convert() {
+void InterpreterCore::Convert(
+    std::vector<paddle::framework::OpFuncNode>* op_func_nodes) {
   auto& vec_meta_info = global_scope_->MutableVecMetaInfo();
   auto var_nums = global_scope_->VarSize();
   input_var2op_info_.resize(var_nums);
+  auto nodes = *op_func_nodes;
 
-  auto op_nums = vec_func_list_.size();
+  auto op_nums = nodes.size();
   vec_instruction_.reserve(op_nums);
   dependecy_count_.resize(op_nums);
 
   for (size_t op_idx = 0; op_idx < op_nums; ++op_idx) {
-    auto& op_func_node = vec_func_list_[op_idx];
+    auto& op_func_node = nodes[op_idx];
     auto* dev_ctx_ = stream_analyzer_.ParseDeviceContext(op_func_node);
 
-    vec_instruction_.emplace_back(op_idx, op_func_node, *dev_ctx_);
+    vec_instruction_.emplace_back(op_idx, std::move(op_func_node), *dev_ctx_);
     auto& instr = vec_instruction_.back();
 
     OpInOutInfo info;
@@ -101,7 +103,7 @@ void InterpreterCore::Convert() {
         input_var2op_info_.at(id).push_back(op_idx);
         // var can be gc-ed
         if (!info.IsBuilt()) {
-          info.Build(op_func_node.operator_base_);
+          info.Build(op_func_node.operator_base_.get());
         }
         auto* var_desc = global_scope_->VarDesc(id);
         if (var_desc) {
@@ -519,11 +521,12 @@ void InterpreterCore::Prepare(
   if (!is_build_) {
     paddle::framework::interpreter::build_variable_scope(block_, global_scope_);
     FeedInput();
+    std::vector<paddle::framework::OpFuncNode> op_func_nodes;
     paddle::framework::interpreter::build_op_func_list(
-        place_, block_, &vec_func_list_, global_scope_);
+        place_, block_, &op_func_nodes, global_scope_);
     is_build_ = true;
     // convert vec func_list to graph
-    Convert();
+    Convert(&op_func_nodes);
   }
   // NOTE: Because feed_tensor will be GC after
   // paddle::framework::build_op_func_list, so we should

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -54,7 +54,7 @@ class InterpreterCore {
       const std::vector<framework::LoDTensor>& feed_tensors);
 
  private:
-  void Convert();
+  void Convert(std::vector<paddle::framework::OpFuncNode>* op_func_nodes);
 
   void BuildAndCacheInstructionCtx(Instruction* instr_node);
 
@@ -84,7 +84,6 @@ class InterpreterCore {
   const BlockDesc& block_;       // not owned
   VariableScope* global_scope_;  // not owned
 
-  std::vector<paddle::framework::OpFuncNode> vec_func_list_;
   std::vector<Instruction> vec_instruction_;  // deconstruct before OpFuncNode
 
   std::vector<size_t> dependecy_count_;

--- a/paddle/fluid/framework/new_executor/new_executor_defs.cc
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.cc
@@ -629,5 +629,109 @@ void VariableScopeListener::onCreateScope(Scope* Scope) {}
 void VariableScopeListener::onDeleteScope(Scope* Scope) {}
 void VariableScopeListener::onClear() {}
 
+Instruction::Instruction(size_t id, const OpFuncNode& op_func_node,
+                         const platform::DeviceContext& dev_ctx)
+    : id_(id), op_func_node_(op_func_node), dev_ctx_(dev_ctx) {
+  PADDLE_ENFORCE_GE(id, 0, platform::errors::PreconditionNotMet(
+                               "Required id >= 0, but received id = %d", id));
+}
+
+size_t Instruction::Id() const { return id_; }
+
+const std::map<std::string, std::vector<int>>& Instruction::Inputs() const {
+  return op_func_node_.input_index;
+}
+
+const std::map<std::string, std::vector<int>>& Instruction::Outputs() const {
+  return op_func_node_.output_index;
+}
+
+const std::unordered_set<int>& Instruction::NoDataTransformVars() const {
+  return op_func_node_.no_data_transform_index;
+}
+
+OpKernelComputeFunc Instruction::KernelFunc() const {
+  return op_func_node_.kernel_func_;
+}
+
+OpFuncType Instruction::KernelType() const { return op_func_node_.type_; }
+
+OperatorBase* Instruction::OpBase() const {
+  auto* op_base = op_func_node_.operator_base_;
+  PADDLE_ENFORCE_NOT_NULL(op_base, platform::errors::PreconditionNotMet(
+                                       "op_base shall not be nullptr."));
+  return op_base;
+}
+
+NextInstruction& Instruction::NextInstructions() { return next_instruction_; }
+
+const NextInstruction& Instruction::NextInstructions() const {
+  return next_instruction_;
+}
+
+void Instruction::AddGCCheckVar(size_t id) { gc_check_var_list_.push_back(id); }
+
+const std::vector<size_t>& Instruction::GCCheckVars() const {
+  return gc_check_var_list_;
+}
+
+void Instruction::ResetContext(const VariableValueMap& in_vars,
+                               const VariableValueMap& out_vars) {
+  runtime_ctx_.reset(new RuntimeContext(in_vars, out_vars));
+  infershape_ctx_.reset(
+      new InterpretercoreInferShapeContext(*OpBase(), *runtime_ctx_.get()));
+  // NOTE: Because execution_ctx_ is constructed by `scope&`, so we fake an
+  // empty here to avoid illegal local reference.
+  static framework::Scope scope_;
+  execution_ctx_.reset(
+      new ExecutionContext(*OpBase(), scope_, dev_ctx_, *runtime_ctx_.get()));
+}
+
+std::shared_ptr<RuntimeContext> Instruction::InnerRuntimeContext() const {
+  return runtime_ctx_;
+}
+
+std::shared_ptr<InterpretercoreInferShapeContext>
+Instruction::InnerInferShapeContext() const {
+  return infershape_ctx_;
+}
+
+std::shared_ptr<ExecutionContext> Instruction::InnerExecutionContext() const {
+  return execution_ctx_;
+}
+
+const platform::DeviceContext& Instruction::DeviceContext() const {
+  return dev_ctx_;
+}
+
+const std::vector<std::pair<Variable*, Variable*>>& Instruction::InplaceInfo()
+    const {
+  return vec_inplace_in_to_out_;
+}
+
+void Instruction::AddInplace(Variable* in, Variable* out) {
+  vec_inplace_in_to_out_.emplace_back(in, out);
+}
+
+const std::vector<EventInter>& Instruction::InputEvents() const {
+  return intput_events_;
+}
+
+const std::vector<EventInter>& Instruction::OutputEvents() const {
+  return output_events_;
+}
+
+void Instruction::AddInputEvent(size_t var_id,
+                                std::shared_ptr<platform::DeviceEvent> event,
+                                platform::DeviceType waiter_type) {
+  intput_events_.emplace_back(var_id, event, waiter_type);
+}
+
+void Instruction::AddOutputEvent(size_t var_id,
+                                 std::shared_ptr<platform::DeviceEvent> event,
+                                 platform::DeviceType waiter_type) {
+  output_events_.emplace_back(var_id, event, waiter_type);
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/new_executor_defs.cc
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.cc
@@ -629,7 +629,7 @@ void VariableScopeListener::onCreateScope(Scope* Scope) {}
 void VariableScopeListener::onDeleteScope(Scope* Scope) {}
 void VariableScopeListener::onClear() {}
 
-Instruction::Instruction(size_t id, const OpFuncNode& op_func_node,
+Instruction::Instruction(size_t id, OpFuncNode&& op_func_node,
                          const platform::DeviceContext& dev_ctx)
     : id_(id), op_func_node_(op_func_node), dev_ctx_(dev_ctx) {
   PADDLE_ENFORCE_GE(id, 0, platform::errors::PreconditionNotMet(
@@ -657,10 +657,10 @@ OpKernelComputeFunc Instruction::KernelFunc() const {
 OpFuncType Instruction::KernelType() const { return op_func_node_.type_; }
 
 OperatorBase* Instruction::OpBase() const {
-  auto* op_base = op_func_node_.operator_base_;
+  auto op_base = op_func_node_.operator_base_;
   PADDLE_ENFORCE_NOT_NULL(op_base, platform::errors::PreconditionNotMet(
                                        "op_base shall not be nullptr."));
-  return op_base;
+  return op_base.get();
 }
 
 NextInstruction& Instruction::NextInstructions() { return next_instruction_; }

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -269,7 +269,8 @@ enum class OpFuncType {
 class RuntimeInferShapeContext;
 
 struct OpFuncNode {
-  OperatorBase* operator_base_;
+  // TODO(zhiqiu): Better make it unique_ptr
+  std::shared_ptr<OperatorBase> operator_base_;
   std::map<std::string, std::vector<int>> input_index;
   std::map<std::string, std::vector<int>> output_index;
   std::unordered_set<int> no_data_transform_index;
@@ -281,7 +282,7 @@ struct OpFuncNode {
 
 class Instruction {
  public:
-  Instruction(size_t id, const OpFuncNode& op_func_node,
+  Instruction(size_t id, OpFuncNode&& op_func_node,
               const platform::DeviceContext& dev_ctx);
 
   size_t Id() const;
@@ -336,7 +337,7 @@ class Instruction {
 
  private:
   size_t id_;
-  const OpFuncNode& op_func_node_;          // not owned
+  OpFuncNode op_func_node_;
   const platform::DeviceContext& dev_ctx_;  // not owned
 
   std::shared_ptr<RuntimeContext> runtime_ctx_;

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -282,95 +282,57 @@ struct OpFuncNode {
 class Instruction {
  public:
   Instruction(size_t id, const OpFuncNode& op_func_node,
-              const platform::DeviceContext& dev_ctx)
-      : id_(id), op_func_node_(op_func_node), dev_ctx_(dev_ctx) {
-    PADDLE_ENFORCE_GE(id, 0, platform::errors::PreconditionNotMet(
-                                 "Required id >= 0, but received id = %d", id));
-  }
+              const platform::DeviceContext& dev_ctx);
 
-  size_t Id() const { return id_; }
+  size_t Id() const;
 
-  const std::map<std::string, std::vector<int>>& Inputs() const {
-    return op_func_node_.input_index;
-  }
+  const std::map<std::string, std::vector<int>>& Inputs() const;
 
-  const std::map<std::string, std::vector<int>>& Outputs() const {
-    return op_func_node_.output_index;
-  }
+  const std::map<std::string, std::vector<int>>& Outputs() const;
 
-  const std::unordered_set<int>& NoDataTransformVars() const {
-    return op_func_node_.no_data_transform_index;
-  }
+  const std::unordered_set<int>& NoDataTransformVars() const;
 
-  OpKernelComputeFunc KernelFunc() const { return op_func_node_.kernel_func_; }
+  OpKernelComputeFunc KernelFunc() const;
 
-  OpFuncType KernelType() const { return op_func_node_.type_; }
+  OpFuncType KernelType() const;
 
-  OperatorBase* OpBase() const {
-    auto* op_base = op_func_node_.operator_base_;
-    PADDLE_ENFORCE_NOT_NULL(op_base, platform::errors::PreconditionNotMet(
-                                         "op_base shall not be nullptr."));
-    return op_base;
-  }
+  OperatorBase* OpBase() const;
 
-  NextInstruction& NextInstructions() { return next_instruction_; }
+  NextInstruction& NextInstructions();
 
-  const NextInstruction& NextInstructions() const { return next_instruction_; }
+  const NextInstruction& NextInstructions() const;
 
-  void AddGCCheckVar(size_t id) { gc_check_var_list_.push_back(id); }
+  void AddGCCheckVar(size_t id);
 
-  const std::vector<size_t>& GCCheckVars() const { return gc_check_var_list_; }
+  const std::vector<size_t>& GCCheckVars() const;
 
   void ResetContext(const VariableValueMap& in_vars,
-                    const VariableValueMap& out_vars) {
-    runtime_ctx_.reset(new RuntimeContext(in_vars, out_vars));
-    infershape_ctx_.reset(
-        new InterpretercoreInferShapeContext(*OpBase(), *runtime_ctx_.get()));
-    // NOTE: Because execution_ctx_ is constructed by `scope&`, so we fake an
-    // empty here to avoid illegal local reference.
-    static framework::Scope scope_;
-    execution_ctx_.reset(
-        new ExecutionContext(*OpBase(), scope_, dev_ctx_, *runtime_ctx_.get()));
-  }
+                    const VariableValueMap& out_vars);
 
-  std::shared_ptr<RuntimeContext> InnerRuntimeContext() const {
-    return runtime_ctx_;
-  }
+  std::shared_ptr<RuntimeContext> InnerRuntimeContext() const;
 
   std::shared_ptr<InterpretercoreInferShapeContext> InnerInferShapeContext()
-      const {
-    return infershape_ctx_;
-  }
+      const;
 
-  std::shared_ptr<ExecutionContext> InnerExecutionContext() const {
-    return execution_ctx_;
-  }
+  std::shared_ptr<ExecutionContext> InnerExecutionContext() const;
 
-  const platform::DeviceContext& DeviceContext() const { return dev_ctx_; }
+  const platform::DeviceContext& DeviceContext() const;
 
-  const std::vector<std::pair<Variable*, Variable*>>& InplaceInfo() const {
-    return vec_inplace_in_to_out_;
-  }
+  const std::vector<std::pair<Variable*, Variable*>>& InplaceInfo() const;
 
-  void AddInplace(Variable* in, Variable* out) {
-    vec_inplace_in_to_out_.emplace_back(in, out);
-  }
+  void AddInplace(Variable* in, Variable* out);
 
-  const std::vector<EventInter>& InputEvents() const { return intput_events_; }
+  const std::vector<EventInter>& InputEvents() const;
 
-  const std::vector<EventInter>& OutputEvents() const { return output_events_; }
+  const std::vector<EventInter>& OutputEvents() const;
 
   void AddInputEvent(size_t var_id,
                      std::shared_ptr<platform::DeviceEvent> event,
-                     platform::DeviceType waiter_type) {
-    intput_events_.emplace_back(var_id, event, waiter_type);
-  }
+                     platform::DeviceType waiter_type);
 
   void AddOutputEvent(size_t var_id,
                       std::shared_ptr<platform::DeviceEvent> event,
-                      platform::DeviceType waiter_type) {
-    output_events_.emplace_back(var_id, event, waiter_type);
-  }
+                      platform::DeviceType waiter_type);
 
  private:
   size_t id_;

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -364,6 +364,11 @@ static bool IsMemcpyH2D(const Instruction& instr) {
 static bool IsMemcpyD2H(const Instruction& instr) {
   return instr.OpBase()->Type() == kMemcpyD2H;
 }
+
+static bool IsCpuOp(const Instruction& instr) {
+  return platform::is_cpu_place(instr.DeviceContext().GetPlace());
+}
+
 }  // namespace interpreter
 
 }  // namespace framework

--- a/paddle/fluid/framework/new_executor/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.cc
@@ -27,6 +27,10 @@ namespace framework {
  *
  * For example: matmul(gpu) -> out_var -> memcpy_d2h
  * out_var should be associated with an event.
+ *
+ * NOTE(zhiqiu): There are two special case that no event is needed:
+ *  1. the variable is marked as NoDataTransformVar
+ *  2. the variable is marked as NoNeedDataBuffer
  */
 std::vector<size_t> StreamAnalyzer::ParseEventVarIds(
     const Instruction& cur_instr, const Instruction& next_instr) {
@@ -35,11 +39,34 @@ std::vector<size_t> StreamAnalyzer::ParseEventVarIds(
     unique_var_ids.insert(item.second.begin(), item.second.end());
   }
 
+  auto is_no_need_buffer = [&next_instr](std::string name) {
+    auto* op = next_instr.OpBase();
+    auto& inferer = op->Info().NoNeedBufferVarsInferer();
+    if (inferer) {
+      auto no_need_buffer_ins =
+          inferer(op->Inputs(), op->Outputs(), op->Attrs());
+      return no_need_buffer_ins.count(name) != 0;
+    }
+    return false;
+  };
+
   std::vector<size_t> new_event_var_ids;
   for (auto& item : next_instr.Inputs()) {
     for (auto var_id : item.second) {
-      if (unique_var_ids.count(var_id) > 0 &&
-          next_instr.NoDataTransformVars().count(var_id) == 0) {
+      if (unique_var_ids.count(var_id) > 0) {
+        if (next_instr.NoDataTransformVars().count(var_id)) {
+          continue;
+          VLOG(4) << "Skip inserting event at variable " << item.first
+                  << " of operator " << next_instr.OpBase()->Type()
+                  << " since it is NoDataTransform";
+        }
+        if (is_no_need_buffer(item.first)) {
+          continue;
+          VLOG(4) << "Skip inserting event at variable " << item.first
+                  << " of operator " << next_instr.OpBase()->Type()
+                  << " since it is NoNeedBufferVar";
+        }
+
         new_event_var_ids.push_back(var_id);
       }
     }
@@ -69,8 +96,9 @@ void StreamAnalyzer::Schedule(const std::vector<size_t>& downstream_ops,
   std::vector<size_t> event_var_ids;
   for (auto next_op_id : downstream_ops) {
     auto& next_instr = instructions->at(next_op_id);
-
     if (IsDirectRun(cur_instr, next_instr)) {
+      VLOG(4) << "DirectRun: " << cur_instr.OpBase()->Type() << "->"
+              << next_instr.OpBase()->Type();
       next_instruction.AddDirectRun(next_op_id);
     } else {
       // Always insert events between different stream
@@ -82,8 +110,12 @@ void StreamAnalyzer::Schedule(const std::vector<size_t>& downstream_ops,
       AssociateInputWithEvents(new_event_var_ids, &next_instr, waiter_type);
 
       if (waiter_type == platform::kCPU) {  // GPU -> CPU
+        VLOG(4) << "SyncRun: " << cur_instr.OpBase()->Type() << "->"
+                << next_instr.OpBase()->Type();
         next_instruction.AddSyncRun(next_op_id);
       } else {  // GPU -> GPU(different stream)
+        VLOG(4) << "EventRun: " << cur_instr.OpBase()->Type() << "->"
+                << next_instr.OpBase()->Type();
         next_instruction.ADDEventRun(next_op_id);
       }
     }
@@ -116,12 +148,15 @@ platform::DeviceContext* StreamAnalyzer::ParseDeviceContext(
  * NOTE(dev): The following cases are considered as directly run:
  *
  *  1. with same dev_ctx_, such as: CPU -> CPU, GPU -> GPU
- *  2. D2H -> CPU
- *  3. CPU -> H2D
+ *  2. CPU -> any (it is possible: CPU op->VAR->GPU op, when var is no need
+ * buffer or no need data transform)
+ *  3. D2H -> CPU
+ *  4. CPU -> H2D
  */
 bool StreamAnalyzer::IsDirectRun(Instruction& cur_instr,
                                  const Instruction& next_instr) {
   return (&cur_instr.DeviceContext() == &next_instr.DeviceContext() ||
+          interpreter::IsCpuOp(cur_instr) ||
           interpreter::IsMemcpyD2H(cur_instr) ||
           interpreter::IsMemcpyH2D(next_instr));
 }

--- a/paddle/fluid/framework/new_executor/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.cc
@@ -55,16 +55,16 @@ std::vector<size_t> StreamAnalyzer::GetNeedEventVarIds(
     for (auto var_id : item.second) {
       if (unique_var_ids.count(var_id) > 0) {
         if (next_instr.NoDataTransformVars().count(var_id)) {
-          continue;
           VLOG(4) << "Skip inserting event at variable " << item.first
                   << " of operator " << next_instr.OpBase()->Type()
                   << " since it is NoDataTransform";
+          continue;
         }
         if (is_no_need_buffer(item.first)) {
-          continue;
           VLOG(4) << "Skip inserting event at variable " << item.first
                   << " of operator " << next_instr.OpBase()->Type()
                   << " since it is NoNeedBufferVar";
+          continue;
         }
 
         need_event_var_ids.push_back(var_id);

--- a/paddle/fluid/framework/new_executor/stream_analyzer.h
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.h
@@ -35,12 +35,13 @@ class StreamAnalyzer {
   platform::DeviceContext* ParseDeviceContext(const OpFuncNode& op_func_node);
 
  private:
-  std::vector<size_t> ParseEventVarIds(const Instruction& cur_instr,
-                                       const Instruction& next_instr);
+  std::vector<size_t> GetNeedEventVarIds(const Instruction& cur_instr,
+                                         const Instruction& next_instr);
 
-  void AssociateInputWithEvents(const std::vector<size_t>& new_event_var_id,
-                                Instruction* next_instr,
-                                platform::DeviceType waiter_type);
+  void ConstructEventForVar(const std::vector<size_t>& new_event_var_id,
+                            Instruction* next_instr,
+                            platform::DeviceType waiter_type,
+                            const platform::Place& place);
 
   bool IsDirectRun(Instruction& cur_instr,  // NOLINT
                    const Instruction& next_instr);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- Support NoNeedBufferVar in streamAnalyzer: 
    CPU op->VAR->GPU op, when var is no need buffer or no need data transform, the event on var is not need and it can be `DirectRun`.
- Refine code of `Instruction`, `InterpreterCore`, `OpFuncNode`
  - OpFuncNode holds `shared_ptr` of `OperatorBase`
  - Instruction holds OpFuncNode
  - InterpreterCore do not holds Instruction but not OpFuncNode