### PR TITLE
Fix bugs that copy occurs when tensor "in" and tensor "out" is same in reshape kernel

### DIFF
--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -392,7 +392,8 @@ class ReshapeKernel {
             ctx.GetPlace()),
         std::move(meta));
     pten::DenseTensor *pt_out = nullptr;
-    if (in == out) {
+    if (in != nullptr && out != nullptr &&
+        in->Holder()->ptr() == out->Holder()->ptr()) {
       pt_out = pt_x.get();
     } else {
       pt_out = pt_out_tmp.get();

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -392,7 +392,8 @@ class ReshapeKernel {
             ctx.GetPlace()),
         std::move(meta));
     pten::DenseTensor *pt_out = nullptr;
-    if (in != nullptr && out != nullptr &&
+    if (in != nullptr && out != nullptr && in->Holder() != nullptr &&
+        out->Holder() != nullptr &&
         in->Holder()->ptr() == out->Holder()->ptr()) {
       pt_out = pt_x.get();
     } else {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fluid下的reshape kernel有一个bug，在输入和输出内存一样的时候，依然会执行copy，造成性能下降