### PR TITLE
Refine ParallelExecutor data feeding when feed is a dict

### DIFF
--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -102,6 +102,9 @@ class ParallelExecutor {
                        const std::vector<std::string> &skip_vars);
 
  private:
+  void FeedTensorsIntoLocalScopesImpl(
+      const std::unordered_map<std::string, LoDTensor> *tensors, size_t n);
+
   // broadcast the parameters from the 0th device.
   // trainer_id the trainer index in nccl distributed training.
   void BCastParamsToDevices(const std::vector<std::string> &vars,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
Make ParallelExecutor data feeding use `ShareDataWith` when feed is a dict and the `len(places) == 1`.