### PR TITLE
[Bug fix] Fix for wrong results in segmentation models

### DIFF
--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -230,6 +230,9 @@ inline dnnl::memory::format_tag GetMKLDNNFormat(dnnl::memory::desc mem_desc) {
       } else if (strides[2] >= strides[3] && strides[3] >= strides[1] &&
                  strides[1] >= strides[0]) {
         return dnnl::memory::format_tag::cdba;
+      } else if (strides[3] >= strides[2] && strides[2] >= strides[0] &&
+                 strides[0] >= strides[1]) {
+        return dnnl::memory::format_tag::dcab;
       } else {
         return dnnl::memory::format_tag::nhwc;
       }


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Added dcab format tag support. "Any" format tag was choosing it, but we weren't supporting that and elementwise_add kernel was causing incorrect results in a segmentation model. We really need to add memory descriptor as a field to tensor class to avoid that kind of issues in future. It is a fix for #35307
