### PR TITLE
Fix slice error in jit.to_static mode

### DIFF
--- a/paddle/fluid/operators/slice_op.h
+++ b/paddle/fluid/operators/slice_op.h
@@ -334,7 +334,7 @@ class SliceGradKernel : public framework::OpKernel<T> {
     auto decrease_axis = ctx.Attr<std::vector<int>>("decrease_axis");
     auto decrease_size = decrease_axis.size();
     if (decrease_size > 0) {
-      if (decrease_size == static_cast<size_t>(in_dims.size()) {
+      if (decrease_size == static_cast<size_t>(in_dims.size())) {
         // all dims decrease
         std::vector<int> origin_out_shape(decrease_size, 1);
         out_dims = framework::make_ddim(std::vector<int>(decrease_size, 1));

--- a/paddle/fluid/operators/slice_op.h
+++ b/paddle/fluid/operators/slice_op.h
@@ -43,6 +43,10 @@ inline void DealTensorArray(const framework::ExecutionContext& ctx,
   end = std::max(end, static_cast<int64_t>(0));
   end = std::min(end, in_size);
 
+  if (starts[0] == -1 && end == 0) {
+    end = start + 1;
+  }
+
   PADDLE_ENFORCE_GT(end, start,
                     platform::errors::InvalidArgument(
                         "Attr(ends) should be greater than attr(starts) in "
@@ -330,7 +334,7 @@ class SliceGradKernel : public framework::OpKernel<T> {
     auto decrease_axis = ctx.Attr<std::vector<int>>("decrease_axis");
     auto decrease_size = decrease_axis.size();
     if (decrease_size > 0) {
-      if (decrease_size == (size_t)in_dims.size()) {
+      if (decrease_size == static_cast<size_t>(in_dims.size()) {
         // all dims decrease
         std::vector<int> origin_out_shape(decrease_size, 1);
         out_dims = framework::make_ddim(std::vector<int>(decrease_size, 1));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
修复动转静下tensor arrya使用Slice索引异常的问题。错误信息如下：

![image](https://user-images.githubusercontent.com/13048366/151167923-edeafcb8-bc2b-478e-a9c8-ac6e74d01e56.png)
