### PR TITLE
[WIP] Support TensorDesc.Content in CompileTime

### DIFF
--- a/paddle/fluid/eager/legacy/infer_shape_context.h
+++ b/paddle/fluid/eager/legacy/infer_shape_context.h
@@ -216,13 +216,13 @@ class EagerInferShapeContext : public paddle::framework::InferShapeContext {
 
   // TODO(paddle-dev): Can this be template?
   std::vector<paddle::framework::InferShapeVarPtr> GetInputVarPtrs(
-      const std::string& name) override {
+      const std::string& name) const override {
     PADDLE_THROW(paddle::platform::errors::PermissionDenied(
         "GetInputVarPtrs not support in dygraph runtime context"));
   }
 
   std::vector<paddle::framework::InferShapeVarPtr> GetOutputVarPtrs(
-      const std::string& name) override {
+      const std::string& name) const override {
     PADDLE_THROW(paddle::platform::errors::PermissionDenied(
         "GetOutputVarPtrs not support in dygraph runtime context"));
   }

--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -35,7 +35,7 @@ proto_library(pass_desc_proto SRCS pass_desc.proto DEPS framework_proto)
 
 proto_library(op_def_proto SRCS op_def.proto DEPS framework_proto)
 cc_library(op_def_api SRCS op_def_api.cc DEPS op_def_proto boost)
-cc_library(tensor_desc SRCS tensor_desc.cc DEPS enforce framework_proto boost)
+cc_library(tensor_desc SRCS tensor_desc.cc DEPS enforce framework_proto boost glog)
 
 FILE(GLOB OP_DEF_FILES ${PADDLE_SOURCE_DIR}/paddle/fluid/operators/compat/*.pbtxt)
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/op_def.pbtxt 

--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -35,6 +35,7 @@ proto_library(pass_desc_proto SRCS pass_desc.proto DEPS framework_proto)
 
 proto_library(op_def_proto SRCS op_def.proto DEPS framework_proto)
 cc_library(op_def_api SRCS op_def_api.cc DEPS op_def_proto boost)
+cc_library(tensor_desc SRCS tensor_desc.cc DEPS enforce framework_proto boost)
 
 FILE(GLOB OP_DEF_FILES ${PADDLE_SOURCE_DIR}/paddle/fluid/operators/compat/*.pbtxt)
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/op_def.pbtxt 
@@ -211,7 +212,7 @@ cc_test(operator_exception_test SRCS operator_exception_test.cc DEPS operator op
 cc_library(version SRCS version.cc)
 cc_test(version_test SRCS version_test.cc DEPS version)
 
-cc_library(proto_desc SRCS var_desc.cc op_desc.cc block_desc.cc program_desc.cc process_mesh_desc.cc DEPS attribute shape_inference op_info operator glog version)
+cc_library(proto_desc SRCS var_desc.cc op_desc.cc block_desc.cc program_desc.cc process_mesh_desc.cc DEPS attribute shape_inference op_info operator glog version tensor_desc)
 
 cc_library(op_registry SRCS op_registry.cc DEPS op_proto_maker op_info operator glog proto_desc)
 

--- a/paddle/fluid/framework/framework.proto
+++ b/paddle/fluid/framework/framework.proto
@@ -159,8 +159,15 @@ message VarType {
   message TensorDesc {
     // Should only be PODType. Is enforced in C++
     required Type data_type = 1;
-    repeated int64 dims = 2;    // [UNK, 640, 480] is saved as [-1, 640, 480]
-    repeated int32 content = 3; //  Only support few data.
+    repeated int64 dims = 2; // [UNK, 640, 480] is saved as [-1, 640, 480]
+
+    // Store tensor content with small dims in compiled time to help infer
+    // shape.
+    // Only support rank=1 or scalar.
+    repeated int32 int32_val = 3;
+    repeated int64 int64_val = 4;
+    repeated float float_val = 5;
+    // repeated string string_val = 6;
   }
   optional TensorDesc selected_rows = 2;
 

--- a/paddle/fluid/framework/framework.proto
+++ b/paddle/fluid/framework/framework.proto
@@ -159,7 +159,8 @@ message VarType {
   message TensorDesc {
     // Should only be PODType. Is enforced in C++
     required Type data_type = 1;
-    repeated int64 dims = 2; // [UNK, 640, 480] is saved as [-1, 640, 480]
+    repeated int64 dims = 2;    // [UNK, 640, 480] is saved as [-1, 640, 480]
+    repeated int32 content = 3; //  Only support few data.
   }
   optional TensorDesc selected_rows = 2;
 

--- a/paddle/fluid/framework/framework.proto
+++ b/paddle/fluid/framework/framework.proto
@@ -162,12 +162,11 @@ message VarType {
     repeated int64 dims = 2; // [UNK, 640, 480] is saved as [-1, 640, 480]
 
     // Store tensor content with small dims in compiled time to help infer
-    // shape.
-    // Only support rank=1 or scalar.
+    // shape. Only support rank=1 or scalar.
     repeated int32 int32_val = 3;
     repeated int64 int64_val = 4;
     repeated float float_val = 5;
-    // repeated string string_val = 6;
+    repeated string string_val = 6;
   }
   optional TensorDesc selected_rows = 2;
 

--- a/paddle/fluid/framework/new_executor/new_executor_defs.cc
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.cc
@@ -309,7 +309,7 @@ bool InterpretercoreInferShapeContext::IsRuntime() const { return true; }
 
 // TODO(paddle-dev): Can this be template?
 std::vector<InferShapeVarPtr> InterpretercoreInferShapeContext::GetInputVarPtrs(
-    const std::string& name) {
+    const std::string& name) const {
   const std::vector<Variable*>& vars = InputVars(name);
   std::vector<InferShapeVarPtr> res;
   res.reserve(vars.size());
@@ -318,7 +318,7 @@ std::vector<InferShapeVarPtr> InterpretercoreInferShapeContext::GetInputVarPtrs(
 }
 
 std::vector<InferShapeVarPtr>
-InterpretercoreInferShapeContext::GetOutputVarPtrs(const std::string& name) {
+InterpretercoreInferShapeContext::GetOutputVarPtrs(const std::string& name) const {
   const std::vector<Variable*>& vars = OutputVars(name);
   std::vector<InferShapeVarPtr> res;
   res.reserve(vars.size());

--- a/paddle/fluid/framework/new_executor/new_executor_defs.cc
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.cc
@@ -318,7 +318,8 @@ std::vector<InferShapeVarPtr> InterpretercoreInferShapeContext::GetInputVarPtrs(
 }
 
 std::vector<InferShapeVarPtr>
-InterpretercoreInferShapeContext::GetOutputVarPtrs(const std::string& name) const {
+InterpretercoreInferShapeContext::GetOutputVarPtrs(
+    const std::string& name) const {
   const std::vector<Variable*>& vars = OutputVars(name);
   std::vector<InferShapeVarPtr> res;
   res.reserve(vars.size());

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -86,10 +86,10 @@ class InterpretercoreInferShapeContext : public InferShapeContext {
 
   // TODO(paddle-dev): Can this be template?
   std::vector<InferShapeVarPtr> GetInputVarPtrs(
-      const std::string& name) override;
+      const std::string& name) const override;
 
   std::vector<InferShapeVarPtr> GetOutputVarPtrs(
-      const std::string& name) override;
+      const std::string& name) const override;
 
   DDim GetInputDim(const std::string& name) const override;
 

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -200,7 +200,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
   }
 
   std::vector<InferShapeVarPtr> GetInputVarPtrs(
-      const std::string &name) override {
+      const std::string &name) const override {
     const std::vector<std::string> arg_names = Inputs(name);
     std::vector<InferShapeVarPtr> res;
     res.reserve(arg_names.size());
@@ -212,7 +212,7 @@ class CompileTimeInferShapeContext : public InferShapeContext {
   }
 
   std::vector<InferShapeVarPtr> GetOutputVarPtrs(
-      const std::string &name) override {
+      const std::string &name) const override {
     const std::vector<std::string> arg_names = Outputs(name);
     std::vector<InferShapeVarPtr> res;
     res.reserve(arg_names.size());

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -871,7 +871,7 @@ class RuntimeInferShapeContext : public InferShapeContext {
 
   // TODO(paddle-dev): Can this be template?
   std::vector<InferShapeVarPtr> GetInputVarPtrs(
-      const std::string& name) override {
+      const std::string& name) const override {
     const std::vector<Variable*>& vars = InputVars(name);
     std::vector<InferShapeVarPtr> res;
     res.reserve(vars.size());
@@ -880,7 +880,7 @@ class RuntimeInferShapeContext : public InferShapeContext {
   }
 
   std::vector<InferShapeVarPtr> GetOutputVarPtrs(
-      const std::string& name) override {
+      const std::string& name) const override {
     const std::vector<Variable*>& vars = OutputVars(name);
     std::vector<InferShapeVarPtr> res;
     res.reserve(vars.size());

--- a/paddle/fluid/framework/shape_inference.h
+++ b/paddle/fluid/framework/shape_inference.h
@@ -103,9 +103,9 @@ class InferShapeContext {
   virtual bool IsRuntime() const = 0;
 
   virtual std::vector<InferShapeVarPtr> GetInputVarPtrs(
-      const std::string &name) = 0;
+      const std::string &name) const = 0;
   virtual std::vector<InferShapeVarPtr> GetOutputVarPtrs(
-      const std::string &name) = 0;
+      const std::string &name) const = 0;
 
  protected:
   virtual std::vector<DDim> GetRepeatedDims(const std::string &name) const = 0;

--- a/paddle/fluid/framework/tensor_desc.cc
+++ b/paddle/fluid/framework/tensor_desc.cc
@@ -1,0 +1,101 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/tensor_desc.h"
+
+namespace paddle {
+namespace framework {
+
+// template<typename T>
+// const std::vector<T>& ExtractTensorDescValue(const TensorDescValue& desc_val)
+// {
+//   // PADDLE_ENFORCE_EQ(desc_val.type(), typeid(std::vector<T>),
+//   //                   platform::errors::PreconditionNotMet(
+//   //                       "Found mismatch type in
+//   ExtractTensorDescValue."));
+//   return BOOST_GET_CONST(std::vector<T>, desc_val);
+// }
+
+template <typename T, typename RepeatedField>
+inline static void VectorToRepeated(const std::vector<T> &vec,
+                                    RepeatedField *repeated_field) {
+  repeated_field->Clear();
+  repeated_field->Reserve(vec.size());
+  for (const auto &elem : vec) {
+    *repeated_field->Add() = elem;
+  }
+}
+
+// convert between std::vector and protobuf repeated.
+template <typename T>
+inline static std::vector<T> RepeatedToVector(
+    const google::protobuf::RepeatedField<T> &repeated_field) {
+  std::vector<T> ret;
+  ret.reserve(repeated_field.size());
+  std::copy(repeated_field.begin(), repeated_field.end(),
+            std::back_inserter(ret));
+  return ret;
+}
+
+TensorDescValue GetTensorDescValue(
+    const proto::VarType::TensorDesc &tensor_desc) {
+  switch (tensor_desc.data_type()) {
+    case proto::VarType::Type::VarType_Type_INT32: {
+      return RepeatedToVector(tensor_desc.int32_val());
+    }
+    case proto::VarType::Type::VarType_Type_INT64: {
+      return RepeatedToVector(tensor_desc.int64_val());
+    }
+    case proto::VarType::Type::VarType_Type_FP32: {
+      return RepeatedToVector(tensor_desc.float_val());
+    }
+    // case proto::VarType::Type::VarType_Type_STRING: {
+    //   return RepeatedToVector(tensor_desc.string_val());
+    // }
+
+    default:
+      PADDLE_THROW(platform::errors::Unavailable(
+          "Unsupport TensorDesc type %d.", tensor_desc.data_type()));
+  }
+
+  return boost::blank();
+}
+
+void SetTensorDescValue(proto::VarType::TensorDesc *tensor_desc,
+                        const TensorDescValue &val) {
+  switch (tensor_desc->data_type()) {
+    case proto::VarType::Type::VarType_Type_INT32: {
+      auto &vec = ExtractTensorDescValue<std::vector<int>>(val);
+      VectorToRepeated(vec, tensor_desc->mutable_int32_val());
+    }
+    case proto::VarType::Type::VarType_Type_INT64: {
+      auto &vec = ExtractTensorDescValue<std::vector<int64_t>>(val);
+      VectorToRepeated(vec, tensor_desc->mutable_int64_val());
+    }
+    case proto::VarType::Type::VarType_Type_FP32: {
+      auto &vec = ExtractTensorDescValue<std::vector<float>>(val);
+      VectorToRepeated(vec, tensor_desc->mutable_float_val());
+    }
+    // case proto::VarType::Type::VarType_Type_STRING: {
+    //   auto &vec = ExtractTensorDescValue<std::vector<std::string>>(val);
+    //   VectorToRepeated(vec, tensor_desc->mutable_string_val());
+    // }
+    default:
+      PADDLE_THROW(platform::errors::Unavailable(
+          "Unsupport TensorDesc type %d.", tensor_desc->data_type()));
+  }
+}
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/tensor_desc.cc
+++ b/paddle/fluid/framework/tensor_desc.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/framework/tensor_desc.h"
+#include <algorithm>
 #include <string>
 
 #include "glog/logging.h"
@@ -89,7 +90,14 @@ void SetTensorDescValue(proto::VarType::TensorDesc *tensor_desc,
       break;
     }
     case proto::VarType::INT64: {
-      auto &vec = ExtractTensorDescValue<std::vector<int64_t>>(val);
+      std::vector<int64_t> vec;
+      // NOTE(dev): value from python is type<int> which is int32.
+      if (val.type() == typeid(std::vector<int>)) {
+        auto vec_int = ExtractTensorDescValue<std::vector<int>>(val);
+        std::copy(vec_int.begin(), vec_int.end(), std::back_inserter(vec));
+      } else {
+        vec = ExtractTensorDescValue<std::vector<int64_t>>(val);
+      }
       VectorToRepeated(vec, tensor_desc->mutable_int64_val());
       break;
     }

--- a/paddle/fluid/framework/tensor_desc.h
+++ b/paddle/fluid/framework/tensor_desc.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <string>
+#include <vector>
+#include "paddle/fluid/framework/framework.pb.h"
+#include "paddle/fluid/framework/type_defs.h"
+
+#include "boost/variant/get.hpp"
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/errors.h"
+
+namespace paddle {
+namespace framework {
+
+template <typename T>
+const T& ExtractTensorDescValue(const TensorDescValue& desc_val) {
+  // PADDLE_ENFORCE_EQ(desc_val.type(), typeid(std::vector<T>),
+  //                   platform::errors::PreconditionNotMet(
+  //                       "Found mismatch type in ExtractTensorDescValue."));
+  return BOOST_GET_CONST(T, desc_val);
+}
+
+TensorDescValue GetTensorDescValue(
+    const proto::VarType::TensorDesc& tensor_desc);
+
+void SetTensorDescValue(proto::VarType::TensorDesc* tensor_desc,
+                        const TensorDescValue& val);
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/tensor_desc.h
+++ b/paddle/fluid/framework/tensor_desc.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #pragma once
-#include <string>
 #include <vector>
 #include "paddle/fluid/framework/framework.pb.h"
 #include "paddle/fluid/framework/type_defs.h"

--- a/paddle/fluid/framework/type_defs.h
+++ b/paddle/fluid/framework/type_defs.h
@@ -48,7 +48,7 @@ using Attribute = boost::variant<
 // The order should be as same as TensorDesc in framework.proto
 using TensorDescValue =
     boost::variant<boost::blank, std::vector<int>, std::vector<int64_t>,
-                   std::vector<float>, int64_t>;  // std::vector<std::string>>;
+                   std::vector<float>, std::vector<std::string>, int64_t>;
 
 using AttributeMap = std::unordered_map<std::string, Attribute>;
 

--- a/paddle/fluid/framework/type_defs.h
+++ b/paddle/fluid/framework/type_defs.h
@@ -45,6 +45,11 @@ using Attribute = boost::variant<
     std::vector<std::string>, bool, std::vector<bool>, BlockDesc*, int64_t,
     std::vector<BlockDesc*>, std::vector<int64_t>, std::vector<double>>;
 
+// The order should be as same as TensorDesc in framework.proto
+using TensorDescValue =
+    boost::variant<boost::blank, std::vector<int>, std::vector<int64_t>,
+                   std::vector<float>, int64_t>;  // std::vector<std::string>>;
+
 using AttributeMap = std::unordered_map<std::string, Attribute>;
 
 #ifdef PADDLE_WITH_ASCEND_CL

--- a/paddle/fluid/framework/var_desc.cc
+++ b/paddle/fluid/framework/var_desc.cc
@@ -135,8 +135,11 @@ TensorDescValue VarDesc::GetDescValue() const {
   return GetTensorDescValue(tensor_desc());
 }
 
-// bool VarDesc::HasDescValue() const { return tensor_desc().content_size() > 0;
-// }
+bool VarDesc::HasDescValue() const {
+  auto &desc = tensor_desc();
+  return desc.int32_val_size() > 0 || desc.int64_val_size() > 0 ||
+         desc.float_val_size() > 0 || desc.string_val_size() > 0;
+}
 
 void VarDesc::SetLoDLevel(int32_t lod_level) {
   switch (desc_.type().type()) {

--- a/paddle/fluid/framework/var_desc.cc
+++ b/paddle/fluid/framework/var_desc.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/var_desc.h"
 
 #include "glog/logging.h"
+#include "paddle/fluid/framework/tensor_desc.h"
 #include "paddle/fluid/platform/enforce.h"
 
 namespace paddle {
@@ -126,15 +127,16 @@ std::vector<proto::VarType::Type> VarDesc::GetDataTypes() const {
   return res;
 }
 
-void VarDesc::SetContent(const std::vector<int32_t> &val) {
-  VectorToRepeated(val, mutable_tensor_desc()->mutable_content());
+void VarDesc::SetDescValue(const TensorDescValue &val) {
+  SetTensorDescValue(mutable_tensor_desc(), val);
 }
 
-std::vector<int32_t> VarDesc::GetContent() const {
-  return RepeatedToVector(tensor_desc().content());
+TensorDescValue VarDesc::GetDescValue() const {
+  return GetTensorDescValue(tensor_desc());
 }
 
-bool VarDesc::HasContent() const { return tensor_desc().content_size() > 0; }
+// bool VarDesc::HasDescValue() const { return tensor_desc().content_size() > 0;
+// }
 
 void VarDesc::SetLoDLevel(int32_t lod_level) {
   switch (desc_.type().type()) {

--- a/paddle/fluid/framework/var_desc.cc
+++ b/paddle/fluid/framework/var_desc.cc
@@ -126,6 +126,16 @@ std::vector<proto::VarType::Type> VarDesc::GetDataTypes() const {
   return res;
 }
 
+void VarDesc::SetContent(const std::vector<int32_t> &val) {
+  VectorToRepeated(val, mutable_tensor_desc()->mutable_content());
+}
+
+std::vector<int32_t> VarDesc::GetContent() const {
+  return RepeatedToVector(tensor_desc().content());
+}
+
+bool VarDesc::HasContent() const { return tensor_desc().content_size() > 0; }
+
 void VarDesc::SetLoDLevel(int32_t lod_level) {
   switch (desc_.type().type()) {
     case proto::VarType::LOD_TENSOR:

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -110,6 +110,12 @@ class VarDesc {
 
   void SetType(proto::VarType::Type type);
 
+  void SetContent(const std::vector<int32_t> &val);
+
+  std::vector<int32_t> GetContent() const;
+
+  bool HasContent() const;
+
   bool Persistable() const { return desc_.persistable(); }
 
   void SetPersistable(bool persistable) { desc_.set_persistable(persistable); }

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -114,7 +114,7 @@ class VarDesc {
 
   TensorDescValue GetDescValue() const;
 
-  // bool HasDescValue() const;
+  bool HasDescValue() const;
 
   bool Persistable() const { return desc_.persistable(); }
 

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -110,11 +110,11 @@ class VarDesc {
 
   void SetType(proto::VarType::Type type);
 
-  void SetContent(const std::vector<int32_t> &val);
+  void SetDescValue(const TensorDescValue &val);
 
-  std::vector<int32_t> GetContent() const;
+  TensorDescValue GetDescValue() const;
 
-  bool HasContent() const;
+  // bool HasDescValue() const;
 
   bool Persistable() const { return desc_.persistable(); }
 

--- a/paddle/fluid/imperative/infer_shape_context.h
+++ b/paddle/fluid/imperative/infer_shape_context.h
@@ -216,13 +216,13 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
 
   // TODO(paddle-dev): Can this be template?
   std::vector<framework::InferShapeVarPtr> GetInputVarPtrs(
-      const std::string& name) override {
+      const std::string& name) const override {
     PADDLE_THROW(platform::errors::PermissionDenied(
         "GetInputVarPtrs not support in dygraph runtime context"));
   }
 
   std::vector<framework::InferShapeVarPtr> GetOutputVarPtrs(
-      const std::string& name) override {
+      const std::string& name) const override {
     PADDLE_THROW(platform::errors::PermissionDenied(
         "GetOutputVarPtrs not support in dygraph runtime context"));
   }

--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -79,7 +79,7 @@ if(WITH_UNITY_BUILD)
     include(unity_build_rule.cmake)
 endif()
 
-set(OP_HEADER_DEPS ${OP_HEADER_DEPS} pten pten_api_utils)
+set(OP_HEADER_DEPS ${OP_HEADER_DEPS} pten pten_api_utils tensor_desc)
 
 register_operators(EXCLUDES py_layer_op py_func_op warpctc_op dgc_op load_combine_op lstm_op run_program_op eye_op
         recurrent_op save_combine_op sparse_attention_op sync_batch_norm_op spectral_op cinn_launch_op ${OP_MKL_DEPS} DEPS ${OP_HEADER_DEPS})

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -83,8 +83,8 @@ class ReshapeOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_EQ(ctx->HasOutput("Out"), true,
                       platform::errors::InvalidArgument(
                           "Output(Out) of ReshapeOp should not be null."));
-    // TODO(Aurelius84): Do we only need deal complie time case?
-    if (HasCompiledContent(ctx, "ShapeTensor")) {
+    if (ctx->HasInputs("ShapeTensor")) {
+      if (ctx->IsRuntime()) return;
       // top prority shape
       auto ShapeTensor = ctx->Inputs("ShapeTensor");
       PADDLE_ENFORCE_GT(
@@ -94,6 +94,7 @@ class ReshapeOp : public framework::OperatorWithKernel {
               "which contains Tensor, the shape's size can't be zero. "
               "But received shape's size is %d.",
               ShapeTensor.size()));
+
       auto infer_shape =
           GetScalarsFromVarDescs<int>(ctx, "ShapeTensor", /*default_val=*/-1);
       const int64_t copy_dim_val = 0;

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -95,7 +95,7 @@ class ReshapeOp : public framework::OperatorWithKernel {
               "But received shape's size is %d.",
               ShapeTensor.size()));
       auto infer_shape =
