### PR TITLE
Add roll op fp16 type

### DIFF
--- a/paddle/fluid/operators/roll_op.cc
+++ b/paddle/fluid/operators/roll_op.cc
@@ -157,6 +157,7 @@ REGISTER_OPERATOR(roll_grad, ops::RollGradOp,
 REGISTER_OP_CPU_KERNEL(
     roll, ops::RollKernel<paddle::platform::CPUDeviceContext, float>,
     ops::RollKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::RollKernel<paddle::platform::CPUDeviceContext, plat::float16>,
     ops::RollKernel<paddle::platform::CPUDeviceContext, int>,
     ops::RollKernel<paddle::platform::CPUDeviceContext, int64_t>,
     ops::RollKernel<paddle::platform::CPUDeviceContext,
@@ -166,6 +167,7 @@ REGISTER_OP_CPU_KERNEL(
 REGISTER_OP_CPU_KERNEL(
     roll_grad, ops::RollGradKernel<paddle::platform::CPUDeviceContext, float>,
     ops::RollGradKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::RollGradKernel<paddle::platform::CPUDeviceContext, plat::float16>,
     ops::RollGradKernel<paddle::platform::CPUDeviceContext, int>,
     ops::RollGradKernel<paddle::platform::CPUDeviceContext, int64_t>,
     ops::RollGradKernel<paddle::platform::CPUDeviceContext,

--- a/paddle/fluid/operators/roll_op.cc
+++ b/paddle/fluid/operators/roll_op.cc
@@ -20,6 +20,8 @@
 #include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/platform/complex.h"
 
+namespace plat = paddle::platform;
+
 namespace paddle {
 namespace operators {
 

--- a/paddle/fluid/operators/roll_op.cu
+++ b/paddle/fluid/operators/roll_op.cu
@@ -19,6 +19,8 @@
 #include "paddle/fluid/platform/complex.h"
 #include "paddle/fluid/platform/cuda_primitives.h"
 
+namespace plat = paddle::platform;
+
 namespace paddle {
 namespace operators {
 
@@ -208,6 +210,7 @@ namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     roll, ops::RollKernel<paddle::platform::CUDADeviceContext, float>,
     ops::RollKernel<paddle::platform::CUDADeviceContext, double>,
+    ops::RollKernel<paddle::platform::CUDADeviceContext, plat::float16>,
     ops::RollKernel<paddle::platform::CUDADeviceContext, int>,
     ops::RollKernel<paddle::platform::CUDADeviceContext, int64_t>,
     ops::RollKernel<paddle::platform::CUDADeviceContext,
@@ -217,6 +220,7 @@ REGISTER_OP_CUDA_KERNEL(
 REGISTER_OP_CUDA_KERNEL(
     roll_grad, ops::RollGradKernel<paddle::platform::CUDADeviceContext, float>,
     ops::RollGradKernel<paddle::platform::CUDADeviceContext, double>,
+    ops::RollGradKernel<paddle::platform::CUDADeviceContext, plat::float16>,
     ops::RollGradKernel<paddle::platform::CUDADeviceContext, int>,
     ops::RollGradKernel<paddle::platform::CUDADeviceContext, int64_t>,
     ops::RollGradKernel<paddle::platform::CUDADeviceContext,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Add roll op fp16 type support for amp training.
