### PR TITLE
[fleet_executor] add mutex lock for handling message during initialization

### DIFF
--- a/paddle/fluid/distributed/fleet_executor/carrier.cc
+++ b/paddle/fluid/distributed/fleet_executor/carrier.cc
@@ -48,6 +48,7 @@ bool Carrier::EnqueueInterceptorMessage(
     // handle control message
     return true;
   } else {
+    creating_flag_mutex_.lock();
     if (creating_interceptors_) {
       // Cannot handle the message to interceptor since interceptors
       // are still under creating. Will enqueue into a tmp stack.
@@ -55,6 +56,7 @@ bool Carrier::EnqueueInterceptorMessage(
       message_tmp_.emplace_back(interceptor_message);
       return true;
     }
+    creating_flag_mutex_.unlock();
     int64_t dst_id = interceptor_message.dst_id();
     Interceptor* dst_interceptor = GetInterceptor(dst_id);
     bool rst =
@@ -112,6 +114,7 @@ Interceptor* Carrier::SetInterceptor(int64_t interceptor_id,
 
 void Carrier::SetCreatingFlag(bool flag) {
   // set the creating flag
+  std::unique_lock<std::mutex> lock(creating_flag_mutex_);
   VLOG(3) << "Carrier is set the creating flag from " << creating_interceptors_
           << " to " << flag << ".";
   creating_interceptors_ = flag;
@@ -147,6 +150,7 @@ void Carrier::CreateInterceptors() {
     }
     // The carrier will be always waiting for outside initializer
     // since there is no interceptor has been created during auto init
+    std::unique_lock<std::mutex> lock(creating_flag_mutex_);
     creating_interceptors_ = false;
     HandleTmpMessages();
   }

--- a/paddle/fluid/distributed/fleet_executor/carrier.cc
+++ b/paddle/fluid/distributed/fleet_executor/carrier.cc
@@ -131,6 +131,7 @@ void Carrier::HandleTmpMessages() {
   // `HandleTmpMessages` method, the creating_interceptors_ flag
   // must be false, therefore, there won't have conflict with the
   // lock on the tmp_message_mutex_ inside `EnqueueInterceptorMessage`
+  // on the same thread.
   std::unique_lock<std::mutex> lock(tmp_message_mutex_);
   VLOG(3) << "Carrier has received " << message_tmp_.size()
           << " messages during creating interceptors.";

--- a/paddle/fluid/distributed/fleet_executor/carrier.h
+++ b/paddle/fluid/distributed/fleet_executor/carrier.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -79,6 +80,7 @@ class Carrier final {
 
   std::vector<InterceptorMessage> message_tmp_{};
   bool creating_interceptors_{true};
+  std::mutex creating_flag_mutex_;
   bool is_init_{false};
 };
 

--- a/paddle/fluid/distributed/fleet_executor/carrier.h
+++ b/paddle/fluid/distributed/fleet_executor/carrier.h
@@ -79,6 +79,7 @@ class Carrier final {
       interceptor_idx_to_interceptor_;
 
   std::vector<InterceptorMessage> message_tmp_{};
+  std::mutex tmp_message_mutex_;
   bool creating_interceptors_{true};
   std::mutex creating_flag_mutex_;
   bool is_init_{false};


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
MessageBus's listening port thread and Carrier's thread many read/write the `creating_interceptors_` flag and the `message_tmp_` simultaneously, therefore need an mutex to handle it.
