### PR TITLE
Disable the accuracy test in op benchmark ci temporary, because ci will not fail when accuracy check failed.

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_add_op.cu
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op.cu
@@ -20,7 +20,6 @@ namespace plat = paddle::platform;
 namespace paddle {
 namespace operators {
 
-// Add comment to test ci.
 template <typename T>
 static __global__ void SimpleElemwiseAddGradCUDAKernel(
     const T* __restrict__ dout, int size, int vec_size, T* dx, T* dy) {

--- a/paddle/fluid/operators/elementwise/elementwise_add_op.cu
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op.cu
@@ -20,6 +20,7 @@ namespace plat = paddle::platform;
 namespace paddle {
 namespace operators {
 
+// Add comment to test ci.
 template <typename T>
 static __global__ void SimpleElemwiseAddGradCUDAKernel(
     const T* __restrict__ dout, int size, int vec_size, T* dx, T* dy) {

--- a/tools/ci_op_benchmark.sh
+++ b/tools/ci_op_benchmark.sh
@@ -175,7 +175,7 @@ function run_op_benchmark_test {
     echo "$api_info" >> $api_info_file
   done
   # install tensorflow for testing accuary
-  pip install tensorflow==2.3.0 tensorflow-probability
+  # pip install tensorflow==2.3.0 tensorflow-probability
   for branch_name in "dev_whl" "pr_whl"
   do
     LOG "[INFO] Uninstall Paddle ..."
@@ -190,7 +190,7 @@ function run_op_benchmark_test {
                                 $logs_dir \
                                 $VISIBLE_DEVICES \
                                 "gpu" \
-                                "both" \
+                                "speed" \
                                 $api_info_file \
                                 "paddle"
     popd > /dev/null


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
当前OP Benchmark CI会安装tf、与tf对比计算精度，但是结果不一致时，CI不会fail，反而浪费了CI时间。因OP Benchmark CI主要负责监控性能，当前框架大面积重构，容易出现大PR，导致OP Benchmark CI超时fail。故先关闭OP Benchmark CI中的精度测试，见[测试CI log](https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/4600958/job/11181296)。