### PR TITLE
[AMP] Add use_warning check by GPU Compute Capability of amp

### DIFF
--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -218,6 +218,13 @@ def amp_guard(enable=True,
             % tracer._expected_place)
         enable = False
 
+    if tracer._expected_place.is_gpu_place():
+        prop = paddle.device.cuda.get_device_capability()
+        if prop[0] < 7:
+            warnings.warn(
+                "AMP only support NVIDIA GPU with Compute Capability 7.0 or higher, current GPU is: %s, with Compute Capability: %d.%d."
+                % (paddle.device.cuda.get_device_name(), prop[0], prop[1]))
+
     if level == 'O1':
         amp_level = AMP_LEVEL.O1
         _white_list = WHITE_LIST


### PR DESCRIPTION
### PR types
New features

### PR changes
Others

### Describe
混合精度训练加速主要依赖与NV显卡的Tensor Core，目前Tensor Core仅支持Compute Capability在7.0及其以上的显卡，如果低于7.0将输出警告：
`UserWarning: AMP only support NVIDIA GPU with Compute Capability 7.0 or higher, current GPU is: Tesla K40m, with Compute Capability: 3.5.`