### PR TITLE
[Paddle-TRT] Increase trt reduce mean fp16 tolerance, test=allcase

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reduce_mean.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reduce_mean.py
@@ -120,7 +120,7 @@ class TrtConvertReduceMeanTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-4, 1e-4)
+            attrs, False), (2e-4, 2e-4)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -129,7 +129,7 @@ class TrtConvertReduceMeanTest(TrtLayerAutoScanTest):
                                                                      True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-4, 1e-4)
+            attrs, True), (2e-4, 2e-4)
 
         pass
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Current TensorRT unittest may not actually run the fp16 precision even though set the fp16 to the predictor.

The reason is that TensorRT will select the fastest precision. The unit tests almost has small network and fp32 I/O, and the engine may found that fp32 is faster than fp16.

In this PR, I found the original threshold for fp16 reduce mean is too small and it results some random fails if the TensorRT actually found a faster fp16 algorithm.
