### PR TITLE
fix reduce_max/reduce_min bug

### DIFF
--- a/paddle/pten/kernels/hybird/general/reduce_impl.h
+++ b/paddle/pten/kernels/hybird/general/reduce_impl.h
@@ -31,11 +31,12 @@ void Reduce(const DeviceContext& dev_ctx,
             DataType out_dtype,
             DenseTensor* out) {
   // If the dims has full dim, set the reduce_all is True
-  const auto& input_dim_size = x.dims().size();
+  const int& input_dim_size = x.dims().size();
   std::set<int> dims_set(dims.begin(), dims.end());
   bool full_dim = true;
-  for (auto i = 0; i < input_dim_size; ++i) {
-    if (dims_set.find(i) == dims_set.end()) {
+  for (int i = 0; i < input_dim_size; ++i) {
+    if (dims_set.find(i) == dims_set.end() &&
+        dims_set.find(i - input_dim_size) == dims_set.end()) {
       full_dim = false;
       break;
     }

--- a/python/paddle/fluid/tests/unittests/test_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_max_op.py
@@ -98,6 +98,15 @@ class ApiMaxTest(unittest.TestCase):
         self.assertEqual((np_z1 == z_expected).all(), True)
         self.assertEqual((np_z2 == z_expected).all(), True)
 
+    def test_all_negative_axis(self):
+        paddle.disable_static()
+        x = paddle.rand(shape=[2, 2])
+        np_x = x.numpy()
+        z1 = paddle.max(x, axis=(-2, -1))
+        np_z1 = z1.numpy()
+        z_expected = np.array(np.max(np_x, axis=(0, 1)))
+        self.assertEqual((np_z1 == z_expected).all(), True)
+
 
 class TestOutDtype(unittest.TestCase):
     def test_max(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
fix bug：
paddle.max / paddle.min api，在CPU设备上，当参数axis.size() == input.dims.size()，且存在axis[i] < 0时，结果出错。出错原因为判断reduce_all的逻辑不完善，没有考虑过negative的axis。
<!-- Describe what this PR does -->
