### PR TITLE
Try to remove if !defined(WIN32) macro guard for fast gelu

### DIFF
--- a/paddle/fluid/operators/gelu_op.cu
+++ b/paddle/fluid/operators/gelu_op.cu
@@ -24,7 +24,7 @@ namespace operators {
 #ifdef __NVCC__
 template <bool FastMode>
 static __device__ __forceinline__ float FP32FastTanh(float x) {
-#if __CUDA_ARCH__ >= 750 && CUDA_VERSION >= 11000 && !defined(_WIN32)
+#if __CUDA_ARCH__ >= 750 && CUDA_VERSION >= 11000
   if (FastMode) {
     float y;
     asm("tanh.approx.f32 %0,%1; \n\t" : "=f"(y) : "f"(x));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
OPs

### Describe
Try to remove if !defined(WIN32) macro guard for fast gelu. Windows should have `tanh.approx.f32` PTX instruction as well.