### PR TITLE
【PTen】Fix bug  of cmake when WITH_PYTHON=OFF

### DIFF
--- a/paddle/pten/api/lib/CMakeLists.txt
+++ b/paddle/pten/api/lib/CMakeLists.txt
@@ -22,6 +22,10 @@ set(api_source_file ${CMAKE_SOURCE_DIR}/paddle/pten/api/lib/api.cc)
 set(api_header_file_tmp ${api_header_file}.tmp)
 set(api_source_file_tmp ${api_source_file}.tmp)
 
+if (NOT PYTHON_EXECUTABLE)
+  find_package(PythonInterp REQUIRED)
+endif()
+
 add_custom_command(
   OUTPUT ${api_header_file} ${api_source_file}
   COMMAND ${PYTHON_EXECUTABLE} -m pip install pyyaml


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
![image](https://user-images.githubusercontent.com/13048366/145388756-dccb82e6-a6bc-485e-8bf5-90ce0df9d5e8.png)
修复cmake配置`WITH_PYTHON=OFF`时如图中所示的编译错误。
由于C++ API自动生成需要依赖Python脚本的执行，但`WITH_PYTHON`编译选项配置为OFF时，cmake无法找到Python可执行文件的路径，因此会抛出上述错误。本PR中增加了该场景下Python可执行文件路径的检测和处理。
