### PR TITLE
[fleet_executor] run time graph on python side

### DIFF
--- a/paddle/fluid/distributed/fleet_executor/fleet_executor.cc
+++ b/paddle/fluid/distributed/fleet_executor/fleet_executor.cc
@@ -62,8 +62,8 @@ void FleetExecutor::Init(
     }
     runtime_graph_->SetInterceptorIdToRank(task_id_to_rank);
     runtime_graph_->SetInterceptorIdToNode(interceptor_id_to_task);
-    for (auto& op : ops) {
-      op.release();
+    for (auto& unique_op : ops) {
+      unique_op.release();
     }
   }
   root_scope_ = scope;

--- a/paddle/fluid/distributed/fleet_executor/fleet_executor.cc
+++ b/paddle/fluid/distributed/fleet_executor/fleet_executor.cc
@@ -38,8 +38,10 @@ void FleetExecutor::Init(
     const platform::Place& place, const std::vector<TaskNode*>& task_nodes,
     const std::unordered_map<int64_t, int64_t>& task_id_to_rank) {
   if (task_nodes.size() == 0) {
+    LOG(INFO) << "fleet executor will use c++ side scheduler construction.";
     runtime_graph_ = std::make_shared<RuntimeGraph>(program_desc, exe_desc_);
   } else {
+    LOG(INFO) << "fleet executor has been set dependency on python side.";
     runtime_graph_ = std::make_shared<RuntimeGraph>();
     std::unordered_map<int64_t, TaskNode*> interceptor_id_to_task;
     for (auto task_node : task_nodes) {

--- a/paddle/fluid/distributed/fleet_executor/task_node.cc
+++ b/paddle/fluid/distributed/fleet_executor/task_node.cc
@@ -49,6 +49,9 @@ TaskNode::TaskNode(int32_t role,
       task_id_(task_id),
       max_run_times_(max_run_times),
       max_slot_nums_(max_slot_nums) {
+  if (op_descs.empty()) {
+    return;
+  }
   for (const auto& desc : op_descs) {
     ops_vec_.emplace_back(framework::OpRegistry::CreateOp(*desc));
   }

--- a/paddle/fluid/distributed/fleet_executor/task_node.cc
+++ b/paddle/fluid/distributed/fleet_executor/task_node.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/distributed/fleet_executor/task_node.h"
+#include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/operator.h"
 
@@ -39,7 +40,25 @@ TaskNode::TaskNode(const framework::ProgramDesc& program, int64_t rank,
   }
 }
 
-TaskNode::TaskNode(int32_t role, const std::vector<OperatorBase*>& ops,
+TaskNode::TaskNode(int32_t role,
+                   const std::vector<framework::OpDesc*>& op_descs,
+                   int64_t rank, int64_t task_id, int64_t max_run_times,
+                   int64_t max_slot_nums)
+    : role_(role),
+      rank_(rank),
+      task_id_(task_id),
+      max_run_times_(max_run_times),
+      max_slot_nums_(max_slot_nums) {
+  for (const auto& desc : op_descs) {
+    ops_vec_.emplace_back(framework::OpRegistry::CreateOp(*desc));
+  }
+  for (const auto& op : ops_vec_) {
+    ops_.emplace_back(op.get());
+  }
+}
+
+TaskNode::TaskNode(int32_t role,
+                   const std::vector<framework::OperatorBase*>& ops,
                    int64_t rank, int64_t task_id, int64_t max_run_times,
                    int64_t max_slot_nums)
     : ops_(ops),

--- a/paddle/fluid/distributed/fleet_executor/task_node.h
+++ b/paddle/fluid/distributed/fleet_executor/task_node.h
@@ -90,12 +90,12 @@ class TaskNode final {
   DISABLE_COPY_AND_ASSIGN(TaskNode);
   TaskNode() = default;
   // ops_ will be removed in the future
-  std::vector<OperatorBase*> ops_{};
+  std::vector<OperatorBase*> ops_;
   // task_id-->buff_size
   std::unordered_map<int64_t, int64_t> upstream_;
   std::unordered_map<int64_t, int64_t> downstream_;
   framework::ProgramDesc program_;
-  std::vector<std::unique_ptr<OperatorBase>> ops_vec_{};
+  std::vector<std::unique_ptr<OperatorBase>> ops_vec_;
   std::unordered_map<const OperatorBase*, std::vector<std::string>>
       unused_vars_;
 

--- a/paddle/fluid/distributed/fleet_executor/task_node.h
+++ b/paddle/fluid/distributed/fleet_executor/task_node.h
@@ -25,6 +25,7 @@
 namespace paddle {
 namespace framework {
 class OperatorBase;
+class OpDesc;
 }
 namespace distributed {
 
@@ -33,8 +34,12 @@ class TaskNode final {
   using OperatorBase = paddle::framework::OperatorBase;
   TaskNode(int32_t role, int64_t rank, int64_t task_id, int64_t max_run_times,
            int64_t max_slot_nums);
-  TaskNode(int32_t role, const std::vector<OperatorBase*>& ops, int64_t rank,
-           int64_t task_id, int64_t max_run_times, int64_t max_slot_nums);
+  TaskNode(int32_t role, const std::vector<framework::OpDesc*>& op_descs,
+           int64_t rank, int64_t task_id, int64_t max_run_times,
+           int64_t max_slot_nums);
+  TaskNode(int32_t role, const std::vector<framework::OperatorBase*>& ops,
+           int64_t rank, int64_t task_id, int64_t max_run_times,
+           int64_t max_slot_nums);
   TaskNode(const paddle::framework::ProgramDesc& program, int64_t rank,
            int64_t max_run_times, int64_t max_slot_nums);
   ~TaskNode() = default;

--- a/paddle/fluid/distributed/fleet_executor/task_node.h
+++ b/paddle/fluid/distributed/fleet_executor/task_node.h
@@ -90,12 +90,12 @@ class TaskNode final {
   DISABLE_COPY_AND_ASSIGN(TaskNode);
   TaskNode() = default;
   // ops_ will be removed in the future
-  std::vector<OperatorBase*> ops_;
+  std::vector<OperatorBase*> ops_{};
   // task_id-->buff_size
   std::unordered_map<int64_t, int64_t> upstream_;
   std::unordered_map<int64_t, int64_t> downstream_;
   framework::ProgramDesc program_;
-  std::vector<std::unique_ptr<OperatorBase>> ops_vec_;
+  std::vector<std::unique_ptr<OperatorBase>> ops_vec_{};
   std::unordered_map<const OperatorBase*, std::vector<std::string>>
       unused_vars_;
 

--- a/paddle/fluid/pybind/bind_fleet_executor.cc
+++ b/paddle/fluid/pybind/bind_fleet_executor.cc
@@ -38,9 +38,14 @@ void BindFleetExecutor(py::module* m) {
 
   py::class_<TaskNode>(*m, "TaskNode")
       .def(py::init<const framework::ProgramDesc&, int64_t, int64_t, int64_t>())
+      .def(py::init<int32_t, const std::vector<OperatorBase*>&, int64_t,
+                    int64_t, int64_t, int64_t>())
       .def("task_id", &TaskNode::task_id)
       .def("add_upstream_task", &TaskNode::AddUpstreamTask)
-      .def("add_downstream_task", &TaskNode::AddDownstreamTask);
+      .def("add_downstream_task", &TaskNode::AddDownstreamTask)
+      .def("set_run_pre_steps", &TaskNode::SetRunPerSteps)
+      .def("set_run_at_offset", &TaskNode::SetRunAtOffset)
+      .def("set_type", &TaskNode::SetType);
 }
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/fluid/pybind/bind_fleet_executor.cc
+++ b/paddle/fluid/pybind/bind_fleet_executor.cc
@@ -28,7 +28,7 @@ namespace pybind {
 
 using paddle::distributed::FleetExecutor;
 using paddle::distributed::TaskNode;
-using paddle::framework::OperatorBase;
+using paddle::framework::OpDesc;
 
 void BindFleetExecutor(py::module* m) {
   py::class_<FleetExecutor>(*m, "FleetExecutor")
@@ -39,7 +39,7 @@ void BindFleetExecutor(py::module* m) {
 
   py::class_<TaskNode>(*m, "TaskNode")
       .def(py::init<const framework::ProgramDesc&, int64_t, int64_t, int64_t>())
-      .def(py::init<int32_t, const std::vector<OperatorBase*>&, int64_t,
+      .def(py::init<int32_t, const std::vector<framework::OpDesc*>&, int64_t,
                     int64_t, int64_t, int64_t>())
       .def("task_id", &TaskNode::task_id)
       .def("add_upstream_task", &TaskNode::AddUpstreamTask)

--- a/paddle/fluid/pybind/bind_fleet_executor.cc
+++ b/paddle/fluid/pybind/bind_fleet_executor.cc
@@ -28,6 +28,7 @@ namespace pybind {
 
 using paddle::distributed::FleetExecutor;
 using paddle::distributed::TaskNode;
+using paddle::framework::OperatorBase;
 
 void BindFleetExecutor(py::module* m) {
   py::class_<FleetExecutor>(*m, "FleetExecutor")

--- a/paddle/fluid/pybind/bind_fleet_executor.cc
+++ b/paddle/fluid/pybind/bind_fleet_executor.cc
@@ -45,7 +45,8 @@ void BindFleetExecutor(py::module* m) {
       .def("add_downstream_task", &TaskNode::AddDownstreamTask)
       .def("set_run_pre_steps", &TaskNode::SetRunPerSteps)
       .def("set_run_at_offset", &TaskNode::SetRunAtOffset)
-      .def("set_type", &TaskNode::SetType);
+      .def("set_type", &TaskNode::SetType)
+      .def("role", &TaskNode::role);
 }
 }  // namespace pybind
 }  // namespace paddle

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .meta_optimizers.common import OpRole, OP_ROLE_KEY
+from paddle.distributed.fleet.meta_optimizers.common import OpRole, OP_ROLE_KEY
 from paddle.fluid import core
 
 
@@ -73,7 +73,7 @@ def is_backward_op(op_role):
 def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
     coord_sys = CoordSys(dist_opt)
     coord = coord_sys.rank_to_coord(cur_rank)
-    max_slot_times = max_run_times - coord['pp_idx']
+    max_slot_times = int(max_run_times - coord['pp_idx'])
     num_of_functionality = 4
 
     def create_task_node(role, ops, offset, node_type):

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -89,13 +89,13 @@ def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
     for op in program.block(0).ops:
         op_role = int(op.all_attrs()[OP_ROLE_KEY])
         if is_lr_sched_op(op_role):
-            lr_ops.append(op)
+            lr_ops.append(op.desc)
         elif is_optimizer_op(op_role):
-            opt_ops.append(op)
+            opt_ops.append(op.desc)
         elif is_forward_op(op_role):
-            fwd_ops.append(op)
+            fwd_ops.append(op.desc)
         elif is_backward_op(op_role):
-            bwd_ops.append(op)
+            bwd_ops.append(op.desc)
         else:
             raise "The op role: " + str(
                 op_role
@@ -130,9 +130,9 @@ def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
         cur_id = cur_rank * num_of_functionality + i
         prev_id = cur_id - 1
         next_id = cur_id + 1
-        upstream_id = pp_upstream * num_of_functionality + i
-        downstream_id = pp_downstream * num_of_functionality + i
-        pp_buff_size = dist_opt['pp_degree'] - coord['pp_idx']
+        upstream_id = int(pp_upstream * num_of_functionality + i)
+        downstream_id = int(pp_downstream * num_of_functionality + i)
+        pp_buff_size = int(dist_opt['pp_degree'] - coord['pp_idx'])
         ups = []
         downs = []
         if not is_lr_sched_op(task_role):

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -38,11 +38,11 @@ class CoordSys:
 
     def rank_to_coord(self, rank):
         mp_idx = rank % self.mp_degree
-        rank /= self.mp_degree
+        rank //= self.mp_degree
         sharding_idx = rank % self.sharding_degree
-        rank /= self.sharding_degree
+        rank //= self.sharding_degree
         pp_idx = rank % self.pp_degree
-        rank /= self.pp_degree
+        rank //= self.pp_degree
         dp_idx = rank % self.dp_degree
         return {
             'mp_idx': mp_idx,

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -112,8 +112,7 @@ def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
 
     def create_task_node(role, ops, offset, node_type):
         task_id = int(cur_rank * num_of_functionality + offset)
-        print("Creating task node with role: ", role, ", and with id: ",
-              task_id)
+        print("Creating task node with role:", role, "and with id:", task_id)
         node = core.TaskNode(role, ops, cur_rank, task_id, max_run_times,
                              max_slot_times)
         node.set_type(node_type)
@@ -192,10 +191,10 @@ def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
             if not first_stage:
                 downs.append((upstream_id, 2))
         for up in ups:
-            print("Task: ", cur_id, "'s upstream includes: ", up[0], ".")
+            print("Task:", cur_id, "'s upstream includes:", up[0])
             task_node.add_upstream_task(up[0], up[1])
         for down in downs:
-            print("Task: ", cur_id, "'s downstream includes: ", down[0], ".")
+            print("Task:", cur_id, "'s downstream includes:", down[0])
             task_node.add_downstream_task(down[0], down[1])
     task_id_to_rank = {}
     for i in range(nrank):

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -11,3 +11,130 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from .meta_optimizers.common import OpRole, OP_ROLE_KEY
+from paddle.fluid import core
+
+
+class CoordSys:
+    def __init__(self, dist_opt):
+        self.dp_degree = dist_opt.get('dp_degree', 1)
+        self.pp_degree = dist_opt.get('pp_degree', 1)
+        self.sharding_degree = dist_opt.get('sharding_degree', 1)
+        self.mp_degree = dist_opt.get('mp_degree', 1)
+
+    def _invalide_coord(self, coord):
+        return coord['mp_idx'] < 0 or coord['mp_idx'] >= self.mp_degree or \
+               coord['sharding_idx'] < 0 or coord['sharding_idx'] >= self.sharding_degree or \
+               coord['pp_idx'] < 0 or coord['pp_idx'] >= self.pp_degree or \
+               coord['dp_idx'] < 0 or coord['dp_idx'] >= self.dp_degree
+
+    def coord_to_rank(self, coord):
+        if self._invalide_coord(coord):
+            return -1
+        return coord['dp_idx'] * self.pp_degree * self.sharding_degree * self.mp_degree + \
+               coord['pp_idx'] * self.sharding_degree * self.mp_degree + \
+               coord['sharding_idx'] * self.mp_degree + coord['mp_idx']
+
+    def rank_to_coord(self, rank):
+        mp_idx = rank % self.mp_degree
+        rank /= self.mp_degree
+        sharding_idx = rank % self.sharding_degree
+        rank /= self.sharding_degree
+        pp_idx = rank % self.pp_degree
+        rank /= self.pp_degree
+        dp_idx = rank % self.dp_degree
+        return {
+            'mp_idx': mp_idx,
+            'sharding_idx': sharding_idx,
+            'pp_idx': pp_idx,
+            'dp_idx': dp_idx
+        }
+
+
+def one_f_one_b(program, cur_rank, max_run_times, dist_opt):
+    coord_sys = CoordSys(dist_opt)
+    coord = coord_sys.rank_to_coord(cur_rank)
+    max_slot_times = max_run_times - coord['pp_idx']
+    lr_ops, fwd_ops, bwd_ops, opt_ops = [], [], [], []
+    num_of_functionality = 4
+    for op in program.block(0).ops:
+        op_role = int(op.all_attrs()[OP_ROLE_KEY])
+        if op_role == int(OpRole.Optimize.LRSched):
+            lr_ops.append(op)
+        elif op_role == int(OpRole.Optimize):
+            opt_ops.append(op)
+        elif op_role == int(OpRole.Forward) or op_role == (int(OpRole.Forward) ^
+                                                           int(OpRole.Loss)):
+            fwd_ops.append(op)
+        elif op_role == int(OpRole.Backward) or op_role == (int(OpRole.Backward)
+                                                            ^ int(OpRole.Loss)):
+            bwd_ops.append(op)
+        else:
+            raise "The op role: " + str(
+                op_role
+            ) + " isn't one of LRSched, forward, backward or optimizer."
+    lr_task_node = core.TaskNode(
+        int(OpRole.Optimize.LRSched), lr_ops, cur_rank,
+        cur_rank * num_of_functionality, max_run_times, max_slot_times)
+    lr_task_node.set_type("Amplifier")
+    lr_task_node.set_run_pre_steps(max_run_times)
+    fwd_task_node = core.TaskNode(
+        int(OpRole.Forward), fwd_ops, cur_rank,
+        cur_rank * num_of_functionality + 1, max_run_times, max_slot_times)
+    fwd_task_node.set_type("Compute")
+    bwd_task_node = core.TaskNode(
+        int(OpRole.Backward), bwd_ops, cur_rank,
+        cur_rank * num_of_functionality + 2, max_run_times, max_slot_times)
+    bwd_task_node.set_type("Compute")
+    opt_task_node = core.TaskNode(
+        int(OpRole.Optimize), opt_ops, cur_rank,
+        cur_rank * num_of_functionality + 3, max_run_times, max_slot_times)
+    opt_task_node.set_type("Amplifier")
+    opt_task_node.set_run_pre_steps(max_run_times)
+    opt_task_node.set_run_at_offset(max_run_times - 1)
+
+    # lr(1:m) -> forward -> backward -> (m:1)optimize
+    #               ↑          ↓
+    # lr(1:m) -> forward -> backward -> (m:1)optimize
+    #               ↑          ↓
+    # lr(1:m) -> forward -> backward -> (m:1)optimize
+    upstream_coord, downstream_coord = coord, coord
+    upstream_coord['pp_idx'] -= 1
+    downstream_coord['pp_idx'] += 1
+    pp_upstream = coord_sys.coord_to_rank(upstream_coord)
+    pp_downstream = coord_sys.coord_to_rank(downstream_coord)
+    first_stage = (pp_upstream == -1)
+    last_stage = (pp_downstream == -1)
+    tmp = [lr_task_node, fwd_task_node, bwd_task_node, opt_task_node]
+    for i in range(4):
+        cur_task_node = tmp[i]
+        cur_id = cur_rank * num_of_functionality + i
+        prev_id = cur_id - 1
+        next_id = cur_id + 1
+        upstream_id = pp_upstream * num_of_functionality + i
+        downstream_id = pp_downstream * num_of_functionality + i
+        pp_buff_size = dist_opt['pp_degree'] - coord['pp_idx']
+        ups = []
+        downs = []
+        if i != 0:
+            buf_size = pp_buff_size if i == 2 else 2
+            ups.append((prev_id, buf_size))
+        if i != 3:
+            buf_size = pp_buff_size if i == 1 else 2
+            downs.append((next_id, buf_size))
+        if i == 1:
+            if not first_stage:
+                ups.append((upstream_id, 2))
+            if not last_stage:
+                downs.append((downstream_id, 2))
+        elif i == 2:
+            if not last_stage:
+                ups.append((downstream_id, 2))
+            if not first_stage:
+                downs.append((upstream_id, 2))
+        for up in ups:
+            cur_task_node.add_upstream_task(up[0], up[1])
+        for down in downs:
+            cur_task_node.add_downstream_task(down[0], down[1])
+    return tmp

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -77,9 +77,11 @@ def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
     num_of_functionality = 4
 
     def create_task_node(role, ops, offset, node_type):
-        node = core.TaskNode(role, ops, cur_rank,
-                             cur_rank * num_of_functionality + offset,
-                             max_run_times, max_slot_times)
+        task_id = cur_rank * num_of_functionality + offset
+        print("Creating task node with role: ", role, ", and with id: ",
+              task_id)
+        node = core.TaskNode(role, ops, cur_rank, task_id, max_run_times,
+                             max_slot_times)
         node.set_type(node_type)
         return node
 

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -104,6 +104,7 @@ def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
         task_nodes (list): four task nodes for current rank
         task_id_to_rank (dict): task nodes' ids to it's corresponding rank
     """
+    print("fleet executor will use python side 1f1b scheduler.")
     coord_sys = CoordSys(dist_opt)
     coord = coord_sys.rank_to_coord(cur_rank)
     max_slot_times = int(max_run_times - coord['pp_idx'])

--- a/python/paddle/distributed/fleet/fleet_executor_utils.py
+++ b/python/paddle/distributed/fleet/fleet_executor_utils.py
@@ -117,14 +117,14 @@ def one_f_one_b(program, cur_rank, max_run_times, dist_opt, nrank):
     # lr(1:m) -> forward -> backward -> (m:1)optimize
     #               ↑          ↓
     # lr(1:m) -> forward -> backward -> (m:1)optimize
-    upstream_coord, downstream_coord = coord, coord
-    upstream_coord['pp_idx'] -= 1
-    downstream_coord['pp_idx'] += 1
+    upstream_coord, downstream_coord = coord.copy(), coord.copy()
+    upstream_coord['pp_idx'] = upstream_coord['pp_idx'] - 1
+    downstream_coord['pp_idx'] = downstream_coord['pp_idx'] + 1
     pp_upstream = coord_sys.coord_to_rank(upstream_coord)
     pp_downstream = coord_sys.coord_to_rank(downstream_coord)
     first_stage = (pp_upstream == -1)
     last_stage = (pp_downstream == -1)
-    for i in range(4):
+    for i in range(num_of_functionality):
         task_node = task_nodes[i]
         task_role = task_node.role()
         cur_id = cur_rank * num_of_functionality + i

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1991,8 +1991,8 @@ class Executor(object):
                     fleet_opt.get('num_micro_batches', 1),
                     fleet_opt.get('dist_strategy', {}), nrank)
                 # NOTE: have to hold these vars, otherwise will be destructed
-                self.tasks = tasks
-                self.task_id_to_rank = task_id_to_rank
+                fleet_opt['tasks'] = tasks
+                fleet_opt['task_id_to_rank'] = task_id_to_rank
         fleet_exe = core.FleetExecutor(fleet_exe_desc.SerializeToString())
         place = core.Place()
         place.set_place(self.place)

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1994,7 +1994,7 @@ class Executor(object):
         place = core.Place()
         place.set_place(self.place)
         fleet_exe.init(program.desc, scope, place, tasks, task_id_to_rank)
-        return fleet_exe
+        return fleet_exe, tasks, task_id_to_rank
 
     def _run_using_fleet_executor(self,
                                   program=None,
@@ -2031,9 +2031,11 @@ class Executor(object):
             self._add_program_cache(cache_key, cached_program)
         if cached_ctx is None:
             fleet_opt = program._pipeline_opt["fleet_opt"]
-            cached_ctx = self._prepare_fleet_executor(
+            cached_ctx, tasks, task_node_to_id = self._prepare_fleet_executor(
                 program=cached_program, scope=cached_scope, fleet_opt=fleet_opt)
             self._add_ctx_cache(cache_key, cached_ctx)
+            self.tasks = tasks
+            self.task_node_to_id = task_node_to_id
         if feed:
             self._feed_data(cached_program, feed, feed_var_name, cached_scope)
 

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1983,11 +1983,13 @@ class Executor(object):
         assert nrank == num_of_gpu, "The number of rank is not equal to the number of gpu."
         task_id_to_rank = fleet_opt.get("task_id_to_rank", {})
         tasks = fleet_opt.get("tasks", [])
-        if len(tasks) == 0:
-            tasks, task_id_to_rank = one_f_one_b(
-                program, cur_rank,
-                fleet_opt.get('num_micro_batches', 1),
-                fleet_opt.get('dist_strategy', {}), nrank)
+        if 'python_side' in fleet_opt == 0:
+            strategy = fleet_opt['python_side']
+            if strategy == '1F1B':
+                tasks, task_id_to_rank = one_f_one_b(
+                    program, cur_rank,
+                    fleet_opt.get('num_micro_batches', 1),
+                    fleet_opt.get('dist_strategy', {}), nrank)
         fleet_exe = core.FleetExecutor(fleet_exe_desc.SerializeToString())
         place = core.Place()
         place.set_place(self.place)

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -35,7 +35,6 @@ import copy
 from . import framework
 from .incubate.checkpoint import auto_checkpoint as acp
 from .compiler import _prune_feed_ops
-from ..distributed.fleet.fleet_executor_utils import *
 
 __all__ = ['Executor', 'global_scope', 'scope_guard']
 
@@ -1983,9 +1982,10 @@ class Executor(object):
         assert nrank == num_of_gpu, "The number of rank is not equal to the number of gpu."
         task_id_to_rank = fleet_opt.get("task_id_to_rank", {})
         tasks = fleet_opt.get("tasks", [])
-        if 'python_side' in fleet_opt == 0:
+        if 'python_side' in fleet_opt:
             strategy = fleet_opt['python_side']
             if strategy == '1F1B':
+                from paddle.distributed.fleet.fleet_executor_utils import one_f_one_b
                 tasks, task_id_to_rank = one_f_one_b(
                     program, cur_rank,
                     fleet_opt.get('num_micro_batches', 1),

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1992,8 +1992,8 @@ class Executor(object):
                 fleet_opt['tasks'] = tasks
                 fleet_opt['task_id_to_rank'] = task_id_to_rank
             else:
-                raise "Fleet_executor only supports 1F1B scheduler if you choose python side split, but received " + str(
-                    strategy) + "."
+                raise "Fleet_executor only supports 1F1B scheduler if you choose python side split, " \
+                      "but received " + str(strategy) + "."
         else:
             task_id_to_rank = fleet_opt.get("task_id_to_rank", {})
             tasks = fleet_opt.get("tasks", [])

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1980,8 +1980,6 @@ class Executor(object):
             fleet_exe_desc.num_micro_batches = fleet_opt["num_micro_batches"]
         num_of_gpu = fleet_exe_desc.dp_degree * fleet_exe_desc.mp_degree * fleet_exe_desc.pp_degree
         assert nrank == num_of_gpu, "The number of rank is not equal to the number of gpu."
-        task_id_to_rank = fleet_opt.get("task_id_to_rank", {})
-        tasks = fleet_opt.get("tasks", [])
         if 'python_side' in fleet_opt:
             strategy = fleet_opt['python_side']
             if strategy == '1F1B':
@@ -1993,6 +1991,12 @@ class Executor(object):
                 # NOTE: have to hold these vars, otherwise will be destructed
                 fleet_opt['tasks'] = tasks
                 fleet_opt['task_id_to_rank'] = task_id_to_rank
+            else:
+                raise "Fleet_executor only supports 1F1B scheduler if you choose python side split, but received " + str(
+                    strategy) + "."
+        else:
+            task_id_to_rank = fleet_opt.get("task_id_to_rank", {})
+            tasks = fleet_opt.get("tasks", [])
         fleet_exe = core.FleetExecutor(fleet_exe_desc.SerializeToString())
         place = core.Place()
         place.set_place(self.place)

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -35,6 +35,7 @@ import copy
 from . import framework
 from .incubate.checkpoint import auto_checkpoint as acp
 from .compiler import _prune_feed_ops
+from ..distributed.fleet.fleet_executor_utils import *
 
 __all__ = ['Executor', 'global_scope', 'scope_guard']
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_executor.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_executor.py
@@ -33,7 +33,8 @@ class TestFleetExecutor(unittest.TestCase):
         strategy.pipeline_configs = {"accumulate_steps": 1}
         fleet_opt = {
             "dist_strategy": strategy.sharding_configs,
-            "num_micro_batches": strategy.pipeline_configs["accumulate_steps"]
+            "num_micro_batches": strategy.pipeline_configs["accumulate_steps"],
+            "python_side": "1F1B"
         }
         return fleet_opt
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
replace the c++ side runtime_graph with the python side one_f_one_b function.

loss compare on GPT2 with pp=mp=dp=2
<img width="570" alt="pr" src="https://user-images.githubusercontent.com/25279174/146153925-65bfe13a-a95c-4ebc-807e-3444753c1c83.png">


#### TODO List:
1. Move the whole graph cutting from c++ to python.
2. Remove all RuntimeGraph
3. Update the python configuration entrance
4. Adapt for interleaved
