### PR TITLE
[AMP] Check call order of paddle.amp.decorate and paddle.DataParallel

### DIFF
--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -145,6 +145,10 @@ def check_models(models):
             raise RuntimeError(
                 "Current train mode is pure fp16, models should be paddle.nn.Layer, but receive {}.".
                 format(type(model)))
+        if isinstance(model, paddle.DataParallel):
+            raise RuntimeError(
+                "For distributed AMP training, you should first use paddle.amp.decorate() to decotate origin model, and then call paddle.DataParallel get distributed model."
+            )
 
 
 def check_optimizers(optimizers):

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1537,7 +1537,6 @@ class Layer(object):
         if include_sublayers:
             for layer in self.children():
                 layer._apply(func, device, dtype, blocking, include_sublayers)
-                layer._dtype = dtype
 
         for key, param in self._parameters.items():
             if param is not None:
@@ -1551,6 +1550,8 @@ class Layer(object):
 
         for key, buf in self._buffers.items():
             self._buffers[key] = func(buf, device, dtype, blocking)
+
+        self._dtype = dtype
 
     def _to_impl(self,
                  device=None,

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1537,6 +1537,7 @@ class Layer(object):
         if include_sublayers:
             for layer in self.children():
                 layer._apply(func, device, dtype, blocking, include_sublayers)
+                layer._dtype = dtype
 
         for key, param in self._parameters.items():
             if param is not None:

--- a/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
@@ -536,6 +536,14 @@ class TestAmpDecorator(unittest.TestCase):
 
         self.assertRaises(TypeError, test_error_model)
 
+        def test_error_distributed_model():
+            model = fluid.dygraph.Conv2D(3, 2, 3, bias_attr=False, act=None)
+            model = paddle.DataParallel(model)
+            with fluid.dygraph.guard():
+                model = paddle.amp.decorate(models=model, level='O2')
+
+        self.assertRaises(RuntimeError, test_error_distributed_model)
+
         def test_error_optimizer():
             class MyOptimizer(object):
                 def __init__(self):


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
APIs

### Describe
对于使用amp-o2的分布式训练，要求```paddle.amp.decorate```需要在```paddle.DataParallel```初始化分布式训练的网络前。

在```paddle.amp.decorate```接口添加对上述逻辑的检查。如果调用顺序有错，将报出如下```RuntimeError```：

```For distributed AMP training, you should first use paddle.amp.decorate() to decotate origin model, and then call paddle.DataParallel get distributed model.```
