### PR TITLE
Add corner case in PTQ scale calculation

### DIFF
--- a/paddle/fluid/inference/api/mkldnn_quantizer.cc
+++ b/paddle/fluid/inference/api/mkldnn_quantizer.cc
@@ -306,7 +306,7 @@ AnalysisPredictor::MkldnnQuantizer::GetKLScalingFactor(
     std::vector<int> reference_distr_P(&hist[0], &hist[i]);
     auto outliers_count =
         std::accumulate(&hist[i], &hist[precision_hist_num_bins], 0);
-    if (reference_distr_P[i - 1] == 0) {
+    if (i <= 0 || reference_distr_P[i - 1] == 0) {
       continue;
     }
     reference_distr_P[i - 1] += outliers_count;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
During post-training quantization of the Retinanet model, I encountered the problem in KL scaling factor calculation. It turned out that it was not checked whether the iterator, set by the algorithm, was a positive number. This PR adds a condition that will prevent us from reaching the vector value with a negative index.