### PR TITLE
fix accumulator bug when multiple inplace OPs are executed continuously 

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -434,5 +434,21 @@ class TestLossIsInplaceVar(unittest.TestCase):
         self.assertTrue(np.array_equal(inplace_grad_var_a, grad_var_a))
 
 
+class TestContinuouslyInplace(unittest.TestCase):
+    def test_continuously_inplace(self):
+        paddle.disable_static()
+
+        a = paddle.rand([2, 3])
+        a.stop_gradient = False
+        b = a * 2
+
+        b.reshape_([-1])
+        b.reshape_([2, 3])
+        b.reshape_([-1])
+
+        b.backward()
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -436,8 +436,6 @@ class TestLossIsInplaceVar(unittest.TestCase):
 
 class TestContinuouslyInplace(unittest.TestCase):
     def test_continuously_inplace(self):
-        paddle.disable_static()
-
         a = paddle.rand([2, 3])
         a.stop_gradient = False
         b = a * 2
@@ -447,7 +445,6 @@ class TestContinuouslyInplace(unittest.TestCase):
         b.reshape_([-1])
 
         b.backward()
-        paddle.enable_static()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

#### bug

多个inplace op连续执行时，会报accumulator无法找到var的bug。

<img width="723" alt="图片" src="https://user-images.githubusercontent.com/26408901/147310232-aabcbbc9-0fae-4945-9908-d046c98bfd9e.png">

原因是现在的accumulator分为2种：

- `accumulators_with_grad_node_`以`var`和`grad_pending_node`作为key，一般用于有grad_node的var。
- `accumulators_`只以`var`作为key，一般用于没有grad_node的var。

但是注意，这里var的grad_node，是根据op的grad_pending_node来判断的。因为反向图结构是根据grad_pending_node构造起来的，一般grad_pending_node都不会变。而var的grad_node在构造网络时（inplace操作）、反向网络执行过程中都可能发生改变（op被析构）。

这个bug也是因为没有分清`grad_node`和`grad_pending_node`的使用导致的。
向`accumulators_with_grad_node_`和`accumulators_`插入数据时，使用的key是`grad_pending_node`。但是判断应该使用`accumulators_with_grad_node_`还是`accumulators_`，却是用`grad_node`来判断的。`grad_node`信息在反向网络执行过程中发生变化，导致使用的accumulator错误。

#### 修复

判断使用`accumulators_with_grad_node_`还是`accumulators_`时，使用op的`grad_pending_node`信息而不是var的`grad_node`信息。

