### PR TITLE
lower numpy version in requirements

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.20.0
-numpy>=1.20 ; python_version>="3.5"
+numpy==1.19.5 ; python_version>="3.5"
 protobuf>=3.1.0
 Pillow
 six

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.20.0
-numpy==1.19.5 ; python_version>="3.5"
+numpy>=1.13
 protobuf>=3.1.0
 Pillow
 six

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -10,3 +10,4 @@ paddle2onnx>=0.8.2
 scipy>=1.6
 prettytable
 distro
+numpy>=1.20


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- numpy1.20.0 desent support python3.6, the highest numpy version supporting python3.6 is 1.19.5
![9e6741eeffc4491ff05c7e12f3ca6584](https://user-images.githubusercontent.com/51314274/146890638-68a6ae16-1559-4366-889f-5f41310285b0.png)
<img width="990" alt="cf7cffb740df7ed52c71d39ef3be9493" src="https://user-images.githubusercontent.com/51314274/146890786-127a884e-47c4-4eba-b989-6e9aa37db69e.png">

- test_spectral_op need import _get_forward_norm from numpy.fft._pocketfft, which is introduced since numpy1.20.0
- delete numpy's python version limit since cmake has restrict python >=3.6
- numpy<=1.19.3 is no longer needed since higher version can also success( see build [case](https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4363576/job/10319608) of py37 38 39)

In short, set numpy>=1.13 to let pip choose the newest available numpy version, and it can also solve the difference problem between build and unittest

