### PR TITLE
update 3 tests

### DIFF
--- a/paddle/fluid/framework/ir/conv_elementwise_add_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_fuse_pass.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ ConvElementwiseAddFusePass::ConvElementwiseAddFusePass() {
       .AddAttr("dilations")
       .End()
       .AddAttr("data_format")
-      .IsStringIn({"NCHW", "NHWC", "AnyLayout"})
+      .IsStringIn({"NCHW" /*, "NHWC", "AnyLayout"*/})
       .End();
 
   AddOpCompat(OpCompat("elementwise_add"))
@@ -87,7 +87,7 @@ void ConvElementwiseAddFusePass::ApplyImpl(ir::Graph* graph) const {
 
   patterns::ConvElementwiseadd pattern(gpd.mutable_pattern(), pattern_name);
   pattern(x);
-
+  int found_conv_eltwise_count = 0;
   auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
                      Graph* g) {
     if (!IsCompat(subgraph, g)) {
@@ -135,9 +135,12 @@ void ConvElementwiseAddFusePass::ApplyImpl(ir::Graph* graph) const {
 
     // Delete the unneeded nodes.
     GraphSafeRemoveNodes(graph, {conv_op, conv_out, elementwise_add_op});
+    found_conv_eltwise_count++;
   };
 
   gpd(graph, handler);
+  // check if detect conv2d_fusion subgraph!
+  AddStatis(found_conv_eltwise_count);
 }
 
 }  // namespace ir

--- a/python/paddle/fluid/tests/unittests/ir/inference/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/ir/inference/CMakeLists.txt
@@ -80,6 +80,7 @@ if (WITH_MKLDNN AND TENSORRT_FOUND AND WITH_GPU)
   set_tests_properties(test_fc_fuse_pass PROPERTIES TIMEOUT 240)
   set_tests_properties(test_simplify_with_basic_ops_pass_autoscan PROPERTIES TIMEOUT 60)
   set_tests_properties(test_adaptive_pool2d_convert_global_pass_autoscan PROPERTIES TIMEOUT 60)
+  set_tests_properties(test_conv_eltwiseadd_affine_channel_fuse_pass PROPERTIES TIMEOUT 100)
 endif()
 
 if (WITH_MKLDNN)

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_fuse_pass.py
@@ -105,8 +105,7 @@ class TestConvEltwiseAddFusePass(PassAutoScanTest):
         program_config = ProgramConfig(
             ops=ops,
             inputs={
-                "input_data":
-                TensorConfig(data_gen=partial(generate_input, attrs)),
+                "input_data": TensorConfig(data_gen=partial(generate_input)),
             },
             weights={
                 "conv2d_weight":

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_fuse_pass.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,41 +12,145 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
-import unittest
+from auto_scan_test import PassAutoScanTest, IgnoreReasons
+from program_config import TensorConfig, ProgramConfig, OpConfig
 import numpy as np
-from inference_pass_test import InferencePassTest
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid.core import PassVersionChecker
-from paddle.fluid.core import AnalysisConfig
-"""Test for fusion of conv and elementwise_add."""
+import paddle.inference as paddle_infer
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import unittest
+
+import hypothesis
+from hypothesis import given, settings, seed, example, assume
+import hypothesis.strategies as st
 
 
-class ConvElementwiseAddFusePassTest(InferencePassTest):
-    def setUp(self):
-        with fluid.program_guard(self.main_program, self.startup_program):
-            data = fluid.data(
-                name="data", shape=[-1, 3, 100, 100], dtype="float32")
-            param_attr = fluid.ParamAttr(
-                initializer=fluid.initializer.Xavier(uniform=False),
-                learning_rate=0.001)
-            conv_out = fluid.layers.conv2d(
-                input=data, num_filters=3, filter_size=3, bias_attr=param_attr)
+class TestConvEltwiseAddFusePass(PassAutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        attrs = [
+            program_config.ops[i].attrs
+            for i in range(len(program_config.ops))
+        ]
 
-        self.feeds = {
-            "data": np.random.random((1, 3, 100, 100)).astype("float32")
-        }
-        self.fetch_list = [conv_out]
-        self.enable_mkldnn = False
+        if attrs[0]['data_format'] == "NHWC" and attrs[1]['axis'] != 3:
+            return False
 
-    def test_check_output(self):
-        if core.is_compiled_with_cuda():
-            use_gpu = True
-            self.check_output_with_option(use_gpu)
-        self.assertTrue(
-            PassVersionChecker.IsCompatible('conv_elementwise_add_fuse_pass'))
+        return True
+
+    def sample_program_config(self, draw):
+        padding_algorithm = draw(st.sampled_from(["EXPLICIT", "SAME", "VALID"]))
+        groups = draw(st.integers(min_value=1, max_value=3))
+        data_format = draw(st.sampled_from(["NCHW", "NHWC"]))
+        axis = draw(st.sampled_from([1]))
+        filter_channel = draw(st.integers(min_value=1, max_value=16)) * 4
+        filter_size = draw(st.integers(min_value=1, max_value=4))
+        in_channel = groups * filter_channel
+        out_channel_factor = draw(st.integers(min_value=1, max_value=16)) * 4
+        out_channel = groups * out_channel_factor
+        batch_size = draw(st.integers(min_value=1, max_value=4))
+        dilations = draw(
+            st.lists(
+                st.integers(
+                    min_value=1, max_value=2), min_size=2, max_size=2))
+        paddings = draw(
+            st.lists(
+                st.integers(
+                    min_value=0, max_value=2), min_size=2, max_size=2))
+        strides = draw(
+            st.lists(
+                st.integers(
+                    min_value=1, max_value=2), min_size=2, max_size=2))
+
+        x_shape = [
+            batch_size, in_channel, 64, 64
+        ] if data_format == "NCHW" else [batch_size, 64, 64, in_channel]
+        w_shape = [out_channel, filter_channel, filter_size, filter_size]
+        scale_shape = [out_channel]
+        bias_shape = [out_channel]
+
+        def generate_input():
+            return np.random.random(x_shape).astype(np.float32)
+
+        def generate_weight():
+            return np.random.random(w_shape).astype(np.float32)
+
+        def generate_bias():
+            return np.random.random(bias_shape).astype(np.float32)
+
+        def generate_scale_bias():
+            return np.random.random(bias_shape).astype(np.float32)
+
+        conv2d_op = OpConfig(
+            "conv2d",
+            inputs={
+                "Input": ["input_data"],
+                "Filter": ["conv2d_weight"],
+            },
+            outputs={"Output": ["conv_output"]},
+            data_format=data_format,
+            dilations=dilations,
+            padding_algorithm=padding_algorithm,
+            groups=groups,
+            paddings=paddings,
+            strides=strides,
+            is_test=True)
+        eltwise_op = OpConfig(
+            "elementwise_add",
+            inputs={"X": ["conv_output"],
+                    "Y": ["conv2d_bias"]},
+            outputs={"Out": ["elementwise_output"]},
+            axis=axis)
+        ops = [conv2d_op, eltwise_op]
+
+        program_config = ProgramConfig(
+            ops=ops,
+            inputs={
+                "input_data":
+                TensorConfig(data_gen=partial(generate_input, attrs)),
+            },
+            weights={
+                "conv2d_weight":
+                TensorConfig(data_gen=partial(generate_weight)),
+                "conv2d_bias":
+                TensorConfig(data_gen=partial(generate_scale_bias)),
+            },
+            outputs=["elementwise_output"])
+        return program_config
+
+    def sample_predictor_configs(self, program_config):
+        config = self.create_inference_config(use_gpu=True)
+        yield config, ['conv2d_fusion'], (1e-4, 1e-4)
+
+        # # TRT
+        config = self.create_trt_inference_config()
+        config.enable_tensorrt_engine(
+            workspace_size=1 << 20,
+            max_batch_size=4,
+            min_subgraph_size=1,
+            precision_mode=paddle_infer.PrecisionType.Float32,
+            use_static=False,
+            use_calib_mode=False)
+        yield config, ['conv2d_fusion'], (1e-4, 1e-4)
+
+    def add_ignore_pass_case(self):
+        # If the problem has been fixed, the judgment 
+        # in is_program_valid needs to be deleted!!!
+        def teller1(program_config, predictor_config):
+            if program_config.ops[0].attrs['data_format'] == "NHWC":
+                return True
+            return False
+
+        self.add_ignore_check_case(
+            teller1, IgnoreReasons.PASS_ACCURACY_ERROR,
+            "The output format of conv2d is wrong when data_format attribute is NHWC, \
+            it will trigger Broadcast dimension mismatch bug \
+            when data_format attribute is NHWC and axis of eltwise op is 1 for this pass."
+        )
+
+    def test(self):
+        self.run_and_statis(
+            quant=False,
+            passes=["conv_elementwise_add_fuse_pass"], )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
新增conv_affine_channel_fuse_pass单测
新增conv_eltwiseadd_affine_channel_fuse_pass单测
新增conv_elementwise_add_fuse_pass单测

bug：conv_affine_channel_fuse_pass融合出来的elementwise_add op没有设置shape和datatype等属性的问题，在可视化模型中没有shape等信息显示。
该Pass不支持NHWC的输入，在Pass的compat检查中把这个加上，NHWC的时候不走Pass，保证正确性。

fix：仿照ConvBNFusePass::ApplyImpl中相关逻辑的实现，需要在初始化eltwise_y之前（即创建eltwise_y_in_node和eltwise_y_in_tensor之前），在已经创建好的eltwise_y_in_desc上设置好SetShape和SetDataType等信息。

另外，针对conv_ac的两个pass，为了列出bias下mkldnn的问题，将bias设为随机boolean值，并加在ignore_pass_case中，当has_bias==true且predictor_config为mkldnn_enabled()==TRUE时跳过即可过单测。