### PR TITLE
Fix the conflict between include_dirs and _compile_dir

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -471,16 +471,17 @@ def normalize_extension_kwargs(kwargs, use_cuda=False):
     Normalize include_dirs, library_dir and other attributes in kwargs.
     """
     assert isinstance(kwargs, dict)
-    include_dirs = []
+    compile_include_dirs = []
     # NOTE: the "_compile_dir" argument is not public to users. It is only
     # reserved for internal usage. We do not guarantee that this argument
     # is always valid in the future release versions.
     compile_dir = kwargs.get("_compile_dir", None)
     if compile_dir:
-        include_dirs = _get_include_dirs_when_compiling(compile_dir)
+        compile_include_dirs = _get_include_dirs_when_compiling(compile_dir)
 
     # append necessary include dir path of paddle
-    include_dirs = kwargs.get('include_dirs', include_dirs)
+    include_dirs = list(kwargs.get('include_dirs', []))
+    include_dirs.extend(compile_include_dirs)
     include_dirs.extend(find_paddle_includes(use_cuda))
 
     kwargs['include_dirs'] = include_dirs


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix the conflict between `include_dirs` and `_compile_dir` in custom op compilation. Previously, `include_dirs` would overwrite the `_compile_dir` settings.