### PR TITLE
[Custom Ops]Assert _compile_dir/includes.txt existence

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -449,7 +449,7 @@ def _get_include_dirs_when_compiling(compile_dir):
     include_dirs_file = 'includes.txt'
     path = os.path.abspath(compile_dir)
     include_dirs_file = os.path.join(path, include_dirs_file)
-    assert os.path.isfile(include_dirs_file), "{} not exists".format(
+    assert os.path.isfile(include_dirs_file), "File {} does not exist".format(
         include_dirs_file)
     with open(include_dirs_file, 'r') as f:
         include_dirs = [line.strip() for line in f.readlines() if line.strip()]

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -449,8 +449,8 @@ def _get_include_dirs_when_compiling(compile_dir):
     include_dirs_file = 'includes.txt'
     path = os.path.abspath(compile_dir)
     include_dirs_file = os.path.join(path, include_dirs_file)
-    if not os.path.isfile(include_dirs_file):
-        return []
+    assert os.path.isfile(include_dirs_file), "{} not exists".format(
+        include_dirs_file)
     with open(include_dirs_file, 'r') as f:
         include_dirs = [line.strip() for line in f.readlines() if line.strip()]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Add assertion that `_compile_dir/includes.txt` must exist to find errors asap.  Related to https://github.com/PaddlePaddle/Paddle/pull/38211 .