### PR TITLE
implementation of broadcast sub backward by reduce 

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_sub_op.cu
+++ b/paddle/fluid/operators/elementwise/elementwise_sub_op.cu
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/elementwise/elementwise_op_broadcast.cu.h"
 #include "paddle/fluid/operators/elementwise/elementwise_sub_op.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_functor_op.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_op.cu.h"
 #include "paddle/fluid/platform/complex.h"
 #include "paddle/fluid/platform/float16.h"
 
@@ -23,6 +25,40 @@ namespace plat = paddle::platform;
 namespace paddle {
 namespace operators {
 
+//   template <typename T>
+// static __global__ void SimpleElemwiseSubGradCUDAKernel(
+//     const T* __restrict__ dout, int size, int vec_size, T* dx, T* dy) {
+//   int tid = blockIdx.x * blockDim.x + threadIdx.x;
+//   int stride = gridDim.x * blockDim.x;
+//   int loop = size / vec_size;
+//   int remainder = size % vec_size;
+//   const float4* dout_vec = reinterpret_cast<const float4*>(dout);
+//   float4* dx_vec = reinterpret_cast<float4*>(dx);
+//   float4* dy_vec = reinterpret_cast<float4*>(dy);
+//   float4 tmp_loop;
+
+//   for (int i = tid; i < loop; i += stride) {
+//     tmp_loop = dout_vec[i];
+//     if(dx != nullptr){
+//       dx_vec[i] = tmp_loop;
+//     }
+//     dy_vec[i] = -tmp_loop;
+//   }
+
+//   if (tid == loop && remainder != 0) {
+//     T tmp_rem;
+//     while (remainder) {
+//       int idx = size - remainder;
+//       remainder--;
+//       tmp_rem = dout[idx];
+//       if(dx != nullptr){
+//         dx[idx] = tmp_rem;
+//       }
+//       dy[idx] = -tmp_rem;
+//     }
+//   }
+// }
+
 template <typename T>
 static __global__ void SimpleElemwiseSubGradCUDAKernel(const T* dout,
                                                        int64_t size, T* dx,
@@ -30,9 +66,78 @@ static __global__ void SimpleElemwiseSubGradCUDAKernel(const T* dout,
   int col = blockIdx.x * blockDim.x + threadIdx.x;
 
   while (col < size) {
-    dx[col] = dout[col];
+    // if(dx != nullptr){
+       dx[col] = dout[col];
+    // }
     dy[col] = -dout[col];
     col += blockDim.x * gridDim.x;
+  }
+}
+
+template <typename T>
+static __global__ void SimpleElemwiseSubGradCUDAKernel(const T* dout,
+                                                       int64_t size,
+                                                       T* dy) {
+  int col = blockIdx.x * blockDim.x + threadIdx.x;
+
+  while (col < size) {
+    dy[col] = -dout[col];
+    col += blockDim.x * gridDim.x;
+  }
+}
+
+template <typename DeviceContext, typename T>
+typename std::enable_if<
+    std::is_same<DeviceContext, platform::CUDADeviceContext>::value>::type
+default_elementwise_sub_grad(const framework::ExecutionContext& ctx,
+                             const framework::Tensor* x,
+                             const framework::Tensor* y,
+                             const framework::Tensor* out,
+                             const framework::Tensor* dout,
+                             framework::Tensor* dx, framework::Tensor* dy) {
+  int axis = ctx.Attr<int>("axis");
+  auto* dout_data = dout->data<T>();
+  // dx
+  if (dx != nullptr) {
+    auto* dx_data = dx->mutable_data<T>(ctx.GetPlace());
+    if (dx->dims() == dout->dims()) {
+      if (dx_data != dout_data) {
+        framework::TensorCopy(
+            *dout, ctx.GetPlace(),
+            ctx.template device_context<platform::DeviceContext>(), dx);
+      }
+    } else {
+      // For inplace strategy, dx will be stored in addr of dout, which makes
+      // the result of dy wrong.
+      if (dx->IsSharedBufferWith(*dout)) {
+        dx->clear();
+        dx->mutable_data<T>(x->dims(), ctx.GetPlace());
+      }
+      std::vector<int> reduce_dims = GetReduceDim(x->dims(), out->dims(), axis);
+      gpuStream_t stream = ctx.cuda_device_context().stream();
+      TensorReduceFunctorImpl<T, T, CustomSum>(*dout, dx, reduce_dims, stream);
+    }
+  }
+  // dy
+  if (dy != nullptr) {
+    auto* dy_data = dy->mutable_data<T>(ctx.GetPlace());
+    if (dy->dims() == dout->dims()) {
+      if (dy_data != dout_data) {
+        dim3 block_size = dim3(ELEMENTWISE_BLOCK_SIZE, 1);
+        auto size = dy->numel();
+        dim3 grid_size =
+            dim3((size + ELEMENTWISE_BLOCK_SIZE - 1) / ELEMENTWISE_BLOCK_SIZE, 1);
+        SimpleElemwiseSubGradCUDAKernel<
+            T><<<grid_size, block_size, 0,
+                ctx.template device_context<plat::CUDADeviceContext>().stream()>>>(
+            dout->data<T>(), size,
+            dy->mutable_data<T>(ctx.GetPlace()));
+      }
+    } else {
+      std::vector<int> reduce_dims = GetReduceDim(y->dims(), out->dims(), axis);
+      gpuStream_t stream = ctx.cuda_device_context().stream();
+      TensorReduceFunctorImpl<T, T, CustomSub>(*dout, dy, reduce_dims, stream);
+    }
   }
 }
 
@@ -44,15 +149,15 @@ elementwise_sub_grad(const framework::ExecutionContext& ctx,
                      const framework::Tensor* out,
                      const framework::Tensor* dout, framework::Tensor* dx,
                      framework::Tensor* dy) {
-  dim3 block_size = dim3(ELEMENTWISE_BLOCK_SIZE, 1);
-  auto size = x->numel();
-  dim3 grid_size =
-      dim3((size + ELEMENTWISE_BLOCK_SIZE - 1) / ELEMENTWISE_BLOCK_SIZE, 1);
-  SimpleElemwiseSubGradCUDAKernel<
-      T><<<grid_size, block_size, 0,
-           ctx.template device_context<plat::CUDADeviceContext>().stream()>>>(
-      dout->data<T>(), size, dx->mutable_data<T>(ctx.GetPlace()),
-      dy->mutable_data<T>(ctx.GetPlace()));
+        dim3 block_size = dim3(ELEMENTWISE_BLOCK_SIZE, 1);
+        auto size = x->numel();
+        dim3 grid_size =
+            dim3((size + ELEMENTWISE_BLOCK_SIZE - 1) / ELEMENTWISE_BLOCK_SIZE, 1);
+        SimpleElemwiseSubGradCUDAKernel<
+            T><<<grid_size, block_size, 0,
+                ctx.template device_context<plat::CUDADeviceContext>().stream()>>>(
+            dout->data<T>(), size, dx->mutable_data<T>(ctx.GetPlace()),
+            dy->mutable_data<T>(ctx.GetPlace()));
 }
 
 }  // namespace operators

--- a/paddle/fluid/operators/elementwise/elementwise_sub_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_sub_op.h
@@ -74,17 +74,16 @@ struct SubGradDY {
 template <typename DeviceContext, typename T>
 typename std::enable_if<
     std::is_same<DeviceContext, platform::CPUDeviceContext>::value>::type
-default_elementwise_sub_grad(const framework::ExecutionContext &ctx,
-                             const framework::Tensor *x,
-                             const framework::Tensor *y,
-                             const framework::Tensor *out,
-                             const framework::Tensor *dout,
-                             framework::Tensor *dx, framework::Tensor *dy) {
+default_elementwise_sub_grad(const framework::ExecutionContext& ctx,
+                             const framework::Tensor* x,
+                             const framework::Tensor* y,
+                             const framework::Tensor* out,
+                             const framework::Tensor* dout,
+                             framework::Tensor* dx, framework::Tensor* dy) {
   int axis = ctx.Attr<int>("axis");
 
   ElemwiseExplicitGradCompute<DeviceContext, T, SubGradDX<T>, SubGradDY<T>>(
-          ctx, *x, *y, *out, *dout, axis, dx, dy, SubGradDX<T>(),
-          SubGradDY<T>());
+      ctx, *x, *y, *out, *dout, axis, dx, dy, SubGradDX<T>(), SubGradDY<T>());
 }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
@@ -92,21 +91,21 @@ default_elementwise_sub_grad(const framework::ExecutionContext &ctx,
 template <typename DeviceContext, typename T>
 typename std::enable_if<
     std::is_same<DeviceContext, platform::CUDADeviceContext>::value>::type
-elementwise_add_grad(const framework::ExecutionContext &ctx,
-                     const framework::Tensor *x, const framework::Tensor *y,
-                     const framework::Tensor *out,
-                     const framework::Tensor *dout, framework::Tensor *dx,
-                     framework::Tensor *dy);
+elementwise_add_grad(const framework::ExecutionContext& ctx,
+                     const framework::Tensor* x, const framework::Tensor* y,
+                     const framework::Tensor* out,
+                     const framework::Tensor* dout, framework::Tensor* dx,
+                     framework::Tensor* dy);
 
 template <typename DeviceContext, typename T>
 typename std::enable_if<
     std::is_same<DeviceContext, platform::CUDADeviceContext>::value>::type
-default_elementwise_sub_grad(const framework::ExecutionContext &ctx,
-                             const framework::Tensor *x,
-                             const framework::Tensor *y,
-                             const framework::Tensor *out,
-                             const framework::Tensor *dout,
-                             framework::Tensor *dx, framework::Tensor *dy);
+default_elementwise_sub_grad(const framework::ExecutionContext& ctx,
+                             const framework::Tensor* x,
+                             const framework::Tensor* y,
+                             const framework::Tensor* out,
+                             const framework::Tensor* dout,
+                             framework::Tensor* dx, framework::Tensor* dy);
 #endif
 
 template <typename DeviceContext, typename T>
@@ -151,7 +150,8 @@ class ElementwiseSubGradKernel : public ElemwiseGradKernel<T> {
     if (dx != nullptr && dy != nullptr && (dx->dims() == dy->dims())) {
       elementwise_sub_grad<DeviceContext, T>(ctx, x, y, out, dout, dx, dy);
     } else {
-      default_elementwise_sub_grad<DeviceContext, T>(ctx, x, y, out, dout, dx, dy);
+      default_elementwise_sub_grad<DeviceContext, T>(ctx, x, y, out, dout, dx,
+                                                     dy);
     }
   }
 };

--- a/paddle/fluid/operators/kernel_primitives/functor_primitives.h
+++ b/paddle/fluid/operators/kernel_primitives/functor_primitives.h
@@ -91,7 +91,7 @@ struct DivideFunctor {
  */
 template <typename Tx, typename Ty = Tx>
 struct InverseFunctor {
-  HOSTDEVICE inline InverseFunctor() { }
+  HOSTDEVICE inline InverseFunctor() {}
 
   HOSTDEVICE explicit inline InverseFunctor(int n) {}
 

--- a/paddle/fluid/operators/kernel_primitives/functor_primitives.h
+++ b/paddle/fluid/operators/kernel_primitives/functor_primitives.h
@@ -87,6 +87,20 @@ struct DivideFunctor {
 };
 
 /**
+ * @brief Default inverse functor
+ */
+template <typename Tx, typename Ty = Tx>
+struct InverseFunctor {
+  HOSTDEVICE inline InverseFunctor() { }
+
+  HOSTDEVICE explicit inline InverseFunctor(int n) {}
+
+  HOSTDEVICE inline Ty operator()(const Tx& x) const {
+    return static_cast<Ty>(-x);
+  }
+};
+
+/**
  * @brief Default unary square functor
  */
 template <typename Tx, typename Ty = Tx>

--- a/paddle/fluid/operators/reduce_ops/reduce_functor_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_functor_op.h
@@ -65,6 +65,17 @@ struct CustomSum {
 };
 
 template <typename Tx, typename Ty = Tx>
+struct CustomSub {
+  using Transformer = kps::InverseFunctor<Tx>;
+
+  inline Ty initial() { return static_cast<Ty>(0.0f); }
+
+  __device__ __forceinline__ Ty operator()(const Ty &a, const Ty &b) const {
+    return  b + a;
+  }
+};
+
+template <typename Tx, typename Ty = Tx>
 struct CustomMean {
   using Transformer = kps::DivideFunctor<Tx>;
 

--- a/paddle/fluid/operators/reduce_ops/reduce_functor_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_functor_op.h
@@ -71,7 +71,7 @@ struct CustomSub {
   inline Ty initial() { return static_cast<Ty>(0.0f); }
 
   __device__ __forceinline__ Ty operator()(const Ty &a, const Ty &b) const {
-    return  b + a;
+    return b + a;
   }
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
使用reduce实现broadcast sub 反向，相比于原始性能数据如下：


Case | pytorch | paddle(优化前) | 优化前相比pytorch | paddle(优化后) | 优化后相比pytorch | 加速比
-- | -- | -- | -- | -- | -- | --
[50, 128, 1000], [128, 1000] | 0.30086 | 0.18073 | 优于 (39.93%) | 0.17129 | 优于(43.07%) | 1.06
[50, 128, 1000], [1, 128, 1000] | 0.30359 | 0.17959 | 优于 (40.84%) | 0.17206 | 优于(43.32%) | 1.04
[16, 2048, 7, 7], [16, 2048] | 0.09000 | 0.07593 | 优于 (15.63%) | 0.06041 | 优于(32.88%) | 1.26
[16, 2048, 16, 16], [16, 2048, 16,   16] | 0.38284 | 0.25730 | 优于 (32.79%) | 0.25788 | 优于(32.64%) | 1.00
[6, 1, 80, 46080], [1] | 0.20880 | 1.85418 | 差于 (7.88x) | 0.11859 | 优于(43.2%) | 15.64
[512, 896, 4, 12], [512, 896, 4,   1] | 1.11503 | 2.82007 | 差于 (1.53x) | 0.64902 | 优于(41.79%) | 4.35
[512, 896, 4, 12], [512, 896, 4,   1] fp16 | 0.71971 | 2.73426 | 差于 (2.80x) | 0.43191 | 优于(39.99%) | 6.33
[32, 12, 128, 128], [32, 1, 1,   128] fp16 | 0.18400 | 0.45639 | 差于 (1.48x) | 0.09958 | 优于(45.88%) | 4.58
[32, 1, 1, 128], [1, 12, 128, 1]   fp16 | 0.19077 | 0.31292 | 差于 (64.03%) | 0.10816 | 优于(43.3%) | 2.89


