### PR TITLE
Hot fix for dataloader thread error because of pten

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -213,8 +213,9 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
         # execution, so it is impossible to cache KernelContext for each op.
         # However, it is not thread-safe if using only one global kernel context in
         # dynamic graph. If the pten op of paddle is used in the DataLoader thread,
-        # it may cause access errors. There is currently no solution to this
-        # problem, we will find a better solution later and remove this setting.
+        # it may cause access errors. We temporarily do not execute pten kernel
+        # in this scenariowe andwe will find a better solution later and remove
+        # this setting.
         set_flags({'FLAGS_run_pten_kernel': False})
 
         while not self._thread_done_event.is_set():

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -214,7 +214,7 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
         # However, it is not thread-safe if using only one global kernel context in
         # dynamic graph. If the pten op of paddle is used in the DataLoader thread,
         # it may cause access errors. We temporarily do not execute pten kernel
-        # in this scenariowe andwe will find a better solution later and remove
+        # in this scenario and will find a better solution later and remove
         # this setting.
         set_flags({'FLAGS_run_pten_kernel': False})
 

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -24,7 +24,7 @@ import threading
 import numpy as np
 import multiprocessing
 from collections import namedtuple
-from paddle.fluid.framework import _set_expected_place, _current_expected_place
+from paddle.fluid.framework import _set_expected_place, _current_expected_place, set_flags
 
 # NOTE: queue has a different name in python2 and python3
 import queue
@@ -201,6 +201,21 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
         # Which may cost hundreds of MB of GPU memory on CUDAPlace(0) if calling some cuda 
         # APIs in this thread.
         _set_expected_place(legacy_expected_place)
+
+        # NOTE(chenweihang): [ Why need to set not to execute pten kernel here? ]
+        # Now, in order to ensure that the execution performance of the dynamic
+        # graph mode in pten compatible state does not decline significantly,
+        # we have adopted the approach of caching a KernelContext globally for
+        # the dynamic graph tracer to reduce the construction and deconstruction
+        # overhead of data interfaces such as the compatible state DenseTensor.
+        # The static graph is each op caches a KernelContext, but the op of
+        # the dynamic graph will be constructed and destroyed every round of
+        # execution, so it is impossible to cache KernelContext for each op.
+        # However, it is not thread-safe if using only one global kernel context in
+        # dynamic graph. If the pten op of paddle is used in the DataLoader thread,
+        # it may cause access errors. There is currently no solution to this
+        # problem, we will find a better solution later and remove this setting.
+        set_flags({'FLAGS_run_pten_kernel': False})
 
         while not self._thread_done_event.is_set():
             try:
@@ -500,6 +515,9 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         # Which may cost hundreds of MB of GPU memory on CUDAPlace(0) if calling some cuda 
         # APIs in this thread.
         _set_expected_place(legacy_expected_place)
+
+        # NOTE(chenweihang): See Note [ Why need to set not to execute pten kernel here? ]
+        set_flags({'FLAGS_run_pten_kernel': False})
 
         while not self._thread_done_event.is_set():
             batch = self._get_data()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Hot fix for dataloader thread error because of pten

 Now, in order to ensure that the execution performance of the dynamic graph mode in pten compatible state does not decline significantly, we have adopted the approach of caching a KernelContext globally for the dynamic graph tracer to reduce the construction and deconstruction overhead of data interfaces such as the compatible state DenseTensor. 

The static graph is each op caches a KernelContext, but the op of the dynamic graph will be constructed and destroyed every round of execution, so it is impossible to cache KernelContext for each op. 

However, it is not thread-safe if using only one global kernel context in dynamic graph. If the pten op of paddle is used in the DataLoader thread, it may cause access errors. We temporarily do not execute pten kernel in this scenario and will find a better solution later and remove this setting. 
