### PR TITLE
Write out includes.txt for developers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,3 +416,7 @@ add_subdirectory(paddle)
 if(WITH_PYTHON)
     add_subdirectory(python)
 endif()
+
+get_directory_property(all_inc_dirs INCLUDE_DIRECTORIES)
+list(JOIN all_inc_dirs "\r\n" all_inc_dirs)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/includes.txt" ${all_inc_dirs})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Sometimes, developer may need to do some coding outside the PaddlePaddle framework. They may need all the including paths of the PaddlePaddle framework when compiling from source code.

This PR writes out all of the including directories of the PaddlePaddle framework when compiling from source code to a file named `includes.txt` in the `build` directory. 