### PR TITLE
fix the problem of inconsistency between the behavior of "cross_entropy" API in dygraph and static graph

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1649,26 +1649,6 @@ def cross_entropy(input,
     if input_dims - 1 == label_dims:
         label = paddle.unsqueeze(label, axis=axis)
     if in_dygraph_mode():
-        if soft_label == False:
-            valid_label = paddle.where(label == ignore_index,
-                                       paddle.zeros_like(label), label)
-            # TODO: Temporarily use paddle.nonzero instead of paddle.max 
-            # to detect and find out possible illegal label values
-            if len(paddle.nonzero(valid_label < 0)) > 0:
-                invalid_label = paddle.gather_nd(
-                    valid_label, paddle.nonzero(valid_label < 0))
-                raise ValueError(
-                    "Target({}) is out of class_dimension's lower bound({})".
-                    format(invalid_label[0], 0))
-            # TODO: Temporarily use paddle.nonzero instead of paddle.max 
-            # to detect and find out possible illegal label values
-            if len(paddle.nonzero(valid_label >= input.shape[axis])) > 0:
-                invalid_label = paddle.gather_nd(
-                    valid_label,
-                    paddle.nonzero(valid_label >= input.shape[axis]))
-                raise ValueError(
-                    "Target({}) is out of class_dimension's upper bound({})".
-                    format(invalid_label[0], input.shape[axis] - 1))
         if core.is_compiled_with_npu():
             _, _, out = _C_ops.softmax_with_cross_entropy(
                 input, label, 'soft_label', soft_label, 'ignore_index',
@@ -1700,6 +1680,26 @@ def cross_entropy(input,
                 out = _C_ops.elementwise_mul(out, weight_gather_reshape)
 
             else:
+                valid_label = paddle.where(label == ignore_index,
+                                           paddle.zeros_like(label), label)
+                # TODO: Temporarily use paddle.nonzero instead of paddle.max 
+                # to detect and find out possible illegal label values
+                if len(paddle.nonzero(valid_label < 0)) > 0:
+                    invalid_label = paddle.gather_nd(
+                        valid_label, paddle.nonzero(valid_label < 0))
+                    raise ValueError(
+                        "Target({}) is out of class_dimension's lower bound({})".
+                        format(invalid_label[0], 0))
+                # TODO: Temporarily use paddle.nonzero instead of paddle.max 
+                # to detect and find out possible illegal label values
+                if len(paddle.nonzero(valid_label >= input.shape[axis])) > 0:
+                    invalid_label = paddle.gather_nd(
+                        valid_label,
+                        paddle.nonzero(valid_label >= input.shape[axis]))
+                    raise ValueError(
+                        "Target({}) is out of class_dimension's upper bound({})".
+                        format(invalid_label[0], input.shape[axis] - 1))
+
                 if input.shape[axis] != weight.shape[-1]:
                     raise ValueError(
                         "input's class_dimension({}) must equal to "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
ATT