### PR TITLE
[NVIDIA] Fix test_segment_ops unit test failed on V100

### DIFF
--- a/paddle/fluid/operators/math/segment_pooling.cu
+++ b/paddle/fluid/operators/math/segment_pooling.cu
@@ -120,8 +120,9 @@ __global__ void SegmentMeanKernel(const Index* segment_ids, const T* input,
 }
 
 template <typename T, typename Index, typename Helper, typename Pool>
-__global__ void SegmentOpsKernel(const Index* segment_ids, const T* input,
-                                 T* output, Helper h, Pool pool) {
+__global__ void __launch_bounds__(1024, 1)
+    SegmentOpsKernel(const Index* segment_ids, const T* input, T* output,
+                     Helper h, Pool pool) {
   CUDA_KERNEL_LOOP(stripe_index, h.total_stripe_count) {
     Index segment_offset, dim_index_base, actual_height;
     Index inner_dim_size = h.inner_dim_size;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
From ``--ptxas-options=-v``, [SegmentOpsKernel](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/operators/math/segment_pooling.cu#L123) uses 66 registers in a block. 
```
ptxas info    : Function properties for _ZN6paddle9operators16SegmentOpsKernelIdlNS0_13ArrangeHelperIlEENS0_7MinPoolIdEEEEvPKT0_PKT_PS9_T1_T2_
    56 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 66 registers, 425 bytes cmem[0]
ptxas info    : Compiling entry function '_ZN6paddle9operators16SegmentOpsKernelIdlNS0_13ArrangeHelperIlEENS0_7MaxPoolIdEEEEvPKT0_PKT_PS9_T1_T2_' for 'sm_70'
ptxas info    : Function properties for _ZN6paddle9operators16SegmentOpsKernelIdlNS0_13ArrangeHelperIlEENS0_7MaxPoolIdEEEEvPKT0_PKT_PS9_T1_T2_
    56 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 66 registers, 425 bytes cmem[0]
ptxas info    : Compiling entry function '_ZN6paddle9operators16SegmentOpsKernelIdlNS0_13ArrangeHelperIlEENS0_7SumPoolIdEEEEvPKT0_PKT_PS9_T1_T2_' for 'sm_70'
ptxas info    : Function properties for _ZN6paddle9operators16SegmentOpsKernelIdlNS0_13ArrangeHelperIlEENS0_7SumPoolIdEEEEvPKT0_PKT_PS9_T1_T2_
    56 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads
ptxas info    : Used 66 registers, 425 bytes cmem[0]
```

Then [SegmentPoolFunctor](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/operators/math/segment_pooling.cu#L317) launch ``SegmentOpsKernel`` with [1024 threads per block](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/platform/device/gpu/gpu_launch_config.h#L91) results **cudaErrorLaunchOutOfResources (error 701)**, because V100 has only 65536 registers per SM, there is no any block can be executed on V100 with above configuration (66*1024=67584).

There are two ways to resolve this problem:
1. Reduce the threads per block launch configuration
2. add ``__launch_bound__`` to give information to ``nvcc`` compiler for reducing registers usage

I choose ``__launch_bound__`` solution because changing [gpu_launch_config](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/platform/device/gpu/gpu_launch_config.h#L91) may affect other ops.