### PR TITLE
Revert "modify the fix_seed attribute in dropout op is a def attribute.test=d…"

### DIFF
--- a/paddle/fluid/operators/dropout_op.cc
+++ b/paddle/fluid/operators/dropout_op.cc
@@ -88,8 +88,8 @@ class DropoutOpMaker : public framework::OpProtoAndCheckerMaker {
                   "training. Setting this flag to true is only useful in "
                   "unittest or for debug that always the same output units "
                   "will be dropped.")
-        .SetDefault(false);
-
+        .SetDefault(false)
+        .AsExtra();
     AddAttr<int>("seed", "Dropout random seed.").SetDefault(0).AsExtra();
     AddAttr<std::string>(
         "dropout_implementation",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Reverts PaddlePaddle/Paddle#38100
业务验证，pr 38100的临时取消对fix_seed属性的裁剪，并不能解决业务bug. 因此将该pr进行revert.