### PR TITLE
[Eager] fix mac import hang

### DIFF
--- a/paddle/fluid/pybind/eager_op_function_generator.cc
+++ b/paddle/fluid/pybind/eager_op_function_generator.cc
@@ -487,12 +487,12 @@ int main(int argc, char* argv[]) {
       << "};\n\n";
 
   out << "inline void BindEagerOpFunctions(pybind11::module *module) {\n"
+      << "  InitOpsAttrTypeMap();\n"
       << "  auto m = module->def_submodule(\"ops\");\n"
       << "  if (PyModule_AddFunctions(m.ptr(), ExtestMethods) < 0) {\n"
       << "    PADDLE_THROW(platform::errors::Fatal (\"Add functions to "
          "core.eager.ops failed!\"));\n"
       << "  }\n\n"
-      << "  InitOpsAttrTypeMap();"
       << "}\n\n"
       << "} // namespace pybind\n"
       << "} // namespace paddle\n";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
修改了InitOpsAttrTypeMap和PyModule_AddFunctions的调用顺序。
因为在Mac下，如果后调用InitOpsAttrTypeMap，会导致CPU打满，内存全部申请光。具体原因经几个同事讨论未能解释清楚。
暂时调整调用顺序，已修复线上bug。