### PR TITLE
[part 8]modify mean op to match ElementwiseSameDims template

### DIFF
--- a/paddle/fluid/operators/mean_op.cu
+++ b/paddle/fluid/operators/mean_op.cu
@@ -59,8 +59,7 @@ class MeanCUDAKernel : public framework::OpKernel<T> {
       return;
     }
 
-    using MT = typename details::MPTypeTrait<T>::Type;
-    using Div = kernel_primitives::DivideFunctor<T, MT>;
+    using Div = kernel_primitives::DivideFunctor<T, T>;
     std::vector<int> reduce_dims;
     reduce_dims.reserve(rank);
     for (decltype(rank) i = 0; i < rank; ++i) {

--- a/paddle/pten/kernels/gpu/math_kernel.cu
+++ b/paddle/pten/kernels/gpu/math_kernel.cu
@@ -53,21 +53,6 @@ namespace pten {
   }
 
 /**
- * Util Functors
- */
-
-template <typename T>
-struct DivideFunctor {
-  HOSTDEVICE explicit inline DivideFunctor(int n)
-      : n_inv(static_cast<T>(1.0 / n)) {}
-
-  HOSTDEVICE inline T operator()(const T x) const { return x * n_inv; }
-
- private:
-  T n_inv;
-};
-
-/**
  * Kernels
  */
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does --> modify mean op to match ElementwiseSameDims template

因 #38859 对LaunchSameDimsElementwiseCudaKernel支持不同类型输入时，发现导致mean op单测运行失败，报错如下：
![image](https://user-images.githubusercontent.com/26615455/150086180-93311b15-f31c-41d0-8185-469814cfb38d.png)

原因：在mean op中计算逻辑分为2步，首先用输入元素除以元素总数，然后再进行求和。

其中第一步，使用LaunchSameDimsElementwiseCudaKernel接口，在#38859 中输出类型是根据compute functor返回值得到的。当输入类型为fp16时，如下，除法操作是转化为fp32进行，结果也为fp32类型。而在第二步求和时，还会对第一步的结果专为fp32，再计算。
```
  HOSTDEVICE inline Ty operator()(const Tx x) const {
    return static_cast<Ty>(static_cast<MPType>(x) * n_inv);
  }
```

mean op中模版参数Ty指定为了MPType，即fp32，因此在LaunchSameDimsElementwiseCudaKernel中推断OutT为fp32类型，但是实际输出tensor类型为fp16，因此导致了运行错误。

