### PR TITLE
[Paddle-TRT] Replace GeLU plugin with TensorRT built-in layer for TensorRT 7.0.

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
@@ -48,7 +48,8 @@ class GeluOpConverter : public OpConverter {
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
 
     nvinfer1::ILayer* layer = nullptr;
-    if (BOOST_GET_CONST(bool, op_desc.GetAttr("approximate"))) {
+    if (op_desc.HasAttr("approximate") &&
+        BOOST_GET_CONST(bool, op_desc.GetAttr("approximate"))) {
 #if IS_TRT_VERSION_GE(7000)
       nvinfer1::Dims input_shape;
       input_shape.nbDims = input->getDimensions().nbDims;
@@ -65,63 +66,60 @@ class GeluOpConverter : public OpConverter {
                             std::move(tmp_tensor));
         return tmp_data;
       };
-      float* fPow = create_weights(3.0f, "fPow");
-      float* fMultiply = create_weights(0.044715f, "fMultiply");
-      float* fSqrt =
-          create_weights(0.79788456080286535587989211986876f, "fSqrt");
-      float* fOne = create_weights(1.0f, "fOne");
-      float* fHalf = create_weights(0.5f, "fHalf");
-      /*
-      static const float fPow = 3.0f;
-      static const float fMultiply = 0.044715f;
-      static const float fSqrt = 0.79788456080286535587989211986876f;
-      static const float fOne = 1.0f;
-      static const float fHalf = 0.5f;
-      */
-      auto POW =
-          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
-                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
-                                                 static_cast<void*>(fPow), 1});
-      auto MULTIPLY = TRT_ENGINE_ADD_LAYER(
+      float* constant_pow = create_weights(3.0f, "constant_pow");
+      float* constant_multiply = create_weights(0.044715f, "constant_multiply");
+      float* constant_sqrt =
+          create_weights(0.79788456080286535587989211986876f, "constant_sqrt");
+      float* constant_one = create_weights(1.0f, "constant_one");
+      float* constant_half = create_weights(0.5f, "constant_half");
+      auto constant_layer_pow = TRT_ENGINE_ADD_LAYER(
           engine_, Constant, input_shape,
           nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
-                            static_cast<void*>(fMultiply), 1});
-      auto SQRT =
-          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
-                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
-                                                 static_cast<void*>(fSqrt), 1});
-      auto ONE =
-          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
-                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
-                                                 static_cast<void*>(fOne), 1});
-      auto HALF =
-          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
-                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
-                                                 static_cast<void*>(fHalf), 1});
-      auto X_pow =
-          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *input, *POW->getOutput(0),
-                               nvinfer1::ElementWiseOperation::kPOW);
-      auto X_mul = TRT_ENGINE_ADD_LAYER(
-          engine_, ElementWise, *X_pow->getOutput(0), *MULTIPLY->getOutput(0),
-          nvinfer1::ElementWiseOperation::kPROD);
-      auto X_add =
-          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *X_mul->getOutput(0),
-                               *input, nvinfer1::ElementWiseOperation::kSUM);
-      auto X_sqrt = TRT_ENGINE_ADD_LAYER(
-          engine_, ElementWise, *X_add->getOutput(0), *SQRT->getOutput(0),
-          nvinfer1::ElementWiseOperation::kPROD);
-      auto X_tanh =
-          TRT_ENGINE_ADD_LAYER(engine_, Activation, *X_sqrt->getOutput(0),
-                               nvinfer1::ActivationType::kTANH);
-      auto X_one = TRT_ENGINE_ADD_LAYER(
-          engine_, ElementWise, *X_tanh->getOutput(0), *ONE->getOutput(0),
-          nvinfer1::ElementWiseOperation::kSUM);
-      auto CDF = TRT_ENGINE_ADD_LAYER(engine_, ElementWise,
-                                      *X_one->getOutput(0), *HALF->getOutput(0),
-                                      nvinfer1::ElementWiseOperation::kPROD);
-      auto y =
-          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *CDF->getOutput(0), *input,
+                            static_cast<void*>(constant_pow), 1});
+      auto constant_layer_multiply = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(constant_multiply), 1});
+      auto constant_layer_sqrt = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(constant_sqrt), 1});
+      auto constant_layer_one = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(constant_one), 1});
+      auto constant_layer_half = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(constant_half), 1});
+      auto layer_pow = TRT_ENGINE_ADD_LAYER(
+          engine_, ElementWise, *input, *constant_layer_pow->getOutput(0),
+          nvinfer1::ElementWiseOperation::kPOW);
+      auto layer_mul =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_pow->getOutput(0),
+                               *constant_layer_multiply->getOutput(0),
                                nvinfer1::ElementWiseOperation::kPROD);
