### PR TITLE
Fix fc_mkldnn format issue

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -95,8 +95,17 @@ void CPUQuantizePass::QuantizeInput(Graph* g, Node* op, Node* input,
   q_desc.SetAttr("Shift", shift);
   q_desc.SetAttr("is_negative_input", !is_input_unsigned);
 
-  q_desc.SetAttr("output_format",
-                 Has("data_layout") ? Get<std::string>("data_layout") : "NHWC");
+  // fix to fc format error
+  if (op->Op()->Type() == "fc" &&
+      op->Op()->GetAttrIfExists<int>("in_num_col_dims") == 2) {
+    q_desc.SetAttr("output_format", Has("data_layout")
+                                        ? Get<std::string>("data_layout")
+                                        : "NCHW");
+  } else {
+    q_desc.SetAttr("output_format", Has("data_layout")
+                                        ? Get<std::string>("data_layout")
+                                        : "NHWC");
+  }
   auto quantize_op = g->CreateOpNode(&q_desc);  // OpDesc will be copied.
 
   // update op's input


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes 

### PR changes
OPs

### Describe
Adding fc mldnn passes in ernie int8 model caused format error, so the fix is to change NHWC to NCHW in this narrow case. It is a workaround to error "DNNL FC only supports in_num_col_dims equal to 2 when input format is equal to ncw."
