### PR TITLE
Add Cumsum compute API in Kernel Primitives

### DIFF
--- a/paddle/fluid/operators/kernel_primitives/compute_primitives.h
+++ b/paddle/fluid/operators/kernel_primitives/compute_primitives.h
@@ -386,6 +386,39 @@ __device__ __forceinline__ void Reduce(T* out, const T* in,
   }
 }
 
+// attention please set share_size = blockDim.x;
+// data and b are the register pointer
+#define shared_size 64
+template <typename InT, typename OutT, int NX, int NY, int BlockSize,
+          class OpFunc>
+__device__ __forceinline__ void cumsum(OutT* out, const InT* in,
+                                       OpFunc compute) {
+  __shared__ InT temp[shared_size * 2 + (shared_size * 2) / 32];
+  int tidx = threadIdx.x;
+  temp[tidx + tidx / 32] = data[0];
+  temp[shared_size + tidx + (shared_size + tidx) / 32] = data[1];
+  for (int stride = 1; stride <= blockDim.x; stride *= 2) {
+    __syncthreads();
+    int index = (tidx + 1) * 2 * stride - 1;
+    if (index < (blockDim.x * 2)) {
+      temp[index + index / 32] += temp[index - stride + (index - stride) / 32];
+    }
+  }
+  for (int stride = (blockDim.x * 2) / 4; stride > 0; stride /= 2) {
+    __syncthreads();
+    int index = (tidx + 1) * 2 * stride - 1;
+    if ((index + stride) < (blockDim.x * 2)) {
+      temp[index + stride + (stride + index) / 32] +=
+          temp[index + (index) / 32];
+    }
+  }
+
+  __syncthreads();
+  out[0] = static_cast<OutT>(temp[tidx + tidx / 32]);
+  out[1] =
+      static_cast<OutT>(temp[tidx + shared_size + (tidx + shared_size) / 32]);
+}
+
 }  // namespace kernel_primitives
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/kernel_primitives/compute_primitives.h
+++ b/paddle/fluid/operators/kernel_primitives/compute_primitives.h
@@ -395,8 +395,8 @@ __device__ __forceinline__ void cumsum(OutT* out, const InT* in,
                                        OpFunc compute) {
   __shared__ InT temp[shared_size * 2 + (shared_size * 2) / 32];
   int tidx = threadIdx.x;
-  temp[tidx + tidx / 32] = data[0];
-  temp[shared_size + tidx + (shared_size + tidx) / 32] = data[1];
+  temp[tidx + tidx / 32] = in[0];
+  temp[shared_size + tidx + (shared_size + tidx) / 32] = in[1];
   for (int stride = 1; stride <= blockDim.x; stride *= 2) {
     __syncthreads();
     int index = (tidx + 1) * 2 * stride - 1;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add Cumsum compute API in Kernel Primitives

benchmark异常说明：
本 PR 属于新增 API ，目前并没有OP使用。OP-benchmark CI 中错误OP与本次修改无关：

2022-01-21 19:26:34 [check_op_benchmark_result.py:153] [ERROR] Check speed result with case "matmul_8 (backward)" failed.
2022-01-21 19:26:34 [check_op_benchmark_result.py:153] [ERROR] Check speed result with case "matmul_8 (forward)" failed.
2022-01-21 19:26:34 [check_op_benchmark_result.py:153] [ERROR] Check speed result with case "max_2 (backward)" failed.