### PR TITLE
optimize performance of offload in dygraph sharding stage2

### DIFF
--- a/python/paddle/distributed/collective.py
+++ b/python/paddle/distributed/collective.py
@@ -127,8 +127,8 @@ def _get_group_map():
     global _group_map
     if not _group_map:
         genv = _get_global_env()
-        _group_map[0] = Group(genv.rank, genv.world_size,
-                              list(range(genv.world_size)))
+        _group_map[0] = Group(
+            genv.rank, genv.world_size, ranks=list(range(genv.world_size)))
     return _group_map
 
 

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/sharding_optimizer_stage2.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/sharding_optimizer_stage2.py
@@ -96,7 +96,7 @@ class ShardingOptimizerStage2(Optimizer):
                        self._local_params))) > 0
 
         self.group = dist.new_group(_get_global_group()
-                                    .id) if group is None else group
+                                    .ranks) if group is None else group
 
         self.world_size = self.group.nranks
         self.rank = self.group.rank

--- a/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/sharding_optimizer_stage2.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/dygraph_optimizer/sharding_optimizer_stage2.py
@@ -30,11 +30,11 @@ from paddle.optimizer import Optimizer
 from paddle.fluid.clip import ClipGradByGlobalNorm
 from paddle.distributed.collective import _get_global_group
 
-from ...utils.internal_storage import ParamStorage
+from ...utils.internal_storage import ParamStorage, GradStorage
 from ...meta_parallel.sharding.sharding_utils import Type, device_guard, ShardingClipGrad
 
-# CUDA alignment 256 bytes
-alignment = {"gpu": 256, }
+# CUDA alignment 256 bytes, cpu alignment 4096 bytes
+alignment = {"gpu": 256, "cpu": 4096}
 align = {
     Type.fp16.value: 2,
     Type.fp32.value: 4,
@@ -116,6 +116,10 @@ class ShardingOptimizerStage2(Optimizer):
 
         self.offload = offload  # Using for offload
         self.offload_device = "cpu"
+        self.offload_buffer_size = 0
+        self.offload_param2align = {}
+        self.offload_params = None
+        self.offload_grads = None
 
         self._master_params = {}
 
@@ -131,7 +135,6 @@ class ShardingOptimizerStage2(Optimizer):
                         value=param.cast(dtype=Type.fp32.value).numpy(),
                         place=core.CPUPlace(),
                         stop_gradient=param.stop_gradient)
-            self._optim._master_weights = self._master_params
         else:
             for param in trainable_params:
                 if param.dtype == Type.fp16.value:
@@ -265,6 +268,67 @@ class ShardingOptimizerStage2(Optimizer):
         for d in dtype_to_pop:
             self.param_storages.pop(d)
 
