### PR TITLE
make the type of  total_ops to int64

### DIFF
--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -254,6 +254,7 @@ def dynamic_flops(model, inputs, custom_ops=None, print_detail=False):
         model(inputs)
 
     total_ops = 0
+    total_ops = paddle.to_tensor(total_ops, dtype=paddle.int64)
     total_params = 0
     for m in model.sublayers():
         if len(list(m.children())) > 0:


### PR DESCRIPTION
### PR types
Bug fixes
File name : /paddle/hapi/dynamic_flops.py
### PR changes
OPs
The type of a variable is converted from int32 to int64
### Describe
 Describe what this PR does
When calculating flops, since the type of total_ops parameter is int32, and flops is generally very large, it will exceed the range of int32, which leads to flops calculation errors, even a negative number. I changed this type to int64 to make the range of flops that can be calculated more big.