### PR TITLE
Remove PADDLE_WITH_TESTING macro for GetGpuBasePtr

### DIFF
--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -244,17 +244,20 @@ class RecordedGpuMallocHelper {
 #endif
   }
 
-#ifdef PADDLE_WITH_TESTING
   void *GetBasePtr(void *ptr) {
+#ifdef PADDLE_WITH_TESTING
     auto it = gpu_ptrs.upper_bound(ptr);
-
     if (it == gpu_ptrs.begin()) {
       return nullptr;
     }
-
     return *(--it);
-  }
+#else
+    PADDLE_THROW(platform::errors::Unimplemented(
+        "The RecordedGpuMallocHelper::GetBasePtr is only implemented with "
+        "testing, should not use for release."));
+    return nullptr;
 #endif
+  }
 
   bool GetMemInfo(size_t *avail, size_t *total, size_t *actual_avail,
                   size_t *actual_total) {
@@ -375,11 +378,9 @@ void EmptyCache(void) {
   }
 }
 
-#ifdef PADDLE_WITH_TESTING
 void *GetGpuBasePtr(void *ptr, int dev_id) {
   return RecordedGpuMallocHelper::Instance(dev_id)->GetBasePtr(ptr);
 }
-#endif
 
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/device/gpu/gpu_info.h
+++ b/paddle/fluid/platform/device/gpu/gpu_info.h
@@ -145,10 +145,9 @@ bool IsGpuMallocRecorded(int dev_id);
 //! Empty idle cached memory held by the allocator.
 void EmptyCache(void);
 
-//! Get the primitive pointer return from cudaMalloc, just for testing
-#ifdef PADDLE_WITH_TESTING
+//! Get the primitive pointer return from cudaMalloc, just implemented with
+//! testing, do not use for release
 void *GetGpuBasePtr(void *ptr, int dev_id);
-#endif
 
 }  // namespace platform
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
The macro PADDLE_WITH_TESTING in _gpu_info.h_ has a negative impact on the optimization of CI compilation speed, this PR removes it.