### PR TITLE
use ShareBufferWith instead of ShareDataWith for ops with view mechanism

### DIFF
--- a/paddle/fluid/pybind/op_function.h
+++ b/paddle/fluid/pybind/op_function.h
@@ -188,7 +188,7 @@ static inline void HandleViewBetweenInputAndOutput(
 
     auto* view_output_tensor =
         view_output_var->MutableVar()->GetMutable<framework::LoDTensor>();
-    view_output_tensor->ShareDataWith(input_tensor);
+    view_output_tensor->ShareBufferWith(input_tensor);
     view_output_tensor->ShareInplaceVersionCounterWith(input_tensor);
 
     VLOG(3) << "Perform View between Output Var(" << view_output_var->Name()
@@ -314,7 +314,7 @@ static inline void CastPyArg2AttrString(
     Py_ssize_t size;
     const char* data;
     data = PyUnicode_AsUTF8AndSize(obj, &size);
-    attrs[key] = std::string(data, (size_t)size);
+    attrs[key] = std::string(data, static_cast<size_t>(size));
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "%s(): argument (position %d) must be "
@@ -674,7 +674,7 @@ static inline void CastPyArg2AttrStrings(
         Py_ssize_t size;
         const char* data;
         data = PyUnicode_AsUTF8AndSize(item, &size);
-        value.emplace_back(std::string(data, (size_t)size));
+        value.emplace_back(std::string(data, static_cast<size_t>(size)));
       } else {
         PADDLE_THROW(platform::errors::InvalidArgument(
             "%s(): argument (position %d) must be "
@@ -737,7 +737,7 @@ static inline void ConstructAttrMapFromPyArgs(
           op_type, arg_pos, ((PyTypeObject*)obj->ob_type)->tp_name));  // NOLINT
     }
 
-    std::string key(key_ptr, (size_t)key_len);
+    std::string key(key_ptr, static_cast<size_t>(key_len));
     auto iter = attr_type_map->find(key);
     if (iter == attr_type_map->end()) {
       continue;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Use ShareBufferWith instead of ShareDataWith for ops with view mechanism.
Change: shape and data type is not shared of operatos with view mechanism. Only holder and offset are shared.
This enables view mechanism between tensors with different data type and shape.
