### PR TITLE
Add gpu kernel for new api : linalg.lstsq

### DIFF
--- a/cmake/operators.cmake
+++ b/cmake/operators.cmake
@@ -202,6 +202,7 @@ function(op_library TARGET)
         list(REMOVE_ITEM hip_srcs "eigvalsh_op.cu")
         list(REMOVE_ITEM hip_srcs "qr_op.cu")
         list(REMOVE_ITEM hip_srcs "eigh_op.cu")
+        list(REMOVE_ITEM hip_srcs "lstsq_op.cu")
         list(REMOVE_ITEM hip_srcs "multinomial_op.cu")
         list(REMOVE_ITEM hip_srcs "decode_jpeg_op.cu")
         hip_library(${TARGET} SRCS ${cc_srcs} ${hip_cc_srcs} ${miopen_cu_cc_srcs} ${miopen_cu_srcs} ${mkldnn_cc_srcs} ${hip_srcs} DEPS ${op_library_DEPS}

--- a/paddle/fluid/operators/lstsq_op.cu
+++ b/paddle/fluid/operators/lstsq_op.cu
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef PADDLE_WITH_HIP
+// HIP not support cusolver
+
 #include <string>
 #include <vector>
 #include "paddle/fluid/operators/lstsq_op.h"
@@ -187,3 +190,5 @@ namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     lstsq, ops::LstsqCUDAKernel<paddle::platform::CUDADeviceContext, float>,
     ops::LstsqCUDAKernel<paddle::platform::CUDADeviceContext, double>);
+
+#endif  // not PADDLE_WITH_HIP

