### PR TITLE
fix bug of -DPADDLE_WITH_SSE3 not set

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -31,10 +31,12 @@ endif(NOT WITH_PROFILER)
 if(WITH_AVX AND AVX_FOUND)
     set(SIMD_FLAG ${AVX_FLAG})
     add_definitions(-DPADDLE_WITH_AVX)
-elseif(SSE3_FOUND)
-    if(NOT WIN32)
-        set(SIMD_FLAG ${SSE3_FLAG})
-    endif()
+elseif(SSE3_FOUND AND NOT WIN32)
+    set(SIMD_FLAG ${SSE3_FLAG})
+endif()
+
+if (SSE3_FOUND)
+    # TODO: Runtime detection should be used here.
     add_definitions(-DPADDLE_WITH_SSE3)
 endif()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix bug of that -DPADDLE_WITH_SSE3 cant be set when WITH_AVX AND AVX_FOUND. This bug is discovered according to intel's [issue](https://github.com/PaddlePaddle/Paddle/issues/38921), the original commit adb54eb caused this problem.