### PR TITLE
Refine pass by removing CommOpt, CalcOpt, ParallelOpt

### DIFF
--- a/python/paddle/distributed/passes/cpp_pass.py
+++ b/python/paddle/distributed/passes/cpp_pass.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .pass_base import CPPPassWrapper, register_pass
+from .pass_base import PassType, CPPPassWrapper, register_pass
 
 
 @register_pass("fuse_elewise_add_act")
@@ -23,3 +23,6 @@ class FuseElementwiseAddActPass(CPPPassWrapper):
     @property
     def cpp_name(self):
         return "fuse_elewise_add_act_pass"
+
+    def _type(self):
+        return PassType.FUSION_OPT

--- a/python/paddle/distributed/passes/fuse_all_reduce.py
+++ b/python/paddle/distributed/passes/fuse_all_reduce.py
@@ -14,7 +14,7 @@
 
 from paddle.framework import core
 from paddle.fluid import unique_name
-from .pass_base import CommOptPass, register_pass
+from .pass_base import PassBase, PassType, register_pass
 from collections import OrderedDict
 import numpy as np
 
@@ -329,7 +329,7 @@ def insert_fuse_all_reduce_by_memory_size(block, groups, max_memory_size):
 
 
 @register_pass("fuse_all_reduce")
-class FuseAllReducePass(CommOptPass):
+class FuseAllReducePass(PassBase):
     def __init__(self):
         super(FuseAllReducePass, self).__init__()
         self.set_attr("max_memory_size", -1)
@@ -340,6 +340,9 @@ class FuseAllReducePass(CommOptPass):
 
     def _check_conflict(self, other_pass):
         return True
+
+    def _type(self):
+        return PassType.COMM_OPT
 
     # NOTE: why FuseAllReducePass can override apply_single_impl instead of 
     # apply_impl? AllReduce is a collective operation, so the program of each 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Distributed pass related PR. Remove CommOpt, CalcOpt, ParallelOpt and add `PassBase._type` method.

Fix https://github.com/PaddlePaddle/Paddle/pull/36643#discussion_r747922024.