### PR TITLE
disable shuffle_channel_detect_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -78,10 +78,12 @@ const std::vector<std::string> kTRTSubgraphPasses({
   "conv_affine_channel_fuse_pass",  //
       "adaptive_pool2d_convert_global_pass",
       "conv_eltwiseadd_affine_channel_fuse_pass",  //
-      "shuffle_channel_detect_pass",               //
-      "quant_conv2d_dequant_fuse_pass",            //
-      "delete_quant_dequant_op_pass",              //
-      "delete_quant_dequant_filter_op_pass",       //
+      // TODO(baoachun): this pass does not use attributes
+      // when reshape+transpoe fused to shuffle_channel
+      // "shuffle_channel_detect_pass",               //
+      "quant_conv2d_dequant_fuse_pass",       //
+      "delete_quant_dequant_op_pass",         //
+      "delete_quant_dequant_filter_op_pass",  //
       // "fc_fuse_pass",                                 //
       "simplify_with_basic_ops_pass",           //
       "embedding_eltwise_layernorm_fuse_pass",  //


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe

1、暂时禁掉shuffle_channel_detect_pass，该pass会将reshape+transpose融合为shuffle_channel，但没有处理reshape和transpose的属性，导致推理报错

<!-- Describe what this PR does -->
