### PR TITLE
[Dy2stat]Support `for i in [x,y,z]` statements in dy2stat

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -945,7 +945,8 @@ class ForLoopTuplePreTransformer(gast.NodeTransformer):
     def is_for_iter(self, for_node):
         assert isinstance(for_node,
                           gast.For), "Input node is not gast.For node."
-        if isinstance(for_node.iter, (gast.Name, gast.Attribute)):
+        if isinstance(for_node.iter,
+                      (gast.Name, gast.Attribute, gast.List, gast.Tuple)):
             return True
         elif isinstance(for_node.iter, gast.Call) and isinstance(
                 for_node.iter.func,

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -1046,7 +1046,8 @@ class ForNodeVisitor(object):
             gast.Name) and self.node.iter.func.id == "range"
 
     def is_for_iter(self):
-        if isinstance(self.node.iter, (gast.Name, gast.Attribute)):
+        if isinstance(self.node.iter,
+                      (gast.Name, gast.Attribute, gast.List, gast.Tuple)):
             return True
         elif isinstance(self.node.iter, gast.Call) and isinstance(
                 self.node.iter.func,

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -945,8 +945,7 @@ class ForLoopTuplePreTransformer(gast.NodeTransformer):
     def is_for_iter(self, for_node):
         assert isinstance(for_node,
                           gast.For), "Input node is not gast.For node."
-        if isinstance(for_node.iter,
-                      (gast.Name, gast.Attribute, gast.List, gast.Tuple)):
+        if isinstance(for_node.iter, (gast.Name, gast.Attribute)):
             return True
         elif isinstance(for_node.iter, gast.Call) and isinstance(
                 for_node.iter.func,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
该PR使得动转静模块能够正确转换如下的`for i in [1, 2, 3]`语句。
```python
import paddle
class Net(paddle.nn.Layer):
    @paddle.jit.to_static
    def forward(self):
        # import pdb; pdb.set_trace()
        for i in [1, 2, 3]:
            print(i)
net = Net()
net()
```
PR中对List和Tuple进行了支持；对于Dict，由于动转静会改写生成类似`Dict[index]`的语句，比如
`{'a': 1, 'b': 2}[__for_loop_var_index_0]`这样的语句是错误，所以如果要支持Dict，还需要进行其他的修改。
![image](https://user-images.githubusercontent.com/23097963/141980038-a0460e81-bc20-49f7-a044-919769ea013c.png)
