### PR TITLE
polish unittest of test_pretrained_model

### DIFF
--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -523,15 +523,17 @@ class TestModelFunction(unittest.TestCase):
                 optimizer=optim, loss=CrossEntropyLoss(reduction="sum"))
             model.save(path)
             model.load(path)
-            shutil.rmtree(path)
             fluid.disable_dygraph() if dynamic else None
+        shutil.rmtree(path)
 
     def test_dynamic_load(self):
         mnist_data = MnistDataset(mode='train')
+
+        path = os.path.join(tempfile.mkdtemp(), '.cache_dynamic_load')
+        if not os.path.exists(path):
+            os.makedirs(path)
+
         for new_optimizer in [True, False]:
-            path = os.path.join(tempfile.mkdtemp(), '.cache_dynamic_load')
-            if not os.path.exists(path):
-                os.makedirs(path)
             paddle.disable_static()
             net = LeNet()
             inputs = [InputSpec([None, 1, 28, 28], 'float32', 'x')]
@@ -548,8 +550,8 @@ class TestModelFunction(unittest.TestCase):
             model.fit(mnist_data, batch_size=64, verbose=0)
             model.save(path)
             model.load(path)
-            shutil.rmtree(path)
             paddle.enable_static()
+        shutil.rmtree(path)
 
     def test_dynamic_save_static_load(self):
         path = os.path.join(tempfile.mkdtemp(),
@@ -733,6 +735,12 @@ class TestModelFunction(unittest.TestCase):
     def test_export_deploy_model(self):
         self.set_seed()
         np.random.seed(201)
+
+        save_dir = os.path.join(tempfile.mkdtemp(),
+                                '.cache_test_export_deploy_model')
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+
         for dynamic in [True, False]:
             paddle.disable_static() if dynamic else None
             prog_translator = ProgramTranslator()
@@ -741,10 +749,7 @@ class TestModelFunction(unittest.TestCase):
             inputs = [InputSpec([None, 1, 28, 28], 'float32', 'x')]
             model = Model(net, inputs)
             model.prepare()
-            save_dir = os.path.join(tempfile.mkdtemp(),
-                                    '.cache_test_export_deploy_model')
-            if not os.path.exists(save_dir):
-                os.makedirs(save_dir)
+
             tensor_img = np.array(
                 np.random.random((1, 1, 28, 28)), dtype=np.float32)
 
@@ -765,8 +770,10 @@ class TestModelFunction(unittest.TestCase):
                                   fetch_list=fetch_targets)
                 np.testing.assert_allclose(
                     results, ori_results, rtol=1e-5, atol=1e-7)
-                shutil.rmtree(save_dir)
+
             paddle.enable_static()
+
+        shutil.rmtree(save_dir)
 
     def test_dygraph_export_deploy_model_about_inputs(self):
         self.set_seed()
@@ -774,11 +781,11 @@ class TestModelFunction(unittest.TestCase):
         mnist_data = MnistDataset(mode='train')
         paddle.disable_static()
         # without inputs
+        save_dir = os.path.join(tempfile.mkdtemp(),
+                                '.cache_test_dygraph_export_deploy')
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
         for initial in ["fit", "train_batch", "eval_batch", "predict_batch"]:
