### PR TITLE
Fix multi tensor momentum regular bug

### DIFF
--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -192,7 +192,7 @@ class Momentum(Optimizer):
 
     def _update_regularization(self, weight_decay):
         reg_method = ""
-        reg_coeff = 0
+        reg_coeff = 0.0
 
         if (isinstance(weight_decay, L2DecayRegularizer)):
             reg_method = "l2_decay"
@@ -306,7 +306,7 @@ class Momentum(Optimizer):
             # the param's regularization has been done before, we avoid do l2decay in momentum.
             elif param.regularizer is not None:
                 regularization_method = ""
-                regularization_coeff = 0
+                regularization_coeff = 0.0
 
         find_master = self._multi_precision and param_and_grad[
             0].dtype == core.VarDesc.VarType.FP16

--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -380,7 +380,7 @@ class Momentum(Optimizer):
                 if isinstance(param.regularizer, L2DecayRegularizer):
                     regularization_method = "l2_decay"
                     regularization_coeff = param.regularizer._regularization_coeff
-                else:
+                elif param.regularizer is not None:
                     regularization_method = ""
                     regularization_coeff = 0.0
             if param.dtype == paddle.float32:


### PR DESCRIPTION
### PR types
Bug fixes


### PR changes
APIs

### Describe
修改multi tensor策略下momentum优化器参数regularizer属性为None时的逻辑错误。
 - 问题：
如果momentum优化器初始化时设置了weight_decay属性，当parameter的regluarizer属性为None的时候，regularization_method和regularization_coeff将采用weight_decay属性，但错误的设置为了""和0.0