### PR TITLE
fix gcd and lcm data type

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3559,8 +3559,8 @@ def gcd(x, y, name=None):
         If x.shape != y.shape, they must be broadcastable to a common shape (which becomes the shape of the output).
 
     Args:
-        x (Tensor): An N-D Tensor, the data type is int8，int16，int32，int64，uint8. 
-        y (Tensor): An N-D Tensor, the data type is int8，int16，int32，int64，uint8. 
+        x (Tensor): An N-D Tensor, the data type is int32，int64. 
+        y (Tensor): An N-D Tensor, the data type is int32，int64. 
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -3621,8 +3621,8 @@ def gcd(x, y, name=None):
 
         return x
     else:
-        check_variable_and_dtype(x, 'x', ['int32', 'int64', 'int8', 'int16', 'uint8'], 'gcd')
-        check_variable_and_dtype(y, 'y', ['int32', 'int64', 'int8', 'int16', 'uint8'], 'gcd')
+        check_variable_and_dtype(x, 'x', ['int32', 'int64'], 'gcd')
+        check_variable_and_dtype(y, 'y', ['int32', 'int64'], 'gcd')
         out, _ = paddle.static.nn.while_loop(_gcd_cond_fn, _gcd_body_fn, [x, y])
         return out
 
@@ -3637,8 +3637,8 @@ def lcm(x, y, name=None):
         If x.shape != y.shape, they must be broadcastable to a common shape (which becomes the shape of the output).
 
     Args:
-        x (Tensor): An N-D Tensor, the data type is int8，int16，int32，int64，uint8. 
-        y (Tensor): An N-D Tensor, the data type is int8，int16，int32，int64，uint8. 
+        x (Tensor): An N-D Tensor, the data type is int32，int64. 
+        y (Tensor): An N-D Tensor, the data type is int32，int64. 
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
gcd和lcm的实现是在python层调用了broadcast_to，由于[broadcast_to](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/broadcast_to_cn.html#broadcast-to)支持的数据类型是：bool、float32、float64、int32或int64，即整型只支持int32和int64，所以gcd和lcm的数据类型只支持int32和int64，其他整型类型会出错。
![b11c2a13c3d0a8436f6fe442702ed7a7](https://user-images.githubusercontent.com/6836917/150098914-e4d23fd7-1a23-4aeb-9315-d7f81547a916.png)

中文文档相应修改：https://github.com/PaddlePaddle/docs/pull/4194

-----
目前broadcast_to不支持uint8,int8,int16的原因是：
- 调用的是expand_v2_op.cc里使用eigen模版，如果注册这三种类型，会出现编译失败
<img width="1265" alt="cc5488f0a23f6851edac512b61811768" src="https://user-images.githubusercontent.com/6836917/150288899-943437a9-49f1-4032-a326-93ab10e56b2b.png">

- 用eigen模版的reduce类Op，也只支持int32和int64。比如min，需要在后续考虑支持多种类型
<img width="745" alt="e787dc5d98a1651828a12ec8ada24dbd" src="https://user-images.githubusercontent.com/6836917/150288994-16384081-852c-41b1-9535-b5bf460fd817.png">