### PR TITLE
[heterps]Refactor heter trainer

### DIFF
--- a/paddle/fluid/distributed/service/heter_server.h
+++ b/paddle/fluid/distributed/service/heter_server.h
@@ -207,6 +207,11 @@ class RequestSendAndRecvHandler final : public HeterRequestHandler {
     }
   }
 
+  int GetThreadNum() {
+    std::unique_lock<std::mutex> lk(scope_mutex_);
+    return (*task_queue_).size();
+  }
+
   void SetTaskQueue(SharedTaskQueue task_queue) { task_queue_ = task_queue; }
 
   int Handle(const MultiVarMsg* request, MultiVarMsg* response,
@@ -352,6 +357,8 @@ class HeterServer {
   void SetMicroBatchScopes(SharedMicroScope micro_scopes) {
     request_handler_->SetMicroScopes(micro_scopes);
   }
+
+  int GetThreadNum() { return request_handler_->GetThreadNum(); }
 
   void SetTaskQueue(SharedTaskQueue task_queue) {
     request_handler_->SetTaskQueue(task_queue);

--- a/paddle/fluid/distributed/service/heter_server.h
+++ b/paddle/fluid/distributed/service/heter_server.h
@@ -192,13 +192,19 @@ class RequestSendAndRecvHandler final : public HeterRequestHandler {
 
   virtual ~RequestSendAndRecvHandler() {}
 
-  // void SetMiniScopes(SharedMiniScope mini_scopes) {
-  //  mini_scopes_ = mini_scopes;
-  //  num_minibatch_ = mini_scopes_->size();
-  //}
+  void SetMiniScopes(SharedMiniScope mini_scopes) {
+    mini_scopes_ = mini_scopes;
+    num_minibatch_ = mini_scopes_->size();
+  }
+
   void SetMicroScopes(SharedMicroScope micro_scopes) {
     micro_scopes_ = micro_scopes;
-    num_microbatch_ = micro_scopes_->size();
+    for (auto& scope_pair : (*micro_scopes_)) {
+      // auto mini_idx = scope_pair.first;
+      auto& micro_scopes = scope_pair.second;
+      num_microbatch_ = micro_scopes->size();
+      break;
+    }
   }
 
   void SetTaskQueue(SharedTaskQueue task_queue) { task_queue_ = task_queue; }
@@ -235,14 +241,32 @@ class RequestSendAndRecvHandler final : public HeterRequestHandler {
     int minibatch_index = micro_id / 10;
     int microbatch_index = micro_id % 10;
 
-    // PADDLE_ENFORCE_EQ(
-    //    (*mini_scopes_).find(minibatch_index) != (*mini_scopes_).end(), 1,
-    //    platform::errors::InvalidArgument(
-    //        "minibatch index should in current trainer"));
-    PADDLE_ENFORCE_EQ(
-        (*micro_scopes_).find(minibatch_index) != (*micro_scopes_).end(), 1,
-        platform::errors::InvalidArgument(
-            "minibatch index should in current trainer"));
+    // check minibatch_index is in mini_scopes_
+    std::unique_lock<std::mutex> lk(scope_mutex_);
+    if ((*mini_scopes_).find(minibatch_index) != (*mini_scopes_).end()) {
+      lk.unlock();
+      // PADDLE_ENFORCE_EQ(
+      //    (*mini_scopes_).find(minibatch_index) != (*mini_scopes_).end(), 1,
+      //    platform::errors::InvalidArgument(
+      //        "minibatch index should in current trainer"));
+      PADDLE_ENFORCE_EQ(
+          (*micro_scopes_).find(minibatch_index) != (*micro_scopes_).end(), 1,
+          platform::errors::InvalidArgument(
+              "minibatch index should in current trainer"));
+
+    } else {
+      // create mini scope & micro scopes
+      auto* minibatch_scope = &(scope_->NewScope());
+      (*mini_scopes_)[minibatch_index] = minibatch_scope;
+      for (int i = 0; i < num_microbatch_; i++) {
+        auto* micro_scope = &(minibatch_scope->NewScope());
+        (*((*micro_scopes_)[minibatch_index])).push_back(micro_scope);
+      }
+      (*task_queue_)[minibatch_index].reset(
+          new ::paddle::framework::BlockingQueue<
+              std::pair<std::string, int>>());
+      lk.unlock();
+    }
 
     auto* micro_scope =
         (*((*micro_scopes_)[minibatch_index]))[microbatch_index];
@@ -253,7 +277,6 @@ class RequestSendAndRecvHandler final : public HeterRequestHandler {
     // blocking queue handles multi thread
     (*task_queue_)[minibatch_index]->Push(
         std::make_pair(message_name, microbatch_index));
-
     auto response_var_nums = request->recv_var_names_size();
     std::vector<std::string> response_var_names(response_var_nums),
         empty_var_names{};
@@ -269,11 +292,12 @@ class RequestSendAndRecvHandler final : public HeterRequestHandler {
 
  private:
   // share with HeterPipelineTrainer
-  // SharedMiniScope mini_scopes_{nullptr};
+  SharedMiniScope mini_scopes_{nullptr};
   SharedMicroScope micro_scopes_{nullptr};
 
   int num_microbatch_;
   int num_minibatch_;
+  std::mutex scope_mutex_;
 
   bool is_first_stage_ = false;
   bool is_last_stage_ = false;
@@ -321,9 +345,9 @@ class HeterServer {
     request_handler_ = request_handler;
   }
 
-  // void SetMiniBatchScopes(SharedMiniScope mini_scopes) {
-  //  request_handler_->SetMiniScopes(mini_scopes);
-  //}
+  void SetMiniBatchScopes(SharedMiniScope mini_scopes) {
+    request_handler_->SetMiniScopes(mini_scopes);
+  }
 
   void SetMicroBatchScopes(SharedMicroScope micro_scopes) {
     request_handler_->SetMicroScopes(micro_scopes);

--- a/paddle/fluid/distributed/service/heter_server.h
+++ b/paddle/fluid/distributed/service/heter_server.h
@@ -263,6 +263,8 @@ class RequestSendAndRecvHandler final : public HeterRequestHandler {
       // create mini scope & micro scopes
       auto* minibatch_scope = &(scope_->NewScope());
       (*mini_scopes_)[minibatch_index] = minibatch_scope;
+      (*micro_scopes_)[minibatch_index].reset(
+          new std::vector<paddle::framework::Scope*>{});
       for (int i = 0; i < num_microbatch_; i++) {
         auto* micro_scope = &(minibatch_scope->NewScope());
         (*((*micro_scopes_)[minibatch_index])).push_back(micro_scope);
@@ -278,7 +280,6 @@ class RequestSendAndRecvHandler final : public HeterRequestHandler {
 
     distributed::DeserializeFromMultiVarMsgAndIOBuf(
         *request, &request_io_buffer, *dev_ctx_, micro_scope);
-
     // blocking queue handles multi thread
     (*task_queue_)[minibatch_index]->Push(
         std::make_pair(message_name, microbatch_index));

--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -631,10 +631,17 @@ class HeterSectionWorker : public DeviceWorker {
   std::shared_ptr<std::vector<Scope*>> GetMicrobatchScopes() {
     return microbatch_scopes_;
   }
+  void SetMicrobatchScopes(
+      std::shared_ptr<std::vector<Scope*>> microbatch_scopes) {
+    microbatch_scopes_ = microbatch_scopes;
+  }
   using SHARED_THREAD_QUEUE = std::shared_ptr<
       ::paddle::framework::BlockingQueue<std::pair<std::string, int>>>;
 
   SHARED_THREAD_QUEUE GetThreadQueue() { return thread_queue_; }
+  void SetThreadQueue(SHARED_THREAD_QUEUE thread_queue) {
+    thread_queue_ = thread_queue;
+  }
   void CopyParameters(int microbatch_id, const ProgramDesc& program,
                       const platform::Place& place);
   void SetMinibatchScope(Scope* scope) { minibatch_scope_ = scope; }

--- a/paddle/fluid/framework/heter_pipeline_trainer.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer.cc
@@ -265,7 +265,6 @@ void HeterPipelineTrainer::Run() {
           this_worker->CreateMicrobatchScopes();
           // this_worker->SetMicrobatchScopes((*micro_scopes_)[worker_index]);
           this_worker->SetThreadQueue((*task_queue_)[worker_index]);
-
           if (!debug_) {
             threads_.push_back(
                 std::thread(&DeviceWorker::TrainFiles, this_worker.get()));

--- a/paddle/fluid/framework/heter_pipeline_trainer.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer.cc
@@ -77,34 +77,51 @@ void HeterPipelineTrainer::Initialize(const TrainerDesc& trainer_desc,
     trainers_.push_back(trainer_num);
   }
   int cpu_trainer_num = trainers_[0];
-  int cur_stage_trainer_num = trainers_[pipeline_stage_];
-  int global_thread_num = cpu_trainer_num * thread_num_;
-  int previous_trainers = 0;
-  for (int i = 0; i < pipeline_stage_; i++) previous_trainers += trainers_[i];
-  int stage_trainer_id =
-      trainer_id_ - previous_trainers;  // trainer id in current stage
-  int cnt = -1;
-  for (int i = stage_trainer_id; i < global_thread_num;
-       i += cur_stage_trainer_num) {
-    cnt++;
-    workers_[i] = DeviceWorkerFactory::CreateDeviceWorker(
+  // int cur_stage_trainer_num = trainers_[pipeline_stage_];
+  // int global_thread_num = cpu_trainer_num * thread_num_;
+  // int previous_trainers = 0;
+  // for (int i = 0; i < pipeline_stage_; i++) previous_trainers +=
+  // trainers_[i];
+  // int stage_trainer_id =
+  //    trainer_id_ - previous_trainers;  // trainer id in current stage
+
+  if (pipeline_stage_ == 0) {  // for cpu trainer
+    int cnt = -1;
+    int real_thread_id = trainer_id_;
+    for (int i = 0; i < thread_num_; i++) {
+      cnt++;
+      workers_[real_thread_id] = DeviceWorkerFactory::CreateDeviceWorker(
+          trainer_desc.device_worker_name());
+      auto this_worker =
+          std::dynamic_pointer_cast<paddle::framework::HeterSectionWorker>(
+              workers_[real_thread_id]);
+      this_worker->SetDebug(debug_);
+      this_worker->SetNeedDumpField(need_dump_field_);
+      this_worker->SetNeedDumpParam(need_dump_param_);
+      this_worker->SetDumpFieldVector(dump_fields_);
+      this_worker->SetDumpParamVector(dump_param_);
+      this_worker->InitRandomDumpConfig(trainer_desc);
+      this_worker->SetDeviceIndex(real_thread_id);
+      real_thread_id += cpu_trainer_num;
+      // if (pipeline_stage_ == 0) {
+      this_worker->SetDataFeed(readers[cnt]);
+      //}
+      this_worker->SetMicrobatchNum(num_microbatches_);
+      this_worker->SetPipelineStageNum(num_pipeline_stages_);
+      this_worker->SetPipelineStage(pipeline_stage_);
+    }
+  } else {  // for heter_trainer
+    // heter trainer with thread_id == -1 is not for
+    // real training
+    workers_[-1] = DeviceWorkerFactory::CreateDeviceWorker(
         trainer_desc.device_worker_name());
     auto this_worker =
         std::dynamic_pointer_cast<paddle::framework::HeterSectionWorker>(
-            workers_[i]);
-    this_worker->SetDebug(debug_);
-    this_worker->SetNeedDumpField(need_dump_field_);
-    this_worker->SetNeedDumpParam(need_dump_param_);
-    this_worker->SetDumpFieldVector(dump_fields_);
-    this_worker->SetDumpParamVector(dump_param_);
-    this_worker->InitRandomDumpConfig(trainer_desc);
-    this_worker->SetDeviceIndex(i);
-    if (pipeline_stage_ == 0) {
-      this_worker->SetDataFeed(readers[cnt]);
-    }
+            workers_[-1]);
     this_worker->SetMicrobatchNum(num_microbatches_);
     this_worker->SetPipelineStageNum(num_pipeline_stages_);
     this_worker->SetPipelineStage(pipeline_stage_);
+    this_worker->SetDeviceIndex(-1);
   }
 }
 
@@ -177,7 +194,7 @@ void HeterPipelineTrainer::Run() {
   }
   auto heter_server = paddle::distributed::HeterServer::GetInstance();
   heter_server->WaitServerReady();
-  // heter_server->SetMiniBatchScopes(mini_scopes_);
+  heter_server->SetMiniBatchScopes(mini_scopes_);
   heter_server->SetMicroBatchScopes(micro_scopes_);
   heter_server->SetTaskQueue(task_queue_);
   // main training logic
@@ -193,6 +210,7 @@ void HeterPipelineTrainer::Run() {
       }
     }
   } else {  // for heter worker
+    // start thread_worker with thread_id = -1
     for (auto& worker_pair : workers_) {
       auto device_worker = worker_pair.second;
       if (!debug_) {
@@ -201,6 +219,58 @@ void HeterPipelineTrainer::Run() {
       } else {
         threads_.push_back(std::thread(&DeviceWorker::TrainFilesWithProfiler,
                                        device_worker.get()));
+      }
+    }
+    bool epoch_finish = false;
+    while (!epoch_finish) {
+      auto heter_server = paddle::distributed::HeterServer::GetInstance();
+      if (heter_server->IsStop()) {
+        epoch_finish = true;
+        continue;
+      }
+      // create new thread_worker
+      size_t thread_num = (*micro_scopes_).size();
+      while (thread_num > threads_.size()) {
+        for (auto& worker_pair : (*micro_scopes_)) {
+          auto worker_index = worker_pair.first;
+          if (workers_.find(worker_index) != workers_.end()) continue;
+          workers_[worker_index] = DeviceWorkerFactory::CreateDeviceWorker(
+              trainer_desc_.device_worker_name());
+          auto this_worker =
+              std::dynamic_pointer_cast<paddle::framework::HeterSectionWorker>(
+                  workers_[worker_index]);
+          this_worker->SetDebug(debug_);
+          this_worker->SetNeedDumpField(need_dump_field_);
+          this_worker->SetNeedDumpParam(need_dump_param_);
+          this_worker->SetDumpFieldVector(dump_fields_);
+          this_worker->SetDumpParamVector(dump_param_);
+          this_worker->InitRandomDumpConfig(trainer_desc_);
+          this_worker->SetDeviceIndex(worker_index);
+          this_worker->SetMicrobatchNum(num_microbatches_);
+          this_worker->SetPipelineStageNum(num_pipeline_stages_);
+          this_worker->SetPipelineStage(pipeline_stage_);
+          this_worker->SetPlace(place_);
+          this_worker->Initialize(trainer_desc_);
+          this_worker->SetRootScope(root_scope_);
+
+          // generate mini_batch scope for every worker
+          // auto* minibatch_scope = &root_scope_->NewScope();
+          auto* minibatch_scope = (*mini_scopes_)[worker_index];
+          // (*mini_scopes_)[worker_index] = minibatch_scope;
+          this_worker->SetMinibatchScope(minibatch_scope);
+          // after set micro num & mini batch scope
+          this_worker->CreateMicrobatchScopes();
+          this_worker->SetMicrobatchScopes((*micro_scopes_)[worker_index]);
+          this_worker->SetThreadQueue((*task_queue_)[worker_index]);
+
+          if (!debug_) {
+            threads_.push_back(
+                std::thread(&DeviceWorker::TrainFiles, this_worker.get()));
+          } else {
+            threads_.push_back(std::thread(
+                &DeviceWorker::TrainFilesWithProfiler, this_worker.get()));
+          }
+        }
       }
     }
   }

--- a/paddle/fluid/framework/heter_pipeline_trainer.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer.cc
@@ -59,12 +59,6 @@ void HeterPipelineTrainer::Initialize(const TrainerDesc& trainer_desc,
   thread_num_ = trainer_desc.thread_num();
   ParseDumpConfig(trainer_desc);
   SetDebug(trainer_desc.debug());
-  // for (int i = 0; i < trainer_desc.downpour_param().stat_var_names_size();
-  //     i++) {
-  //  need_merge_var_names_.push_back(
-  //      trainer_desc.downpour_param().stat_var_names(i));
-  //}
-  // get filelist from trainer_desc here
   const std::vector<paddle::framework::DataFeed*> readers =
       dataset->GetReaders();
   VLOG(3) << "readers num: " << readers.size();

--- a/paddle/fluid/framework/heter_pipeline_trainer.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer.cc
@@ -301,7 +301,11 @@ void HeterPipelineTrainer::Finalize() {
 }
 
 Scope* HeterPipelineTrainer::GetWorkerScope(int thread_id) {
-  return workers_[thread_id]->GetThreadScope();
+  if (workers_.find(thread_id) != workers_.end()) {
+    return workers_[thread_id]->GetThreadScope();
+  } else {
+    return nullptr;
+  }
 }
 
 }  // end namespace framework

--- a/paddle/fluid/framework/heter_pipeline_trainer_test.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer_test.cc
@@ -170,34 +170,22 @@ TEST(HeterPipelineTrainerTest, GPU) {
 
   tmp1->Initialize(t, dataset.get());
 
-  std::cout << "after tmp1 initialize" << std::endl;
   tmp1->InitTrainerEnv(p, place);
-  std::cout << "after tmp1 init TrainerEnv" << std::endl;
   tmp1->InitOtherEnv(p);
-  std::cout << "after tmp1 init OtherEnv" << std::endl;
   tmp1->GetWorkerScope(0);
-  std::cout << "after tmp1 get worker scope" << std::endl;
   tmp1->ResetDataset(dataset.get());
-  std::cout << "after tmp1 reset data" << std::endl;
   tmp1->Finalize();
-  std::cout << "after tmp1 finalize" << std::endl;
 
   // tmp2
   std::shared_ptr<TrainerBase> tmp2;
   tmp2 = TrainerFactory::CreateTrainer(t2.class_name());
   tmp2->SetScope(&root_scope2);
   tmp2->Initialize(t2, dataset.get());
-  std::cout << "after tmp2 initialize" << std::endl;
   tmp2->InitTrainerEnv(p2, place2);
-  std::cout << "after tmp2 init TrainerEnv" << std::endl;
   tmp2->InitOtherEnv(p2);
-  std::cout << "after tmp2 init OtherEnv" << std::endl;
   tmp2->GetWorkerScope(0);
-  std::cout << "after tmp2 get worker scope" << std::endl;
   tmp2->ResetDataset(dataset.get());
-  std::cout << "after tmp2 reset data" << std::endl;
   tmp2->Finalize();
-  std::cout << "after tmp2 finalize" << std::endl;
 
   // tmp3
   std::shared_ptr<TrainerBase> tmp3;
@@ -214,7 +202,6 @@ TEST(HeterPipelineTrainerTest, GPU) {
   tmp3->GetWorkerScope(0);
   tmp3->ResetDataset(dataset.get());
   tmp3->Finalize();
-  std::cout << "after tmp3 finalize" << std::endl;
 
   // tmp4 for coverage
   std::shared_ptr<TrainerBase> tmp4;

--- a/paddle/fluid/framework/heter_pipeline_trainer_test.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer_test.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)) && \
-    (defined PADDLE_WITH_PSCORE)
+#if (defined PADDLE_WITH_CUDA) && (defined PADDLE_WITH_PSCORE)
 #include "gtest/gtest.h"
 #include "paddle/fluid/framework/device_worker.h"
 #include "paddle/fluid/framework/device_worker_factory.h"

--- a/paddle/fluid/framework/heter_pipeline_trainer_test.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer_test.cc
@@ -167,23 +167,37 @@ TEST(HeterPipelineTrainerTest, GPU) {
   std::shared_ptr<TrainerBase> tmp1;
   tmp1 = TrainerFactory::CreateTrainer(t.class_name());
   tmp1->SetScope(&root_scope);
+
   tmp1->Initialize(t, dataset.get());
+
+  std::cout << "after tmp1 initialize" << std::endl;
   tmp1->InitTrainerEnv(p, place);
+  std::cout << "after tmp1 init TrainerEnv" << std::endl;
   tmp1->InitOtherEnv(p);
+  std::cout << "after tmp1 init OtherEnv" << std::endl;
   tmp1->GetWorkerScope(0);
+  std::cout << "after tmp1 get worker scope" << std::endl;
   tmp1->ResetDataset(dataset.get());
+  std::cout << "after tmp1 reset data" << std::endl;
   tmp1->Finalize();
+  std::cout << "after tmp1 finalize" << std::endl;
 
   // tmp2
   std::shared_ptr<TrainerBase> tmp2;
   tmp2 = TrainerFactory::CreateTrainer(t2.class_name());
   tmp2->SetScope(&root_scope2);
   tmp2->Initialize(t2, dataset.get());
+  std::cout << "after tmp2 initialize" << std::endl;
   tmp2->InitTrainerEnv(p2, place2);
+  std::cout << "after tmp2 init TrainerEnv" << std::endl;
   tmp2->InitOtherEnv(p2);
+  std::cout << "after tmp2 init OtherEnv" << std::endl;
   tmp2->GetWorkerScope(0);
+  std::cout << "after tmp2 get worker scope" << std::endl;
   tmp2->ResetDataset(dataset.get());
+  std::cout << "after tmp2 reset data" << std::endl;
   tmp2->Finalize();
+  std::cout << "after tmp2 finalize" << std::endl;
 
   // tmp3
   std::shared_ptr<TrainerBase> tmp3;
@@ -200,6 +214,7 @@ TEST(HeterPipelineTrainerTest, GPU) {
   tmp3->GetWorkerScope(0);
   tmp3->ResetDataset(dataset.get());
   tmp3->Finalize();
+  std::cout << "after tmp3 finalize" << std::endl;
 
   // tmp4 for coverage
   std::shared_ptr<TrainerBase> tmp4;

--- a/paddle/fluid/framework/heter_pipeline_trainer_test.cc
+++ b/paddle/fluid/framework/heter_pipeline_trainer_test.cc
@@ -167,9 +167,7 @@ TEST(HeterPipelineTrainerTest, GPU) {
   std::shared_ptr<TrainerBase> tmp1;
   tmp1 = TrainerFactory::CreateTrainer(t.class_name());
   tmp1->SetScope(&root_scope);
-
   tmp1->Initialize(t, dataset.get());
-
   tmp1->InitTrainerEnv(p, place);
   tmp1->InitOtherEnv(p);
   tmp1->GetWorkerScope(0);

--- a/paddle/fluid/framework/heter_section_worker.cc
+++ b/paddle/fluid/framework/heter_section_worker.cc
@@ -417,22 +417,24 @@ void HeterSectionWorker::PrintFetchVars() {
 }
 
 void HeterSectionWorker::TrainFilesWithProfiler() {
-  VLOG(3) << "begin section_worker TrainFilesWithProfiler";
-  batch_num_ = 0;
-  epoch_finish_ = false;
-  total_ins_num_ = 0;
-  op_name_.clear();
-  op_total_time_.clear();
-  if (pipeline_stage_ == 0) {
-    device_reader_->Start();
-  }
-  while (!epoch_finish_) {
-    Run();
-    dev_ctx_->Wait();
-    if (epoch_finish_) {
-      // dump param for debug
-      if (need_dump_field_ || need_dump_param_) {
-        writer_.Flush();
+  if (thread_id_ >= 0) {
+    VLOG(3) << "begin section_worker TrainFilesWithProfiler";
+    batch_num_ = 0;
+    epoch_finish_ = false;
+    total_ins_num_ = 0;
+    op_name_.clear();
+    op_total_time_.clear();
+    if (pipeline_stage_ == 0) {
+      device_reader_->Start();
+    }
+    while (!epoch_finish_) {
+      Run();
+      dev_ctx_->Wait();
+      if (epoch_finish_) {
+        // dump param for debug
+        if (need_dump_field_ || need_dump_param_) {
+          writer_.Flush();
+        }
       }
     }
   }

--- a/paddle/fluid/framework/trainer.h
+++ b/paddle/fluid/framework/trainer.h
@@ -347,11 +347,6 @@ class HeterPipelineTrainer : public TrainerBase {
   int thread_num_;
   std::vector<std::thread> threads_;
 
-  std::vector<std::string> need_merge_var_names_;
-#ifdef PADDLE_WITH_HETERPS
-  std::vector<platform::Place> places_;
-#endif
-
   int num_microbatches_;
   platform::Place place_;
   TrainerDesc trainer_desc_;

--- a/paddle/fluid/operators/pscore/heter_listen_and_server_test.cc
+++ b/paddle/fluid/operators/pscore/heter_listen_and_server_test.cc
@@ -161,13 +161,20 @@ TEST(HETER_LISTEN_AND_SERV, CPU) {
   b_rpc_service->WaitServerReady();
   using MicroScope =
       std::unordered_map<int, std::shared_ptr<std::vector<framework::Scope*>>>;
+  using MiniScope = std::unordered_map<int, framework::Scope*>;
+  std::shared_ptr<MiniScope> mini_scopes(new MiniScope{});
   std::shared_ptr<MicroScope> micro_scopes(new MicroScope{});
   std::shared_ptr<std::vector<framework::Scope*>> micro_scope(
       new std::vector<framework::Scope*>{});
-  (*micro_scope).push_back(new framework::Scope());
-  (*micro_scope).push_back(new framework::Scope());
+  auto* mini_scope = new framework::Scope();
+  (*mini_scopes)[0] = mini_scope;
+  auto* micro_scope_0 = &(mini_scope->NewScope());
+  auto* micro_scope_1 = &(mini_scope->NewScope());
+  (*micro_scope).push_back(micro_scope_0);
+  (*micro_scope).push_back(micro_scope_1);
   (*micro_scopes)[0] = micro_scope;
   b_rpc_service->SetMicroBatchScopes(micro_scopes);
+  b_rpc_service->SetMiniBatchScopes(mini_scopes);
 
   using TaskQueue =
       std::unordered_map<int,

--- a/paddle/fluid/operators/pscore/heter_server_test.cc
+++ b/paddle/fluid/operators/pscore/heter_server_test.cc
@@ -194,13 +194,20 @@ TEST(SENDANDRECV, CPU) {
   b_rpc_service->WaitServerReady();
   using MicroScope =
       std::unordered_map<int, std::shared_ptr<std::vector<framework::Scope*>>>;
+  using MiniScope = std::unordered_map<int, framework::Scope*>;
+  std::shared_ptr<MiniScope> mini_scopes(new MiniScope{});
   std::shared_ptr<MicroScope> micro_scopes(new MicroScope{});
   std::shared_ptr<std::vector<framework::Scope*>> micro_scope(
       new std::vector<framework::Scope*>{});
-  (*micro_scope).push_back(new framework::Scope());
-  (*micro_scope).push_back(new framework::Scope());
+  auto* mini_scope = new framework::Scope();
+  (*mini_scopes)[0] = mini_scope;
+  auto* micro_scope_0 = &(mini_scope->NewScope());
+  auto* micro_scope_1 = &(mini_scope->NewScope());
+  (*micro_scope).push_back(micro_scope_0);
+  (*micro_scope).push_back(micro_scope_1);
   (*micro_scopes)[0] = micro_scope;
   b_rpc_service->SetMicroBatchScopes(micro_scopes);
+  b_rpc_service->SetMiniBatchScopes(mini_scopes);
 
   using TaskQueue =
       std::unordered_map<int,

--- a/paddle/fluid/operators/pscore/send_and_recv_op_cpu_test.cc
+++ b/paddle/fluid/operators/pscore/send_and_recv_op_cpu_test.cc
@@ -167,12 +167,18 @@ TEST(SENDANDRECV, CPU) {
   b_rpc_service->WaitServerReady();
   using MicroScope =
       std::unordered_map<int, std::shared_ptr<std::vector<framework::Scope*>>>;
+  using MiniScope = std::unordered_map<int, framework::Scope*>;
+  std::shared_ptr<MiniScope> mini_scopes(new MiniScope{});
   std::shared_ptr<MicroScope> micro_scopes(new MicroScope{});
+  auto* mini_scope = new framework::Scope();
+  (*mini_scopes)[0] = mini_scope;
   std::shared_ptr<std::vector<framework::Scope*>> micro_scope(
       new std::vector<framework::Scope*>{});
-  (*micro_scope).push_back(new framework::Scope());
+  auto* micro_scope_0 = &(mini_scope->NewScope());
+  (*micro_scope).push_back(micro_scope_0);
   (*micro_scopes)[0] = micro_scope;
   b_rpc_service->SetMicroBatchScopes(micro_scopes);
+  b_rpc_service->SetMiniBatchScopes(mini_scopes);
 
   using TaskQueue =
       std::unordered_map<int,

--- a/paddle/fluid/operators/pscore/send_and_recv_op_gpu_test.cc
+++ b/paddle/fluid/operators/pscore/send_and_recv_op_gpu_test.cc
@@ -187,12 +187,18 @@ TEST(SENDANDRECV, GPU) {
   b_rpc_service2->WaitServerReady();
   using MicroScope =
       std::unordered_map<int, std::shared_ptr<std::vector<framework::Scope*>>>;
+  using MiniScope = std::unordered_map<int, framework::Scope*>;
+  std::shared_ptr<MiniScope> mini_scopes(new MiniScope{});
   std::shared_ptr<MicroScope> micro_scopes(new MicroScope{});
+  auto* mini_scope = new framework::Scope();
+  (*mini_scopes)[0] = mini_scope;
   std::shared_ptr<std::vector<framework::Scope*>> micro_scope(
       new std::vector<framework::Scope*>{});
-  (*micro_scope).push_back(new framework::Scope());
+  auto* micro_scope_0 = &(mini_scope->NewScope());
+  (*micro_scope).push_back(micro_scope_0);
   (*micro_scopes)[0] = micro_scope;
   b_rpc_service2->SetMicroBatchScopes(micro_scopes);
+  b_rpc_service2->SetMiniBatchScopes(mini_scopes);
 
   using TaskQueue =
       std::unordered_map<int,

--- a/paddle/fluid/operators/pscore/send_and_recv_op_gpu_test.cc
+++ b/paddle/fluid/operators/pscore/send_and_recv_op_gpu_test.cc
@@ -12,8 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#if (defined PADDLE_WITH_CUDA || defined PADDLE_WITH_HIP) && \
-    (defined PADDLE_WITH_PSCORE)
+#if (defined PADDLE_WITH_CUDA) && (defined PADDLE_WITH_PSCORE)
 
 #include <stdlib.h>
 #include <memory>

--- a/python/paddle/distributed/fleet/base/fleet_base.py
+++ b/python/paddle/distributed/fleet/base/fleet_base.py
@@ -692,7 +692,7 @@ class Fleet(object):
 
     @is_non_distributed_check
     @inited_runtime_handler
-    def run_heter_worker(self, dataset):
+    def run_heter_worker(self):
         """
         run_heter_worker will run heter trainer main program with executor.
 
@@ -713,7 +713,7 @@ class Fleet(object):
                     fleet.run_heter_worker(dataset)
 
         """
-        self._runtime_handle._run_heter_worker(dataset)
+        self._runtime_handle._run_heter_worker()
 
     @is_non_distributed_check
     @inited_runtime_handler
@@ -1636,13 +1636,13 @@ class Fleet(object):
                 ]
                 param_grads_fp16 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and (param._grad_ivar(
-                    ).dtype == core.VarDesc.VarType.FP16)
+                    if (param._grad_ivar() is not None) and
+                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP16)
                 ]
                 param_grads_fp32 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and (param._grad_ivar(
-                    ).dtype == core.VarDesc.VarType.FP32)
+                    if (param._grad_ivar() is not None) and
+                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP32)
                 ]
             temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
             temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))

--- a/python/paddle/distributed/fleet/base/fleet_base.py
+++ b/python/paddle/distributed/fleet/base/fleet_base.py
@@ -1636,13 +1636,13 @@ class Fleet(object):
                 ]
                 param_grads_fp16 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and
-                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP16)
+                    if (param._grad_ivar() is not None) and (param._grad_ivar(
+                    ).dtype == core.VarDesc.VarType.FP16)
                 ]
                 param_grads_fp32 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and
-                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP32)
+                    if (param._grad_ivar() is not None) and (param._grad_ivar(
+                    ).dtype == core.VarDesc.VarType.FP32)
                 ]
             temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
             temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))

--- a/python/paddle/distributed/fleet/base/fleet_base.py
+++ b/python/paddle/distributed/fleet/base/fleet_base.py
@@ -713,7 +713,7 @@ class Fleet(object):
                     fleet.run_heter_worker(dataset)
 
         """
-        self._runtime_handle._run_heter_worker()
+        self._runtime_handle._run_heter_worker(dataset)
 
     @is_non_distributed_check
     @inited_runtime_handler
@@ -1636,13 +1636,13 @@ class Fleet(object):
                 ]
                 param_grads_fp16 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and (param._grad_ivar(
-                    ).dtype == core.VarDesc.VarType.FP16)
+                    if (param._grad_ivar() is not None) and
+                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP16)
                 ]
                 param_grads_fp32 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and (param._grad_ivar(
-                    ).dtype == core.VarDesc.VarType.FP32)
+                    if (param._grad_ivar() is not None) and
+                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP32)
                 ]
             temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
             temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))

--- a/python/paddle/distributed/fleet/base/fleet_base.py
+++ b/python/paddle/distributed/fleet/base/fleet_base.py
@@ -692,7 +692,7 @@ class Fleet(object):
 
     @is_non_distributed_check
     @inited_runtime_handler
-    def run_heter_worker(self):
+    def run_heter_worker(self, dataset):
         """
         run_heter_worker will run heter trainer main program with executor.
 
@@ -1636,13 +1636,13 @@ class Fleet(object):
                 ]
                 param_grads_fp16 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and
-                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP16)
+                    if (param._grad_ivar() is not None) and (param._grad_ivar(
+                    ).dtype == core.VarDesc.VarType.FP16)
                 ]
                 param_grads_fp32 = [
                     param._grad_ivar() for param in optimizer._parameter_list
-                    if (param._grad_ivar() is not None) and
-                    (param._grad_ivar().dtype == core.VarDesc.VarType.FP32)
+                    if (param._grad_ivar() is not None) and (param._grad_ivar(
+                    ).dtype == core.VarDesc.VarType.FP32)
                 ]
             temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
             temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -199,17 +199,19 @@ see: http://www.paddlepaddle.org/documentation/docs/zh/1.6/user_guides/howto/tra
         "--heter_workers",
         type=str,
         default="",
-        help="User defined heter workers ip:port")
+        help="User defined heter workers in all stage ip1:port1;ip2:port2")
     ps_group.add_argument(
         "--heter_devices",
         type=str,
         default="",
-        help="User defined heter devices")
+        help="User defined heter devices in all stage cpu;gpu;cpu")
 
     ps_group.add_argument("--worker_num", type=int, help="number of workers")
     ps_group.add_argument("--server_num", type=int, help="number of servers")
     ps_group.add_argument(
-        "--heter_worker_num", type=int, help="number of heter_workers")
+        "--heter_worker_num",
+        type=str,
+        help="number of heter_workers in all stage")
     ps_group.add_argument("--http_port", type=int, help="Gloo http Port")
 
     # parameter elastic mode

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -199,19 +199,19 @@ see: http://www.paddlepaddle.org/documentation/docs/zh/1.6/user_guides/howto/tra
         "--heter_workers",
         type=str,
         default="",
-        help="User defined heter workers in all stage ip1:port1;ip2:port2")
+        help="User defined heter workers in each stage ip1:port1;ip2:port2")
     ps_group.add_argument(
         "--heter_devices",
         type=str,
         default="",
-        help="User defined heter devices in all stage cpu;gpu;cpu")
+        help="User defined heter devices in each stage cpu;gpu;cpu")
 
     ps_group.add_argument("--worker_num", type=int, help="number of workers")
     ps_group.add_argument("--server_num", type=int, help="number of servers")
     ps_group.add_argument(
         "--heter_worker_num",
         type=str,
-        help="number of heter_workers in all stage")
+        help="number of heter_workers in each stage 1;2;3")
     ps_group.add_argument("--http_port", type=int, help="Gloo http Port")
 
     # parameter elastic mode

