### PR TITLE
supports the slice of upper tensor, test=develop

### DIFF
--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -383,9 +383,10 @@ class ReshapeKernel {
     // TODO(YuanRisheng) we can use MakePtenDenseTensor after #36916 merge.
     const auto alloc = std::make_shared<paddle::experimental::DefaultAllocator>(
         paddle::platform::CPUPlace());
-    pten::DenseTensorMeta meta{pten::TransToPtenDataType(in->type()),
-                               in->dims(),
-                               pten::TransToPtenDataLayout(in->layout())};
+    pten::DenseTensorMeta meta{
+        pten::TransToPtenDataType(in->type()),
+        pten::DenseTensorShape(in->dims(),
+                               pten::TransToPtenDataLayout(in->layout()))};
     auto pt_out_tmp =
         std::make_shared<pten::DenseTensor>(alloc, std::move(meta));
     pten::DenseTensor *pt_out = nullptr;

--- a/paddle/pten/core/compat_utils.h
+++ b/paddle/pten/core/compat_utils.h
@@ -45,6 +45,40 @@ class CompatibleDenseTensorUtils {
     static_cast<paddle::experimental::SharedStorage*>(tensor->storage_.get())
         ->Reset();
   }
+
+  static DenseTensor Slice(DenseTensor* tensor,
+                           int64_t begin_idx,
+                           int64_t end_idx) {
+    tensor->check_memory_size();
+    PADDLE_ENFORCE_GE(begin_idx,
+                      0,
+                      paddle::platform::errors::OutOfRange(
+                          "The start row index must be greater than 0."
+                          "But received the start index is d%.",
+                          begin_idx));
+    PADDLE_ENFORCE_LE(end_idx,
+                      tensor->dims()[0],
+                      paddle::platform::errors::OutOfRange(
+                          "The end row index is out of bound."));
+    PADDLE_ENFORCE_LT(
+        begin_idx,
+        end_idx,
+        paddle::platform::errors::InvalidArgument(
+            "The start row index must be less than the end row index."
+            "But received the start index = %d, the end index = %d.",
+            begin_idx,
+            end_idx));
+    DenseTensor ret =
+        DenseTensor(copy_intrusive(tensor->storage_), tensor->meta_);
+    if (tensor->dims()[0] != 1) {
+      ret.meta_.shape.dims[0] = end_idx - begin_idx;
+      ret.meta_.shape.offset =
+          tensor->meta_.shape.offset +
+          begin_idx * (tensor->numel() / tensor->dims()[0]) *
+              paddle::experimental::SizeOf(tensor->data_type());
+    }
+    return ret;
+  }
 };
 
 }  // namespace pten

--- a/paddle/pten/core/dense_tensor.cc
+++ b/paddle/pten/core/dense_tensor.cc
@@ -64,7 +64,8 @@ void* DenseTensor::mutable_data(size_t request_bytes) {
   if (storage_->size() < bytes) {
     storage_->Realloc(bytes);
   }
-  return storage_->data();
+  return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(storage_->data()) +
+                                 meta_.shape.offset);
 }
 
 template <typename T>
@@ -94,7 +95,8 @@ const void* DenseTensor::data() const {
       storage_,
       paddle::platform::errors::PreconditionNotMet(
           "The storage must be valid when call the mutable data function."));
