### PR TITLE
reduce compile time of amax and amin

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_min_max_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_min_max_op.h
@@ -125,13 +125,14 @@ struct AMaxOrAMinGradFunctor {
     HANDLE_AXIS_DIM(3, 2);
     HANDLE_AXIS_DIM(4, 2);
     HANDLE_AXIS_DIM(4, 3);
-    HANDLE_AXIS_DIM(5, 2);
-    HANDLE_AXIS_DIM(5, 3);
-    HANDLE_AXIS_DIM(5, 4);
-    HANDLE_AXIS_DIM(6, 2);
-    HANDLE_AXIS_DIM(6, 3);
-    HANDLE_AXIS_DIM(6, 4);
-    HANDLE_AXIS_DIM(6, 5);
+    // comments for accelerating compiling temporarily.
+    // HANDLE_AXIS_DIM(5, 2);
+    // HANDLE_AXIS_DIM(5, 3);
+    // HANDLE_AXIS_DIM(5, 4);
+    // HANDLE_AXIS_DIM(6, 2);
+    // HANDLE_AXIS_DIM(6, 3);
+    // HANDLE_AXIS_DIM(6, 4);
+    // HANDLE_AXIS_DIM(6, 5);
   }
 };
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1775,7 +1775,8 @@ def amax(x, axis=None, keepdim=False, name=None):
         while max propagates gradient to all of them.
 
     Args:
-        x(Tensor): A tensor, the data type is float32, float64, int32, int64.
+        x(Tensor): A tensor, the data type is float32, float64, int32, int64,
+            the dimension is no more than 4.
         axis(int|list|tuple, optional): The axis along which the maximum is computed.
             If :attr:`None`, compute the maximum over all elements of
             `x` and return a Tensor with a single element,
@@ -1874,7 +1875,8 @@ def amin(x, axis=None, keepdim=False, name=None):
         while min propagates gradient to all of them.
 
     Args:
-        x(Tensor): A tensor, the data type is float32, float64, int32, int64.
+        x(Tensor): A tensor, the data type is float32, float64, int32, int64, 
+            the dimension is no more than 4.
         axis(int|list|tuple, optional): The axis along which the minimum is computed.
             If :attr:`None`, compute the minimum over all elements of
             `x` and return a Tensor with a single element,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
amax和amin的反向使用模版，导致CI上编译时间比较长
- before：
  - PR-build（GPU全架构编译）：
     - #38417 跑了2小时
![image](https://user-images.githubusercontent.com/6836917/147552862-a7ab370c-82e0-4133-9c92-6236c616cf77.png)
https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4413320/job/10491766
     - #38525 40分钟
![image](https://user-images.githubusercontent.com/6836917/147551902-f5c58946-3b4b-41fe-890b-44f76fab837c.png)
https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4413320/job/10491766 
   - PR-coverage（只编译V100架构）时间没有受影响
- after：减少模版数量。支持维度从6维降低到4维，跑了20分钟
  https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4424518/job/10527669
<img width="835" alt="图片" src="https://user-images.githubusercontent.com/6836917/147559424-08212cc5-ea8c-40bf-9242-8415a20b0076.png">

后续Paddle-build会考虑只编译1到2个架构来减少时间，不过amax/amin的维度还得降低，不然会影响发包时候的编译速度