--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -498,13 +498,15 @@ def launch():
 
         - ``--workers``: User defined workers ip:port, e.g., ``--workers="192.168.0.16:6171,192.168.0.16:6172,192.168.0.17:6171,192.168.0.17:6172"``
 
-        - ``--heter_workers``: User defined heter workers ip:port, e.g., ``--heter_workers="192.168.0.16:6172,192.168.0.17:6172"``
+        - ``--heter_workers``: User defined heter workers ip1:port1;ip2:port2, e.g., ``--heter_workers="192.168.0.16:6172;192.168.0.17:6172"``
 
         - ``--worker_num``: Number of workers (It recommend to set when in the emulated distributed environment using single node)
 
         - ``--server_num``: Number of servers (It recommend to set when in the emulated distributed environment using single node)
 
-        - ``--heter_worker_num``: Number of heter_workers (It recommend to set when in the emulated distributed environment using single node)
+        - ``--heter_worker_num``: Number of heter_workers in each stage (It recommend to set when in the emulated distributed environment using single node)
+        
+        - ``--heter_devices``: Type of heter_device in each stage
 
         - ``--http_port``: Gloo http Port
 

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -888,8 +888,8 @@ def get_mapped_cluster_from_args(args, device_mode):
             start_port = int(os.environ.get('FLAGS_START_PORT'))
             free_ports = [
                 x
-                for x in range(start_port,
-                               start_port + len(node_ranks_mapping[node_rank]))
+                for x in range(start_port, start_port + len(node_ranks_mapping[
+                    node_rank]))
             ]
         else:
             free_ports = find_free_ports(len(node_ranks_mapping[node_rank]))

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -768,44 +768,44 @@ def get_custom_endpoints(origin_endpoints, offset=0):
     return paddle_user_define_endpoints
 
 
