### PR TITLE
[CustomOp] Revert attr type change

### DIFF
--- a/paddle/pten/api/ext/op_meta_info.h
+++ b/paddle/pten/api/ext/op_meta_info.h
@@ -186,6 +186,14 @@ struct KernelFuncImpl<Return (*)(Args...), impl_fn> {
   PD_SPECIALIZE_ComputeCallHelper(const float&);
   PD_SPECIALIZE_ComputeCallHelper(const int64_t&);
 
+  // NOTE(chenweihang): Used to be compatible with the 2.1 released
+  // interface, but not recommended
+  PD_SPECIALIZE_ComputeCallHelper(std::string);
+  PD_SPECIALIZE_ComputeCallHelper(std::vector<int>);
+  PD_SPECIALIZE_ComputeCallHelper(std::vector<float>);
+  PD_SPECIALIZE_ComputeCallHelper(std::vector<int64_t>);
+  PD_SPECIALIZE_ComputeCallHelper(std::vector<std::string>);
+
   // end: base template
   template <typename T>
   struct ComputeCallHelper<TypeTag<T>> {
@@ -328,6 +336,13 @@ struct InferShapeFuncImpl<Return (*)(Args...), impl_fn> {
   PD_SPECIALIZE_InferShapeCallHelper_FOR_ATTR(const int&);
   PD_SPECIALIZE_InferShapeCallHelper_FOR_ATTR(const float&);
   PD_SPECIALIZE_InferShapeCallHelper_FOR_ATTR(const int64_t&);
+
+  // NOTE(chenweihang): Used to be compatible with the 2.1 released
+  // interface, but not recommended
+  PD_SPECIALIZE_InferShapeCallHelper_FOR_ATTR(std::string);
+  PD_SPECIALIZE_InferShapeCallHelper_FOR_ATTR(std::vector<int>);
+  PD_SPECIALIZE_InferShapeCallHelper_FOR_ATTR(std::vector<float>);
+  PD_SPECIALIZE_InferShapeCallHelper_FOR_ATTR(std::vector<std::string>);
 
   // end: base template
   template <typename T>

--- a/python/paddle/fluid/tests/custom_op/attr_test_op.cc
+++ b/python/paddle/fluid/tests/custom_op/attr_test_op.cc
@@ -127,11 +127,11 @@ std::vector<paddle::Tensor> AttrTestForward(
     int int_attr,
     float float_attr,
     int64_t int64_attr,
-    const std::string& str_attr,
-    const std::vector<int>& int_vec_attr,
-    const std::vector<float>& float_vec_attr,
-    const std::vector<int64_t>& int64_vec_attr,
-    const std::vector<std::string>& str_vec_attr) {
+    std::string str_attr,
+    std::vector<int> int_vec_attr,
+    std::vector<float> float_vec_attr,
+    std::vector<int64_t> int64_vec_attr,
+    std::vector<std::string> str_vec_attr) {
   auto out = paddle::Tensor(paddle::PlaceType::kCPU, x.shape());
 
   PD_DISPATCH_FLOATING_TYPES(
@@ -160,10 +160,10 @@ std::vector<std::vector<int64_t>> AttrTestInferShape(
     int int_attr,
     float float_attr,
     int64_t int64_attr,
-    const std::string& str_attr,
-    const std::vector<int>& int_vec_attr,
-    const std::vector<float>& float_vec_attr,
-    const std::vector<std::string>& str_vec_attr) {
+    std::string str_attr,
+    std::vector<int> int_vec_attr,
+    std::vector<float> float_vec_attr,
+    std::vector<std::string> str_vec_attr) {
   return {x_shape};
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[CustomOp] Revert attr type change

之前曾经开放过如下几个attr的输入类型支持

```
std::string,
std::vector<int>,
std::vector<float>,
std::vector<int64_t>,
std::vector<std::string>
```

虽然官方文档并没有宣传过我们支持这几个特性，但用户可能仍然误用了这几种形式，为了确保兼容性，将这几种类型添加回来