### PR TITLE
block xxhash warning of c4711

### DIFF
--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -31,6 +31,9 @@ ENDIF()
 
 if (WIN32)
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/xxhash.lib")
+  # block warning about inline function
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4710 /wd4711")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4710 /wd4711")
 else()
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/libxxhash.a")
 endif ()
@@ -60,6 +63,12 @@ if(WIN32)
                       -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
                       -DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
                       -DBUILD_SHARED_LIBS=OFF
+                      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                      -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
+                      -DCMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}
+                      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                      -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
+                      -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
                       ${OPTIONAL_CACHE_ARGS}
       TEST_COMMAND      ""
       BUILD_BYPRODUCTS ${XXHASH_LIBRARIES}

--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -31,9 +31,6 @@ ENDIF()
 
 if (WIN32)
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/xxhash.lib")
-  # block warning about inline function
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4710 /wd4711")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4710 /wd4711")
 else()
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/libxxhash.a")
 endif ()
@@ -63,10 +60,10 @@ if(WIN32)
                       -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
                       -DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
                       -DBUILD_SHARED_LIBS=OFF
-                      -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                      -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} /wd4710 /wd4711"
                       -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
                       -DCMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}
-                      -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                      -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} /wd4710 /wd4711"
                       -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
                       -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
                       ${OPTIONAL_CACHE_ARGS}

--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -31,8 +31,12 @@ ENDIF()
 
 if (WIN32)
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/xxhash.lib")
+  set(XXHASH_CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4710 /wd4711")
+  set(XXHASH_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4710 /wd4711")
 else()
   set(XXHASH_LIBRARIES "${XXHASH_INSTALL_DIR}/lib/libxxhash.a")
+  set(XXHASH_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+  set(XXHASH_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif ()
 
 cache_third_party(extern_xxhash
@@ -60,10 +64,10 @@ if(WIN32)
                       -DCMAKE_GENERATOR=${CMAKE_GENERATOR}
                       -DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
                       -DBUILD_SHARED_LIBS=OFF
-                      -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} /wd4710 /wd4711"
+                      -DCMAKE_CXX_FLAGS=${XXHASH_CMAKE_CXX_FLAGS}
                       -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
                       -DCMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}
-                      -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} /wd4710 /wd4711"
+                      -DCMAKE_C_FLAGS=${XXHASH_CMAKE_C_FLAGS}
                       -DCMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG}
                       -DCMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
                       ${OPTIONAL_CACHE_ARGS}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
block xxhash's warning C4711: function * selected for automatic inline expansion when build in windows

- add /wd4710 /wd4711 in c/cxx_flags to block these warnings
- add cmake_flags in configure_command

**before**
![image](https://user-images.githubusercontent.com/51314274/143170171-a6bd79aa-84d7-4b73-920e-f6090ff473b9.png)
**after**
![image](https://user-images.githubusercontent.com/51314274/143169327-7b646cf6-702c-446d-bd9f-dd416e2c9a7a.png)
