### PR TITLE
fix zero division problem

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_sentiment.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_sentiment.py
@@ -324,6 +324,9 @@ def train(args, to_static):
                 if batch_id % args.log_step == 0:
                     time_end = time.time()
                     used_time = time_end - time_begin
+                    # used_time may be 0.0, cause zero division error
+                    if used_time < 1e-5:
+                        used_time = 1e-5
                     print("step: %d, ave loss: %f, speed: %f steps/s" %
                           (batch_id, avg_cost.numpy()[0],
                            args.log_step / used_time))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
used_time may be 0.0, cause zero division error