-            save_dir = os.path.join(tempfile.mkdtemp(),
-                                    '.cache_test_dygraph_export_deploy')
-            if not os.path.exists(save_dir):
-                os.makedirs(save_dir)
             net = LeNet()
             model = Model(net)
             optim = fluid.optimizer.Adam(
@@ -799,7 +806,7 @@ class TestModelFunction(unittest.TestCase):
                     model.predict_batch([img])
 
             model.save(save_dir, training=False)
-            shutil.rmtree(save_dir)
+        shutil.rmtree(save_dir)
         # with inputs, and the type of inputs is InputSpec
         save_dir = os.path.join(tempfile.mkdtemp(),
                                 '.cache_test_dygraph_export_deploy_2')

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -199,7 +199,9 @@ class TestModel(unittest.TestCase):
         cls.inputs = [InputSpec([-1, 1, 28, 28], 'float32', 'image')]
         cls.labels = [InputSpec([None, 1], 'int64', 'label')]
 
-        cls.save_dir = tempfile.mkdtemp()
+        cls.save_dir = os.path.join(tempfile.mkdtemp(), '.cache_test_model')
+        if not os.path.exists(cls.save_dir):
+            os.makedirs(cls.save_dir)
         cls.weight_path = os.path.join(cls.save_dir, 'lenet')
         fluid.dygraph.save_dygraph(dy_lenet.state_dict(), cls.weight_path)
 
@@ -505,7 +507,9 @@ class TestModelFunction(unittest.TestCase):
             fluid.disable_dygraph() if dynamic else None
 
     def test_save_load(self):
-        path = tempfile.mkdtemp()
+        path = os.path.join(tempfile.mkdtemp(), '.cache_test_save_load')
+        if not os.path.exists(path):
+            os.makedirs(path)
         for dynamic in [True, False]:
             device = paddle.set_device('cpu')
             fluid.enable_dygraph(device) if dynamic else None
@@ -517,15 +521,17 @@ class TestModelFunction(unittest.TestCase):
             model = Model(net, inputs, labels)
             model.prepare(
                 optimizer=optim, loss=CrossEntropyLoss(reduction="sum"))
-            model.save(path + '/test')
-            model.load(path + '/test')
+            model.save(path)
+            model.load(path)
             shutil.rmtree(path)
             fluid.disable_dygraph() if dynamic else None
 
     def test_dynamic_load(self):
         mnist_data = MnistDataset(mode='train')
         for new_optimizer in [True, False]:
-            path = tempfile.mkdtemp()
+            path = os.path.join(tempfile.mkdtemp(), '.cache_dynamic_load')
+            if not os.path.exists(path):
+                os.makedirs(path)
             paddle.disable_static()
             net = LeNet()
             inputs = [InputSpec([None, 1, 28, 28], 'float32', 'x')]
@@ -540,13 +546,16 @@ class TestModelFunction(unittest.TestCase):
             model.prepare(
                 optimizer=optim, loss=CrossEntropyLoss(reduction="sum"))
             model.fit(mnist_data, batch_size=64, verbose=0)
-            model.save(path + '/test')
-            model.load(path + '/test')
+            model.save(path)
+            model.load(path)
             shutil.rmtree(path)
             paddle.enable_static()
 
     def test_dynamic_save_static_load(self):
-        path = tempfile.mkdtemp()
+        path = os.path.join(tempfile.mkdtemp(),
+                            '.cache_dynamic_save_static_load')
+        if not os.path.exists(path):
+            os.makedirs(path)
         # dynamic saving
         device = paddle.set_device('cpu')
         fluid.enable_dygraph(device)
@@ -554,7 +563,7 @@ class TestModelFunction(unittest.TestCase):
         optim = fluid.optimizer.SGD(learning_rate=0.001,
                                     parameter_list=model.parameters())
         model.prepare(optimizer=optim, loss=CrossEntropyLoss(reduction="sum"))
-        model.save(path + '/test')
+        model.save(path)
         fluid.disable_dygraph()
 
         inputs = [InputSpec([None, 20], 'float32', 'x')]
@@ -563,12 +572,14 @@ class TestModelFunction(unittest.TestCase):
         optim = fluid.optimizer.SGD(learning_rate=0.001,
                                     parameter_list=model.parameters())
         model.prepare(optimizer=optim, loss=CrossEntropyLoss(reduction="sum"))
-        model.load(path + '/test')
+        model.load(path)
         shutil.rmtree(path)
 
     def test_static_save_dynamic_load(self):
-        path = tempfile.mkdtemp()
-
+        path = os.path.join(tempfile.mkdtemp(),
+                            '.cache_test_static_save_dynamic_load')
+        if not os.path.exists(path):
+            os.makedirs(path)
         net = MyModel()
         inputs = [InputSpec([None, 20], 'float32', 'x')]
         labels = [InputSpec([None, 1], 'int64', 'label')]
@@ -576,7 +587,7 @@ class TestModelFunction(unittest.TestCase):
                                     parameter_list=net.parameters())
         model = Model(net, inputs, labels)
         model.prepare(optimizer=optim, loss=CrossEntropyLoss(reduction="sum"))
-        model.save(path + '/test')
+        model.save(path)
 
         device = paddle.set_device('cpu')
         fluid.enable_dygraph(device)  #if dynamic else None
@@ -588,7 +599,7 @@ class TestModelFunction(unittest.TestCase):
                                     parameter_list=net.parameters())
         model = Model(net, inputs, labels)
         model.prepare(optimizer=optim, loss=CrossEntropyLoss(reduction="sum"))