-          GetScalarsFromVarDescs(ctx, "ShapeTensor", /*default_val=*/-1);
+          GetScalarsFromVarDescs<int>(ctx, "ShapeTensor", /*default_val=*/-1);
       const int64_t copy_dim_val = 0;
       auto in_dims = ctx->GetInputDim("X");
       for (size_t i = 0; i < infer_shape.size(); ++i) {
@@ -119,7 +119,7 @@ class ReshapeOp : public framework::OperatorWithKernel {
     if (ctx->HasInput("Shape") && shape.empty()) {
       std::vector<int32_t> vec_dims;
       if (HasCompiledContent(ctx, "Shape")) {
-        vec_dims = GetVecDataFromVarDesc(ctx, "Shape");
+        vec_dims = GetVecDataFromVarDesc<int>(ctx, "Shape");
       } else {
         vec_dims =
             std::vector<int>(framework::product(ctx->GetInputDim("Shape")), -1);

--- a/paddle/fluid/operators/top_k_v2_op.cc
+++ b/paddle/fluid/operators/top_k_v2_op.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/top_k_v2_op.h"
 #include <memory>
+#include "paddle/fluid/operators/utils.h"
 
 namespace paddle {
 namespace operators {
@@ -38,10 +39,9 @@ class TopkV2Op : public framework::OperatorWithKernel {
 
     if (axis < 0) axis += dim_size;
 
-    int k;
-    auto k_is_tensor = ctx->HasInput("K");
-    if (k_is_tensor) {
-      k = -1;
+    int k = -1;
+    if (HasCompiledContent(ctx, "K")) {
+      k = GetScalarDataFromVarDesc(ctx, "K");
     } else {
       k = static_cast<int>(ctx->Attrs().Get<int>("k"));
       PADDLE_ENFORCE_EQ(k >= 1, true,

--- a/paddle/fluid/operators/top_k_v2_op.cc
+++ b/paddle/fluid/operators/top_k_v2_op.cc
@@ -40,8 +40,11 @@ class TopkV2Op : public framework::OperatorWithKernel {
     if (axis < 0) axis += dim_size;
 
     int k = -1;
-    if (HasCompiledContent(ctx, "K")) {
-      k = GetScalarDataFromVarDesc<int>(ctx, "K");
+    if (ctx->HasInput("K")) {
+      if (HasCompiledContent(ctx, "K")) {
+        k = GetScalarDataFromVarDesc<int>(ctx, "K");
+        VLOG(1) << "k tensor " << k;
+      }
     } else {
       k = static_cast<int>(ctx->Attrs().Get<int>("k"));
       PADDLE_ENFORCE_EQ(k >= 1, true,
@@ -64,7 +67,7 @@ class TopkV2Op : public framework::OperatorWithKernel {
     }
 
     framework::DDim dims = input_dims;
-
+    VLOG(1) << "k " << k;
     dims[axis] = k;
     ctx->SetOutputDim("Out", dims);
     ctx->SetOutputDim("Indices", dims);

--- a/paddle/fluid/operators/top_k_v2_op.cc
+++ b/paddle/fluid/operators/top_k_v2_op.cc
@@ -41,7 +41,7 @@ class TopkV2Op : public framework::OperatorWithKernel {
 
     int k = -1;
     if (HasCompiledContent(ctx, "K")) {
-      k = GetScalarDataFromVarDesc(ctx, "K");
+      k = GetScalarDataFromVarDesc<int>(ctx, "K");
     } else {
       k = static_cast<int>(ctx->Attrs().Get<int>("k"));
       PADDLE_ENFORCE_EQ(k >= 1, true,

--- a/paddle/fluid/operators/utils.h
+++ b/paddle/fluid/operators/utils.h
@@ -74,7 +74,7 @@ inline std::vector<T> GetScalarsFromVarDescs(framework::InferShapeContext* ctx,
 inline bool HasCompiledContent(const framework::InferShapeContext* ctx,
                                const std::string& name) {
   bool flag = false;
-  if (!ctx->IsRuntime() && ctx->HasInput(name)) {
+  if (!ctx->IsRuntime()) {
     auto var_descs = ctx->GetInputVarPtrs(name);
     if (!var_descs.empty()) {
       flag = std::any_of(

--- a/paddle/fluid/operators/utils.h
+++ b/paddle/fluid/operators/utils.h
@@ -75,7 +75,7 @@ inline bool HasCompiledContent(const framework::InferShapeContext* ctx,
     if (!var_descs.empty()) {
       flag = std::any_of(
           var_descs.begin(), var_descs.end(),
-          [](const framework::InferShapeVarPtr& var_ptr) {
+          [](framework::InferShapeVarPtr& var_ptr) {
             return BOOST_GET(framework::VarDesc*, var_ptr)->HasContent();
           });
     }

--- a/paddle/fluid/operators/utils.h
+++ b/paddle/fluid/operators/utils.h
@@ -77,13 +77,11 @@ inline bool HasCompiledContent(const framework::InferShapeContext* ctx,
   if (!ctx->IsRuntime() && ctx->HasInput(name)) {
     auto var_descs = ctx->GetInputVarPtrs(name);
     if (!var_descs.empty()) {
-      flag = std::any_of(var_descs.begin(), var_descs.end(),
-                         [](framework::InferShapeVarPtr& var_ptr) {
-                           // FIXME(Aurelius84): return
-                           // BOOST_GET(framework::VarDesc*,
-                           // var_ptr)->HasContent();
-                           return true;
-                         });
+      flag = std::any_of(
+          var_descs.begin(), var_descs.end(),
+          [](framework::InferShapeVarPtr& var_ptr) {
+            return BOOST_GET(framework::VarDesc*, var_ptr)->HasDescValue();
+          });
     }
   }
   return flag;

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -171,6 +171,9 @@ void BindVarDsec(pybind11::module *m) {
       .def("set_shape", &pd::VarDesc::SetShape)
       .def("set_shapes", &pd::VarDesc::SetShapes)
       .def("get_shape", &pd::VarDesc::GetShape)
+      .def("set_content", &pd::VarDesc::SetContent)
+      .def("get_content", &pd::VarDesc::GetContent)
+      .def("has_content", &pd::VarDesc::HasContent)
       .def("set_dtype", &pd::VarDesc::SetDataType)
       .def("set_dtypes", &pd::VarDesc::SetDataTypes)
       .def("shape", &pd::VarDesc::GetShape,

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -171,9 +171,8 @@ void BindVarDsec(pybind11::module *m) {
       .def("set_shape", &pd::VarDesc::SetShape)
       .def("set_shapes", &pd::VarDesc::SetShapes)
       .def("get_shape", &pd::VarDesc::GetShape)
-      .def("set_content", &pd::VarDesc::SetContent)
-      .def("get_content", &pd::VarDesc::GetContent)
-      .def("has_content", &pd::VarDesc::HasContent)
+      .def("set_desc_value", &pd::VarDesc::SetDescValue)
+      .def("get_desc_value", &pd::VarDesc::GetDescValue)
       .def("set_dtype", &pd::VarDesc::SetDataType)
       .def("set_dtypes", &pd::VarDesc::SetDataTypes)
       .def("shape", &pd::VarDesc::GetShape,

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -173,6 +173,7 @@ void BindVarDsec(pybind11::module *m) {
       .def("get_shape", &pd::VarDesc::GetShape)
       .def("set_desc_value", &pd::VarDesc::SetDescValue)
       .def("get_desc_value", &pd::VarDesc::GetDescValue)
+      .def("has_desc_value", &pd::VarDesc::HasDescValue)
       .def("set_dtype", &pd::VarDesc::SetDataType)
       .def("set_dtypes", &pd::VarDesc::SetDataTypes)
       .def("shape", &pd::VarDesc::GetShape,

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11428,6 +11428,7 @@ def shape(input):
     ], 'shape')
     helper = LayerHelper('shape', **locals())
     out = helper.create_variable_for_type_inference(dtype='int32')
+    out.desc.set_content(input.shape)
     helper.append_op(
         type='shape',
         inputs={'Input': input},

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11428,7 +11428,7 @@ def shape(input):
     ], 'shape')
     helper = LayerHelper('shape', **locals())
     out = helper.create_variable_for_type_inference(dtype='int32')
-    out.desc.set_content(input.shape)
+    out.desc.set_desc_value(input.shape)
     helper.append_op(
         type='shape',
         inputs={'Input': input},

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -354,7 +354,8 @@ def _convert_to_tensor_list(old_list, dtype="int32"):
             assert isinstance(ele, six.integer_types)
             temp_out = fill_constant([1], dtype, ele, force_cpu=True)
             # TODO(Aurelius84): consider to move it into fill_constant
-            temp_out.desc.set_desc_value([ele])
+            if hasattr(temp_out, 'desc'):
+                temp_out.desc.set_desc_value([ele])
             new_list_tensor.append(temp_out)
     return new_list_tensor
 

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -354,7 +354,7 @@ def _convert_to_tensor_list(old_list, dtype="int32"):
             assert isinstance(ele, six.integer_types)
             temp_out = fill_constant([1], dtype, ele, force_cpu=True)
             # TODO(Aurelius84): consider to move it into fill_constant
-            temp_out.desc.set_content([ele])
+            temp_out.desc.set_desc_value([ele])
             new_list_tensor.append(temp_out)
     return new_list_tensor
 

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -353,6 +353,8 @@ def _convert_to_tensor_list(old_list, dtype="int32"):
         else:
             assert isinstance(ele, six.integer_types)
             temp_out = fill_constant([1], dtype, ele, force_cpu=True)
+            # TODO(Aurelius84): consider to move it into fill_constant
+            temp_out.desc.set_content([ele])
             new_list_tensor.append(temp_out)
     return new_list_tensor
 

--- a/python/paddle/fluid/tests/unittests/test_tensor_desc.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_desc.py
@@ -22,7 +22,7 @@ class TestTopk(unittest.TestCase):
         self.k = 2
 
     def test_compile_infer(self):
-        k = paddle.full([1], fill_value=self.k, dtype='int64')
+        k = paddle.full([1], fill_value=self.k, dtype='int32')
         k.desc.set_desc_value([self.k])
         out, _ = paddle.topk(self.x, k)
         self.assertEqual(out.shape[0], self.k)
@@ -36,7 +36,7 @@ class TestReshape(unittest.TestCase):
     def test_compile_infer(self):
         shape = paddle.shape(self.x)
         out = paddle.reshape(self.x, shape)
-        self.assertEqual(shape.desc.get_content(), list(self.shape))
+        self.assertEqual(shape.desc.get_desc_value(), list(self.shape))
         self.assertEqual(out.shape, self.shape)
 
 

--- a/python/paddle/fluid/tests/unittests/test_tensor_desc.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_desc.py
@@ -23,7 +23,7 @@ class TestTopk(unittest.TestCase):
 
     def test_compile_infer(self):
         k = paddle.full([1], fill_value=self.k, dtype='int64')
-        k.desc.set_content([self.k])
+        k.desc.set_desc_value([self.k])
         out, _ = paddle.topk(self.x, k)
         self.assertEqual(out.shape[0], self.k)
 

--- a/python/paddle/fluid/tests/unittests/test_tensor_desc.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_desc.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import unittest
+
+
+class TestTopk(unittest.TestCase):
+    def setUp(self):
+        self.x = paddle.randn([10])
+        self.k = 2
+
+    def test_compile_infer(self):
+        k = paddle.full([1], fill_value=self.k, dtype='int64')
+        k.desc.set_content([self.k])
+        out, _ = paddle.topk(self.x, k)
+        self.assertEqual(out.shape[0], self.k)
+
+
+class TestReshape(unittest.TestCase):
+    def setUp(self):
+        self.shape = (2, 3, 4)
+        self.x = paddle.randn(self.shape)
+
+    def test_compile_infer(self):
+        shape = paddle.shape(self.x)
+        out = paddle.reshape(self.x, shape)
+        self.assertEqual(shape.desc.get_content(), list(self.shape))
+        self.assertEqual(out.shape, self.shape)
+
+
+if __name__ == "__main__":
+    paddle.enable_static()
+    unittest.main()

--- a/tools/static_mode_white_list.py
+++ b/tools/static_mode_white_list.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 STATIC_MODE_TESTING_LIST = [
+    'test_tensor_desc',
     'test_affine_channel_op',
     'test_transfer_dtype_op',
     'test_transfer_layout_op',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

Support TensorDesc.Content in CompileTime

![image](https://user-images.githubusercontent.com/9301846/145542628-36a63558-d522-460e-8f49-64c49d17b309.png)


```python
class TestTopk(unittest.TestCase):
    def setUp(self):
        self.x = paddle.randn([10])
        self.k = 2

    def test_compile_infer(self):
        k = paddle.full([1], fill_value=self.k, dtype='int64')
        k.desc.set_content([self.k])
        out, _ = paddle.topk(self.x, k)
        self.assertEqual(out.shape[0], self.k)


class TestReshape(unittest.TestCase):
    def setUp(self):
        self.shape = (2, 3, 4)
        self.x = paddle.randn(self.shape)

    def test_compile_infer(self):
        shape = paddle.shape(self.x)
        out = paddle.reshape(self.x, shape)
        self.assertEqual(shape.desc.get_content(), list(self.shape))
        self.assertEqual(out.shape, self.shape)

```
