### PR TITLE
[PTen] Add slice api implemention for Tensor

### DIFF
--- a/paddle/pten/tests/api/CMakeLists.txt
+++ b/paddle/pten/tests/api/CMakeLists.txt
@@ -15,3 +15,4 @@ cc_test(test_fill_api SRCS test_fill_api.cc DEPS pten_tensor pten_api pten_api_u
 cc_test(test_flatten_api SRCS test_flatten_api.cc DEPS pten_tensor pten_api pten_api_utils)
 cc_test(test_elementwise_api SRCS test_elementwise_api.cc DEPS pten_tensor pten_api pten_api_utils)
 cc_test(test_reshape_api SRCS test_reshape_api.cc DEPS pten_tensor pten_api pten_api_utils)
+cc_test(test_slice_api SRCS test_slice_api.cc DEPS pten_tensor pten_api pten_api_utils)

--- a/paddle/pten/tests/api/test_slice_api.cc
+++ b/paddle/pten/tests/api/test_slice_api.cc
@@ -34,15 +34,15 @@ TEST(Tensor, slice) {
 
   // check slice result
   ASSERT_EQ(slice_x.dims().size(), 2);
-  ASSERT_EQ(slice_x.dims()[0], 2);
+  ASSERT_EQ(slice_x.dims()[0], 1);
   ASSERT_EQ(slice_x.dims()[1], 3);
-  ASSERT_EQ(slice_x.numel(), 6);
+  ASSERT_EQ(slice_x.numel(), 3);
   ASSERT_EQ(slice_x.is_cpu(), true);
   ASSERT_EQ(slice_x.type(), pten::DataType::INT64);
   ASSERT_EQ(slice_x.layout(), pten::DataLayout::NCHW);
   ASSERT_EQ(slice_x.initialized(), true);
   for (int64_t i = 0; i < slice_x.numel(); ++i) {
-    ASSERT_EQ(slice_x.data<int64_t>()[i], 1);
+    ASSERT_EQ(slice_x.mutable_data<int64_t>()[i], 1);
   }
 }
 

--- a/paddle/pten/tests/api/test_slice_api.cc
+++ b/paddle/pten/tests/api/test_slice_api.cc
@@ -1,0 +1,50 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "paddle/pten/api/include/creation.h"
+#include "paddle/pten/api/include/tensor.h"
+#include "paddle/pten/core/kernel_registry.h"
+
+PT_DECLARE_MODULE(CreationCPU);
+
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+PT_DECLARE_MODULE(CreationCUDA);
+#endif
+
+namespace pten {
+namespace tests {
+
+TEST(Tensor, slice) {
+  auto x = paddle::experimental::full({4, 3}, 1, pten::DataType::INT64);
+  auto slice_x = x.slice(1, 2);
+
+  // check slice result
+  ASSERT_EQ(slice_x.dims().size(), 2);
+  ASSERT_EQ(slice_x.dims()[0], 2);
+  ASSERT_EQ(slice_x.dims()[1], 3);
+  ASSERT_EQ(slice_x.numel(), 6);
+  ASSERT_EQ(slice_x.is_cpu(), true);
+  ASSERT_EQ(slice_x.type(), pten::DataType::INT64);
+  ASSERT_EQ(slice_x.layout(), pten::DataLayout::NCHW);
+  ASSERT_EQ(slice_x.initialized(), true);
+  for (int64_t i = 0; i < slice_x.numel(); ++i) {
+    ASSERT_EQ(slice_x.data<int64_t>()[i], 1);
+  }
+}
+
+}  // namespace tests
+}  // namespace pten


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

[PTen] Add slice api implemention for Tensor

https://github.com/PaddlePaddle/Paddle/pull/37122 的TODO事项之一，恢复Tensor的slice接口支持，确保兼容，目前slice仍然通过辅助函数实现，后续会替换为调用pten api实现，并且功能上也会扩展，目前只是一个极简的slice功能