### PR TITLE
[Cherry-pick][Dy2stat]set net.forward to original forward function in flops (#36852)

### DIFF
--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -17,6 +17,7 @@ import warnings
 import paddle.nn as nn
 import numpy as np
 from .static_flops import static_flops, Table
+from paddle.fluid.dygraph.dygraph_to_static.program_translator import unwrap_decorators
 
 __all__ = []
 
@@ -100,6 +101,10 @@ def flops(net, input_size, custom_ops=None, print_detail=False):
             #Total Flops: 347560     Total Params: 61610
     """
     if isinstance(net, nn.Layer):
+        # If net is a dy2stat model, net.forward is StaticFunction instance,
+        # we set net.forward to original forward function.
+        _, net.forward = unwrap_decorators(net.forward)
+
         inputs = paddle.randn(input_size)
         return dynamic_flops(
             net,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
set net.forward to original forward function in flops when net is a dy2stat model.