### PR TITLE
Fix the bug of SetAllocationForOutputTenosr

### DIFF
--- a/paddle/pten/core/dense_tensor.cc
+++ b/paddle/pten/core/dense_tensor.cc
@@ -231,9 +231,14 @@ void DenseTensor::ResetHolder(const std::shared_ptr<pten::Allocation>& holder) {
           "Only the offset is supported to zero when the holder is reset."));
 
   if (holder_) {
+    // TODO(zyfncg): The change of static_cast<> in check will recover back
+    // when SetAllocationForOutputTenosr is deleted.
+    // Now the numel() may return -1, and will cast to a very large number when
+    // compare with a data with unsigned long type, this will make checking
+    // failed, so it's a temporary solution to deal with this problem.
     PADDLE_ENFORCE_LE(
-        numel() * SizeOf(dtype()) + meta_.offset,
-        holder->size(),
+        numel() * static_cast<int64_t>(SizeOf(dtype())),
+        static_cast<int64_t>(holder->size()),
         paddle::platform::errors::InvalidArgument(
             "The size of Holder is not enough to store the Tensor."));
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复SetAllocationForOutputTenosr在调用ResetHolder时Check无法通过的问题，具体错误信息如下：
![image](https://user-images.githubusercontent.com/13048366/150756607-91db65c5-c83b-4295-8c4b-3facf881f0cc.png)