-        model.load(path + '/test')
+        model.load(path)
         shutil.rmtree(path)
         fluid.disable_dygraph()
 
@@ -730,7 +741,8 @@ class TestModelFunction(unittest.TestCase):
             inputs = [InputSpec([None, 1, 28, 28], 'float32', 'x')]
             model = Model(net, inputs)
             model.prepare()
-            save_dir = tempfile.mkdtemp()
+            save_dir = os.path.join(tempfile.mkdtemp(),
+                                    '.cache_test_export_deploy_model')
             if not os.path.exists(save_dir):
                 os.makedirs(save_dir)
             tensor_img = np.array(
@@ -763,7 +775,8 @@ class TestModelFunction(unittest.TestCase):
         paddle.disable_static()
         # without inputs
         for initial in ["fit", "train_batch", "eval_batch", "predict_batch"]:
-            save_dir = tempfile.mkdtemp()
+            save_dir = os.path.join(tempfile.mkdtemp(),
+                                    '.cache_test_dygraph_export_deploy')
             if not os.path.exists(save_dir):
                 os.makedirs(save_dir)
             net = LeNet()
@@ -788,7 +801,8 @@ class TestModelFunction(unittest.TestCase):
             model.save(save_dir, training=False)
             shutil.rmtree(save_dir)
         # with inputs, and the type of inputs is InputSpec
-        save_dir = tempfile.mkdtemp()
+        save_dir = os.path.join(tempfile.mkdtemp(),
+                                '.cache_test_dygraph_export_deploy_2')
         if not os.path.exists(save_dir):
             os.makedirs(save_dir)
         net = LeNet()
@@ -988,13 +1002,14 @@ class TestRaiseError(unittest.TestCase):
     def test_save_infer_model_without_inputs_and_run_in_dygraph(self):
         paddle.disable_static()
         net = MyModel()
-        save_dir = tempfile.mkdtemp()
+        save_dir = os.path.join(tempfile.mkdtemp(), '.cache_test_save_infer')
         if not os.path.exists(save_dir):
             os.makedirs(save_dir)
         with self.assertRaises(RuntimeError):
             model = Model(net)
             model.save(save_dir, training=False)
         paddle.enable_static()
+        shutil.rmtree(save_dir)
 
     def test_save_infer_model_without_file_prefix(self):
         paddle.enable_static()

--- a/python/paddle/tests/test_pretrained_model.py
+++ b/python/paddle/tests/test_pretrained_model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 import tempfile
 import shutil
@@ -26,7 +27,9 @@ import paddle.vision.models as models
 # when used pretrained model
 class TestPretrainedModel(unittest.TestCase):
     def infer(self, arch):
-        path = tempfile.mkdtemp()
+        path = os.path.join(tempfile.mkdtemp(), '.cache_test_pretrained_model')
+        if not os.path.exists(path):
+            os.makedirs(path)
         x = np.array(np.random.random((2, 3, 224, 224)), dtype=np.float32)
         res = {}
         for dygraph in [True, False]:
@@ -52,11 +55,14 @@ class TestPretrainedModel(unittest.TestCase):
         np.testing.assert_allclose(res['dygraph'], res['static'])
 
     def test_models(self):
+        # TODO (LielinJiang): when model file cache is ok. add following test back
+        # 'resnet18', 'vgg16', 'alexnet', 'resnext50_32x4d', 'inception_v3', 
+        # 'densenet121', 'googlenet', 'wide_resnet50_2', 'wide_resnet101_2'  
         arches = [
-            'mobilenet_v1', 'mobilenet_v2', 'resnet18', 'vgg16', 'alexnet',
-            'resnext50_32x4d', 'inception_v3', 'densenet121', 'squeezenet1_0',
-            'squeezenet1_1', 'googlenet', 'shufflenet_v2_x0_25',
-            'shufflenet_v2_swish', 'wide_resnet50_2', 'wide_resnet101_2'
+            'mobilenet_v1',
+            'mobilenet_v2',
+            'squeezenet1_0',
+            'shufflenet_v2_x0_25',
         ]
         for arch in arches:
             self.infer(arch)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. 修复mac上单测tempfile无法自动删除的问题
2. 删除视觉领域api models中单测部分大模型，加速单测。后续添加缓存后，把需要的单测的大模型再加回来