+      auto layer_add =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_mul->getOutput(0),
+                               *input, nvinfer1::ElementWiseOperation::kSUM);
+      auto layer_sqrt =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_add->getOutput(0),
+                               *constant_layer_sqrt->getOutput(0),
+                               nvinfer1::ElementWiseOperation::kPROD);
+      auto layer_tanh =
+          TRT_ENGINE_ADD_LAYER(engine_, Activation, *layer_sqrt->getOutput(0),
+                               nvinfer1::ActivationType::kTANH);
+      auto layer_one =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_tanh->getOutput(0),
+                               *constant_layer_one->getOutput(0),
+                               nvinfer1::ElementWiseOperation::kSUM);
+      auto layer_CDF =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_one->getOutput(0),
+                               *constant_layer_half->getOutput(0),
+                               nvinfer1::ElementWiseOperation::kPROD);
+      auto y =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_CDF->getOutput(0),
+                               *input, nvinfer1::ElementWiseOperation::kPROD);
       layer = y;
 #else
       PADDLE_THROW(platform::errors::Fatal(
@@ -129,6 +127,57 @@ class GeluOpConverter : public OpConverter {
           "your TRT version is no less than 7.0"));
 #endif
     } else {
+#if IS_TRT_VERSION_GE(7000)
+      nvinfer1::Dims input_shape;
+      input_shape.nbDims = input->getDimensions().nbDims;
+      for (int i = 0; i < input_shape.nbDims; ++i) {
+        input_shape.d[i] = 1;
+      }
+      std::string out_name = op_desc.Output("Out").front();
+      auto create_weights = [&](float data, std::string type) -> float* {
+        std::unique_ptr<framework::Tensor> tmp_tensor(new framework::Tensor());
+        tmp_tensor->Resize({1});
+        auto* tmp_data = tmp_tensor->mutable_data<float>(platform::CPUPlace());
+        tmp_data[0] = data;
+        engine_->SetWeights(out_name + "_gelu_op_" + type,
+                            std::move(tmp_tensor));
+        return tmp_data;
+      };
+      float* constant_one = create_weights(1.0f, "constant_one");
+      float* constant_half = create_weights(0.5f, "constant_half");
+      float* constant_rsqrt2 =
+          create_weights(0.70710678118f, "constant_rsqrt2");
+      auto constant_layer_one = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(constant_one), 1});
+      auto constant_layer_half = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(constant_half), 1});
+      auto constant_layer_rsqrt2 = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(constant_rsqrt2), 1});
+      auto layer_mul = TRT_ENGINE_ADD_LAYER(
+          engine_, ElementWise, *input, *constant_layer_rsqrt2->getOutput(0),
+          nvinfer1::ElementWiseOperation::kPROD);
+      auto layer_erf =
+          TRT_ENGINE_ADD_LAYER(engine_, Unary, *layer_mul->getOutput(0),
+                               nvinfer1::UnaryOperation::kERF);
+      auto layer_add =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_erf->getOutput(0),
+                               *constant_layer_one->getOutput(0),
+                               nvinfer1::ElementWiseOperation::kSUM);
+      auto layer_CDF =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_add->getOutput(0),
+                               *constant_layer_half->getOutput(0),
+                               nvinfer1::ElementWiseOperation::kPROD);
+      auto y =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *layer_CDF->getOutput(0),
+                               *input, nvinfer1::ElementWiseOperation::kPROD);
+      layer = y;
+#else  // if IS_TRT_VERSION_GE(7000)
       int input_num = op_desc.Input("X").size();
       if (engine_->with_dynamic_shape()) {
 #if IS_TRT_VERSION_GE(6000)
@@ -148,6 +197,7 @@ class GeluOpConverter : public OpConverter {
         plugin::GeluPlugin* plugin = new plugin::GeluPlugin(with_fp16);
         layer = engine_->AddPlugin(&input, input_num, plugin);
       }
+#endif  // if IS_TRT_VERSION_GE(7000)
     }
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "gelu", {output_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gelu_op.cc
@@ -43,30 +43,111 @@ class GeluOpConverter : public OpConverter {
   void operator()(const framework::proto::OpDesc& op,
                   const framework::Scope& scope, bool test_mode) override {
     VLOG(4) << "convert fluid gelu op to tensorrt gelu layer";
-
     framework::OpDesc op_desc(op, nullptr);
     // Declare inputs
-    int input_num = op_desc.Input("X").size();
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
 
     nvinfer1::ILayer* layer = nullptr;
-    if (engine_->with_dynamic_shape()) {
-#if IS_TRT_VERSION_GE(6000)
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::GeluPluginDynamic* plugin =
-          new plugin::GeluPluginDynamic(with_fp16);
-      layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
+    if (BOOST_GET_CONST(bool, op_desc.GetAttr("approximate"))) {
+#if IS_TRT_VERSION_GE(7000)
+      nvinfer1::Dims input_shape;
+      input_shape.nbDims = input->getDimensions().nbDims;
+      for (int i = 0; i < input_shape.nbDims; ++i) {
+        input_shape.d[i] = 1;
+      }
+      std::string out_name = op_desc.Output("Out").front();
+      auto create_weights = [&](float data, std::string type) -> float* {
+        std::unique_ptr<framework::Tensor> tmp_tensor(new framework::Tensor());
+        tmp_tensor->Resize({1});
+        auto* tmp_data = tmp_tensor->mutable_data<float>(platform::CPUPlace());
+        tmp_data[0] = data;
+        engine_->SetWeights(out_name + "_gelu_op_" + type,
+                            std::move(tmp_tensor));
+        return tmp_data;
+      };
+      float* fPow = create_weights(3.0f, "fPow");
+      float* fMultiply = create_weights(0.044715f, "fMultiply");
+      float* fSqrt =
+          create_weights(0.79788456080286535587989211986876f, "fSqrt");
+      float* fOne = create_weights(1.0f, "fOne");
+      float* fHalf = create_weights(0.5f, "fHalf");
+      /*
+      static const float fPow = 3.0f;
+      static const float fMultiply = 0.044715f;
+      static const float fSqrt = 0.79788456080286535587989211986876f;
+      static const float fOne = 1.0f;
+      static const float fHalf = 0.5f;
+      */
+      auto POW =
+          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
+                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                                                 static_cast<void*>(fPow), 1});
+      auto MULTIPLY = TRT_ENGINE_ADD_LAYER(
+          engine_, Constant, input_shape,
+          nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                            static_cast<void*>(fMultiply), 1});
+      auto SQRT =
+          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
+                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                                                 static_cast<void*>(fSqrt), 1});
+      auto ONE =
+          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
+                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                                                 static_cast<void*>(fOne), 1});
+      auto HALF =
+          TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape,
+                               nvinfer1::Weights{nvinfer1::DataType::kFLOAT,
+                                                 static_cast<void*>(fHalf), 1});
+      auto X_pow =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *input, *POW->getOutput(0),
+                               nvinfer1::ElementWiseOperation::kPOW);
+      auto X_mul = TRT_ENGINE_ADD_LAYER(
+          engine_, ElementWise, *X_pow->getOutput(0), *MULTIPLY->getOutput(0),
+          nvinfer1::ElementWiseOperation::kPROD);
+      auto X_add =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *X_mul->getOutput(0),
+                               *input, nvinfer1::ElementWiseOperation::kSUM);
+      auto X_sqrt = TRT_ENGINE_ADD_LAYER(
+          engine_, ElementWise, *X_add->getOutput(0), *SQRT->getOutput(0),
+          nvinfer1::ElementWiseOperation::kPROD);
+      auto X_tanh =
+          TRT_ENGINE_ADD_LAYER(engine_, Activation, *X_sqrt->getOutput(0),
+                               nvinfer1::ActivationType::kTANH);
+      auto X_one = TRT_ENGINE_ADD_LAYER(
+          engine_, ElementWise, *X_tanh->getOutput(0), *ONE->getOutput(0),
+          nvinfer1::ElementWiseOperation::kSUM);
+      auto CDF = TRT_ENGINE_ADD_LAYER(engine_, ElementWise,
+                                      *X_one->getOutput(0), *HALF->getOutput(0),
+                                      nvinfer1::ElementWiseOperation::kPROD);
+      auto y =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *CDF->getOutput(0), *input,
+                               nvinfer1::ElementWiseOperation::kPROD);
+      layer = y;
 #else
       PADDLE_THROW(platform::errors::Fatal(
-          "You are running the TRT Dynamic Shape mode, need to confirm that "
-          "your TRT version is no less than 6.0"));
+          "You are running GeLU Op with approximate True, need to confirm that "
+          "your TRT version is no less than 7.0"));
 #endif
     } else {
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
-      plugin::GeluPlugin* plugin = new plugin::GeluPlugin(with_fp16);
-      layer = engine_->AddPlugin(&input, input_num, plugin);
+      int input_num = op_desc.Input("X").size();
+      if (engine_->with_dynamic_shape()) {
+#if IS_TRT_VERSION_GE(6000)
+        bool with_fp16 =
+            engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
+        plugin::GeluPluginDynamic* plugin =
+            new plugin::GeluPluginDynamic(with_fp16);
+        layer = engine_->AddDynamicPlugin(&input, input_num, plugin);
+#else
+        PADDLE_THROW(platform::errors::Fatal(
+            "You are running the TRT Dynamic Shape mode, need to confirm that "
+            "your TRT version is no less than 6.0"));
+#endif
+      } else {
+        bool with_fp16 =
+            engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
+        plugin::GeluPlugin* plugin = new plugin::GeluPlugin(with_fp16);
+        layer = engine_->AddPlugin(&input, input_num, plugin);
+      }
     }
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "gelu", {output_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1018,11 +1018,6 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
                 << desc.Output("Out").size();
         return false;
       }
