### PR TITLE
optimize dygraph performance with move runtime import to begining

### DIFF
--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -93,10 +93,10 @@ def check_type(input, input_name, expected_type, op_name, extra_message=''):
     if in_dygraph_mode():
         return
 
-    from .dygraph.dygraph_to_static.program_translator import in_declarative_mode
     # NOTE: `in_declarative_mode` is used to determined whether this op is called under
     # @declarative in transformation from dygrah to static layer. We add VarBase in
     # expected_type to skip checking because varBase may be created and used in unusual way.
+    from .dygraph.base import in_declarative_mode
     # Need a better design to be fix this.
     if in_declarative_mode():
         if not isinstance(expected_type, tuple):

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -23,7 +23,6 @@ from paddle.fluid import framework
 from paddle.fluid.multiprocess_utils import CleanupFuncRegistrar
 from .tracer import Tracer
 import logging
-from ..data_feeder import convert_dtype
 import warnings
 from ..framework import _get_paddle_place
 import paddle
@@ -32,6 +31,17 @@ __all__ = [
     'no_grad', 'no_grad_', 'grad', 'guard', 'enable_dygraph', 'disable_dygraph',
     'enabled', 'to_variable'
 ]
+
+# Flag that indicates whether running code under `@declarative`
+_in_declarative_mode_ = False
+
+
+def in_declarative_mode():
+    """
+    Return a bool value that indicates whether running code under `@declarative`
+
+    """
+    return _in_declarative_mode_
 
 
 def _switch_to_static_graph_(func):
@@ -63,7 +73,6 @@ _functional_dygraph_context_manager = None
 
 @signature_safe_contextmanager
 def param_guard(parameters):
-    from paddle.fluid.dygraph.dygraph_to_static.program_translator import in_declarative_mode
     # Note: parameters is a reference of self._parameters or self._buffers
     if in_declarative_mode() and not framework.in_dygraph_mode() and parameters:
         origin_parameters = parameters.copy()

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -23,7 +23,7 @@ from paddle.fluid import framework
 from paddle.fluid.multiprocess_utils import CleanupFuncRegistrar
 from .tracer import Tracer
 import logging
-from .data_feeder import convert_dtype
+from ..data_feeder import convert_dtype
 import warnings
 from ..framework import _get_paddle_place
 import paddle

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -23,6 +23,7 @@ from paddle.fluid import framework
 from paddle.fluid.multiprocess_utils import CleanupFuncRegistrar
 from .tracer import Tracer
 import logging
+from .data_feeder import convert_dtype
 import warnings
 from ..framework import _get_paddle_place
 import paddle

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -56,6 +56,16 @@ switch_to_static_graph = wrap_decorator(_switch_to_static_graph_)
 
 
 @signature_safe_contextmanager
+def _switch_declarative_mode_guard_(is_declarative=True):
+
+    global _in_declarative_mode_
+    original_val = _in_declarative_mode_
+    _in_declarative_mode_ = is_declarative
+    yield
+    _in_declarative_mode_ = original_val
+
+
+@signature_safe_contextmanager
 def program_desc_tracing_guard(enable):
     tracer = framework._dygraph_tracer()
     if tracer:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -573,18 +573,6 @@ class StaticFunction(object):
         return self._function_spec
 
 
-# Flag that indicates whether running code under `@declarative`
-_in_declarative_mode_ = False
-
-
-def in_declarative_mode():
-    """
-    Return a bool value that indicates whether running code under `@declarative`
-
-    """
-    return _in_declarative_mode_
-
-
 @signature_safe_contextmanager
 def _switch_declarative_mode_guard_(is_declarative=True):
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -573,16 +573,6 @@ class StaticFunction(object):
         return self._function_spec
 
 
