### PR TITLE
Fix master weight bug for multi_tensor optimizer(momentum, adam)

### DIFF
--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -551,8 +551,7 @@ class Adam(Optimizer):
         multi_tensor_list = ['FP32_LODTensor', 'FP16_LODTensor']
         for key in multi_tensor_list:
             if len(self._param_dict[key]) > 0:
-                if key == 'FP32_LODTensor':
-                    self._multi_precision = False
+                find_master = self._multi_precision and key == 'FP16_LODTensor'
 
                 _beta1 = self._beta1 if not isinstance(
                     self._beta1, Variable) else self._beta1.numpy().item(0)
@@ -571,7 +570,7 @@ class Adam(Optimizer):
                         self._beta2_pow_acc_dict[key],
                         self._master_weight_dict[key], 'epsilon', self._epsilon,
                         'beta1', _beta1, 'beta2', _beta2, 'multi_precision',
-                        self._multi_precision)
+                        find_master)
                 else:
                     inputs = {
                         "Param": self._param_dict[key],
@@ -594,11 +593,11 @@ class Adam(Optimizer):
                         "beta1": _beta1,
                         "beta2": _beta2
                     }
-                    if self._multi_precision:
+                    if find_master:
                         inputs["MasterParam"] = self._master_weight_dict[key]
                         outputs["MasterParamOut"] = self._master_weight_dict[
                             key]
-                        attrs["multi_precision"] = self._multi_precision
+                        attrs["multi_precision"] = find_master
                     target_block.append_op(
                         type="merged_adam",
                         inputs=inputs,

--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -464,8 +464,7 @@ class Momentum(Optimizer):
         multi_tensor_list = ['FP32_LODTensor', 'FP16_LODTensor']
         for key in multi_tensor_list:
             if len(self._param_dict[key]) > 0:
-                if key == 'FP32_LODTensor':
-                    self._multi_precision = False
+                find_master = self._multi_precision and key == 'FP16_LODTensor'
 
                 if framework.in_dygraph_mode():
                     _, _, _ = _C_ops.merged_momentum(
@@ -478,7 +477,7 @@ class Momentum(Optimizer):
                         self._regularization_method_dict[key],
                         'regularization_coeff',
                         self._regularization_coeff_dict[key], 'multi_precision',
-                        self._multi_precision)
+                        find_master)
                 else:
                     inputs = {
                         "Param": self._param_dict[key],
@@ -498,11 +497,11 @@ class Momentum(Optimizer):
                         "regularization_coeff":
                         self._regularization_coeff_dict[key],
                     }
-                    if self._multi_precision:
+                    if find_master:
                         inputs["MasterParam"] = self._master_weight_dict[key]
                         outputs["MasterParamOut"] = self._master_weight_dict[
                             key]
-                        attrs["multi_precision"] = self._multi_precision
+                        attrs["multi_precision"] = find_master
                     target_block.append_op(
                         type="merged_momentum",
                         inputs=inputs,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
momentum和adam优化器的multi_tensor分支中，优化FP32参数的时候会对multi_precision属性进行修改，导致FP16参数无法利用到master weight策略。
