### PR TITLE
cherrypick [Paddle-Inference] op_teller: add all convert_op to int8

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -59,6 +59,8 @@ struct SimpleOpTypeSetTeller : public Teller {
 #if CUDA_VERSION >= 10020
     teller_set.insert("reshape");
     teller_set.insert("reshape2");
+    int8_teller_set.insert("reshape");
+    int8_teller_set.insert("reshape2");
 #endif
   }
 
@@ -74,24 +76,54 @@ struct SimpleOpTypeSetTeller : public Teller {
  private:
   // use this set for no calib int8.
   std::unordered_set<std::string> int8_teller_set{"mul",
-                                                  "conv2d",
                                                   "matmul",
-                                                  "stack",
+                                                  "conv2d",
                                                   "conv2d_fusion",
                                                   "pool2d",
                                                   "relu",
-                                                  "depthwise_conv2d",
                                                   "softmax",
                                                   "sigmoid",
+                                                  "hard_swish",
+                                                  "depthwise_conv2d",
                                                   "batch_norm",
+                                                  "concat",
+                                                  "tanh",
+                                                  "pad",
                                                   "elementwise_add",
+                                                  "elementwise_mul",
+                                                  "dropout",
+                                                  "prelu",
+                                                  "conv2d_transpose",
+                                                  "depthwise_conv2d_transpose",
                                                   "leaky_relu",
                                                   "fc",
-                                                  "concat",
+                                                  "shuffle_channel",
+                                                  "swish",
+                                                  "split",
+                                                  "instance_norm",
+                                                  "gelu",
+                                                  "layer_norm",
                                                   "scale",
-                                                  "elementwise_mul",
-                                                  "conv2d_transpose",
-                                                  "hard_swish"};
+                                                  "stack",
+                                                  "transpose2",
+                                                  "transpose",
+                                                  "flatten2",
+                                                  "flatten",
+                                                  "gather",
+                                                  "gather_nd",
+                                                  "yolo_box",
+                                                  "roi_align",
+                                                  "affine_channel",
+                                                  "nearest_interp",
+                                                  "anchor_generator",
+                                                  "reduce_sum",
+                                                  "reduce_mean",
+                                                  "conv3d",
+                                                  "conv3d_transpose",
+                                                  "mish",
+                                                  "nearest_interp_v2",
+                                                  "pool3d",
+                                                  "deformable_conv"};
   std::unordered_set<std::string> teller_set{"mul",
                                              "matmul",
                                              "conv2d",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
将所有的 convert_op 在 int8 中注册