### PR TITLE
fix LoDTensorArray crash in Debug mode build

### DIFF
--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -37,6 +37,9 @@ PADDLE_DEFINE_EXPORTED_bool(
     "If set true, the queue.pop will only get data from queue but not "
     "remove the data from queue for speed testing");
 
+// disable auto conversion to list in Python
+PYBIND11_MAKE_OPAQUE(paddle::framework::LoDTensorArray);
+
 namespace paddle {
 namespace pybind {
 

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -273,6 +273,8 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
             else:
                 if self._return_list:
                     data = self._reader.read_next_list()
+                    for i in range(len(data)):
+                        data[i] = data[i]._move_to_list()
                     data = [
                         _restore_batch(d, s)
                         for d, s in zip(data, self._structure_infos[:len(
@@ -718,6 +720,8 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
             else:
                 if self._return_list:
                     data = self._reader.read_next_list()
+                    for i in range(len(data)):
+                        data[i] = data[i]._move_to_list()
                     data = [
                         _restore_batch(d, s)
                         for d, s in zip(data, self._structure_infos[:len(

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -1254,7 +1254,10 @@ class GeneratorLoader(DataLoaderBase):
     def __next__(self):
         try:
             if self._return_list:
-                return self._reader.read_next_list()
+                data = self._reader.read_next_list()
+                for i in range(len(data)):
+                    data[i] = data[i]._move_to_list()
+                return data
             else:
                 return self._reader.read_next()
         except StopIteration:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe

Paddle中 LoDTensorArray 实际为 std::vector`<LoDTensor>` ，Pybind11针对stl容器提供自动转换功能，std::vector`<LoDTensor>`自动转换为List[LoDTensor]；通过bind前添加PYBIND11_MAKE_OPAQUE(paddle::framework::LoDTensorArray)避免自动转换。

现有实现中：
pybind.cc中，bind前通过添加PYBIND11_MAKE_OPAQUE，避免自动转换为Python的List，Python层LoDTensorArray相关的功能基于此(LoDTensorArray不是Python List)完成。

reader_py.cc中，bind也有使用std::vector<`framework::LoDTensor`>，且在bind前没有添加PYBIND11_MAKE_OPAQUE，所以接口中会自动转换为List。

这样在Python层两者一起使用会造成不一致的情况，进而导致Debug Mode下参数传递问题。

为修复这种不一致，可以在reader_py.cc中添加PYBIND11_MAKE_OPAQUE，但这会产生副作用，即reader_py.cc中也有bind接口是期望自动转换的：`MultiDeviceFeedReader::ResultList()`，所以随着PYBIND11_MAKE_OPAQUE的添加，同时需要在Python层对期望得到List的调用进行LoDTensorArray对象的手动_move_to_list()调用，这样能够保持LoDTensorArray使用的一致性，同时也可以显式转换避免问题。

相关：https://github.com/PaddlePaddle/Paddle/pull/37387  #32252 #24863