### PR TITLE
cherry-pick #38026:fix bug of reduce_max/reduce_min

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.h
@@ -47,10 +47,17 @@ inline void GetShuffledDim(const DDim& src_dims, DDim* dst_dims,
   std::vector<bool> src_dims_check(src_dims.size(), false);
   size_t src_size = src_dims.size();
   size_t reduce_size = reduced_dims.size();
+  std::vector<int> regular_reduced_dims = reduced_dims;
+  for (size_t i = 0; i < regular_reduced_dims.size(); i++) {
+    if (regular_reduced_dims[i] < 0) {
+      regular_reduced_dims[i] = src_size + regular_reduced_dims[i];
+    }
+  }
   for (size_t i = 0; i < reduce_size; ++i) {
-    dst_dims->at(src_size - reduce_size + i) = src_dims[reduced_dims[i]];
-    (*perm_axis)[src_size - reduce_size + i] = reduced_dims[i];
-    src_dims_check[reduced_dims[i]] = true;
+    dst_dims->at(src_size - reduce_size + i) =
+        src_dims[regular_reduced_dims[i]];
+    (*perm_axis)[src_size - reduce_size + i] = regular_reduced_dims[i];
+    src_dims_check[regular_reduced_dims[i]] = true;
   }
 
   size_t offset = 0;

--- a/python/paddle/fluid/tests/unittests/test_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_max_op.py
@@ -86,6 +86,18 @@ class ApiMaxTest(unittest.TestCase):
         z_expected = np.array(np.max(np_x, axis=0))
         self.assertEqual((np_z == z_expected).all(), True)
 
+    def test_big_dimension(self):
+        paddle.disable_static()
+        x = paddle.rand(shape=[2, 2, 2, 2, 2, 2, 2])
+        np_x = x.numpy()
+        z1 = paddle.max(x, axis=-1)
+        z2 = paddle.max(x, axis=6)
+        np_z1 = z1.numpy()
+        np_z2 = z2.numpy()
+        z_expected = np.array(np.max(np_x, axis=6))
+        self.assertEqual((np_z1 == z_expected).all(), True)
+        self.assertEqual((np_z2 == z_expected).all(), True)
+
 
 class TestOutDtype(unittest.TestCase):
     def test_max(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
cherrypick #38026
修复：addle.max在输入dimension > 6 且 axis < 0时运行出错
<!-- Describe what this PR does -->
