### PR TITLE
continue if transform not support dtype

### DIFF
--- a/paddle/fluid/framework/new_executor/data_transfer.cc
+++ b/paddle/fluid/framework/new_executor/data_transfer.cc
@@ -266,10 +266,7 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
         tensor_in =
             static_cast<const Tensor*>(&(var->Get<LoDTensorArray>()[0]));
       } else {
-        PADDLE_THROW(platform::errors::InvalidArgument(
-            "Variable type is %s, expect LoDTensor or SelectedRows or "
-            "LoDTensorArray.",
-            ToTypeName(var->Type())));
+        continue;
       }
       if (!tensor_in->IsInitialized()) {
         continue;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
当ApplyDataTransform遇到不支持的Tensor类型时，直接continue，是不是抛出错误。