+        if self.offload:
+            self._optim._master_weights = self._master_params
+            cpu_master_params = [p for p in self._master_params.values()]
+            for param in cpu_master_params:
+                size = np.prod(param.shape) * align[Type.fp32.value]
+                remaining = size % alignment[self.offload_device]
+                ali = 0 if remaining == 0 else alignment[
+                    self.offload_device] - remaining
+                align_ = ali // align[Type.fp32.value]
+                self.offload_buffer_size += np.prod(param.shape) + align_
+                self.offload_param2align[param.name] = align_
+
+            if cpu_master_params:
+                with device_guard(self.rank, self.offload_device):
+                    self.offload_params = ParamStorage(
+                        size=self.offload_buffer_size,
+                        dtype=Type.fp32.value,
+                        device=self.offload_device)
+                    self.offload_params.add_rank_params(
+                        cpu_master_params, self.offload_param2align, False)
+                    self.offload_params.buffer.stop_gradient = False
+
+                    self.offload_grads = GradStorage(
+                        size=self.offload_buffer_size,
+                        dtype=Type.fp32.value,
+                        device=self.offload_device,
+                        destination=self.rank,
+                        parm2align=self.offload_param2align,
+                        convert_cpu=True)
+                    for p in cpu_master_params:
+                        self.offload_grads.add_grad(
+                            p, self.offload_param2align[p.name])
+
+                    self._optim._parameter_list = [self.offload_params.buffer]
+                    self._optim._master_weights[
+                        self.offload_params.buffer.
+                        name] = self.offload_params.buffer
+
+    def _offload_acc_grad(self, param_name, grad_fp32_cpu):
+        """accumulate grads with offload strategy"""
+        with device_guard(self.rank, self.offload_device):
+            if param_name in self._master_params.keys():
+                if self._master_params[param_name].grad is None:
+                    self._master_params[param_name]._copy_gradient_from(
+                        grad_fp32_cpu)
+                else:
+                    self._master_params[param_name].grad.add_(grad_fp32_cpu)
+
+        self.offload_params.buffer._copy_gradient_from(
+            self.offload_grads.buffer)
+
+    def _offload_scale_grad(self, scale_size):
+        """scale grads with offload strategy"""
+        with device_guard(self.rank, self.offload_device):
+            self.offload_grads.buffer.scale_(scale=scale_size)
+
+    def _offload_clear_grad(self):
+        """clear grads with offload strategy"""
+        with device_guard(self.rank, self.offload_device):
+            self.offload_grads.buffer.zero_()
+
     def step(self):
         """
         A wrapper for Optimizer's step function to finish the update operation of the optimizer.
@@ -296,14 +360,11 @@ class ShardingOptimizerStage2(Optimizer):
             with device_guard(device=self.offload_device):
                 self._optim.step()
 
-            dev_id = 0 if paddle.get_device() == "cpu" else int(
-                paddle.get_device().split(":")[1])
-
+            dev_id = int(paddle.get_device().split(":")[1])
             for param in self._local_params:
                 if param.name in self._master_params.keys():
                     param.set_value(self._master_params[param.name].cuda(dev_id)
                                     .cast(dtype=param.dtype))
-                    self._master_params[param.name].clear_gradient(False)
         else:
             self._optim.step()
 

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_stage2.py
@@ -173,37 +173,40 @@ class ShardingStage2(nn.Layer):
         """
         # Release grad storages
         for dtype in self._grad_storages.keys():
-            if self._rank in self._grad_storages[dtype].keys():
-                if not self._offload:
-                    self._grad_storages[dtype][self._rank].buffer.zero_()
+            if not self._offload and self._rank in self._grad_storages[
+                    dtype].keys():
+                self._grad_storages[dtype][self._rank].buffer.zero_()
 
-        # Release params
+        # Release grads of params
         for param in self._trainable_params:
             if param.name in self._param_grads and param.grad is not None:
                 param.clear_gradient()
+
+        # Release grads of master params with offload strategy
+        if self._offload:
+            self._sharding_optimizers[0]._offload_clear_grad()
 
     def _grad_scale(self):
         """
         Before the gradient accumulation, scale the gradient.
         """
-        if self._offload:
-            for param in self._trainable_params:
-                if param.name in self._sharding_optimizers[
-                        0]._master_params.keys():
-                    self._sharding_optimizers[0]._master_params[
-                        param.name].grad.scale_(scale=self._world_size_scaling)
-        else:
-            # Scale grad storages
-            for dtype in self._grad_storages.keys():
-                if self._rank in self._grad_storages[dtype].keys():
-                    self._grad_storages[dtype][self._rank].buffer.scale_(
-                        scale=self._world_size_scaling)
+        # Scale grad storages
+        for dtype in self._grad_storages.keys():
+            if not self._offload and self._rank in self._grad_storages[
+                    dtype].keys():
+                self._grad_storages[dtype][self._rank].buffer.scale_(
+                    scale=self._world_size_scaling)
 
