### PR TITLE
fix bug of sample method in Uniform class

### DIFF
--- a/python/paddle/distribution.py
+++ b/python/paddle/distribution.py
@@ -305,7 +305,8 @@ class Uniform(Distribution):
         else:
             output_shape = shape + batch_shape
             output = nn.uniform_random(
-                output_shape, seed=seed, dtype=self.dtype) * (tensor.zeros(
+                output_shape, dtype=self.dtype, min=0., max=1.,
+                seed=seed) * (tensor.zeros(
                     output_shape, dtype=self.dtype) + (self.high - self.low))
             output = elementwise_add(output, self.low, name=name)
             if self.all_arg_is_float:

--- a/python/paddle/fluid/tests/unittests/test_distribution.py
+++ b/python/paddle/fluid/tests/unittests/test_distribution.py
@@ -336,6 +336,29 @@ class UniformTest11(UniformTest):
                 name='values', shape=[dims], dtype='float32')
 
 
+class UniformTestSample(unittest.TestCase):
+    def setUp(self):
+        self.init_param()
+
+    def init_param(self):
+        self.low = 3.0
+        self.high = 4.0
+
+    def test_uniform_sample(self):
+        paddle.disable_static()
+        uniform = Uniform(low=self.low, high=self.high)
+        s = uniform.sample([100])
+        self.assertTrue((s >= self.low).all())
+        self.assertTrue((s < self.high).all())
+        paddle.enable_static()
+
+
+class UniformTestSample2(UniformTestSample):
+    def init_param(self):
+        self.low = -5.0
+        self.high = 2.0
+
+
 class NormalNumpy(DistributionNumpy):
     def __init__(self, loc, scale):
         self.loc = np.array(loc)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

- bug复现:
```
import paddle
m = paddle.distribution.Uniform(low=3.0, high=4.0)
m.sample([10])
# Tensor(shape=[10], dtype=float32, place=CPUPlace, stop_gradient=True,
#      [2.00340462, 3.64297724, 2.68817616, 3.17984104, 2.28135157, 2.12152386,
#        3.07929516, 3.23669910, 2.43350005, 2.12983274])
```
得到的采样结果不在用户指定的 [3.0, 4.0) 区间内。

- 问题
sample方法的逻辑是，首先在 [0.0, 1.0) 区间内采样得到s，再通过 `s * (high - low) + low`方法得到最终采样结果。
但是对s采样的时候，错误地在 [-1.0, 1.0) 区间内采样了，所以最终采样结果也错了。

- 修复
将s的采样区间从 [-1.0, 1.0) 改为 [0.0, 1.0) 。