### PR TITLE
Fix for conv2D training error

### DIFF
--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -377,6 +377,14 @@ class MKLDNNHandlerT {
     if (bwd_pd_ == nullptr) {
       return false;
     } else {
+      if (std::is_same<TBackward_params, mkldnn_dummy_primitive>::value ==
+          false) {
+        const std::string key_bw_w_pd = key_ + "@bwd_w_pd";
+        bwd_w_pd_ =
+            std::static_pointer_cast<typename TBackward_params::primitive_desc>(
+                dev_ctx_.GetBlob(key_bw_w_pd));
+      }
+
       // When BWD is cached then still we need to Get FWD PD
       const std::string key_fpd = key_ + "@fwd_pd";
       fwd_pd_ = std::static_pointer_cast<typename TForward::primitive_desc>(

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -50,6 +50,7 @@ class TestConv2DBF16Op(TestConv2DOp):
         self.init_fuse_residual()
         self.init_data_type()
         self.init_force_fp32_output()
+        self.init_infer_or_train()
 
         self.conv2d_param = {
             'stride': self.stride,
@@ -83,6 +84,9 @@ class TestConv2DBF16Op(TestConv2DOp):
         if self.input_type is not np.float32:
             self.input = convert_float_to_uint16(self.input)
 
+        if self.weight_type is not np.float32:
+            self.filter = convert_float_to_uint16(self.filter)
+
         self.inputs = {
             'Input': self.input,
             'Filter': OpTest.np_dtype_to_fluid_dtype(
@@ -104,6 +108,8 @@ class TestConv2DBF16Op(TestConv2DOp):
             'force_fp32_output': self.force_fp32_output,
             'fuse_residual_connection': self.fuse_residual
         }
+
+        self.init_additional_attrs()
 
     def test_check_output(self):
         self.check_output_with_place(core.CPUPlace())
@@ -141,6 +147,12 @@ class TestConv2DBF16Op(TestConv2DOp):
     def init_fuse_residual(self):
         self.fuse_residual = True
 
+    def init_infer_or_train(self):
+        self.weight_type = np.float32
+
+    def init_additional_attrs(self):
+        self.attrs['is_test'] = True
+
 
 @OpTestTool.skip_if_not_cpu_bf16()
 class TestConv2DWithGradBF16Op(TestConv2DBF16Op):
@@ -149,6 +161,12 @@ class TestConv2DWithGradBF16Op(TestConv2DBF16Op):
 
     def init_fuse_residual(self):
         self.fuse_residual = None
+
+    def init_additional_attrs(self):
+        self.attrs['is_test'] = False
+
+    def init_infer_or_train(self):
+        self.weight_type = np.uint16
 
     def test_check_grad(self):
         dout = self.conv_output_float


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix for conv2D training error on LeNet model. The issue was associated with wrong weights datatype(in inference they are in FP32 datatype, but in training they are in BF16). Also fixed error with no re-creating backward weights primitive descriptor in isCached method
