### PR TITLE
[NPU] add int64 support for scatter op

### DIFF
--- a/paddle/fluid/operators/scatter_op_npu.cc
+++ b/paddle/fluid/operators/scatter_op_npu.cc
@@ -61,7 +61,7 @@ class ScatterNPUKernel : public framework::OpKernel<T> {
     auto* out = ctx.Output<Tensor>("Out");
 
     auto place = ctx.GetPlace();
-    // out->mutable_data<T>(place);
+    out->mutable_data<T>(place);
 
     framework::Tensor tmp_tensor(index->type());
     const auto index_dims = index->dims();
@@ -77,8 +77,6 @@ class ScatterNPUKernel : public framework::OpKernel<T> {
             .stream();
 
     if (x->type() == framework::proto::VarType::INT64) {
-      LOG(WARNING) << "x->type(): " << x->type();
-
       Tensor x_fp32(framework::proto::VarType::FP32);
       x_fp32.Resize(x->dims());
       CastToFP32(ctx, stream, *x, &x_fp32);
@@ -104,8 +102,6 @@ class ScatterNPUKernel : public framework::OpKernel<T> {
 
       CastToInt64(ctx, stream, out_fp32, out);
     } else {
-      out->mutable_data<T>(place);
-
       if (overwrite) {
         const auto& runner_update = NpuOpRunner(
             "TensorScatterUpdate", {*x, *index, *updates}, {*out}, {});

--- a/paddle/fluid/operators/scatter_op_npu.cc
+++ b/paddle/fluid/operators/scatter_op_npu.cc
@@ -25,6 +25,30 @@ namespace operators {
 
 using Tensor = framework::Tensor;
 
+static void CastToInt64(const framework::ExecutionContext& ctx,
+                        const aclrtStream& stream, const Tensor& in,
+                        Tensor* out) {
+  out->mutable_data<int64_t>(ctx.GetPlace());
+  NpuOpRunner runner;
+  runner.SetType("Cast")
+      .AddInput(in)
+      .AddOutput(*out)
+      .AddAttr("dst_type", ACL_INT64)
+      .Run(stream);
+}
+
+static void CastToFP32(const framework::ExecutionContext& ctx,
+                       const aclrtStream& stream, const Tensor& in,
+                       Tensor* out) {
+  out->mutable_data<float>(ctx.GetPlace());
+  NpuOpRunner runner;
+  runner.SetType("Cast")
+      .AddInput(in)
+      .AddOutput(*out)
+      .AddAttr("dst_type", ACL_FLOAT)
+      .Run(stream);
+}
+
 template <typename DeviceContext, typename T>
 class ScatterNPUKernel : public framework::OpKernel<T> {
  public:
@@ -37,7 +61,7 @@ class ScatterNPUKernel : public framework::OpKernel<T> {
     auto* out = ctx.Output<Tensor>("Out");
 
     auto place = ctx.GetPlace();
-    out->mutable_data<T>(place);
+    // out->mutable_data<T>(place);
 
     framework::Tensor tmp_tensor(index->type());
     const auto index_dims = index->dims();
@@ -52,14 +76,45 @@ class ScatterNPUKernel : public framework::OpKernel<T> {
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
-    if (overwrite) {
-      const auto& runner_update = NpuOpRunner(
-          "TensorScatterUpdate", {*x, *index, *updates}, {*out}, {});
-      runner_update.Run(stream);
+    if (x->type() == framework::proto::VarType::INT64) {
+      LOG(WARNING) << "x->type(): " << x->type();
+
+      Tensor x_fp32(framework::proto::VarType::FP32);
+      x_fp32.Resize(x->dims());
+      CastToFP32(ctx, stream, *x, &x_fp32);
+
+      Tensor updates_fp32(framework::proto::VarType::FP32);
+      updates_fp32.Resize(updates->dims());
+      CastToFP32(ctx, stream, *updates, &updates_fp32);
+
+      Tensor out_fp32(framework::proto::VarType::FP32);
+      out_fp32.Resize(out->dims());
+      out_fp32.mutable_data<float>(ctx.GetPlace());
+
+      if (overwrite) {
+        const auto& runner_update =
+            NpuOpRunner("TensorScatterUpdate", {x_fp32, *index, updates_fp32},
+                        {out_fp32}, {});
+        runner_update.Run(stream);
+      } else {
+        const auto& runner_add = NpuOpRunner(
+            "TensorScatterAdd", {x_fp32, *index, updates_fp32}, {out_fp32}, {});
+        runner_add.Run(stream);
+      }
+
+      CastToInt64(ctx, stream, out_fp32, out);
     } else {
-      const auto& runner_add =
-          NpuOpRunner("TensorScatterAdd", {*x, *index, *updates}, {*out}, {});
-      runner_add.Run(stream);
+      out->mutable_data<T>(place);
+
+      if (overwrite) {
+        const auto& runner_update = NpuOpRunner(
+            "TensorScatterUpdate", {*x, *index, *updates}, {*out}, {});
+        runner_update.Run(stream);
+      } else {
+        const auto& runner_add =
+            NpuOpRunner("TensorScatterAdd", {*x, *index, *updates}, {*out}, {});
+        runner_add.Run(stream);
+      }
     }
   }
 };
@@ -70,6 +125,9 @@ namespace ops = paddle::operators;
 
 REGISTER_OP_NPU_KERNEL(
     scatter, ops::ScatterNPUKernel<paddle::platform::NPUDeviceContext, float>,
+#ifdef PADDLE_WITH_ASCEND_INT64
+    ops::ScatterNPUKernel<paddle::platform::NPUDeviceContext, int64_t>,
+#endif
     ops::ScatterNPUKernel<paddle::platform::NPUDeviceContext,
                           paddle::platform::float16>);
 #endif

--- a/paddle/fluid/operators/scatter_op_npu.cc
+++ b/paddle/fluid/operators/scatter_op_npu.cc
@@ -25,30 +25,6 @@ namespace operators {
 
 using Tensor = framework::Tensor;
 
-static void CastToInt64(const framework::ExecutionContext& ctx,
-                        const aclrtStream& stream, const Tensor& in,
-                        Tensor* out) {
-  out->mutable_data<int64_t>(ctx.GetPlace());
-  NpuOpRunner runner;
-  runner.SetType("Cast")
-      .AddInput(in)
-      .AddOutput(*out)
-      .AddAttr("dst_type", ACL_INT64)
-      .Run(stream);
-}
-
-static void CastToFP32(const framework::ExecutionContext& ctx,
-                       const aclrtStream& stream, const Tensor& in,
-                       Tensor* out) {
-  out->mutable_data<float>(ctx.GetPlace());
-  NpuOpRunner runner;
-  runner.SetType("Cast")
-      .AddInput(in)
-      .AddOutput(*out)
-      .AddAttr("dst_type", ACL_FLOAT)
-      .Run(stream);
-}
-
 template <typename DeviceContext, typename T>
 class ScatterNPUKernel : public framework::OpKernel<T> {
  public:
@@ -72,44 +48,48 @@ class ScatterNPUKernel : public framework::OpKernel<T> {
       index = &tmp_tensor;
     }
 
-    auto stream =
-        ctx.template device_context<paddle::platform::NPUDeviceContext>()
-            .stream();
+    const auto& dev_ctx =
+        ctx.template device_context<paddle::platform::NPUDeviceContext>();
+    auto op_func_update = [](const std::vector<Tensor>& inputs,
+                             const std::vector<Tensor>& outputs,
+                             const NPUAttributeMap& attrs,
+                             const platform::NPUDeviceContext& dev_ctx) {
+      const auto& runner =
+          NpuOpRunner("TensorScatterUpdate", inputs, outputs, attrs);
+      runner.Run(dev_ctx.stream());
+    };
+    auto op_func_add = [](const std::vector<Tensor>& inputs,
+                          const std::vector<Tensor>& outputs,
+                          const NPUAttributeMap& attrs,
+                          const platform::NPUDeviceContext& dev_ctx) {
+      const auto& runner =
+          NpuOpRunner("TensorScatterAdd", inputs, outputs, attrs);
+      runner.Run(dev_ctx.stream());
+    };
 
-    if (x->type() == framework::proto::VarType::INT64) {
-      Tensor x_fp32(framework::proto::VarType::FP32);
-      x_fp32.Resize(x->dims());
-      CastToFP32(ctx, stream, *x, &x_fp32);
-
-      Tensor updates_fp32(framework::proto::VarType::FP32);
-      updates_fp32.Resize(updates->dims());
-      CastToFP32(ctx, stream, *updates, &updates_fp32);
-
-      Tensor out_fp32(framework::proto::VarType::FP32);
-      out_fp32.Resize(out->dims());
-      out_fp32.mutable_data<float>(ctx.GetPlace());
-
-      if (overwrite) {
-        const auto& runner_update =
-            NpuOpRunner("TensorScatterUpdate", {x_fp32, *index, updates_fp32},
-                        {out_fp32}, {});
-        runner_update.Run(stream);
+    if (overwrite) {
+      if (x->type() == framework::proto::VarType::INT64) {
+        NpuOpRunner::TypeAdapter(
+            {*x, *index, *updates}, {*out}, {}, dev_ctx, op_func_update,
+            {framework::proto::VarType::INT32, framework::proto::VarType::INT32,
+             framework::proto::VarType::INT32},
+            {framework::proto::VarType::INT32});
       } else {
-        const auto& runner_add = NpuOpRunner(
-            "TensorScatterAdd", {x_fp32, *index, updates_fp32}, {out_fp32}, {});
-        runner_add.Run(stream);
-      }
-
-      CastToInt64(ctx, stream, out_fp32, out);
-    } else {
-      if (overwrite) {
         const auto& runner_update = NpuOpRunner(
             "TensorScatterUpdate", {*x, *index, *updates}, {*out}, {});
-        runner_update.Run(stream);
+        runner_update.Run(dev_ctx.stream());
+      }
+    } else {
+      if (x->type() == framework::proto::VarType::INT64) {
+        NpuOpRunner::TypeAdapter(
+            {*x, *index, *updates}, {*out}, {}, dev_ctx, op_func_add,
+            {framework::proto::VarType::INT32, framework::proto::VarType::INT32,
+             framework::proto::VarType::INT32},
+            {framework::proto::VarType::INT32});
       } else {
         const auto& runner_add =
             NpuOpRunner("TensorScatterAdd", {*x, *index, *updates}, {*out}, {});
-        runner_add.Run(stream);
+        runner_add.Run(dev_ctx.stream());
       }
     }
   }
@@ -124,6 +104,7 @@ REGISTER_OP_NPU_KERNEL(
 #ifdef PADDLE_WITH_ASCEND_INT64
     ops::ScatterNPUKernel<paddle::platform::NPUDeviceContext, int64_t>,
 #endif
+    ops::ScatterNPUKernel<paddle::platform::NPUDeviceContext, int>,
     ops::ScatterNPUKernel<paddle::platform::NPUDeviceContext,
                           paddle::platform::float16>);
 #endif

--- a/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
@@ -17,9 +17,8 @@ from __future__ import print_function
 import numpy as np
 import unittest
 import sys
-# sys.path.append("..")
-# from op_test import OpTest
-from paddle.fluid.tests.unittests.op_test import OpTest
+sys.path.append("..")
+from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core

--- a/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
@@ -27,7 +27,7 @@ paddle.enable_static()
 SEED = 2021
 
 
-class TestCast1(OpTest):
+class TestCast1_FP32(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "scatter"
@@ -50,7 +50,7 @@ class TestCast1(OpTest):
         self.check_output_with_place(self.place)
 
 
-class TestCast2(OpTest):
+class TestCast_INT32(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "scatter"
@@ -73,7 +73,7 @@ class TestCast2(OpTest):
         self.check_output_with_place(self.place)
 
 
-class TestCast3(OpTest):
+class TestCast2_FP32(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "scatter"
@@ -96,7 +96,7 @@ class TestCast3(OpTest):
         self.check_output_with_place(self.place)
 
 
-class TestCast4(OpTest):
+class TestCast3_FP32(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "scatter"

--- a/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
@@ -17,8 +17,9 @@ from __future__ import print_function
 import numpy as np
 import unittest
 import sys
-sys.path.append("..")
-from op_test import OpTest
+# sys.path.append("..")
+# from op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
@@ -109,6 +110,29 @@ class TestCast4(OpTest):
         output_np = np.copy(ref_np)
         output_np[1] = updates_np[0]
         output_np[2] = updates_np[1]
+        self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
+        self.outputs = {'Out': output_np}
+        self.attrs = {'overwrite': True}
+
+    def set_npu(self):
+        self.__class__.use_npu = True
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+
+class TestCast_INT64(OpTest):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "scatter"
+        self.place = paddle.NPUPlace(0)
+
+        ref_np = np.ones((3, 2)).astype("int64")
+        index_np = np.array([1]).astype("int32")
+        updates_np = np.zeros((1, 2)).astype("int64")
+
+        output_np = np.copy(ref_np)
+        output_np[index_np] = updates_np
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
         self.attrs = {'overwrite': True}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
add int64 support for scatter op

<img width="959" alt="a7e2fde0ef2622ab3c7af81842ac6ff8" src="https://user-images.githubusercontent.com/34057289/142855059-2d2dd5ab-18e7-47fd-bad8-fa903f7207c4.png">
