### PR TITLE
Fix gelu op compilation error on CUDA 10

### DIFF
--- a/paddle/fluid/operators/gelu_op.cu
+++ b/paddle/fluid/operators/gelu_op.cu
@@ -24,7 +24,7 @@ namespace operators {
 #ifdef __NVCC__
 template <bool FastMode>
 static __device__ __forceinline__ float FP32FastTanh(float x) {
-#if __CUDA_ARCH__ >= 750 && !defined(_WIN32)
+#if __CUDA_ARCH__ >= 750 && CUDA_VERSION >= 11000 && !defined(_WIN32)
   if (FastMode) {
     float y;
     asm("tanh.approx.f32 %0,%1; \n\t" : "=f"(y) : "f"(x));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
The PTX instruction `tanh.approx.fp32` is undefined in CUDA < 11.0. Try to fix the compilation error on CUDA 10.x container due to https://github.com/PaddlePaddle/Paddle/pull/38980 .