### PR TITLE
Add log when EnableMKLDN() and EnableMemoryOptim() are both set

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -527,6 +527,9 @@ void AnalysisConfig::Update() {
 #ifdef PADDLE_WITH_MKLDNN
   // Do not optimize when mkldnn is on
   if (enable_memory_optim_ && !use_mkldnn_) {
+    LOG(WARNING) << "You tried to enable memory optim, but now you are under "
+                    "mkldnn ON, so enable_memory_optim_ will not work. You can "
+                    "limit memory usage by setting SetCacheCapacity";
 #else
   if (enable_memory_optim_) {
 #endif

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -527,9 +527,11 @@ void AnalysisConfig::Update() {
 #ifdef PADDLE_WITH_MKLDNN
   // Do not optimize when mkldnn is on
   if (enable_memory_optim_ && !use_mkldnn_) {
-    LOG(WARNING) << "You tried to enable memory optim, but now you are under "
-                    "mkldnn ON, so enable_memory_optim_ will not work. You can "
-                    "limit memory usage by setting SetCacheCapacity";
+    LOG(WARNING) << "You tried to set EnableMemoryOptim()"
+                    " ON when EnableMKLDNN() ON, "
+                    "in which case memory_optimize_pass will not work."
+                    " You can limit memory usage under MKLDNN ON "
+                    "by setting config.SetCacheCapacity(xx)";
 #else
   if (enable_memory_optim_) {
 #endif

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -526,12 +526,17 @@ void AnalysisConfig::Update() {
 
 #ifdef PADDLE_WITH_MKLDNN
   // Do not optimize when mkldnn is on
+  if (enable_memory_optim_ && use_mkldnn_) {
+    LOG(WARNING)
+        << "When you set config.EnableMKLDNN(), setting "
+           "config.EnableMemoryOptim() "
+           "will not work. But you can limit MKLDNN memory consumption "
+           "by config.SetCacheCapacity(10) to limit dynamic input shape cache "
+           "size to 10"
+           "or config.SetCacheCapacity(0) to have best performance without "
+           "memory limitation";
+  }
   if (enable_memory_optim_ && !use_mkldnn_) {
-    LOG(WARNING) << "You tried to set EnableMemoryOptim()"
-                    " ON when EnableMKLDNN() ON, "
-                    "in which case memory_optimize_pass will not work."
-                    " You can limit memory usage under MKLDNN ON "
-                    "by setting config.SetCacheCapacity(xx)";
 #else
   if (enable_memory_optim_) {
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
When `config.EnableMKLDNN()` and `config.EnableMemoryOptim()` are both set ON, "memory_optimize_pass" will not be added, also notify users to use `config.SetMkldnnCacheCapacity(xx)` when mkldnn enabled.
