### PR TITLE
fix memeory_optimize_pass bug (#37324)

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -105,7 +105,8 @@ void MemoryOptimizePass::CollectVarMemorySize(
                                         "sequence_pool",
                                         "recurrent",
                                         "lod_reset",
-                                        "fetch"};
+                                        "fetch",
+                                        "share_data"};
     for (auto* tmp : node->inputs) {
       CHECK(tmp->IsOp());
       std::string op_type = tmp->Op()->Type();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
37324 的 cherry-pick 
在内存复用时，没有考虑 算子输入输出 ShareDataWith 的情况
目前发现 share_data 属于这种情况，加入黑名单