### PR TITLE
[AMP] Fix amp.decorate bug: parameters for non leaf layers cannot be decotated

### DIFF
--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -128,12 +128,10 @@ def pure_fp16_initialize(models):
     for idx in range(len(models)):
         for layer in models[idx].sublayers(include_self=True):
             layer._casted_by_pure_fp16 = True
-            if len(layer._sub_layers) is 0:
-
-                if (layer._dtype is 'float16') or isinstance(layer, (
-                        paddle.nn.BatchNorm, paddle.nn.LayerNorm)):
-                    continue
-                layer.to(dtype='float16')
+            if (layer._dtype is 'float16') or isinstance(layer, (
+                    paddle.nn.BatchNorm, paddle.nn.LayerNorm)):
+                continue
+            layer.to(dtype='float16')
     return models
 
 

--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -131,7 +131,7 @@ def pure_fp16_initialize(models):
             if (layer._dtype is 'float16') or isinstance(layer, (
                     paddle.nn.BatchNorm, paddle.nn.LayerNorm)):
                 continue
-            layer.non_sublayer_to(dtype='float16')
+            layer._to_impl(dtype='float16', include_sublayers=False)
     return models
 
 

--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -131,7 +131,7 @@ def pure_fp16_initialize(models):
             if (layer._dtype is 'float16') or isinstance(layer, (
                     paddle.nn.BatchNorm, paddle.nn.LayerNorm)):
                 continue
-            layer.to_1(dtype='float16')
+            layer.non_sublayer_to(dtype='float16')
     return models
 
 

--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -131,7 +131,7 @@ def pure_fp16_initialize(models):
             if (layer._dtype is 'float16') or isinstance(layer, (
                     paddle.nn.BatchNorm, paddle.nn.LayerNorm)):
                 continue
-            layer.to(dtype='float16')
+            layer.to_1(dtype='float16')
     return models
 
 

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1524,73 +1524,6 @@ class Layer(object):
             blocking=blocking,
             include_sublayers=True)
 
-    def non_sublayer_to(self, device=None, dtype=None, blocking=None):
-        '''
-        Cast the parameters and buffers of Layer (not include sublayers) by the give device, dtype and blocking.
-
-        Parameters:
-            device(str|paddle.CPUPlace()|paddle.CUDAPlace()|paddle.CUDAPinnedPlace()|paddle.XPUPlace()|None, optional): The device of the Layer which want to be stored.
-            If None, the device is the same with the original Tensor. If device is string, it can be ``cpu``, ``gpu:x`` and ``xpu:x``, where ``x`` is the
-            index of the GPUs or XPUs. Default: None.
-
-            dtype(str|numpy.dtype|paddle.dtype|None, optional): The type of the data. If None, the dtype is the same with the original Tensor. Default: None.
-
-            blocking(bool|None, optional): If False and the source is in pinned memory, the copy will be
-              asynchronous with respect to the host. Otherwise, the argument has no effect. If None, the blocking is set True. Default: None.
-            
-        Returns:
-            self
-
-        Examples:
-            .. code-block:: python
-
-                # required: skip
-                import paddle
-
-                class MyLayer(paddle.nn.Layer):
-                    def __init__(self):
-                        super(MyLayer, self).__init__()
-                        self._linear = paddle.nn.Linear(1, 1)
-                        w_tmp = self.create_parameter([1,1])
-                        self.add_parameter("w_tmp", w_tmp)
-                    def forward(self, input):
-                        return self._linear(input)
-                
-                layer = MyLayer()
-                for name, param in layer.named_parameters():
-                    print(name, param.dtype, param.device) 
-                
-                # w_tmp Parameter containing:
-                # Tensor(shape=[1, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-                #     [[-0.55699259]])
-                # _linear.weight Parameter containing:
-                # Tensor(shape=[1, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-                #     [[-1.27518642]])
-                # _linear.bias Parameter containing:
-                # Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-                #    [0.])
-                
-                mylayer.non_sublayer_to(dtype='float64', device='cpu')
-                for name, param in layer.named_parameters():
-                    print(name, param.dtype, param.device) 
-                
-                # w_tmp Parameter containing:
-                # Tensor(shape=[1, 1], dtype=float64, place=CPUPlace, stop_gradient=False,
-                #     [[-0.55699259]])
-                # _linear.weight Parameter containing:
-                # Tensor(shape=[1, 1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-                #     [[-1.27518642]])
-                # _linear.bias Parameter containing:
-                # Tensor(shape=[1], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
-                    [0.])
-
-        '''
-        return self._to_impl(
-            device=device,
-            dtype=dtype,
-            blocking=blocking,
-            include_sublayers=False)
-
     def _apply(self, func, device, dtype, blocking, include_sublayers=True):
         if include_sublayers:
             for layer in self.children():
@@ -1631,7 +1564,7 @@ class Layer(object):
 
         Returns:
             self
-            
+
         '''
 
         if device is None and dtype is None and blocking is None:


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
修复paddle.amp.decorate()bug：无法对非叶子网络层的参数改写为fp16
