### PR TITLE
fix for cufft: some early versions of cufft do not define CUFFT_VERSION in the header

### DIFF
--- a/paddle/fluid/operators/spectral_op.cu
+++ b/paddle/fluid/operators/spectral_op.cu
@@ -313,7 +313,12 @@ void exec_fft(const DeviceContext& ctx, const Tensor* X, Tensor* out,
   // create plan
   FFTConfigKey key =
       create_fft_configkey(collapsed_input, collapsed_output, signal_ndim);
-  if (CUFFT_VERSION < 10200) {
+  bool using_cache = false;
+#if !defined(CUFFT_VERSION) || (CUFFT_VERSION < 10200)
+  using_cache = true;
+#endif
+
+  if (using_cache) {
     const int64_t device_id = static_cast<int64_t>(
         reinterpret_cast<const platform::CUDAPlace*>(&collapsed_input.place())
             ->GetDeviceId());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Some early versions of cufft do not define CUFFT_VERSION in the header. This PR add a branching for whether CUFFT_VSERSION is defined or not to avoid compiling error with these cufft versions.