### PR TITLE
[new-exec] skip compiled program

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1332,13 +1332,14 @@ class Executor(object):
 
         def _can_use_interpreter_core(program, place):
             compiled = isinstance(program, compiler.CompiledProgram)
-            # NOTE(zhiqiu): only single card compiled program is supported 
+            # NOTE(zhiqiu): do not support compiled program now
             if compiled:
-                if program._is_data_parallel and len(
-                        program._get_places(place, program._places)) == 1:
-                    return True
-                else:
-                    return False
+                return False
+                # if program._is_data_parallel and len(
+                #         program._get_places(place, program._places)) == 1:
+                #     return True
+                # else:
+                #     return False
             else:
                 assert isinstance(program, Program)
                 return True

--- a/python/paddle/fluid/tests/unittests/interpreter/test_standalone_executor.py
+++ b/python/paddle/fluid/tests/unittests/interpreter/test_standalone_executor.py
@@ -261,7 +261,7 @@ class SwitchExecutorInterfaceWithFeed(unittest.TestCase):
 
     def test_compiled_program(self):
         data = np.ones([2, 2], dtype="float32")
-        feed = {"a": data, 'fake_input': data}
+        feed = {"a": data}
 
         res = self.run_new_executor(feed, use_compiled=True)
         gt = self.run_raw_executor(feed, use_compiled=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
ATT,  skip compiled program when setting `FLAGS_USE_STANDALONE_EXECUTOR=1` since some tests is designed to test the graph and PE.