### PR TITLE
[Cherry-Pick][Dy2stat]Fix error in tensor_shape_transformer.  (#37999)

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
@@ -282,6 +282,10 @@ class TensorShapeTransformer(gast.NodeTransformer):
             return False
 
         if isinstance(node, gast.Attribute):
+            # If node is `paddle.shape`, return False
+            if (node.attr == 'shape' and isinstance(node.value, gast.Name) and
+                    node.value.id == 'paddle'):
+                return False
             if node.attr != 'shape':
                 return False
             return True

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -217,6 +217,12 @@ def dyfunc_change_shape_after_assign(x):
     return res
 
 
+def dyfunc_len_paddle_shape():
+    x = paddle.to_tensor([1, 2, 3])
+    if len(paddle.shape(x)) > 0:
+        print(x)
+
+
 # 1. Basic tests without control flow
 class TestTensorShapeBasic(unittest.TestCase):
     def setUp(self):
@@ -580,6 +586,12 @@ class TestFindStatiConvertVarShapeSuffixVar(unittest.TestCase):
         func = paddle.jit.to_static(dyfunc_with_if_2, input_spec=[x_spec])
         # Call this function to trigger program translation.
         func.concrete_program
+
+
+class TestPaddleShape(unittest.TestCase):
+    def test_paddle_shape(self):
+        func = paddle.jit.to_static(dyfunc_len_paddle_shape)
+        self.assertEqual('paddle.shape(x)' in func.code, True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复tensor_shape_transformer中的错误。
之前在类似`if len(paddle.shape(x)[0]) > 0`中，paddle会被当做一个变量被传入convert_var_shape函数中