### PR TITLE
add dirichlet random sample op in cpu and gpu kernel

### DIFF
--- a/paddle/fluid/operators/dirichlet_op.cc
+++ b/paddle/fluid/operators/dirichlet_op.cc
@@ -1,0 +1,102 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/dirichlet_op.h"
+
+#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_op.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_sum_op.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename T>
+struct DirichletSampler<platform::CPUDeviceContext, T> {
+  void operator()(const framework::ExecutionContext& ctx, const Tensor* alpha,
+                  Tensor* out) {
+    auto& dev_ctx = ctx.device_context<platform::CPUDeviceContext>();
+    std::random_device rd;
+    std::mt19937 generator(rd());
+
+    auto uniform = [&generator]() -> T {
+      std::uniform_real_distribution<T> u(0.0, 1.0);
+      return u(generator);
+    };
+    BaseSampler<T, decltype(uniform)> standard_uniform(uniform);
+
+    auto normal = [&generator]() {
+      std::normal_distribution<T> n(0.0, 1.0);
+      return n(generator);
+    };
+    BaseSampler<T, decltype(normal)> standard_normal(normal);
+
+    framework::Tensor gamma;
+    gamma.mutable_data<T>(alpha->dims(), dev_ctx.GetPlace());
+
+    GammaSampler<T, decltype(uniform), decltype(normal)> gamma_sampler(
+        alpha->data<T>(), gamma.data<T>(), standard_uniform, standard_normal);
+
+    platform::ForRange<platform::CPUDeviceContext> for_range(dev_ctx,
+                                                             alpha->numel());
+    for_range(gamma_sampler);
+
+    framework::Tensor gamma_sum;
+    auto gamma_sum_dims_vector = vectorize(gamma.dims());
+    gamma_sum_dims_vector[gamma_sum_dims_vector.size() - 1] = 1;
+    gamma_sum.mutable_data<T>(framework::make_ddim(gamma_sum_dims_vector),
+                              dev_ctx.GetPlace());
+
+    std::vector<int> reduce_dims;
+    reduce_dims.push_back(gamma_sum_dims_vector.size() - 1);
+    ReduceKernelFunctor<platform::CPUDeviceContext, T, SumFunctor>(
+        &gamma, &gamma_sum, reduce_dims, true, false, ctx)
+        .template apply<T>();
+
+    ElementwiseComputeEx<DivFunctor<T>, platform::CPUDeviceContext, T, T>(
+        ctx, &gamma, &gamma_sum, -1, DivFunctor<T>(), out);
+  }
+};
+
+class DirichletOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("Alpha", "(Tensor), The dirichlet Alpha parameter");
+    AddOutput("Out", "(Tensor), The output tensor of sample");
+    AddComment(R"DOC(Sample random data from dirichlet distribution.)DOC");
+  }
+};
+
+class DirichletOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("Alpha"), "Input", "Alpha", "dirichlet");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "dirichlet");
+
+    ctx->ShareDim("Alpha", /*->*/ "Out");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+REGISTER_OP_WITHOUT_GRADIENT(dirichlet, paddle::operators::DirichletOp,
+                             paddle::operators::DirichletOpMaker);
+REGISTER_OP_CPU_KERNEL(
+    dirichlet,
+    paddle::operators::DirichletKernel<paddle::platform::CPUDeviceContext,
+                                       float>,
+    paddle::operators::DirichletKernel<paddle::platform::CPUDeviceContext,
+                                       double>);