--- a/paddle/fluid/operators/lstsq_op.cu
+++ b/paddle/fluid/operators/lstsq_op.cu
@@ -1,0 +1,189 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+#include "paddle/fluid/operators/lstsq_op.h"
+#include "paddle/fluid/operators/qr_op.h"
+#include "paddle/fluid/platform/dynload/cusolver.h"
+
+namespace paddle {
+namespace operators {
+
+using paddle::framework::Tensor;
+
+template <typename DeviceContext, typename T>
+class LstsqCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    const Tensor& x = *context.Input<Tensor>("X");
+    const Tensor& y = *context.Input<Tensor>("Y");
+    auto* solution = context.Output<Tensor>("Solution");
+
+    auto dito =
+        math::DeviceIndependenceTensorOperations<platform::CUDADeviceContext,
+                                                 T>(context);
+    auto& dev_ctx =
+        context.template device_context<platform::CUDADeviceContext>();
+
+    auto x_dims = x.dims();
+    auto y_dims = y.dims();
+    int dim_size = x_dims.size();
+    int m = x_dims[dim_size - 2];
+    int n = x_dims[dim_size - 1];
+    int m_y = y_dims[dim_size - 2];
+    int n_y = y_dims[dim_size - 1];
+    int min_mn = std::min(m, n);
+    int max_mn = std::max(m, n);
+    int k = min_mn;
+
+    int x_stride = MatrixStride(x);
+    int y_stride = MatrixStride(y);
+    int tau_stride = min_mn;
+    int batch_count = BatchCount(x);
+
+    Tensor new_x, new_y;
+    new_x.mutable_data<T>(context.GetPlace(),
+                          size_t(batch_count * m * n * sizeof(T)));
+    new_y.mutable_data<T>(context.GetPlace(),
+                          size_t(batch_count * m_y * n_y * sizeof(T)));
+    framework::TensorCopy(x, context.GetPlace(), &new_x);
+    framework::TensorCopy(y, context.GetPlace(), &new_y);
+
+    // Prepare tau
+    auto tau_dims_vec = framework::vectorize<int>(x_dims);
+    tau_dims_vec.pop_back();
+    tau_dims_vec[tau_dims_vec.size() - 1] = min_mn;
+    Tensor tau = dito.Fill(tau_dims_vec, 0);
+    auto tau_data = tau.mutable_data<T>(context.GetPlace());
+
+    auto tmp_x = dito.Transpose(new_x);
+    auto tmp_y = dito.Transpose(new_y);
+    framework::TensorCopy(tmp_x, new_x.place(), &new_x);
+    framework::TensorCopy(tmp_y, new_y.place(), &new_y);
+
+    auto x_data = new_x.mutable_data<T>(context.GetPlace());
+    auto y_data = new_y.mutable_data<T>(context.GetPlace());
+
+    // step 1, compute QR factorization using geqrf
+    BatchedGeqrf<DeviceContext, T>(dev_ctx, batch_count, m, n, x_data, m,
+                                   tau_data, x_stride, tau_stride);
+
+    // Step 2, B <- Q^H B
+    BatchedOrmqr<DeviceContext, T>(dev_ctx, true, true, batch_count, m, n, k,
+                                   x_data, x_stride, tau_data, tau_stride,
+                                   y_data, y_stride);
+
+    auto trans_r = dito.Transpose(new_x);
+    auto trans_b = dito.Transpose(new_y);
+    auto slice_r = dito.Slice(trans_r, {-2}, {0}, {min_mn});
+    auto slice_b = dito.Slice(trans_b, {-2}, {0}, {min_mn});
+    auto tmp_r = dito.TrilTriu(slice_r, 0, false);
+    framework::TensorCopy(tmp_r, new_x.place(), &new_x);
+    framework::TensorCopy(slice_b, new_y.place(), &new_y);
+
+    // Step 3, solve R X = B
+    triangular_solve<DeviceContext, T>(dev_ctx, new_x, new_y, solution, true,
+                                       false, false);
+  }
+};
+
+template <>
+void BatchedOrmqr<platform::CUDADeviceContext, float>(
+    const platform::CUDADeviceContext& dev_ctx, bool left, bool transpose,
+    int batch_size, int m, int n, int k, float* a, int a_stride, float* tau,
+    int tau_stride, float* other, int other_stride) {
+  int lwork = 0;
+  auto side = left ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
+  auto trans = transpose ? CUBLAS_OP_T : CUBLAS_OP_N;
+  int lda = std::max<int>(1, left ? m : n);
+  int ldc = std::max<int>(1, m);
+
+  auto handle = dev_ctx.cusolver_dn_handle();
+  PADDLE_ENFORCE_GPU_SUCCESS(platform::dynload::cusolverDnSormqr_bufferSize(
+      handle, side, trans, m, n, k, a, lda, tau, other, ldc, &lwork));
+  auto workspace = memory::Alloc(dev_ctx, lwork * sizeof(float));
+  float* workspace_ptr = reinterpret_cast<float*>(workspace->ptr());
+  auto info = memory::Alloc(dev_ctx, sizeof(int));
+  int* info_d = reinterpret_cast<int*>(info->ptr());
+
+  for (int i = 0; i < batch_size; ++i) {
+    float* a_working_ptr = &a[i * a_stride];
+    float* tau_working_ptr = &tau[i * tau_stride];
+    float* other_working_ptr = &other[i * other_stride];
+    // compute ormgr
+    PADDLE_ENFORCE_GPU_SUCCESS(platform::dynload::cusolverDnSormqr(
+        handle, side, trans, m, n, k, a_working_ptr, lda, tau_working_ptr,
+        other_working_ptr, ldc, workspace_ptr, lwork, info_d));
+
+    // check the error info
+    int info_h;
+    memory::Copy(platform::CPUPlace(), &info_h,
+                 BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()),
+                 info_d, sizeof(int), dev_ctx.stream());
+    PADDLE_ENFORCE_EQ(
+        info_h, 0,
+        platform::errors::PreconditionNotMet(
+            "For batch [%d]: CUSolver info is not zero but [%d]", i, info_h));
+  }
+}
+
+template <>
+void BatchedOrmqr<platform::CUDADeviceContext, double>(
+    const platform::CUDADeviceContext& dev_ctx, bool left, bool transpose,
+    int batch_size, int m, int n, int k, double* a, int a_stride, double* tau,
+    int tau_stride, double* other, int other_stride) {
+  int lwork = 0;
+  auto side = left ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
+  auto trans = transpose ? CUBLAS_OP_T : CUBLAS_OP_N;
+  int lda = std::max<int>(1, left ? m : n);
+  int ldc = std::max<int>(1, m);
+
+  auto handle = dev_ctx.cusolver_dn_handle();
+  PADDLE_ENFORCE_GPU_SUCCESS(platform::dynload::cusolverDnDormqr_bufferSize(
+      handle, side, trans, m, n, k, a, lda, tau, other, ldc, &lwork));
+  auto workspace = memory::Alloc(dev_ctx, lwork * sizeof(double));
+  double* workspace_ptr = reinterpret_cast<double*>(workspace->ptr());
+  auto info = memory::Alloc(dev_ctx, sizeof(int));
+  int* info_d = reinterpret_cast<int*>(info->ptr());
+
+  for (int i = 0; i < batch_size; ++i) {
+    double* a_working_ptr = &a[i * a_stride];
+    double* tau_working_ptr = &tau[i * tau_stride];
+    double* other_working_ptr = &other[i * other_stride];
+    // compute ormgr
+    PADDLE_ENFORCE_GPU_SUCCESS(platform::dynload::cusolverDnDormqr(
+        handle, side, trans, m, n, k, a_working_ptr, lda, tau_working_ptr,
+        other_working_ptr, ldc, workspace_ptr, lwork, info_d));
+
+    // check the error info
+    int info_h;
+    memory::Copy(platform::CPUPlace(), &info_h,
+                 BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()),
+                 info_d, sizeof(int), dev_ctx.stream());
+    PADDLE_ENFORCE_EQ(
+        info_h, 0,
+        platform::errors::PreconditionNotMet(
+            "For batch [%d]: CUSolver info is not zero but [%d]", i, info_h));
+  }
+}
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OP_CUDA_KERNEL(
+    lstsq, ops::LstsqCUDAKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::LstsqCUDAKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/lstsq_op.h
+++ b/paddle/fluid/operators/lstsq_op.h
@@ -26,6 +26,7 @@
 #include "paddle/fluid/operators/svd_helper.h"
 #include "paddle/fluid/operators/transpose_op.h"
 #include "paddle/fluid/operators/triangular_solve_op.h"
+#include "paddle/fluid/platform/dynload/cusolver.h"
 #include "paddle/fluid/platform/for_range.h"
 
 #define EPSILON 1e-6

--- a/paddle/fluid/operators/lstsq_op.h
+++ b/paddle/fluid/operators/lstsq_op.h
@@ -26,7 +26,6 @@
 #include "paddle/fluid/operators/svd_helper.h"
 #include "paddle/fluid/operators/transpose_op.h"
 #include "paddle/fluid/operators/triangular_solve_op.h"
-#include "paddle/fluid/platform/dynload/cusolver.h"
 #include "paddle/fluid/platform/for_range.h"
 
 #define EPSILON 1e-6

--- a/paddle/fluid/operators/qr_op.h
+++ b/paddle/fluid/operators/qr_op.h
@@ -131,5 +131,13 @@ class QrGradKernel : public framework::OpKernel<T> {
   }
 };
 
