### PR TITLE
[AMP] Add set_state_dict for gradscaler

### DIFF
--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -632,3 +632,29 @@ class GradScaler(AmpScaler):
                 scaler.load_state_dict(scaler_state)
         """
         super(GradScaler, self).load_state_dict(state_dict)
+
+    def set_state_dict(self, state_dict):
+        """
+        Set the scaler state.
+        
+        Args:
+           state_dict(dict): scaler state.  Should be an object returned from a call to `GradScaler.state_dict()`.
+                
+        Examples:
+
+            .. code-block:: python
+
+                # required: gpu,xpu
+                import paddle
+
+                scaler = paddle.amp.GradScaler(enable=True,
+                                               init_loss_scaling=1024,
+                                               incr_ratio=2.0,
+                                               decr_ratio=0.5,
+                                               incr_every_n_steps=1000,
+                                               decr_every_n_nan_or_inf=2,
+                                               use_dynamic_loss_scaling=True)
+                scaler_state = scaler.state_dict()
+                scaler.set_state_dict(scaler_state)
+        """
+        super(GradScaler, self).load_state_dict(state_dict)

--- a/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
@@ -497,7 +497,7 @@ class TestGradScalerStateDict(unittest.TestCase):
             if use_save_load and batch_id == 2:
                 paddle.save(scaler.state_dict(), 'ResNet_model.pdparams')
                 dict_load = paddle.load('ResNet_model.pdparams')
-                scaler.load_state_dict(dict_load)
+                scaler.set_state_dict(dict_load)
         if use_data_loader:
             train_reader._reset()
         return dy_out, dy_param_value, dy_grad_value


### PR DESCRIPTION
### PR types
New features

### PR changes
APIs

### Describe
[issue](https://github.com/PaddlePaddle/Paddle/issues/38157) 反馈`paddle.amp.GradScaler`用的是`load_state_dict`。但是`nn.Layer`和`optimizer`用的是`set_state_dict`。
新增`paddle.amp.GradScaler`的`set_state_dict`接口。

