### PR TITLE
clear local scope every setp

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -122,6 +122,16 @@ paddle::framework::FetchList InterpreterCore::Run(
     ExecuteInstructionList(vec_instruction_);
   }
 
+  if (create_local_scope_) {
+    auto vars = local_scope_->LocalVars();
+    for (auto var : vars) {
+      if (var->IsType<LoDTensorArray>()) {
+        auto* lod_tensor_arr = var->GetMutable<LoDTensorArray>();
+        lod_tensor_arr->clear();
+      }
+    }
+  }
+
   // return Fetch Tensors
   auto* fetch_var = global_scope_->Var(interpreter::kFetchVarName);
   return std::move(*fetch_var->GetMutable<framework::FetchList>());

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -89,7 +89,7 @@ paddle::framework::FetchList InterpreterCore::Run(
   }
 
   if (create_local_scope_) {
-    ClearLocalScope();
+    ClearLoDTensorArrayInLocalScope();
   }
 
   // return Fetch Tensors
@@ -127,7 +127,7 @@ paddle::framework::FetchList InterpreterCore::Run(
   }
 
   if (create_local_scope_) {
-    ClearLocalScope();
+    ClearLoDTensorArrayInLocalScope();
   }
 
   // return Fetch Tensors
@@ -135,7 +135,10 @@ paddle::framework::FetchList InterpreterCore::Run(
   return std::move(*fetch_var->GetMutable<framework::FetchList>());
 }
 
-void InterpreterCore::ClearLocalScope() {
+// At the end of each step, the holder of Tensor in LoDTensorArray is null.
+// Clear these Tensors and leave LoDTensorArray empty, otherwise an exception
+// will occur in the next step
+void InterpreterCore::ClearLoDTensorArrayInLocalScope() {
   auto vars = local_scope_->LocalVars();
   for (auto var : vars) {
     if (var->IsType<LoDTensorArray>()) {
@@ -628,7 +631,7 @@ interpreter::CostInfo InterpreterCore::DryRun(
   }
 
   if (create_local_scope_) {
-    ClearLocalScope();
+    ClearLoDTensorArrayInLocalScope();
   }
 
   return cost_info;

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -86,6 +86,8 @@ class InterpreterCore {
 
   void SetFeedVarsInplaceSkip(const std::vector<std::string>& feed_names);
 
+  void ClearLocalScope();
+
   bool is_build_;
 
   const platform::Place& place_;

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -86,7 +86,7 @@ class InterpreterCore {
 
   void SetFeedVarsInplaceSkip(const std::vector<std::string>& feed_names);
 
-  void ClearLocalScope();
+  void ClearLoDTensorArrayInLocalScope();
 
   bool is_build_;
 

--- a/paddle/fluid/framework/new_executor/interpretercore_garbage_collector.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_garbage_collector.cc
@@ -79,7 +79,6 @@ void InterpreterCoreGarbageCollector::Add(paddle::framework::Variable* var,
     for (auto& t : *tensor_arr) {
       Add(t.MoveMemoryHolder(), event, ctx);
     }
-    tensor_arr->clear();
   } else if (var->IsType<std::vector<Scope*>>()) {
     // NOTE(@xiongkun03) conditional_op / while_op will create a STEP_SCOPE
     // refer to executor.cc to see what old garbage collector does.

--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -411,7 +411,6 @@ void build_op_func_list(const platform::Place& place,
         for (auto& t : *lod_tensor_arr) {
           garbages->emplace_back(t.MoveMemoryHolder());
         }
-        lod_tensor_arr->clear();
       } else {
         PADDLE_THROW(platform::errors::Unimplemented(
             "Type %s of variable %s is not supported eager deletion.",

--- a/paddle/fluid/framework/scope.cc
+++ b/paddle/fluid/framework/scope.cc
@@ -146,6 +146,18 @@ std::vector<std::string> Scope::LocalVarNames() const {
   return known_vars;
 }
 
+std::vector<Variable*> Scope::LocalVars() {
+  std::vector<Variable*> known_vars;
+  {
+    SCOPE_VARS_READER_LOCK
+    known_vars.reserve(this->vars_.size());
+    for (auto& p : vars_) {
+      known_vars.emplace_back(p.second.get());
+    }
+  }
+  return known_vars;
+}
+
 void Scope::DeleteScope(Scope* scope) const {
   {
     SCOPE_KIDS_WRITER_LOCK

--- a/paddle/fluid/framework/scope.h
+++ b/paddle/fluid/framework/scope.h
@@ -134,8 +134,11 @@ class Scope : public ScopeBase {
 
   const std::list<Scope*>& kids() const { return kids_; }
 
-  // enumerate all the variables current contains.
+  // enumerate all the variable names current contains.
   std::vector<std::string> LocalVarNames() const;
+
+  // enumerate all the variables current contains.
+  std::vector<Variable*> LocalVars();
 
   // Rename variable to a new name
   void Rename(const std::string& origin_name,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
PR https://github.com/PaddlePaddle/Paddle/pull/37474 在解决`test_transformer`单测时，在GC中clear了 LoDTensorArray。这导致`test_slice_op`单测失败：
- `test_transformer`单测遇到的问题是，第一轮运行完后，某LoDTensorArray Tensors中的Holder被GC回收了，而LoDTensorArray的vector中仍保留着原有的几个没有Holder的Tensor。而在第二轮时，算子直接在原有LoDTensorArray基础上push_back了几个新的Tensor，此时，前几个Tensor的Holder是为空的。进而导致了后续运行中出现错误。
- 而在GC中clear了LoDTensorArray后，`test_slice_op`单测中发生如下场景：slice的输入为一个LoDTensorArray，同时这个输入也是slice_grad的输入，但slice_grad对这个LoDTensorArray的要求是NoNeedBuffer的。slice_grad只需要这个LoDTensorArray的size。因此在slice运行结束后就GC了LoDTensorArray，**并clear了vector**。而到slice_grad运行时，则无法拿到LoDTensorArray的size。

在原Executor是通过在step结束时，调用DeleteScope会清理掉所有的Variable，因此不会有该问题。
原PE中，也是通过设置`num_iteration_per_drop_scope`清理scope时，我猜测，在`test_transformer`这种场景下`num_iteration_per_drop_scope`的值必须为1。

目前本PR的做法是，在每个Step结束，如果local scope中的Var是LoDTensorArray类型，则调用clear。
需要做GC检查吗？
- 我认为不需要做GC，如果这个阶段仍有未回收的Holder，那么可以认为是GC的bug，应该改善GC。