### PR TITLE
Arg weight of lerp support float in static mode

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_lerp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lerp_op.py
@@ -94,13 +94,11 @@ class TestLerpAPI(unittest.TestCase):
             with paddle.static.program_guard(paddle.static.Program()):
                 x = paddle.fluid.data('x', [1, 4], dtype=self.dtype)
                 y = paddle.fluid.data('y', [1, 4], dtype=self.dtype)
-                w = paddle.fluid.data('w', [1], dtype=self.dtype)
-                out = paddle.lerp(x, y, w)
+                out = paddle.lerp(x, y, 0.5)
                 exe = paddle.static.Executor(place)
                 res = exe.run(feed={
                     'x': self.x.reshape([1, 4]),
                     'y': self.y.reshape([1, 4]),
-                    'w': self.w
                 })
             for r in res:
                 self.assertEqual(np.allclose(self.res_ref, r), True)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -2650,6 +2650,9 @@ def lerp(x, y, weight, name=None):
             weight = paddle.to_tensor(weight, dtype=x.dtype)
         return _C_ops.lerp(x, y, weight)
 
+    if isinstance(weight, float):
+        weight = paddle.full(shape=[1], fill_value=weight, dtype=x.dtype)
+
     check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'lerp')
     check_variable_and_dtype(y, 'y', ['float32', 'float64'], 'lerp')
     check_variable_and_dtype(weight, 'weight', ['float32', 'float64'], 'lerp')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
静态图中，API `lerp` 参数 `weight` 支持使用float类型