### PR TITLE
[heterps]fix pipe-train bug: save and pull overlap may cause error

### DIFF
--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
@@ -490,9 +490,8 @@ void PSGPUWrapper::LoadIntoMemory(bool is_shuffle) {
 
 void PSGPUWrapper::start_build_thread() {
   running_ = true;
-  VLOG(3) << "start build CPU&GPU ps thread.";
+  VLOG(3) << "start build CPU ps thread.";
   pre_build_threads_ = std::thread([this] { pre_build_thread(); });
-  build_threads_ = std::thread([this] { build_thread(); });
 }
 
 void PSGPUWrapper::pre_build_thread() {
@@ -515,30 +514,28 @@ void PSGPUWrapper::pre_build_thread() {
   VLOG(3) << "build cpu thread end";
 }
 
-void PSGPUWrapper::build_thread() {
-  // build: build_pull + build_gputask
-  while (running_) {
-    std::shared_ptr<HeterContext> gpu_task = nullptr;
-    if (!gpu_free_channel_->Get(gpu_task)) {
-      continue;
-    }
-    if (!buildcpu_ready_channel_->Get(gpu_task)) {
-      continue;
-    }
-    VLOG(3) << "thread BuildGPUTask start.";
-    platform::Timer timer;
-    timer.Start();
-    BuildPull(gpu_task);
-    timer.Pause();
-    timer.Start();
-    BuildGPUTask(gpu_task);
-    timer.Pause();
-    VLOG(1) << "thread BuildGPUTask end, cost time: " << timer.ElapsedSec()
-            << "s";
-
-    train_ready_channel_->Put(gpu_task);
+void PSGPUWrapper::build_task() {
+  // build_task: build_pull + build_gputask
+  std::shared_ptr<HeterContext> gpu_task = nullptr;
+  // train end, gpu free
+  if (!gpu_free_channel_->Get(gpu_task)) {
+    return;
   }
-  VLOG(3) << "build gpu thread end";
+  // ins and pre_build end
+  if (!buildcpu_ready_channel_->Get(gpu_task)) {
+    return;
+  }
+
+  VLOG(1) << "BuildPull start.";
+  platform::Timer timer;
+  timer.Start();
+  BuildPull(gpu_task);
+  BuildGPUTask(gpu_task);
+  timer.Pause();
+  VLOG(1) << "BuildPull + BuildGPUTask end, cost time: " << timer.ElapsedSec()
+          << "s";
+
+  current_task_ = gpu_task;
 }
 
 void PSGPUWrapper::BeginPass() {
@@ -548,11 +545,15 @@ void PSGPUWrapper::BeginPass() {
     PADDLE_THROW(
         platform::errors::Fatal("[BeginPass] current task is not ended."));
   }
-  // load+build done
-  if (!train_ready_channel_->Get(current_task_)) {
-    PADDLE_THROW(platform::errors::Fatal("train_ready_channel_ failed."));
-  }
+
+  build_task();
   timer.Pause();
+
+  if (current_task_ == nullptr) {
+    PADDLE_THROW(platform::errors::Fatal(
+        "[BeginPass] after build_task, current task is not null."));
+  }
+
   VLOG(1) << "BeginPass end, cost time: " << timer.ElapsedSec() << "s";
 }
 

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
@@ -91,7 +91,7 @@ class PSGPUWrapper {
   void EndPass();
   void start_build_thread();
   void pre_build_thread();
-  void build_thread();
+  void build_task();
 
   void Finalize() {
     VLOG(3) << "PSGPUWrapper Begin Finalize.";
@@ -101,7 +101,6 @@ class PSGPUWrapper {
     data_ready_channel_->Close();
     buildcpu_ready_channel_->Close();
     gpu_free_channel_->Close();
-    train_ready_channel_->Close();
     running_ = false;
     VLOG(3) << "begin stop pre_build_threads_";
     pre_build_threads_.join();
@@ -169,8 +168,6 @@ class PSGPUWrapper {
       buildcpu_ready_channel_->SetCapacity(3);
       gpu_free_channel_->Open();
       gpu_free_channel_->SetCapacity(1);
-      train_ready_channel_->Open();
-      train_ready_channel_->SetCapacity(1);
 
       current_task_ = nullptr;
       gpu_free_channel_->Put(current_task_);
@@ -305,10 +302,6 @@ class PSGPUWrapper {
   std::shared_ptr<
       paddle::framework::ChannelObject<std::shared_ptr<HeterContext>>>
       gpu_free_channel_ =
-          paddle::framework::MakeChannel<std::shared_ptr<HeterContext>>();
-  std::shared_ptr<
-      paddle::framework::ChannelObject<std::shared_ptr<HeterContext>>>
-      train_ready_channel_ =
           paddle::framework::MakeChannel<std::shared_ptr<HeterContext>>();
   std::shared_ptr<HeterContext> current_task_ = nullptr;
   std::thread pre_build_threads_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix pipe-train bug: save and pull overlap may cause get_field error
before:
```
Wed Nov 10 23:00:12 INFO: going to save delta model after update
I1110 23:00:29.506243 15886 ps_gpu_wrapper.cc:293] pull sparse from CpuPS into GpuPS cost 28.0899 seconds.
I1110 23:00:45.613412 15886 ps_gpu_wrapper.cc:425] GpuPs prepare for build hbm cost 16.1071 seconds.
I1110 23:00:46.988054 15886 ps_gpu_wrapper.cc:468] GpuPs build table total costs: 1.37453 s.
I1110 23:00:46.988124 15886 ps_gpu_wrapper.cc:536] thread BuildGPUTask end, cost time: 1.37462s
Wed Nov 10 23:01:16 INFO: begin save delta model for 20211106 - 3
```

after:
```
Tue Nov 16 08:51:46 INFO: going to save delta model after update
Tue Nov 16 08:52:10 INFO: begin save delta model for 20210815 - 1
going to save_delta_model
Tue Nov 16 08:55:47 INFO: ===========going to train day/pass x/2===========
I1116 08:55:47.992974 33335 ps_gpu_wrapper.cc:535] BuildPull start.
Tue Nov 16 08:55:47 INFO: cur_pass: 3 cur_path:
I1116 08:55:48.008092 33335 ps_gpu_wrapper.cc:293] pull sparse from CpuPS into GpuPS cost 0.015066 seconds.
I1116 08:55:48.038103 33335 ps_gpu_wrapper.cc:425] GpuPs prepare for build hbm cost 0.029945 seconds.
I1116 08:55:48.121467 33335 ps_gpu_wrapper.cc:468] GpuPs build table total costs: 0.083289 s.
I1116 08:55:48.121517 33335 ps_gpu_wrapper.cc:541] BuildPull + BuildGPUTask end, cost time: 0.128521s
I1116 08:55:48.121523 33335 ps_gpu_wrapper.cc:569] BeginPass end, cost time: 0.128571s
```