### PR TITLE
Fix bugs in Translated Layer when change mode from train/eval to eval/train 

### DIFF
--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -1286,17 +1286,11 @@ class TranslatedLayer(layers.Layer):
 
     def train(self):
         self._is_test = False
-        # Layer-level setting
         self.training = True
-        for layer in self.sublayers():
-            layer.training = True
 
     def eval(self):
         self._is_test = True
-        # Layer-level setting
         self.training = False
-        for layer in self.sublayers():
-            layer.training = False
 
     def program(self, method_name='forward'):
         """

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -1286,9 +1286,17 @@ class TranslatedLayer(layers.Layer):
 
     def train(self):
         self._is_test = False
+        # Layer-level setting
+        self.training = True
+        for layer in self.sublayers():
+            layer.training = True
 
     def eval(self):
         self._is_test = True
+        # Layer-level setting
+        self.training = False
+        for layer in self.sublayers():
+            layer.training = False
 
     def program(self, method_name='forward'):
         """

--- a/python/paddle/fluid/tests/unittests/test_translated_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_translated_layer.py
@@ -183,6 +183,20 @@ class TestTranslatedLayer(unittest.TestCase):
         for spec_x, spec_y in zip(expect_spec, actual_spec):
             self.assertEqual(spec_x, spec_y)
 
+    def test_layer_state(self):
+        # load
+        translated_layer = paddle.jit.load(self.model_path)
+
+        translated_layer.eval()
+        self.assertEqual(translated_layer.training, False)
+        for layer in translated_layer.sublayers():
+            self.assertEqual(layer.training, False)
+
+        translated_layer.train()
+        self.assertEqual(translated_layer.training, True)
+        for layer in translated_layer.sublayers():
+            self.assertEqual(layer.training, True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_translated_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_translated_layer.py
@@ -48,6 +48,7 @@ class LinearNet(nn.Layer):
     def __init__(self):
         super(LinearNet, self).__init__()
         self._linear = nn.Linear(IMAGE_SIZE, CLASS_NUM)
+        self._dropout = paddle.nn.Dropout(p=0.5)
 
     @paddle.jit.to_static(input_spec=[
         paddle.static.InputSpec(
@@ -186,10 +187,10 @@ class TestTranslatedLayer(unittest.TestCase):
     def test_layer_state(self):
         # load
         translated_layer = paddle.jit.load(self.model_path)
-
         translated_layer.eval()
         self.assertEqual(translated_layer.training, False)
         for layer in translated_layer.sublayers():
+            print("123")
             self.assertEqual(layer.training, False)
 
         translated_layer.train()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
当载入动转静模型的时候，使用train/eval进行模式切换Layer，修复Training状态未改变的问题