### PR TITLE
[new-exec] fix program cache key

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -584,7 +584,7 @@ class _ExecutorCache(object):
         new_exe = self._get_exe_from_cache(program, scope)
         return new_exe.run(feed, fetch_list, return_numpy)
 
-    def _get_exe_from_cache(self, program, scope):
+    def _get_exe_from_cache(self, program, scope, feed, fetch_list):
         """
         Return cached _StandaloneExecutor instance. If not found, create associated 
         _StandaloneExecutor instance with given program and cache it.
@@ -593,12 +593,13 @@ class _ExecutorCache(object):
             program, Program), "Required type(Program), but received {}".format(
                 type(program).__name__)
 
-        if str(program) not in self._cached_executors:
+        key = _get_strong_program_cache_key(program, feed, fetch_list)
+        if key not in self._cached_executors:
             new_program = program.clone()
             new_exe = _StandaloneExecutor(self._place, new_program, scope)
-            self._cached_executors[str(program)] = new_exe
+            self._cached_executors[key] = new_exe
 
-        return self._cached_executors[str(program)]
+        return self._cached_executors[key]
 
 
 class Executor(object):
@@ -1370,8 +1371,8 @@ class Executor(object):
 
                 # NPTE(zhiqiu): Construct standalone_executor first, so 
                 # the scope is binded with the variable_scope of standalone_executor
-                new_exe = self._executor_cache._get_exe_from_cache(program,
-                                                                   scope)
+                new_exe = self._executor_cache._get_exe_from_cache(
+                    program, scope, feed, fetch_list)
 
                 self._feed_data(program, feed, feed_var_name, scope)
                 if hasattr(program, 'lr_sheduler'):

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1361,6 +1361,12 @@ class Executor(object):
                         "feed requires dict as its Parameter. But you passed in %s"
                         % (type(feed)))
                 feed = self._update_feed(program, feed)
+
+                # NPTE(zhiqiu): Construct standalone_executor first, so 
+                # the scope is binded with the variable_scope of standalone_executor
+                new_exe = self._executor_cache._get_exe_from_cache(
+                    inner_program, scope, feed, fetch_list)
+
                 program = self._add_feed_fetch_ops(
                     program=inner_program,
                     feed=feed,
@@ -1368,11 +1374,6 @@ class Executor(object):
                     feed_var_name=feed_var_name,
                     fetch_var_name=fetch_var_name,
                     use_fetch_v2=True)
-
-                # NPTE(zhiqiu): Construct standalone_executor first, so 
-                # the scope is binded with the variable_scope of standalone_executor
-                new_exe = self._executor_cache._get_exe_from_cache(
-                    program, scope, feed, fetch_list)
 
                 self._feed_data(program, feed, feed_var_name, scope)
                 if hasattr(program, 'lr_sheduler'):

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -580,27 +580,6 @@ class _ExecutorCache(object):
         self._place = place
         self._cached_executors = {}
 
-    def run(self, program, scope, feed, fetch_list, return_numpy=True):
-        new_exe = self._get_exe_from_cache(program, scope)
-        return new_exe.run(feed, fetch_list, return_numpy)
-
-    def _get_exe_from_cache(self, program, scope, feed, fetch_list):
-        """
-        Return cached _StandaloneExecutor instance. If not found, create associated 
-        _StandaloneExecutor instance with given program and cache it.
-        """
-        assert isinstance(
-            program, Program), "Required type(Program), but received {}".format(
-                type(program).__name__)
-
-        key = _get_strong_program_cache_key(program, feed, fetch_list)
-        if key not in self._cached_executors:
-            new_program = program.clone()
-            new_exe = _StandaloneExecutor(self._place, new_program, scope)
-            self._cached_executors[key] = new_exe
-
-        return self._cached_executors[key]
-
 
 class Executor(object):
     """

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1362,10 +1362,8 @@ class Executor(object):
                         % (type(feed)))
                 feed = self._update_feed(program, feed)
 
-                # NPTE(zhiqiu): Construct standalone_executor first, so 
-                # the scope is binded with the variable_scope of standalone_executor
-                new_exe = self._executor_cache._get_exe_from_cache(
-                    inner_program, scope, feed, fetch_list)
+                key = _get_strong_program_cache_key(inner_program, feed,
+                                                    fetch_list)
 
                 program = self._add_feed_fetch_ops(
                     program=inner_program,
@@ -1374,6 +1372,16 @@ class Executor(object):
                     feed_var_name=feed_var_name,
                     fetch_var_name=fetch_var_name,
                     use_fetch_v2=True)
+
+                # a little bit tricy here, use inner_program before _add_feed_fetch_ops to get key
+                # while use program to geet _StandaloneExecutor
+                if key not in self._executor_cache._cached_executors:
+                    new_program = program.clone()
+                    new_exe = _StandaloneExecutor(self.place, new_program,
+                                                  scope)
+                    self._executor_cache._cached_executors[key] = new_exe
+
+                new_exe = self._executor_cache._cached_executors[key]
 
                 self._feed_data(program, feed, feed_var_name, scope)
                 if hasattr(program, 'lr_sheduler'):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[new-exec] fix program cache key

The original implementation use `str(program)` as cache key, which has two problems:

- some attributes can not be decoded,

> in load_inference_mode
> ...
> UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 24: invalid start byte

- the program's content may be `vary large`, thus cost much time

