### PR TITLE
[new-exec] avoid adding_feed_fetch in each run

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1385,23 +1385,24 @@ class Executor(object):
                 key = _get_strong_program_cache_key(inner_program, feed,
                                                     fetch_list)
 
-                program = self._add_feed_fetch_ops(
-                    program=inner_program,
-                    feed=feed,
-                    fetch_list=fetch_list,
-                    feed_var_name=feed_var_name,
-                    fetch_var_name=fetch_var_name,
-                    use_fetch_v2=True)
-
                 # a little bit tricy here, use inner_program before _add_feed_fetch_ops to get key
                 # while use program to geet _StandaloneExecutor
                 if key not in self._executor_cache._cached_executors:
+                    program = self._add_feed_fetch_ops(
+                        program=inner_program,
+                        feed=feed,
+                        fetch_list=fetch_list,
+                        feed_var_name=feed_var_name,
+                        fetch_var_name=fetch_var_name,
+                        use_fetch_v2=True)
+
                     new_program = program.clone()
                     new_exe = _StandaloneExecutor(self.place, new_program,
                                                   scope)
-                    self._executor_cache._cached_executors[key] = new_exe
+                    self._executor_cache._cached_executors[key] = (new_program,
+                                                                   new_exe)
 
-                new_exe = self._executor_cache._cached_executors[key]
+                program, new_exe = self._executor_cache._cached_executors[key]
 
                 self._feed_data(program, feed, feed_var_name, scope)
                 if hasattr(program, 'lr_sheduler'):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[new-exec] avoid adding_feed_fetch in each run

- Before
Calling `_add_feed_fetch_ops` once per `exe.run` with `FLAGS_USE_STANDALONE_EXECUTOR=true`

- After
Calling `_add_feed_fetch_ops` only once in `exe.run`, and use the cached program afterwards.

yolov3 22.38 img/s->31.5 img/s, + 40.7 %