### PR TITLE
add new API: paddle.clone;Tensor.element_size;nn.utils.parameters_to_vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ if(WIN32)
         endforeach(flag_var)
     endif()
 
+    # NOTE(zhouwei): msvc max/min macro conflict with std::min/max, define NOMINMAX globally
+    add_definitions("-DNOMINMAX")
     # windows build turn off warnings, use parallel compiling.
     foreach(flag_var
         CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE

--- a/paddle/fluid/framework/var_desc.cc
+++ b/paddle/fluid/framework/var_desc.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/var_desc.h"
 
 #include "glog/logging.h"
+#include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/platform/enforce.h"
 
 namespace paddle {
@@ -114,6 +115,10 @@ void VarDesc::SetDataTypes(
 
 proto::VarType::Type VarDesc::GetDataType() const {
   return tensor_desc().data_type();
+}
+
+size_t VarDesc::ElementSize() const {
+  return framework::SizeOfType(GetDataType());
 }
 
 std::vector<proto::VarType::Type> VarDesc::GetDataTypes() const {

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -96,6 +96,8 @@ class VarDesc {
 
   proto::VarType::Type GetDataType() const;
 
+  size_t ElementSize() const;
+
   std::vector<proto::VarType::Type> GetDataTypes() const;
 
   void SetLoDLevel(int32_t lod_level);

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/framework/operator.h"
 #include "paddle/fluid/framework/type_defs.h"
 #include "paddle/fluid/framework/var_type.h"
@@ -37,7 +38,6 @@
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/macros.h"
 #include "paddle/pten/include/core.h"
-
 namespace paddle {
 namespace framework {
 class Variable;
@@ -211,6 +211,8 @@ class VarBase {
   }
 
   framework::proto::VarType::Type DataType() const { return var_->DataType(); }
+
+  size_t ElementSize() const { return framework::SizeOfType(var_->DataType()); }
 
   void SetForwardDataType(framework::proto::VarType::Type data_type) {
     var_->SetForwardDataType(data_type);

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -2013,6 +2013,29 @@ void BindImperative(py::module *m_ptr) {
              auto *t = self->MutableVar()->GetMutable<framework::LoDTensor>();
              return t->numel();
            })
+      .def("element_size", &imperative::VarBase::ElementSize, R"DOC(
+        Returns the size in bytes of an element in the Tensor.
+        
+        Examples:
+          .. code-block:: python
+
+            import paddle
+
+            x = paddle.to_tensor(1, dtype='bool')
+            x.element_size() # 1
+
+            x = paddle.to_tensor(1, dtype='float16')
+            x.element_size() # 2
+
+            x = paddle.to_tensor(1, dtype='float32')
+            x.element_size() # 4
+
+            x = paddle.to_tensor(1, dtype='float64')
+            x.element_size() # 8
+
+            x = paddle.to_tensor(1, dtype='complex128')
+            x.element_size() # 16
+       )DOC")
       .def_property("name", &imperative::VarBase::Name,
                     &imperative::VarBase::SetName)
       .def_property("stop_gradient",
@@ -2020,28 +2043,40 @@ void BindImperative(py::module *m_ptr) {
                     &imperative::VarBase::SetOverridedStopGradient)
       .def_property("persistable", &imperative::VarBase::Persistable,
                     &imperative::VarBase::SetPersistable)
-      .def_property_readonly(
-          "shape",
-          [](imperative::VarBase &self) {
-            if (self.Var().IsType<framework::LoDTensor>()) {
-              return framework::vectorize<int>(
-                  self.Var().Get<framework::LoDTensor>().dims());
-            } else if (self.Var().IsType<framework::SelectedRows>()) {
-              return framework::vectorize<int>(
-                  self.Var().Get<framework::SelectedRows>().value().dims());
-            } else if (self.Var().IsType<framework::Strings>()) {
-              return std::vector<int>{static_cast<int>(
-                  self.Var().Get<framework::Strings>().size())};
-            } else if (self.Var().IsType<framework::Vocab>()) {
-              return std::vector<int>{
-                  static_cast<int>(self.Var().Get<framework::Vocab>().size())};
-            } else {
-              VLOG(2) << "It is meaningless to get shape of "
-                         "variable type "
-                      << GetTypeName(self);
-              return std::vector<int>();
-            }
-          })
+      .def_property_readonly("shape",
+                             [](imperative::VarBase &self) {
+                               if (self.Var().IsType<framework::LoDTensor>()) {
+                                 return framework::vectorize<int>(
+                                     self.Var()
+                                         .Get<framework::LoDTensor>()
+                                         .dims());
+                               } else if (self.Var()
+                                              .IsType<
+                                                  framework::SelectedRows>()) {
+                                 return framework::vectorize<int>(
+                                     self.Var()
+                                         .Get<framework::SelectedRows>()
+                                         .value()
+                                         .dims());
+                               } else if (self.Var()
+                                              .IsType<framework::Strings>()) {
+                                 return std::vector<int>{static_cast<int>(
+                                     self.Var()
+                                         .Get<framework::Strings>()
+                                         .size())};
+                               } else if (self.Var()
+                                              .IsType<framework::Vocab>()) {
+                                 return std::vector<int>{static_cast<int>(
+                                     self.Var()
+                                         .Get<framework::Vocab>()
+                                         .size())};
+                               } else {
+                                 VLOG(2) << "It is meaningless to get shape of "
+                                            "variable type "
+                                         << GetTypeName(self);
+                                 return std::vector<int>();
+                               }
+                             })
       .def_property_readonly("is_leaf", &imperative::VarBase::IsLeaf,
                              R"DOC(
       Whether a Tensor is leaf Tensor.

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -179,6 +179,8 @@ void BindVarDsec(pybind11::module *m) {
            pybind11::return_value_policy::reference)
       .def("dtype", &pd::VarDesc::GetDataType,
            pybind11::return_value_policy::reference)
+      .def("element_size", &pd::VarDesc::ElementSize,
+           pybind11::return_value_policy::reference)
       .def("dtypes", &pd::VarDesc::GetDataTypes,
            pybind11::return_value_policy::reference)
       .def("lod_level", &pd::VarDesc::GetLoDLevel)

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -91,6 +91,7 @@ from .tensor.creation import empty  # noqa: F401
 from .tensor.creation import empty_like  # noqa: F401
 from .tensor.creation import assign  # noqa: F401
 from .tensor.creation import complex  # noqa: F401
+from .tensor.creation import clone  # noqa: F401
 from .tensor.linalg import matmul  # noqa: F401
 from .tensor.linalg import dot  # noqa: F401
 from .tensor.linalg import norm  # noqa: F401
@@ -587,4 +588,5 @@ __all__ = [  # noqa
            'fmin',
            'moveaxis',
            'repeat_interleave',
+           'clone',
 ]

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1396,6 +1396,33 @@ class Variable(object):
 
     __repr__ = __str__
 
+    def element_size(self):
+        """
+        Returns the size in bytes of an element in the Tensor.
+        
+        Examples:
+          .. code-block:: python
+
+            import paddle
+            paddle.enable_static()
+
+            x = paddle.static.data(name='x1', shape=[3, 2], dtype='bool')
+            x.element_size() # 1
+
+            x = paddle.static.data(name='x2', shape=[3, 2], dtype='int16')
+            x.element_size() # 2
+
+            x = paddle.static.data(name='x3', shape=[3, 2], dtype='float16')
+            x.element_size() # 2
+
+            x = paddle.static.data(name='x4', shape=[3, 2], dtype='float32')
+            x.element_size() # 4
+
+            x = paddle.static.data(name='x5', shape=[3, 2], dtype='float64')
+            x.element_size() # 8
+        """
+        return self.desc.element_size()
+
     @property
     def stop_gradient(self):
         """

--- a/python/paddle/fluid/tests/unittests/test_assign_op.py
+++ b/python/paddle/fluid/tests/unittests/test_assign_op.py
@@ -169,6 +169,31 @@ class TestAssignOApi(unittest.TestCase):
         self.assertTrue(np.allclose(result3.numpy(), np.array([1])))
         paddle.enable_static()
 
+    def test_clone(self):
+        paddle.disable_static()
+        x = paddle.ones([2])
+        x.stop_gradient = False
+        clone_x = paddle.clone(x)
+
+        y = clone_x**3
+        y.backward()
+
+        self.assertTrue(np.array_equal(x, [1, 1]), True)
+        self.assertTrue(np.array_equal(clone_x.grad.numpy(), [3, 3]), True)
+        self.assertTrue(np.array_equal(x.grad.numpy(), [3, 3]), True)
+        paddle.enable_static()
+
+        with program_guard(Program(), Program()):
+            x_np = np.random.randn(2, 3).astype('float32')
+            x = paddle.static.data("X", shape=[2, 3])
+            clone_x = paddle.clone(x)
+            exe = paddle.static.Executor()
+            y_np = exe.run(paddle.static.default_main_program(),
+                           feed={'X': x_np},
+                           fetch_list=[clone_x])[0]
+
+        self.assertTrue(np.array_equal(y_np, x_np), True)
+
 
 class TestAssignOpErrorApi(unittest.TestCase):
     def test_errors(self):

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -18,18 +18,19 @@ import unittest
 import copy
 import paddle
 from paddle.fluid.dygraph import guard
-from paddle.fluid.framework import default_main_program
+from paddle.fluid.framework import default_main_program, Variable
 import paddle.fluid.core as core
 from paddle.fluid.executor import Executor
 import paddle.fluid.io as io
 from paddle.fluid.initializer import ConstantInitializer
 import numpy as np
 
+paddle.enable_static()
 main_program = default_main_program()
 
 
 class ParameterChecks(unittest.TestCase):
-    def check_parameter(self):
+    def test_parameter(self):
         shape = [784, 100]
         val = 1.0625
         b = main_program.global_block()
@@ -43,13 +44,13 @@ class ParameterChecks(unittest.TestCase):
         self.assertEqual((784, 100), param.shape)
         self.assertEqual(core.VarDesc.VarType.FP32, param.dtype)
         self.assertEqual(0, param.block.idx)
-        exe = Executor(core.CPUPlace())
+        exe = Executor(paddle.CPUPlace())
         p = exe.run(main_program, fetch_list=[param])[0]
-        self.assertTrue(np.allclose(p, np.ones(shape) * val))
+        self.assertTrue(np.array_equal(p, np.ones(shape) * val))
         p = io.get_parameter_value_by_name('fc.w', exe, main_program)
-        self.assertTrue(np.allclose(np.array(p), np.ones(shape) * val))
+        self.assertTrue(np.array_equal(p, np.ones(shape) * val))
 
-    def check_parambase(self):
+    def test_parambase(self):
         with guard():
             linear = paddle.nn.Linear(10, 10)
             param = linear.weight
@@ -71,7 +72,7 @@ class ParameterChecks(unittest.TestCase):
             pram_copy2 = copy.deepcopy(param, memo)
             self.assertEqual(id(param_copy), id(pram_copy2))
 
-    def check_exceptions(self):
+    def test_exception(self):
         b = main_program.global_block()
         with self.assertRaises(ValueError):
             b.create_parameter(
@@ -86,16 +87,52 @@ class ParameterChecks(unittest.TestCase):
             b.create_parameter(
                 name='test', shape=[-1], dtype='float32', initializer=None)
 
+    def test_parambase_to_vector(self):
+        with guard():
+            linear1 = paddle.nn.Linear(
+                10,
+                15,
+                paddle.ParamAttr(
+                    initializer=paddle.nn.initializer.Constant(3.)))
 
-class TestParameter(ParameterChecks):
-    def _test_parameter(self):
-        self.check_parameter()
+            vec = paddle.nn.utils.parameters_to_vector(linear1.parameters())
+            self.assertTrue(isinstance(vec, Variable))
+            self.assertTrue(vec.shape, [165])
 
-    def test_parambase(self):
-        self.check_parambase()
+            linear2 = paddle.nn.Linear(10, 15)
+            paddle.nn.utils.vector_to_parameters(vec, linear2.parameters())
+            self.assertTrue(
+                np.array_equal(linear1.weight.numpy(), linear2.weight.numpy()),
+                True)
+            self.assertTrue(
+                np.array_equal(linear1.bias.numpy(), linear2.bias.numpy()),
+                True)
+            self.assertTrue(linear2.weight.is_leaf, True)
+            self.assertTrue(linear2.bias.is_leaf, True)
 
-    def test_exceptions(self):
-        self.check_exceptions()
+    def test_parameter_to_vector(self):
+        main_program = paddle.static.Program()
+        start_program = paddle.static.Program()
+        with paddle.static.program_guard(main_program, start_program):
+            linear1 = paddle.nn.Linear(
+                10,
+                15,
+                paddle.ParamAttr(
+                    initializer=paddle.nn.initializer.Constant(3.)))
+
+            vec = paddle.nn.utils.parameters_to_vector(linear1.parameters())
+            self.assertTrue(isinstance(vec, Variable))
+            self.assertTrue(vec.shape, [165])
+
+            linear2 = paddle.nn.Linear(10, 15)
+            paddle.nn.utils.vector_to_parameters(vec, linear2.parameters())
+
+        exe = paddle.static.Executor()
+        exe.run(start_program)
+        outs = exe.run(main_program,
+                       fetch_list=[linear1.parameters(), linear2.parameters()])
+        self.assertTrue(np.array_equal(outs[0], outs[2]))
+        self.assertTrue(np.array_equal(outs[1], outs[3]))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -497,6 +497,41 @@ class TestVarBase(unittest.TestCase):
             var = fluid.dygraph.to_variable(self.array)
             self.assertTrue(isinstance(str(var), str))
 
+    def test_element_size(self):
+        with fluid.dygraph.guard():
+            x = paddle.to_tensor(1, dtype='bool')
+            self.assertEqual(x.element_size(), 1)
+
+            x = paddle.to_tensor(1, dtype='float16')
+            self.assertEqual(x.element_size(), 2)
+
+            x = paddle.to_tensor(1, dtype='float32')
+            self.assertEqual(x.element_size(), 4)
+
+            x = paddle.to_tensor(1, dtype='float64')
+            self.assertEqual(x.element_size(), 8)
+
+            x = paddle.to_tensor(1, dtype='int8')
+            self.assertEqual(x.element_size(), 1)
+
+            x = paddle.to_tensor(1, dtype='int16')
+            self.assertEqual(x.element_size(), 2)
+
+            x = paddle.to_tensor(1, dtype='int32')
+            self.assertEqual(x.element_size(), 4)
+
+            x = paddle.to_tensor(1, dtype='int64')
+            self.assertEqual(x.element_size(), 8)
+
+            x = paddle.to_tensor(1, dtype='uint8')
+            self.assertEqual(x.element_size(), 1)
+
+            x = paddle.to_tensor(1, dtype='complex64')
+            self.assertEqual(x.element_size(), 8)
+
+            x = paddle.to_tensor(1, dtype='complex128')
+            self.assertEqual(x.element_size(), 16)
+
     def test_backward(self):
         with fluid.dygraph.guard():
             var = fluid.dygraph.to_variable(self.array)

--- a/python/paddle/fluid/tests/unittests/test_variable.py
+++ b/python/paddle/fluid/tests/unittests/test_variable.py
@@ -63,6 +63,35 @@ class TestVariable(unittest.TestCase):
         self.assertRaises(ValueError,
                           lambda: b.create_var(name="fc.w", shape=(24, 100)))
 
+    def test_element_size(self):
+        with fluid.program_guard(Program(), Program()):
+            x = paddle.static.data(name='x1', shape=[2], dtype='bool')
+            self.assertEqual(x.element_size(), 1)
+
+            x = paddle.static.data(name='x2', shape=[2], dtype='float16')
+            self.assertEqual(x.element_size(), 2)
+
+            x = paddle.static.data(name='x3', shape=[2], dtype='float32')
+            self.assertEqual(x.element_size(), 4)
+
+            x = paddle.static.data(name='x4', shape=[2], dtype='float64')
+            self.assertEqual(x.element_size(), 8)
+
+            x = paddle.static.data(name='x5', shape=[2], dtype='int8')
+            self.assertEqual(x.element_size(), 1)
+
+            x = paddle.static.data(name='x6', shape=[2], dtype='int16')
+            self.assertEqual(x.element_size(), 2)
+
+            x = paddle.static.data(name='x7', shape=[2], dtype='int32')
+            self.assertEqual(x.element_size(), 4)
+
+            x = paddle.static.data(name='x8', shape=[2], dtype='int64')
+            self.assertEqual(x.element_size(), 8)
+
+            x = paddle.static.data(name='x9', shape=[2], dtype='uint8')
+            self.assertEqual(x.element_size(), 1)
+
     def test_step_scopes(self):
         prog = Program()
         b = prog.current_block()

--- a/python/paddle/nn/utils/__init__.py
+++ b/python/paddle/nn/utils/__init__.py
@@ -14,7 +14,8 @@
 
 from .spectral_norm_hook import spectral_norm
 from .weight_norm_hook import weight_norm, remove_weight_norm  # noqa: F401
+from .transform_parameters import parameters_to_vector, vector_to_parameters  # noqa: F401
 
 __all__ = [  #noqa
-    'weight_norm', 'remove_weight_norm', 'spectral_norm'
+    'weight_norm', 'remove_weight_norm', 'spectral_norm', 'parameters_to_vector', 'vector_to_parameters'
 ]

--- a/python/paddle/nn/utils/transform_parameters.py
+++ b/python/paddle/nn/utils/transform_parameters.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserve.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import reduce
+
+import paddle
+from paddle.fluid.framework import Variable, in_dygraph_mode
+from paddle.fluid.layer_helper import LayerHelper
+from paddle.fluid.data_feeder import check_variable_and_dtype
+from paddle import _C_ops
+
+
+def parameters_to_vector(parameters, name=None):
+    """
+    Flatten parameters to a 1-D Tensor.
+
+    Args:
+        parameters(Iterable[Tensor]): Iterable Tensors that are trainable parameters of a Layer.
+        name(str, optional): The default value is None. Normally there is no need for user to set this
+            property. For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        A 1-D Tensor, which represents the parameters of a Layer.
+    
+
+    Examples:
+       .. code-block:: python
+
+            import paddle
+            linear = paddle.nn.Linear(10, 15)
+
+            paddle.nn.utils.parameters_to_vector(linear.parameters())
+            # 1-D Tensor: [165]
+
+    """
+    vec_list = []
+    if in_dygraph_mode():
+        for param in parameters:
+            vec, _ = _C_ops.reshape2(param, None, 'shape', [-1])
+            vec_list.append(vec)
+        return _C_ops.concat(vec_list, 'axis', 0)
+
+    helper = LayerHelper("parameters_to_vector", **locals())
+    param_dtype = parameters[0].dtype
+    for id, param in enumerate(parameters):
+        check_variable_and_dtype(
+            param, 'parameters[{}]'.format(id),
+            ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'],
+            "parameters_to_vector")
+        if param.dtype != param_dtype:
+            raise TypeError(
+                "All the Tensors in the parameters must have the same data type."
+            )
+        vec = helper.create_variable_for_type_inference(dtype=param_dtype)
+        x_shape = helper.create_variable_for_type_inference(dtype=param_dtype)
+        # use View strategy that don't have Tensor Copy
+        helper.append_op(
+            type='reshape2',
+            inputs={'X': param},
+            outputs={'Out': vec,
+                     'XShape': x_shape},
+            attrs={'shape': [-1]})
+        vec_list.append(vec)
+
+    param_vec = helper.create_variable_for_type_inference(dtype=param_dtype)
+    helper.append_op(
+        type='concat',
+        inputs={'X': vec_list},
+        outputs={'Out': param_vec},
+        attrs={'axis': 0})
+    return param_vec
+
+
+def vector_to_parameters(vec, parameters, name=None):
+    """
+    Transform a Tensor with 1-D shape to the parameters.
+
+    Args:
+        vec (Tensor): A Tensor with 1-D shape, which represents the parameters of a Layer.
+        parameters (Iterable[Tensor]): Iterable Tensors that are trainable parameters of a Layer.
+        name(str, optional): The default value is None. Normally there is no need for user to set this
+            property. For more information, please refer to :ref:`api_guide_Name`.
+
+    Examples:
+       .. code-block:: python
+
+            import paddle
+            weight_attr = paddle.ParamAttr(initializer=paddle.nn.initializer.Constant(3.))
+            linear1 = paddle.nn.Linear(10, 15, weight_attr)
+
+            vec = paddle.nn.utils.parameters_to_vector(linear1.parameters())
+
+            linear2 = paddle.nn.Linear(10, 15)
+            # copy weight of linear1 to linear2
+            paddle.nn.utils.vector_to_parameters(vec, linear2.parameters())
+            # weight: Tensor(shape=[10, 15], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
+            #                 [[3. , ..., 3. ],
+            #                  [..., ..., ...],
+            #                  [3. , ..., 3. ]])
+    """
+    start = 0
+    helper = LayerHelper("vector_to_parameters", **locals())
+    if in_dygraph_mode():
+        with paddle.no_grad():
+            for param in parameters:
+                shape = param.shape
+                numel = reduce(lambda x, y: x * y, shape)
+                end = start + numel
+                slice_data = _C_ops.slice(vec, None, None, 'axes', [0],
+                                          'infer_flags', [1], 'starts',
+                                          [start], 'ends', [end])
+                _C_ops.reshape2_(slice_data, None, 'shape', shape)
+                helper.append_op(
+                    type='assign',
+                    inputs={'X': slice_data},
+                    outputs={'Out': param})
+                start += numel
+            return
+
+    check_variable_and_dtype(
+        vec, 'x', ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'],
+        "vector_to_parameters")
+    assert len(vec.shape) == 1, "'vec' must be a Tensor with 1-D shape."
+
+    for param in parameters:
+        shape = param.shape
+        numel = reduce(lambda x, y: x * y, shape)
+        end = start + numel
+
+        slice_data = helper.create_variable_for_type_inference(
+            dtype=param.dtype)
+        helper.append_op(
+            type='slice',
+            inputs={'Input': vec},
+            outputs={'Out': slice_data},
+            attrs={
+                'axes': [0],
+                'infer_flags': [1],
+                'starts': [start],
+                'ends': [end]
+            })
+
+        # avoid backward for parameters
+        slice_data.stop_gradient = True
+        x_shape = helper.create_variable_for_type_inference(dtype=param.dtype)
+        out = helper.create_variable_for_type_inference(dtype=param.dtype)
+
+        # use Inplace strategy that don't have Tensor Copy
+        helper.append_op(
+            type='reshape2',
+            inputs={'X': slice_data},
+            outputs={'Out': slice_data,
+                     'XShape': x_shape},
+            attrs={'shape': shape})
+
+        helper.append_op(
+            type='assign', inputs={'X': slice_data}, outputs={'Out': param})
+        start += numel

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1158,8 +1158,7 @@ def empty_like(x, dtype=None, name=None):
 
 def assign(x, output=None):
     """
- 
- 
+
     The OP copies the :attr:`x` to the :attr:`output`.
  
     Parameters:
@@ -1190,6 +1189,36 @@ def assign(x, output=None):
     check_type(x, 'x', (Variable, np.ndarray, list, tuple, float, int, bool),
                'assign')
     return tensor.assign(x, output)
+
+
+def clone(x, name=None):
+    """
+    Returns a copy of input Tensor. It will always have a Tensor copy. 
+    
+    In addition, This function is derivable, so gradients will flow back from the output to input.
+
+    Parameters:
+        x (Tensor): The input Tensor.
+        name(str, optional): The default value is None. Normally there is no need for user to set this
+            property. For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns: A Tensor copied from ``input`` .
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+
+            x = paddle.ones([2])
+            x.stop_gradient = False
+            clone_x = paddle.clone(x)
+
+            y = clone_x**3
+            y.backward()
+            print(clone_x.grad)          # [3]
+            print(x.grad)                # [3]
+    """
+    return x.clone()
 
 
 #NOTE(zhiqiu): not public 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1.New API:  `paddle.clone`
---
Returns a copy of input Tensor. It will always have a Tensor copy. 
    
Tn addition, the OP provides gradient propagation.
```
import paddle

x = paddle.ones([2], stop_gradient=False)
clone_x = paddle.clone(x)

y = clone_x**3
y.backward()
print(clone_x.grad)          # [3]
print(x.grad)                     # [3]
```
   <img width="814" alt="infoflow 2021-12-14 16-01-21" src="https://user-images.githubusercontent.com/52485244/145957281-cb02eb97-393e-4c20-bae8-dfb0727d6058.png">


2.New API:  `paddle.Tensor.element_size` 
---
Returns the size in bytes of an element in the Tensor.
```
import paddle

x = paddle.static.data(name='x', shape=[3, 2], dtype='bool')
x.element_size() # 1

x = paddle.static.data(name='x', shape=[3, 2], dtype='int16')
x.element_size() # 2

x = paddle.static.data(name='x', shape=[3, 2], dtype='float16')
x.element_size() # 2

x = paddle.static.data(name='x', shape=[3, 2], dtype='float32')
x.element_size() # 4

x = paddle.static.data(name='x', shape=[3, 2], dtype='float64')
x.element_size() # 8
```

3.New API：`paddle.nn.utils.parameters_to_vector`
---
Flatten parameters to a 1-D Tensor.
```
import paddle
linear = paddle.nn.Linear(10, 15)

paddle.nn.utils.parameters_to_vector(linear.parameters())
# 1-D Tensor: [165]
```

<img width="837" alt="infoflow 2021-12-14 16-02-15" src="https://user-images.githubusercontent.com/52485244/145957365-ab3955d4-0dae-4632-8bf7-086f1cf5df9f.png">


4.New API：`paddle.nn.utils.vector_to_parameters`
---
Transform a Tensor with 1-D shape to the parameters.
```
import paddle
linear1 = paddle.nn.Linear(10, 15, paddle.ParamAttr(paddle.nn.initializer.Constant(3.)))

vec = paddle.nn.utils.parameters_to_vector(linear1.parameters())

linear2 = paddle.nn.Linear(10, 15)
# copy weight of linear1 to linear2
paddle.nn.utils.vector_to_parameters(vec, linear2.parameters())  
# weight: Tensor(shape=[10, 15], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
#                 [[3. , ..., 3. ],
#                  [..., ..., ...],
#                  [3. , ..., 3. ]])
```

<img width="805" alt="infoflow 2021-12-14 16-02-29" src="https://user-images.githubusercontent.com/52485244/145957384-45a25430-8c9c-4308-947a-ba39ffccbd0b.png">


