### PR TITLE
fix dygraph_grad_maker to support the situation where inplace var is leaf var (by using set_value method)

### DIFF
--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -173,27 +173,11 @@ void BasicEngine::PrepareGradAccumulators(
     for (const auto& var : pair.second) {
       if (!var) continue;
 
-      if (!var->HasGradNode()) {
-        auto& accumulator = accumulators_[var.get()];
-        if (!accumulator) {
-          if (FLAGS_sort_sum_gradient) {
-            accumulator.reset(new SortedGradientAccumulator(var.get()));
-          } else {
-            accumulator.reset(new EagerGradientAccumulator(var.get()));
-          }
-        }
-
-        accumulator->IncreaseRefCnt();
-
-        VLOG(3) << "Prepare to acccumulate variable grad " << var->Name() << "("
-                << var.get()
-                << ") that don't have grad node  with reference count "
-                << accumulator->RefCnt();
-      } else {
+      bool find_grad_node_of_var = false;
+      if (var->HasGradNode()) {
         // Because Inplace op overwrites the grad_node of the input grad_var. So
         // only the information of grad_pending_node can be used to find the
         // grad_node of grad_var.
-        bool find_grad_node_of_var = false;
         for (auto& grad_pending_node : grad_pending_nodes) {
           PADDLE_ENFORCE_NOT_NULL(
               grad_pending_node,
@@ -245,11 +229,33 @@ void BasicEngine::PrepareGradAccumulators(
             break;
           }
         }
-        PADDLE_ENFORCE_EQ(
-            find_grad_node_of_var, true,
-            platform::errors::NotFound(
-                "No grad node corresponding to grad Tensor (%s) was found.",
-                var->Name()));
+        if (!find_grad_node_of_var) {
+          // Special case: `set_value` is inplace op, and it can change
+          // the var with `stop_gradient=True` to the var with
+          // `stop_gradient=False `.
+          // This inplace var has grad_node (the inplace op), but it
+          // isn't the input of grad_pending_op.
+          VLOG(6) << "No grad node corresponding to grad Tensor ("
+                  << var->Name() << ") was found.";
+        }
+      }
+
+      if (!var->HasGradNode() || !find_grad_node_of_var) {
+        auto& accumulator = accumulators_[var.get()];
+        if (!accumulator) {
+          if (FLAGS_sort_sum_gradient) {
+            accumulator.reset(new SortedGradientAccumulator(var.get()));
+          } else {
+            accumulator.reset(new EagerGradientAccumulator(var.get()));
+          }
+        }
+
+        accumulator->IncreaseRefCnt();
+
+        VLOG(3) << "Prepare to acccumulate variable grad " << var->Name() << "("
+                << var.get()
+                << ") that don't have grad node  with reference count "
+                << accumulator->RefCnt();
       }
     }
   }
@@ -435,16 +441,8 @@ void BasicEngine::Execute() {
           std::unordered_map<VariableWrapper*,
                              std::unique_ptr<GradientAccumulator>>::iterator
               iter;
-          if (!var->HasGradNode()) {
-            VLOG(10) << "Find gradient of var (" << var->Name()
-                     << ") with no grad_node.";
-            iter = accumulators_.find(var.get());
-            PADDLE_ENFORCE_EQ(
-                iter != accumulators_.end(), true,
-                platform::errors::NotFound(
-                    "Cannot find gradient of variable %s", var->Name()));
-          } else {
-            bool flag_find_grad = false;
+          bool flag_find_grad = false;
+          if (var->HasGradNode()) {
             VLOG(10) << "Find gradient of var (" << var->Name()
                      << ") with grad_node.";
             for (auto& grad_pending_node :
@@ -459,8 +457,16 @@ void BasicEngine::Execute() {
                 }
               }
             }
+            if (!flag_find_grad) {
+              VLOG(6) << "Cannot find gradient of variable " << var->Name();
+            }
+          }
+          if (!var->HasGradNode() || !flag_find_grad) {
+            VLOG(10) << "Find gradient of var (" << var->Name()
+                     << ") with no grad_node.";
+            iter = accumulators_.find(var.get());
             PADDLE_ENFORCE_EQ(
-                flag_find_grad, true,
+                iter != accumulators_.end(), true,
                 platform::errors::NotFound(
                     "Cannot find gradient of variable %s", var->Name()));
           }

--- a/paddle/fluid/imperative/dygraph_grad_maker.h
+++ b/paddle/fluid/imperative/dygraph_grad_maker.h
@@ -269,8 +269,14 @@ class TracedGradOp {
         for (auto& var : vars) {
           if (var && !var->OverridedStopGradient() && var->GradNode()) {
             if (map_dirty_grad_node_.find(var) != map_dirty_grad_node_.end()) {
+              // Because inplace var isn't a leaf var, it should have
+              // dirty_grad_node.
               node_->InsertGradPendingNode(map_dirty_grad_node_[var]);
-            } else {
+            } else if (node_ != var->GradNode()) {
+              // For non-inplace var.
+              // Special case: `set_value` is inplace op, and it can change
+              // the var with `stop_gradient=True` to the var with
+              // `stop_gradient=False`.
               node_->InsertGradPendingNode(var->GradNode());
             }
           }

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -1330,5 +1330,41 @@ class TestGradientTruncated(unittest.TestCase):
             array = array[0]
 
 
+class TestSetValueInplaceLeafVar(unittest.TestCase):
+    def test_inplace_var_become_leaf_var(self):
+        paddle.disable_static()
+
+        a_grad_1, b_grad_1, a_grad_2, b_grad_2 = 0, 1, 2, 3
+        with paddle.fluid.dygraph.guard():
+            paddle.seed(100)
+            a = paddle.rand(shape=[1, 4])
+            b = paddle.rand(shape=[1, 4])
+            a.stop_gradient = False
+            b.stop_gradient = False
+            c = a / b
+            c.sum().backward()
+            a_grad_1 = a.grad.numpy()
+            b_grad_1 = b.grad.numpy()
+
+        with paddle.fluid.dygraph.guard():
+            paddle.seed(100)
+            a = paddle.rand(shape=[1, 4])
+            b = paddle.rand(shape=[1, 4])
+            a.stop_gradient = False
+            b.stop_gradient = False
+            c = a / b
+            d = paddle.zeros((4, 4))
+            self.assertTrue(d.stop_gradient)
+            d[0, :] = c
+            self.assertFalse(d.stop_gradient)
+            d[0, :].sum().backward()
+            a_grad_2 = a.grad.numpy()
+            b_grad_2 = b.grad.numpy()
+
+        self.assertTrue(np.array_equal(a_grad_1, a_grad_2))
+        self.assertTrue(np.array_equal(b_grad_1, b_grad_2))
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->



#### 问题一：dygraph_grad_maker指定grad_pending_node的问题

stop_gradient=False的叶子节点本来是无法进行inplace操作的。但是set_value操作可以对stop_gradient=True的叶子节点进行inplace操作（set_value为inplace操作），且操作过程中，可以将set_value的tensor的stop_gradient变成False。等同于对stop_gradient=False的叶子节点进行了inplace操作，框架中没有相应的处理导致报错。

问题示例：
```python
import paddle

a = paddle.rand(shape=[1, 4])
b = paddle.rand(shape=[1, 4])
a.stop_gradient = False
b.stop_gradient = False

d = paddle.zeros((4, 4))  # d为叶子节点，其stop_gradient=True
print(d.stop_gradient)

d[0, :] = a / b  # 由于a和b的stop_gradient=False，在set_value操作后，d的stop_gradient值变为False
d[0, :].sum().backward()

print(a.grad)
# None
print(b.grad)
# None
```
问题：输出a和b的grad时，没有结果输出来。梯度在之前被截断了。


- 问题定位

**结论：在`dygraph_grad_maker.cc`中为`grad_node`设定`grad_pending_node`时出错。**

模拟上面set_value的问题：`x = inplace_op(x, y)`，也就是对`x`作inplace操作，且`x.stop_gradient=True`，`y.stop_gradient=False`。操作完后，`x.stop_gradient=False`，`y.stop_gradient=False`。

为了容易区分，我们将做inplace的输入和输出`x`加标志为`x1 = inplace_op(x0, y)`，其中`x0`与`x1`为同一个var。
那么在使用`dygraph_grad_maker.cc`创建其对应的grad_op时，公式为`grad_x0 = inplace_grad_op(x0, y, grad_x1)`，`grad_y = inplace_grad_op(x0, y, grad_x1)`。其中，`grad_y = inplace_grad_op(x0, y, grad_x1)`操作没有问题，`grad_x0 = inplace_grad_op(x0, y, grad_x1)`有问题，分析如下。

按照`dygraph_grad_maker.cc`中的逻辑，首先为`inplace_grad_op` SetInput，在该过程中，会指定`grad_x1->grad_node = inplace_grad_op`。
然后为`inplace_grad_op` SetOutput，在该过程中，会为`inplace_grad_op`指定`grad_pending_node`，即`inplace_grad_op->grad_pending_node = grad_x0->grad_node = grad_x1->grad_node = inplace_grad_op`（其中`grad_x0`与`grad_x1`为同一个var）。成环导致无法输出最终结果。

**实际上，在inplace操作中，我们已经为了防止反向网络成环，加入了`dirty_grad_node`来防止成环。但是，由于`set_value`操作会让叶子节点做inplace操作，`dirty_grad_node`不会对叶子节点生效，因此在这种特殊情况下，反向还是成环了。**


- 修复

在`dirty_grad_node`处理不了的情况下，直接不允许`grad_pending_node`与当前的`grad_node`相同，就避免成环了。




#### 问题二：basic_engine中处理stop_gradient=False的叶子节点

由于以前默认stop_gradient=False的叶子节点无法做inplace操作，因此用于梯度累加的`accumulators_with_grad_node_`并没有考虑该情况。

也就是说，原来的逻辑是：只要一个grad_var有grad_node，那么使用grad_var和对应的grad_pending_node作为key。对于stop_gradient=False的叶子inplace_grad_var，它有grad_node，所以本来应该使用`accumulators_with_grad_node_`来进行梯度累加的统计。但是，这个inplace_grad_var并不是其对应的grad_pending_node的输入，因为他是叶子节点，不是任何grad_op的输入。

在框架原来的逻辑中，对于这种grad_var不是grad_pending_node的输入的情况，会直接报错。

现在不报错了，而是特殊处理这种情况。在这种情况下，会将该inplace_var作为叶子节点，使用`accumulators_`来统计梯度累加信息。
