### PR TITLE
[bug fix] fix unfold runtime bug

### DIFF
--- a/paddle/fluid/operators/unfold_op.cc
+++ b/paddle/fluid/operators/unfold_op.cc
@@ -143,40 +143,47 @@ class UnfoldOp : public framework::OperatorWithKernel {
             "but recieved dilations_height: %d dilations_width: %d.",
             dilations[0], dilations[1]));
 
-    std::vector<int> out_dims;
-    out_dims.push_back(in_dims[0]);
+    bool contain_unknown_dim = framework::contain_unknown_dim(in_dims);
+    bool check = ctx->IsRuntime() || !contain_unknown_dim;
+    if (check) {
+      std::vector<int> out_dims;
+      out_dims.push_back(in_dims[0]);
 
-    int output_channels = in_dims[1] * kernel_sizes[0] * kernel_sizes[1];
-    out_dims.push_back(output_channels);
+      int output_channels = in_dims[1] * kernel_sizes[0] * kernel_sizes[1];
+      out_dims.push_back(output_channels);
 
-    int output_height =
-        CalcOutputSize(in_dims[2], kernel_sizes[0], dilations[0], paddings[0],
-                       paddings[2], strides[0]);
-    int output_width = CalcOutputSize(in_dims[3], kernel_sizes[1], dilations[1],
-                                      paddings[1], paddings[3], strides[1]);
-    // check output height and width
-    PADDLE_ENFORCE_GT(
-        output_height, 0,
-        platform::errors::InvalidArgument(
-            "The sliding blocks calculated from input spatial size (%d, %d), "
-            "kernel_sizes (%d, %d), strides (%d, %d), dilations (%d, %d), "
-            "is (%d, %d), which should be a positive integer.",
-            in_dims[2], in_dims[3], kernel_sizes[0], kernel_sizes[1],
-            strides[0], strides[1], dilations[0], dilations[1], output_height,
-            output_width));
-    PADDLE_ENFORCE_GT(
-        output_width, 0,
-        platform::errors::InvalidArgument(
-            "The sliding blocks calculated from input spatial size (%d, %d), "
-            "kernel_sizes (%d, %d), strides (%d, %d), dilations (%d, %d), "
-            "is (%d, %d), which should be a positive integer.",
-            in_dims[2], in_dims[3], kernel_sizes[0], kernel_sizes[1],
-            strides[0], strides[1], dilations[0], dilations[1], output_height,
-            output_width));
-    int output_col_length = output_height * output_width;
-    out_dims.push_back(output_col_length);
+      int output_height =
+          CalcOutputSize(in_dims[2], kernel_sizes[0], dilations[0], paddings[0],
+                         paddings[2], strides[0]);
+      int output_width =
+          CalcOutputSize(in_dims[3], kernel_sizes[1], dilations[1], paddings[1],
+                         paddings[3], strides[1]);
+      // check output height and width
+      PADDLE_ENFORCE_GT(
+          output_height, 0,
+          platform::errors::InvalidArgument(
+              "The sliding blocks calculated from input spatial size "
+              "(%d, %d), kernel_sizes (%d, %d), strides (%d, %d), "
+              "dilations (%d, %d), is (%d, %d), which should be a "
+              "positive integer.",
+              in_dims[2], in_dims[3], kernel_sizes[0], kernel_sizes[1],
+              strides[0], strides[1], dilations[0], dilations[1], output_height,
+              output_width));
+      PADDLE_ENFORCE_GT(
+          output_width, 0,
+          platform::errors::InvalidArgument(
+              "The sliding blocks calculated from input spatial size "
+              "(%d, %d), kernel_sizes (%d, %d), strides (%d, %d), "
+              "dilations (%d, %d), is (%d, %d), which should be a "
+              "positive integer.",
+              in_dims[2], in_dims[3], kernel_sizes[0], kernel_sizes[1],
+              strides[0], strides[1], dilations[0], dilations[1], output_height,
+              output_width));
+      int output_col_length = output_height * output_width;
+      out_dims.push_back(output_col_length);
 
-    ctx->SetOutputDim("Y", framework::make_ddim(out_dims));
+      ctx->SetOutputDim("Y", framework::make_ddim(out_dims));
+    }
   }
 
  protected:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix unfold in runtime bug：
before：
in static, input size is -1, an error will be reported in compile time
<img width="1421" alt="b7e32358c7d2d226e0ae8a6e68e8564c" src="https://user-images.githubusercontent.com/23647349/148731251-d479d694-494a-4744-a042-52b77d8704d2.png">

after：
InferShape check will only be checked at runtime