### PR TITLE
execute UT in distributed way

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
@@ -341,7 +341,8 @@ class StaticAnalysisVisitor(object):
             # like `self.x: float = 2.1`.
             ret_type = {NodeVarType.type_from_annotation(node.annotation)}
             # if annotation and value(Constant) are diffent type, we use value type
-            if node.value:
+            if node.value and self.node_to_wrapper_map[
+                    node.value].node_var_type != {NodeVarType.UNKNOWN}:
                 ret_type = self.node_to_wrapper_map[node.value].node_var_type
             if isinstance(node.target, gast.Name):
                 self.node_to_wrapper_map[node.target].node_var_type = ret_type


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
将coverage 单测分成两部分【单卡与多卡（2卡与独占）】分布在不同的机器上执行，增大机器的流动性，以降低单个PR的CI返回时间。
其中，覆盖率的收集与合并是放在后执行完的机器上。如paddle-test-single先执行完，那么就在paddle-test-multi上进行合并覆盖率数据以及产出最终的增量覆盖率数据。
测试如下：（测试点为修改不同的文件，覆盖率是否能正确返回）
1.  全量执行测试且无覆盖率输出：
     原coverage流水线：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4410722/job/10483954  GPU机器执行任务的时间为87min。
     新coverage流水线：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4410738/job/10483984  GPU机器执行时间分别为49min、46min。【49 + 46  - 87 = 8min，主要是用在了解压上 】
     以上两条CI对于用户而言，该CI第二条需要等待49min即可拿到结果。
2. 