+template <typename DeviceContext, typename T>
+void BatchedGeqrf(const DeviceContext& dev_ctx, int batch_size, int m, int n,
+                  T* a, int lda, T* tau, int a_stride, int tau_stride);
+
+template <typename DeviceContext, typename T>
+void BatchedOrgqr(const DeviceContext& dev_ctx, int batch_size, int m, int n,
+                  int k, T* a, int lda, T* tau, int a_stride, int tau_stride);
+
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/platform/dynload/cusolver.h
+++ b/paddle/fluid/platform/dynload/cusolver.h
@@ -77,6 +77,8 @@ CUSOLVER_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSOLVER_WRAP);
   __macro(cusolverDnZgeqrf_bufferSize);   \
   __macro(cusolverDnSorgqr_bufferSize);   \
   __macro(cusolverDnDorgqr_bufferSize);   \
+  __macro(cusolverDnSormqr_bufferSize);   \
+  __macro(cusolverDnDormqr_bufferSize);   \
   __macro(cusolverDnCungqr_bufferSize);   \
   __macro(cusolverDnZungqr_bufferSize);   \
   __macro(cusolverDnDestroyGesvdjInfo);   \
@@ -90,6 +92,8 @@ CUSOLVER_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSOLVER_WRAP);
   __macro(cusolverDnZgeqrf);              \
   __macro(cusolverDnSorgqr);              \
   __macro(cusolverDnDorgqr);              \
+  __macro(cusolverDnSormqr);              \
+  __macro(cusolverDnDormqr);              \
   __macro(cusolverDnCungqr);              \
   __macro(cusolverDnZungqr);
 

--- a/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
@@ -32,7 +32,7 @@ class LinalgLstsqTestCase(unittest.TestCase):
 
     def init_config(self):
         self.dtype = 'float64'
-        self.rcond = 1e-15
+        self.rcond = None
         self.driver = "gels"
         self._input_shape_1 = (5, 4)
         self._input_shape_2 = (5, 3)
@@ -168,7 +168,7 @@ class LinalgLstsqTestCaseRcond(LinalgLstsqTestCase):
 class LinalgLstsqTestCaseGelsFloat32(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float32'
-        self.rcond = 1e-15
+        self.rcond = None
         self.driver = "gels"
         self._input_shape_1 = (10, 5)
         self._input_shape_2 = (10, 2)

--- a/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
@@ -147,13 +147,22 @@ class LinalgLstsqTestCase(unittest.TestCase):
                         rtol=1e-5)
 
 
