### PR TITLE
fix dynamic recompute no grad warning

### DIFF
--- a/python/paddle/distributed/fleet/utils/recompute.py
+++ b/python/paddle/distributed/fleet/utils/recompute.py
@@ -63,7 +63,8 @@ def swith_rng_state(rng_state):
 class RecomputeFunction(PyLayer):
     @staticmethod
     def forward(ctx, run_function, preserve_rng_state, *args):
-        check_recompute_necessary(args)
+        if framework._dygraph_tracer()._has_grad:
+            check_recompute_necessary(args)
 
         # store for recomputing 
         ctx.run_function = run_function


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix dynamic recompute no grad warning when using `model.eval()`
