### PR TITLE
[Code Clean] Clean useless return in cudnn_helper.h

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -164,7 +164,7 @@ void ChooseAlgo(const std::vector<PerfType>& perf_results,
       VLOG(3) << "    choose algo: " << result.algo << ", TC: " << math_type_str
               << ", time: " << result.time << " ms"
               << ", wksp = " << result.memory << ", status = " << result.status;
-      return;
+      break;
     }
   }
 }
@@ -197,7 +197,6 @@ static void SetConvMathType(const framework::ExecutionContext& ctx,
     VLOG(5) << "NOT use cudnn_tensor_op_math";
   }
 #endif
-  return;
 }
 
 struct ConvArgs {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- According to after-merged advice of [PR34409](https://github.com/PaddlePaddle/Paddle/pull/34409), clean useless `return` syntax. 