### PR TITLE
fix inplace bug when the first grad_var(loss_grad) is inplace var

### DIFF
--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -73,7 +73,6 @@ void BasicEngine::Init(
       VLOG(5) << "Clear the auto-grad graph from grad var " << var->Name()
               << " because of retain_graph=False when calling backward";
       var->GradVarBase()->SetGraphIsFreed(true);
-      var->GradVarBase()->ClearGradNode();
     }
 
     if (init_node == nullptr || var->OverridedStopGradient()) {

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -409,5 +409,30 @@ class TestDygraphInplaceSubtract(TestDygraphInplaceAdd):
         return var.subtract_(self.input_var_2)
 
 
+class TestLossIsInplaceVar(unittest.TestCase):
+    def test_loss_is_inplace_var(self):
+        with paddle.fluid.dygraph.guard():
+            var_a = paddle.ones((2, 2))
+            var_a.stop_gradient = False
+
+            var_b = var_a * 2
+            loss = var_b.tanh_()
+
+            loss.backward()
+            inplace_grad_var_a = var_a.grad.numpy()
+
+        with paddle.fluid.dygraph.guard():
+            var_a = paddle.ones((2, 2))
+            var_a.stop_gradient = False
+
+            var_b = var_a * 2
+            loss = var_b.tanh()
+
+            loss.backward()
+            grad_var_a = var_a.grad.numpy()
+
+        self.assertTrue(np.array_equal(inplace_grad_var_a, grad_var_a))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

#### 问题

对一个非叶子节点执行Inplace操作后，立即执行backward，该节点及更前的节点的梯度结果不对；但是在该节点之后再增加一个节点z，并在z上执行backward，则结果正常。

问题复现（以paddle.Tensor.tanh_为例）：

- 不做inplace操作

```
import paddle

x = paddle.ones((2,2))
x.stop_gradient = False

y = x * 2
l = y.tanh()  # not inplace strategy
l.backward()

print("paddle x.grad: ", x.grad.numpy())
# paddle x.grad:  [[0.14130163 0.14130163]
# [0.14130163 0.14130163]]
```

- 执行inplace操作后，立即执行backward：结果不对

```
import paddle

x = paddle.ones((2,2))
x.stop_gradient = False

y = x * 2
l = y.tanh_()  # inplace strategy
l.backward()

print("paddle x.grad: ", x.grad.numpy())
# paddle x.grad:  [[2.1413016 2.1413016]
# [2.1413016 2.1413016]]
```

- 执行inplace操作后，先增加一个非inplace节点，再执行backward：结果正常

```
import paddle

x = paddle.ones((2,2))
x.stop_gradient = False

y = x * 2
l = y.tanh_()  # inplace strategy
l = l.sum()   # add non-inplace node
l.backward()

print("paddle x.grad: ", x.grad.numpy())
# paddle x.grad:  [[0.14130163 0.14130163]
# [0.14130163 0.14130163]]
```


#### 原因分析

- 现象分析：
执行inplace操作后，马上执行backward反向，表示反向的第一个grad_var（一般为loss_grad）为inplace var。
从打印的结果及log分析，这种情况出错的原因在于，该inplace var进行了不必要的梯度累加操作。

- 出现不必要梯度累加的原因在于：
在`BasicEngine::Init()`方法里，对loss_grad进行初始化并获取第一个反向grad_node（init_node）时，会在获取了init_node后，将loss_grad的grad_node clear掉，也就是loss_grad没有grad_node了，导致loss_grad被识别为叶子节点。
又由于loss_grad是一个inplace var，这个inplace var在网络中出现了多次，叶子节点出现多次时便会出现梯度累加操作。

- 结论：
在`BasicEngine::Init()`方法里，将loss_grad的grad_node clear掉了，导致非叶子节点被误认为是叶子节点，引起梯度累加。


#### 修复

在`BasicEngine::Init()`方法里，不clear loss_grad的grad_node，也就是loss_grad在反向执行时仍然为非叶子节点。