-  return storage_->data();
+  return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(storage_->data()) +
+                                 meta_.shape.offset);
 }
 
 void DenseTensor::check_memory_size() const {

--- a/paddle/pten/core/dense_tensor.h
+++ b/paddle/pten/core/dense_tensor.h
@@ -165,12 +165,6 @@ class DenseTensor : public TensorBase,
   /// \return The const data pointer value of raw type.
   const void* data() const;
 
-  /// \brief Get the shallow clone of current tensor.
-  /// \return The shallow clone of current tensor.
-  DenseTensor shallow_clone() const {
-    return DenseTensor(copy_intrusive(storage_), meta_);
-  }
-
  private:
   friend class CompatibleDenseTensorUtils;
 

--- a/paddle/pten/core/dense_tensor.h
+++ b/paddle/pten/core/dense_tensor.h
@@ -80,16 +80,7 @@ class DenseTensor : public TensorBase,
 
   /// \brief Returns the dims of the tensor.
   /// \return The dims of the tensor.
-  const DDim& dims() const noexcept { return meta_.dims; }
-
-  /// \brief Returns the lod of the tensor.
-  /// \return The lod of the tensor.
-  const std::vector<std::vector<size_t>>& lod() const noexcept {
-    return meta_.lod;
-  }
-
-  /// \brief Set the lod of the tensor.
-  void set_lod(const std::vector<std::vector<size_t>>& lod) { meta_.lod = lod; }
+  const DDim& dims() const noexcept { return meta_.shape.dims; }
 
   /// \brief Returns the data type of the tensor.
   /// \return The data type of the tensor.
@@ -97,7 +88,14 @@ class DenseTensor : public TensorBase,
 
   /// \brief Returns the data layout of the tensor.
   /// \return The data layout of the tensor.
-  DataLayout layout() const noexcept { return meta_.layout; }
+  DataLayout layout() const noexcept { return meta_.shape.layout; }
+
+  /// \brief Returns the shape of the tensor.
+  /// \return The shape of the tensor.
+  const DenseTensorShape& shape() const noexcept { return meta_.shape; }
+
+  /// \brief Returns Set the shape of the tensor.
+  void set_shape(const DenseTensorShape& shape);
 
   /// \brief Returns the data place of the tensor.
   /// \return The data place of the tensor.
@@ -124,11 +122,6 @@ class DenseTensor : public TensorBase,
   /// to avoid wrong access.
   /// \param dims The new dims of the dense tensor.
   void Resize(const DDim& dims);
-
-  /// \brief Change the dims information in the metadata.
-  /// \param dims The new dims of the dense tensor. The product of the dims
-  /// elements must be consistent with the original value.
-  void set_dims(const DDim& dims);
 
   /// \brief Returns the actual storage size occupied by tensor, may be larger
   /// than its shape dims.

--- a/paddle/pten/core/dense_tensor.h
+++ b/paddle/pten/core/dense_tensor.h
@@ -84,7 +84,7 @@ class DenseTensor : public TensorBase,
 
   /// \brief Returns the data type of the tensor.
   /// \return The data type of the tensor.
-  DataType data_type() const noexcept { return meta_.type; }
+  DataType data_type() const noexcept { return meta_.dtype; }
 
   /// \brief Returns the data layout of the tensor.
   /// \return The data layout of the tensor.

--- a/paddle/pten/core/tensor_meta.h
+++ b/paddle/pten/core/tensor_meta.h
@@ -52,6 +52,7 @@ struct DenseTensorShape {
   DDim dims{std::initializer_list<int64_t>{}};
   DataLayout layout{DataLayout::NCHW};
   LoD lod;
+  size_t offset{0};
 };
 
 inline DenseTensorShape::DenseTensorShape(const DDim& dims) : dims(dims) {}
@@ -77,7 +78,7 @@ inline bool operator==(const DenseTensorShape& lhs,
                        const DenseTensorShape& rhs) {
   bool ret = true;
   return ret && (lhs.dims == rhs.dims) && (lhs.layout == rhs.layout) &&
-         (lhs.lod == rhs.lod);
+         (lhs.lod == rhs.lod) && (lhs.offset == rhs.offset);
 }
 
 /// \brief The meta data of dense tensor. Take the structure type

--- a/paddle/pten/core/tensor_meta.h
+++ b/paddle/pten/core/tensor_meta.h
@@ -31,8 +31,11 @@ namespace pten {
 using DDim = paddle::framework::DDim;
 using LoD = std::vector<std::vector<size_t>>;
 
+/// \brief The shape data of dense tensor. Together with the data type
+/// information, it determines how the underlying storage area should
+/// be read. Take the structure type and use all default operations.
+
 struct DenseTensorShape {
-  using DataType = paddle::experimental::DataType;
   using DataLayout = paddle::experimental::DataLayout;
 
   DenseTensorShape() = default;
@@ -42,6 +45,8 @@ struct DenseTensorShape {
                    DataLayout layout,
                    const std::vector<std::vector<size_t>>& lod);
 
+  /// \brief Test whether the shape is valid. Does not throw exceptions.
+  /// \return Whether the shape is valid.
   bool valid() const noexcept;
 
   DDim dims{std::initializer_list<int64_t>{}};
@@ -77,8 +82,10 @@ inline bool operator==(const DenseTensorShape& lhs,
 
 /// \brief The meta data of dense tensor. Take the structure type
 /// and use all default operations.
-///
+
 struct DenseTensorMeta {
+  using DataType = paddle::experimental::DataType;
+
   DenseTensorMeta() = default;
   DenseTensorMeta(DataType type, const DenseTensorShape& shape);
   DenseTensorMeta(DataType type, DenseTensorShape&& shape);
@@ -87,29 +94,27 @@ struct DenseTensorMeta {
   /// \return Whether the metadata is valid.
   bool valid() const noexcept;
 
-  /// During the entire life cycle of a DenseTensor, the following attributes
-  /// marked with `const` are expected to remain unchanged.
-  DataType type{DataType::UNDEFINED};
+  DataType dtype{DataType::UNDEFINED};
   DenseTensorShape shape;
 };
 
 inline DenseTensorMeta::DenseTensorMeta(DataType type,
                                         const DenseTensorShape& shape)
-    : type(type), shape(shape) {}
+    : dtype(type), shape(shape) {}
 
 inline DenseTensorMeta::DenseTensorMeta(DataType type, DenseTensorShape&& shape)
-    : type(type), shape(std::move(shape)) {}
+    : dtype(type), shape(std::move(shape)) {}
 
 inline bool DenseTensorMeta::valid() const noexcept {
   bool valid{true};
-  valid = valid && (type != DataType::UNDEFINED);
+  valid = valid && (dtype != DataType::UNDEFINED);
   valid = valid && (shape.valid());
   return valid;
 }
 
 inline bool operator==(const DenseTensorMeta& lhs, const DenseTensorMeta& rhs) {
   bool ret = true;
-  return ret && (lhs.type == rhs.type) && (lhs.shape == rhs.shape);
+  return ret && (lhs.dtype == rhs.dtype) && (lhs.shape == rhs.shape);
 }
 
 }  // namespace pten

--- a/paddle/pten/infermeta/nary.cc
+++ b/paddle/pten/infermeta/nary.cc
@@ -21,7 +21,7 @@ DenseTensorMeta FullInferShape(const std::vector<int64_t>& shape,
                                DataType dtype,
                                DataLayout layout) {
   const auto& out_dims = paddle::framework::make_ddim(shape);
-  return {dtype, out_dims, layout};
+  return {dtype, DenseTensorShape(out_dims, layout)};
 }
 
 }  // namespace pten

--- a/paddle/pten/infermeta/unary.cc
+++ b/paddle/pten/infermeta/unary.cc
@@ -23,14 +23,15 @@ DenseTensorMeta UnchangedInferShape(const DenseTensorMeta& x_meta) {
 
 DenseTensorMeta ReductionInferShape(const DenseTensorMeta& x_meta) {
   const auto& out_dims = paddle::framework::make_ddim({1});
-  DenseTensorMeta return_meta(x_meta.type, out_dims, x_meta.layout);
+  DenseTensorMeta return_meta(x_meta.dtype,
+                              DenseTensorShape(out_dims, x_meta.shape.layout));
   return return_meta;
 }
 
 DenseTensorMeta FlattenInferShape(const DenseTensorMeta& x_meta,
                                   int start_axis,
                                   int stop_axis) {
-  auto& x_dims = x_meta.dims;
+  auto& x_dims = x_meta.shape.dims;
   int in_dims_size = x_dims.size();
   if (start_axis < 0) {
     start_axis = start_axis + in_dims_size;
@@ -63,12 +64,13 @@ DenseTensorMeta FlattenInferShape(const DenseTensorMeta& x_meta,
     out_shape.push_back(x_dims[i]);
   }
   const auto& out_dims = paddle::framework::make_ddim(out_shape);
-  DenseTensorMeta return_meta(x_meta.type, out_dims, x_meta.layout);
+  DenseTensorMeta return_meta(x_meta.dtype,
+                              DenseTensorShape(out_dims, x_meta.shape.layout));
 
-  if (x_dims[0] == return_meta.dims[0]) {
+  if (x_dims[0] == return_meta.shape.dims[0]) {
     // Only pass LoD when the first dimension of output and Input(X)
     // are the same.
-    return_meta.lod = x_meta.lod;
+    return_meta.shape.lod = x_meta.shape.lod;
   }
 
   return return_meta;
@@ -77,9 +79,10 @@ DenseTensorMeta FlattenInferShape(const DenseTensorMeta& x_meta,
 DenseTensorMeta FullLikeInferShape(const DenseTensorMeta& x_meta,
                                    DataType dtype,
                                    DataLayout layout) {
-  return {dtype == DataType::UNDEFINED ? x_meta.type : dtype,
-          x_meta.dims,
-          layout == DataLayout::UNDEFINED ? x_meta.layout : layout};
+  return {dtype == DataType::UNDEFINED ? x_meta.dtype : dtype,
+          DenseTensorShape(
+              x_meta.shape.dims,
+              layout == DataLayout::UNDEFINED ? x_meta.shape.layout : layout)};
 }
 
 }  // namespace pten

--- a/paddle/pten/infermeta/unary.cc
+++ b/paddle/pten/infermeta/unary.cc
@@ -212,13 +212,14 @@ DenseTensorMeta InferShapeFromVecValue(const DenseTensorMeta& x_meta,
                     paddle::platform::errors::InvalidArgument(
                         "The parameter 'shape' in ReshapeOp must be set. "
                         "But received 'shape' is empty."));
-  auto x_dims = x_meta.dims;
+  auto x_dims = x_meta.shape.dims;
   auto out_dims = ValidateShape(shape, x_dims);
-  DenseTensorMeta return_meta(x_meta.type, out_dims, x_meta.layout);
-  if (x_dims[0] == return_meta.dims[0]) {
+  DenseTensorMeta return_meta(x_meta.dtype,
+                              DenseTensorShape(out_dims, x_meta.shape.layout));
+  if (x_dims[0] == return_meta.shape.dims[0]) {
     // Only pass LoD when the first dimension of output and Input(X)
     // are the same.
-    return_meta.lod = x_meta.lod;
+    return_meta.shape.lod = x_meta.shape.lod;
   }
   return return_meta;
 }

--- a/paddle/pten/kernels/cpu/manipulation.cc
+++ b/paddle/pten/kernels/cpu/manipulation.cc
@@ -40,14 +40,16 @@ void FlattenWithXShape(const CPUContext& dev_ctx,
                        DenseTensor* out,
                        DenseTensor* xshape) {
   Flatten<T>(dev_ctx, x, start_axis, stop_axis, out);
-  const auto& in_dims = x.meta().dims;
+  const auto& in_dims = x.dims();
   std::vector<int64_t> xshape_dims(in_dims.size() + 1);
   xshape_dims[0] = 0;
   for (int i = 0; i < in_dims.size(); ++i) {
     xshape_dims[i + 1] = in_dims[i];
   }
   xshape->Resize(paddle::framework::make_ddim(xshape_dims));
-  xshape->set_lod(x.lod());
+  auto shape = xshape->shape();
+  shape.lod = shape.lod;
+  xshape->set_shape(shape);
 }
 
 }  // namespace pten

--- a/paddle/pten/kernels/cpu/manipulation.cc
+++ b/paddle/pten/kernels/cpu/manipulation.cc
@@ -50,11 +50,11 @@ void ReshapeFromVectorVal(const CPUContext& dev_ctx,
                           DenseTensor* out) {
   auto out_meta = InferShapeFromVecValue(x.meta(), shape);
   if (&x == out) {
-    out->Resize(out_meta.dims);
+    out->Resize(out_meta.shape.dims);
     return;
   }
   pten::Copy(dev_ctx, x, out);
-  out->Resize(out_meta.dims);
+  out->Resize(out_meta.shape.dims);
 }
 
 void ReshapeFromVectorValWithXShape(const CPUContext& dev_ctx,

--- a/paddle/pten/kernels/cuda/manipulation.cu
+++ b/paddle/pten/kernels/cuda/manipulation.cu
@@ -40,14 +40,16 @@ void FlattenWithXShape(const CUDAContext& dev_ctx,
                        DenseTensor* out,
                        DenseTensor* xshape) {
   Flatten<T>(dev_ctx, x, start_axis, stop_axis, out);
-  const auto& in_dims = x.meta().dims;
+  const auto& in_dims = x.dims();
   std::vector<int64_t> xshape_dims(in_dims.size() + 1);
   xshape_dims[0] = 0;
   for (int i = 0; i < in_dims.size(); ++i) {
     xshape_dims[i + 1] = in_dims[i];
   }
   xshape->Resize(paddle::framework::make_ddim(xshape_dims));
-  xshape->set_lod(x.lod());
+  auto shape = xshape->shape();
+  shape.lod = shape.lod;
+  xshape->set_shape(shape);
 }
 
 }  // namespace pten

--- a/paddle/pten/kernels/cuda/manipulation.cu
+++ b/paddle/pten/kernels/cuda/manipulation.cu
@@ -50,12 +50,12 @@ void ReshapeFromVectorVal(const CUDAContext& dev_ctx,
                           DenseTensor* out) {
   auto out_meta = InferShapeFromVecValue(x.meta(), shape);
   if (&x == out) {
-    LOG(INFO) << "out_meta dims:" << out_meta.dims;
-    out->Resize(out_meta.dims);
+    LOG(INFO) << "out_meta dims:" << out_meta.shape.dims;
+    out->Resize(out_meta.shape.dims);
     return;
   }
   pten::Copy(dev_ctx, x, false, out);
-  out->Resize(out_meta.dims);
+  out->Resize(out_meta.shape.dims);
 }
 
 void ReshapeFromVectorValWithXShape(const CUDAContext& dev_ctx,

--- a/paddle/pten/kernels/cuda/math.cu
+++ b/paddle/pten/kernels/cuda/math.cu
@@ -81,10 +81,11 @@ void Mean(const CUDAContext& dev_ctx, const DenseTensor& x, DenseTensor* out) {
       dev_ctx.GetPlace());
   pten::DenseTensor tmp(
       alloc,
-      DenseTensorMeta(x.data_type(),
-                      paddle::framework::make_ddim(
-                          {static_cast<int64_t>(temp_storage_bytes)}),
-                      x.layout()));
+      DenseTensorMeta(
+          x.data_type(),
+          DenseTensorShape(paddle::framework::make_ddim(
+                               {static_cast<int64_t>(temp_storage_bytes)}),
+                           x.layout())));
   void* temp_storage = tmp.mutable_data<T>();
   err = cub::DeviceReduce::Sum(static_cast<uint8_t*>(temp_storage),
                                temp_storage_bytes,

--- a/paddle/pten/kernels/xpu/manipulation.cc
+++ b/paddle/pten/kernels/xpu/manipulation.cc
@@ -47,7 +47,9 @@ void FlattenWithXShape(const XPUContext& dev_ctx,
     xshape_dims[i + 1] = in_dims[i];
   }
   xshape->Resize(paddle::framework::make_ddim(xshape_dims));
-  xshape->set_lod(x.lod());
+  auto shape = xshape->shape();
+  shape.lod = shape.lod;
+  xshape->set_shape(shape);
 }
 
 }  // namespace pten

--- a/paddle/pten/tests/api/test_dot_api.cc
+++ b/paddle/pten/tests/api/test_dot_api.cc
@@ -37,16 +37,18 @@ TEST(API, dot) {
       paddle::platform::CPUPlace());
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
-      pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 10}),
-                            pten::DataLayout::NCHW));
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 10}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x->mutable_data<float>();
 
   auto dense_y = std::make_shared<pten::DenseTensor>(
       alloc,
-      pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 10}),
-                            pten::DataLayout::NCHW));
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 10}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_y_data = dense_y->mutable_data<float>();
 
   float sum[3] = {0.0, 0.0, 0.0};

