### PR TITLE
[Dy2st]Fix error when set buffer in forward

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1176,11 +1176,18 @@ class Layer(object):
                         # but should all non-Variable _buffers[name] be re-assign? We
                         # should consider it in the future. I current wrote this as
                         # conservative code.
-                        if _buffers[name] is None or type(_buffers[
-                                name]) == core.VarBase:
+                        if (in_declarative_mode() and
+                                not framework.in_dygraph_mode() and
+                                _buffers[name] is None):
+                            raise RuntimeError(
+                                'In Dy2stat, self.{0} is a buffer and self.{0} is '
+                                'not allowed to be set to Variable when self.{0} is None.'.
+                                format(name))
+                        elif _buffers[name] is None or type(
+                                getattr(self, name)) == core.VarBase:
                             _buffers[name] = assign(value)
                         else:
-                            assign(value, _buffers[name])
+                            assign(value, getattr(self, name))
                     elif value is not None:
                         raise TypeError(
                             "assignment to buffers '{}' should be of type core.VarBase or None, but got '{}'"

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1094,7 +1094,7 @@ class Layer(object):
         if '_parameters' in self.__dict__:
             _parameters = self.__dict__['_parameters']
             if name in self._parameters:
-                if in_declarative_mode() and not framework.in_dygraph_mode():
+                if in_declarative_mode():
                     return _convert_into_variable(self._parameters[name])
                 return self._parameters[name]
         if '_sub_layers' in self.__dict__:
@@ -1104,7 +1104,7 @@ class Layer(object):
         if '_buffers' in self.__dict__:
             _buffers = self.__dict__['_buffers']
             if name in _buffers:
-                if in_declarative_mode() and not framework.in_dygraph_mode():
+                if in_declarative_mode():
                     return _convert_into_variable(_buffers[name])
                 return _buffers[name]
         return object.__getattribute__(self, name)
@@ -1176,9 +1176,7 @@ class Layer(object):
                         # but should all non-Variable _buffers[name] be re-assign? We
                         # should consider it in the future. I current wrote this as
                         # conservative code.
-                        if (in_declarative_mode() and
-                                not framework.in_dygraph_mode() and
-                                _buffers[name] is None):
+                        if in_declarative_mode() and _buffers[name] is None:
                             raise RuntimeError(
                                 'In Dy2stat, self.{0} is a buffer and self.{0} is '
                                 'not allowed to be set to Variable when self.{0} is None.'.

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -205,6 +205,7 @@ class NetWithControlFlowIf(fluid.dygraph.Layer):
         self.alpha = 10.
         self.constant_vars = {}
 
+    @paddle.jit.to_static
     def forward(self, input):
         hidden_dim = input.shape[-1]
         if hidden_dim != self.hidden_dim:

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
@@ -408,5 +408,45 @@ class TestCallNonForwardFunc(unittest.TestCase):
         paddle.enable_static()
 
 
+class SetBuffersNet1(paddle.nn.Layer):
+    def __init__(self):
+        super(SetBuffersNet1, self).__init__()
+        self.a = paddle.to_tensor([1])
+
+    @paddle.jit.to_static
+    def forward(self):
+        self.a = self.a + 1
+        return self.a
+
+
+class SetBuffersNet2(paddle.nn.Layer):
+    def __init__(self):
+        super(SetBuffersNet2, self).__init__()
+        self.b = paddle.to_tensor([2])
+
+    @paddle.jit.to_static
+    def forward(self):
+        self.b = None
+        self.b = paddle.to_tensor([3])
+        return self.b
+
+
+class TestCallNonForwardFunc(unittest.TestCase):
+    def test_set_buffers1(self):
+        paddle.disable_static()
+        net = SetBuffersNet1()
+        out = net()
+        self.assertEqual(out.numpy().tolist(), [2])
+        paddle.jit.save(net, './SetBuffersNet1')
+        paddle.enable_static()
+
+    def test_set_buffers2(self):
+        paddle.disable_static()
+        net = SetBuffersNet2()
+        with self.assertRaises(RuntimeError):
+            out = net()
+        paddle.enable_static()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
@@ -431,7 +431,7 @@ class SetBuffersNet2(paddle.nn.Layer):
         return self.b
 
 
-class TestCallNonForwardFunc(unittest.TestCase):
+class TestSetBuffers(unittest.TestCase):
     def test_set_buffers1(self):
         paddle.disable_static()
         net = SetBuffersNet1()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -20,7 +20,7 @@ import unittest
 import paddle
 from paddle.fluid.dygraph.jit import declarative
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator
-from paddle.fluid.dygraph.base import _switch_declarative_mode_guard_
+# from paddle.fluid.dygraph.base import _switch_declarative_mode_guard_
 
 from ifelse_simple_func import *
 
@@ -412,16 +412,15 @@ class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
 
     def test_ast_to_func(self):
         ProgramTranslator().enable(True)
-        # Why need _switch_declarative_mode_guard_() here? 
+        with self.assertRaises(TypeError):
+            static_func = paddle.jit.to_static(self.dyfunc)
+            out = static_func(self.x)
+        # Why need set `_in_declarative_mode_` here? 
         # In Dy2St we use `with _switch_declarative_mode_guard_()` to indicate 
         # that the code block is under @to_static, but in this UT 
         # an exception is thrown during Dy2St, making the `_in_declarative_mode_` 
-        # a wrong value. So We use with _switch_declarative_mode_guard_()` 
-        # here correct setting `_in_declarative_mode_`.
-        with _switch_declarative_mode_guard_():
-            with self.assertRaises(TypeError):
-                static_func = paddle.jit.to_static(self.dyfunc)
-                out = static_func(self.x)
+        # a wrong value. So We need set `_in_declarative_mode_` to False manually.
+        paddle.fluid.dygraph.base._in_declarative_mode_ = False
         ProgramTranslator().enable(False)
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -20,6 +20,7 @@ import unittest
 import paddle
 from paddle.fluid.dygraph.jit import declarative
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator
+from paddle.fluid.dygraph.base import _switch_declarative_mode_guard_
 
 from ifelse_simple_func import *
 
@@ -410,14 +411,12 @@ class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
         self.dyfunc = dyfunc_ifelse_ret_int4
 
     def test_ast_to_func(self):
-        with self.assertRaises(TypeError):
-            ProgramTranslator().enable(True)
-            static_func = paddle.jit.to_static(self.dyfunc)
-            out = static_func(self.x)
-
-    def __del__(self):
+        ProgramTranslator().enable(True)
+        with _switch_declarative_mode_guard_():
+            with self.assertRaises(TypeError):
+                static_func = paddle.jit.to_static(self.dyfunc)
+                out = static_func(self.x)
         ProgramTranslator().enable(False)
-        super(TestDy2StIfElseRetInt4, self).__del__()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -20,7 +20,6 @@ import unittest
 import paddle
 from paddle.fluid.dygraph.jit import declarative
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator
-# from paddle.fluid.dygraph.base import _switch_declarative_mode_guard_
 
 from ifelse_simple_func import *
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -412,6 +412,12 @@ class TestDy2StIfElseRetInt4(TestDy2StIfElseRetInt1):
 
     def test_ast_to_func(self):
         ProgramTranslator().enable(True)
+        # Why need _switch_declarative_mode_guard_() here? 
+        # In Dy2St we use `with _switch_declarative_mode_guard_()` to indicate 
+        # that the code block is under @to_static, but in this UT 
+        # an exception is thrown during Dy2St, making the `_in_declarative_mode_` 
+        # a wrong value. So We use with _switch_declarative_mode_guard_()` 
+        # here correct setting `_in_declarative_mode_`.
         with _switch_declarative_mode_guard_():
             with self.assertRaises(TypeError):
                 static_func = paddle.jit.to_static(self.dyfunc)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#37296 合入后，下面的示例代码中存在两个问题
1. 对于subnet的self.a，在动转静中是一个buffer变量，在forward中使用语句`self.a = self.a + 10`进行set时，由于取消了Layer.__call__中的param_guard操作，Layer._buffers变量不会被转为Variable，那么在Layer.__setattr__函数中最后会进入下图中的if中，assign产生一个新的variable，_buffers[name]也有原来的tensor变为了assig的variable，同时jit.save时会报错。
![image](https://user-images.githubusercontent.com/23097963/147560973-b0f2a563-0c99-483a-8a86-958906f99343.png)
![image](https://user-images.githubusercontent.com/23097963/147561226-a6ef3239-6434-433d-a0da-0c6ad11857ff.png)

2. 动转静中self.b变量被设置为None后重新被赋值为一个tensor，会产生1中类似错误，我们在代码中禁止了类似操作。
```python
import paddle

class SubNet(paddle.nn.Layer):
    def __init__(self):
        super(SubNet, self).__init__()
        self.a = paddle.to_tensor([1])
        self.b = paddle.to_tensor([2])
    
    def forward(self, x):
        self.a = self.a + 10
        self.b = None
        self.b = paddle.to_tensor([3])
        return x

class Net(paddle.nn.Layer):
    def __init__(self):
        super(Net, self).__init__()
        self.sub_net = SubNet()

    @paddle.jit.to_static
    def forward(self, x):
        out = self.sub_net(x)
        return out
```
