### PR TITLE
Fix data transform bug in new executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -289,7 +289,6 @@ std::tuple<std::string, OpFuncNode> apply_place_transform_for_var(
     const OpKernelType& expected_kernel_key, const platform::Place& place,
     const std::string& var_name, const std::string& outer_name,
     const OpFuncNode& op_func_node, Variable* var, VariableScope* var_scope) {
-  auto& ins_name2id = op_func_node.input_index;
   auto& all_op_kernels = OperatorWithKernel::AllOpKernels();
   platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
   std::string new_var_name =
@@ -307,7 +306,7 @@ std::tuple<std::string, OpFuncNode> apply_place_transform_for_var(
           : is_gpu_place(expected_kernel_key.place_) ? 1 : -1;
 
   std::map<std::string, std::vector<int>> copy_ins_name2id;
-  copy_ins_name2id["X"] = ins_name2id.at(outer_name);
+  copy_ins_name2id["X"] = {var_scope->VarId(var_name)};
   std::map<std::string, std::vector<int>> copy_out_name2id;
   copy_out_name2id["Out"] = {var_scope->VarId(new_var_name)};
 

--- a/paddle/fluid/framework/new_executor/standalone_executor_test.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor_test.cc
@@ -61,6 +61,8 @@ USE_OP(elementwise_max);
 USE_OP(elementwise_div);
 USE_OP(sgd);
 USE_OP(squared_l2_norm);
+USE_OP(memcpy_h2d);
+USE_OP(memcpy_d2h);
 
 paddle::framework::ProgramDesc load_from_file(const std::string& file_name) {
   std::ifstream fin(file_name, std::ios::in | std::ios::binary);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

修复了在data 不同place之间插入memcpy时，生成op_func_node.inputs的bug，此处应该固定使用 {var_name}，而不应该使用 op_func_node.input_index，在某些case下可能会导致memcpy_xx_op有多个输入导致报错