### PR TITLE
Pawepiot bf16 debug crash fix

### DIFF
--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -36,6 +36,7 @@ PADDLE_DEFINE_EXPORTED_bool(
     reader_queue_speed_test_mode, false,
     "If set true, the queue.pop will only get data from queue but not "
     "remove the data from queue for speed testing");
+PYBIND11_MAKE_OPAQUE(paddle::framework::LoDTensorArray);
 
 namespace paddle {
 namespace pybind {


### PR DESCRIPTION
**PR types**
Bug fixes 

**PR changes**
Others

**Describe**
This PR is a fix for bf16 debug compilation crash. 

```
C++ Traceback (most recent call last):
--------------------------------------
0   std::vector<paddle::framework::LoDTensor, std::allocator<paddle::framework::LoDTensor> >::clear()
1   std::vector<paddle::framework::LoDTensor, std::allocator<paddle::framework::LoDTensor> >::_M_erase_at_end(paddle::framework::LoDTensor*)
2   void std::_Destroy<paddle::framework::LoDTensor*, paddle::framework::LoDTensor>(paddle::framework::LoDTensor*, paddle::framework::LoDTensor*, std::allocator<paddle::framework::LoDTensor>&)
3   void std::_Destroy<paddle::framework::LoDTensor*>(paddle::framework::LoDTensor*, paddle::framework::LoDTensor*)
4   void std::_Destroy_aux<false>::__destroy<paddle::framework::LoDTensor*>(paddle::framework::LoDTensor*, paddle::framework::LoDTensor*)
5   void std::_Destroy<paddle::framework::LoDTensor>(paddle::framework::LoDTensor*)
6   paddle::framework::LoDTensor::~LoDTensor()
7   std::vector<paddle::framework::CPUVector<unsigned long>, std::allocator<paddle::framework::CPUVector<unsigned long> > >::~vector()
8   void std::_Destroy<paddle::framework::CPUVector<unsigned long>*, paddle::framework::CPUVector<unsigned long> >(paddle::framework::CPUVector<unsigned long>*, paddle::framework::CPUVector<unsigned long>*, std::allocator<paddle::framework::CPUVector<unsigned long> >&)
9   void std::_Destroy<paddle::framework::CPUVector<unsigned long>*>(paddle::framework::CPUVector<unsigned long>*, paddle::framework::CPUVector<unsigned long>*)
10  void std::_Destroy_aux<false>::__destroy<paddle::framework::CPUVector<unsigned long>*>(paddle::framework::CPUVector<unsigned long>*, paddle::framework::CPUVector<unsigned long>*)
11  void std::_Destroy<paddle::framework::CPUVector<unsigned long> >(paddle::framework::CPUVector<unsigned long>*)
12  paddle::framework::CPUVector<unsigned long>::~CPUVector()
13  std::vector<unsigned long, std::allocator<unsigned long> >::~vector()

----------------------
Error Message Summary:
----------------------
FatalError: `Segmentation fault` is detected by the operating system.
  [TimeInfo: *** Aborted at 1637328431 (unix time) try "date -d @1637328431" if you are using GNU date ***]
  [SignalInfo: *** SIGSEGV (@0x7) received by PID 114189 (TID 0x7f323e7d0700) from PID 7 ***]


```
