### PR TITLE
Fix default behavior if block=None in static mode of Initializer API

### DIFF
--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -53,11 +53,7 @@ class Initializer(object):
 
     def _check_block(self, block):
         if block is None:
-            if in_dygraph_mode():
-                block = default_main_program().global_block()
-            else:
-                raise ValueError(
-                    "The parameter 'block' is needed in static graph mode.")
+            block = default_main_program().global_block()
 
         return block
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix default behavior if block=None in static mode of Initializer API