### PR TITLE
GetWorkspaceSize trigger modfication in heuristic cudnn conv

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -502,7 +502,8 @@ struct SearchAlgorithm<cudnnConvolutionBwdFilterAlgoPerf_t> {
               args.cdesc.desc(), args.wdesc.desc(), kNUM_CUDNN_BWD_FILTER_ALGS,
               &perf_count, perf_results.get()));
       algo = (perf_results.get())[best_algo_idx].algo;
-      workspace_size = GetWorkspaceSize(args, algo);
+      workspace_size = (perf_results.get())[best_algo_idx].memory;
+
       if (workspace_size > workspace_size_limit) {
         workspace_size = workspace_size_limit;
 #if CUDNN_VERSION >= 8000

--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -251,7 +251,7 @@ struct SearchAlgorithm<cudnnConvolutionFwdAlgoPerf_t> {
               args.cdesc.desc(), args.odesc.desc(), kNUM_CUDNN_FWD_ALGS,
               &perf_count, perf_results.get()));
       algo = (perf_results.get())[best_algo_idx].algo;
-      workspace_size = GetWorkspaceSize(args, algo);
+      workspace_size = (perf_results.get())[best_algo_idx].memory;
 
       if (workspace_size > workspace_size_limit) {
 #if CUDNN_VERSION >= 8000


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- Once interface `cudnnGetConvolutionForwardAlgorithm_v7`  was done, structures included in `perf_results` really recorded resource consumed by every cudnn_conv_algotithm, therefore, `GetWorkspaceSize`  seems to be redundant, and return value of `GetWorkspaceSize`  is equal with `(perf_results.get)[0].memory` according to conv2d tests both in op benchmark and ctest.