-def cloud_ps_heter_env_set(args):
-    environs = {}
-
-    paddle_trainer_endpoints = os.getenv("TRAINER_IP_PORT_LIST", "")
-    assert paddle_trainer_endpoints != None
-
-    paddle_pserver_endpoints = os.getenv("PSERVER_IP_PORT_LIST", "")
-    assert paddle_pserver_endpoints != None
-
-    # hard code for paddlecloud custom-framework
-    avilable_ports = os.getenv("TRAINER_PORTS", "").split(",")
-    assert len(
-        avilable_ports
-    ) >= 2, "set paddle_ports_num >= 2 in config.ini for paddlecloud job submit"
-
-    # hard code for paddlecloud custom-framework
-    trainers_num = len(paddle_pserver_endpoints.split(","))
-    assert trainers_num != 0
-    environs["PADDLE_TRAINERS_NUM"] = trainers_num
-    environs["TRAINERS_NUM"] = trainers_num
-
-    # hard code for paddlecloud custom-framework
-    environs["PADDLE_HETER_TRAINER_IP_PORT_LIST"] = paddle_trainer_endpoints
-    environs["PADDLE_PSERVERS_IP_PORT_LIST"] = paddle_pserver_endpoints
-    environs["PADDLE_TRAINER_ENDPOINTS"] = get_custom_endpoints(
-        paddle_pserver_endpoints, 1)
-    heter_worker_num = len(paddle_trainer_endpoints.split(","))
-    if (args.heter_worker_num != None) and (
-            heter_worker_num != args.heter_worker_num):
-        warnings.warn(
-            "Your fleetrun setting: heter_worker_num is {}, but we find {} device can be used, this setting has been changed.".
-            format(args.heter_worker_num, heter_worker_num))
-        args.heter_worker_num = heter_worker_num
-
-    for k, v in environs.items():
-        os.environ[k] = str(v)
-    logger.info("Set heter parameter server env: {}".format(
-        pretty_print_envs(environs)))
+#def cloud_ps_heter_env_set(args):
+#    environs = {}
+#
+#    paddle_trainer_endpoints = os.getenv("TRAINER_IP_PORT_LIST", "")
+#    assert paddle_trainer_endpoints != None
+#
+#    paddle_pserver_endpoints = os.getenv("PSERVER_IP_PORT_LIST", "")
+#    assert paddle_pserver_endpoints != None
+#
+#    # hard code for paddlecloud custom-framework
+#    avilable_ports = os.getenv("TRAINER_PORTS", "").split(",")
+#    assert len(
+#        avilable_ports
+#    ) >= 2, "set paddle_ports_num >= 2 in config.ini for paddlecloud job submit"
+#
+#    # hard code for paddlecloud custom-framework
+#    trainers_num = len(paddle_pserver_endpoints.split(","))
+#    assert trainers_num != 0
+#    environs["PADDLE_TRAINERS_NUM"] = trainers_num
+#    environs["TRAINERS_NUM"] = trainers_num
+#
+#    # hard code for paddlecloud custom-framework
+#    environs["PADDLE_HETER_TRAINER_IP_PORT_LIST"] = paddle_trainer_endpoints
+#    environs["PADDLE_PSERVERS_IP_PORT_LIST"] = paddle_pserver_endpoints
+#    environs["PADDLE_TRAINER_ENDPOINTS"] = get_custom_endpoints(
+#        paddle_pserver_endpoints, 1)
+#    heter_worker_num = len(paddle_trainer_endpoints.split(","))
+#    if (args.heter_worker_num != None) and (
+#            heter_worker_num != args.heter_worker_num):
+#        warnings.warn(
+#            "Your fleetrun setting: heter_worker_num is {}, but we find {} device can be used, this setting has been changed.".
+#            format(args.heter_worker_num, heter_worker_num))
+#        args.heter_worker_num = heter_worker_num
+#
+#    for k, v in environs.items():
+#        os.environ[k] = str(v)
+#    logger.info("Set heter parameter server env: {}".format(
+#        pretty_print_envs(environs)))
 
 
 def get_mapped_cluster(node_ips, node_ip, trainer_endpoints, device_mode,
@@ -888,8 +888,8 @@ def get_mapped_cluster_from_args(args, device_mode):
             start_port = int(os.environ.get('FLAGS_START_PORT'))
             free_ports = [
                 x
-                for x in range(start_port, start_port + len(node_ranks_mapping[
-                    node_rank]))
+                for x in range(start_port,
+                               start_port + len(node_ranks_mapping[node_rank]))
             ]
         else:
             free_ports = find_free_ports(len(node_ranks_mapping[node_rank]))
@@ -997,7 +997,7 @@ class ParameterServerLauncher(object):
 
             self.stage_heter_map[1] = self.worker_endpoints
             if args.heter_worker_num:
-                self.stage_heter_trainer_num = args.heter_worker_num.split(",")
+                self.stage_heter_trainer_num = args.heter_worker_num.split(";")
                 self.stage_heter_trainer_num = [
                     int(trainer_num)
                     for trainer_num in self.stage_heter_trainer_num

--- a/python/paddle/distributed/fleet/runtime/the_one_ps.py
+++ b/python/paddle/distributed/fleet/runtime/the_one_ps.py
@@ -889,7 +889,6 @@ class TheOnePSRuntime(RuntimeBase):
         self._init_worker()
 
     def _run_heter_worker(self,
-                          dataset=None,
                           scope=None,
                           thread=0,
                           debug=False,
@@ -900,7 +899,7 @@ class TheOnePSRuntime(RuntimeBase):
         executor = self._get_executor()
         executor.train_from_dataset(
             program=fluid.default_main_program(),
-            dataset=dataset,
+            dataset=None,
             debug=debug,
             fetch_list=fetch_list,
             fetch_info=fetch_info,

--- a/python/paddle/distributed/fleet/runtime/the_one_ps.py
+++ b/python/paddle/distributed/fleet/runtime/the_one_ps.py
@@ -889,6 +889,7 @@ class TheOnePSRuntime(RuntimeBase):
         self._init_worker()
 
     def _run_heter_worker(self,
+                          dataset=None,
                           scope=None,
                           thread=0,
                           debug=False,

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1672,6 +1672,33 @@ class Executor(object):
             dataset.set_thread(1)
             dataset.set_filelist(['None'])
             dataset.set_use_var(data_vars)
+        elif program._heter_pipeline_opt is not None:
+            stage_id = program._heter_pipeline_opt["pipeline_stage"]
+            if stage_id != 0:
+                import paddle
+                if dataset is not None:
+                    raise RuntimeError(
+                        "dataset should be None for heter pipeline mode")
+                # The following fake dataset is created to call 
+                # the _prepare_trainer api, and it is meaningless.
+                data_vars = []
+                for var in program.global_block().vars.values():
+                    if var.is_data:
+                        data_vars.append(var)
+                if core.is_compiled_with_npu():
+                    dataset = paddle.fluid.DatasetFactory().create_dataset(
+                        'InMemoryDataset')
+                else:
+                    dataset = paddle.fluid.DatasetFactory().create_dataset(
+                        'FileInstantDataset')
+                dataset.set_batch_size(1)
+                dataset.set_thread(1)
+                dataset.set_filelist(['None'])
+                dataset.set_use_var(data_vars)
+            else:
+                if dataset is None:
+                    raise RuntimeError(
+                        "dataset is need and should be initialized")
         else:
             if dataset is None:
                 raise RuntimeError("dataset is need and should be initialized")

--- a/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
@@ -154,14 +154,14 @@ class TestHeterPipelinePsCTR2x2(FleetDistHeterRunnerBase):
         fleet.init_worker()
 
         thread_num = int(os.getenv("CPU_NUM", 2))
-        batch_size = 128
+        batch_size = 4
 
-        block_size = len(train_file_list) // fleet.worker_num()
-        worker_id = fleet.worker_index()
-        filelist = train_file_list[worker_id * block_size:(worker_id + 1) *
-                                   block_size]
+        #block_size = len(train_file_list) // fleet.worker_num()
+        #worker_id = fleet.worker_index()
+        #filelist = train_file_list[worker_id * block_size:(worker_id + 1) *
+        #                           block_size]
 
-        #filelist = fleet.util.get_file_shard(train_file_list)
+        filelist = fleet.util.get_file_shard(train_file_list)
         print("filelist: {}".format(filelist))
 
         # config dataset
@@ -202,7 +202,7 @@ class TestHeterPipelinePsCTR2x2(FleetDistHeterRunnerBase):
         #fleet.init_worker()
 
         thread_num = int(os.getenv("CPU_NUM", 2))
-        batch_size = 128
+        batch_size = 4
 
         #filelist = fleet.util.get_file_shard(train_file_list)
         #block_size = len(train_file_list) // fleet.worker_num()

--- a/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
@@ -195,7 +195,7 @@ class TestHeterPipelinePsCTR2x2(FleetDistHeterRunnerBase):
             "section_program"]
         print(real_program)
 
-        train_file_list = ctr_dataset_reader.prepare_fake_data()
+        #train_file_list = ctr_dataset_reader.prepare_fake_data()
 
         #exe = fluid.Executor(fluid.CPUPlace())
         #exe.run(fluid.default_startup_program())
@@ -205,21 +205,23 @@ class TestHeterPipelinePsCTR2x2(FleetDistHeterRunnerBase):
         batch_size = 128
 
         #filelist = fleet.util.get_file_shard(train_file_list)
-        block_size = len(train_file_list) // fleet.worker_num()
-        filelist = train_file_list[0:block_size]
-        print("filelist: {}".format(filelist))
+        #block_size = len(train_file_list) // fleet.worker_num()
+        #filelist = train_file_list[0:block_size]
+        #print("filelist: {}".format(filelist))
 
         # config dataset
-        dataset = fluid.DatasetFactory().create_dataset()
-        dataset.set_batch_size(batch_size)
-        dataset.set_use_var(self.feeds)
-        pipe_command = 'python3 ctr_dataset_reader.py'
-        dataset.set_pipe_command(pipe_command)
+        #dataset = fluid.DatasetFactory().create_dataset()
+        #dataset.set_batch_size(batch_size)
+        #dataset.set_use_var(self.feeds)
+        #pipe_command = 'python3 ctr_dataset_reader.py'
+        #dataset.set_pipe_command(pipe_command)
 
-        dataset.set_filelist(filelist)
-        dataset.set_thread(thread_num)
+        #dataset.set_filelist(filelist)
+        #dataset.set_thread(thread_num)
 
-        fleet.run_heter_worker(dataset)
+        pass_start = time.time()
+        fleet.run_heter_worker()
+        pass_time = time.time() - pass_start
         print("do_dataset_heter_training done. using time {}".format(pass_time))
 
         #for epoch_id in range(1):

--- a/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
@@ -156,11 +156,6 @@ class TestHeterPipelinePsCTR2x2(FleetDistHeterRunnerBase):
         thread_num = int(os.getenv("CPU_NUM", 2))
         batch_size = 4
 
-        #block_size = len(train_file_list) // fleet.worker_num()
-        #worker_id = fleet.worker_index()
-        #filelist = train_file_list[worker_id * block_size:(worker_id + 1) *
-        #                           block_size]
-
         filelist = fleet.util.get_file_shard(train_file_list)
         print("filelist: {}".format(filelist))
 
@@ -195,29 +190,8 @@ class TestHeterPipelinePsCTR2x2(FleetDistHeterRunnerBase):
             "section_program"]
         print(real_program)
 
-        #train_file_list = ctr_dataset_reader.prepare_fake_data()
-
-        #exe = fluid.Executor(fluid.CPUPlace())
-        #exe.run(fluid.default_startup_program())
-        #fleet.init_worker()
-
         thread_num = int(os.getenv("CPU_NUM", 2))
         batch_size = 4
-
-        #filelist = fleet.util.get_file_shard(train_file_list)
-        #block_size = len(train_file_list) // fleet.worker_num()
-        #filelist = train_file_list[0:block_size]
-        #print("filelist: {}".format(filelist))
-
-        # config dataset
-        #dataset = fluid.DatasetFactory().create_dataset()
-        #dataset.set_batch_size(batch_size)
-        #dataset.set_use_var(self.feeds)
-        #pipe_command = 'python3 ctr_dataset_reader.py'
-        #dataset.set_pipe_command(pipe_command)
-
-        #dataset.set_filelist(filelist)
-        #dataset.set_thread(thread_num)
 
         pass_start = time.time()
         fleet.run_heter_worker()

--- a/python/paddle/fluid/tests/unittests/test_fleet_launch_ps.sh
+++ b/python/paddle/fluid/tests/unittests/test_fleet_launch_ps.sh
@@ -30,7 +30,7 @@ heter_worker_port_0=$(( PADDLE_DIST_UT_PORT + 8 ))
 heter_worker_port_1=$(( PADDLE_DIST_UT_PORT + 9 ))
 
 function test_launch_ps(){
-    python -m paddle.distributed.fleet.launch \
+    python3 -m paddle.distributed.fleet.launch \
         --servers="127.0.0.1:${server_port_00},127.0.0.1:${server_port_10}" \
         --workers="127.0.0.1:${worker_port_00},127.0.0.1:${worker_port_10}" \
         fleet_ps_training.py 2> ut1.elog
@@ -43,11 +43,12 @@ function test_launch_ps(){
 }
 
 function test_launch_ps_heter(){
-    python -m paddle.distributed.fleet.launch \
+    python3 -m paddle.distributed.fleet.launch \
         --servers="127.0.0.1:${server_port_01},127.0.0.1:${server_port_11}" \
         --workers="127.0.0.1:${worker_port_01},127.0.0.1:${worker_port_11}" \
         --heter_workers="127.0.0.1:${heter_worker_port_0},127.0.0.1:${heter_worker_port_1}" \
         --heter_devices="gpu" \
+        --heter_worker_num="2" \
         fleet_heter_ps_training.py 2> ut2.elog
     if grep -q "server are killed" ut2.elog; then
         echo "test heter trainer launch succeed"

--- a/python/paddle/fluid/tests/unittests/test_fleet_launch_ps.sh
+++ b/python/paddle/fluid/tests/unittests/test_fleet_launch_ps.sh
@@ -30,7 +30,7 @@ heter_worker_port_0=$(( PADDLE_DIST_UT_PORT + 8 ))
 heter_worker_port_1=$(( PADDLE_DIST_UT_PORT + 9 ))
 
 function test_launch_ps(){
-    python3 -m paddle.distributed.fleet.launch \
+    python -m paddle.distributed.fleet.launch \
         --servers="127.0.0.1:${server_port_00},127.0.0.1:${server_port_10}" \
         --workers="127.0.0.1:${worker_port_00},127.0.0.1:${worker_port_10}" \
         fleet_ps_training.py 2> ut1.elog
@@ -43,7 +43,7 @@ function test_launch_ps(){
 }
 
 function test_launch_ps_heter(){
-    python3 -m paddle.distributed.fleet.launch \
+    python -m paddle.distributed.fleet.launch \
         --servers="127.0.0.1:${server_port_01},127.0.0.1:${server_port_11}" \
         --workers="127.0.0.1:${worker_port_01},127.0.0.1:${worker_port_11}" \
         --heter_workers="127.0.0.1:${heter_worker_port_0},127.0.0.1:${heter_worker_port_1}" \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
示例： PR: https://github.com/PaddlePaddle/FleetX/pull/563
背景：异构参数服务器的流水线训练，trainer的类型有cpu trainer和heter trainer, heter trainer主要就是使用各种加速器训练模型子图。
修改原因：之前的设计不好，heter worker需要使用dataset作为输入，原因主要是heter worker需要知道cpu trainer开了多少个线程，这个线程数是从 dataset->GetReaders() 获取的，而dataset会根据实际训练的文件数动态调整线程数，因为还需要每个cpu trainer都读取同样的文件数。现在这个PR修改了这个设计，使得cpu trainer可以读取不同数量的文件，从而开数量不同的线程，而heter trainer会根据cpu trainer发送过来的消息动态调整线程。用户使用的API也大大简化。
修改以后影响: 支持CPU trainer可以读取不同的文件数，开不同数量的线程，用户使用API简化，与PS纯CPU训练方式对齐
使用方式:
重构以前          
<img width="472" alt="image" src="https://user-images.githubusercontent.com/17705473/141926940-94e91c4a-8a7e-4dbb-8525-ce733b7c15d7.png">
      重构以后使用方式:      
<img width="452" alt="image" src="https://user-images.githubusercontent.com/17705473/141923822-7cf18172-b804-41d5-ae3f-b080d5749a30.png">