### PR TITLE
【cherry-pick】Fix bug of slice_grad using use_mkldnn attr (#37571)

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1066,8 +1066,9 @@ bool OperatorWithKernel::SupportsMKLDNN(
 
 bool OperatorWithKernel::CanMKLDNNBeUsed(const framework::ExecutionContext& ctx,
                                          proto::VarType::Type data_type) const {
-  bool use_mkldnn_ctx =
-      ctx.Attr<bool>("use_mkldnn") && platform::is_cpu_place(ctx.GetPlace());
+  bool use_mkldnn_ctx = ctx.HasAttr("use_mkldnn") &&
+                        ctx.Attr<bool>("use_mkldnn") &&
+                        platform::is_cpu_place(ctx.GetPlace());
   return use_mkldnn_ctx && this->SupportsMKLDNN(data_type);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
![22e3217f14d6ddc8f667a6d23167f697](https://user-images.githubusercontent.com/13048366/143526229-e558719c-7f86-49c2-864a-66a6b8008742.png)

slice_grad op在选择kernel过程中出现了图中错误，问题原因是在获取use_mkldnn属性时，map中未找到该键值，所以抛出out_of_range异常
本PR在map获取use_mkldnn属性数据前增加了是否存在该键值的判断逻辑，从而避免出现上述异常