### PR TITLE
put back test_imperative_optimizer

### DIFF
--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -91,6 +91,7 @@ disable_wingpu_test="^test_model$|\
 ^test_activation_op$|\
 ^test_norm_nn_grad$|\
 ^test_bilinear_interp_op$|\
+^test_imperative_optimizer$|\
 ^test_imperative_optimizer_v2$|\
 ^disable_wingpu_test$"
 
@@ -145,6 +146,7 @@ disable_wincpu_test="^jit_kernel_test$|\
 ^test_resnet_v2$|\
 ^test_build_strategy$|\
 ^test_se_resnet$|\
+^test_imperative_optimizer$|\
 ^disable_wincpu_test$"
 
 # these unittest that cost long time, diabled temporarily, Maybe moved to the night
@@ -184,7 +186,6 @@ long_time_test="^test_gru_op$|\
 ^test_sgd_op$|\
 ^test_transformer$|\
 ^test_imperative_auto_mixed_precision$|\
-^test_imperative_optimizer_v2$|\
 ^test_trt_matmul_quant_dequant$|\
 ^test_strided_slice_op$"
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
put back test_imperative_optimizer long_time_test since it often failed