### PR TITLE
[Demo] Custom Kernel for Paddle, test=develop

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -433,11 +433,12 @@ message(STATUS "branch: ${PADDLE_BRANCH}")
 configure_file(commit.h.in commit.h)
 
 cc_library(custom_operator SRCS custom_operator.cc DEPS tensor attribute framework_proto op_registry operator dynamic_loader string_helper pten_tensor op_meta_info pten_api)
+cc_library(custom_kernel SRCS custom_kernel.cc DEPS tensor attribute framework_proto op_registry operator dynamic_loader string_helper pten_tensor op_kernel_api pten_api)
 
 #cc_binary(test_executor SRCS test_executor.cc DEPS executor op_registry ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS} )
 #cc_binary(new_executor SRCS new_exec_test.cc DEPS operator op_registry executor ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS} profiler)
 
-set(FLUID_FRAMEWORK_MODULES proto_desc memory lod_tensor executor data_feed_proto layer dynamic_loader custom_operator)
+set(FLUID_FRAMEWORK_MODULES proto_desc memory lod_tensor executor data_feed_proto layer dynamic_loader custom_operator custom_kernel)
 
 cc_library(paddle_framework DEPS ${FLUID_FRAMEWORK_MODULES})
 

--- a/paddle/fluid/framework/custom_kernel.cc
+++ b/paddle/fluid/framework/custom_kernel.cc
@@ -1,0 +1,147 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/framework/custom_kernel.h"  // todo
+#include "paddle/fluid/framework/op_kernel_api_helper.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/platform/dynload/dynamic_loader.h"
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/pten/api/ext/op_kernel_api.h"
+
+namespace paddle {
+namespace framework {
+
+// // custom op kernel call function define
+// static void RunOpKernelFunc(const framework::ExecutionContext& ctx,
+//                           const OpKernelFunc& func) {
+//   VLOG(1) << "Custom Operator: Run ComputeFunc.";
+//   try {
+//     func(reinterpret_cast<PD_ExecutionContext*>(const_cast<ExecutionContext*>(&ctx)));
+//   } catch (platform::EnforceNotMet& exception) {
+//     throw std::move(exception);
+//   } catch (std::exception& ex) {
+//     PADDLE_THROW(platform::errors::External("%s", ex.what()));
+//   } catch (...) {
+//     PADDLE_THROW(platform::errors::Fatal(
+//         "Custom operator raises an unknown exception in rumtime."));
+//   }
+// }
+
+// void CustomerKernelBuilder::ResigterCustomKernel(const OpKernelFunc& func) {
+//   std::string op_type = name_;
+//   std::string library_type = "CPU";
+//   std::string data_layout = "ANYLAYOUT";
+//   paddle::framework::OpKernelType
+//   key(paddle::framework::proto::VarType::FP32, paddle::platform::CPUPlace(),
+//                    paddle::framework::StringToDataLayout(data_layout),
+//                    paddle::framework::StringToLibraryType(library_type.c_str()));
+//   // paddle::framework::OperatorWithKernel::AllOpKernels()[op_type][key] =
+//   builder->compute_function;
+//   VLOG(1) << "Custom Kernel: op kernel key: " << key;
+//   OperatorWithKernel::AllOpKernels()[op_type][key] =
+//       [func](const framework::ExecutionContext& ctx) {
+//         VLOG(1) << "Custom Kernel: run custom kernel func in lambda.";
+//         RunOpKernelFunc(ctx, func);
+//       };
+// }
+
+////////////////////// User APIs ///////////////////////
+
+namespace detail {
+
+// dynamic lib load func
+template <typename T>
+static T* DynLoad(void* handle, std::string name) {
+  T* func = reinterpret_cast<T*>(dlsym(handle, name.c_str()));
+#if !defined(_WIN32)
+  auto errorno = dlerror();
+#else
+  auto errorno = GetLastError();
+#endif  // !_WIN32
+  PADDLE_ENFORCE_NOT_NULL(
+      func, platform::errors::NotFound(
+                "Failed to load dynamic operator library, error message(%s).",
+                errorno));
+  return func;
+}
+
+}  // namespace detail
+
+// custom op kernel call function define
+static void RunOpKernelFunc(const framework::ExecutionContext& ctx,
+                            const OpKernelFunc& func) {
+  std::cout << "Custom Kernel: Run ComputeFunc." << std::endl;
+  try {
+    func(reinterpret_cast<PD_ExecutionContext*>(
+        const_cast<ExecutionContext*>(&ctx)));
+  } catch (platform::EnforceNotMet& exception) {
+    throw std::move(exception);
+  } catch (std::exception& ex) {
+    PADDLE_THROW(platform::errors::External("%s", ex.what()));
+  } catch (...) {
+    PADDLE_THROW(platform::errors::Fatal(
+        "Custom kernel raises an unknown exception in rumtime."));
+  }
+}
+
+void RegisterKernelWithMetaInfo(
+    const std::vector<OpKernelInfo>& op_meta_infos) {
+  auto& base_op_meta = op_meta_infos.front();
+
+  auto op_name = OpKernelInfoHelper::GetOpName(base_op_meta);
+  auto& kernel_fn = OpKernelInfoHelper::GetKernelFn(base_op_meta);
+
+  std::string library_type = "PLAIN";
+  std::string data_layout = "ANYLAYOUT";
+  paddle::framework::OpKernelType key(
+      paddle::framework::proto::VarType::INT64, paddle::platform::CPUPlace(),
+      paddle::framework::StringToDataLayout(data_layout),
+      paddle::framework::StringToLibraryType(library_type.c_str()));
+  OperatorWithKernel::AllOpKernels()[op_name][key] =
+      [kernel_fn](const framework::ExecutionContext& ctx) {
+        std::cout << "Custom Kernel: run custom kernel func in lambda."
+                  << std::endl;
+        RunOpKernelFunc(ctx, kernel_fn);
+      };
+}
+
+void RegisterKernelWithMetaInfoMap(
+    const paddle::OpKernelInfoMap& op_meta_info_map) {
+  auto& meta_info_map = op_meta_info_map.GetMap();
+  std::cout << "Custom Kernel: size of op meta info map - "
+            << meta_info_map.size() << std::endl;
+  // pair: {op_type, OpMetaInfo}
+  for (auto& pair : meta_info_map) {
+    std::cout << "Custom Kernel: pair first -> op name: " << pair.first
+              << std::endl;
+    RegisterKernelWithMetaInfo(pair.second);
+  }
+}
+
+// load kernel api
+// typedef void (*PDKernelInitFn)();
+void LoadCustomKernel(const std::string& dso_name) {
+  void* handle = paddle::platform::dynload::GetOpDsoHandle(dso_name);
+  std::cout << "load custom_op lib: " << dso_name << std::endl;
+  typedef OpKernelInfoMap& get_op_meta_info_map_t();
+  auto* get_op_meta_info_map =
+      detail::DynLoad<get_op_meta_info_map_t>(handle, "PD_GetOpKernelInfoMap");
+  auto& op_meta_info_map = get_op_meta_info_map();
+
+  RegisterKernelWithMetaInfoMap(op_meta_info_map);
+}
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/custom_kernel.h
+++ b/paddle/fluid/framework/custom_kernel.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include "paddle/pten/api/ext/op_kernel_api.h"
+
+namespace paddle {
+namespace framework {
+
+// User api to load customer kernel dso
+void LoadCustomKernel(const std::string& dso_name);
+
+void RegisterKernelWithMetaInfoMap(
+    const paddle::OpKernelInfoMap& op_meta_info_map);
+
+void RegisterKernelWithMetaInfo(const std::vector<OpKernelInfo>& op_meta_infos);
+
+// class CustomerKernelBuilder {
+//  public:
+//   explicit CustomerKernelBuilder(std::string&& op_name, std::string&& place,
+//   std::string&& dtype) : name_(op_name), place_(place), dtype_(dtype) {}
+
+//   void ResigterCustomKernel(const OpKernelFunc& func);
+
+//  public:
+//   // 1. kernel desc
+//   std::string name_;
+//   std::string place_;
+//   std::string dtype_;
+// };
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/op_kernel_api_helper.h
+++ b/paddle/fluid/framework/op_kernel_api_helper.h
@@ -1,0 +1,36 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "paddle/pten/api/ext/op_kernel_api.h"
+
+namespace paddle {
+namespace framework {
+
+class OpKernelInfoHelper {
+ public:
+  static const std::string& GetOpName(const paddle::OpKernelInfo& info) {
+    return info.name_;
+  }
+  static const OpKernelFunc& GetKernelFn(const paddle::OpKernelInfo& info) {
+    return info.kernel_fn_;
+  }
+};
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/inference/api/CMakeLists.txt
+++ b/paddle/fluid/inference/api/CMakeLists.txt
@@ -32,10 +32,10 @@ cc_library(paddle_pass_builder SRCS paddle_pass_builder.cc)
 
 if(WITH_CRYPTO)
     cc_library(paddle_inference_api SRCS api.cc api_impl.cc helper.cc DEPS lod_tensor scope reset_tensor_array 
-              analysis_config paddle_infer_contrib zero_copy_tensor trainer_desc_proto paddle_crypto custom_operator)
+              analysis_config paddle_infer_contrib zero_copy_tensor trainer_desc_proto paddle_crypto custom_operator custom_kernel)
 else()
     cc_library(paddle_inference_api SRCS api.cc api_impl.cc helper.cc DEPS lod_tensor scope reset_tensor_array 
-              analysis_config paddle_infer_contrib zero_copy_tensor trainer_desc_proto custom_operator)
+              analysis_config paddle_infer_contrib zero_copy_tensor trainer_desc_proto custom_operator custom_kernel)
 endif()
 
 if(WIN32)

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -2,7 +2,7 @@ set(PYBIND_DEPS pybind python proto_desc memory executor fleet_wrapper box_wrapp
   feed_fetch_method pass generate_pass pass_builder parallel_executor profiler layer tracer engine scope_pool
   analysis_predictor imperative_profiler imperative_flag save_load_util dlpack_tensor device_context
   gloo_wrapper infer_io_utils heter_wrapper generator op_version_registry ps_gpu_wrapper custom_operator
-  cost_model cuda_graph_with_memory_pool fleet_executor)
+  custom_kernel cost_model cuda_graph_with_memory_pool fleet_executor)
 
 if (WITH_PSCORE)
   set(PYBIND_DEPS ${PYBIND_DEPS} ps_service)

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -28,6 +28,7 @@ limitations under the License. */
 #include <utility>
 #include <vector>
 
+#include "paddle/fluid/framework/custom_kernel.h"
 #include "paddle/fluid/framework/custom_operator.h"
 #include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/data_type_transform.h"
@@ -2191,6 +2192,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("init_glog", framework::InitGLOG);
   m.def("load_op_meta_info_and_register_op",
         framework::LoadOpMetaInfoAndRegisterOp);
+  m.def("load_custom_kernel", framework::LoadCustomKernel);
   m.def("init_devices", []() { framework::InitDevices(); });
 
   m.def("is_compiled_with_cuda", IsCompiledWithCUDA);

--- a/paddle/pten/api/ext/op_kernel_api.h
+++ b/paddle/pten/api/ext/op_kernel_api.h
@@ -1,0 +1,119 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "paddle/pten/api/ext/dll_decl.h"
+#include "paddle/pten/api/ext/exception.h"
+#include "paddle/pten/api/ext/op_meta_info.h"
+#include "paddle/pten/api/include/tensor.h"
+#include "paddle/utils/any.h"
+
+namespace paddle {
+namespace framework {
+class PADDLE_API OpKernelInfoHelper;
+}  // namespace framework
+
+////////////////////// Kernel Function (PD_KERNEL) ////////////////////////
+typedef struct PD_KernelBuilder PD_KernelBuilder;
+typedef struct PD_ExecutionContext PD_ExecutionContext;
+
+using OpKernelFunc = void (*)(const PD_ExecutionContext*);
+
+////////////////////// Op Kernel Info //////////////////////
+class PADDLE_API OpKernelInfo {
+ public:
+  explicit OpKernelInfo(const std::string& op_name) : name_(op_name) {}
+
+  // format: PD_KERNEL(...)
+  OpKernelInfo& SetKernelFn(OpKernelFunc&& func);
+
+ private:
+  friend class framework::OpKernelInfoHelper;
+
+  // 1. desc info
+  std::string name_;
+  //   std::vector<std::string> inputs_;
+  //   std::vector<std::string> outputs_;
+  //   std::vector<std::string> attrs_;
+
+  // 2. func info
+  OpKernelFunc kernel_fn_{nullptr};
+  //   InferShapeFunc infer_shape_fn_{nullptr};
+  //   InferDtypeFunc infer_dtype_fn_{nullptr};
+};
+
+//////////////// Op Kernel Info Map /////////////////
+
+class PADDLE_API OpKernelInfoMap {
+ public:
+  // this function's impl should keep in header file.
+  // if move to cc file, meta info can not be added
+  // into map
+  static OpKernelInfoMap& Instance() {
+    static OpKernelInfoMap g_custom_kernel_info_map;
+    return g_custom_kernel_info_map;
+  }
+
+  std::vector<OpKernelInfo>& operator[](const std::string& name);
+
+  const std::unordered_map<std::string, std::vector<OpKernelInfo>>& GetMap()
+      const;
+
+ private:
+  OpKernelInfoMap() = default;
+  std::unordered_map<std::string, std::vector<OpKernelInfo>> map_;
+
+  PD_DISABLE_COPY_AND_ASSIGN(OpKernelInfoMap);
+};
+
+//////////////// Op Kernel Info Builder /////////////////
+
+class PADDLE_API OpKernelInfoBuilder {
+ public:
+  explicit OpKernelInfoBuilder(std::string&& name);
+  OpKernelInfoBuilder& SetKernelFn(OpKernelFunc func);
+
+ private:
+  // Forward Op name
+  std::string name_;
+  // ref current info ptr
+  OpKernelInfo* info_ptr_;
+};
+
+#define PD_BUILD_KERNEL(op_name)                                        \
+  STATIC_ASSERT_GLOBAL_NAMESPACE(                                       \
+      __reg_op__##op_name,                                              \
+      "PD_BUILD_KERNEL must be called in global namespace.");           \
+  static ::paddle::OpKernelInfoBuilder __op_kernel_info_##op_name##__ = \
+      ::paddle::OpKernelInfoBuilder(#op_name)
+
+}  // namespace paddle
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+paddle::OpKernelInfoMap& PD_GetOpKernelInfoMap();
+
+PADDLE_API int PD_NumInputs(const paddle::PD_ExecutionContext* ctx);
+
+#ifdef __cplusplus
+}  // end extern "C"
+#endif

--- a/paddle/pten/api/lib/CMakeLists.txt
+++ b/paddle/pten/api/lib/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 cc_library(kernel_dispatch SRCS kernel_dispatch.cc DEPS pten_tensor device_context kernel_factory)
 
 cc_library(op_meta_info SRCS op_meta_info.cc DEPS pten_tensor)
+cc_library(op_kernel_api SRCS op_kernel_api.cc DEPS pten_tensor)
 
 set(api_gen_file ${CMAKE_SOURCE_DIR}/python/paddle/utils/code_gen/api_gen.py)
 set(api_yaml_file ${CMAKE_SOURCE_DIR}/python/paddle/utils/code_gen/api.yaml)

--- a/paddle/pten/api/lib/op_kernel_api.cc
+++ b/paddle/pten/api/lib/op_kernel_api.cc
@@ -1,0 +1,76 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/pten/api/ext/op_kernel_api.h"
+#include "paddle/fluid/framework/custom_kernel.h"  // todo
+#include "paddle/fluid/framework/operator.h"
+
+namespace paddle {
+
+////////////////////// Op Kernel Info //////////////////////
+
+OpKernelInfo& OpKernelInfo::SetKernelFn(OpKernelFunc&& func) {
+  kernel_fn_ = std::forward<OpKernelFunc>(func);
+  return *this;
+}
+
+//////////////// Op Kernel Info Map /////////////////
+
+std::vector<OpKernelInfo>& OpKernelInfoMap::operator[](
+    const std::string& name) {
+  return map_[name];
+}
+
+const std::unordered_map<std::string, std::vector<OpKernelInfo>>&
+OpKernelInfoMap::GetMap() const {
+  return map_;
+}
+
+//////////////// Op Kernel Info Builder /////////////////
+
+OpKernelInfoBuilder::OpKernelInfoBuilder(std::string&& name) {
+  // 1. member assign
+  name_ = std::forward<std::string>(name);
+  // 2. check and meta info build
+  auto& info_vector = OpKernelInfoMap::Instance()[name_];
+
+  auto op_meta = OpKernelInfo(name_);
+  info_vector.emplace_back(std::move(op_meta));
+  // 3. get current info ptr
+  info_ptr_ = &(info_vector.back());
+}
+
+OpKernelInfoBuilder& OpKernelInfoBuilder::SetKernelFn(OpKernelFunc func) {
+  info_ptr_->SetKernelFn(std::forward<OpKernelFunc>(func));
+  return *this;
+}
+
+/////////////////////// Op register API /////////////////////////
+
+}  // namespace paddle
+
+// C-API to get global OpKernelInfoMap.
+paddle::OpKernelInfoMap& PD_GetOpKernelInfoMap() {
+  return paddle::OpKernelInfoMap::Instance();
+}
+
+int PD_NumInputs(const paddle::PD_ExecutionContext* ctx) {
+  auto* cc_ctx = reinterpret_cast<paddle::framework::ExecutionContext*>(
+      const_cast<paddle::PD_ExecutionContext*>(ctx));
+  auto innamelist = cc_ctx->InNameList();
+  for (auto& input : innamelist) {
+    std::cout << "PD_NumInputs: " << input << std::endl;
+  }
+  return static_cast<int>(innamelist.size());
+}

--- a/python/paddle/utils/cpp_extension/__init__.py
+++ b/python/paddle/utils/cpp_extension/__init__.py
@@ -21,6 +21,7 @@ from .cpp_extension import setup  # noqa: F401
 from .extension_utils import parse_op_info  # noqa: F401
 from .extension_utils import get_build_directory  # noqa: F401
 from .extension_utils import load_op_meta_info_and_register_op  # noqa: F401
+from .extension_utils import load_custom_kernel  # noqa: F401
 
 __all__ = [ #noqa
         'CppExtension',

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -127,6 +127,10 @@ def load_op_meta_info_and_register_op(lib_filename):
     return OpProtoHolder.instance().update_op_proto()
 
 
+def load_custom_kernel(lib_filename):
+    core.load_custom_kernel(lib_filename)
+
+
 def custom_write_stub(resource, pyfile):
     """
     Customized write_stub function to allow us to inject generated python


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

自定义Kernel的Demo代码，与目前自定义OP的主要区别在于，无需获取Paddle已有OP的定义和属性，注册一个已有OP的Kernel。

用户使用方式如下：

第一步：写一个`relu.cc` 文件，实现Compute函数，其中函数可以通过 `PD_NumInputs` 获取Paddle已有OP的输入tensor数了

```c++
#include <iostream>
#include "paddle/extension.h"
#include "paddle/pten/api/ext/op_kernel_api.h"

static void ReluOp_Compute(const paddle::PD_ExecutionContext* ctx) {
  int num = PD_NumInputs(ctx);
  std::cout << "input num = " << num << std::endl;
}

PD_BUILD_KERNEL(relu)
    .SetKernelFn(ReluOp_Compute);
```

第二步：编译得到 `relu.so`，编译命令如下，其中 -I/-L 地址通过pip show paddlepaddle得到，即为paddle whl包安装地址

```bash
g++ -std=c++14 -shared relu.cc -o relu.so -fPIC \
    -I/opt/conda/lib/python3.7/site-packages/paddle/include \
    -L/opt/conda/lib/python3.7/site-packages/paddle/fluid/ \
    -l:core_avx.so -O2 --verbose
```

第三步：加载自定义so，并运行，测试文件如下：

```python
import paddle
import paddle.nn.functional as F
import numpy as np

for k in paddle.fluid.core._get_all_register_op_kernels()["relu"]:
    print(k)

print('------------- above is origial kernels of relu ----------')

paddle.utils.cpp_extension.load_custom_kernel('/workspace/temp/paddle/cutsom_kernel/relu.so')

print('------------- below is new all kernels of relu ----------')

for k in paddle.fluid.core._get_all_register_op_kernels()["relu"]:
    print(k)

print('====================================')

x = paddle.to_tensor(np.array([-2, 0, 1]).astype('int64'))
out = F.relu(x) # [0., 0., 1.]
```

最后运行的到结果输出如下：


![image](https://user-images.githubusercontent.com/16605440/145194206-c94292c5-e09a-45d0-a8c1-6a122294fc44.png)
