### PR TITLE
supports the slice of upper tensor, test=develop

### DIFF
--- a/paddle/pten/core/compat_utils.h
+++ b/paddle/pten/core/compat_utils.h
@@ -45,6 +45,39 @@ class CompatibleDenseTensorUtils {
     static_cast<paddle::experimental::SharedStorage*>(tensor->storage_.get())
         ->Reset();
   }
+
+  static DenseTensor Slice(DenseTensor* tensor,
+                           int64_t begin_idx,
+                           int64_t end_idx) {
+    tensor->check_memory_size();
+    PADDLE_ENFORCE_GE(begin_idx,
+                      0,
+                      paddle::platform::errors::OutOfRange(
+                          "The start row index must be greater than 0."
+                          "But received the start index is d%.",
+                          begin_idx));
+    PADDLE_ENFORCE_LE(end_idx,
+                      tensor->dims()[0],
+                      paddle::platform::errors::OutOfRange(
+                          "The end row index is out of bound."));
+    PADDLE_ENFORCE_LT(
+        begin_idx,
+        end_idx,
+        paddle::platform::errors::InvalidArgument(
+            "The start row index must be less than the end row index."
+            "But received the start index = %d, the end index = %d.",
+            begin_idx,
+            end_idx));
+    DenseTensor ret =
+        DenseTensor(copy_intrusive(tensor->storage_), tensor->meta_);
+    if (tensor->dims()[0] != 1) {
+      ret.meta_.dims[0] = end_idx - begin_idx;
+      ret.meta_.offset = tensor->meta_.offset +
+                         begin_idx * (tensor->numel() / tensor->dims()[0]) *
+                             paddle::experimental::SizeOf(tensor->data_type());
+    }
+    return ret;
+  }
 };
 
 }  // namespace pten

--- a/paddle/pten/core/dense_tensor.h
+++ b/paddle/pten/core/dense_tensor.h
@@ -172,12 +172,6 @@ class DenseTensor : public TensorBase,
   /// \return The const data pointer value of raw type.
   const void* data() const;
 
-  /// \brief Get the shallow clone of current tensor.
-  /// \return The shallow clone of current tensor.
-  DenseTensor shallow_clone() const {
-    return DenseTensor(copy_intrusive(storage_), meta_);
-  }
-
  private:
   friend class CompatibleDenseTensorUtils;
 

--- a/paddle/pten/core/tensor_meta.h
+++ b/paddle/pten/core/tensor_meta.h
@@ -57,6 +57,7 @@ struct DenseTensorMeta {
   const DataType type{DataType::UNDEFINED};
   const DataLayout layout{DataLayout::NCHW};
   LoD lod;
+  size_t offset{0};
 };
 
 inline DenseTensorMeta::DenseTensorMeta(DataType type, const DDim& dims)
@@ -86,7 +87,7 @@ inline bool operator==(const DenseTensorMeta& lhs, const DenseTensorMeta& rhs) {
   bool ret = true;
   return ret && (lhs.is_scalar == rhs.is_scalar) && (lhs.dims == rhs.dims) &&
          (lhs.type == rhs.type) && (lhs.layout == rhs.layout) &&
-         (lhs.lod == rhs.lod);
+         (lhs.lod == rhs.lod) && (lhs.offset == rhs.offset);
 }
 
 }  // namespace pten

--- a/paddle/pten/tests/core/test_dense_tensor.cc
+++ b/paddle/pten/tests/core/test_dense_tensor.cc
@@ -125,20 +125,5 @@ TEST(dense_tensor, resize) {
   CHECK_EQ(storage->size(), 6u);
 }
 
-TEST(dense_tensor, shallow_clone) {
-  const DDim dims({1, 2});
-  const DataType dtype{DataType::INT8};
-  const DataLayout layout{DataLayout::NHWC};
-  const std::vector<std::vector<size_t>> lod{};
-  DenseTensorMeta meta(dtype, dims, layout, lod);
-
-  auto alloc = std::make_shared<FancyAllocator>();
-  DenseTensor tensor_0(alloc, meta);
-
-  auto tensor_1 = tensor_0.shallow_clone();
-  CHECK(tensor_0.meta() == tensor_1.meta());
-  CHECK(tensor_0.release() == tensor_1.release());
-}
-
 }  // namespace tests
 }  // namespace pten


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
支持上层 Tensor 的 slice 功能。slice 和 stride 预期是 `DenseTensor` 的基础功能，现有主框架、Pytorch、Anakin 等框架在推理和训练中都有使用。因为预期将有统一的 `view` 功能，所以暂时删除浅拷贝接口，且 slice 相关代码暂时放置在友元中。

讨论结论：
1、`DenseTensor` 的作用是以确定的数据类型和排布规则解释相应的存储区域。为避免使用繁琐，`DenseTensorMeta` 将继续保持扁平的状态。
2、`TensorShape` 不再单独封装，但对其成员进行单独设置的成员函数将仍将进行限制，以尽量减少 `DenseTensor` 的不合法状态出现的可能性。
3、为向后兼容，`data_type` 不放到 `Storage` 中，以便推导。
4、原提交 https://github.com/PaddlePaddle/Paddle/pull/37169 对数据抽象进行了修改，但经讨论未予采纳。