-class LinalgLstsqTestCase(LinalgLstsqTestCase):
+class LinalgLstsqTestCase1(LinalgLstsqTestCase):
+    def init_config(self):
+        self.dtype = 'float32'
+        self.rcond = 1e-15
+        self.driver = "gels"
+        self._input_shape_1 = (9, 9)
+        self._input_shape_2 = (9, 5)
+
+
+class LinalgLstsqTestCase2(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float64'
         self.rcond = 1e-15
-        self.driver = "gelsy"
+        self.driver = "gels"
         self._input_shape_1 = (5, 10)
-        self._input_shape_2 = (5, 5)
+        self._input_shape_2 = (5, 8)
 
 
 class LinalgLstsqTestCaseRcond(LinalgLstsqTestCase):
@@ -210,13 +219,22 @@ class LinalgLstsqTestCaseBatch2(LinalgLstsqTestCase):
         self._input_shape_2 = (10, 8, 2)
 
 
-class LinalgLstsqTestCaseLarge(LinalgLstsqTestCase):
+class LinalgLstsqTestCaseLarge1(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float64'
         self.rcond = 1e-15
         self.driver = "gelsd"
         self._input_shape_1 = (200, 100)
         self._input_shape_2 = (200, 50)
+
+
+class LinalgLstsqTestCaseLarge2(LinalgLstsqTestCase):
+    def init_config(self):
+        self.dtype = 'float64'
+        self.rcond = 1e-15
+        self.driver = "gelss"
+        self._input_shape_1 = (50, 600)
+        self._input_shape_2 = (50, 300)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
@@ -24,8 +24,8 @@ import paddle.fluid.core as core
 class LinalgLstsqTestCase(unittest.TestCase):
     def setUp(self):
         self.devices = ["cpu"]
-        # if core.is_compiled_with_cuda():
-        #     self.devices.append("gpu:0")
+        if core.is_compiled_with_cuda():
+            self.devices.append("gpu:0")
         self.init_config()
         self.generate_input()
         self.generate_output()
@@ -152,8 +152,8 @@ class LinalgLstsqTestCase(LinalgLstsqTestCase):
         self.dtype = 'float64'
         self.rcond = 1e-15
         self.driver = "gels"
-        self._input_shape_1 = (5, 10)
-        self._input_shape_2 = (5, 5)
+        self._input_shape_1 = (8, 7)
+        self._input_shape_2 = (8, 5)
 
 
 class LinalgLstsqTestCaseRcond(LinalgLstsqTestCase):
@@ -163,6 +163,7 @@ class LinalgLstsqTestCaseRcond(LinalgLstsqTestCase):
         self.driver = "gels"
         self._input_shape_1 = (3, 2)
         self._input_shape_2 = (3, 3)
+        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseGelsFloat32(LinalgLstsqTestCase):
@@ -198,18 +199,20 @@ class LinalgLstsqTestCaseBatch1(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float32'
         self.rcond = 1e-15
-        self.driver = None
+        self.driver = "gelss"
         self._input_shape_1 = (2, 3, 10)
         self._input_shape_2 = (2, 3, 4)
+        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseBatch2(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float64'
         self.rcond = 1e-15
-        self.driver = "gelss"
+        self.driver = "gelsd"
         self._input_shape_1 = (10, 8, 6)
         self._input_shape_2 = (10, 8, 2)
+        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseLarge(LinalgLstsqTestCase):

--- a/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
@@ -32,8 +32,8 @@ class LinalgLstsqTestCase(unittest.TestCase):
 
     def init_config(self):
         self.dtype = 'float64'
-        self.rcond = None
-        self.driver = "gels"
+        self.rcond = 1e-15
+        self.driver = "gelsd"
         self._input_shape_1 = (5, 4)
         self._input_shape_2 = (5, 3)
 
@@ -177,7 +177,7 @@ class LinalgLstsqTestCaseGelsFloat32(LinalgLstsqTestCase):
 class LinalgLstsqTestCaseGelssFloat64(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float64'
-        self.rcond = 1e-15
+        self.rcond = None
         self.driver = "gelss"
         self._input_shape_1 = (5, 5)
         self._input_shape_2 = (5, 1)

--- a/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
@@ -24,9 +24,9 @@ import paddle.fluid.core as core
 class LinalgLstsqTestCase(unittest.TestCase):
     def setUp(self):
         self.devices = ["cpu"]
-        if core.is_compiled_with_cuda():
-            self.devices.append("gpu:0")
         self.init_config()
+        if core.is_compiled_with_cuda() and self.driver == "gels":
+            self.devices.append("gpu:0")
         self.generate_input()
         self.generate_output()
 
@@ -151,19 +151,18 @@ class LinalgLstsqTestCase(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float64'
         self.rcond = 1e-15
-        self.driver = "gels"
-        self._input_shape_1 = (8, 7)
-        self._input_shape_2 = (8, 5)
+        self.driver = "gelsy"
+        self._input_shape_1 = (5, 10)
+        self._input_shape_2 = (5, 5)
 
 
 class LinalgLstsqTestCaseRcond(LinalgLstsqTestCase):
     def init_config(self):
-        self.dtype = 'float32'
+        self.dtype = 'float64'
         self.rcond = 1e-7
-        self.driver = "gels"
+        self.driver = "gelsd"
         self._input_shape_1 = (3, 2)
         self._input_shape_2 = (3, 3)
-        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseGelsFloat32(LinalgLstsqTestCase):
@@ -182,7 +181,6 @@ class LinalgLstsqTestCaseGelssFloat64(LinalgLstsqTestCase):
         self.driver = "gelss"
         self._input_shape_1 = (5, 5)
         self._input_shape_2 = (5, 1)
-        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseGelsyFloat32(LinalgLstsqTestCase):
@@ -192,7 +190,6 @@ class LinalgLstsqTestCaseGelsyFloat32(LinalgLstsqTestCase):
         self.driver = "gelsy"
         self._input_shape_1 = (8, 2)
         self._input_shape_2 = (8, 10)
-        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseBatch1(LinalgLstsqTestCase):
@@ -202,17 +199,15 @@ class LinalgLstsqTestCaseBatch1(LinalgLstsqTestCase):
         self.driver = "gelss"
         self._input_shape_1 = (2, 3, 10)
         self._input_shape_2 = (2, 3, 4)
-        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseBatch2(LinalgLstsqTestCase):
     def init_config(self):
         self.dtype = 'float64'
         self.rcond = 1e-15
-        self.driver = "gelsd"
+        self.driver = "gelss"
         self._input_shape_1 = (10, 8, 6)
         self._input_shape_2 = (10, 8, 2)
-        self.devices = ["cpu"]
 
 
 class LinalgLstsqTestCaseLarge(LinalgLstsqTestCase):
@@ -222,7 +217,6 @@ class LinalgLstsqTestCaseLarge(LinalgLstsqTestCase):
         self.driver = "gelsd"
         self._input_shape_1 = (200, 100)
         self._input_shape_2 = (200, 50)
-        self.devices = ["cpu"]
 
 
 if __name__ == '__main__':

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2623,15 +2623,15 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
     the least squares problem of a system of linear equations.
 
     Args:
-        x (Tensor): A tensor with shape ``(*, M, N)`` , the data type of the input Tensor `x` 
+        x (Tensor): A tensor with shape ``(*, M, N)`` , the data type of the input Tensor ``x``
             should be one of float32, float64.
-        y (Tensor): A tensor with shape ``(*, M, K)`` , the data type of the input Tensor `y` 
+        y (Tensor): A tensor with shape ``(*, M, K)`` , the data type of the input Tensor ``y`` 
             should be one of float32, float64.
-        rcond(float, optional): A float pointing number used to determine the effective rank of x.
-            If `rcond` is None, it will be set to max(M, N) times the machine precision of x_dtype.
+        rcond(float, optional): A float pointing number used to determine the effective rank of ``x``.
+            If ``rcond`` is None, it will be set to max(M, N) times the machine precision of x_dtype.
         driver(str, optional):  The name of LAPACK method to be used. For CPU inputs the valid values 
             are ‘gels’, ‘gelsy’, ‘gelsd, ‘gelss’. For CUDA input, the only valid driver is ‘gels’. If 
-            `driver` is None, ‘gelsy’ is used for CPU inputs and ‘gels’ for CUDA inputs.
+            ``driver`` is None, ‘gelsy’ is used for CPU inputs and ‘gels’ for CUDA inputs.
         name(str, optional): The default value is None. Normally there is no need for user to set 
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
@@ -2639,11 +2639,11 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
         Tuple: A tuple of 4 Tensors which is (``solution``, ``residuals``, ``rank``, ``singular_values``). 
         ``solution`` is a tensor with shape ``(*, N, K)``, meaning the least squares solution. ``residuals`` 
         is a tensor with shape ``(*, K)``, meaning the squared residuals of the solutions, which is computed 
-        when M > N and every matrix in `x` is full-rank, otherwise return an empty tensor. ``rank`` is a tensor 
-        with shape ``(*)``, meaning the ranks of the matrices in `x`, which is computed when `driver` in 
+        when M > N and every matrix in ``x`` is full-rank, otherwise return an empty tensor. ``rank`` is a tensor 
+        with shape ``(*)``, meaning the ranks of the matrices in ``x``, which is computed when ``driver`` in 
         (‘gelsy’, ‘gelsd’, ‘gelss’), otherwise return an empty tensor. ``singular_values`` is a tensor with 
-        shape ``(*, min(M, N))``, meaning singular values of the matrices in `x`, which is computed when `driver` 
-        in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
+        shape ``(*, min(M, N))``, meaning singular values of the matrices in ``x``, which is computed when 
+        ``driver`` in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2623,19 +2623,31 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
     the least squares problem of a system of linear equations.
 
     Args:
-        x (Tensor): A tensor with shape :math:`[_, M, N]` , The data 
-            type of the input Tensor x should be one of float32, float64.
-        y (Tensor): A tensor with shape :math:`[_, M, K]` , The data 
-            type of the input Tensor y should be one of float32, float64.
+        x (Tensor): A tensor with shape :math:`[_, M, N]` , the data type of the input Tensor `x` 
+            should be one of float32, float64.
+        y (Tensor): A tensor with shape :math:`[_, M, K]` , the data type of the input Tensor `y` 
+            should be one of float32, float64.
         rcond(float, optional): A float pointing number used to determine the effective rank of x.
             If `rcond` is None, it will be set to max(M, N) times the machine precision of x_dtype.
-        driver(str, optional):  The name of LAPACK method to be used. If `driver` is None, ‘gelsy’ 
-            is used for CPU inputs and ‘gels’ for CUDA inputs.
+        driver(str, optional):  The name of LAPACK method to be used. For CPU inputs the valid values 
+            are ‘gels’, ‘gelsy’, ‘gelsd, ‘gelss’. For CUDA input, the only valid driver is ‘gels’. If 
+            `driver` is None, ‘gelsy’ is used for CPU inputs and ‘gels’ for CUDA inputs.
         name(str, optional): The default value is None. Normally there is no need for user to set 
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
         Tuple: A tuple including solution, residuals, rank, singular_values.
+
+        solution: A tensor with shape :math:`[_, N, K]`, the least squares solution.
+
+        residuals: A tensor with shape :math:`[_, K]`, the squared residuals of the solutions. 
+            It is computed when M > N and every matrix in `x` is full-rank, otherwise return an empty tensor. 
+        
+        rank: A tensor with shape :math:`[_]`, ranks of the matrices in `x`. It is computed when driver 
+            in (‘gelsy’, ‘gelsd’, ‘gelss’), otherwise return an empty tensor.
+        
+        singular_values: A tensor with shape :math:`[_, min(M, N)]`, singular values of the matrices in `x`. 
+            It is computed when driver in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2623,9 +2623,9 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
     the least squares problem of a system of linear equations.
 
     Args:
-        x (Tensor): A tensor with shape :math:`[_, M, N]` , the data type of the input Tensor `x` 
+        x (Tensor): A tensor with shape ``(*, M, N)`` , the data type of the input Tensor `x` 
             should be one of float32, float64.
-        y (Tensor): A tensor with shape :math:`[_, M, K]` , the data type of the input Tensor `y` 
+        y (Tensor): A tensor with shape ``(*, M, K)`` , the data type of the input Tensor `y` 
             should be one of float32, float64.
         rcond(float, optional): A float pointing number used to determine the effective rank of x.
             If `rcond` is None, it will be set to max(M, N) times the machine precision of x_dtype.
@@ -2636,14 +2636,14 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        Tuple: A tuple including solution, residuals, rank, singular_values.
-        solution: A tensor with shape :math:`[_, N, K]`, the least squares solution.
-        residuals: A tensor with shape :math:`[_, K]`, the squared residuals of the solutions. 
-            It is computed when M > N and every matrix in `x` is full-rank, otherwise return an empty tensor. 
-        rank: A tensor with shape :math:`[_]`, ranks of the matrices in `x`. It is computed when `driver `
-            in (‘gelsy’, ‘gelsd’, ‘gelss’), otherwise return an empty tensor.
-        singular_values: A tensor with shape :math:`[_, min(M, N)]`, singular values of the matrices in `x`. 
-            It is computed when `driver` in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
+        Tuple: A tuple of 4 Tensors which is (``solution``, ``residuals``, ``rank``, ``singular_values``). 
+        ``solution`` is a tensor with shape ``(*, N, K)``, meaning the least squares solution. ``residuals`` 
+        is a tensor with shape ``(*, K)``, meaning the squared residuals of the solutions, which is computed 
+        when M > N and every matrix in `x` is full-rank, otherwise return an empty tensor. ``rank`` is a tensor 
+        with shape ``(*)``, meaning the ranks of the matrices in `x`, which is computed when `driver ` in 
+        (‘gelsy’, ‘gelsd’, ‘gelss’), otherwise return an empty tensor. ``singular_values`` is a tensor with 
+        shape ``(*, min(M, N))``, meaning singular values of the matrices in `x`, which is computed when `driver` 
+        in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
 
     Examples:
         .. code-block:: python
@@ -2672,6 +2672,8 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             # [[ 0.39386186,  0.10230173,  0.93606132],
             # [ 0.10741687, -0.29028133,  0.11892585],
             # [-0.05115091,  0.51918161, -0.19948854]]
+            print(results[1])
+            # []
     """
     device = paddle.get_device()
     if device == "cpu":

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2643,11 +2643,11 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
         residuals: A tensor with shape :math:`[_, K]`, the squared residuals of the solutions. 
             It is computed when M > N and every matrix in `x` is full-rank, otherwise return an empty tensor. 
         
-        rank: A tensor with shape :math:`[_]`, ranks of the matrices in `x`. It is computed when driver 
+        rank: A tensor with shape :math:`[_]`, ranks of the matrices in `x`. It is computed when `driver `
             in (‘gelsy’, ‘gelsd’, ‘gelss’), otherwise return an empty tensor.
         
         singular_values: A tensor with shape :math:`[_, min(M, N)]`, singular values of the matrices in `x`. 
-            It is computed when driver in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
+            It is computed when `driver` in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2617,8 +2617,56 @@ def eigvalsh(x, UPLO='L', name=None):
     return out_value
 
 
-def lstsq(x, y, rcond=1e-15, driver=None, name=None):
-    device = paddle.device.get_device()
+def lstsq(x, y, rcond=None, driver=None, name=None):
+    """
+    Computes a solution to
+    the least squares problem of a system of linear equations.
+
+    Args:
+        x (Tensor): A tensor with shape :math:`[_, M, N]` , The data 
+            type of the input Tensor x should be one of float32, float64.
+        y (Tensor): A tensor with shape :math:`[_, M, K]` , The data 
+            type of the input Tensor y should be one of float32, float64.
+        rcond(float, optional): A float pointing number used to determine the effective rank of x.
+            If `rcond` is None, it will be set to max(M, N) times the machine precision of x_dtype.
+        driver(str, optional):  The name of LAPACK method to be used. If `driver` is None, ‘gelsy’ 
+            is used for CPU inputs and ‘gels’ for CUDA inputs.
+        name(str, optional): The default value is None. Normally there is no need for user to set 
+            this property. For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tuple: A tuple including solution, residuals, rank, singular_values.
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+            import numpy as np
+
+            paddle.set_device("cpu")
+            x = paddle.to_tensor([[1, 3], [3, 2], [5, 6.]])
+            y = paddle.to_tensor([[3, 4, 6], [5, 3, 4], [1, 2, 1.]])
+            results = paddle.linalg.lstsq(x, y, driver="gelsd")
+            print(results[0])
+            # [[ 0.78350395, -0.22165027, -0.62371236],
+              [-0.11340097,  0.78866047,  1.14948535]]
+            print(results[1])
+            # [19.81443405, 10.43814468, 30.56185532])
+            print(results[2])
+            # 2
+            print(results[3])
+            # [9.03455734, 1.54167950]
+
+            paddle.set_device("gpu:0")
+            x = paddle.to_tensor([[10, 2, 3], [3, 10, 5], [5, 6, 12.]])
+            y = paddle.to_tensor([[4, 2, 9], [2, 0, 3], [2, 5, 3.]])
+            results = paddle.linalg.lstsq(x, y, driver="gels")
+            print(results[0])
+            # [[ 0.39386186,  0.10230173,  0.93606132],
+              [ 0.10741687, -0.29028133,  0.11892585],
+              [-0.05115091,  0.51918161, -0.19948854]]
+    """
+    device = paddle.get_device()
     if device == "cpu":
         if driver not in (None, "gels", "gelss", "gelsd", "gelsy"):
             raise ValueError(
@@ -2633,6 +2681,19 @@ def lstsq(x, y, rcond=1e-15, driver=None, name=None):
         driver = "gels" if driver is None else driver
     else:
         raise RuntimeError("Only support lstsq api for CPU or CUDA device.")
+
+    if x.dtype == y.dtype and x.dtype in (paddle.float32, paddle.float64):
+        pass
+    else:
+        raise ValueError(
+            "Only support x and y have the same dtype such as 'float32' and 'float64'."
+        )
+
+    if rcond is None:
+        if x.dtype == paddle.float32:
+            rcond = 1e-7 * max(x.shape[-2], x.shape[-1])
+        elif x.dtype == paddle.float64:
+            rcond = 1e-15 * max(x.shape[-2], x.shape[-1])
 
     if in_dygraph_mode():
         solution, rank, singular_values = _C_ops.lstsq(x, y, "rcond", rcond,

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2661,7 +2661,7 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             results = paddle.linalg.lstsq(x, y, driver="gelsd")
             print(results[0])
             # [[ 0.78350395, -0.22165027, -0.62371236],
-              [-0.11340097,  0.78866047,  1.14948535]]
+            # [-0.11340097,  0.78866047,  1.14948535]]
             print(results[1])
             # [19.81443405, 10.43814468, 30.56185532])
             print(results[2])
@@ -2675,8 +2675,8 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             results = paddle.linalg.lstsq(x, y, driver="gels")
             print(results[0])
             # [[ 0.39386186,  0.10230173,  0.93606132],
-              [ 0.10741687, -0.29028133,  0.11892585],
-              [-0.05115091,  0.51918161, -0.19948854]]
+            # [ 0.10741687, -0.29028133,  0.11892585],
+            # [-0.05115091,  0.51918161, -0.19948854]]
     """
     device = paddle.get_device()
     if device == "cpu":

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2627,11 +2627,13 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             should be one of float32, float64.
         y (Tensor): A tensor with shape ``(*, M, K)`` , the data type of the input Tensor ``y`` 
             should be one of float32, float64.
-        rcond(float, optional): A float pointing number used to determine the effective rank of ``x``.
-            If ``rcond`` is None, it will be set to max(M, N) times the machine precision of x_dtype.
-        driver(str, optional):  The name of LAPACK method to be used. For CPU inputs the valid values 
-            are ‘gels’, ‘gelsy’, ‘gelsd, ‘gelss’. For CUDA input, the only valid driver is ‘gels’. If 
-            ``driver`` is None, ‘gelsy’ is used for CPU inputs and ‘gels’ for CUDA inputs.
+        rcond(float, optional): The default value is None. A float pointing number used to determine 
+            the effective rank of ``x``. If ``rcond`` is None, it will be set to max(M, N) times the 
+            machine precision of x_dtype.
+        driver(str, optional): The default value is None. The name of LAPACK method to be used. For 
+            CPU inputs the valid values are ‘gels’, ‘gelsy’, ‘gelsd, ‘gelss’. For CUDA input, the only 
+            valid driver is ‘gels’. If ``driver`` is None, ‘gelsy’ is used for CPU inputs and ‘gels’ 
+            for CUDA inputs.
         name(str, optional): The default value is None. Normally there is no need for user to set 
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
@@ -2649,7 +2651,6 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
         .. code-block:: python
 
             import paddle
-            import numpy as np
 
             paddle.set_device("cpu")
             x = paddle.to_tensor([[1, 3], [3, 2], [5, 6.]])

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2640,7 +2640,7 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
         ``solution`` is a tensor with shape ``(*, N, K)``, meaning the least squares solution. ``residuals`` 
         is a tensor with shape ``(*, K)``, meaning the squared residuals of the solutions, which is computed 
         when M > N and every matrix in `x` is full-rank, otherwise return an empty tensor. ``rank`` is a tensor 
-        with shape ``(*)``, meaning the ranks of the matrices in `x`, which is computed when `driver ` in 
+        with shape ``(*)``, meaning the ranks of the matrices in `x`, which is computed when `driver` in 
         (‘gelsy’, ‘gelsd’, ‘gelss’), otherwise return an empty tensor. ``singular_values`` is a tensor with 
         shape ``(*, min(M, N))``, meaning singular values of the matrices in `x`, which is computed when `driver` 
         in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2637,15 +2637,11 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
 
     Returns:
         Tuple: A tuple including solution, residuals, rank, singular_values.
-
         solution: A tensor with shape :math:`[_, N, K]`, the least squares solution.
-
         residuals: A tensor with shape :math:`[_, K]`, the squared residuals of the solutions. 
             It is computed when M > N and every matrix in `x` is full-rank, otherwise return an empty tensor. 
-        
         rank: A tensor with shape :math:`[_]`, ranks of the matrices in `x`. It is computed when `driver `
             in (‘gelsy’, ‘gelsd’, ‘gelss’), otherwise return an empty tensor.
-        
         singular_values: A tensor with shape :math:`[_, min(M, N)]`, singular values of the matrices in `x`. 
             It is computed when `driver` in (‘gelsd’, ‘gelss’), otherwise return an empty tensor.
 
@@ -2669,7 +2665,6 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             print(results[3])
             # [9.03455734, 1.54167950]
 
-            paddle.set_device("gpu:0")
             x = paddle.to_tensor([[10, 2, 3], [3, 10, 5], [5, 6, 12.]])
             y = paddle.to_tensor([[4, 2, 9], [2, 0, 3], [2, 5, 3.]])
             results = paddle.linalg.lstsq(x, y, driver="gels")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Add gpu kernel for new api : linalg.lstsq
You can see the implementation of cpu kernel in [PR38585](https://github.com/PaddlePaddle/Paddle/pull/38585)
The docs_cn of paddle.linalg.lstsq is merged by [docs-PR4174](https://github.com/PaddlePaddle/docs/pull/4174)

1、usage example：
```
import paddle
paddle.set_device("cpu")
x = paddle.to_tensor([[1, 3], [3, 2], [5, 6.]])
y = paddle.to_tensor([[3, 4, 6], [5, 3, 4], [1, 2, 1.]])
results = paddle.linalg.lstsq(x, y, driver="gelsd")

# solution
print(results[0]) 
# [[ 0.78350395, -0.22165027, -0.62371236],
# [-0.11340097,  0.78866047,  1.14948535]]

# residuals
print(results[1])
# [19.81443405, 10.43814468, 30.56185532])

# rank
print(results[2])
# 2

# singular values
print(results[3])
# [9.03455734, 1.54167950]
```

2、docs_cn：

![image](https://user-images.githubusercontent.com/86215757/148715214-c250cd16-c7a2-4916-af15-312bcd3e8925.png)

3、docs_en：

![image](https://user-images.githubusercontent.com/86215757/148715244-3a7b7ed5-424f-4c8f-bd6f-de599e8e8a54.png)
