### PR TITLE
block unknown option /arch:SSE3

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -32,11 +32,9 @@ if(WITH_AVX AND AVX_FOUND)
     set(SIMD_FLAG ${AVX_FLAG})
     add_definitions(-DPADDLE_WITH_AVX)
 elseif(SSE3_FOUND)
-    set(SIMD_FLAG "")
-endif()
-
-if (SSE3_FOUND)
-    # TODO: Runtime detection should be used here.
+    if(NOT WIN32)
+        set(SIMD_FLAG ${SSE3_FLAG})
+    endif()
     add_definitions(-DPADDLE_WITH_SSE3)
 endif()
 

--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -32,7 +32,7 @@ if(WITH_AVX AND AVX_FOUND)
     set(SIMD_FLAG ${AVX_FLAG})
     add_definitions(-DPADDLE_WITH_AVX)
 elseif(SSE3_FOUND)
-    set(SIMD_FLAG ${SSE3_FLAG})
+    set(SIMD_FLAG "")
 endif()
 
 if (SSE3_FOUND)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
When build in windows with_avx=off, SIMD_FLAG=${SSE3_FLAG}), this will add "/arch:SSE3" option in CMAKE_C/CC_FLAGS. However, both x86 and x64 do not surpport this option according to [microsoft](https://docs.microsoft.com/zh-cn/cpp/build/reference/arch-x86?view=msvc-140). As a result cl will show a warning: ignoring unknown option '/arch:SSE3' .
![image](https://user-images.githubusercontent.com/51314274/142853378-f632a968-9574-4c26-9030-a036f89d918f.png)

**before**
![Pasted Graphic 12](https://user-images.githubusercontent.com/51314274/143170233-4824c7cf-fea2-48fb-95ec-919b32f70ff5.png)

**after**
![image](https://user-images.githubusercontent.com/51314274/143170394-d429864f-a2e5-41cd-bb9c-c09bc92175b2.png)
