### PR TITLE
[NPU] fix expand op

### DIFF
--- a/paddle/fluid/operators/expand_op_npu.cc
+++ b/paddle/fluid/operators/expand_op_npu.cc
@@ -89,13 +89,17 @@ class ExpandNPUKernel : public framework::OpKernel<T> {
     out0->Resize(out_dims);
     out0->mutable_data<T>(place);
 
-    bool is_expand_times_all_one = (out_dims == in_dims) ? true : false;
+    bool is_expand_times_all_one =
+        (out0->numel() == in0->numel()) ? true : false;
 
     if (is_expand_times_all_one) {
       memory::Copy(BOOST_GET_CONST(platform::NPUPlace, place),
                    out0->mutable_data<T>(place),
                    BOOST_GET_CONST(platform::NPUPlace, place), in0->data<T>(),
                    in0->numel() * sizeof(T), stream);
+      if (out_dims != in_dims) {
+        out0->Resize(out_dims);
+      }
     } else {
       const auto& runner =
           NpuOpRunner("TileD", {*in0}, {*out0}, {{"multiples", expand_times}});

--- a/python/paddle/fluid/tests/unittests/npu/test_expand_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_expand_op_npu.py
@@ -132,5 +132,26 @@ class TestExpandNet(unittest.TestCase):
         self.assertTrue(np.allclose(npu_loss, cpu_loss))
 
 
+# ------------------------------------------------
+# Special Cases for NPU
+# ------------------------------------------------
+
+
+class TestExpand_expand_times_all_one(TestExpand):
+    def setUp(self):
+        self.set_npu()
+        self.op_type = "expand"
+        self.place = paddle.NPUPlace(0)
+
+        self.init_dtype()
+        np.random.seed(SEED)
+        x = np.random.randn(3, 1, 7).astype(self.dtype)
+        out = np.tile(x, [1, 1, 1])
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.attrs = {'expand_times': [1, 1, 1]}
+        self.outputs = {'Out': out}
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
当 expand_times 全为 1 时，Ascend 的 TileD 会抛出 异常 500002。

![image](https://user-images.githubusercontent.com/34057289/147538650-ba114278-3626-4afc-9303-81188b508070.png)
