### PR TITLE
Fix python execute in cmake of api-gen

### DIFF
--- a/paddle/pten/api/lib/CMakeLists.txt
+++ b/paddle/pten/api/lib/CMakeLists.txt
@@ -24,7 +24,7 @@ set(api_source_file_tmp ${api_source_file}.tmp)
 
 add_custom_command(
   OUTPUT ${api_header_file} ${api_source_file}
-  COMMAND python ${api_gen_file} 
+  COMMAND ${PYTHON_EXECUTABLE} ${api_gen_file} 
                  --api_yaml_path ${api_yaml_file}
                  --api_header_path ${api_header_file_tmp}
                  --api_source_path ${api_source_file_tmp}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
原先API自动生成的cmake中执行python脚本直接使用了`python`命令，在部分环境中会出现python版本执行紊乱的问题，本PR中使用`PYTHON_EXECUTABLE`进行替换以解决该问题