### PR TITLE
【PTen】Add cmake dependency for api_gen.py

### DIFF
--- a/paddle/pten/api/lib/CMakeLists.txt
+++ b/paddle/pten/api/lib/CMakeLists.txt
@@ -31,7 +31,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${api_header_file_tmp} ${api_header_file}
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${api_source_file_tmp} ${api_source_file}
   COMMENT "copy_if_different ${api_header_file} ${api_source_file}"
-  DEPENDS ${api_yaml_file}
+  DEPENDS ${api_yaml_file} ${api_gen_file}
   VERBATIM)
 
 cc_library(utils_api SRCS utils.cc DEPS pten_tensor pten kernel_dispatch)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
添加API自动生成python脚本为cmake编译的依赖项，以解决原先api_gen.py修改无法触发代码自动生成的问题