### PR TITLE
we should memset data as 0 after new data(which the value is random)

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_capi_pd_tensor_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_pd_tensor_tester.cc
@@ -47,6 +47,7 @@ void PD_run() {
   int shape[4] = {batch, channel, height, width};
   int shape_size = 4;
   float* data = new float[batch * channel * height * width];
+  memset(data, 0, batch * channel * height * width);
   PD_PaddleBufReset(buf, static_cast<void*>(data),
                     sizeof(float) * (batch * channel * height * width));
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
BUG fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
由于new 并不能保证堆上数据初始化，因此直接用作tensor 的data 会导致异常值。可以在data new 出来之后，用memset 进行初始化。