### PR TITLE
Add support bias is none for fused_attention op.

### DIFF
--- a/paddle/fluid/operators/fused/fused_attention_op.cu
+++ b/paddle/fluid/operators/fused/fused_attention_op.cu
@@ -96,9 +96,11 @@ class FusedAttentionOpKernel : public framework::OpKernel<T> {
 
     auto *x_data = input_x->data<T>();
     auto *qkv_weight_data = qkv_weight->data<T>();
-    auto *qkv_bias_data = qkv_bias->data<T>();
+    auto *qkv_bias_data = (qkv_bias == nullptr) ? nullptr : qkv_bias->data<T>();
     auto *qkv_out_data = qkv_out->mutable_data<T>(ctx.GetPlace());
-    auto *qkv_bias_out_data = qkv_bias_out->mutable_data<T>(ctx.GetPlace());
+    auto *qkv_bias_out_data =
+        (qkv_bias == nullptr) ? nullptr
+                              : qkv_bias_out->mutable_data<T>(ctx.GetPlace());
 
     // get data ptr for FMHA.
     auto *transpose_out_2_data =
@@ -117,7 +119,8 @@ class FusedAttentionOpKernel : public framework::OpKernel<T> {
 
     // get data ptr for out_linear.
     auto *out_linear_weight_data = out_linear_weight->data<T>();
-    auto *out_linear_bias_data = out_linear_bias->data<T>();
+    auto *out_linear_bias_data =
+        (out_linear_bias == nullptr) ? nullptr : out_linear_bias->data<T>();
     auto *out_linear_out_data = out_linear_out->mutable_data<T>(ctx.GetPlace());
 
     // get data ptr for bias+dropout+residual+layernorm
@@ -139,9 +142,15 @@ class FusedAttentionOpKernel : public framework::OpKernel<T> {
 
     auto layer_norm_compute = AttnLayerNorm<T>(ctx.cuda_device_context(),
                                                epsilon, bsz_seq, dim_embed);
+
+    bool compute_bias = true;
+    if (qkv_bias == nullptr) {
+      compute_bias = false;
+    }
     // (transA, transB, compute_bias) = (false, true, true)
-    auto qkv_compute = AttnMatMul<T>(ctx.cuda_device_context(), false, true,
-                                     bsz_seq, output_size, input_size, true);
+    auto qkv_compute =
+        AttnMatMul<T>(ctx.cuda_device_context(), false, true, bsz_seq,
+                      output_size, input_size, compute_bias);
 
     AttnDropoutParam attn_dropout_param(
         is_test_1, dropout_implementation_1, attn_dropout_rate,
@@ -176,10 +185,17 @@ class FusedAttentionOpKernel : public framework::OpKernel<T> {
       qkv_compute.ComputeForward(qkv_weight, input_x, qkv_bias, qkv_out,
                                  qkv_bias_out);
     }
-    fmha_ref_compute.ComputeForward(*qkv_bias_out, src_mask, transpose_out_2,
-                                    qk_out, src_mask_out, softmax_out,
-                                    attn_dropout_mask_out, attn_dropout_out,
-                                    qktv_out, fmha_out);
+    if (qkv_bias == nullptr) {
+      fmha_ref_compute.ComputeForward(*qkv_out, src_mask, transpose_out_2,
+                                      qk_out, src_mask_out, softmax_out,
+                                      attn_dropout_mask_out, attn_dropout_out,
+                                      qktv_out, fmha_out);
+    } else {
+      fmha_ref_compute.ComputeForward(*qkv_bias_out, src_mask, transpose_out_2,
+                                      qk_out, src_mask_out, softmax_out,
+                                      attn_dropout_mask_out, attn_dropout_out,
+                                      qktv_out, fmha_out);
+    }
 
     // fmha_out: [batch_size, seq_len, num_head, head_dim]
     // weight:   [embed_dim, embed_dim]
@@ -249,9 +265,10 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
     auto *out_linear_bias = ctx.Input<Tensor>("OutLinearBias");
     auto *src_mask_data = (src_mask == nullptr ? nullptr : src_mask->data<T>());
     auto *qkv_weight_data = qkv_weight->data<T>();
-    auto *qkv_bias_data = qkv_bias->data<T>();
+    auto *qkv_bias_data = (qkv_bias == nullptr) ? nullptr : qkv_bias->data<T>();
     auto *out_linear_weight_data = out_linear_weight->data<T>();
-    auto *out_linear_bias_data = out_linear_bias->data<T>();
+    auto *out_linear_bias_data =
+        (out_linear_bias == nullptr) ? nullptr : out_linear_bias->data<T>();
 
     // fw output
     auto *fmha_out = ctx.Input<Tensor>("FMHAOut");
@@ -299,8 +316,15 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
     auto *d_bias_dropout_residual_out =
         ctx.Output<Tensor>(framework::GradVarName("BiasDropoutResidualOut"));
     auto *d_x_data = d_x->mutable_data<T>(ctx.GetPlace());
-    auto *d_qkv_out_data = d_qkv_out->mutable_data<T>(ctx.GetPlace());
-    auto *d_qkv_bias_out_data = d_qkv_bias_out->mutable_data<T>(ctx.GetPlace());
+    // when qkv_bias is not nullptr, d_qkv_out is equals to d_qkv_bias_out, the
+    // space can be reused.
+    auto *d_qkv_out_data = (d_qkv_bias_out != nullptr)
+                               ? nullptr
+                               : d_qkv_out->mutable_data<T>(ctx.GetPlace());
+    auto *d_qkv_bias_out_data =
+        (d_qkv_bias_out == nullptr)
+            ? nullptr
+            : d_qkv_bias_out->mutable_data<T>(ctx.GetPlace());
     auto *d_qktv_out_data = d_qktv_out->mutable_data<T>(ctx.GetPlace());
     auto *d_transpose_out_2_data =
         d_transpose_out_2->mutable_data<T>(ctx.GetPlace());
@@ -326,11 +350,15 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
     auto *d_ln_2_bias = ctx.Output<Tensor>(framework::GradVarName("Ln2Bias"));
 
     auto *d_qkv_weight_data = d_qkv_weight->mutable_data<T>(ctx.GetPlace());
-    auto *d_qkv_bias_data = d_qkv_bias->mutable_data<T>(ctx.GetPlace());
+    auto *d_qkv_bias_data = (d_qkv_bias == nullptr)
+                                ? nullptr
+                                : d_qkv_bias->mutable_data<T>(ctx.GetPlace());
     auto *d_out_linear_weight_data =
         d_out_linear_weight->mutable_data<T>(ctx.GetPlace());
     auto *d_out_linear_bias_data =
-        d_out_linear_bias->mutable_data<T>(ctx.GetPlace());
+        (d_out_linear_bias == nullptr)
+            ? nullptr
+            : d_out_linear_bias->mutable_data<T>(ctx.GetPlace());
 
     const auto input_x_dims = input_x->dims();
     const auto qkv_w_dims = qkv_weight->dims();
@@ -352,12 +380,15 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
 
     bool transA = false;
     bool transB = true;
-    bool compute_bias = true;
+    bool compute_qkv_bias = true;
+    if (qkv_bias == nullptr) {
+      compute_qkv_bias = false;
+    }
     auto layer_norm_compute = AttnLayerNorm<T>(ctx.cuda_device_context(),
                                                epsilon, bsz_seq, dim_embed);
     auto qkv_compute =
         AttnMatMul<T>(ctx.cuda_device_context(), transA, transB, bsz_seq,
-                      output_size, input_size, compute_bias);
+                      output_size, input_size, compute_qkv_bias);
     AttnDropoutParam attn_dropout_param(
         is_test_1, dropout_implementation_1, attn_dropout_prob,
         is_upscale_in_train_1, is_fix_seed_1, seed_val_1, seed_1);
@@ -367,7 +398,7 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
     output_size = hidden_size;
     transA = false;
     transB = false;
-    compute_bias = false;
+    bool compute_bias = false;
     auto out_linear_compute =
         AttnMatMul<T>(ctx.cuda_device_context(), transA, transB, bsz_seq,
                       output_size, input_size, compute_bias);
@@ -405,14 +436,19 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
                                        d_out_linear_out, d_fmha_out,
                                        d_out_linear_weight, nullptr);
 
-    fmha_ref_compute.ComputeBackward(
-        *transpose_out_2, src_mask, *softmax_out, *attn_dropout_mask_out,
-        *attn_dropout_out, *qk_out, *src_mask_out, *d_fmha_out, d_qktv_out,
-        d_attn_dropout_out, d_softmax_out, d_src_mask_out, d_qk_out,
-        d_transpose_out_2, nullptr, d_qkv_bias_out);
-    cudaMemcpyAsync(d_qkv_out_data, d_qkv_bias_out_data,
-                    bsz_seq * 3 * num_head * dim_head * sizeof(T),
-                    cudaMemcpyDeviceToDevice);
+    if (qkv_bias != nullptr) {
+      fmha_ref_compute.ComputeBackward(
+          *transpose_out_2, src_mask, *softmax_out, *attn_dropout_mask_out,
+          *attn_dropout_out, *qk_out, *src_mask_out, *d_fmha_out, d_qktv_out,
+          d_attn_dropout_out, d_softmax_out, d_src_mask_out, d_qk_out,
+          d_transpose_out_2, nullptr, d_qkv_bias_out);
+    } else {
+      fmha_ref_compute.ComputeBackward(
+          *transpose_out_2, src_mask, *softmax_out, *attn_dropout_mask_out,
+          *attn_dropout_out, *qk_out, *src_mask_out, *d_fmha_out, d_qktv_out,
+          d_attn_dropout_out, d_softmax_out, d_src_mask_out, d_qk_out,
+          d_transpose_out_2, nullptr, d_qkv_out);
+    }
 
     if (pre_layer_norm) {
       auto *ln_mean = ctx.Input<Tensor>("LnMean");
@@ -432,15 +468,24 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
       auto *d_ln_bias_data =
           (d_ln_bias == nullptr ? nullptr
                                 : d_ln_bias->mutable_data<U>(ctx.GetPlace()));
-
-      qkv_compute.ComputeBackward(ln_out, qkv_weight, d_qkv_bias_out, d_ln_out,
-                                  d_qkv_weight, d_qkv_bias);
+      if (qkv_bias != nullptr) {
+        qkv_compute.ComputeBackward(ln_out, qkv_weight, d_qkv_bias_out,
+                                    d_ln_out, d_qkv_weight, d_qkv_bias);
+      } else {
+        qkv_compute.ComputeBackward(ln_out, qkv_weight, d_qkv_out, d_ln_out,
+                                    d_qkv_weight, d_qkv_bias);
+      }
       layer_norm_compute.ComputeBackward(x_data, d_ln_out_data, ln_scale_data,
                                          ln_mean_data, ln_var_data, d_x_data,
                                          d_ln_scale_data, d_ln_bias_data);
     } else {
-      qkv_compute.ComputeBackward(input_x, qkv_weight, d_qkv_bias_out, d_x,
-                                  d_qkv_weight, d_qkv_bias);
+      if (qkv_bias != nullptr) {
+        qkv_compute.ComputeBackward(input_x, qkv_weight, d_qkv_bias_out, d_x,
+                                    d_qkv_weight, d_qkv_bias);
+      } else {
+        qkv_compute.ComputeBackward(input_x, qkv_weight, d_qkv_out, d_x,
+                                    d_qkv_weight, d_qkv_bias);
+      }
     }
     // gradient accumulation
     std::vector<const Tensor *> ins;

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -356,6 +356,9 @@ def fused_multi_head_attention(x,
             0] == 3, "The shape of qkv_weight should be [3, num_head, head_dim, embed_dim]."
         assert qkv_weight.shape[3] == x.shape[
             2], "The 3rd dim of qkv_weight and 2nd dim of x should be the same, i.e., embed_dim."
+        assert qkv_weight.shape[1] * qkv_weight.shape[2] == qkv_weight.shape[
+            3], "embed_dim must be divisible by num_heads."
+
         _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, final_out = _C_ops.fused_attention(
             x, pre_ln_scale, pre_ln_bias, qkv_weight, qkv_bias, attn_mask,
             linear_weight, linear_bias, ln_scale, ln_bias, 'pre_layer_norm',


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs 

### Describe
Fix bus of fused_attention op.
1.Add support for bias is none, as well as corresponding unittest.
2.Add assert  for input shape limitations in case of API misuse, where 
`num_head * head_dim` should equal to `embed_dim`.

Results of related unittests:
![image](https://user-images.githubusercontent.com/11663212/142805453-0adac24a-c642-41c5-a798-1e4c561fae10.png)

![image](https://user-images.githubusercontent.com/11663212/142805546-d0447ee7-75ca-4abd-bc21-8356c4740824.png)