-
-      if (desc.HasAttr("approximate")) {
-        if (BOOST_GET_CONST(bool, desc.GetAttr("approximate"))) return false;
-      }
-
       auto* block = desc.Block();
       if (block == nullptr) {
         VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
@@ -1030,6 +1025,14 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
                    "the pass.";
         return false;
       }
+
+#if IS_TRT_VERSION_LT(7000)
+      if (desc.HasAttr("approximate")) {
+        VLOG(3) << "approximate gelu op needs TensorRT 7.0 and after";
+        if (BOOST_GET_CONST(bool, desc.GetAttr("approximate"))) return false;
+      }
+#endif
+
       auto x_var_name = desc.Input("X")[0];
       auto* x_var_desc = block->FindVar(x_var_name);
       const auto x_shape = x_var_desc->GetShape();

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1018,13 +1018,6 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
                 << desc.Output("Out").size();
         return false;
       }
-      auto* block = desc.Block();
-      if (block == nullptr) {
-        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
-                   "Developers need to check whether block_desc is passed in "
-                   "the pass.";
-        return false;
-      }
 
 #if IS_TRT_VERSION_LT(7000)
       if (desc.HasAttr("approximate")) {
@@ -1032,6 +1025,14 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
         if (BOOST_GET_CONST(bool, desc.GetAttr("approximate"))) return false;
       }
 #endif
+
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
 
       auto x_var_name = desc.Input("X")[0];
       auto* x_var_desc = block->FindVar(x_var_name);

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gelu.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gelu.py
@@ -98,10 +98,20 @@ class TrtConvertGeluTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if attrs[0]['approximate'] == True or self.dims == 1:
+            valid_version = (7, 0, 0)
+            compile_version = paddle_infer.get_trt_compile_version()
+            runtime_version = paddle_infer.get_trt_runtime_version()
+            self.assertTrue(compile_version == runtime_version)
+            # Dimension one only runs on Paddle OP
+            if self.dims == 1:
                 return 0, 3
-            else:
+            if compile_version >= valid_version:
                 return 1, 2
+            else:
+                if attrs[0]['approximate'] == True:
+                    return 0, 3
+                else:
+                    return 1, 2
 
         attrs = [
             program_config.ops[i].attrs


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Replace GeLU plugin with TensorRt built-in layer after TensorRT 7.0.
The benefit is that TensorRT can fuse the fc + gelu layer.
We implement both approximate and nonapproximate GeLU.