### PR TITLE
unique fetch var name

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -38,11 +38,13 @@ static constexpr size_t kHostNumThreads = 4;
 
 InterpreterCore::InterpreterCore(const platform::Place& place,
                                  const BlockDesc& block,
-                                 VariableScope* global_scope)
+                                 VariableScope* global_scope,
+                                 const std::string& fetch_var_name)
     : place_(place),
       block_(block),
       global_scope_(global_scope),
-      stream_analyzer_(place) {
+      stream_analyzer_(place),
+      fetch_var_name_(fetch_var_name) {
   is_build_ = false;
   async_work_queue_.reset(
       new interpreter::AsyncWorkQueue(kHostNumThreads, &main_thread_blocker_));
@@ -89,7 +91,7 @@ paddle::framework::FetchList InterpreterCore::Run(
   }
 
   // return Fetch Tensors
-  auto* fetch_var = global_scope_->Var(interpreter::kFetchVarName);
+  auto* fetch_var = global_scope_->Var(fetch_var_name_);
   return *(fetch_var->GetMutable<framework::FetchList>());
 }
 
@@ -121,7 +123,7 @@ paddle::framework::FetchList InterpreterCore::Run() {
   }
 
   // return Fetch Tensors
-  auto* fetch_var = global_scope_->Var(interpreter::kFetchVarName);
+  auto* fetch_var = global_scope_->Var(fetch_var_name_);
   return *(fetch_var->GetMutable<framework::FetchList>());
 }
 

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -40,9 +40,10 @@ using AtomicVectorSizeT = std::vector<std::unique_ptr<std::atomic<size_t>>>;
 
 class InterpreterCore {
  public:
-  InterpreterCore(const platform::Place& place, const BlockDesc& block,
-                  VariableScope* global_scope,
-                  const std::string& fetch_var_name = "");
+  InterpreterCore(
+      const platform::Place& place, const BlockDesc& block,
+      VariableScope* global_scope,
+      const std::string& fetch_var_name = interpreter::kFetchVarName);
 
   ~InterpreterCore();
 

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -41,7 +41,8 @@ using AtomicVectorSizeT = std::vector<std::unique_ptr<std::atomic<size_t>>>;
 class InterpreterCore {
  public:
   InterpreterCore(const platform::Place& place, const BlockDesc& block,
-                  VariableScope* global_scope);
+                  VariableScope* global_scope,
+                  const std::string& fetch_var_name = "");
 
   ~InterpreterCore();
 
@@ -112,6 +113,8 @@ class InterpreterCore {
   std::vector<paddle::platform::DeviceEvent> gc_event_;
   bool create_local_scope_{true};
   Scope* local_scope_{nullptr};  // not owned
+
+  std::string fetch_var_name_;
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -415,9 +415,12 @@ void build_op_func_list(const platform::Place& place,
   }
 }
 
-void add_fetch(const std::vector<std::string>& fetch_names,
-               framework::BlockDesc* block) {
-  auto* fetch_holder = block->Var(kFetchVarName);
+std::string add_fetch(const std::vector<std::string>& fetch_names,
+                      framework::BlockDesc* block) {
+  static int fetch_var_name_id = 1;
+  std::string fetch_var_name =
+      kFetchVarName + std::to_string(fetch_var_name_id++);
+  auto* fetch_holder = block->Var(fetch_var_name);
   fetch_holder->SetType(proto::VarType::FETCH_LIST);
   fetch_holder->SetPersistable(true);
 
@@ -427,11 +430,13 @@ void add_fetch(const std::vector<std::string>& fetch_names,
     auto* op = block->AppendOp();
     op->SetType("fetch_v2");
     op->SetInput("X", {fetch_name});
-    op->SetOutput("Out", {kFetchVarName});
+    op->SetOutput("Out", {fetch_var_name});
     op->SetAttr("col", {static_cast<int>(i)});
     op->CheckAttrs();
     i++;
   }
+
+  return fetch_var_name;
 }
 
 std::vector<size_t> merge_vector(const std::vector<size_t>& first,

--- a/paddle/fluid/framework/new_executor/interpretercore_util.h
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.h
@@ -106,8 +106,8 @@ void build_op_func_list(const platform::Place& place,
 std::map<int, std::list<int>> build_op_downstream_map(
     const std::vector<Instruction>& vec_instruction);
 
-void add_fetch(const std::vector<std::string>& fetch_names,
-               framework::BlockDesc* block);
+std::string add_fetch(const std::vector<std::string>& fetch_names,
+                      framework::BlockDesc* block);
 
 std::vector<size_t> merge_vector(const std::vector<size_t>& first,
                                  const std::vector<size_t>& second);

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -114,9 +114,10 @@ std::shared_ptr<InterpreterCore> StandaloneExecutor::GetInterpreterCore(
       // new program.
       auto new_prog = std::make_shared<framework::ProgramDesc>(main_prog_);
       auto* block = new_prog->MutableBlock(0);
-      interpreter::add_fetch(fetch_names, block);
+      auto fetch_var_name = interpreter::add_fetch(fetch_names, block);
 
-      core = std::make_shared<InterpreterCore>(place_, *block, &global_scope_);
+      core = std::make_shared<InterpreterCore>(place_, *block, &global_scope_,
+                                               fetch_var_name);
       core->SetCopyProgram(new_prog);
     } else {
       core = std::make_shared<InterpreterCore>(place_, main_prog_.Block(0),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
让fetch var name取唯一的名字。
这么做的原因是在`test_executor_return_tensor_not_overwriting`单测中，有两个执行器，但是，由于默认都使用的是global scope，所以，两个执行器用了同一个scope。因此导致fetch var name冲突。进而导致第二个执行器fetch的时候直接使用了第一个执行器mutable_data的内存。覆盖了第一个执行器fetch的tensor。