### PR TITLE
Enable FC_MKLDNN pass by default for int8

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -280,6 +280,9 @@ void CpuPassStrategy::EnableMKLDNN() {
 void CpuPassStrategy::EnableMkldnnQuantizer() {
 #ifdef PADDLE_WITH_MKLDNN
   if (!use_mkldnn_quantizer_) {
+    // INT8 implies FC oneDNN passes to be used
+    passes_.push_back("fc_mkldnn_pass");
+    passes_.push_back("fc_act_mkldnn_fuse_pass");
     passes_.push_back("cpu_quantize_placement_pass");
   }
   use_mkldnn_quantizer_ = true;

--- a/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
@@ -47,10 +47,6 @@ TEST(Analyzer_int8_image_classification, quantization) {
     std::shared_ptr<std::vector<PaddleTensor>> warmup_data =
         paddle::inference::GetWarmupData(input_slots_all);
 
-    // INT8 implies FC oneDNN passes to be used
-    q_cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    q_cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
-
     // configure quantizer
     q_cfg.EnableMkldnnQuantizer();
     q_cfg.mkldnn_quantizer_config()->SetWarmupData(warmup_data);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
Some models will benefit from enabling int8 FC MKLDNN pass by default
