### PR TITLE
Disable the check of missing op benchmark script temporarily.

### DIFF
--- a/paddle/fluid/operators/cinn_launch_op.cc
+++ b/paddle/fluid/operators/cinn_launch_op.cc
@@ -121,6 +121,7 @@ void CinnLaunchContext::MutableTensorData(const std::string& var_name,
 
   auto cinn_tensor = GetCinnTensor(cinn_name);
   // TODO(CtfGo): support mutable corresponding c++ type after CINN ready
+  VLOG(4) << "Only support float in cinn_launch op now.";
   paddle_tensor->mutable_data<float>(
       framework::make_ddim(cinn_tensor->shape().data()), place);
 }

--- a/tools/ci_op_benchmark.sh
+++ b/tools/ci_op_benchmark.sh
@@ -236,8 +236,9 @@ function check_CHANGE_OP_MAP {
   do
     if [ -z "${BENCHMARK_OP_MAP[$op_name]}" ]
     then
-      exit_code=8
-      LOG "[ERROR] Missing test script of \"${op_name}\"(${CHANGE_OP_MAP[$op_name]}) in benchmark."
+      # Disable the check of missing op benchmark script temporarily.
+      # exit_code=8
+      LOG "[WARNING] Missing test script of \"${op_name}\"(${CHANGE_OP_MAP[$op_name]}) in benchmark."
     fi
   done
   if [ $exit_code -ne 0 ]; then


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
如题，暂时关闭OP Benchmark CI中对于缺脚本的检查，并在cinn_launch_op.cc中加了一行log验证修改是否生效。但.cc的修改，OP Benchmark CI不会监控，后续PR再验证吧。