### PR TITLE
Fix bug for UT GetAllocatorInterfaceTest

### DIFF
--- a/paddle/fluid/memory/stream_safe_cuda_alloc_test.cu
+++ b/paddle/fluid/memory/stream_safe_cuda_alloc_test.cu
@@ -225,21 +225,22 @@ TEST(StreamSafeCUDAAllocInterfaceTest, AllocInterfaceTest) {
 
 TEST(StreamSafeCUDAAllocInterfaceTest, GetAllocatorInterfaceTest) {
   platform::CUDAPlace place = platform::CUDAPlace();
-  auto &instance = allocation::AllocatorFacade::Instance();
-  const std::shared_ptr<Allocator> &allocator = instance.GetAllocator(place);
-
   size_t alloc_size = 256;
-  std::shared_ptr<Allocation> allocation_from_allocator =
-      allocator->Allocate(alloc_size);
-  EXPECT_GE(allocation_from_allocator->size(), alloc_size);
-  void *address = allocation_from_allocator->ptr();
-  allocation_from_allocator.reset();
 
   std::shared_ptr<Allocation> allocation_implicit_stream =
       AllocShared(place, alloc_size);
   EXPECT_GE(allocation_implicit_stream->size(), alloc_size);
-  EXPECT_EQ(allocation_implicit_stream->ptr(), address);
+  void *address = allocation_implicit_stream->ptr();
   allocation_implicit_stream.reset();
+
+  auto &instance = allocation::AllocatorFacade::Instance();
+  const std::shared_ptr<Allocator> &allocator = instance.GetAllocator(place);
+
+  std::shared_ptr<Allocation> allocation_from_allocator =
+      allocator->Allocate(alloc_size);
+  EXPECT_GE(allocation_from_allocator->size(), alloc_size);
+  EXPECT_EQ(allocation_from_allocator->ptr(), address);
+  allocation_from_allocator.reset();
 
   Release(place);
   CheckMemLeak(place);

--- a/paddle/fluid/memory/stream_safe_cuda_alloc_test.cu
+++ b/paddle/fluid/memory/stream_safe_cuda_alloc_test.cu
@@ -276,7 +276,7 @@ TEST(StreamSafeCUDAAllocInterfaceTest, GetStreamInterfaceTest) {
           paddle::platform::DeviceContextPool::Instance().Get(place))
           ->stream();
   std::shared_ptr<Allocation> allocation_implicit_stream =
-      Alloc(place, alloc_size);
+      AllocShared(place, alloc_size);
   EXPECT_EQ(GetStream(allocation_implicit_stream), default_stream);
 
   gpuStream_t new_stream;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
When the _GetAllocatorInterfaceTest_ is the first executed test case in _stream_safe_cuda_alloc_test_, the _GetAllocator_ call will fail since the Allocator has been not created yet. It occurs in some test environments and cause a CI error:
![image](https://user-images.githubusercontent.com/17673696/148188938-7d4452d7-6cad-4788-a9a2-8ab06d5ec14a.png)

This PR fix this bug, and by the way replace some shared_ptr with unique_ptr in this UT.