### PR TITLE
[cherry-pick-2.2] Fix bugs when bias add none in static graph for fused_attention op. 

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -388,10 +388,12 @@ def fused_multi_head_attention(x,
         if pre_ln_bias:
             inputs['LnBias'] = [pre_ln_bias]
         inputs['QKVW'] = [qkv_weight]
-        inputs['QKVBias'] = [qkv_bias]
+        if qkv_bias is not None:
+            inputs['QKVBias'] = [qkv_bias]
         inputs['SrcMask'] = attn_mask
         inputs['OutLinearW'] = [linear_weight]
-        inputs['OutLinearBias'] = [linear_bias]
+        if linear_bias is not None:
+            inputs['OutLinearBias'] = [linear_bias]
         if ln_scale:
             inputs['Ln2Scale'] = [ln_scale]
         if ln_bias:


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
OPs

### Describe

cherry-pick of PR #37566:

Based on #37411, this PR:
1. Continue to fix the bugs when bias add is none in static graph for fused_attention op.
2. Polish and improve the unittests in test_fused_attention_op_api.py.