--- a/paddle/fluid/operators/dirichlet_op.cc
+++ b/paddle/fluid/operators/dirichlet_op.cc
@@ -21,23 +21,23 @@
 
 namespace paddle {
 namespace operators {
-template <typename T, typename uniform_sampler_t, typename normal_sampler_t>
+template <typename T, typename UniformSamplerT, typename NormalSamplerT>
 struct GammaCPUFunctor {
   GammaCPUFunctor(const T* alpha, T* gamma,
-                  BaseSampler<T, uniform_sampler_t> uniform,
-                  BaseSampler<T, normal_sampler_t> normal)
+                  BaseSampler<T, UniformSamplerT> uniform,
+                  BaseSampler<T, NormalSamplerT> normal)
       : alpha_(alpha), gamma_(gamma), uniform_(uniform), normal_(normal) {}
 
   HOST void operator()(int64_t index) {
-    auto sample = sample_gamma<T, T, uniform_sampler_t, normal_sampler_t>(
+    auto sample = sample_gamma<T, T, UniformSamplerT, NormalSamplerT>(
         alpha_[index], uniform_, normal_);
     gamma_[index] = std::max(std::numeric_limits<T>::min(), sample);
   }
 
   const T* alpha_;
   T* gamma_;
-  BaseSampler<T, uniform_sampler_t> uniform_;
-  BaseSampler<T, normal_sampler_t> normal_;
+  BaseSampler<T, UniformSamplerT> uniform_;
+  BaseSampler<T, NormalSamplerT> normal_;
 };
 
 template <typename T>

--- a/paddle/fluid/operators/dirichlet_op.cu
+++ b/paddle/fluid/operators/dirichlet_op.cu
@@ -12,14 +12,84 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/fluid/framework/generator.h"
 #include "paddle/fluid/operators/dirichlet_op.h"
+#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_op.h"
+#include "paddle/fluid/operators/reduce_ops/reduce_sum_op.h"
+#include "paddle/fluid/platform/for_range.h"
+
+#ifdef PADDLE_WITH_CUDA
+#include <curand_kernel.h>
+#endif
+#ifdef PADDLE_WITH_HIP
+#include <hiprand_kernel.h>
+#endif
 
 namespace paddle {
 namespace operators {
 template <typename T>
+struct GammaCUDAFunctor {
+  GammaCUDAFunctor(const T* alpha, T* gamma, uint64_t seed, uint64_t offset)
+      : alpha_(alpha), gamma_(gamma), seed_(seed), offset_(offset) {}
+
+  DEVICE void operator()(int64_t index) {
+    // curand initialization
+    curandStatePhilox4_32_10_t state;
+    curand_init(/*seed=*/seed_, /*subsequence=*/index, /*offset=*/offset_,
+                &state);
+
+    // sample
+    auto uniform_lambda = [&state]() { return curand_uniform(&state); };
+    BaseSampler<T, decltype(uniform_lambda)> standard_uniform(uniform_lambda);
+    auto normal_lambda = [&state]() { return curand_normal(&state); };
+    BaseSampler<T, decltype(normal_lambda)> standard_normal(normal_lambda);
+
+    auto sample =
+        sample_gamma<T, T, decltype(uniform_lambda), decltype(normal_lambda)>(
+            alpha_[index], standard_uniform, standard_normal);
+    gamma_[index] = std::max(std::numeric_limits<T>::min(), sample);
+  }
+
+  const T* alpha_;
+  T* gamma_;
+  const uint64_t seed_;
+  const uint64_t offset_;
+};
+
+template <typename T>
 struct DirichletSampler<platform::CUDADeviceContext, T> {
-  void operator()(const framework::ExecutionContext& ctx, const Tensor* alpha,
-                  Tensor* out) {}
+  void operator()(const framework::ExecutionContext& ctx,
+                  const framework::Tensor* alpha, framework::Tensor* out) {
+    auto& dev_ctx = ctx.device_context<platform::CUDADeviceContext>();
+
+    // init state, seed & offset for all threads
+    auto p_gen = framework::GetDefaultCUDAGenerator();
+    auto seed_and_offset = p_gen->IncrementOffset(10);  // hard-coded offset
+    auto seed = seed_and_offset.first;
+    auto offset = seed_and_offset.second;
+
+    // sample from K gamma distributions, where K=alpha.numel()
+    framework::Tensor gamma_samples;
+    gamma_samples.mutable_data<T>(alpha->dims(), dev_ctx.GetPlace());
+    GammaCUDAFunctor<T> gamma_functor(alpha->data<T>(), gamma_samples.data<T>(),
+                                      seed, offset);
+    platform::ForRange<platform::CUDADeviceContext> for_range(dev_ctx,
+                                                              out->numel());
+    for_range(gamma_functor);
+
+    // normalize them into a simplex, along the last axis
+    framework::Tensor gamma_sum;
+    auto new_shape = gamma_samples.dims();
+    new_shape[new_shape.size() - 1] = 1;
+    gamma_sum.mutable_data<T>(new_shape, dev_ctx.GetPlace());
+
+    ReduceKernelFunctor<platform::CPUDeviceContext, T, SumFunctor>(
+        &gamma_samples, &gamma_sum, {new_shape.size() - 1}, true, false, ctx)
+        .template apply<T>();
+    ElementwiseComputeEx<DivFunctor<T>, platform::CPUDeviceContext, T, T>(
+        ctx, &gamma_samples, &gamma_sum, -1, DivFunctor<T>(), out);
+  }
 };
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/dirichlet_op.cu
+++ b/paddle/fluid/operators/dirichlet_op.cu
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/dirichlet_op.h"
+
+namespace paddle {
+namespace operators {
+template <typename T>
+struct DirichletSampler<platform::CUDADeviceContext, T> {
+  void operator()(const framework::ExecutionContext& ctx, const Tensor* alpha,
+                  Tensor* out) {}
+};
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OP_CUDA_KERNEL(
+    dirichlet, ops::DirichletKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::DirichletKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/dirichlet_op.cu
+++ b/paddle/fluid/operators/dirichlet_op.cu
@@ -27,15 +27,15 @@
 #endif
 
 #if defined(PADDLE_WITH_CUDA)
-using compatRandStatePhilox4_32_10_t = curandStatePhilox4_32_10_t;
-#define compat_rand_init curand_init
-#define compat_rand_uniform curand_uniform
-#define compat_rand_normal curand_normal
+using COMPAT_RANDSTATEPHILOX4_32_10_T = curandStatePhilox4_32_10_t;
+#define COMPAT_RAND_INIT curand_init
+#define COMPAT_RAND_UNIFORM curand_uniform
+#define COMPAT_RAND_NORMAL curand_normal
 #elif defined(PADDLE_WITH_HIP)
-using compatRandStatePhilox4_32_10_t = hiprandStatePhilox4_32_10_t;
-#define compat_rand_init hiprand_init
-#define compat_rand_uniform hiprand_uniform
-#define compat_rand_normal hiprand_normal
+using COMPAT_RANDSTATEPHILOX4_32_10_T = hiprandStatePhilox4_32_10_t;
+#define COMPAT_RAND_INIT hiprand_init
+#define COMPAT_RAND_UNIFORM hiprand_uniform
+#define COMPAT_RAND_NORMAL hiprand_normal
 #endif
 
 namespace paddle {
@@ -47,14 +47,14 @@ struct GammaCUDAFunctor {
 
   DEVICE void operator()(int64_t index) {
     // curand initialization
-    compatRandStatePhilox4_32_10_t state;
-    compat_rand_init(/*seed=*/seed_, /*subsequence=*/index, /*offset=*/offset_,
+    COMPAT_RANDSTATEPHILOX4_32_10_T state;
+    COMPAT_RAND_INIT(/*seed=*/seed_, /*subsequence=*/index, /*offset=*/offset_,
                      &state);
 
     // sample
-    auto uniform_lambda = [&state]() { return compat_rand_uniform(&state); };
+    auto uniform_lambda = [&state]() { return COMPAT_RAND_UNIFORM(&state); };
     BaseSampler<T, decltype(uniform_lambda)> standard_uniform(uniform_lambda);
-    auto normal_lambda = [&state]() { return compat_rand_normal(&state); };
+    auto normal_lambda = [&state]() { return COMPAT_RAND_NORMAL(&state); };
     BaseSampler<T, decltype(normal_lambda)> standard_normal(normal_lambda);
 
     auto sample =

--- a/paddle/fluid/operators/dirichlet_op.h
+++ b/paddle/fluid/operators/dirichlet_op.h
@@ -1,0 +1,147 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <iostream>
+#include <random>
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/platform/for_range.h"
+
+// ROCM hcc doesn't work well with using std:: in kernel functions
+#if defined(__CUDA_ARCH__)
+#else
+#define compat_exp std::exp
+#define compat_ceil std::ceil
+#define compat_floor std::floor
+#define compat_log std::log
+#define compat_pow std::pow
+#define compat_sqrt std::sqrt
+#define compat_tan std::tan
+#define compat_abs std::abs
+#define compat_log1p std::log1p
+#endif
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+
+template <typename scalar_t, typename sampler_t>
+struct BaseSampler {
+  sampler_t sampler_;
+  HOSTDEVICE BaseSampler(const sampler_t& sampler) : sampler_(sampler) {}
+  HOSTDEVICE scalar_t sample() { return sampler_(); }
+};
+
+// `sample_gamma` is d from Numpy's distributions.c, and add support for
+//  paddle data type and code style.
+//  Source MIT licensed:
+/* Copyright 2005 Robert Kern (robert.kern@gmail.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+template <typename scalar_t, typename accscalar_t, typename uniform_sampler_t,
+          typename normal_sampler_t>
+HOSTDEVICE scalar_t
+sample_gamma(scalar_t alpha,
+             BaseSampler<accscalar_t, uniform_sampler_t> standard_uniform,
+             BaseSampler<accscalar_t, normal_sampler_t> standard_normal) {
+  accscalar_t scale = 1.0f;
+
+  // Boost alpha for higher acceptance probability.
+  if (alpha < 1.0f) {
+    if (alpha == 0.f) return 0.f;
+    scale *= compat_pow(1 - standard_uniform.sample(), 1.0f / alpha);
+    alpha += 1.0f;
+  }
+
+  // This implements the acceptance-rejection method of Marsaglia and Tsang
+  // (2000)
+  // doi:10.1145/358407.358414
+  const accscalar_t d = alpha - 1.0f / 3.0f;
+  const accscalar_t c = 1.0f / compat_sqrt(9.0f * d);
+  for (;;) {
+    accscalar_t x, y;
+    do {
+      x = standard_normal.sample();
+      y = 1.0f + c * x;
+    } while (y <= 0);
+    const accscalar_t v = y * y * y;
+    const accscalar_t u = 1 - standard_uniform.sample();
+    const accscalar_t xx = x * x;
+    if (u < 1.0f - 0.0331f * xx * xx)
+      return static_cast<scalar_t>(scale * d * v);
+    if (compat_log(u) < 0.5f * xx + d * (1.0f - v + compat_log(v)))
+      return static_cast<scalar_t>(scale * d * v);
+  }
+}
+
+template <typename T, typename uniform_sampler_t, typename normal_sampler_t>
+struct GammaSampler {
+  GammaSampler(const T* alpha, T* gamma,
+               BaseSampler<T, uniform_sampler_t> uniform,
+               BaseSampler<T, normal_sampler_t> normal)
+      : alpha_(alpha), gamma_(gamma), uniform_(uniform), normal_(normal) {}
+
+  HOSTDEVICE void operator()(int64_t index) {
+    auto sample = sample_gamma<T, T, uniform_sampler_t, normal_sampler_t>(
+        alpha_[index], uniform_, normal_);
+    gamma_[index] = std::max(std::numeric_limits<T>::min(), sample);
+  }
+
+  const T* alpha_;
+  T* gamma_;
+  BaseSampler<T, uniform_sampler_t> uniform_;
+  BaseSampler<T, normal_sampler_t> normal_;
+};
+
+template <typename DeviceContext, typename T>
+struct DirichletSampler {
+  void operator()(const framework::ExecutionContext& ctx, const Tensor* alpha,
+                  Tensor* out);
+};
+
+template <typename DeviceContext, typename T>
+class DirichletKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    const auto* alpha = ctx.Input<Tensor>("Alpha");
+    auto* out = ctx.Output<Tensor>("Out");
+    out->mutable_data<T>(ctx.GetPlace());
+    DirichletSampler<DeviceContext, T> sample;
+    sample(ctx, alpha, out);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -261,6 +261,7 @@ from .tensor.random import rand  # noqa: F401
 from .tensor.random import randint  # noqa: F401
 from .tensor.random import randint_like  # noqa: F401
 from .tensor.random import randperm  # noqa: F401
+from .tensor.random import dirichlet  #noqa: F401
 from .tensor.search import argmax  # noqa: F401
 from .tensor.search import argmin  # noqa: F401
 from .tensor.search import argsort  # noqa: F401

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -261,7 +261,6 @@ from .tensor.random import rand  # noqa: F401
 from .tensor.random import randint  # noqa: F401
 from .tensor.random import randint_like  # noqa: F401
 from .tensor.random import randperm  # noqa: F401
-from .tensor.random import dirichlet  #noqa: F401
 from .tensor.search import argmax  # noqa: F401
 from .tensor.search import argmin  # noqa: F401
 from .tensor.search import argsort  # noqa: F401

--- a/python/paddle/fluid/tests/unittests/distribution/test_dirichlet_op.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_dirichlet_op.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import re
+import sys
+import unittest
+
+import numpy as np
+import paddle
+import paddle.fluid.core as core
+import paddle.fluid.dygraph as dg
+import paddle.static as static
+import scipy.stats
+from numpy.random import random as rand
+sys.path.append("../")
+from op_test import OpTest
+from paddle.fluid import Program, program_guard
+
+paddle.enable_static()
+
+
+class TestDirichletOp(OpTest):
+    # Because dirichlet random sample have not gradient, we skip gradient check.
+    no_need_check_grad = True
+
+    def setUp(self):
+        self.op_type = "dirichlet"
+        self.alpha = np.array((1., 2.))
+        self.sample_shape = (100000, 2)
+
+        self.inputs = {'Alpha': np.broadcast_to(self.alpha, self.sample_shape)}
+        self.attrs = {}
+        self.outputs = {'Out': np.zeros(self.sample_shape)}
+
+    def test_check_output(self):
+        self.check_output_customized(self._hypothesis_testing)
+
+    def _hypothesis_testing(self, outs):
+        self.assertEqual(outs[0].shape, self.sample_shape)
+        self.assertTrue(np.all(outs[0] > 0.0))
+        self.assertLess(
+            scipy.stats.kstest(
+                outs[0][:, 0],
+                # scipy dirichlet have not cdf, use beta to replace it.
+                scipy.stats.beta(
+                    a=self.alpha[0], b=self.alpha[1]).cdf)[0],
+            0.01)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Dirichlet and Beta distribution API need fast dirichlet random generator for draw sample data,  we implement it in cpu and cuda backend use [reject-accept](https://dl.acm.org/doi/10.1145/358407.358414) sample and[ inverse-transform](https://en.wikipedia.org/wiki/Inverse_transform_sampling) sample method.