### PR TITLE
Reupload: Added numpy bf16 datatype support via custom pip package

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_python_bf16_numpy_datatype.py
+++ b/python/paddle/fluid/tests/unittests/test_python_bf16_numpy_datatype.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/paddle/fluid/tests/unittests/test_python_bf16_numpy_datatype.py
+++ b/python/paddle/fluid/tests/unittests/test_python_bf16_numpy_datatype.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from paddle_bfloat import bfloat16
+import unittest
+
+
+class TestBF16DataType(unittest.TestCase):
+    def test_matmul(self):
+        a_bf16 = np.random.random((6, 7)).astype(bfloat16)
+        b_bf16 = np.random.random((7, 8)).astype(bfloat16)
+        c_bf16 = np.matmul(a_bf16, b_bf16)
+
+        a_fp32 = a_bf16.astype(np.float32)
+        b_fp32 = b_bf16.astype(np.float32)
+        c_fp32 = np.matmul(a_fp32, b_fp32)
+
+        self.assertTrue(np.allclose(c_bf16, c_fp32))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,5 @@
 requests>=2.20.0
-numpy>=1.13 ; python_version>="3.5" and platform_system != "Windows"
-numpy>=1.13, <=1.19.3 ; python_version>="3.5" and platform_system == "Windows"
+numpy>=1.13
 protobuf>=3.1.0
 Pillow
 six

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,4 +6,4 @@ Pillow
 six
 decorator
 astor
-paddle_bfloat==0.1.1
+paddle_bfloat==0.1.2

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,9 @@
 requests>=2.20.0
-numpy>=1.13
+numpy>=1.13 ; python_version>="3.5" and platform_system != "Windows"
+numpy>=1.13, <=1.19.3 ; python_version>="3.5" and platform_system == "Windows"
 protobuf>=3.1.0
 Pillow
 six
 decorator
 astor
+paddle_bfloat==0.1.1


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
This PR adds bfloat16 datatype support for numpy via an external package. Sample usage is included in UT. That will shorten the time of loading word2vec BF16 model significantly and will allow us to remove "convert_float_to_uint16" function from UTs. It is a reupload of #35332
