### PR TITLE
Fix scatter_op fp16 perf problem.

### DIFF
--- a/paddle/fluid/operators/scatter.cu.h
+++ b/paddle/fluid/operators/scatter.cu.h
@@ -19,18 +19,12 @@ limitations under the License. */
 #include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/memory/malloc.h"
 #include "paddle/fluid/platform/device/gpu/gpu_primitives.h"
-// #include "paddle/fluid/platform/device/gpu/gpu_device_function.h"
-#include "paddle/fluid/platform/device/gpu/gpu_dnn.h"
 #include "paddle/fluid/platform/place.h"
 
 namespace paddle {
 namespace operators {
 
 using Tensor = framework::Tensor;
-template <typename T>
-using CudnnDataType = platform::CudnnDataType<T>;
-template <typename T>
-using BatchNormParamType = typename CudnnDataType<T>::BatchNormParamType;
 
 template <typename T, typename IndexT = int>
 __global__ void ScatterInitCUDAKernel(const IndexT* indices, T* output,
@@ -73,36 +67,6 @@ __global__ void ScatterCUDAKernel(const T* params, const IndexT* indices,
       *(output + out_i) = *(params + i);
     } else {
       paddle::platform::CudaAtomicAdd(output + out_i, *(params + i));
-    }
-  }
-}
-
-// todo:
-template <typename IndexT = int>
-__global__ void ScatterCUDAKernel(const paddle::float16* params,
-                                  const IndexT* indices,
-                                  paddle::float16* output, size_t index_size,
-                                  size_t slice_size, bool overwrite) {
-  using U = BatchNormParamType<paddle::float16>;
-  CUDA_KERNEL_LOOP_TYPE(i, index_size * slice_size, int64_t) {
-    int64_t indices_i = i / slice_size;
-    int64_t slice_i = i - indices_i * slice_size;  // offset inside the slice
-    IndexT scatter_i = indices[indices_i];
-
-    PADDLE_ENFORCE(scatter_i >= 0,
-                   "The index is out of bounds, "
-                   "please check whether the dimensions of index and "
-                   "input meet the requirements. It should "
-                   "be greater than or equal to 0, but received [%d]",
-                   scatter_i);
-    int64_t out_i = scatter_i * slice_size + slice_i;
-    if (overwrite) {
-      *(output + out_i) = *(params + i);
-    } else {
-      U out_tmp = static_cast<U>(output[out_i]);
-      U in_tmp = static_cast<U>(params[i]);
-      paddle::platform::CudaAtomicAdd(&out_tmp, in_tmp);
-      output[out_i] = static_cast<paddle::float16>(out_tmp);
     }
   }
 }

--- a/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
@@ -18,7 +18,9 @@ from ... import core
 __all__ = ["CustomOpLists", "AutoMixedPrecisionLists"]
 
 # lookup_table fp16 is slower than fp32, though fp16 is supported.
-_extra_unsupported_fp16_list = {'lookup_table', 'lookup_table_v2'}
+_extra_unsupported_fp16_list = {
+    'lookup_table', 'lookup_table_v2', 'scatter', 'scatter_grad'
+}
 
 
 class AutoMixedPrecisionLists(object):

--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -71,7 +71,9 @@ AMP_RELATED_FLAGS_SETTING = {
 }
 
 PURE_FP16_WHITE_LIST = {' '}
-PURE_FP16_BLACK_LIST = {'lookup_table', 'lookup_table_v2'}
+PURE_FP16_BLACK_LIST = {
+    'lookup_table', 'lookup_table_v2', 'scatter', 'scatter_grad'
+}
 
 
 #NOTE(zhiqiu): similar as paddle.fluid.contrib.mixed_precision.fp16_lists.AutoMixedPrecisionLists._update_list


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
OPs

### Describe
The performance of scatter op of fp16 when override is false is not well because of the bad performance of CudaAtomicAdd on fp16. In this pr, we fix this performance issue by adding scatter op into _extra_unsupported_fp16_list for static graph and PURE_FP16_BLACK_LIST for dygraph.