### PR TITLE
modify for wincheck-inference case

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -260,7 +260,7 @@ set ON_INFER=ON
 call :cmake || goto cmake_error
 call :build || goto build_error
 call :test_whl_pacakage || goto test_whl_pacakage_error
-:: call :test_unit || goto test_unit_error
+call :test_unit || goto test_unit_error
 ::call :test_inference || goto test_inference_error
 :: call :check_change_of_unittest || goto check_change_of_unittest_error
 goto:success
@@ -686,6 +686,10 @@ echo cmake .. -G %GENERATOR% -DCMAKE_BUILD_TYPE=Release -DWITH_AVX=%WITH_AVX% -D
 -DWITH_TENSORRT=%WITH_TENSORRT% -DTENSORRT_ROOT="%TENSORRT_ROOT%" -DMSVC_STATIC_CRT=%MSVC_STATIC_CRT% ^
 -DWITH_UNITY_BUILD=%WITH_UNITY_BUILD% -DCUDA_ARCH_NAME=%CUDA_ARCH_NAME% >> %work_dir%\win_cmake.sh
 set FLAGS_fraction_of_gpu_memory_to_use=0.92
+
+cd /d %work_dir%\%BUILD_DIR%
+set UT_list=test_strided_slice_op
+%PYTHON_ROOT%\python.exe %work_dir%\tools\parallel_UT_rule.py "${UT_list}"
 
 %cache_dir%\tools\busybox64.exe bash %work_dir%\tools\windows\run_unittests.sh %NIGHTLY_MODE% %PRECISION_TEST% %WITH_GPU%
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_sentiment.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_sentiment.py
@@ -324,6 +324,9 @@ def train(args, to_static):
                 if batch_id % args.log_step == 0:
                     time_end = time.time()
                     used_time = time_end - time_begin
+                    # in cuda11.2, used_time may be 0.0, cause zero division error
+                    if used_time < 1e-5:
+                        used_time = 1e-5
                     print("step: %d, ave loss: %f, speed: %f steps/s" %
                           (batch_id, avg_cost.numpy()[0],
                            args.log_step / used_time))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- fix test_sentiment's zero division problem
- open test_unit in wincheck_inference case
- only test added_ut temporarily when running CI-windows-inference in cuda112
