### PR TITLE
[Eager]patch tensor method func

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -90,6 +90,8 @@ def _test_eager_guard(tracer=None):
     if not _already_patch_eager_tensor:
         from .dygraph.varbase_patch_methods import monkey_patch_varbase
         monkey_patch_varbase()
+        from .dygraph import monkey_patch_math_varbase
+        monkey_patch_math_varbase()
         _already_patch_eager_tensor = True
     if tracer is None:
         core._set_eager_tracer(_dygraph_tracer_)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
monkey_patch_math_varbase函数需要调用两次才能将所有的method patch到Tensor上。修改这个bug。
目前，EagerTensor和VarBase拥有的method基本一致，仍存在少量diff：
目前，dir(core.eager.EagerTensor())的数据如下：
['T', '__add__', '__and__', '__array__', '__array_ufunc__', '__bool__', '__class__', '__deepcopy__', '__delattr__', '__dir__', '__div__', '__doc__', '__eq__', '__float__', '__floordiv__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__gt__', '__hash__', '__index__', '__init__', '__init_subclass__', '__int__', '__invert__', '__le__', '__len__', '__long__', '__lt__', '__matmul__', '__mod__', '__module__', '__mul__', '__ne__', '__neg__', '__new__', '__nonzero__', '__or__', '__pow__', '__radd__', '__rdiv__', '__reduce__', '__reduce_ex__', '__repr__', '__rmul__', '__rpow__', '__rsub__', '__rtruediv__', '__setattr__', '__setitem__', '__sizeof__', '__str__', '__sub__', '__subclasshook__', '__truediv__', '__xor__', '_clear_gradient', '_copy_to', '_grad_ivar', '_is_initialized', '_place_str', '_to', '_to_static_var', '_zero_grads', 'abs', 'acos', 'acosh', 'add', 'add_', 'add_n', 'addmm', 'all', 'allclose', 'amax', 'amin', 'angle', 'any', 'argmax', 'argmin', 'argsort', 'as_complex', 'as_real', 'asin', 'asinh', 'astype', 'atan', 'atanh', 'backward', 'bincount', 'bitwise_and', 'bitwise_not', 'bitwise_or', 'bitwise_xor', 'block', 'bmm', 'broadcast_shape', 'broadcast_tensors', 'broadcast_to', 'cast', 'ceil', 'ceil_', 'cholesky', 'cholesky_solve', 'chunk', 'clear_grad', 'clear_gradient', 'clip', 'clip_', 'concat', 'cond', 'conj', 'copy_', 'cos', 'cosh', 'cov', 'cross', 'cumprod', 'cumsum', 'deg2rad', 'diagonal', 'diff', 'digamma', 'dim', 'dist', 'divide', 'dot', 'dtype', 'eig', 'eigvals', 'eigvalsh', 'equal', 'equal_all', 'erf', 'erfinv', 'erfinv_', 'exp', 'exp_', 'expand', 'expand_as', 'exponential_', 'flatten', 'flatten_', 'flip', 'floor', 'floor_', 'floor_divide', 'floor_mod', 'fmax', 'fmin', 'gather', 'gather_nd', 'gcd', 'grad', 'gradient', 'greater_equal', 'greater_than', 'histogram', 'imag', 'increment', 'index_sample', 'index_select', 'inner', 'inplace_version', 'inverse', 'is_complex', 'is_empty', 'is_floating_point', 'is_integer', 'is_tensor', 'isclose', 'isfinite', 'isinf', 'isnan', 'item', 'kron', 'kthvalue', 'lcm', 'lerp', 'lerp_', 'less_equal', 'less_than', 'lgamma', 'log', 'log10', 'log1p', 'log2', 'logical_and', 'logical_not', 'logical_or', 'logical_xor', 'logit', 'logsumexp', 'lstsq', 'lu', 'lu_unpack', 'masked_select', 'matmul', 'matrix_power', 'max', 'maximum', 'mean', 'median', 'min', 'minimum', 'mm', 'mod', 'mode', 'moveaxis', 'multi_dot', 'multiplex', 'multiply', 'mv', 'name', 'nansum', 'ndim', 'ndimension', 'neg', 'nonzero', 'norm', 'not_equal', 'numel', 'numpy', 'outer', 'persistable', 'place', 'pow', 'prod', 'put_along_axis', 'put_along_axis_', 'qr', 'quantile', 'rad2deg', 'rank', 'real', 'reciprocal', 'reciprocal_', 'register_hook', 'remainder', 'repeat_interleave', 'reshape', 'reshape_', 'retain_grads', 'reverse', 'roll', 'rot90', 'round', 'round_', 'rsqrt', 'rsqrt_', 'scale', 'scale_', 'scatter', 'scatter_', 'scatter_nd', 'scatter_nd_add', 'set_value', 'shape', 'shard_index', 'sign', 'sin', 'sinh', 'size', 'slice', 'solve', 'sort', 'split', 'sqrt', 'sqrt_', 'square', 'squeeze', 'squeeze_', 'stack', 'stanh', 'std', 'stop_gradient', 'strided_slice', 'subtract', 'subtract_', 'sum', 't', 'take_along_axis', 'tanh', 'tanh_', 'tensordot', 'tile', 'topk', 'trace', 'transpose', 'trunc', 'unbind', 'uniform_', 'unique', 'unique_consecutive', 'unsqueeze', 'unsqueeze_', 'unstack', 'var', 'where']

