### PR TITLE
Rename full infer_meta

### DIFF
--- a/paddle/pten/include/creation.h
+++ b/paddle/pten/include/creation.h
@@ -30,7 +30,7 @@ DenseTensor FullLike(
     DataType dtype = DataType::UNDEFINED,
     Backend backend = Backend::UNDEFINED,  // Is backend needed here?
     DataLayout layout = DataLayout::UNDEFINED) {
-  auto out_meta = FullLikeInferMeta(x.meta(), dtype, layout);
+  auto out_meta = CreateLikeInferMeta(x.meta(), dtype, layout);
   pten::DenseTensor dense_out(
       pten::make_intrusive<paddle::experimental::SharedStorage>(
           dev_ctx.GetPlace()),

--- a/paddle/pten/infermeta/nary.cc
+++ b/paddle/pten/infermeta/nary.cc
@@ -17,16 +17,16 @@ limitations under the License. */
 
 namespace pten {
 
-DenseTensorMeta FullInferMeta(const std::vector<int64_t>& shape,
-                              DataType dtype,
-                              DataLayout layout) {
+DenseTensorMeta CreateInferMeta(const std::vector<int64_t>& shape,
+                                DataType dtype,
+                                DataLayout layout) {
   const auto& out_dims = paddle::framework::make_ddim(shape);
   return {dtype, out_dims, layout};
 }
 
-DenseTensorMeta FullInferMeta(const ScalarArray& shape,
-                              DataType dtype,
-                              DataLayout layout) {
+DenseTensorMeta CreateInferMeta(const ScalarArray& shape,
+                                DataType dtype,
+                                DataLayout layout) {
   const auto& out_dims = paddle::framework::make_ddim(shape.GetData());
   return {dtype, out_dims, layout};
 }

--- a/paddle/pten/infermeta/nary.h
+++ b/paddle/pten/infermeta/nary.h
@@ -27,12 +27,12 @@ namespace pten {
 //  Because functions in this file
 //  not only can infer shape, but alse need infer lod or other useful data.
 
-DenseTensorMeta FullInferMeta(const std::vector<int64_t>& shape,
-                              DataType dtype,
-                              DataLayout layout);
+DenseTensorMeta CreateInferMeta(const std::vector<int64_t>& shape,
+                                DataType dtype,
+                                DataLayout layout);
 
-DenseTensorMeta FullInferMeta(const ScalarArray& shape,
-                              DataType dtype,
-                              DataLayout layout);
+DenseTensorMeta CreateInferMeta(const ScalarArray& shape,
+                                DataType dtype,
+                                DataLayout layout);
 
 }  // namespace pten

--- a/paddle/pten/infermeta/unary.cc
+++ b/paddle/pten/infermeta/unary.cc
@@ -227,9 +227,15 @@ DenseTensorMeta InferMetaFromVecValue(const DenseTensorMeta& x_meta,
   return return_meta;
 }
 
+DenseTensorMeta ReshapeInferMeta(const DenseTensorMeta& x_meta,
+                                 const ScalarArray& shape) {
+  return InferMetaFromVecValue(x_meta, shape.GetData());
+}
+
 DenseTensorMeta ReduceInferMeta(const DenseTensorMeta& x_meta,
                                 const std::vector<int64_t>& axis,
-                                bool keep_dim) {
+                                bool keep_dim,
+                                DataType dtype) {
   bool reduce_all = true;
   std::set<int64_t> dims_set(axis.begin(), axis.end());
   for (int64_t i = 0; i < x_meta.dims.size(); ++i) {
@@ -263,10 +269,16 @@ DenseTensorMeta ReduceInferMeta(const DenseTensorMeta& x_meta,
   }
   DDim out_dim = paddle::framework::make_ddim(out_dim_vector);
 
-  DataType out_dtype = x_meta.dtype;
-  if (x_meta.dtype == DataType::BOOL || x_meta.dtype == DataType::INT32 ||
-      x_meta.dtype == DataType::INT64) {
-    out_dtype = DataType::INT64;
+  DataType out_dtype;
+  if (dtype != DataType::UNDEFINED) {
+    out_dtype = dtype;
+  } else {
+    if (x_meta.dtype == DataType::BOOL || x_meta.dtype == DataType::INT32 ||
+        x_meta.dtype == DataType::INT64) {
+      out_dtype = DataType::INT64;
+    } else {
+      out_dtype = x_meta.dtype;
+    }
   }
 
   DenseTensorMeta return_meta(out_dtype, out_dim, x_meta.layout);

--- a/paddle/pten/infermeta/unary.cc
+++ b/paddle/pten/infermeta/unary.cc
@@ -81,9 +81,9 @@ DenseTensorMeta CastInferMeta(const DenseTensorMeta& x_meta,
   return out_meta;
 }
 
-DenseTensorMeta FullLikeInferMeta(const DenseTensorMeta& x_meta,
-                                  DataType dtype,
-                                  DataLayout layout) {
+DenseTensorMeta CreateLikeInferMeta(const DenseTensorMeta& x_meta,
+                                    DataType dtype,
+                                    DataLayout layout) {
   return {dtype == DataType::UNDEFINED ? x_meta.dtype : dtype,
           x_meta.dims,
           layout == DataLayout::UNDEFINED ? x_meta.layout : layout};
@@ -227,15 +227,9 @@ DenseTensorMeta InferMetaFromVecValue(const DenseTensorMeta& x_meta,
   return return_meta;
 }
 
-DenseTensorMeta ReshapeInferMeta(const DenseTensorMeta& x_meta,
-                                 const ScalarArray& shape) {
-  return InferMetaFromVecValue(x_meta, shape.GetData());
-}
-
 DenseTensorMeta ReduceInferMeta(const DenseTensorMeta& x_meta,
                                 const std::vector<int64_t>& axis,
-                                bool keep_dim,
-                                DataType dtype) {
+                                bool keep_dim) {
   bool reduce_all = true;
   std::set<int64_t> dims_set(axis.begin(), axis.end());
   for (int64_t i = 0; i < x_meta.dims.size(); ++i) {
@@ -269,16 +263,10 @@ DenseTensorMeta ReduceInferMeta(const DenseTensorMeta& x_meta,
   }
   DDim out_dim = paddle::framework::make_ddim(out_dim_vector);
 
-  DataType out_dtype;
-  if (dtype != DataType::UNDEFINED) {
-    out_dtype = dtype;
-  } else {
-    if (x_meta.dtype == DataType::BOOL || x_meta.dtype == DataType::INT32 ||
-        x_meta.dtype == DataType::INT64) {
-      out_dtype = DataType::INT64;
-    } else {
-      out_dtype = x_meta.dtype;
-    }
+  DataType out_dtype = x_meta.dtype;
+  if (x_meta.dtype == DataType::BOOL || x_meta.dtype == DataType::INT32 ||
+      x_meta.dtype == DataType::INT64) {
+    out_dtype = DataType::INT64;
   }
 
   DenseTensorMeta return_meta(out_dtype, out_dim, x_meta.layout);

--- a/paddle/pten/infermeta/unary.h
+++ b/paddle/pten/infermeta/unary.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 // See Note [ Why still include the fluid headers? ]
+#include "paddle/pten/common/scalar_array.h"
 #include "paddle/pten/core/tensor_meta.h"
 
 namespace pten {
@@ -50,7 +51,11 @@ DenseTensorMeta CreateLikeInferMeta(const DenseTensorMeta& x_meta,
 DenseTensorMeta InferMetaFromVecValue(const DenseTensorMeta& x_meta,
                                       const std::vector<int64_t>& shape);
 
+DenseTensorMeta ReshapeInferMeta(const DenseTensorMeta& x_meta,
+                                 const ScalarArray& shape);
+
 DenseTensorMeta ReduceInferMeta(const DenseTensorMeta& x_meta,
                                 const std::vector<int64_t>& axis,
-                                bool keep_dim);
+                                bool keep_dim,
+                                DataType dtype = DataType::UNDEFINED);
 }  // namespace pten

--- a/paddle/pten/infermeta/unary.h
+++ b/paddle/pten/infermeta/unary.h
@@ -15,7 +15,6 @@ limitations under the License. */
 #pragma once
 
 // See Note [ Why still include the fluid headers? ]
-#include "paddle/pten/common/scalar_array.h"
 #include "paddle/pten/core/tensor_meta.h"
 
 namespace pten {
@@ -44,18 +43,14 @@ DenseTensorMeta FlattenInferMeta(const DenseTensorMeta& x_meta,
 DenseTensorMeta CastInferMeta(const DenseTensorMeta& x_meta,
                               const DataType out_dtype);
 
-DenseTensorMeta FullLikeInferMeta(const DenseTensorMeta& x_meta,
-                                  DataType dtype,
-                                  DataLayout layout);
+DenseTensorMeta CreateLikeInferMeta(const DenseTensorMeta& x_meta,
+                                    DataType dtype,
+                                    DataLayout layout);
 
 DenseTensorMeta InferMetaFromVecValue(const DenseTensorMeta& x_meta,
                                       const std::vector<int64_t>& shape);
 
-DenseTensorMeta ReshapeInferMeta(const DenseTensorMeta& x_meta,
-                                 const ScalarArray& shape);
-
 DenseTensorMeta ReduceInferMeta(const DenseTensorMeta& x_meta,
                                 const std::vector<int64_t>& axis,
-                                bool keep_dim,
-                                DataType dtype = DataType::UNDEFINED);
+                                bool keep_dim);
 }  // namespace pten

--- a/python/paddle/utils/code_gen/api.yaml
+++ b/python/paddle/utils/code_gen/api.yaml
@@ -48,7 +48,7 @@
   args : (const ScalarArray& shape, const Scalar& value, DataType dtype=DataType::FLOAT32, Backend place=Backend::CPU, DataLayout layout=DataLayout::NCHW)
   output: Tensor
   infer_meta : 
-    func : FullInferMeta
+    func : CreateInferMeta
     param : [shape, dtype, layout]
   kernel : 
     func : full
@@ -61,7 +61,7 @@
   args : (const Tensor& x, const Scalar& value, DataType dtype = DataType::UNDEFINED, Backend place = Backend::UNDEFINED, DataLayout layout = DataLayout::UNDEFINED)
   output: Tensor
   infer_meta : 
-    func : FullLikeInferMeta
+    func : CreateLikeInferMeta
     param : [x, dtype, layout]
   kernel : 
     func : full_like
@@ -145,15 +145,6 @@
   args : (const Tensor& x, DataType dtype=DataType::UNDEFINED, Backend place=Backend::UNDEFINED, DataLayout layout=DataLayout::UNDEFINED)
   output : Tensor
   invoke : full_like(x, 0, dtype, place, layout)
-
-# - api : full_like
-#   args : (const Tensor& x, const Scalar& value, DataType dtype, Backend place)->Tensor
-#   output: {Tensor : dtype}
-#   kernel : fill_any_like
-#   T : [dtype, x]
-#   backend : [place, x]
-#   layout : []
-#   InferMeta : UnchangedInferMeta(x)
 
 - api : conj
   args : (const Tensor& x)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Rename `FullInterMeta` and `FullLikeInterMeta` to `CreateInterMeta` and `CreateLikeInterMeta`.
The reason is that empty kernel and full kernel use the common infer_meta function, so we rename their infer_meta function.