### PR TITLE
set feed var skip inplace

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -49,7 +49,7 @@ class InterpreterCore {
       const std::vector<std::string>& feed_names,
       const std::vector<framework::LoDTensor>& feed_tensors);
 
-  paddle::framework::FetchList Run();
+  paddle::framework::FetchList Run(const std::vector<std::string>& feed_names);
 
   interpreter::CostInfo DryRun(
       const std::vector<std::string>& feed_names,
@@ -83,6 +83,8 @@ class InterpreterCore {
   void BuildSkipShareLoDInfo();
 
   void BuildOperatorDependences();
+
+  void SetFeedVarsInplaceSkip(const std::vector<std::string>& feed_names);
 
   bool is_build_;
 

--- a/paddle/fluid/framework/new_executor/new_executor_defs.cc
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.cc
@@ -598,6 +598,16 @@ paddle::framework::VarDesc* VariableScope::VarDesc(int id) const {
   return vec_meta_info_[id].var_desc_;
 }
 
+void VariableScope::SetVarSikpInplace(const std::string& name, bool skip) {
+  CheckExist(name);
+  vec_meta_info_[VarId(name)].sikp_inplace_ = skip;
+}
+
+bool VariableScope::GetVarSikpInplace(int id) const {
+  CheckExist(id);
+  return vec_meta_info_[id].sikp_inplace_;
+}
+
 void VariableScope::CheckExist(int id) const {
   PADDLE_ENFORCE_LT(id, var_list_.size(),
                     platform::errors::PreconditionNotMet(

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -145,6 +145,7 @@ struct OpKernelFunc {
 struct VariableMetaInfo {
   int var_ref_count_{0};
   framework::VarDesc* var_desc_{nullptr};
+  bool sikp_inplace_{false};
 
   VariableMetaInfo() {}
   VariableMetaInfo(int var_ref_count, framework::VarDesc* var_desc)
@@ -227,6 +228,10 @@ class VariableScope : public ScopeBase {
   const std::shared_ptr<VariableScopeListener>& Listener() const {
     return listener_;
   }
+
+  void SetVarSikpInplace(const std::string& name, bool skip);
+
+  bool GetVarSikpInplace(int id) const;
 
   friend class VariableScopeListener;
 

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -68,7 +68,7 @@ paddle::framework::FetchList StandaloneExecutor::Run(
     const std::vector<std::string>& fetch_names) {
   auto core = GetInterpreterCore(feed_names, fetch_names, false);
   VLOG(4) << "StandaloneExecutor: " << this << ", InterpreterCore: " << core;
-  return core->Run();
+  return core->Run(feed_names);
 }
 
 framework::interpreter::CostInfo StandaloneExecutor::DryRun(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
在老的Inplace策略里有这样的逻辑：如果是Feed的Var，不对这个Var inplace。否则var的值就被改变，如果再给其它Executor feed就会出错。
在新的执行器里，也加入同样的策略。