### PR TITLE
refactoring matmul_v2 mkldnn hierarchy

### DIFF
--- a/paddle/fluid/operators/mkldnn/matmul_v2_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/matmul_v2_mkldnn_op.cc
@@ -149,7 +149,7 @@ void ExecuteMatMulV2(const ExecutionContext& ctx,
                      std::vector<int64_t>& x_dims, bool trans_x,
                      const Tensor* y, std::vector<int64_t>& y_dims,
                      bool trans_y, Tensor* out, std::vector<int64_t>& out_dims,
-                     int execution_number = 0) const {
+                     int execution_number = 0) {
   MatMulV2MKLDNNHandler<T> handler(onednn_engine, ctx.GetPlace(), x_dims,
                                    trans_x, y_dims, trans_y,
                                    IsOutputFused(ctx));

--- a/paddle/fluid/operators/mkldnn/matmul_v2_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/matmul_v2_mkldnn_op.cc
@@ -134,9 +134,6 @@ float ComputeOutputScale(const ExecutionContext& ctx) {
   float scale_y = ctx.Attr<float>("Scale_y");
   bool force_fp32_out = ctx.Attr<bool>("force_fp32_output");
   float scale_out = force_fp32_out ? 1.f : ctx.Attr<float>("Scale_out");
-  if (scale_x != 1 || scale_y != 1 || force_fp32_out != false) {
-    std::cout << "scale_x: " << scale_x << ", scale_y: " << scale_y
-              << ", force_fp32_out: " << force_fp32_out << "\n";
   }
   return scale_out / (scale_x * scale_y);
 }

--- a/paddle/fluid/operators/mkldnn/matmul_v2_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/matmul_v2_mkldnn_op.cc
@@ -134,7 +134,6 @@ float ComputeOutputScale(const ExecutionContext& ctx) {
   float scale_y = ctx.Attr<float>("Scale_y");
   bool force_fp32_out = ctx.Attr<bool>("force_fp32_output");
   float scale_out = force_fp32_out ? 1.f : ctx.Attr<float>("Scale_out");
-  }
   return scale_out / (scale_x * scale_y);
 }
 


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
Refactoring of mkldnn matmul v2. Using composition of matmul-grad in matmul_v2-grad instead of inheritance.
Instead of chain of inheritance have operators inherit only from paddle::framework::OpKernel<T> as done in other operators.
Some functions have been extracted from classes to allow code reuse without inheritance.
Alternative idea I have is to replace entire class declaration (MatMulGradMKLDNNKernel) in matmul_mkldnn_op.h with declaration of a single method such as MatmulV1GradMKLDNNCompute() and extract necessary methods from the class to do that.
