### PR TITLE
put time compute of unittests to test_unit block

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -662,9 +662,22 @@ set PATH=%THIRD_PARTY_PATH:/=\%\install\openblas\lib;%THIRD_PARTY_PATH:/=\%\inst
 %THIRD_PARTY_PATH:/=\%\install\mkldnn\bin;%THIRD_PARTY_PATH:/=\%\install\warpctc\bin;%PATH%
 
 if "%WITH_GPU%"=="ON" (
-    goto:parallel_test_base_gpu
+    call:parallel_test_base_gpu
 ) else (
-    goto:parallel_test_base_cpu
+    call:parallel_test_base_cpu
+)
+
+set error_code=%ERRORLEVEL%
+
+for /F %%# in ('wmic os get localdatetime^|findstr 20') do set end=%%#
+set end=%end:~4,10%
+call :timestamp "%start%" "%end%" "1 card TestCases Total"
+call :timestamp "%start%" "%end%" "TestCases Total"
+
+if %error_code% NEQ 0 (
+    exit /b 8
+) else ( 
+    goto:eof 
 )
 
 :parallel_test_base_gpu
@@ -688,7 +701,6 @@ echo cmake .. -G %GENERATOR% -DCMAKE_BUILD_TYPE=Release -DWITH_AVX=%WITH_AVX% -D
 -DINFERENCE_DEMO_INSTALL_DIR=%INFERENCE_DEMO_INSTALL_DIR% -DWITH_STATIC_LIB=%WITH_STATIC_LIB% ^
 -DWITH_TENSORRT=%WITH_TENSORRT% -DTENSORRT_ROOT="%TENSORRT_ROOT%" -DMSVC_STATIC_CRT=%MSVC_STATIC_CRT% ^
 -DWITH_UNITY_BUILD=%WITH_UNITY_BUILD% -DCUDA_ARCH_NAME=%CUDA_ARCH_NAME% >> %work_dir%\win_cmake.sh
-set FLAGS_fraction_of_gpu_memory_to_use=0.92
 
 %cache_dir%\tools\busybox64.exe bash %work_dir%\tools\windows\run_unittests.sh %NIGHTLY_MODE% %PRECISION_TEST% %WITH_GPU%
 
@@ -708,10 +720,6 @@ goto:eof
 :test_unit_error
 :: echo 8 > %cache_dir%\error_code.txt
 :: type %cache_dir%\error_code.txt
-for /F %%# in ('wmic os get localdatetime^|findstr 20') do set end=%%#
-set end=%end:~4,10%
-call :timestamp "%start%" "%end%" "1 card TestCases Total"
-call :timestamp "%start%" "%end%" "TestCases Total"
 echo Running unit tests failed, will exit!
 exit /b 8
 
@@ -721,11 +729,6 @@ rem ----------------------------------------------------------------------------
 echo    ========================================
 echo    Step 5. Testing fluid library for inference ...
 echo    ========================================
-
-for /F %%# in ('wmic os get localdatetime^|findstr 20') do set end=%%#
-set end=%end:~4,10%
-call :timestamp "%start%" "%end%" "1 card TestCases Total"
-call :timestamp "%start%" "%end%" "TestCases Total"
 
 tree /F %cd%\paddle_inference_install_dir\paddle
 %cache_dir%\tools\busybox64.exe du -h -d 0 -k %cd%\paddle_inference_install_dir\paddle\lib > lib_size.txt


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
put time compute of unittests to test_unit block instead of in test_inference to avoid not showing timestamp if code block behind not run.