### PR TITLE
fix fc_fuse and modify test code

### DIFF
--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -52,7 +52,7 @@ FCFusePass::FCFusePass() {
       .End()
       .AddAttr("axis")
       .IsNumMatch<int>([](int axis) -> bool {
-        if (axis == -1 || axis >= 1) {
+        if (axis == -1) {
           return true;
         }
         return false;
@@ -130,6 +130,17 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
     GET_IR_NODE_FROM_SUBGRAPH(mul, mul, fc_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(elementwise_add, elementwise_add, fc_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(mul_out, mul_out, fc_pattern);
+
+    // Only support 2D-Tensor as weight for FC
+    std::vector<int64_t> w_shape = w->Var()->GetShape();
+    size_t w_rank = w_shape.size();
+    if (w_rank != 2) return;
+
+    // Shape of bias should be [1, out_size]
+    std::vector<int64_t> b_shape = bias->Var()->GetShape();
+    if (b_shape.size() != 2) return;
+    if (b_shape[0] != 1 || b_shape[1] != w_shape[1]) return;
+
     Node* relu = nullptr;
     Node* relu_out = nullptr;
     if (with_relu) {

--- a/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
@@ -55,14 +55,14 @@ TEST(FCFusePass, basic) {
   auto* bias_0 = layers.data("conv2d_bias_0", {}, true);
   auto* conv2d_out = layers.conv2d(a, filters_0, bias_0, false);
   auto* relu_out_0 = layers.relu(conv2d_out);
-  auto* weights_0 = layers.data("weights_0", {}, true);
+  auto* weights_0 = layers.data("weights_0", {5, 4}, true);
   auto* mul_out_0 = layers.mul(relu_out_0, weights_0);
-  auto* bias_1 = layers.data("bias_1", {}, true);
+  auto* bias_1 = layers.data("bias_1", {4}, true);
   auto* add_out_0 = layers.elementwise_add(mul_out_0, bias_1, nullptr, 1);
   auto* relu_out_1 = layers.relu(add_out_0);
-  auto* weights_1 = layers.data("weights_1", {}, true);
+  auto* weights_1 = layers.data("weights_1", {8, 9}, true);
   auto* mul_out_1 = layers.mul(relu_out_1, weights_1);
-  auto* bias_2 = layers.data("bias_2", {}, true);
+  auto* bias_2 = layers.data("bias_2", {1, 9}, true);
   auto* add_out_1 = layers.elementwise_add(mul_out_1, bias_2, nullptr, 1);
   VLOG(4) << add_out_1;
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/ir/inference/CMakeLists.txt
@@ -72,7 +72,7 @@ set_tests_properties(test_trt_conv3d_op PROPERTIES TIMEOUT 60)
 set_tests_properties(test_trt_conv3d_transpose_op PROPERTIES TIMEOUT 60)
 set_tests_properties(test_trt_nearest_interp_v2_op PROPERTIES TIMEOUT 30)
 set_tests_properties(test_emb_eltwise_layernorm_fuse_pass PROPERTIES TIMEOUT 120)
-set_tests_properties(test_fc_fuse_pass PROPERTIES TIMEOUT 120)
+set_tests_properties(test_fc_fuse_pass PROPERTIES TIMEOUT 240)
 
 if (WITH_MKLDNN)
   set_tests_properties(test_mkldnn_prelu_op PROPERTIES TIMEOUT 300)

--- a/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
@@ -83,6 +83,7 @@ class AutoScanTest(unittest.TestCase):
         self.num_ran_programs = 0
         self.num_invalid_programs = 0
         self.num_skipped_tests = 0
+        self.num_skipped_tests_with_no_diff = 0
         self.num_predictor_kinds = 0
 
     @abc.abstractmethod
@@ -371,6 +372,10 @@ class PassAutoScanTest(AutoScanTest):
         logging.info("Number of Ran Programs: {}".format(self.num_ran_programs))
         logging.info("Number of Skipped Tests: {}".format(
             self.num_skipped_tests))
+        logging.info(
+            "And in these skipped tests, there are {} didn't cause difference".
+            format(self.num_skipped_tests_with_no_diff))
+
         successful_ran_programs = int(self.num_ran_programs -
                                       self.num_skipped_tests /
                                       self.num_predictor_kinds)
@@ -452,6 +457,8 @@ class PassAutoScanTest(AutoScanTest):
                                              results[0])
                     if not skip_flag:
                         self.assert_op_list(op_list)
+                    else:
+                        self.num_skipped_tests_with_no_diff += 1
 
                 except Exception as e:
                     self.fail_log(
@@ -459,6 +466,10 @@ class PassAutoScanTest(AutoScanTest):
                         '\033[1;31m \nERROR INFO: {}\033[0m'.format(str(e)))
                     if not skip_flag:
                         status = False
+                    elif os.getenv("DEBUG_SKIP", "OFF") == "ON":
+                        self.assertTrue(
+                            False,
+                            "DEBUG_SKIP is ON, this skipped case has diff")
                     continue
                 self.success_log('RUN predictor_config ' + self.
                                  inference_config_str(pred_config) + ' done')

--- a/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
@@ -462,10 +462,6 @@ class PassAutoScanTest(AutoScanTest):
                         '\033[1;31m \nERROR INFO: {}\033[0m'.format(str(e)))
                     if not skip_flag:
                         status = False
-                    elif os.getenv("DEBUG_SKIP", "OFF") == "ON":
-                        self.assertTrue(
-                            False,
-                            "DEBUG_SKIP is ON, this skipped case has diff")
                     continue
                 self.success_log('RUN predictor_config ' + self.
                                  inference_config_str(pred_config) + ' done')

--- a/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
@@ -179,7 +179,6 @@ class AutoScanTest(unittest.TestCase):
     @abc.abstractmethod
     def create_inference_config(self,
                                 passes: Optional[List[str]]=None,
-                                disable_passes: Optional[List[str]]=None,
                                 use_gpu: bool=False,
                                 use_mkldnn: bool=False,
                                 ir_optim: Optional[bool]=None):
@@ -197,9 +196,6 @@ class AutoScanTest(unittest.TestCase):
         if passes is not None:
             config.pass_builder().set_passes(passes)
             self.passes = passes
-        if disable_passes is not None:
-            for pass_name in disable_passes:
-                config.delete_pass(pass_name)
         return config
 
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_fc_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_fc_fuse_pass.py
@@ -182,7 +182,7 @@ class TestFcFusePass(PassAutoScanTest):
 
     def test(self):
         self.run_and_statis(
-            quant=False, max_examples=1300, passes=["fc_fuse_pass"])
+            quant=False, max_examples=500, passes=["fc_fuse_pass"])
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_fc_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_fc_fuse_pass.py
@@ -63,14 +63,16 @@ class TestFcFusePass(PassAutoScanTest):
             # shape of bias should be [1, mul_y_shape[-1]] or [mul_y_shape[-1]]
             x_shape = list(program_config.inputs["mul_x"].shape)
             y_shape = list(program_config.weights["mul_y"].shape)
-            bias_shape = program_config.weights["bias"].shape
-            if bias_shape != [1, y_shape[-1]]:
+            bias_shape = list(program_config.weights["bias"].shape)
+            if bias_shape != [y_shape[-1]] and bias_shape != [1, y_shape[-1]]:
                 return True
             return False
 
         def teller2(program_config, predictor_config):
             # TODO fuse has bug while axis != -1
-            if program_config.ops[1].attrs["axis"] != -1:
+            axis = program_config.ops[1].attrs["axis"]
+            if axis != -1 and axis != program_config.ops[0].attrs[
+                    "x_num_col_dims"]:
                 return True
             return False
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_fc_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_fc_fuse_pass.py
@@ -64,6 +64,12 @@ class TestFcFusePass(PassAutoScanTest):
             x_shape = list(program_config.inputs["mul_x"].shape)
             y_shape = list(program_config.weights["mul_y"].shape)
             bias_shape = list(program_config.weights["bias"].shape)
+
+            if predictor_config.tensorrt_engine_enabled():
+                # TensorRT cann't handle all the situation of elementwise_add
+                # disable it until this problem fixed
+                predictor_config.exp_disable_tensorrt_ops(["elementwise_add"])
+
             if bias_shape != [y_shape[-1]] and bias_shape != [1, y_shape[-1]]:
                 return True
             return False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
1. 【初步修复】解决现有fc_fuse_pass存在diff或出错问题
> 1.  `elementwise_add`中`axis`属性限制由原条件(axis==-1 || axis >=1) 改为新条件(axis==-1)
> 2. `mul`中`Y`输入的维度新增限制为`2`
> 3. `elementwise_add`中`Y`输入的形状限制为`[1, out_size]`
2. 【单测】auto_scan中添加参数，支持禁用pass
3. 【单测】test_fc_fuse中添加trt测试
4.  增加统计字段`num_skipped_tests_with_no_diff`

`num_skipped_tests_with_no_diff`
- 当未修复pass前，`num_skipped_tests_with_no_diff`应该尽可能小甚至为0，表示所有被skipped的case确实存在问题
- 当修复pass后，`num_skipped_tests_with_no_diff`应该等于`num_skipped_tests`，表示所有的skipped_tests均已被修复