### PR TITLE
[Bug fix] Fix for MKLDNNDeviceContext error in matmul_v2_transpose_reshape fuse pass when GLOG_v set

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -409,13 +409,15 @@ void AnalysisPredictor::MkldnnPreSet(
 void AnalysisPredictor::MkldnnPostReset() {
 #ifdef PADDLE_WITH_MKLDNN
   // In cache clearing mode.
-  auto dev_ctx = static_cast<platform::MKLDNNDeviceContext *>(
-      (&platform::DeviceContextPool::Instance())->Get(platform::CPUPlace()));
-
   if (config_.mkldnn_cache_capacity_ > 0 &&
-      dev_ctx->GetCachedObjectsNumber() > 0) {
+      static_cast<platform::MKLDNNDeviceContext *>(
+          (&platform::DeviceContextPool::Instance())->Get(platform::CPUPlace()))
+              ->GetCachedObjectsNumber() > 0) {
     if (VLOG_IS_ON(2)) {
-      auto shape_blob_size = dev_ctx->GetShapeBlobSize();
+      auto shape_blob_size = static_cast<platform::MKLDNNDeviceContext *>(
+                                 (&platform::DeviceContextPool::Instance())
+                                     ->Get(platform::CPUPlace()))
+                                 ->GetShapeBlobSize();
       CHECK_LE(shape_blob_size,
                static_cast<size_t>(config_.mkldnn_cache_capacity_));
     }

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -409,12 +409,13 @@ void AnalysisPredictor::MkldnnPreSet(
 void AnalysisPredictor::MkldnnPostReset() {
 #ifdef PADDLE_WITH_MKLDNN
   // In cache clearing mode.
-  if (config_.mkldnn_cache_capacity_ > 0) {
+  auto dev_ctx = static_cast<platform::MKLDNNDeviceContext *>(
+      (&platform::DeviceContextPool::Instance())->Get(platform::CPUPlace()));
+
+  if (config_.mkldnn_cache_capacity_ > 0 &&
+      dev_ctx->GetCachedObjectsNumber() > 0) {
     if (VLOG_IS_ON(2)) {
-      auto shape_blob_size = static_cast<platform::MKLDNNDeviceContext *>(
-                                 (&platform::DeviceContextPool::Instance())
-                                     ->Get(platform::CPUPlace()))
-                                 ->GetShapeBlobSize();
+      auto shape_blob_size = dev_ctx->GetShapeBlobSize();
       CHECK_LE(shape_blob_size,
                static_cast<size_t>(config_.mkldnn_cache_capacity_));
     }


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix for MKLDNNDeviceContext error when GLOG_v env variable was set. It is a fix for #38038 and a reupload of #38411. All this PR does is skipping checking cache if it is empty
