### PR TITLE
remove test_dist_fleet_heter_ctr from parallel_UT_rule.py

### DIFF
--- a/tools/parallel_UT_rule.py
+++ b/tools/parallel_UT_rule.py
@@ -515,7 +515,6 @@ HIGH_PARALLEL_JOB_NEW = [
     'test_dist_fleet_a_sync_optimizer_sync',
     'test_dist_fleet_decay',
     'test_auto_checkpoint2',
-    'test_dist_fleet_heter_ctr',
     'test_dist_fleet_simnet',
     'test_dist_sparse_load_ps1',
     'test_dist_mnist_fleet_save',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
test_dist_fleet_heter_ctr单测存在超时问题，先将该单测移除并行列表，方便负责人定位问题