### PR TITLE
[BugFix]: Elementwise branch selection and Broadcast dimension merge

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_broadcast.cu.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_broadcast.cu.h
@@ -125,7 +125,7 @@ struct DimensionsTransform {
                                     std::vector<DimVector> &in_dims,
                                     DimVector &out, int i, int num) {
       for (int j = 1; j < num; ++j) {
-        equal = (in_dims[0][i] == in_dims[j][i]) ? true : false;
+        equal &= (in_dims[0][i] == in_dims[j][i]) ? true : false;
       }
     };
     auto merge_sequential_one_dims = [](bool &equal,
@@ -134,7 +134,7 @@ struct DimensionsTransform {
       equal = in_dims[0][i] == 1;
       if (equal) {
         for (int j = 1; j < num; ++j) {
-          equal = in_dims[j][i] == out[i];
+          equal &= in_dims[j][i] == out[i];
         }
       }
     };

--- a/paddle/pten/kernels/hybird/cuda/elementwise/elementwise.h
+++ b/paddle/pten/kernels/hybird/cuda/elementwise/elementwise.h
@@ -29,7 +29,7 @@ void LaunchElementwiseCudaKernel(
   std::vector<int> dims_size;
   bool no_broadcast_flag = true;
   for (auto *in : ins) {
-    no_broadcast_flag = ins[0]->dims() == in->dims();
+    no_broadcast_flag &= ins[0]->dims() == in->dims();
     dims_size.emplace_back(in->dims().size());
   }
   if (no_broadcast_flag) {

--- a/paddle/pten/kernels/hybird/cuda/elementwise/elementwise_broadcast.cu.h
+++ b/paddle/pten/kernels/hybird/cuda/elementwise/elementwise_broadcast.cu.h
@@ -131,7 +131,7 @@ struct DimensionsTransform {
                                     int i,
                                     int num) {
       for (int j = 1; j < num; ++j) {
-        equal = (in_dims[0][i] == in_dims[j][i]) ? true : false;
+        equal &= (in_dims[0][i] == in_dims[j][i]) ? true : false;
       }
     };
     auto merge_sequential_one_dims = [](bool &equal,
@@ -142,7 +142,7 @@ struct DimensionsTransform {
       equal = in_dims[0][i] == 1;
       if (equal) {
         for (int j = 1; j < num; ++j) {
-          equal = in_dims[j][i] == out[i];
+          equal &= in_dims[j][i] == out[i];
         }
       }
     };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- Original branch logic cannot correctly deal with the condition below, where the return value of `no_broadcast_flag` is `True` and incorrectly lanuch `LaunchSameDimsElementwiseCudaKernel` function .  
  ```
   input1_dim !== input2.dim
   input1_dim  == input3.dim
  ```

- The original dimension merge logic cannot  correctly deal with the condition below, where dimension merging function  disregards the effect of `input2.dims `
  ```
  input1.dims = [2, 5, 2] 
  input2.dims = [2, 1, 1] 
  input3.dims = [2, 5, 2] 
  ```