### PR TITLE
[Paddle-TRT] Fix dynamic_shape_ernie_test resource life cycle

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
@@ -32,9 +32,7 @@ namespace plugin {
 
 template <typename T>
 EmbEltwiseLayernormPluginDynamicImpl<
-    T>::~EmbEltwiseLayernormPluginDynamicImpl() {
-  this->terminate();
-}
+    T>::~EmbEltwiseLayernormPluginDynamicImpl() {}
 
 inline half fp32tofp16(float x) { return static_cast<half>(x); }
 

--- a/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/qkv_to_context_plugin.cu
@@ -192,11 +192,8 @@ bool QkvToContextPluginDynamic::supportsFormatCombination(
   if (pos == 0) {
     if (with_fp16_) {
 #ifdef TRT_PLUGIN_FP16_AVALIABLE
-      return (
-#if IS_TRT_VERSION_LT(8000)
-                 in.type == nvinfer1::DataType::kFLOAT ||
-#endif
-                 in.type == nvinfer1::DataType::kHALF) &&
+      return (in.type == nvinfer1::DataType::kFLOAT ||
+              in.type == nvinfer1::DataType::kHALF) &&
              (in.format == nvinfer1::TensorFormat::kLINEAR);
 #else
       return (in.type == nvinfer1::DataType::kFLOAT) &&

--- a/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/skip_layernorm_op_plugin.cu
@@ -73,11 +73,8 @@ bool SkipLayerNormPluginDynamic::supportsFormatCombination(
   if (pos == 0) {
     if (with_fp16_) {
 #ifdef TRT_PLUGIN_FP16_AVALIABLE
-      return (
-#if IS_TRT_VERSION_LT(8000)
-                 in.type == nvinfer1::DataType::kFLOAT ||
-#endif
-                 in.type == nvinfer1::DataType::kHALF) &&
+      return (in.type == nvinfer1::DataType::kFLOAT ||
+              in.type == nvinfer1::DataType::kHALF) &&
              (in.format == nvinfer1::TensorFormat::kLINEAR);
 #else
       return (in.type == nvinfer1::DataType::kFLOAT) &&

--- a/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/slice_op_plugin.cu
@@ -83,11 +83,8 @@ SlicePlugin *SlicePlugin::clone() const TRT_NOEXCEPT {
 bool SlicePlugin::supportsFormat(
     nvinfer1::DataType type, nvinfer1::PluginFormat format) const TRT_NOEXCEPT {
   if (with_fp16_) {
-    return ((
-#if IS_TRT_VERSION_LT(8000)
-                type == nvinfer1::DataType::kFLOAT ||
-#endif
-                type == nvinfer1::DataType::kHALF) &&
+    return ((type == nvinfer1::DataType::kFLOAT ||
+             type == nvinfer1::DataType::kHALF) &&
             (format == nvinfer1::PluginFormat::kLINEAR));
   } else {
     return ((type == nvinfer1::DataType::kFLOAT) &&
@@ -287,11 +284,8 @@ bool SlicePluginDynamic::supportsFormatCombination(
   const nvinfer1::PluginTensorDesc &in = in_out[pos];
   if (pos == 0) {
     if (with_fp16_) {
-      return (
-#if IS_TRT_VERSION_LT(8000)
-                 in.type == nvinfer1::DataType::kFLOAT ||
-#endif
-                 in.type == nvinfer1::DataType::kHALF) &&
+      return (in.type == nvinfer1::DataType::kFLOAT ||
+              in.type == nvinfer1::DataType::kHALF) &&
              (in.format == nvinfer1::TensorFormat::kLINEAR);
     } else {
       return (in.type == nvinfer1::DataType::kFLOAT) &&


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
In the previous PR(https://github.com/PaddlePaddle/Paddle/pull/38056), we found the FP32 precision has problem on fp16 tests.
However, the root cause is the emb_layernorm dtor calls `terminate()`. But the `terminate()` should be called by TensorRT instead of the plugin. It caused two times cudaFree().