### PR TITLE
Fix int32 overflow in cuda kernel loop

### DIFF
--- a/paddle/fluid/operators/label_smooth_op.cu
+++ b/paddle/fluid/operators/label_smooth_op.cu
@@ -21,8 +21,7 @@ template <typename T>
 __global__ void LabelSmoothRunOriginKernel(const int N, const float epsilon,
                                            const int label_dim, const T* src,
                                            T* dst) {
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
-  for (; idx < N; idx += blockDim.x * gridDim.x) {
+  CUDA_KERNEL_LOOP(idx, N) {
     dst[idx] = static_cast<T>(1 - epsilon) * src[idx] +
                static_cast<T>(epsilon / label_dim);
   }
@@ -32,8 +31,7 @@ template <typename T>
 __global__ void LabelSmoothRunDistKernel(const int N, const float epsilon,
                                          const int dist_numel, const T* src,
                                          const T* dist_data, T* dst) {
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
-  for (; idx < N; idx += blockDim.x * gridDim.x) {
+  CUDA_KERNEL_LOOP(idx, N) {
     int dist_idx = idx % dist_numel;
     dst[idx] = static_cast<T>(1 - epsilon) * src[idx] +
                static_cast<T>(epsilon) * dist_data[dist_idx];
@@ -43,8 +41,7 @@ __global__ void LabelSmoothRunDistKernel(const int N, const float epsilon,
 template <typename T>
 __global__ void LabelSmoothGradRunKernel(const int N, const float epsilon,
                                          const T* src, T* dst) {
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
-  for (; idx < N; idx += blockDim.x * gridDim.x) {
+  CUDA_KERNEL_LOOP(idx, N) {
     dst[idx] = static_cast<T>(1 - epsilon) * src[idx];
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix int32 overflow in cuda kernel loop

Given 

> Op(label_smooth): Inputs: X{auto_241_[LoDTensor<float, CUDAPlace(0), (40, 128, 250027)>]},   Outputs: Out{auto_242_[LoDTensor<NOT_INITED>]}

a `cuda error 700` error may be raised:

<img width="940" alt="Srror Mostore Srmory" src="https://user-images.githubusercontent.com/6888866/145366240-1b9fd8ca-b4c9-4e6d-91d5-a621828d0953.png">
