### PR TITLE
Support fetch lodtensor array

### DIFF
--- a/paddle/fluid/framework/new_executor/data_transfer.cc
+++ b/paddle/fluid/framework/new_executor/data_transfer.cc
@@ -265,6 +265,11 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
       } else if (var->IsType<LoDTensorArray>()) {
         tensor_in =
             static_cast<const Tensor*>(&(var->Get<LoDTensorArray>()[0]));
+      } else {
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "Variable type is %s, expect LoDTensor or SelectedRows or "
+            "LoDTensorArray.",
+            ToTypeName(var->Type())));
       }
       if (!tensor_in->IsInitialized()) {
         continue;

--- a/paddle/fluid/framework/new_executor/data_transfer.cc
+++ b/paddle/fluid/framework/new_executor/data_transfer.cc
@@ -258,11 +258,14 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
   for (auto& var_name_item : *ins_map_temp) {
     for (size_t i = 0; i < var_name_item.second.size(); ++i) {
       auto var = var_name_item.second[i];
-      if (!(var->IsType<LoDTensor>() || var->IsType<SelectedRows>())) {
-        continue;
-      }
       auto& var_name = new_ins[var_name_item.first].at(i);
-      auto tensor_in = GetLoDTensorOrSelectedRowsValueFromVar(*var);
+      const Tensor* tensor_in;
+      if (var->IsType<LoDTensor>() || var->IsType<SelectedRows>()) {
+        tensor_in = GetLoDTensorOrSelectedRowsValueFromVar(*var);
+      } else if (var->IsType<LoDTensorArray>()) {
+        tensor_in =
+            static_cast<const Tensor*>(&(var->Get<LoDTensorArray>()[0]));
+      }
       if (!tensor_in->IsInitialized()) {
         continue;
       }

--- a/paddle/fluid/operators/memcpy_d2h_op.h
+++ b/paddle/fluid/operators/memcpy_d2h_op.h
@@ -70,7 +70,7 @@ class MemcpyD2HFunctor {
 
  private:
   void CopyLoDTensor(const framework::LoDTensor &src,
-                     framework::LoDTensor &dst) {  // NOLINT
+                     framework::LoDTensor &dst) const {  // NOLINT
     if (dst_place_type_ == 1) {
       framework::TensorCopy(src, platform::CUDAPinnedPlace(), dev_ctx_, &dst);
     } else if (dst_place_type_ == 0) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
D2H支持LoDTensorArray。
DataTransFer时，如果是LoDTensorArray，已LoDTensorArray[0]作为代表，计算kernel_type_for_var。
因此，能支持Fetch GPU LoDTensorArray的能力。