### PR TITLE
Add enabling FC MKLDNN passes

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -95,8 +95,17 @@ void CPUQuantizePass::QuantizeInput(Graph* g, Node* op, Node* input,
   q_desc.SetAttr("Shift", shift);
   q_desc.SetAttr("is_negative_input", !is_input_unsigned);
 
-  q_desc.SetAttr("output_format",
-                 Has("data_layout") ? Get<std::string>("data_layout") : "NHWC");
+  // fix to fc format error
+  if (op->Op()->Type() == "fc" &&
+      op->Op()->GetAttrIfExists<int>("in_num_col_dims") == 2) {
+    q_desc.SetAttr("output_format", Has("data_layout")
+                                        ? Get<std::string>("data_layout")
+                                        : "NCHW");
+  } else {
+    q_desc.SetAttr("output_format", Has("data_layout")
+                                        ? Get<std::string>("data_layout")
+                                        : "NHWC");
+  }
   auto quantize_op = g->CreateOpNode(&q_desc);  // OpDesc will be copied.
 
   // update op's input

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -200,6 +200,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(use_mkldnn_);
   CP_MEMBER(mkldnn_enabled_op_types_);
   CP_MEMBER(mkldnn_cache_capacity_);
+  CP_MEMBER(use_mkldnn_fc_passes_);
   // Bfloat16 related.
   CP_MEMBER(use_mkldnn_bfloat16_);
   CP_MEMBER(bfloat16_enabled_op_types_);
@@ -347,6 +348,17 @@ void AnalysisConfig::EnableMkldnnQuantizer() {
 #else
   LOG(ERROR) << "Please compile with MKLDNN first to use MkldnnQuantizer";
   use_mkldnn_quantizer_ = false;
+#endif
+
+  Update();
+}
+
+void AnalysisConfig::EnableMkldnnFcPasses() {
+#ifdef PADDLE_WITH_MKLDNN
+  use_mkldnn_fc_passes_ = true;
+#else
+  LOG(ERROR) << "Please compile with MKLDNN first to use MkldnnFcPasses";
+  use_mkldnn_fc_passes_ = false;
 #endif
 
   Update();
@@ -544,6 +556,12 @@ void AnalysisConfig::Update() {
     }
 #ifdef PADDLE_WITH_MKLDNN
     pass_builder()->EnableMkldnnQuantizer();
+#endif
+  }
+
+  if (use_mkldnn_fc_passes_) {
+#ifdef PADDLE_WITH_MKLDNN
+    pass_builder()->EnableMkldnnFcPasses();
 #endif
   }
 

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -614,6 +614,12 @@ struct PD_INFER_DECL AnalysisConfig {
   void EnableMkldnnQuantizer();
 
   ///
+  /// \brief Turn on MKLDNN FC passes.
+  ///
+  ///
+  void EnableMkldnnFcPasses();
+
+  ///
   /// \brief Turn on MKLDNN bfloat16.
   ///
   ///
@@ -865,6 +871,7 @@ struct PD_INFER_DECL AnalysisConfig {
   int mkldnn_cache_capacity_{10};
   bool use_mkldnn_quantizer_{false};
   std::shared_ptr<MkldnnQuantizerConfig> mkldnn_quantizer_config_;
+  bool use_mkldnn_fc_passes_{false};
   bool use_mkldnn_bfloat16_{false};
   std::unordered_set<std::string> bfloat16_enabled_op_types_;
 

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -283,6 +283,9 @@ void CpuPassStrategy::EnableMKLDNN() {
 void CpuPassStrategy::EnableMkldnnQuantizer() {
 #ifdef PADDLE_WITH_MKLDNN
   if (!use_mkldnn_quantizer_) {
+    // INT8 implies FC oneDNN passes to be used
+    passes_.push_back("fc_mkldnn_pass");
+    passes_.push_back("fc_act_mkldnn_fuse_pass");
     passes_.push_back("cpu_quantize_placement_pass");
   }
   use_mkldnn_quantizer_ = true;

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -280,12 +280,21 @@ void CpuPassStrategy::EnableMKLDNN() {
 #endif
 }
 
+void CpuPassStrategy::EnableMkldnnFcPasses() {
+#ifdef PADDLE_WITH_MKLDNN
+  if (!use_mkldnn_fc_passes_) {
+    passes_.push_back("fc_mkldnn_pass");
+    passes_.push_back("fc_act_mkldnn_fuse_pass");
+  }
+  use_mkldnn_fc_passes_ = true;
+#else
+  use_mkldnn_fc_passes_ = false;
+#endif
+}
+
 void CpuPassStrategy::EnableMkldnnQuantizer() {
 #ifdef PADDLE_WITH_MKLDNN
   if (!use_mkldnn_quantizer_) {
-    // INT8 implies FC oneDNN passes to be used
-    passes_.push_back("fc_mkldnn_pass");
-    passes_.push_back("fc_act_mkldnn_fuse_pass");
     passes_.push_back("cpu_quantize_placement_pass");
   }
   use_mkldnn_quantizer_ = true;

--- a/paddle/fluid/inference/api/paddle_pass_builder.h
+++ b/paddle/fluid/inference/api/paddle_pass_builder.h
@@ -133,6 +133,9 @@ class PD_INFER_DECL PassStrategy : public PaddlePassBuilder {
   /// \brief Enable MKLDNN quantize optimization.
   virtual void EnableMkldnnQuantizer() {}
 
+  /// \brief Enable MKLDNN fc passes
+  virtual void EnableMkldnnFcPasses() {}
+
   /// \brief Enable MKLDNN bfloat16.
   virtual void EnableMkldnnBfloat16() {}
 
@@ -181,6 +184,7 @@ class PD_INFER_DECL CpuPassStrategy : public PassStrategy {
     use_mkldnn_ = other.use_mkldnn_;
     use_mkldnn_quantizer_ = other.use_mkldnn_quantizer_;
     use_mkldnn_bfloat16_ = other.use_mkldnn_bfloat16_;
+    use_mkldnn_fc_passes_ = other.use_mkldnn_fc_passes_;
   }
   /// \brief Default destructor.
   virtual ~CpuPassStrategy() = default;
@@ -194,12 +198,16 @@ class PD_INFER_DECL CpuPassStrategy : public PassStrategy {
   /// \brief Enable MKLDNN quantize optimization.
   void EnableMkldnnQuantizer() override;
 
+  /// \brief Enable MKLDNN fc passes.
+  void EnableMkldnnFcPasses() override;
+
   /// \brief Enable MKLDNN bfloat16.
   void EnableMkldnnBfloat16() override;
 
  protected:
   /// \cond Protected
   bool use_mkldnn_quantizer_{false};
+  bool use_mkldnn_fc_passes_{false};
   bool use_mkldnn_bfloat16_{false};
   /// \endcond
 };

--- a/paddle/fluid/inference/capi/pd_config.cc
+++ b/paddle/fluid/inference/capi/pd_config.cc
@@ -341,6 +341,14 @@ bool PD_MkldnnQuantizerEnabled(const PD_AnalysisConfig* config) {
   return config->config.mkldnn_quantizer_enabled();
 }
 
+void PD_EnableMkldnnFcPasses(PD_AnalysisConfig* config) {
+  PADDLE_ENFORCE_NOT_NULL(
+      config,
+      paddle::platform::errors::InvalidArgument(
+          "The pointer of analysis configuration shouldn't be nullptr"));
+  config->config.EnableMkldnnFcPasses();
+}
+
 void PD_EnableMkldnnBfloat16(PD_AnalysisConfig* config) {
   PADDLE_ENFORCE_NOT_NULL(
       config,

--- a/paddle/fluid/inference/capi_exp/pd_config.cc
+++ b/paddle/fluid/inference/capi_exp/pd_config.cc
@@ -363,6 +363,10 @@ void PD_ConfigEnableMkldnnQuantizer(__pd_keep PD_Config* pd_config) {
   CHECK_AND_CONVERT_PD_CONFIG;
   config->EnableMkldnnQuantizer();
 }
+void PD_ConfigEnableMkldnnFcPasses(__pd_keep PD_Config* pd_config) {
+  CHECK_AND_CONVERT_PD_CONFIG;
+  config->EnableMkldnnFcPasses();
+}
 void PD_ConfigEnableMkldnnBfloat16(__pd_keep PD_Config* pd_config) {
   CHECK_AND_CONVERT_PD_CONFIG;
   config->EnableMkldnnBfloat16();

--- a/paddle/fluid/inference/capi_exp/pd_config.h
+++ b/paddle/fluid/inference/capi_exp/pd_config.h
@@ -535,6 +535,13 @@ PADDLE_CAPI_EXPORT extern void PD_ConfigEnableMkldnnQuantizer(
 PADDLE_CAPI_EXPORT extern PD_Bool PD_ConfigMkldnnQuantizerEnabled(
     __pd_keep PD_Config* pd_config);
 ///
+/// \brief Turn on MKLDNN FC passes.
+///
+/// \param[in] pd_onfig config
+///
+PADDLE_CAPI_EXPORT extern void PD_ConfigEnableMkldnnFcPasses(
+    __pd_keep PD_Config* pd_config);
+///
 /// \brief Turn on MKLDNN bfloat16.
 ///
 /// \param[in] pd_onfig config

--- a/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
@@ -205,8 +205,7 @@ void profile(bool use_mkldnn = false) {
     std::unordered_set<std::string> op_list = {"softmax", "elementwise_add",
                                                "relu", "fc"};
     cfg.SetMKLDNNOp(op_list);
-    cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    cfg.EnableMkldnnFcPasses();
   }
 
   std::vector<std::vector<PaddleTensor>> outputs;
@@ -262,8 +261,7 @@ void compare(bool use_mkldnn = false) {
     std::unordered_set<std::string> op_list = {"softmax", "elementwise_add",
                                                "relu"};
     cfg.SetMKLDNNOp(op_list);
-    cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    cfg.EnableMkldnnFcPasses();
   }
 
   std::vector<std::vector<PaddleTensor>> input_slots_all;

--- a/paddle/fluid/inference/tests/api/analyzer_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_image_classification_tester.cc
@@ -51,8 +51,7 @@ void profile(bool use_mkldnn = false) {
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
     if (!FLAGS_disable_mkldnn_fc) {
-      cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-      cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+      cfg.EnableMkldnnFcPasses();
     }
   }
   std::vector<std::vector<PaddleTensor>> outputs;
@@ -86,8 +85,7 @@ void compare(bool use_mkldnn = false) {
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
     if (!FLAGS_disable_mkldnn_fc) {
-      cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-      cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+      cfg.EnableMkldnnFcPasses();
     }
   }
 

--- a/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
@@ -48,8 +48,7 @@ TEST(Analyzer_int8_image_classification, quantization) {
         paddle::inference::GetWarmupData(input_slots_all);
 
     // INT8 implies FC oneDNN passes to be used
-    q_cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    q_cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    q_cfg.EnableMkldnnFcPasses();
 
     // configure quantizer
     q_cfg.EnableMkldnnQuantizer();

--- a/paddle/fluid/inference/tests/api/analyzer_seq_pool1_tester_helper.h
+++ b/paddle/fluid/inference/tests/api/analyzer_seq_pool1_tester_helper.h
@@ -162,8 +162,7 @@ void SetConfig(AnalysisConfig *cfg, bool use_mkldnn = false) {
   }
   if (use_mkldnn) {
     cfg->EnableMKLDNN();
-    cfg->pass_builder()->AppendPass("fc_mkldnn_pass");
-    cfg->pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    cfg->EnableMkldnnFcPasses();
   }
   // Enable seqpool_concat_fuse_pass, disabled by default since it takes much
   // time

--- a/paddle/fluid/inference/tests/api/analyzer_transformer_compare_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_transformer_compare_tester.cc
@@ -24,8 +24,7 @@ void compare(bool use_mkldnn = false) {
   SetConfig(&cfg);
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    cfg.EnableMkldnnFcPasses();
   }
 
   std::vector<std::vector<PaddleTensor>> input_slots_all;

--- a/paddle/fluid/inference/tests/api/analyzer_transformer_profile_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_transformer_profile_tester.cc
@@ -25,8 +25,7 @@ void profile(bool use_mkldnn = false) {
   std::vector<std::vector<PaddleTensor>> outputs;
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    cfg.EnableMkldnnFcPasses();
   }
 
   std::vector<std::vector<PaddleTensor>> input_slots_all;

--- a/paddle/fluid/inference/tests/api/analyzer_vis_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_vis_tester.cc
@@ -85,8 +85,7 @@ void profile(bool use_mkldnn = false) {
   SetConfig(&cfg);
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    cfg.EnableMkldnnFcPasses();
   }
   // cfg.pass_builder()->TurnOnDebug();
   std::vector<std::vector<PaddleTensor>> outputs;
@@ -136,8 +135,7 @@ void compare(bool use_mkldnn = false) {
   SetConfig(&cfg);
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
-    cfg.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
+    cfg.EnableMkldnnFcPasses();
   }
 
   std::vector<std::vector<PaddleTensor>> input_slots_all;

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -635,6 +635,7 @@ void BindAnalysisConfig(py::module *m) {
       .def("to_native_config", &AnalysisConfig::ToNativeConfig)
       .def("enable_quantizer", &AnalysisConfig::EnableMkldnnQuantizer)
       .def("enable_mkldnn_bfloat16", &AnalysisConfig::EnableMkldnnBfloat16)
+      .def("enable_mkldnn_fc_passes", &AnalysisConfig::EnableMkldnnFcPasses)
 #ifdef PADDLE_WITH_MKLDNN
       .def("quantizer_config", &AnalysisConfig::mkldnn_quantizer_config,
            py::return_value_policy::reference)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features
### PR changes
OPs

### Describe
* Since many models (especially int8) will benefit from enabling fc_mkldnn_pass and fc_act_mkldnn_fuse_pass, I've made enabling them easier
* Adding fc passes in ernie int8 model caused format error, so the fix is to change NHWC to NCHW in this narrow case
