### PR TITLE
Remove unnecessary header file in renorm_op.cu

### DIFF
--- a/paddle/fluid/operators/renorm_op.cu
+++ b/paddle/fluid/operators/renorm_op.cu
@@ -15,7 +15,6 @@
 #include <algorithm>
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op_impl.cu.h"
-#include "paddle/fluid/operators/reduce_ops/reduce_functor_op.h"
 #include "paddle/fluid/operators/reduce_ops/reduce_op.cu.h"
 #include "paddle/fluid/operators/reduce_ops/reduce_op.h"
 #include "paddle/fluid/operators/renorm_op.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
The header file _"paddle/fluid/operators/reduce_ops/reduce_functor_op.h"_ is nonexistent. It should not be included in _renorm_op.cu_, or will lead to a compile error.
<img width="1018" alt="654fa98de7827f361e02da8e14ae8cc7" src="https://user-images.githubusercontent.com/17673696/147376803-fcf4a7a4-a81e-480e-8f5d-c5ad9efc7cdd.png">

