### PR TITLE
Fix cmake dependence error in pten allocator

### DIFF
--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -79,7 +79,7 @@ if(WITH_UNITY_BUILD)
     include(unity_build_rule.cmake)
 endif()
 
-set(OP_HEADER_DEPS ${OP_HEADER_DEPS} pten)
+set(OP_HEADER_DEPS ${OP_HEADER_DEPS} pten pten_api_utils)
 
 register_operators(EXCLUDES py_layer_op py_func_op warpctc_op dgc_op load_combine_op lstm_op run_program_op eye_op
         recurrent_op save_combine_op sparse_attention_op sync_batch_norm_op spectral_op cinn_launch_op ${OP_MKL_DEPS} DEPS ${OP_HEADER_DEPS})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复pten的allocator，cmake依赖没有设置导致debug编译报错的问题。
```
../../pten/kernels/cuda/libmath_cuda.a(math.cu.o): In function `paddle::experimental::DefaultAllocator::Delete(void*)':
/home/liyurui/work/develop/Paddle/paddle/pten/api/lib/utils/allocator.h:32: undefined reference to `paddle::experimental::DefaultAllocator::deleter_'
collect2: error: ld returned 1 exit status
paddle/fluid/operators/CMakeFiles/feed_forward_test.dir/build.make:292: recipe for target 'paddle/fluid/operators/feed_forward_test' failed
make[2]: *** [paddle/fluid/operators/feed_forward_test] Error 1
CMakeFiles/Makefile2:103648: recipe for target 'paddle/fluid/operators/CMakeFiles/feed_forward_test.dir/all' failed
make[1]: *** [paddle/fluid/operators/CMakeFiles/feed_forward_test.dir/all] Error 2
```