--- a/paddle/pten/tests/api/test_elementwise_api.cc
+++ b/paddle/pten/tests/api/test_elementwise_api.cc
@@ -37,16 +37,17 @@ TEST(API, add) {
       paddle::platform::CPUPlace());
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
-      pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 10}),
-                            pten::DataLayout::NCHW));
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 10}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x->mutable_data<float>();
 
   auto dense_y = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({10}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({10}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_y_data = dense_y->mutable_data<float>();
 
   float sum[3][10] = {0.0};

--- a/paddle/pten/tests/api/test_fill_api.cc
+++ b/paddle/pten/tests/api/test_fill_api.cc
@@ -38,8 +38,8 @@ TEST(API, full_like) {
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 2}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 2}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x->mutable_data<float>();
   dense_x_data[0] = 0;
 
@@ -73,8 +73,8 @@ TEST(API, zeros_like) {
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 2}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 2}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x->mutable_data<float>();
   dense_x_data[0] = 1;
 
@@ -106,8 +106,8 @@ TEST(API, ones_like) {
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::INT32,
-                            framework::make_ddim({3, 2}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 2}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x->mutable_data<int32_t>();
   dense_x_data[0] = 0;
 

--- a/paddle/pten/tests/api/test_flatten_api.cc
+++ b/paddle/pten/tests/api/test_flatten_api.cc
@@ -37,9 +37,10 @@ TEST(API, flatten) {
       paddle::platform::CPUPlace());
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
-      pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 2, 2, 3}),
-                            pten::DataLayout::NCHW));
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 2, 2, 3}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x->mutable_data<float>();
 
   for (int i = 0; i < dense_x->numel(); i++) {

--- a/paddle/pten/tests/api/test_matmul_api.cc
+++ b/paddle/pten/tests/api/test_matmul_api.cc
@@ -38,16 +38,16 @@ TEST(API, matmul_cpu) {
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 3}),
+                                                   pten::DataLayout::NCHW)));
 
   auto* dense_x_data = dense_x->mutable_data<float>();
 
   auto dense_y = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 3}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_y_data = dense_y->mutable_data<float>();
 
   for (size_t i = 0; i < 9; ++i) {
@@ -87,16 +87,16 @@ TEST(API, matmul_cuda) {
   auto ref_x = std::make_shared<pten::DenseTensor>(
       alloc_cpu,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 3}),
+                                                   pten::DataLayout::NCHW)));
 
   auto* ref_x_data = ref_x->mutable_data<float>();
 
   auto ref_y = std::make_shared<pten::DenseTensor>(
       alloc_cpu,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 3}),
