### PR TITLE
add gradient unittest and update code example for max/min

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_max_min_op.py
+++ b/python/paddle/fluid/tests/unittests/test_max_min_op.py
@@ -1,0 +1,149 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid import Program, program_guard
+from op_test import OpTest
+
+paddle.enable_static()
+
+
+class TestMaxMinAPI(unittest.TestCase):
+    def setUp(self):
+        self.init_case()
+        self.cal_np_out_and_gradient()
+        self.place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+
+    def init_case(self):
+        self.x_np = np.array([[0.2, 0.3, 0.5, 0.9], [0.1, 0.2, 0.6, 0.7]])
+        self.shape = [2, 4]
+        self.dtype = 'float64'
+        self.axis = None
+        self.keepdim = False
+
+    # If there are multiple minimum or maximum elements, max/min/ is non-derivable,
+    # its gradient check is not supported by unittest framework, 
+    # thus we calculate the gradient by numpy function.
+    def cal_np_out_and_gradient(self):
+        def _cal_np_out_and_gradient(func):
+            if func is 'max':
+                out = np.max(self.x_np, axis=self.axis, keepdims=self.keepdim)
+            elif func is 'min':
+                out = np.min(self.x_np, axis=self.axis, keepdims=self.keepdim)
+            else:
+                print('This unittest only test max/min, but now is', func)
+            self.np_out[func] = out
+            grad = np.zeros(self.shape)
+            out_b = np.broadcast_to(out, self.shape)
+            grad[self.x_np == out_b] = 1
+            self.np_grad[func] = grad
+
+        self.np_out = dict()
+        self.np_grad = dict()
+        _cal_np_out_and_gradient('max')
+        _cal_np_out_and_gradient('min')
+
+    def _choose_paddle_func(self, func, x):
+        if func is 'max':
+            out = paddle.max(x, self.axis, self.keepdim)
+        elif func is 'min':
+            out = paddle.min(x, self.axis, self.keepdim)
+        else:
+            print('This unittest only test max/min, but now is', func)
+        return out
+
+    # We check the output between paddle API and numpy in static graph.
+    def test_static_graph(self):
+        def _test_static_graph(func):
+            startup_program = fluid.Program()
+            train_program = fluid.Program()
+            with fluid.program_guard(startup_program, train_program):
+                x = fluid.data(name='input', dtype=self.dtype, shape=self.shape)
+                x.stop_gradient = False
+                out = self._choose_paddle_func(func, x)
+
+                exe = fluid.Executor(self.place)
+                res = exe.run(fluid.default_main_program(),
+                              feed={'input': self.x_np},
+                              fetch_list=[out])
+                self.assertTrue((np.array(res[0]) == self.np_out[func]).all())
+
+        _test_static_graph('max')
+        _test_static_graph('min')
+
+    # As dygraph is easy to compute gradient, we check the gradient between 
+    # paddle API and numpy in dygraph.
+    def test_dygraph(self):
+        def _test_dygraph(func):
+            paddle.disable_static()
+            x = paddle.to_tensor(
+                self.x_np, dtype=self.dtype, stop_gradient=False)
+            out = self._choose_paddle_func(func, x)
+            grad_tensor = paddle.ones_like(x)
+            paddle.autograd.backward([out], [grad_tensor], True)
+
+            self.assertEqual(np.allclose(self.np_out[func], out.numpy()), True)
+            self.assertEqual(np.allclose(self.np_grad[func], x.grad), True)
+            paddle.enable_static()
+
+        _test_dygraph('max')
+        _test_dygraph('min')
+
+
+# test multiple minimum or maximum elements
+class TestMaxMinAPI2(TestMaxMinAPI):
+    def init_case(self):
+        self.x_np = np.array([[0.2, 0.3, 0.9, 0.9], [0.1, 0.1, 0.6, 0.7]])
+        self.shape = [2, 4]
+        self.dtype = 'float64'
+        self.axis = None
+        self.keepdim = False
+
+
+# test different axis
+class TestMaxMinAPI3(TestMaxMinAPI):
+    def init_case(self):
+        self.x_np = np.array([[0.2, 0.3, 0.9, 0.9], [0.1, 0.1, 0.6, 0.7]])
+        self.shape = [2, 4]
+        self.dtype = 'float64'
+        self.axis = 0
+        self.keepdim = False
+
+
+# test keepdim = True
+class TestMaxMinAPI4(TestMaxMinAPI):
+    def init_case(self):
+        self.x_np = np.array([[0.2, 0.3, 0.9, 0.9], [0.1, 0.1, 0.6, 0.7]])
+        self.shape = [2, 4]
+        self.dtype = 'float64'
+        self.axis = 1
+        self.keepdim = True
+
+
+# test axis is tuple
+class TestMaxMinAPI5(TestMaxMinAPI):
+    def init_case(self):
+        self.x_np = np.array(
+            [[[1, 2], [3, 4]], [[5, 6], [7, 8]]]).astype(np.int32)
+        self.shape = [2, 2, 2]
+        self.dtype = 'int32'
+        self.axis = (0, 1)
+        self.keepdim = False

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1361,22 +1361,26 @@ def max(x, axis=None, keepdim=False, name=None):
                                  dtype='float64', stop_gradient=False)
             result1 = paddle.max(x)
             result1.backward()
