### PR TITLE
Fix memcpyD2H sync behavior with other stream

### DIFF
--- a/paddle/fluid/operators/memcpy_d2h_op.h
+++ b/paddle/fluid/operators/memcpy_d2h_op.h
@@ -74,7 +74,7 @@ class MemcpyD2HFunctor {
     if (dst_place_type_ == 1) {
       framework::TensorCopy(src, platform::CUDAPinnedPlace(), dev_ctx_, &dst);
     } else if (dst_place_type_ == 0) {
-      framework::TensorCopySync(src, platform::CPUPlace(), &dst);
+      framework::TensorCopy(src, platform::CPUPlace(), dev_ctx_, &dst);
     } else {
       PADDLE_THROW(platform::errors::Unimplemented(
           "memcpy dst_place_type: %d is not supported yet.", dst_place_type_));

--- a/paddle/fluid/operators/memcpy_d2h_op.h
+++ b/paddle/fluid/operators/memcpy_d2h_op.h
@@ -80,7 +80,7 @@ class MemcpyD2HFunctor {
       PADDLE_THROW(platform::errors::Unimplemented(
           "memcpy dst_place_type: %d is not supported yet.", dst_place_type_));
     }
-    // NOTE(Aurelius84): t host <-> device memory copies of a memory block of 64
+    // NOTE(Aurelius84): host <-> device memory copies of a memory block of 64
     // KB or less are asynchronous. See
     // https://forums.developer.nvidia.com/t/host-device-memory-copies-up-to-64-kb-are-asynchronous/17907
     if (src.memory_size() <= WAIT_THRESHOLD) {

--- a/paddle/fluid/operators/memcpy_d2h_op.h
+++ b/paddle/fluid/operators/memcpy_d2h_op.h
@@ -81,8 +81,7 @@ class MemcpyD2HFunctor {
           "memcpy dst_place_type: %d is not supported yet.", dst_place_type_));
     }
     // NOTE(Aurelius84): t host <-> device memory copies of a memory block of 64
-    // KB or less are asynchronous.
-    // See
+    // KB or less are asynchronous. See
     // https://forums.developer.nvidia.com/t/host-device-memory-copies-up-to-64-kb-are-asynchronous/17907
     if (src.memory_size() <= WAIT_THRESHOLD) {
       dev_ctx_.Wait();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix memcpyD2H sync behavior with other stream

在 transformer 上测试，开启GC策略后，速度从 23370 word/s 提升至 31377 word/s