### PR TITLE
copy beta pow to same place when skip_update=1

### DIFF
--- a/paddle/fluid/operators/optimizers/adam_op.cu
+++ b/paddle/fluid/operators/optimizers/adam_op.cu
@@ -198,11 +198,11 @@ class AdamOpCUDAKernel : public framework::OpKernel<T> {
           *mom2, ctx.GetPlace(),
           ctx.template device_context<platform::DeviceContext>(), mom2_out);
       framework::TensorCopy(
-          *beta1_pow, ctx.GetPlace(),
+          *beta1_pow, beta1_pow->place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta1_pow_out);
       framework::TensorCopy(
-          *beta2_pow, ctx.GetPlace(),
+          *beta2_pow, beta2_pow->place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta2_pow_out);
       return;

--- a/paddle/fluid/operators/optimizers/adam_op_npu.cc
+++ b/paddle/fluid/operators/optimizers/adam_op_npu.cc
@@ -84,11 +84,11 @@ class AdamNPUKernel : public framework::OpKernel<T> {
           *mom2, ctx.GetPlace(),
           ctx.template device_context<platform::DeviceContext>(), mom2_out);
       framework::TensorCopy(
-          *beta1_pow, ctx.GetPlace(),
+          *beta1_pow, beta1_pow->place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta1_pow_out);
       framework::TensorCopy(
-          *beta2_pow, ctx.GetPlace(),
+          *beta2_pow, beta2_pow->place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta2_pow_out);
       return;

--- a/paddle/fluid/operators/optimizers/adam_op_xpu.cc
+++ b/paddle/fluid/operators/optimizers/adam_op_xpu.cc
@@ -86,11 +86,11 @@ class AdamOpXPUKernel : public framework::OpKernel<T> {
           mom2, ctx.GetPlace(),
           ctx.template device_context<platform::DeviceContext>(), &mom2_out);
       framework::TensorCopy(
-          beta1_pow, ctx.GetPlace(),
+          *beta1_pow, beta1_pow->place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta1_pow_out);
       framework::TensorCopy(
-          beta2_pow, ctx.GetPlace(),
+          *beta2_pow, beta2_pow->place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta2_pow_out);
       return;

--- a/paddle/fluid/operators/optimizers/adam_op_xpu.cc
+++ b/paddle/fluid/operators/optimizers/adam_op_xpu.cc
@@ -86,11 +86,11 @@ class AdamOpXPUKernel : public framework::OpKernel<T> {
           mom2, ctx.GetPlace(),
           ctx.template device_context<platform::DeviceContext>(), &mom2_out);
       framework::TensorCopy(
-          *beta1_pow, beta1_pow->place(),
+          beta1_pow, beta1_pow.place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta1_pow_out);
       framework::TensorCopy(
-          *beta2_pow, beta2_pow->place(),
+          beta2_pow, beta2_pow.place(),
           ctx.template device_context<platform::DeviceContext>(),
           beta2_pow_out);
       return;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
By default, `beta_pow` of `adam` optimizer is initialized on CPU Place.
When training on CUDA Place, the original implementation will copy it to CUDA Place when skip_update=1.

This PR fixes that.