### PR TITLE
[Paddle-TRT] Fix trt dynamic shape ernie unit test on V100

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
@@ -192,8 +192,11 @@ bool QkvToContextPluginDynamic::supportsFormatCombination(
   if (pos == 0) {
     if (with_fp16_) {
 #ifdef TRT_PLUGIN_FP16_AVALIABLE
-      return (in.type == nvinfer1::DataType::kFLOAT ||
-              in.type == nvinfer1::DataType::kHALF) &&
+      return (
+#if IS_TRT_VERSION_LT(8000)
+                 in.type == nvinfer1::DataType::kFLOAT ||
+#endif
+                 in.type == nvinfer1::DataType::kHALF) &&
              (in.format == nvinfer1::TensorFormat::kLINEAR);
 #else
       return (in.type == nvinfer1::DataType::kFLOAT) &&

--- a/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
@@ -73,8 +73,11 @@ bool SkipLayerNormPluginDynamic::supportsFormatCombination(
   if (pos == 0) {
     if (with_fp16_) {
 #ifdef TRT_PLUGIN_FP16_AVALIABLE
-      return (in.type == nvinfer1::DataType::kFLOAT ||
-              in.type == nvinfer1::DataType::kHALF) &&
+      return (
+#if IS_TRT_VERSION_LT(8000)
+                 in.type == nvinfer1::DataType::kFLOAT ||
+#endif
+                 in.type == nvinfer1::DataType::kHALF) &&
              (in.format == nvinfer1::TensorFormat::kLINEAR);
 #else
       return (in.type == nvinfer1::DataType::kFLOAT) &&

--- a/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
@@ -83,8 +83,11 @@ SlicePlugin *SlicePlugin::clone() const TRT_NOEXCEPT {
 bool SlicePlugin::supportsFormat(
     nvinfer1::DataType type, nvinfer1::PluginFormat format) const TRT_NOEXCEPT {
   if (with_fp16_) {
-    return ((type == nvinfer1::DataType::kFLOAT ||
-             type == nvinfer1::DataType::kHALF) &&
+    return ((
+#if IS_TRT_VERSION_LT(8000)
+                type == nvinfer1::DataType::kFLOAT ||
+#endif
+                type == nvinfer1::DataType::kHALF) &&
             (format == nvinfer1::PluginFormat::kLINEAR));
   } else {
     return ((type == nvinfer1::DataType::kFLOAT) &&
@@ -284,8 +287,11 @@ bool SlicePluginDynamic::supportsFormatCombination(
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
-      return (in.type == nvinfer1::DataType::kFLOAT ||
-              in.type == nvinfer1::DataType::kHALF) &&
+      return (
+#if IS_TRT_VERSION_LT(8000)
+                 in.type == nvinfer1::DataType::kFLOAT ||
+#endif
+                 in.type == nvinfer1::DataType::kHALF) &&
              (in.format == nvinfer1::TensorFormat::kLINEAR);
     } else {
       return (in.type == nvinfer1::DataType::kFLOAT) &&

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_test.cc
@@ -280,14 +280,16 @@ void run(paddle_infer::Predictor* predictor, std::vector<float>* out_data) {
 
 TEST(AnalysisPredictor, ernie_varlen) {
 #if IS_TRT_VERSION_GE(7234)
-  auto predictor = InitPredictor();
-  std::vector<float> out_data;
-  run(predictor.get(), &out_data);
-  std::vector<float> ref_data{0.59814,  0.219882, 0.181978,
-                              0.359796, 0.577414, 0.0627908};
-  float near_tolerance = 1e-3;
-  for (size_t i = 0; i < out_data.size(); i++) {
-    EXPECT_NEAR(ref_data[i], out_data[i], near_tolerance);
+  if (platform::GetGPUComputeCapability(0) >= 75) {
+    auto predictor = InitPredictor();
+    std::vector<float> out_data;
+    run(predictor.get(), &out_data);
+    std::vector<float> ref_data{0.59814,  0.219882, 0.181978,
+                                0.359796, 0.577414, 0.0627908};
+    float near_tolerance = 1e-3;
+    for (size_t i = 0; i < out_data.size(); i++) {
+      EXPECT_NEAR(ref_data[i], out_data[i], near_tolerance);
+    }
   }
 #endif
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
fix_trt_dynamic_shape_ernie unit test is failed on V100 + tensorrt8
This PR patches two things:
1. Only run ernie-varlen unit test on GPU architure after turing (SM75)
2. Fix-len ernie with fp16 will get errors on enqueue if TensorRT selects the fp32 precision. So this PR disables FP32 precision in supportsFormat after TensorRT8.