-            # Scale params
-            for param in self._trainable_params:
-                if param.name in self._param_grads and param.grad is not None:
-                    param.grad.scale_(scale=self._world_size_scaling)
-                    param._reset_grad_inplace_version(True)
+        # Scale grads of params
+        for param in self._trainable_params:
+            if param.name in self._param_grads and param.grad is not None:
+                param.grad.scale_(scale=self._world_size_scaling)
+                param._reset_grad_inplace_version(True)
+
+        # Scale grads of master params with offload strategy
+        if self._offload:
+            self._sharding_optimizers[0]._offload_scale_grad(
+                self._world_size_scaling)
 
     def _init_internal_storage(self, needs_fresh):
         """
@@ -319,9 +322,9 @@ class ShardingStage2(nn.Layer):
                         if dst_rank != self._rank:
                             param.clear_gradient(False)
                         elif self._offload:
-                            self._sharding_optimizers[0]._master_params[
-                                param.name]._copy_gradient_from(param.grad.cpu(
-                                ).cast(dtype=Type.fp32.value))
+                            self._sharding_optimizers[0]._offload_acc_grad(
+                                param.name,
+                                param.grad.cast(dtype=Type.fp32.value).cpu())
                             param.clear_gradient(False)
 
                     # Synchronize the reduce parameter gradient
@@ -375,11 +378,14 @@ class ShardingStage2(nn.Layer):
                                 )
                             elif self._offload:
                                 grad_storage.to(device=self._offload_device)
-                                for param in grad_storage._params:
-                                    self._sharding_optimizers[0]._master_params[
-                                        param.name]._copy_gradient_from(
-                                            param.grad.cast(
-                                                dtype=Type.fp32.value))
+                                for p in grad_storage._params:
+                                    self._sharding_optimizers[
+                                        0]._offload_acc_grad(
+                                            p.name,
+                                            p.grad.cast(dtype=Type.fp32.value))
+                                    p.clear_gradient(False)
+                                    p._gradient_set_empty(False)
+                                grad_storage._device = self._default_device
                                 grad_storage.buffer.value().get_tensor()._clear(
                                 )
 

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_stage2.py
@@ -86,7 +86,7 @@ class ShardingStage2(nn.Layer):
 
         # Communication related attributes
         self._group = dist.new_group(_get_global_group()
-                                     .id) if group is None else group
+                                     .ranks) if group is None else group
         self._world_size_scaling = 1.0 / self._group.nranks
         assert self._group.nranks > 1, "Training must be distributed, ranks must be greater than 1"
         self._rank = self._group.rank

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_stage2.py
@@ -95,8 +95,7 @@ class ShardingStage2(nn.Layer):
 
         # Global statistical parameters
         self._all_params = list(
-            chain(
-                * [optim.local_params for optim in self._sharding_optimizers]))
+            chain(*[optim.local_params for optim in self._sharding_optimizers]))
         self._trainable_params = []
         self._grad_reduced = []
         self._trainable_param2rank = {}
@@ -490,7 +489,7 @@ class ShardingStage2(nn.Layer):
                            ._fill))
 
         self._grad_storage_list = list(
-            chain(* [
+            chain(*[
                 self._grad_storages[dtype].values()
                 for dtype in self._grad_storages.keys()
             ]))

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_utils.py
@@ -152,10 +152,10 @@ def ShardingScaler(scaler, sharding_group):
         param_grads_fp16 = []
         param_grads_fp32 = []
 
-        if getattr(optimizer, '_param_groups', None) and isinstance(
-                optimizer._param_groups[0], dict):
+        if getattr(optimizer._optim, '_param_groups', None) and isinstance(
+                optimizer._optim._param_groups[0], dict):
 
-            for group in optimizer._param_groups:
+            for group in optimizer._optim._param_groups:
                 for param in group['params']:
                     if param._grad_ivar() is not None:
                         param_grads.append(param._grad_ivar())
@@ -166,31 +166,36 @@ def ShardingScaler(scaler, sharding_group):
                             param_grads_fp32.append(param._grad_ivar())
         else:
             param_grads = [
-                param._grad_ivar() for param in optimizer._parameter_list
+                param._grad_ivar() for param in optimizer._optim._parameter_list
                 if param._grad_ivar() is not None
             ]
             param_grads_fp16 = [
-                param._grad_ivar() for param in optimizer._parameter_list
+                param._grad_ivar() for param in optimizer._optim._parameter_list
                 if (param._grad_ivar() is not None
                     ) and (param._grad_ivar().dtype == core.VarDesc.VarType.FP16
                            )
             ]
             param_grads_fp32 = [
-                param._grad_ivar() for param in optimizer._parameter_list
+                param._grad_ivar() for param in optimizer._optim._parameter_list
                 if (param._grad_ivar() is not None
                     ) and (param._grad_ivar().dtype == core.VarDesc.VarType.FP32
                            )
             ]
         temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
         temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))
-        if len(param_grads_fp16):
-            _C_ops.check_finite_and_unscale(param_grads_fp16, self._scale,
-                                            param_grads_fp16,
-                                            temp_found_inf_fp16)
-        if len(param_grads_fp32):
-            _C_ops.check_finite_and_unscale(param_grads_fp32, self._scale,
-                                            param_grads_fp32,
-                                            temp_found_inf_fp32)
+
+        device = "cpu" if optimizer.offload else "gpu"
+        dev_id = 0 if device == "cpu" else int(paddle.get_device().split(":")[1])
+
+        with device_guard(dev_id, device):
+            if len(param_grads_fp16):
+                _C_ops.check_finite_and_unscale(param_grads_fp16, self._scale,
+                                                param_grads_fp16,
+                                                temp_found_inf_fp16)
+            if len(param_grads_fp32):
+                _C_ops.check_finite_and_unscale(param_grads_fp32, self._scale,
+                                                param_grads_fp32,
+                                                temp_found_inf_fp32)
 
         self._found_inf = 1 if temp_found_inf_fp16 or temp_found_inf_fp32 else 0
         is_found_inf = paddle.to_tensor([self._found_inf], dtype="int32")

--- a/python/paddle/fluid/tests/unittests/dygraph_sharding_stage2_offload.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_sharding_stage2_offload.py
@@ -45,7 +45,7 @@ def train_mlp(model, offload=False):
 
     model = paddle.amp.decorate(models=model, level='O2', save_dtype='float32')
     scaler = paddle.amp.GradScaler(init_loss_scaling=32768)
-    scaler = ShardingScaler(scaler, group)
+    scaler = ShardingScaler(scaler)
 
     optimizer = ShardingOptimizerStage2(
         params=model.parameters(),

--- a/python/paddle/fluid/tests/unittests/dygraph_sharding_stage2_offload.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_sharding_stage2_offload.py
@@ -40,7 +40,6 @@ paddle.seed(seed)
 
 
 def train_mlp(model, offload=False):
-    group = paddle.distributed.new_group([0, 1])
     optimizer = optimizer_setting(model=model, use_pure_fp16=True)
 
     model = paddle.amp.decorate(models=model, level='O2', save_dtype='float32')
@@ -48,16 +47,9 @@ def train_mlp(model, offload=False):
     scaler = ShardingScaler(scaler)
 
     optimizer = ShardingOptimizerStage2(
-        params=model.parameters(),
-        optim=optimizer,
-        group=group,
-        offload=offload)
+        params=model.parameters(), optim=optimizer, offload=offload)
     model = ShardingStage2(
-        model,
-        optimizer,
-        group=group,
-        buffer_max_size=2**21,
-        accumulate_grads=True)
+        model, optimizer, buffer_max_size=2**21, accumulate_grads=True)
 
     train_reader = paddle.batch(
         reader_decorator(linear_size), batch_size=batch_size, drop_last=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
optimize performance of offload in dygraph sharding stage2

After performance optimization：
1、precision：（PaddleNLP GPT-3 model）
sharding stage2+fp16+gradients accumulation（with offload versus without offload）
![image](https://user-images.githubusercontent.com/86215757/145925818-eca3a00c-0c45-423b-a5c7-6ce2fcd20a5e.png)


2、performance：（PaddleNLP GPT-3 model）

- hidden size=1024，layer_num=4，global batch size=16，micro batch size=2，sharding_degree=2

- before optimization -- speed: 0.23-0.24 step/s ；ips: 3700-3800 tokens/s

- after optimization    -- speed: 0.58-0.60 step/s ；ips: 9500-9800 tokens/s

3、peek gpu memory： （PaddleNLP GPT-3 model）

- 0.31B parameters -- 3137 MiB（no difference made by performance optimization）

- 1.02B parameters -- 5369 MiB（no difference made by performance optimization）