### PR TITLE
 Add OpFunctor and replace cast, scale,clip, bce_loss and abs_grad with elementwise_no_broadcast

### DIFF
--- a/paddle/pten/kernels/gpu/cast_kernel.cu
+++ b/paddle/pten/kernels/gpu/cast_kernel.cu
@@ -19,6 +19,7 @@
 #include "paddle/pten/core/kernel_registry.h"
 
 // See Note [ Why still include the fluid headers? ]
+#include "paddle/fluid/operators/elementwise/elementwise_op_impl.cu.h"
 #include "paddle/fluid/platform/aligned_vector.h"
 #include "paddle/fluid/platform/bfloat16.h"
 #include "paddle/fluid/platform/device/gpu/gpu_helper.h"
@@ -27,62 +28,24 @@
 
 namespace pten {
 
-template <typename InT, typename OutT, int VecSize>
-__global__ void VecCastCUDAKernel(const InT* in, const int64_t N, OutT* out) {
-  using LoadT = paddle::platform::AlignedVector<InT, VecSize>;
-  using StoreT = paddle::platform::AlignedVector<OutT, VecSize>;
-
-  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
-  for (int64_t i = idx * VecSize; i < N;
-       i += blockDim.x * gridDim.x * VecSize) {
-    LoadT in_val;
-    paddle::platform::Load<InT, VecSize>(&in[i], &in_val);
-
-    StoreT out_val;
-#pragma unroll
-    for (int j = 0; j < VecSize; j++) {
-      out_val[j] = static_cast<OutT>(in_val[j]);
-    }
-
-    paddle::platform::Store<OutT, VecSize>(out_val, &out[i]);
-  }
-}
-
 template <typename InT, typename OutT>
-__global__ void CastCUDAKernel(const InT* in, const int64_t N, OutT* out) {
-  CUDA_KERNEL_LOOP(index, N) { out[index] = static_cast<OutT>(in[index]); }
-}
-
-template <typename InT, typename OutT>
-void CastCUDAKernelImplWithPtr(const GPUContext& dev_ctx,
-                               const InT* in_data,
-                               OutT* out_data,
-                               int64_t size) {
-  paddle::platform::GpuLaunchConfig config =
-      paddle::platform::GetGpuLaunchConfig1D(dev_ctx, size);
-  int vec_size = paddle::platform::GetVectorizedSize<OutT>(out_data);
-  if (!std::is_same<InT, OutT>::value && vec_size == 4 && size % 4 == 0) {
-    VecCastCUDAKernel<InT, OutT, 4><<<config.block_per_grid,
-                                      config.thread_per_block,
-                                      0,
-                                      dev_ctx.stream()>>>(
-        in_data, size, out_data);
-  } else {
-    CastCUDAKernel<InT, OutT><<<config.block_per_grid,
-                                config.thread_per_block,
-                                0,
-                                dev_ctx.stream()>>>(in_data, size, out_data);
+struct CastFuctor {
+  __device__ __forceinline__ OutT operator()(const InT& x) const {
+    return static_cast<OutT>(x);
   }
-}
+};
 
 template <typename InT, typename OutT>
 void CastCUDAKernelImpl(const GPUContext& dev_ctx,
                         const DenseTensor& x,
                         DenseTensor* out) {
-  auto* in_data = x.data<InT>();
-  auto size = x.numel();
-  auto* out_data = out->mutable_data<OutT>();
-  CastCUDAKernelImplWithPtr(dev_ctx, in_data, out_data, size);
+  std::vector<const DenseTensor*> inputs;
+  std::vector<DenseTensor*> outputs;
+  inputs.emplace_back(&x);
+  outputs.emplace_back(out);
+  out->mutable_data<OutT>();
+  LaunchSameDimsElementwiseCudaKernel<ElementwiseType::kUnary, InT, OutT>(
+      dev_ctx, inputs, &outputs, CastFuctor<InT, OutT>());
 }
 
 template <typename T, typename Context>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
 Add OpFunctor and replace cast, scale, full, clip, bce_loss and abs_grad with elementwise_no_broadcast
cast 当前在pten中修改不触发benchmark，现补充性能测试：

cast | case | type | old / us | new / us | speed up
-- | -- | -- | -- | -- | --
case0 | [16, 1785] | bool | 1.328 | 1.413 | 0.94
case1 | [16, 1] | int32->int64 | 1.27 | 1.239 | 1.03
case2 | [16, 1, 513, 513] | int32->float32 | 43.09 | 42.229 | 1.02
case3 | [30522, 1024] | float16->float32 | 246.57 | 236.28 | 1.04
case4 | [1] | in64->float32 | 1.276 | 1.29 | 0.99
case5 | [16, 16, 1] | float32->float16 | 1.269 | 1.312 | 0.97
case6 | [16, 16, 1024] | float16->float32 | 2.025 | 1.842 | 1.10

case0 出现性能下降，主要原因是case规模比较小，机器波动影响占比较大。