### PR TITLE
[Dy2St]Replace comments with blank lines so that error messages are not misplaced

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -548,8 +548,10 @@ def func_to_source_code(function, dedent=True):
             "The type of 'function' should be a function or method, but received {}.".
             format(type(function).__name__))
     source_code_list, _ = inspect.getsourcelines(function)
+    # Replace comments with blank lines so that error messages are not misplaced
     source_code_list = [
-        line for line in source_code_list if not line.lstrip().startswith('#')
+        line if not line.lstrip().startswith('#') else '\n'
+        for line in source_code_list
     ]
     source_code = ''.join(source_code_list)
     if dedent:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Replace comments with blank lines so that error messages are not misplaced