### PR TITLE
fix FakeQuantAbsMax in QAT

### DIFF
--- a/python/paddle/nn/quant/quant_layers.py
+++ b/python/paddle/nn/quant/quant_layers.py
@@ -67,7 +67,7 @@ class FakeQuantAbsMax(layers.Layer):
         if quant_on_weight:
             scale_attr = ParamAttr(
                 name=self._scale_name,
-                initializer=Constant(0.0),
+                initializer=Constant(0.001),
                 trainable=False)
             self._scale = self.create_parameter(
                 shape=[1], attr=scale_attr, dtype=self._dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix abs_max scale initialization problem in QAT.