### PR TITLE
delete mkldnn options of baseline config

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
@@ -440,9 +440,7 @@ class PassAutoScanTest(AutoScanTest):
 
                 # baseline: no ir_optim run
                 base_config = self.create_inference_config(
-                    ir_optim=False,
-                    use_gpu=pred_config.use_gpu(),
-                    use_mkldnn=pred_config.mkldnn_enabled(), )
+                    ir_optim=False, use_gpu=pred_config.use_gpu())
                 try:
                     # baseline
                     base_result = self.run_test_config(


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
When ir_optim=False, use_mkldnn=True is invalid.