### PR TITLE
[pten] fix when out_dtype is same with x.dtype and still transform type error

### DIFF
--- a/paddle/pten/kernels/hybird/cuda/reduce/reduce.h
+++ b/paddle/pten/kernels/hybird/cuda/reduce/reduce.h
@@ -61,8 +61,8 @@ void Reduce(const CUDAContext& dev_ctx,
 
   gpuStream_t stream = dev_ctx.stream();
 
-  if (out_dtype != pten::DataType::UNDEFINED) {
-    PD_DISPATCH_FLOATING_AND_INTEGRAL_AND_COMPLEX_TYPES(
+  if (out_dtype != pten::DataType::UNDEFINED && out_dtype != x.dtype()) {
+    PD_DISPATCH_FLOATeNG_AND_INTEGRAL_AND_COMPLEX_TYPES(
         out_dtype, "TensorReduceFunctorImpl", ([&] {
           pten::detail::TensorReduceFunctorImpl<T, data_t, ReduceFunctor>(
               x, out, reduce_dims, stream);

--- a/paddle/pten/kernels/hybird/cuda/reduce/reduce.h
+++ b/paddle/pten/kernels/hybird/cuda/reduce/reduce.h
@@ -62,7 +62,7 @@ void Reduce(const CUDAContext& dev_ctx,
   gpuStream_t stream = dev_ctx.stream();
 
   if (out_dtype != pten::DataType::UNDEFINED && out_dtype != x.dtype()) {
-    PD_DISPATCH_FLOATeNG_AND_INTEGRAL_AND_COMPLEX_TYPES(
+    PD_DISPATCH_FLOATING_AND_INTEGRAL_AND_COMPLEX_TYPES(
         out_dtype, "TensorReduceFunctorImpl", ([&] {
           pten::detail::TensorReduceFunctorImpl<T, data_t, ReduceFunctor>(
               x, out, reduce_dims, stream);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Fix when out_dtype is same with x.dtype and still transform type error.
This will cause error when  calculating  `tensor.mean(0)` and the type of  tensor is `bool` .