### PR TITLE
Replace EigenBroadcast with ElementwiseBroadcast in ReduceGrad

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op.part.cu
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op.part.cu
@@ -17,15 +17,9 @@
 
 template <typename T>
 using CUDAReduceMeanGradKernel =
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, T,
-                          ops::MeanGradFunctor, true>;
-
-using FP16CUDAReduceMeanGradKernel =
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext,
-                          paddle::platform::float16, ops::FP16MeanGradFunctor,
-                          true>;
+    ops::ReduceCudaGradKernel<T, kps::DivideFunctor>;
 
 REGISTER_OP_CUDA_KERNEL(reduce_mean_grad, CUDAReduceMeanGradKernel<bool>,
-                        FP16CUDAReduceMeanGradKernel,
+                        CUDAReduceMeanGradKernel<paddle::platform::float16>,
                         CUDAReduceMeanGradKernel<float>,
                         CUDAReduceMeanGradKernel<double>);

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
@@ -50,7 +50,7 @@ class ReduceSumOpGradMaker : public framework::SingleGradOpMaker<T> {
 
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const {
-    int in_dtype = ctx.Attr<int>("in_dtype");
+    int in_dtype = ctx.Attr<int>("out_dtype");
     if (in_dtype >= 0) {
       return framework::OpKernelType(
           static_cast<framework::proto::VarType::Type>(in_dtype),

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.h
@@ -74,7 +74,7 @@ class ReduceSumGradKernel : public framework::OpKernel<T> {
     auto dims = context.Attr<std::vector<int>>("dim");
     if (context.GetPlace().GetType() == platform::CPUPlace().GetType() &&
         dims.size() == 1) {
-      int in_dtype = context.Attr<int>("in_dtype");
+      int in_dtype = context.Attr<int>("out_dtype");
 
       if (in_dtype >= 0) {
         Tensor tmp_tensor;

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.part.cu
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.part.cu
@@ -17,8 +17,7 @@
 
 template <typename T>
 using CUDAReduceSumGradKernel =
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, T,
-                          ops::SumGradFunctor, true>;
+    ops::ReduceCudaGradKernel<T, kps::IdentityFunctor>;
 
 REGISTER_OP_CUDA_KERNEL(
     reduce_sum_grad, CUDAReduceSumGradKernel<bool>,

--- a/paddle/pten/kernels/gpu/elementwise.h
+++ b/paddle/pten/kernels/gpu/elementwise.h
@@ -134,12 +134,19 @@ struct DimensionsTransform {
   explicit DimensionsTransform(const std::vector<const DenseTensor *> &ins,
                                const pten::framework::DDim &dims,
                                int axis) {
-    const int N = ins.size();
+    const int N = max(static_cast<int>(ins.size()), 2);
     dim_size = dims.size();
     out_dims = pten::framework::vectorize<int64_t>(dims);
     in_dims.resize(N);
-    for (int j = 0; j < N; ++j) {
-      in_dims[j] = pten::framework::vectorize<int64_t>(ins[j]->dims());
+    if (ins.size() == 1) {
+      // when ins.size() = 1, broadcast input to output
+      in_dims[0] = pten::framework::vectorize<int64_t>(ins[0]->dims());
+      in_dims[1] = out_dims;
+      // Add out_dims to in_dims to avoid errors in dims merging
+    } else {
+      for (int j = 0; j < N; ++j) {
+        in_dims[j] = pten::framework::vectorize<int64_t>(ins[j]->dims());
+      }
     }
     InputDimensionsExtend(N, axis);
 

--- a/paddle/pten/kernels/gpu/reduce_grad.h
+++ b/paddle/pten/kernels/gpu/reduce_grad.h
@@ -41,3 +41,4 @@ void ReduceGrad(const GPUContext& dev_ctx,
       }));
 }
 }  // namespace pten
+#endif

--- a/paddle/pten/kernels/gpu/reduce_grad.h
+++ b/paddle/pten/kernels/gpu/reduce_grad.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// CUDA and HIP use same api
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <set>
+#include <vector>
+#include "paddle/pten/kernels/gpu/elementwise.h"
+namespace pten {
+template <typename InT, typename Functor>
+void ReduceGrad(const GPUContext& dev_ctx,
+                DenseTensor* d_out,
+                DenseTensor* d_x,
+                DataType out_dtype,
+                Functor functor) {
+  std::vector<const DenseTensor*> inputs = {d_out};
+  std::vector<DenseTensor*> outputs = {d_x};
+  PD_VISIT_ALL_TYPES(
+      out_dtype, "LaunchBroadcastElementwiseCudaKernel", ([&] {
+        LaunchBroadcastElementwiseCudaKernel<pten::ElementwiseType::kUnary,
+                                             InT,
+                                             data_t>(
+            dev_ctx, inputs, &outputs, 0, functor);
+      }));
+}
+}  // namespace pten


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Reduce EigenBroadcastcase with ElementwiseBroadcast in ReduceGrad
为扩大KP算子覆盖率，统一将Reduce_sum/mean 反向的Eigen适配代码替换为ElementwiseBroadcast Kernel
ReduceGrad 性能统计对比：

op name | case | axise | dtype | 优化前 （us) | 优化后 （us) | speed   up
-- | -- | -- | -- | -- | -- | --
reduce_sum_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float32 | 626 | 160.73 | 3.89
reduce_sum_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float16 | 633 | 83.64 | 7.57
reduce_sum_grad | [-1L, 8L, 128L] | [1] | float32 | 2.44 | 1.71 | 1.43
reduce_sum_grad | [-1L, 8L, 128L] | [1] | float16 | 2.84 | 1.7 | 1.67
reduce_sum_grad | [30522L, 1024L] | [] | float32 | 150.38 | 138.79 | 1.08
reduce_sum_grad | [30522L, 1024L] | [] | float16 | 89.81 | 43.44 | 2.07
op name | case | axise | dtype | 优化前 （us) | 优化后 （us) | speed up
reduce_mean_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float32 | 672 | 160.71 | 4.18
reduce_mean_grad | [-1L, 2048L, 33L, 33L] | [2,3] | float16 | 681 | 83.1 | 8.19
reduce_mean_grad | [-1L, 8L, 128L] | [1] | float32 | 3.115 | 1.72 | 1.81
reduce_mean_grad | [-1L, 8L, 128L] | [1] | float16 | 3.171 | 1.66 | 1.91
reduce_mean_grad | [30522L, 1024L] | [] | float32 | 152.78 | 138.83 | 1.10
reduce_mean_grad | [30522L, 1024L] | [] | float16 | 134.96 | 69.835 | 1.93

benchmark 异常说明，与本次PR修改无关，本地测试无性能影响：

op   name | shape | dtype | dev (us) | new (us) | speed up
-- | -- | -- | -- | -- | --
p_norm_1 backward | [300, 128, 128], axis = -1 porder = 3.0 | float32 | 178.26 | 178.06 | 1.00112322
matmul_3_backward | [paddle][p_norm] p_norm {       run_tf: True       run_torch: True       axis: -1       porder: 3.0       keepdim: False       x_shape: [300, 128, 128]       x_dtype: float32       atol: 1e-06     [paddle][p_norm] p_norm {       run_tf: True       run_torch: True       axis: -1       porder: 3.0       keepdim: False       x_shape: [300, 128, 128]       x_dtype: float32       atol: 1e-06 | float32 | 12.7867 | 12.865 | 0.99391372
matmul_9_forward | [paddle][matmul] matmul {       run_tf: True       run_torch: True       atol: 1.0       transpose_x: False       transpose_y: False       x_shape: [4, 12, 64, 85]       x_dtype: float16       y_shape: [4, 12, 85, 512]       y_dtype: float16     } | float32 | 26.165 | 26.146 | 1.00072669

op name | xshape | yshape | type | dev us | new (us) | speed up
-- | -- | -- | -- | -- | -- | --
matmul_0_backward | [16, 128, 8] | [16, 8, 32] | float32 | 26.96 | 26.934 | 1.00
matmul_0_forward |   |   |   | 6.126 | 6.128 | 1.00

op name | axise | dtype | shape | dev (us) | new (us) | speed up
-- | -- | -- | -- | -- | -- | --
sum | [1] | float32 | [16, 8, 128] | 1.546 | 1.525 | 0.99



