### PR TITLE
fix bug to support dropout eval grad computing.

### DIFF
--- a/paddle/fluid/operators/dropout_impl_util.h
+++ b/paddle/fluid/operators/dropout_impl_util.h
@@ -34,9 +34,6 @@ inline void GetSeedDataAndIncrement(const platform::CUDADeviceContext& dev_ctx,
     TensorCopySync(*seed, platform::CPUPlace(), &seed_cpu_tensor);
     *seed_data = static_cast<uint64_t>(seed_cpu_tensor.data<int>()[0]);
     *increment = offset;
-  } else if (seed && platform::is_cpu_place(seed->place())) {
-    *seed_data = *(seed->data<int>());
-    *increment = offset;
   } else if (gen_cuda->GetIsInitPy() && (!is_fix_seed)) {
     auto seed_offset = gen_cuda->IncrementOffset(offset);
     *seed_data = seed_offset.first;

--- a/paddle/fluid/operators/dropout_op.cu
+++ b/paddle/fluid/operators/dropout_op.cu
@@ -58,10 +58,6 @@ template <typename DeviceContext, typename T>
 class GPUDropoutGradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {
-    PADDLE_ENFORCE_EQ(!context.Attr<bool>("is_test"), true,
-                      platform::errors::PreconditionNotMet(
-                          "GradOp is only callable when is_test is false"));
-
     auto* grad_x = context.Output<Tensor>(framework::GradVarName("X"));
     auto* grad_y = context.Input<Tensor>(framework::GradVarName("Out"));
     auto* mask = context.Input<Tensor>("Mask");
@@ -71,10 +67,12 @@ class GPUDropoutGradKernel : public framework::OpKernel<T> {
         context.Attr<std::string>("dropout_implementation");
     float dropout_prob = context.Attr<float>("dropout_prob");
 
+    bool is_test = context.Attr<bool>("is_test");
+
     auto& dev_ctx =
         context.template device_context<platform::CUDADeviceContext>();
     DropoutGradGPUKernelDriver<T>(dev_ctx, dropout_implementation, dropout_prob,
-                                  *grad_y, *mask, size, grad_x);
+                                  *grad_y, *mask, size, grad_x, is_test);
   }
 };
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe 
Question: 
#35122 support dropout in eval mode (paddle2.0已经将eval和no_grad解绑，eval下做反向是合理的，竞品也都支持这个行为). But #35621 remove these modifications of #35122. 
In this PR, we recover the modifications in #35122. 



test code:
![image](https://user-images.githubusercontent.com/11663212/142199060-586dde22-3fad-4c0e-8f75-dbf34d0e1fb7.png)


before this PR:
![image](https://user-images.githubusercontent.com/11663212/142199720-fc442bff-4795-4d74-960d-3a4c4c524f33.png)



after this PR:
![image](https://user-images.githubusercontent.com/11663212/142199241-6c336e72-2075-4fd1-bc63-9b4d705663d0.png)