-            print(result1, x.grad) #[0.9], [[0., 0., 0., 1.], [0., 0., 0., 0.]]
+            print(result1, x.grad) 
+            #[0.9], [[0., 0., 0., 1.], [0., 0., 0., 0.]]
 
             x.clear_grad()
             result2 = paddle.max(x, axis=0)
             result2.backward()
-            print(result2, x.grad) #[0.2, 0.3, 0.6, 0.9], [[1., 1., 0., 1.], [0., 0., 1., 0.]]
+            print(result2, x.grad) 
+            #[0.2, 0.3, 0.6, 0.9], [[1., 1., 0., 1.], [0., 0., 1., 0.]]
 
             x.clear_grad()
             result3 = paddle.max(x, axis=-1)
             result3.backward()
-            print(result3, x.grad) #[0.9, 0.7], [[0., 0., 0., 1.], [0., 0., 0., 1.]]
+            print(result3, x.grad) 
+            #[0.9, 0.7], [[0., 0., 0., 1.], [0., 0., 0., 1.]]
 
             x.clear_grad()
             result4 = paddle.max(x, axis=1, keepdim=True)
             result4.backward()
-            print(result4, x.grad) #[[0.9], [0.7]], [[0., 0., 0., 1.], [0., 0., 0., 1.]]
+            print(result4, x.grad) 
+            #[[0.9], [0.7]], [[0., 0., 0., 1.], [0., 0., 0., 1.]]
 
             # data_y is a Tensor with shape [2, 2, 2]
             # the axis is list 
@@ -1385,12 +1389,14 @@ def max(x, axis=None, keepdim=False, name=None):
                                  dtype='float64', stop_gradient=False)
             result5 = paddle.max(y, axis=[1, 2])
             result5.backward()
-            print(result5, y.grad) #[4., 8.], [[[0., 0.], [0., 1.]], [[0., 0.], [0., 1.]]]
+            print(result5, y.grad) 
+            #[4., 8.], [[[0., 0.], [0., 1.]], [[0., 0.], [0., 1.]]]
 
             y.clear_grad()
             result6 = paddle.max(y, axis=[0, 1])
             result6.backward()
-            print(result6, y.grad) #[7., 8.], [[[0., 0.], [0., 0.]], [[0., 0.], [1., 1.]]]
+            print(result6, y.grad) 
+            #[7., 8.], [[[0., 0.], [0., 0.]], [[0., 0.], [1., 1.]]]
     """
 
     reduce_all, axis = _get_reduce_all_value(axis)
@@ -1450,22 +1456,26 @@ def min(x, axis=None, keepdim=False, name=None):
                                  dtype='float64', stop_gradient=False)
             result1 = paddle.min(x)
             result1.backward()
-            print(result1, x.grad) #[0.1], [[0., 0., 0., 0.], [1., 0., 0., 0.]]
+            print(result1, x.grad) 
+            #[0.1], [[0., 0., 0., 0.], [1., 0., 0., 0.]]
 
             x.clear_grad()
             result2 = paddle.min(x, axis=0)
             result2.backward()
-            print(result2, x.grad) #[0.1, 0.2, 0.5, 0.7], [[0., 0., 1., 0.], [1., 1., 0., 1.]]
+            print(result2, x.grad) 
+            #[0.1, 0.2, 0.5, 0.7], [[0., 0., 1., 0.], [1., 1., 0., 1.]]
 
             x.clear_grad()
             result3 = paddle.min(x, axis=-1)
             result3.backward()
-            print(result3, x.grad) #[0.2, 0.1], [[1., 0., 0., 0.], [1., 0., 0., 0.]]
+            print(result3, x.grad) 
+            #[0.2, 0.1], [[1., 0., 0., 0.], [1., 0., 0., 0.]]
 
             x.clear_grad()
             result4 = paddle.min(x, axis=1, keepdim=True)
             result4.backward()
-            print(result4, x.grad) #[[0.2], [0.1]], [[1., 0., 0., 0.], [1., 0., 0., 0.]]
+            print(result4, x.grad) 
+            #[[0.2], [0.1]], [[1., 0., 0., 0.], [1., 0., 0., 0.]]
 
             # data_y is a Tensor with shape [2, 2, 2]
             # the axis is list 
@@ -1474,12 +1484,14 @@ def min(x, axis=None, keepdim=False, name=None):
                                  dtype='float64', stop_gradient=False)
             result5 = paddle.min(y, axis=[1, 2])
             result5.backward()
-            print(result5, y.grad) #[1., 5.], [[[1., 0.], [0., 0.]], [[1., 0.], [0., 0.]]]
+            print(result5, y.grad) 
+            #[1., 5.], [[[1., 0.], [0., 0.]], [[1., 0.], [0., 0.]]]
 
             y.clear_grad()
             result6 = paddle.min(y, axis=[0, 1])
             result6.backward()
-            print(result6, y.grad) #[1., 2.], [[[1., 1.], [0., 0.]], [[0., 0.], [0., 0.]]]
+            print(result6, y.grad) 
+            #[1., 2.], [[[1., 1.], [0., 0.]], [[0., 0.], [0., 0.]]]
     """
 
     reduce_all, axis = _get_reduce_all_value(axis)

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1307,24 +1307,6 @@ def inverse(x, name=None):
         type='inverse', inputs={'Input': [x] }, outputs={'Output': [out]})
     return out
 
