### PR TITLE
[Dy2Stat]Allow ifelse return buildin type in paddle cond

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -254,7 +254,7 @@ def _run_paddle_cond(pred, true_fn, false_fn, true_args, false_args,
     # NOTE 2: Here uses id(var) not var, because `if var in return_var` use operator `==`,
     #  which will call `fluid.layers.equal` and causes error when var in return_vars is not initialized.
     # true_args = [
-    # to_static_variable(var) if id(var) in return_var_ids else var
+    #     to_static_variable(var) if id(var) in return_var_ids else var
     #     for var in true_args
     # ]
     # false_args = [

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -248,20 +248,6 @@ def _remove_no_value_return_var(out):
 
 def _run_paddle_cond(pred, true_fn, false_fn, true_args, false_args,
                      return_vars):
-
-    return_var_ids = [id(var) for var in return_vars]
-    # NOTE 1: Returned vars of Paddle op `control_flow.cond` must be Paddle Tensors
-    # NOTE 2: Here uses id(var) not var, because `if var in return_var` use operator `==`,
-    #  which will call `fluid.layers.equal` and causes error when var in return_vars is not initialized.
-    # true_args = [
-    #     to_static_variable(var) if id(var) in return_var_ids else var
-    #     for var in true_args
-    # ]
-    # false_args = [
-    #     to_static_variable(var) if id(var) in return_var_ids else var
-    #     for var in false_args
-    # ]
-
     pred = cast_bool_if_necessary(pred)
     return control_flow.cond(pred, lambda: true_fn(*true_args),
                              lambda: false_fn(*false_args))

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -253,14 +253,14 @@ def _run_paddle_cond(pred, true_fn, false_fn, true_args, false_args,
     # NOTE 1: Returned vars of Paddle op `control_flow.cond` must be Paddle Tensors
     # NOTE 2: Here uses id(var) not var, because `if var in return_var` use operator `==`,
     #  which will call `fluid.layers.equal` and causes error when var in return_vars is not initialized.
-    true_args = [
-        to_static_variable(var) if id(var) in return_var_ids else var
-        for var in true_args
-    ]
-    false_args = [
-        to_static_variable(var) if id(var) in return_var_ids else var
-        for var in false_args
-    ]
+    # true_args = [
+    # to_static_variable(var) if id(var) in return_var_ids else var
+    #     for var in true_args
+    # ]
+    # false_args = [
+    #     to_static_variable(var) if id(var) in return_var_ids else var
+    #     for var in false_args
+    # ]
 
     pred = cast_bool_if_necessary(pred)
     return control_flow.cond(pred, lambda: true_fn(*true_args),

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -114,7 +114,7 @@ def select_input_with_buildin_type(inputs, mask):
             inputs = [
                 to_static_variable(false_var), to_static_variable(true_var)
             ]
-    # When false_var is int, true_var is Variable(no value placehold) will cause Error
+    # Deal with this situation: false_var is int and true_var is Variable
     elif (isinstance(false_var, (bool, float, six.integer_types)) and
           isinstance(true_var, Variable)) or (isinstance(true_var, (
               bool, float, six.integer_types)) and isinstance(false_var,

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -110,8 +110,8 @@ def select_input_with_buildin_type(inputs, mask):
     if isinstance(false_var, Variable) and isinstance(true_var, Variable):
         return select_input(inputs, mask)
 
-    elif (isinstance(false_var, (support_ret_buildin_type)) and isinstance(
-            false_var, type(true_var))):
+    elif (isinstance(false_var, (support_ret_buildin_type)) and
+          isinstance(false_var, type(true_var))):
         if false_var == true_var:
             return false_var
         else:

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -340,3 +340,16 @@ def if_tensor_case(x):
         x += 1
 
     return x
+
+
+def dyfunc_ifelse_ret_int1(x):
+    index = 0
+    pred = paddle.to_tensor([1])
+    if pred:
+        y = x[index] + 1
+        index = index + 1
+        return y, index
+    else:
+        y = x[index] + 2
+        index = index + 1
+        return y, index

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -366,3 +366,27 @@ def dyfunc_ifelse_ret_int2(x):
         y = x[index] + 2
         index = index + 1
         return y
+
+
+def dyfunc_ifelse_ret_int3(x):
+    index = 0
+    pred = paddle.to_tensor([1])
+    if pred:
+        y = x[index] + 1
+        index = index + 1
+        return index
+    else:
+        y = x[index] + 2
+        return y
+
+
+def dyfunc_ifelse_ret_int4(x):
+    index = 0
+    pred = paddle.to_tensor([1])
+    if pred:
+        y = x[index] + 1
+        index = index + 1
+        return 'unsupport ret'
+    else:
+        y = x[index] + 2
+        return y

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -353,3 +353,16 @@ def dyfunc_ifelse_ret_int1(x):
         y = x[index] + 2
         index = index + 1
         return y, index
+
+
+def dyfunc_ifelse_ret_int2(x):
+    index = 0
+    pred = paddle.to_tensor([1])
+    if pred:
+        y = x[index] + 1
+        index = index + 1
+        return y, index
+    else:
+        y = x[index] + 2
+        index = index + 1
+        return y

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -369,28 +369,55 @@ class TestDy2StIfElseRetInt1(unittest.TestCase):
     def setUp(self):
         self.x = np.random.random([5]).astype('float32')
         self.dyfunc = dyfunc_ifelse_ret_int1
+        self.out = self.get_dy2stat_out()
 
-    def test_ast_to_func(self):
+    def get_dy2stat_out(self):
         ProgramTranslator().enable(True)
         static_func = paddle.jit.to_static(self.dyfunc)
         out = static_func(self.x)
-        self.assertIsInstance(out[0], paddle.Tensor)
-        self.assertIsInstance(out[1], int)
         ProgramTranslator().enable(False)
+        return out
+
+    def test_ast_to_func(self):
+        self.assertIsInstance(self.out[0], paddle.Tensor)
+        self.assertIsInstance(self.out[1], int)
 
 
 class TestDy2StIfElseRetInt2(TestDy2StIfElseRetInt1):
     def setUp(self):
         self.x = np.random.random([5]).astype('float32')
         self.dyfunc = dyfunc_ifelse_ret_int2
+        self.out = self.get_dy2stat_out()
 
     def test_ast_to_func(self):
-        ProgramTranslator().enable(True)
-        static_func = paddle.jit.to_static(self.dyfunc)
-        out = static_func(self.x)
-        self.assertIsInstance(out[0], paddle.Tensor)
-        self.assertIsInstance(out[1], paddle.Tensor)
+        self.assertIsInstance(self.out[0], paddle.Tensor)
+        self.assertIsInstance(self.out[1], paddle.Tensor)
+
+
+class TestDy2StIfElseRetInt3(TestDy2StIfElseRetInt1):
+    def setUp(self):
+        self.x = np.random.random([5]).astype('float32')
+        self.dyfunc = dyfunc_ifelse_ret_int3
+        self.out = self.get_dy2stat_out()
+
+    def test_ast_to_func(self):
+        self.assertIsInstance(self.out, paddle.Tensor)
+
+
+class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
+    def setUp(self):
+        self.x = np.random.random([5]).astype('float32')
+        self.dyfunc = dyfunc_ifelse_ret_int4
+
+    def test_ast_to_func(self):
+        with self.assertRaises(TypeError):
+            ProgramTranslator().enable(True)
+            static_func = paddle.jit.to_static(self.dyfunc)
+            out = static_func(self.x)
+
+    def __del__(self):
         ProgramTranslator().enable(False)
+        super(TestDy2StIfElseRetInt4, self).__del__()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -365,16 +365,32 @@ class TestNewVarCreateInOneBranch(unittest.TestCase):
         self.assertEqual(paddle.jit.to_static(case_func)(True), -2)
 
 
-class TestDygraphIfElseRetInt(unittest.TestCase):
+class TestDy2StIfElseRetInt1(unittest.TestCase):
     def setUp(self):
         self.x = np.random.random([5]).astype('float32')
         self.dyfunc = dyfunc_ifelse_ret_int1
 
     def test_ast_to_func(self):
+        ProgramTranslator().enable(True)
         static_func = paddle.jit.to_static(self.dyfunc)
         out = static_func(self.x)
         self.assertIsInstance(out[0], paddle.Tensor)
-        self.assertEqual(out[1], 1)
+        self.assertIsInstance(out[1], int)
+        ProgramTranslator().enable(False)
+
+
+class TestDy2StIfElseRetInt2(TestDy2StIfElseRetInt1):
+    def setUp(self):
+        self.x = np.random.random([5]).astype('float32')
+        self.dyfunc = dyfunc_ifelse_ret_int2
+
+    def test_ast_to_func(self):
+        ProgramTranslator().enable(True)
+        static_func = paddle.jit.to_static(self.dyfunc)
+        out = static_func(self.x)
+        self.assertIsInstance(out[0], paddle.Tensor)
+        self.assertIsInstance(out[1], paddle.Tensor)
+        ProgramTranslator().enable(False)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -365,5 +365,17 @@ class TestNewVarCreateInOneBranch(unittest.TestCase):
         self.assertEqual(paddle.jit.to_static(case_func)(True), -2)
 
 
+class TestDygraphIfElseRetInt(unittest.TestCase):
+    def setUp(self):
+        self.x = np.random.random([5]).astype('float32')
+        self.dyfunc = dyfunc_ifelse_ret_int1
+
+    def test_ast_to_func(self):
+        static_func = paddle.jit.to_static(self.dyfunc)
+        out = static_func(self.x)
+        self.assertIsInstance(out[0], paddle.Tensor)
+        self.assertEqual(out[1], 1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
PR的修改如下：
1. 此前在paddle cond动转静转写生成的true_fn和false_fn中，如果true_fn和false_fn的某个参数x是bool、int、float类型且x在return语句中，那么在该参数会被转为Variable。本PR之后允许传入的参数是int、float等基本类型，不再将参数自动转换为Variable。
2. 允许true_fn和false_fn返回bool、int、float基本类型。
    - 只有true_fn和false_fn分支返回的结果类型和值都相等时才可以返回。比如true_fn返回了true_var，false_fn对应的返回结果为false_var，只有true_var和false_var均是基本类型，且type(true_var) == type(false_fn) ，且true_var == false_fn才会将结果作为基本类型返回
    - 当true_var和false_fn值不想等；或者一个为基本类型、另一个为Variable，则都会转换为Variable进行返回。
    - 其余情况，比如返回string、list等类型则会报错。