-@signature_safe_contextmanager
-def _switch_declarative_mode_guard_(is_declarative=True):
-
-    global _in_declarative_mode_
-    original_val = _in_declarative_mode_
-    _in_declarative_mode_ = is_declarative
-    yield
-    _in_declarative_mode_ = original_val
-
-
 def _verify_init_in_dynamic_mode(class_instance):
     """
     Verifies the instance is initialized in dynamic mode.
@@ -646,6 +636,7 @@ class ConcreteProgram(object):
         startup_program.random_seed = framework.default_startup_program(
         ).random_seed
 
+        from paddle.fluid.dygraph.base import _switch_declarative_mode_guard_
         with framework.program_guard(main_program, startup_program):
             with _switch_declarative_mode_guard_(is_declarative=True):
                 # 1. Adds `fluid.data` layers for input if needed

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -31,7 +31,7 @@ from .. import unique_name
 from paddle.fluid import core
 from .layer_object_helper import LayerObjectHelper
 from .layer_hooks import record_program_ops_pre_hook, set_op_customized_attrs_post_hook, LayerOpsRecoder
-from .base import program_desc_tracing_guard, param_guard
+from .base import program_desc_tracing_guard, param_guard, in_declarative_mode
 from paddle.fluid import framework
 from ..param_attr import ParamAttr
 from paddle.fluid.executor import Executor, global_scope
@@ -917,7 +917,6 @@ class Layer(core.Layer):
         # In case of ControlFlow, true_fn and false_fn will contain
         # parameters that may not trigger logic of `Operator` to create
         # them. we add this to make sure all parameters is available.
-        from paddle.fluid.dygraph.dygraph_to_static.program_translator import in_declarative_mode
 
         if in_declarative_mode() and not framework.in_dygraph_mode():
             with param_guard(self._parameters), param_guard(self._buffers):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR try to optimize performance with moving runtime import to beginning and we can make dygraph faster 5% on code below:

```
import os
import paddle.fluid.core as core
from paddle import _C_ops
import paddle
import numpy as np
from time import time

num_runs = 100000

os.environ["CUDA_VISIBLE_DEVICES"] = ""
paddle.set_device("cpu")

class FluidMatmulx2(paddle.nn.Layer):
    def __init__(self):
        super(FluidMatmulx2, self).__init__()

        arrW1 = np.ones([4, 128]).astype('float32')
        self.W1 = paddle.to_tensor(arrW1, 'float32', core.CPUPlace())
        self.W1.stop_gradient = False
        
        arrW2 = np.ones([128, 2]).astype('float32')
        self.W2 = paddle.to_tensor(arrW2, 'float32', core.CPUPlace())
        self.W2.stop_gradient = False

    def forward(self, obs):
        Out1 = _C_ops.matmul_v2(obs, self.W1, 'trans_x', False, 'trans_y', False)
        Out = _C_ops.matmul_v2(Out1, self.W2, 'trans_x', False, 'trans_y', False)
        return Out

if __name__ == "__main__":
    input_data = np.ones([32, 4]).astype('float32')
    
    ###########
    # Warm Up #
    ###########
    data_paddle = paddle.to_tensor(input_data.astype(np.float32))
    fluid_matmul = FluidMatmulx2()
    for _ in range(num_runs):
        fluid_matmul.forward(data_paddle)
    
    ###############
    # Performance #
    ###############
    # Fluid Matmul Forward
    data_paddle = paddle.to_tensor(input_data.astype(np.float32))
    ts = time()
    for _ in range(num_runs):
        out = fluid_matmul.forward(data_paddle)
    te = time()
    print("Fluid Matmul Forward: ", 1e6*(te-ts))
    
    # Fluid Matmul Call
    data_paddle = paddle.to_tensor(input_data.astype(np.float32))
    ts = time()
    for _ in range(num_runs):
        out = fluid_matmul(data_paddle)
    te = time()
    print("Fluid Matmul Call: ", 1e6*(te-ts))
```
before:
![image](https://user-images.githubusercontent.com/22361972/144209153-fd5142f9-3323-4cf9-a2e4-f8812cc5d3c8.png)
after:
![image](https://user-images.githubusercontent.com/22361972/144208934-2b1484d7-1b26-4bbd-bc63-929017654b45.png)
