### PR TITLE
Fix dependency problem of pyyaml for api-gen

### DIFF
--- a/paddle/pten/api/lib/CMakeLists.txt
+++ b/paddle/pten/api/lib/CMakeLists.txt
@@ -24,6 +24,7 @@ set(api_source_file_tmp ${api_source_file}.tmp)
 
 add_custom_command(
   OUTPUT ${api_header_file} ${api_source_file}
+  COMMAND ${PYTHON_EXECUTABLE} -m pip install pyyaml
   COMMAND ${PYTHON_EXECUTABLE} ${api_gen_file} 
                  --api_yaml_path ${api_yaml_file}
                  --api_header_path ${api_header_file_tmp}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
![image](https://user-images.githubusercontent.com/13048366/144809461-25612d13-163b-43ac-b000-8386e2c43943.png)

当前编译期API代码生成需要依赖python的`pyyaml`包，部分编译环境中默认未安装`pyyaml`的会出现上图中的错误。本PR主要对该问题进行修复：即在执行API生成脚本前会先尝试安装`pyyaml`依赖包，以避免运行时找不到`pyyaml`依赖包。
