### PR TITLE
Replace EigenBroadcast with ElementwiseBroadcast in ReduceGrad

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op.part.cu
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op.part.cu
@@ -17,15 +17,9 @@
 
 template <typename T>
 using CUDAReduceMeanGradKernel =
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, T,
-                          ops::MeanGradFunctor, true>;
-
-using FP16CUDAReduceMeanGradKernel =
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext,
-                          paddle::platform::float16, ops::FP16MeanGradFunctor,
-                          true>;
+    ops::ReduceCudaGradKernel<T, kps::DivideFunctor>;
 
 REGISTER_OP_CUDA_KERNEL(reduce_mean_grad, CUDAReduceMeanGradKernel<bool>,
-                        FP16CUDAReduceMeanGradKernel,
+                        CUDAReduceMeanGradKernel<paddle::platform::float16>,
                         CUDAReduceMeanGradKernel<float>,
                         CUDAReduceMeanGradKernel<double>);

--- a/paddle/fluid/operators/reduce_ops/reduce_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.h
@@ -743,17 +743,17 @@ class ReduceCudaGradKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& context) const override {
     bool reduce_all = context.Attr<bool>("reduce_all");
     std::vector<int> dims = context.Attr<std::vector<int>>("dim");
-    auto* input0 = context.Input<Tensor>("X");
+    auto* in_x = context.Input<Tensor>("X");
     auto* d_out =
         context.Input<framework::Tensor>(framework::GradVarName("Out"));
     auto* d_x = context.Output<framework::Tensor>(framework::GradVarName("X"));
-    int dim_size = input0->dims().size();
+    int dim_size = in_x->dims().size();
     d_x->mutable_data<T>(context.GetPlace());
     std::vector<int> reduce_dims = GetReduceDim(dims, dim_size, reduce_all);
     auto update_dims = vectorize(d_x->dims());
     int reduce_num = 1;
     for (auto i : reduce_dims) {
-      reduce_num *= (input0->dims())[i];
+      reduce_num *= (in_x->dims())[i];
       update_dims[i] = 1;
     }
     Tensor new_d_out;

--- a/paddle/fluid/operators/reduce_ops/reduce_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.h
@@ -29,7 +29,6 @@ limitations under the License. */
 #include "paddle/pten/kernels/cpu/reduce.h"
 
 #if defined(__HIPCC__) || defined(__NVCC__)
-#include "paddle/fluid/operators/elementwise/elementwise_op_broadcast.cu.h"
 #include "paddle/pten/kernels/gpu/reduce.h"
 #endif
 
@@ -394,7 +393,7 @@ template <typename DeviceContext, typename T, typename Functor,
           bool kNoNeedBufferX = false, bool kNoNeedBufferY = false>
 class ReduceGradKernel : public framework::OpKernel<T> {
  public:
-  void ComputeFromInput(const framework::Tensor* input2,
+  void ComputeFromInput(const Tensor* input2,
                         const framework::ExecutionContext& context) const {
     bool reduce_all = context.Attr<bool>("reduce_all");
     auto dims = context.Attr<std::vector<int>>("dim");
@@ -623,11 +622,12 @@ class ReduceGradOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override {
-    int in_dtype = ctx.Attr<int>("in_dtype");
+    int out_dtype = ctx.Attr<int>("out_dtype");
     auto input_data_type =
-        (in_dtype >= 0) ? static_cast<framework::proto::VarType::Type>(in_dtype)
-                        : OperatorWithKernel::IndicateVarDataType(
-                              ctx, framework::GradVarName("Out"));
+        (out_dtype >= 0)
+            ? static_cast<framework::proto::VarType::Type>(out_dtype)
+            : OperatorWithKernel::IndicateVarDataType(
+                  ctx, framework::GradVarName("Out"));
 #ifdef PADDLE_WITH_MKLDNN
     auto CanMKLDNNReduceGradBeUsed = [&]() {
       auto dx_dims = ctx.Input<Tensor>("X")->dims();
@@ -747,8 +747,9 @@ class ReduceCudaGradKernel : public framework::OpKernel<T> {
     auto* d_out =
         context.Input<framework::Tensor>(framework::GradVarName("Out"));
     auto* d_x = context.Output<framework::Tensor>(framework::GradVarName("X"));
+    auto out_dtype = context.Attr<int>("in_dtype");
+    // get reduce_dim and reduce_num for reduce_mean_grad
     int dim_size = in_x->dims().size();
-    d_x->mutable_data<T>(context.GetPlace());
     std::vector<int> reduce_dims = GetReduceDim(dims, dim_size, reduce_all);
     auto update_dims = vectorize(d_x->dims());
     int reduce_num = 1;
@@ -756,15 +757,32 @@ class ReduceCudaGradKernel : public framework::OpKernel<T> {
       reduce_num *= (in_x->dims())[i];
       update_dims[i] = 1;
     }
-    Tensor new_d_out;
+    // make new tensor
+    framework::Tensor new_d_out(d_out->type());
     new_d_out.ShareDataWith(*d_out);
     new_d_out.Resize(paddle::framework::make_ddim(update_dims));
-    std::vector<const framework::Tensor*> inputs = {&new_d_out};
-    std::vector<framework::Tensor*> outputs = {d_x};
     auto& dev_ctx = context.cuda_device_context();
+    if (out_dtype > 0) {
+      d_x->mutable_data(
+          dev_ctx.GetPlace(),
+          static_cast<framework::proto::VarType::Type>(out_dtype));
+    } else {
+      d_x->mutable_data(
+          dev_ctx.GetPlace(),
+          static_cast<framework::proto::VarType::Type>(d_out->type()));
+    }
+    auto pt_d_out = paddle::experimental::MakePtenDenseTensor(new_d_out);
+    auto pt_d_x = paddle::experimental::MakePtenDenseTensor(*d_x);
+    auto pt_out_dtype = pten::TransToPtenDataType(
+        static_cast<framework::proto::VarType::Type>(out_dtype));
+    if (out_dtype <= 0) {
+      pt_out_dtype = pten::TransToPtenDataType(
+          static_cast<framework::proto::VarType::Type>(d_out->type()));
+    }
     using MPType = typename kps::details::MPTypeTrait<T>::Type;
-    LaunchBroadcastElementwiseCudaKernel<pten::ElementwiseType::kUnary, T, T>(
-        dev_ctx, inputs, &outputs, 0, TransformOp<T, MPType>(reduce_num));
+    pten::ReduceGrad<T, TransformOp<T, MPType>>(
+        dev_ctx, pt_d_out.get(), pt_d_x.get(), pt_out_dtype,
+        TransformOp<T, MPType>(reduce_num));
   }
 };
 #endif

--- a/paddle/fluid/operators/reduce_ops/reduce_op_function.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op_function.h
@@ -16,6 +16,9 @@
 #include <vector>
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
+#if defined(__HIPCC__) || defined(__NVCC__)
+#include "paddle/fluid/operators/elementwise/elementwise_op_broadcast.cu.h"
+#endif
 
 namespace paddle {
 namespace operators {
@@ -97,12 +100,18 @@ void ReduceGradFunctor(const DeviceContext& context,
   auto reduced_dims = framework::make_ddim(reduced_dims_v);
   auto x_reduce = EigenTensor<T, D>::From(input1, reduced_dims);
   auto x_reduce_grad = EigenTensor<T, D>::From(input2, reduced_dims);
-
+#if defined(__HIPCC__) || defined(__NVCC__)
+  std::vector<const framework::Tensor*> inputs = {&input2};
+  std::vector<framework::Tensor*> outputs = {output};
+  using MPType = typename kps::details::MPTypeTrait<T>::Type;
+  LaunchBroadcastElementwiseCudaKernel<pten::ElementwiseType::kUnary, T, T>(
+      context, inputs, &outputs, 0, kps::IdentityFunctor<T>());
+#else
   auto& place = *context.eigen_device();
-
   Functor functor;
   functor(place, &x, &x_reduce, &x_grad, &x_reduce_grad, broadcast_dim,
           broad_cats_times);
+#endif
 }
 
 }  // namespace operators

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
@@ -50,7 +50,7 @@ class ReduceSumOpGradMaker : public framework::SingleGradOpMaker<T> {
 
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const {
-    int in_dtype = ctx.Attr<int>("in_dtype");
+    int in_dtype = ctx.Attr<int>("out_dtype");
     if (in_dtype >= 0) {
       return framework::OpKernelType(
           static_cast<framework::proto::VarType::Type>(in_dtype),

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.h
@@ -74,7 +74,7 @@ class ReduceSumGradKernel : public framework::OpKernel<T> {
     auto dims = context.Attr<std::vector<int>>("dim");
     if (context.GetPlace().GetType() == platform::CPUPlace().GetType() &&
         dims.size() == 1) {
-      int in_dtype = context.Attr<int>("in_dtype");
+      int in_dtype = context.Attr<int>("out_dtype");
 
       if (in_dtype >= 0) {
         Tensor tmp_tensor;

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.part.cu
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.part.cu
@@ -17,8 +17,7 @@
 
 template <typename T>
 using CUDAReduceSumGradKernel =
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, T,
-                          ops::SumGradFunctor, true>;
+    ops::ReduceCudaGradKernel<T, kps::IdentityFunctor>;
 
 REGISTER_OP_CUDA_KERNEL(
     reduce_sum_grad, CUDAReduceSumGradKernel<bool>,

--- a/paddle/pten/kernels/gpu/elementwise.h
+++ b/paddle/pten/kernels/gpu/elementwise.h
@@ -132,7 +132,7 @@ struct DimensionsTransform {
   explicit DimensionsTransform(const std::vector<const DenseTensor *> &ins,
                                const pten::framework::DDim &dims,
                                int axis) {
-    const int N = max(static_cast<int>(intins.size()), 2);
+    const int N = max(static_cast<int>(ins.size()), 2);
     dim_size = dims.size();
     out_dims = paddle::framework::vectorize<int64_t>(dims);
     if (ins.size() == 1) {

--- a/paddle/pten/kernels/gpu/elementwise.h
+++ b/paddle/pten/kernels/gpu/elementwise.h
@@ -137,7 +137,7 @@ struct DimensionsTransform {
     out_dims = pten::framework::vectorize<int64_t>(dims);
     in_dims.resize(N);
     if (ins.size() == 1) {
-      // when ins.size() = 1, broadcast input to output set N = in.size() + 1
+      // when ins.size() = 1, broadcast input to output
       in_dims[0] = pten::framework::vectorize<int64_t>(ins[0]->dims());
       in_dims[1] = out_dims;
       // Add out_dims to in_dims to avoid errors in dims merging

--- a/paddle/pten/kernels/gpu/elementwise.h
+++ b/paddle/pten/kernels/gpu/elementwise.h
@@ -132,12 +132,20 @@ struct DimensionsTransform {
   explicit DimensionsTransform(const std::vector<const DenseTensor *> &ins,
                                const pten::framework::DDim &dims,
                                int axis) {
-    const int N = ins.size();
+    const int N = max(static_cast<int>(intins.size()), 2);
     dim_size = dims.size();
-    out_dims = pten::framework::vectorize<int64_t>(dims);
-    in_dims.resize(N);
-    for (int j = 0; j < N; ++j) {
-      in_dims[j] = pten::framework::vectorize<int64_t>(ins[j]->dims());
+    out_dims = paddle::framework::vectorize<int64_t>(dims);
+    if (ins.size() == 1) {
+      // when ins.size() = 1 set N = in.size() + 1
+      in_dims.resize(N);
+      in_dims[0] = paddle::framework::vectorize<int64_t>(ins[0]->dims());
+      in_dims[1] = out_dims;
+      // Add out_dims to in_dims to avoid errors in dims merging
+    } else {
+      in_dims.resize(N);
+      for (int j = 0; j < N; ++j) {
+        in_dims[j] = paddle::framework::vectorize<int64_t>(ins[j]->dims());
+      }
     }
     InputDimensionsExtend(N, axis);
 

--- a/paddle/pten/kernels/gpu/elementwise.h
+++ b/paddle/pten/kernels/gpu/elementwise.h
@@ -134,17 +134,16 @@ struct DimensionsTransform {
                                int axis) {
     const int N = max(static_cast<int>(ins.size()), 2);
     dim_size = dims.size();
-    out_dims = paddle::framework::vectorize<int64_t>(dims);
+    out_dims = pten::framework::vectorize<int64_t>(dims);
+    in_dims.resize(N);
     if (ins.size() == 1) {
-      // when ins.size() = 1 set N = in.size() + 1
-      in_dims.resize(N);
-      in_dims[0] = paddle::framework::vectorize<int64_t>(ins[0]->dims());
+      // when ins.size() = 1, broadcast input to output set N = in.size() + 1
+      in_dims[0] = pten::framework::vectorize<int64_t>(ins[0]->dims());
       in_dims[1] = out_dims;
       // Add out_dims to in_dims to avoid errors in dims merging
     } else {
-      in_dims.resize(N);
       for (int j = 0; j < N; ++j) {
-        in_dims[j] = paddle::framework::vectorize<int64_t>(ins[j]->dims());
+        in_dims[j] = pten::framework::vectorize<int64_t>(ins[j]->dims());
       }
     }
     InputDimensionsExtend(N, axis);

--- a/paddle/pten/kernels/gpu/reduce.h
+++ b/paddle/pten/kernels/gpu/reduce.h
@@ -45,8 +45,7 @@ namespace cub = hipcub;
 #include "paddle/pten/api/ext/dispatch.h"
 #include "paddle/pten/backends/gpu/gpu_context.h"
 #include "paddle/pten/core/dense_tensor.h"
-#include "paddle/pten/kernels/funcs/elementwise_base.h"
-
+#include "paddle/pten/kernels/gpu/elementwise.h"
 // Reduce split or not, Whether to use ReduceHigherDim
 #define REDUCE_SPLIT_BOUNDARY 512
 #define REDUCE_VEC_SIZE 4

--- a/paddle/pten/kernels/gpu/reduce.h
+++ b/paddle/pten/kernels/gpu/reduce.h
@@ -1255,6 +1255,24 @@ void Reduce(const GPUContext& dev_ctx,
             x, out, TransformOp<T, MPType>(reduce_num), reduce_dims, stream);
   }
 }
+
+template <typename InT, typename Functor>
+void ReduceGrad(const GPUContext& dev_ctx,
+                DenseTensor* d_out,
+                DenseTensor* d_x,
+                DataType out_dtype,
+                Functor functor) {
+  std::vector<const DenseTensor*> inputs = {d_out};
+  std::vector<DenseTensor*> outputs = {d_x};
+  PD_VISIT_ALL_TYPES(
+      out_dtype, "LaunchBroadcastElementwiseCudaKernel", ([&] {
+        LaunchBroadcastElementwiseCudaKernel<pten::ElementwiseType::kUnary,
+                                             InT,
+                                             data_t>(
+            dev_ctx, inputs, &outputs, 0, functor);
+      }));
+}
+
 }  // namespace pten
 
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Reduce EigenBroadcastcase with ElementwiseBroadcast in ReduceGrad
为扩大KP算子覆盖率，统一将Reduce_sum/mean 反向的Eigen适配代码替换为ElementwiseBroadcast Kernel
ReduceGrad 性能统计对比：

op name | case | axise | dtype | 优化前 （us) | 优化后 （us) | speed   up
-- | -- | -- | -- | -- | -- | --
reduce_sum_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float32 | 626 | 160.73 | 3.89
reduce_sum_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float16 | 633 | 83.64 | 7.57
reduce_sum_grad | [-1L, 8L, 128L] | [1] | float32 | 2.44 | 1.71 | 1.43
reduce_sum_grad | [-1L, 8L, 128L] | [1] | float16 | 2.84 | 1.7 | 1.67
reduce_sum_grad | [30522L, 1024L] | [] | float32 | 150.38 | 138.79 | 1.08
reduce_sum_grad | [30522L, 1024L] | [] | float16 | 89.81 | 43.44 | 2.07
op name | case | axise | dtype | 优化前 （us) | 优化后 （us) | speed up
reduce_mean_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float32 | 672 | 160.71 | 4.18
reduce_mean_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float16 | 681 | 83.1 | 8.19
reduce_mean_grad | [-1L, 8L, 128L] | [1] | float32 | 3.115 | 1.72 | 1.81
reduce_mean_grad | [-1L, 8L, 128L] | [1] | float16 | 3.171 | 1.66 | 1.91
reduce_mean_grad | [30522L, 1024L] | [] | float32 | 152.78 | 138.83 | 1.10
reduce_mean_grad | [30522L, 1024L] | [] | float16 | 134.96 | 69.835 | 1.93

benchmark 异常说明，与本次PR修改无关，本地测试无性能影响：

op   name | shape | dtype | dev (us) | new (us) | speed up
-- | -- | -- | -- | -- | --
p_norm_1 backward | [300, 128, 128], axis = -1 porder = 3.0 | float32 | 178.26 | 178.06 | 1.00112322
matmul_3_backward | [paddle][p_norm] p_norm {       run_tf: True       run_torch: True       axis: -1       porder: 3.0       keepdim: False       x_shape: [300, 128, 128]       x_dtype: float32       atol: 1e-06     [paddle][p_norm] p_norm {       run_tf: True       run_torch: True       axis: -1       porder: 3.0       keepdim: False       x_shape: [300, 128, 128]       x_dtype: float32       atol: 1e-06 | float32 | 12.7867 | 12.865 | 0.99391372
matmul_9_forward | [paddle][matmul] matmul {       run_tf: True       run_torch: True       atol: 1.0       transpose_x: False       transpose_y: False       x_shape: [4, 12, 64, 85]       x_dtype: float16       y_shape: [4, 12, 85, 512]       y_dtype: float16     } | float32 | 26.165 | 26.146 | 1.00072669


