### PR TITLE
optimize __call__ to make dygraph faster

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -881,41 +881,49 @@ class Layer(core.Layer):
     def _build_once(self, *args, **kwargs):
         pass
 
+    def _dygraph_call_func(self, *inputs, **kwargs):
+        for forward_pre_hook in self._forward_pre_hooks.values():
+            hook_result = forward_pre_hook(self, inputs)
+            if hook_result is not None:
+                if not isinstance(hook_result, tuple):
+                    hook_result = (hook_result, )
+                inputs = hook_result
+
+        if not self._built:
+            with program_desc_tracing_guard(False):
+                self._build_once(*inputs, **kwargs)
+
+                # TODO(liuyuhui) Only xpu broadcast parameters here.
+                # The other device is to call _sync_params_buffers in DataParallel
+                # to realize the parameter synchronization among multiply cards.
+                if parallel_helper._is_data_parallel_mode(
+                ) and paddle.is_compiled_with_xpu():
+                    parallel_helper._broadcast_parameters(
+                        self._parameters.values())
+
+            self._built = True
+
+        outputs = self.forward(*inputs, **kwargs)
+
+        for forward_post_hook in self._forward_post_hooks.values():
+            hook_result = forward_post_hook(self, inputs, outputs)
+            if hook_result is not None:
+                outputs = hook_result
+
+        return outputs
+
     def __call__(self, *inputs, **kwargs):
         # NOTE(Aurelius84): Why we still need param_guard here?
         # In case of ControlFlow, true_fn and false_fn will contain
         # parameters that may not trigger logic of `Operator` to create
         # them. we add this to make sure all parameters is available.
-        with param_guard(self._parameters), param_guard(self._buffers):
-            for forward_pre_hook in self._forward_pre_hooks.values():
-                hook_result = forward_pre_hook(self, inputs)
-                if hook_result is not None:
-                    if not isinstance(hook_result, tuple):
-                        hook_result = (hook_result, )
-                    inputs = hook_result
+        from paddle.fluid.dygraph.dygraph_to_static.program_translator import in_declarative_mode
 
-            if not self._built:
-                with program_desc_tracing_guard(False):
-                    self._build_once(*inputs, **kwargs)
-
-                    # TODO(liuyuhui) Only xpu broadcast parameters here.
-                    # The other device is to call _sync_params_buffers in DataParallel
-                    # to realize the parameter synchronization among multiply cards.
-                    if parallel_helper._is_data_parallel_mode(
-                    ) and paddle.is_compiled_with_xpu():
-                        parallel_helper._broadcast_parameters(
-                            self._parameters.values())
-
-                self._built = True
-
-            outputs = self.forward(*inputs, **kwargs)
-
-            for forward_post_hook in self._forward_post_hooks.values():
-                hook_result = forward_post_hook(self, inputs, outputs)
-                if hook_result is not None:
-                    outputs = hook_result
-
-            return outputs
+        if in_declarative_mode() and not framework.in_dygraph_mode():
+            with param_guard(self._parameters), param_guard(self._buffers):
+                self._dygraph_call_func(*inputs, **kwargs)
+        else:
+            return self._dygraph_call_func(*inputs, **kwargs)
 
     def forward(self, *inputs, **kwargs):
         """

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -921,7 +921,7 @@ class Layer(core.Layer):
 
         if in_declarative_mode() and not framework.in_dygraph_mode():
             with param_guard(self._parameters), param_guard(self._buffers):
-                self._dygraph_call_func(*inputs, **kwargs)
+                return self._dygraph_call_func(*inputs, **kwargs)
         else:
             return self._dygraph_call_func(*inputs, **kwargs)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR optimize `__call__` in `paddle.Layers` to optimize dygraph performance without `to_static`.
We test multi-layer linear performance with code below:
```
import os
import paddle.fluid.core as core
from paddle import _C_ops
import paddle
import numpy as np
from time import time

num_runs = 100000

os.environ["CUDA_VISIBLE_DEVICES"] = ""
paddle.set_device("cpu")

class FluidMatmulx2(paddle.nn.Layer):
    def __init__(self):
        super(FluidMatmulx2, self).__init__()

        arrW1 = np.ones([4, 128]).astype('float32')
        self.W1 = paddle.to_tensor(arrW1, 'float32', core.CPUPlace())
        self.W1.stop_gradient = False
        
        arrW2 = np.ones([128, 2]).astype('float32')
        self.W2 = paddle.to_tensor(arrW2, 'float32', core.CPUPlace())
        self.W2.stop_gradient = False

    def forward(self, obs):
        Out1 = _C_ops.matmul_v2(obs, self.W1, 'trans_x', False, 'trans_y', False)
        Out = _C_ops.matmul_v2(Out1, self.W2, 'trans_x', False, 'trans_y', False)
        return Out

if __name__ == "__main__":
    input_data = np.ones([32, 4]).astype('float32')
    
    ###########
    # Warm Up #
    ###########
    data_paddle = paddle.to_tensor(input_data.astype(np.float32))
    fluid_matmul = FluidMatmulx2()
    for _ in range(num_runs):
        fluid_matmul.forward(data_paddle)
    
    ###############
    # Performance #
    ###############
    # Fluid Matmul Forward
    data_paddle = paddle.to_tensor(input_data.astype(np.float32))
    ts = time()
    for _ in range(num_runs):
        out = fluid_matmul.forward(data_paddle)
    te = time()
    print("Fluid Matmul Forward: ", 1e6*(te-ts))
    
    # Fluid Matmul Call
    data_paddle = paddle.to_tensor(input_data.astype(np.float32))
    ts = time()
    for _ in range(num_runs):
        out = fluid_matmul(data_paddle)
    te = time()
    print("Fluid Matmul Call: ", 1e6*(te-ts))
   ```
And we have result looks like below:
![image](https://user-images.githubusercontent.com/22361972/144032005-db973eb9-a308-42f4-b221-19210261e59b.png)
This indicates that we have over 20% time cost on python `__call__`,  and with some profile and test, we found that python decorator context used here is pretty slow.

So, we just use `if` statement to optimize it. And we can get performance improve as below:
![image](https://user-images.githubusercontent.com/22361972/144032425-b6722057-9587-4f28-a064-f483052f02bc.png)
