### PR TITLE
[Dy2St]close enable_inplace PASS for PE and open test_mnist_pure_fp16.py for windows

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
@@ -33,13 +33,12 @@ class TestPureFP16(TestMNIST):
         return self.train(to_static=False)
 
     def test_mnist_to_static(self):
-        if paddle.fluid.is_compiled_with_cuda() and os.name != 'nt':
+        if paddle.fluid.is_compiled_with_cuda():
             dygraph_loss = self.train_dygraph()
             static_loss = self.train_static()
             # NOTE: In pure fp16 training, loss is not stable, so we enlarge atol here.
             self.assertTrue(
-                np.allclose(
-                    dygraph_loss, static_loss, atol=1e-3),
+                np.allclose(dygraph_loss, static_loss),
                 msg='dygraph is {}\n static_res is \n{}'.format(dygraph_loss,
                                                                 static_loss))
 
@@ -52,7 +51,9 @@ class TestPureFP16(TestMNIST):
 
         if to_static:
             print("Successfully to apply @to_static.")
-            mnist = paddle.jit.to_static(mnist)
+            build_strategy = paddle.static.BuildStrategy()
+            build_strategy.enable_inplace = False
+            mnist = paddle.jit.to_static(mnist, build_strategy=build_strategy)
 
         optimizer = paddle.optimizer.Adam(
             learning_rate=0.001, parameters=mnist.parameters())

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
@@ -36,8 +36,10 @@ class TestPureFP16(TestMNIST):
         if paddle.fluid.is_compiled_with_cuda():
             dygraph_loss = self.train_dygraph()
             static_loss = self.train_static()
+            # NOTE: In pure fp16 training, loss is not stable, so we enlarge atol here.
             self.assertTrue(
-                np.allclose(dygraph_loss, static_loss),
+                np.allclose(
+                    dygraph_loss, static_loss, atol=1e-3),
                 msg='dygraph is {}\n static_res is \n{}'.format(dygraph_loss,
                                                                 static_loss))
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
@@ -36,7 +36,6 @@ class TestPureFP16(TestMNIST):
         if paddle.fluid.is_compiled_with_cuda():
             dygraph_loss = self.train_dygraph()
             static_loss = self.train_static()
-            # NOTE: In pure fp16 training, loss is not stable, so we enlarge atol here.
             self.assertTrue(
                 np.allclose(dygraph_loss, static_loss),
                 msg='dygraph is {}\n static_res is \n{}'.format(dygraph_loss,
@@ -52,6 +51,8 @@ class TestPureFP16(TestMNIST):
         if to_static:
             print("Successfully to apply @to_static.")
             build_strategy = paddle.static.BuildStrategy()
+            # Why set `build_strategy.enable_inplace = False` here?
+            # Because we find that this PASS strategy of PE makes dy2st training loss unstable.
             build_strategy.enable_inplace = False
             mnist = paddle.jit.to_static(mnist, build_strategy=build_strategy)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_pure_fp16.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_pure_fp16.py
@@ -106,7 +106,9 @@ def train(to_static, build_strategy=None):
 class TestResnet(unittest.TestCase):
     def train(self, to_static):
         program_translator.enable(to_static)
-        return train(to_static)
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.enable_inplace = False
+        return train(to_static, build_strategy)
 
     def test_resnet(self):
         if fluid.is_compiled_with_cuda():
@@ -114,8 +116,7 @@ class TestResnet(unittest.TestCase):
             dygraph_loss = self.train(to_static=False)
             # NOTE: In pure fp16 training, loss is not stable, so we enlarge atol here.
             self.assertTrue(
-                np.allclose(
-                    static_loss, dygraph_loss, atol=1e-3),
+                np.allclose(static_loss, dygraph_loss),
                 msg="static_loss: {} \n dygraph_loss: {}".format(static_loss,
                                                                  dygraph_loss))
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_pure_fp16.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_pure_fp16.py
@@ -107,6 +107,8 @@ class TestResnet(unittest.TestCase):
     def train(self, to_static):
         program_translator.enable(to_static)
         build_strategy = paddle.static.BuildStrategy()
+        # Why set `build_strategy.enable_inplace = False` here?
+        # Because we find that this PASS strategy of PE makes dy2st training loss unstable.
         build_strategy.enable_inplace = False
         return train(to_static, build_strategy)
 
@@ -114,7 +116,6 @@ class TestResnet(unittest.TestCase):
         if fluid.is_compiled_with_cuda():
             static_loss = self.train(to_static=True)
             dygraph_loss = self.train(to_static=False)
-            # NOTE: In pure fp16 training, loss is not stable, so we enlarge atol here.
             self.assertTrue(
                 np.allclose(static_loss, dygraph_loss),
                 msg="static_loss: {} \n dygraph_loss: {}".format(static_loss,

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_pure_fp16.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_pure_fp16.py
@@ -116,8 +116,10 @@ class TestResnet(unittest.TestCase):
         if fluid.is_compiled_with_cuda():
             static_loss = self.train(to_static=True)
             dygraph_loss = self.train(to_static=False)
+            # NOTE: In pure fp16 training, loss is not stable, so we enlarge atol here.
             self.assertTrue(
-                np.allclose(static_loss, dygraph_loss),
+                np.allclose(
+                    static_loss, dygraph_loss, atol=1e-3),
                 msg="static_loss: {} \n dygraph_loss: {}".format(static_loss,
                                                                  dygraph_loss))
 


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
close enable_inplace PASS for PE, and test dy2st pure fp16 training stability