### PR TITLE
add matmul_v2_transpose_reshape_fuse_pass to quant2_int8_mkldnn_pass.py

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
@@ -419,6 +419,7 @@ class Quant2Int8MkldnnPass(object):
         if self._is_fc_quantized(graph):
             graph = self._apply_pass(graph, 'fc_mkldnn_pass')
         graph = self._apply_pass(graph, 'matmul_transpose_reshape_fuse_pass')
+        graph = self._apply_pass(graph, 'matmul_v2_transpose_reshape_fuse_pass')
         # the following pass should be the last one since it will work on all fused ops.
         graph = self._apply_pass(graph, 'runtime_context_cache_pass')
         return graph


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
Add missing matmul_v2_transpose_reshape_fuse_pass to quant2_int8_mkldnn_pass
