### PR TITLE
Change a comment to avoid the disturb to op benchmark ci.

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -1566,7 +1566,7 @@ void ElemwiseExplicitGradCompute(const framework::ExecutionContext &ctx,
 // of broadcast, supporting both CPU and GPU.
 // - CPU implementation cannot support the case when x needs broadcast, thus
 //   this function need to be called with XxxFunctor and XxxInverseFunctor,
-//   like paddle/fluid/operators/elementwise/elementwise_add_op.h#L49 - L55.
+//   like AddFunctor and InverseAddFunctor.
 // - GPU implementation supports all the broadcast cases, thus there is no need
 //   to define and call with XxxInverseFunctor.
 // TODO(liuyiqun): optimize the CPU implementation to support all broadcast


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
- 如果PR修改了头文件，OP Benchmark CI会递归搜索这个头文件被哪些`_op.cu`或`_op.cu.cc`包含了，进而测试可能影响到的op。
- elementwise_op_function.h的一行注释中有`elementwise_add_op.h`，当PR修改了elementwise_add_op.h，当前的OP Benchmark CI会误认为elementwise_add_op.h被elementwise_op_function.h引用了，从而会进一步排查elementwise_op_function.h被哪些算子引用到了。elementwise_op_function.h作为elementwise类型的基础头文件，被很多算子引用到了，导致op benchmark ci由于测试太多op而超时。
- 当前PR先修改这一行comment处理这个问题。最终解法，还是需要修复OP Benchmark CI的脚本。