### PR TITLE
改变解压路径

### DIFF
--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -145,6 +145,8 @@ coverage combine `$(ls python-coverage.data.*)` || NO_PYTHON_COVERAGE_DATA=1
 
 `$(coverage xml -i -o python-coverage.xml)` || [[ "${NO_PYTHON_COVERAGE_DATA}" == "1" ]]
 
+sed -i 's/mnt\/paddle/paddle/g' python-coverage.xml
+
 `$(python3.7 ${PADDLE_ROOT}/tools/coverage/python_coverage.py > python-coverage.info)` || [[ "${NO_PYTHON_COVERAGE_DATA}" == "1" ]]
 
 # python full html report


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
提升tar包解压速度：
经过测试，`/mnt`所在的硬盘性能高于`/`的硬盘性能，读写IO速度更快。因此在进行测试任务时，将编译产出拉到`/mnt`下进行解压，然后在将`/paddle`软链到`/mnt/paddle`即可提高一倍速度。
原解压速度如下：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4309723/job/10130495 
![image](https://user-images.githubusercontent.com/22937122/146298650-a80c62d7-e52f-4999-8662-9917c85637ef.png)
改进解压速度如下：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4309723/job/10130495
![image](https://user-images.githubusercontent.com/22937122/146298819-965d2435-8dda-48e8-a913-0164986649bf.png)
收益7min。

此软链的方法会在生成python覆盖率（即覆盖率的xml文件）时，在xml文件中的覆盖率文件会是`/mnt/paddle/xxxx`，而不是`/paddle/xxxx`，因此需要处理xml文件，将xml文件中的`/mnt`去除。