-def _get_reduce_all_value(axis):
-    """
-    Internal function for max, min. 
-    It computes the attribute reduce_all value based on axis.
-    """
-    if axis is not None and not isinstance(axis, list):
-        if isinstance(axis, tuple):
-            axis = list(axis)
-        elif isinstance(axis, int):
-            axis= [axis]
-        else:
-            raise TypeError(
-                "The type of axis must be int, list or tuple, but received {}".format(type(axis)))
-
-    reduce_all = True if axis == None or axis == [] else False
-    axis = axis if axis != None and axis != [] else [0]
-    return reduce_all, axis
-
 
 def max(x, axis=None, keepdim=False, name=None):
     """
@@ -1399,7 +1381,17 @@ def max(x, axis=None, keepdim=False, name=None):
             #[7., 8.], [[[0., 0.], [0., 0.]], [[0., 0.], [1., 1.]]]
     """
 
-    reduce_all, axis = _get_reduce_all_value(axis)
+    if axis is not None and not isinstance(axis, list):
+        if isinstance(axis, tuple):
+            axis = list(axis)
+        elif isinstance(axis, int):
+            axis= [axis]
+        else:
+            raise TypeError(
+                "The type of axis must be int, list or tuple, but received {}".format(type(axis)))
+
+    reduce_all = True if axis == None or axis == [] else False
+    axis = axis if axis != None and axis != [] else [0]
     if in_dygraph_mode():
         return _C_ops.reduce_max(x, 'dim', axis, 'keep_dim', keepdim,
                                    'reduce_all', reduce_all)
@@ -1494,7 +1486,17 @@ def min(x, axis=None, keepdim=False, name=None):
             #[1., 2.], [[[1., 1.], [0., 0.]], [[0., 0.], [0., 0.]]]
     """
 
-    reduce_all, axis = _get_reduce_all_value(axis)
+    if axis is not None and not isinstance(axis, list):
+        if isinstance(axis, tuple):
+            axis = list(axis)
+        elif isinstance(axis, int):
+            axis= [axis]
+        else:
+            raise TypeError(
+                "The type of axis must be int, list or tuple, but received {}".format(type(axis)))
+
+    reduce_all = True if axis == None or axis == [] else False
+    axis = axis if axis != None and axis != [] else [0]
     if in_dygraph_mode():
         return _C_ops.reduce_min(x, 'dim', axis, 'keep_dim', keepdim,
                                    'reduce_all', reduce_all)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
该PR是新增amax/amin API的前置PR，max/min的前向和amax/amin的前向一样，反向稍有不同。
- 对输入有多个最大/最小值的情况下：max/min 均将梯度完整传回到最大/最小值对应的位置，amax/amin 会将梯度平均传回到最大/最小值对应的位置。因此不能用已有的OpTest测试框架。本PR新增`test_max_min_op.py`，在静态图中对比了paddle API和numpy的前向输出，在动态图中对比了paddle API和numpy的前向输出和反向梯度。简化后续增加amax/amin测试的步骤。
- 更新了max和min的文档，主要是每一步打印了梯度。便于和后续amax/amin的反向梯度做对比，更好的理解这两类API的区别。

英文文档：
- max 
![image](https://user-images.githubusercontent.com/6836917/147222178-772fd964-308b-4101-b138-3700728ae904.png)
- min
![image](https://user-images.githubusercontent.com/6836917/147222298-b363324e-7218-486e-90ab-068d6edc197e.png)

中文文档：https://github.com/PaddlePaddle/docs/pull/4162