+                                                   pten::DataLayout::NCHW)));
   auto* ref_y_data = ref_y->mutable_data<float>();
 
   for (size_t i = 0; i < 9; ++i) {
@@ -112,14 +112,14 @@ TEST(API, matmul_cuda) {
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc_cuda,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 3}),
+                                                   pten::DataLayout::NCHW)));
 
   auto dense_y = std::make_shared<pten::DenseTensor>(
       alloc_cuda,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 3}),
+                                                   pten::DataLayout::NCHW)));
 
   auto& pool = paddle::platform::DeviceContextPool::Instance();
   auto place = paddle::platform::CUDAPlace();
@@ -148,7 +148,8 @@ TEST(API, matmul_cuda) {
   auto ref_out = std::make_shared<pten::DenseTensor>(
       alloc_cpu,
       pten::DenseTensorMeta(
-          pten::DataType::FLOAT32, out.shape(), pten::DataLayout::NCHW));
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(out.shape(), pten::DataLayout::NCHW)));
 
   pten::Copy(*dev_ctx, *dense_out.get(), ref_out.get());
 

--- a/paddle/pten/tests/api/test_mean_api.cc
+++ b/paddle/pten/tests/api/test_mean_api.cc
@@ -38,8 +38,8 @@ TEST(API, mean) {
   auto dense_x = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 4}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({3, 4}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x->mutable_data<float>();
 
   float sum = 0.0;

--- a/paddle/pten/tests/api/test_tensor_utils.cc
+++ b/paddle/pten/tests/api/test_tensor_utils.cc
@@ -26,13 +26,14 @@ using DataLayout = paddle::experimental::DataLayout;
 
 using DenseTensor = pten::DenseTensor;
 using DenseTensorMeta = pten::DenseTensorMeta;
+using DenseTensorShape = pten::DenseTensorShape;
 
 TEST(tensor_utils, dense_tensor_to_lod_tensor) {
   const DDim dims({2, 1});
   const DataType dtype{DataType::FLOAT32};
   const DataLayout layout{DataLayout::NCHW};
   const std::vector<std::vector<size_t>> lod{{0, 2}};
-  DenseTensorMeta meta(dtype, dims, layout, lod);
+  DenseTensorMeta meta(dtype, DenseTensorShape(dims, layout, lod));
 
   auto alloc = std::make_shared<DefaultAllocator>(platform::CPUPlace());
 
@@ -44,8 +45,8 @@ TEST(tensor_utils, dense_tensor_to_lod_tensor) {
   framework::LoDTensor lod_tensor;
   MovesStorage(&dense_tensor, &lod_tensor);
 
-  CHECK(dense_tensor.lod().size() == lod_tensor.lod().size());
-  CHECK(dense_tensor.lod()[0] ==
+  CHECK(dense_tensor.shape().lod.size() == lod_tensor.lod().size());
+  CHECK(dense_tensor.shape().lod[0] ==
         static_cast<std::vector<size_t>>((lod_tensor.lod()[0])));
   CHECK(dense_tensor.data_type() ==
         pten::TransToPtenDataType(lod_tensor.type()));
@@ -60,8 +61,8 @@ TEST(tensor_utils, dense_tensor_to_lod_tensor) {
   CHECK(dense_tensor_1->dims() == dims);
   CHECK(dense_tensor_1->data_type() == dtype);
   CHECK(dense_tensor_1->layout() == layout);
-  CHECK(dense_tensor_1->lod().size() == lod.size());
-  CHECK(dense_tensor_1->lod()[0] == lod[0]);
+  CHECK(dense_tensor_1->shape().lod.size() == lod.size());
+  CHECK(dense_tensor_1->shape().lod[0] == lod[0]);
   const float* data_1 = dense_tensor_1->data<float>();
   CHECK(data_1[0] == 1.0f);
   CHECK(data_1[1] == 2.1f);
@@ -71,7 +72,7 @@ TEST(tensor_utils, dense_tensor_to_tensor) {
   const DDim dims({2, 1});
   const DataType dtype{DataType::FLOAT32};
   const DataLayout layout{DataLayout::NCHW};
-  DenseTensorMeta meta(dtype, dims, layout);
+  DenseTensorMeta meta(dtype, DenseTensorShape(dims, layout));
 
   auto alloc = std::make_shared<DefaultAllocator>(platform::CPUPlace());
 

--- a/paddle/pten/tests/core/test_dense_tensor.cc
+++ b/paddle/pten/tests/core/test_dense_tensor.cc
@@ -64,12 +64,12 @@ TEST(dense_tensor, meta) {
   CHECK(!meta_0.valid());
 
   DenseTensorMeta meta_1(dtype, shape);
-  CHECK(meta_1.type == dtype);
+  CHECK(meta_1.dtype == dtype);
   CHECK(meta_1.shape == shape);
   CHECK(meta_1.valid());
 
   DenseTensorMeta meta_2(dtype, std::move(shape));
-  CHECK(meta_2.type == dtype);
+  CHECK(meta_2.dtype == dtype);
   CHECK(meta_2.shape == shape_1);
   CHECK(meta_2.valid());
 
@@ -99,7 +99,7 @@ TEST(dense_tensor, ctor) {
     bool r{true};
     r = r && (t.numel() == product(m.shape.dims));
     r = r && (t.dims() == m.shape.dims);
-    r = r && (t.data_type() == m.type);
+    r = r && (t.data_type() == m.dtype);
     r = r && (t.layout() == m.shape.layout);
     r = r && (t.place() == paddle::platform::CPUPlace());
     r = r && t.initialized();

--- a/paddle/pten/tests/core/test_dense_tensor.cc
+++ b/paddle/pten/tests/core/test_dense_tensor.cc
@@ -145,20 +145,5 @@ TEST(dense_tensor, resize) {
   CHECK_EQ(storage->size(), 6u);
 }
 
-TEST(dense_tensor, shallow_clone) {
-  const DDim dims({1, 2});
-  const DataType dtype{DataType::INT8};
-  const DataLayout layout{DataLayout::NHWC};
-  const std::vector<std::vector<size_t>> lod{};
-  DenseTensorMeta meta(dtype, DenseTensorShape(dims, layout, lod));
-
-  auto alloc = std::make_shared<FancyAllocator>();
-  DenseTensor tensor_0(alloc, meta);
-
-  auto tensor_1 = tensor_0.shallow_clone();
-  CHECK(tensor_0.meta() == tensor_1.meta());
-  CHECK(tensor_0.release() == tensor_1.release());
-}
-
 }  // namespace tests
 }  // namespace pten

--- a/paddle/pten/tests/kernels/test_copy_dev_api.cc
+++ b/paddle/pten/tests/kernels/test_copy_dev_api.cc
@@ -36,15 +36,15 @@ TEST(DEV_API, copy) {
   auto dense_src = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({2, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({2, 3}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_src->mutable_data<float>();
 
   auto dense_dst = std::make_shared<pten::DenseTensor>(
       alloc,
       pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({2, 3}),
-                            pten::DataLayout::NCHW));
+                            pten::DenseTensorShape(framework::make_ddim({2, 3}),
+                                                   pten::DataLayout::NCHW)));
 
   for (size_t i = 0; i < 2; ++i) {
     for (size_t j = 0; j < 3; ++j) {

--- a/paddle/pten/tests/kernels/test_dot_dev_api.cc
+++ b/paddle/pten/tests/kernels/test_dot_dev_api.cc
@@ -34,16 +34,20 @@ TEST(DEV_API, dot) {
   // 1. create tensor
   const auto alloc = std::make_shared<paddle::experimental::DefaultAllocator>(
       paddle::platform::CPUPlace());
-  pten::DenseTensor dense_x(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({3, 10}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_x(
+      alloc,
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 10}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x.mutable_data<float>();
 
-  pten::DenseTensor dense_y(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({3, 10}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_y(
+      alloc,
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 10}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_y_data = dense_y.mutable_data<float>();
 
   float sum[3] = {0.0, 0.0, 0.0};
@@ -68,8 +72,8 @@ TEST(DEV_API, dot) {
   // 3. check result
   ASSERT_EQ(out.dims().size(), 2);
   ASSERT_EQ(out.dims()[0], 3);
-  ASSERT_EQ(out.meta().type, pten::DataType::FLOAT32);
-  ASSERT_EQ(out.meta().layout, pten::DataLayout::NCHW);
+  ASSERT_EQ(out.data_type(), pten::DataType::FLOAT32);
+  ASSERT_EQ(out.layout(), pten::DataLayout::NCHW);
 
   auto expect_result = sum;
   auto actual_result0 = out.data<float>()[0];

--- a/paddle/pten/tests/kernels/test_elementwise_dev_api.cc
+++ b/paddle/pten/tests/kernels/test_elementwise_dev_api.cc
@@ -34,16 +34,19 @@ TEST(DEV_API, elementwise_add) {
   // 1. create tensor
   const auto alloc = std::make_shared<paddle::experimental::DefaultAllocator>(
       paddle::platform::CPUPlace());
-  pten::DenseTensor dense_x(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({3, 10}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_x(
+      alloc,
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 10}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x.mutable_data<float>();
 
-  pten::DenseTensor dense_y(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({10}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_y(
+      alloc,
+      pten::DenseTensorMeta(pten::DataType::FLOAT32,
+                            pten::DenseTensorShape(framework::make_ddim({10}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_y_data = dense_y.mutable_data<float>();
 
   float sum[3][10] = {0.0};
@@ -71,8 +74,8 @@ TEST(DEV_API, elementwise_add) {
   // 3. check result
   ASSERT_EQ(dense_out.dims().size(), 2);
   ASSERT_EQ(dense_out.dims()[0], 3);
-  ASSERT_EQ(dense_out.meta().type, pten::DataType::FLOAT32);
-  ASSERT_EQ(dense_out.meta().layout, pten::DataLayout::NCHW);
+  ASSERT_EQ(dense_out.data_type(), pten::DataType::FLOAT32);
+  ASSERT_EQ(dense_out.layout(), pten::DataLayout::NCHW);
 
   auto expect_result = sum;
   auto actual_result0 = dense_out.data<float>()[0];

--- a/paddle/pten/tests/kernels/test_fill_dev_api.cc
+++ b/paddle/pten/tests/kernels/test_fill_dev_api.cc
@@ -34,10 +34,11 @@ TEST(DEV_API, fill_any_like) {
   // 1. create tensor
   const auto alloc = std::make_shared<paddle::experimental::DefaultAllocator>(
       paddle::platform::CPUPlace());
-  pten::DenseTensor dense_x(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({3, 2}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_x(
+      alloc,
+      pten::DenseTensorMeta(pten::DataType::FLOAT32,
+                            pten::DenseTensorShape(framework::make_ddim({3, 2}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x.mutable_data<float>();
   dense_x_data[0] = 0;
   float val = 1.0;
@@ -56,8 +57,8 @@ TEST(DEV_API, fill_any_like) {
   ASSERT_EQ(out.dims().size(), 2);
   ASSERT_EQ(out.dims()[0], 3);
   ASSERT_EQ(out.numel(), 6);
-  ASSERT_EQ(out.meta().type, pten::DataType::FLOAT32);
-  ASSERT_EQ(out.meta().layout, pten::DataLayout::NCHW);
+  ASSERT_EQ(out.data_type(), pten::DataType::FLOAT32);
+  ASSERT_EQ(out.layout(), pten::DataLayout::NCHW);
 
   auto* actual_result = out.data<float>();
   for (auto i = 0; i < 6; i++) {

--- a/paddle/pten/tests/kernels/test_flatten_dev_api.cc
+++ b/paddle/pten/tests/kernels/test_flatten_dev_api.cc
@@ -36,9 +36,10 @@ TEST(DEV_API, flatten) {
       paddle::platform::CPUPlace());
   pten::DenseTensor dense_x(
       alloc,
-      pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                            framework::make_ddim({3, 2, 2, 3}),
-                            pten::DataLayout::NCHW));
+      pten::DenseTensorMeta(
+          pten::DataType::FLOAT32,
+          pten::DenseTensorShape(framework::make_ddim({3, 2, 2, 3}),
+                                 pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x.mutable_data<float>();
 
   for (int i = 0; i < dense_x.numel(); i++) {
@@ -62,8 +63,8 @@ TEST(DEV_API, flatten) {
   ASSERT_EQ(out.dims()[1], expect_shape[1]);
   ASSERT_EQ(out.dims()[2], expect_shape[2]);
   ASSERT_EQ(out.numel(), 36);
-  ASSERT_EQ(out.meta().type, pten::DataType::FLOAT32);
-  ASSERT_EQ(out.meta().layout, pten::DataLayout::NCHW);
+  ASSERT_EQ(out.data_type(), pten::DataType::FLOAT32);
+  ASSERT_EQ(out.layout(), pten::DataLayout::NCHW);
 
   bool value_equal = true;
   auto* dense_out_data = out.data<float>();

--- a/paddle/pten/tests/kernels/test_mean_dev_api.cc
+++ b/paddle/pten/tests/kernels/test_mean_dev_api.cc
@@ -34,10 +34,11 @@ TEST(DEV_API, mean) {
   // 1. create tensor
   const auto alloc = std::make_shared<paddle::experimental::DefaultAllocator>(
       paddle::platform::CPUPlace());
-  pten::DenseTensor dense_x(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({3, 4}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_x(
+      alloc,
+      pten::DenseTensorMeta(pten::DataType::FLOAT32,
+                            pten::DenseTensorShape(framework::make_ddim({3, 4}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x.mutable_data<float>();
 
   float sum = 0.0;
@@ -55,8 +56,8 @@ TEST(DEV_API, mean) {
   // 3. check result
   ASSERT_EQ(out.dims().size(), 1);
   ASSERT_EQ(out.numel(), 1);
-  ASSERT_EQ(out.meta().type, pten::DataType::FLOAT32);
-  ASSERT_EQ(out.meta().layout, pten::DataLayout::NCHW);
+  ASSERT_EQ(out.data_type(), pten::DataType::FLOAT32);
+  ASSERT_EQ(out.layout(), pten::DataLayout::NCHW);
 
   auto expect_result = sum / 12;
   auto actual_result = out.data<float>()[0];

--- a/paddle/pten/tests/kernels/test_scale_dev_api.cc
+++ b/paddle/pten/tests/kernels/test_scale_dev_api.cc
@@ -34,10 +34,11 @@ TEST(DEV_API, scale) {
   // 1. create tensor
   const auto alloc = std::make_shared<paddle::experimental::DefaultAllocator>(
       paddle::platform::CPUPlace());
-  pten::DenseTensor dense_x(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({3, 4}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_x(
+      alloc,
+      pten::DenseTensorMeta(pten::DataType::FLOAT32,
+                            pten::DenseTensorShape(framework::make_ddim({3, 4}),
+                                                   pten::DataLayout::NCHW)));
 
   auto* dense_x_data = dense_x.mutable_data<float>();
   for (size_t i = 0; i < 12; ++i) {
@@ -62,8 +63,8 @@ TEST(DEV_API, scale) {
   // 3. check result
   ASSERT_EQ(out.dims().size(), 2);
   ASSERT_EQ(out.numel(), 12);
-  ASSERT_EQ(out.meta().type, pten::DataType::FLOAT32);
-  ASSERT_EQ(out.meta().layout, pten::DataLayout::NCHW);
+  ASSERT_EQ(out.data_type(), pten::DataType::FLOAT32);
+  ASSERT_EQ(out.layout(), pten::DataLayout::NCHW);
 
   auto expect_result = 23;
   auto actual_result = out.data<float>()[11];
@@ -74,20 +75,22 @@ TEST(DEV_API, scale_host) {
   // 1. create tensor
   const auto alloc = std::make_shared<paddle::experimental::DefaultAllocator>(
       paddle::platform::CPUPlace());
-  pten::DenseTensor dense_x(alloc,
-                            pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                  framework::make_ddim({3, 4}),
-                                                  pten::DataLayout::NCHW));
+  pten::DenseTensor dense_x(
+      alloc,
+      pten::DenseTensorMeta(pten::DataType::FLOAT32,
+                            pten::DenseTensorShape(framework::make_ddim({3, 4}),
+                                                   pten::DataLayout::NCHW)));
   auto* dense_x_data = dense_x.mutable_data<float>();
   for (size_t i = 0; i < 12; ++i) {
     dense_x_data[i] = i * 1.0;
   }
   const auto alloc2 = std::make_shared<paddle::experimental::DefaultAllocator>(
       paddle::platform::CPUPlace());
-  pten::DenseTensor scale(alloc2,
-                          pten::DenseTensorMeta(pten::DataType::FLOAT32,
-                                                framework::make_ddim({1}),
-                                                pten::DataLayout::NCHW));
+  pten::DenseTensor scale(
+      alloc2,
+      pten::DenseTensorMeta(pten::DataType::FLOAT32,
+                            pten::DenseTensorShape(framework::make_ddim({1}),
+                                                   pten::DataLayout::NCHW)));
   scale.mutable_data<float>()[0] = 2;
   float bias = 1;
   bool bias_after_scale = true;
@@ -107,8 +110,8 @@ TEST(DEV_API, scale_host) {
   // 3. check result
   ASSERT_EQ(out.dims().size(), 2);
   ASSERT_EQ(out.numel(), 12);
-  ASSERT_EQ(out.meta().type, pten::DataType::FLOAT32);
-  ASSERT_EQ(out.meta().layout, pten::DataLayout::NCHW);
+  ASSERT_EQ(out.data_type(), pten::DataType::FLOAT32);
+  ASSERT_EQ(out.layout(), pten::DataLayout::NCHW);
 
   auto expect_result = 23;
   auto actual_result = out.data<float>()[11];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
1、新增 `DenseTensor` 的 `Slice` 功能，以支持上层接口接入。
2、`DenseTensor` 的作用是以确定的 **数据类型** 和 **排布规则** 解释相应的 **存储区域**。整理排布规则结构如下：
```
DenseTensorMeta: meta
     |----- DataType: dtype
     |----- DenseTensorShape: shape
     |          |----- DDim: dims
     |          |----- DataLayout: layout
     |          |----- LoD: lod
     |          |----- size_t: offset
```