dir(core.VarBase())的数据如下：
['T', '__add__', '__and__', '__array__', '__array_ufunc__', '__bool__', '__class__', '__deepcopy__', '__delattr__', '__dir__', '__div__', '__doc__', '__eq__', '__float__', '__floordiv__', '__format__', '__ge__', '__getattribute__', '__getitem__', '__gt__', '__hash__', '__index__', '__init__', '__init_subclass__', '__int__', '__invert__', '__le__', '__len__', '__long__', '__lt__', '__matmul__', '__mod__', '__module__', '__mul__', '__ne__', '__neg__', '__new__', '__nonzero__', '__or__', '__pow__', '__radd__', '__rdiv__', '__reduce__', '__reduce_ex__', '__repr__', '__rmul__', '__rpow__', '__rsub__', '__rtruediv__', '__setattr__', '__setitem__', '__setitem_varbase__', '__sizeof__', '__str__', '__sub__', '__subclasshook__', '__truediv__', '__xor__', '_alive_vars', '_allreduce', '_bump_inplace_version', '_clear', '_copy_gradient_from', '_copy_to', '_getitem_from_offset', '_getitem_index_not_tensor', '_grad_ivar', '_grad_name', '_grad_value', '_gradient_set_empty', '_inplace_version', '_is_gradient_set_empty', '_is_shared_buffer_with', '_is_sparse', '_numel', '_offset', '_place_str', '_register_backward_hook', '_register_grad_hook', '_register_void_function_post_hook', '_remove_grad_hook', '_reset_grad_inplace_version', '_set_grad_ivar', '_set_grad_type', '_share_buffer_to', '_share_memory', '_slice', '_to', '_to_static_var', 'abs', 'acos', 'acosh', 'add', 'add_', 'add_n', 'addmm', 'all', 'allclose', 'amax', 'amin', 'angle', 'any', 'argmax', 'argmin', 'argsort', 'as_complex', 'as_real', 'asin', 'asinh', 'astype', 'atan', 'atanh', 'backward', 'bincount', 'bitwise_and', 'bitwise_not', 'bitwise_or', 'bitwise_xor', 'block', 'bmm', 'broadcast_shape', 'broadcast_tensors', 'broadcast_to', 'cast', 'ceil', 'ceil_', 'cholesky', 'cholesky_solve', 'chunk', 'clear_grad', 'clear_gradient', 'clip', 'clip_', 'clone', 'concat', 'cond', 'conj', 'copy_', 'cos', 'cosh', 'cov', 'cpu', 'cross', 'cuda', 'cumprod', 'cumsum', 'deg2rad', 'detach', 'diagonal', 'diff', 'digamma', 'dim', 'dist', 'divide', 'dot', 'dtype', 'eig', 'eigvals', 'eigvalsh', 'element_size', 'equal', 'equal_all', 'erf', 'erfinv', 'erfinv_', 'exp', 'exp_', 'expand', 'expand_as', 'exponential_', 'fill_', 'fill_diagonal_', 'fill_diagonal_tensor', 'fill_diagonal_tensor_', 'flatten', 'flatten_', 'flip', 'floor', 'floor_', 'floor_divide', 'floor_mod', 'fmax', 'fmin', 'gather', 'gather_nd', 'gcd', 'grad', 'gradient', 'greater_equal', 'greater_than', 'histogram', 'imag', 'increment', 'index_sample', 'index_select', 'inner', 'inplace_version', 'inverse', 'is_complex', 'is_empty', 'is_floating_point', 'is_integer', 'is_leaf', 'is_tensor', 'isclose', 'isfinite', 'isinf', 'isnan', 'item', 'kron', 'kthvalue', 'lcm', 'lerp', 'lerp_', 'less_equal', 'less_than', 'lgamma', 'log', 'log10', 'log1p', 'log2', 'logical_and', 'logical_not', 'logical_or', 'logical_xor', 'logit', 'logsumexp', 'lstsq', 'lu', 'lu_unpack', 'masked_select', 'matmul', 'matrix_power', 'max', 'maximum', 'mean', 'median', 'min', 'minimum', 'mm', 'mod', 'mode', 'moveaxis', 'multi_dot', 'multiplex', 'multiply', 'mv', 'name', 'nansum', 'ndim', 'ndimension', 'neg', 'nonzero', 'norm', 'not_equal', 'numel', 'numpy', 'outer', 'persistable', 'pin_memory', 'place', 'pow', 'prod', 'put_along_axis', 'put_along_axis_', 'qr', 'quantile', 'rad2deg', 'rank', 'real', 'reciprocal', 'reciprocal_', 'register_hook', 'remainder', 'repeat_interleave', 'reshape', 'reshape_', 'reverse', 'roll', 'rot90', 'round', 'round_', 'rsqrt', 'rsqrt_', 'scale', 'scale_', 'scatter', 'scatter_', 'scatter_nd', 'scatter_nd_add', 'set_value', 'shape', 'shard_index', 'sign', 'sin', 'sinh', 'size', 'slice', 'solve', 'sort', 'split', 'sqrt', 'sqrt_', 'square', 'squeeze', 'squeeze_', 'stack', 'stanh', 'std', 'stop_gradient', 'strided_slice', 'subtract', 'subtract_', 'sum', 't', 'take_along_axis', 'tanh', 'tanh_', 'tensordot', 'tile', 'tolist', 'topk', 'trace', 'transpose', 'trunc', 'type', 'unbind', 'uniform_', 'unique', 'unique_consecutive', 'unsqueeze', 'unsqueeze_', 'unstack', 'value', 'var', 'where', 'zero_']