### PR TITLE
[Dy2stat]Remove all comments of users code when dy2stat

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -549,7 +549,7 @@ def func_to_source_code(function, dedent=True):
             format(type(function).__name__))
     source_code_list, _ = inspect.getsourcelines(function)
     source_code_list = [
-        line for line in source_code_list if not line.startswith('#')
+        line for line in source_code_list if not line.lstrip().startswith('#')
     ]
     source_code = ''.join(source_code_list)
     if dedent:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -547,7 +547,11 @@ def func_to_source_code(function, dedent=True):
         raise TypeError(
             "The type of 'function' should be a function or method, but received {}.".
             format(type(function).__name__))
-    source_code = inspect.getsource(function)
+    source_code_list, _ = inspect.getsourcelines(function)
+    source_code_list = [
+        line for line in source_code_list if not line.startswith('#')
+    ]
+    source_code = ''.join(source_code_list)
     if dedent:
         source_code = textwrap.dedent(source_code)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
@@ -26,6 +26,7 @@ import paddle.fluid as fluid
 from paddle.fluid.dygraph.dygraph_to_static import ProgramTranslator
 from paddle.fluid.dygraph.jit import declarative
 from paddle.fluid.dygraph.nn import Linear
+from paddle.fluid.dygraph.dygraph_to_static.utils import func_to_source_code
 
 from ifelse_simple_func import dyfunc_with_if_else
 
@@ -342,6 +343,19 @@ class TestFunctionTrainEvalMode(unittest.TestCase):
         self.assertEqual(net.training, False)
         with self.assertRaises(RuntimeError):
             net.foo.train()
+
+
+class TestRemoveCommentInDy2St(unittest.TestCase):
+    def func_with_comment(self):
+        # Comment1
+        x = paddle.to_tensor([1, 2, 3])
+        # Comment2
+        # Comment3
+        y = paddle.to_tensor([4, 5, 6])
+
+    def test_remove_comment(self):
+        code_string = func_to_source_code(self.func_with_comment)
+        self.assertEqual('#' not in code_string, True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
动转静时，将函数中的注释行进行删除。
之前对下面的代码进行动转静转写时因为有函数体外的注释行，使用gast库进行func2ast转换时会导致出错，本PR之后将注释行（#开头的行）进行了删除，下面代码动转静不会出错。
```
    def forward(self, x):
        x = self.conv1(x)
        x = F.relu(x)
        x = self.max_pool1(x)
        x = self.max_pool2(x)
        # import pdb; pdb.set_trace()
        #x = paddle.flatten(x, start_axis=1,stop_axis=-1)
#         x = paddle.flatten(x, start_axis=1,stop_axis=-1)
        x = self.flatten(x)
        # x = self.linear1(x)
        return x
```