### PR TITLE
block warning when building cryptopp in windows with ninja

### DIFF
--- a/cmake/external/cryptopp.cmake
+++ b/cmake/external/cryptopp.cmake
@@ -22,9 +22,9 @@ SET(CRYPTOPP_TAG        CRYPTOPP_8_2_0)
 
 IF(WIN32)
   SET(CRYPTOPP_LIBRARIES "${CRYPTOPP_INSTALL_DIR}/lib/cryptopp-static.lib" CACHE FILEPATH "cryptopp library." FORCE)
-  # There is a compilation parameter 'FI\"winapifamily.h\"' can't be used correctly
+  # There is a compilation parameter "/FI\"winapifamily.h\"" or "/FIwinapifamily.h" can't be used correctly
   # with Ninja on Windows. The only difference between the patch file and original
-  # file is that the compilation parameters are changed to 'FIwinapifamily.h'. This
+  # file is that the compilation parameters are changed to '/nologo'. This
   # patch command can be removed when upgrading to a higher version.
   if("${CMAKE_GENERATOR}" STREQUAL "Ninja")
     set(CRYPTOPP_PATCH_COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PADDLE_SOURCE_DIR}/patches/cryptopp/CMakeLists.txt" "<SOURCE_DIR>/")

--- a/patches/cryptopp/CMakeLists.txt
+++ b/patches/cryptopp/CMakeLists.txt
@@ -447,7 +447,7 @@ if (MSVC)
   if (CMAKE_SYSTEM_VERSION MATCHES "10\\.0.*")
     list(APPEND CRYPTOPP_COMPILE_DEFINITIONS "_WIN32_WINNT=0x0A00")
   endif ()
-  list(APPEND CRYPTOPP_COMPILE_OPTIONS "/FIwinapifamily.h")
+  list(APPEND CRYPTOPP_COMPILE_OPTIONS "/nologo")
 endif ()
 
 # Enable PIC for all target machines except 32-bit i386 due to register pressures.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Both "/FI\"winapifamily.h\"" and "/FIwinapifamily.h" will cause compile warning when building cryptopp in windows with ninja, so I substitute it by "/nologo" to block showing of copyright by the way.
**before**
<img width="789" alt="Popeieht (C) Microsote Corporation  All rights revsrved" src="https://user-images.githubusercontent.com/51314274/144982407-cfb8fa4f-5498-4d1d-a45e-e7af38a1f943.png">
**after**
![image](https://user-images.githubusercontent.com/51314274/144982469-37c2206e-9fc3-488b-b95f-7d20f94f3656.png)
