### PR TITLE
fixed corner case in all shape function

### DIFF
--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -363,7 +363,7 @@ def convert_shape_to_list(shape):
     """
     if isinstance(shape, (list, tuple)):
         shape = list(
-            map(lambda x: x.numpy()[0] if isinstance(x, Variable) else x,
+            map(lambda x: x.numpy().flat[0] if isinstance(x, Variable) else x,
                 shape))
     else:
         shape = shape.numpy().astype(int).tolist()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
Fix the corner case when the function has argument shape constructed by list with Tensor and int like the following case.
```
import paddle
import numpy as np
size_a = paddle.to_tensor(np.array(1))
paddle.zeros(shape=[size_a, 100], dtype="float32")

```
This case is caused by the following code
https://github.com/PaddlePaddle/Paddle/blob/086540ccb4e8cde02176f3134adf09e92ac9d3fc/python/paddle/fluid/layers/utils.py#L366.


It runs well in PyTorch
```
import torch
import numpy as np
size_a = torch.from_numpy(np.array(1))
torch.zeros(shape=[size_a, 100], dtype="float32")

```