### PR TITLE
[infrt] fix infrt script bug and function error. test=develop

### DIFF
--- a/paddle/infrt/dialect/infrt_base.h
+++ b/paddle/infrt/dialect/infrt_base.h
@@ -58,12 +58,13 @@ static mlir::IntegerAttr createI32Attr(mlir::OpBuilder &b,  // NOLINT
   return b.getIntegerAttr(b.getI32Type(), constant);
 }
 
-static mlir::ValueRange cvtValueToValueRange(const mlir::Value &operand) {
-  return mlir::ValueRange(operand);
+static mlir::SmallVector<::mlir::Value, 4> cvtValueToValueRange(
+    const mlir::Value &operand) {
+  return mlir::SmallVector<::mlir::Value, 4>(1, operand);
 }
 
-static mlir::ValueRange concatTwoValueRange(mlir::ValueRange operand_0,
-                                            mlir::ValueRange operand_1) {
+static mlir::SmallVector<::mlir::Value, 4> concatTwoValueRange(
+    mlir::ValueRange operand_0, mlir::ValueRange operand_1) {
   mlir::SmallVector<::mlir::Value, 4> operands;
   operands.append(operand_0.begin(), operand_0.end());
   operands.append(operand_1.begin(), operand_1.end());

--- a/paddle/scripts/infrt_build.sh
+++ b/paddle/scripts/infrt_build.sh
@@ -132,4 +132,4 @@ function main() {
 
 main $@
 
-rm -rf tmp_dir
+rm -rf $tmp_dir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复infrt两个bug:
1.   build_infrt脚本编译结束删除临时文件名错误，
2.  工具函数cvtValueToValueRange和concatTwoValueRange的返回类型错误。