### PR TITLE
change dtype of pooling mask to 'int32' for Paddle2ONNX

### DIFF
--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -611,7 +611,7 @@ def max_pool1d(x,
     helper = LayerHelper(op_type, **locals())
     dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
-    mask = helper.create_variable_for_type_inference(dtype)
+    mask = helper.create_variable_for_type_inference('int32')
     outputs = {"Out": pool_out, "Mask": mask}
 
     helper.append_op(
@@ -1053,7 +1053,7 @@ def max_pool2d(x,
                              'max_pool2d')
     dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
-    mask = helper.create_variable_for_type_inference(dtype)
+    mask = helper.create_variable_for_type_inference("int32")
     outputs = {"Out": pool_out, "Mask": mask}
 
     helper.append_op(
@@ -1183,7 +1183,7 @@ def max_pool3d(x,
     check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'max_pool3d')
     dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
-    mask = helper.create_variable_for_type_inference(dtype)
+    mask = helper.create_variable_for_type_inference('int32')
     outputs = {"Out": pool_out, "Mask": mask}
 
     helper.append_op(
@@ -1559,7 +1559,7 @@ def adaptive_max_pool1d(x, output_size, return_mask=False, name=None):
     dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
-    mask = helper.create_variable_for_type_inference(dtype)
+    mask = helper.create_variable_for_type_inference('int32')
     outputs = {"Out": pool_out, "Mask": mask}
 
     helper.append_op(
@@ -1647,7 +1647,7 @@ def adaptive_max_pool2d(x, output_size, return_mask=False, name=None):
     dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
-    mask = helper.create_variable_for_type_inference(dtype)
+    mask = helper.create_variable_for_type_inference('int32')
     outputs = {"Out": pool_out, "Mask": mask}
 
     helper.append_op(
@@ -1740,7 +1740,7 @@ def adaptive_max_pool3d(x, output_size, return_mask=False, name=None):
     dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
-    mask = helper.create_variable_for_type_inference(dtype)
+    mask = helper.create_variable_for_type_inference('int32')
     outputs = {"Out": pool_out, "Mask": mask}
 
     helper.append_op(

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -1144,7 +1144,6 @@ def max_pool3d(x,
                                           return_mask=True)
             # output.shape [None, 3, 16, 16, 16], max_indices.shape [None, 3, 16, 16, 16],
     """
-    
     kernel_size = utils.convert_to_list(kernel_size, 3, 'pool_size')
     if stride is None:
         stride = kernel_size

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -1144,6 +1144,7 @@ def max_pool3d(x,
                                           return_mask=True)
             # output.shape [None, 3, 16, 16, 16], max_indices.shape [None, 3, 16, 16, 16],
     """
+    
     kernel_size = utils.convert_to_list(kernel_size, 3, 'pool_size')
     if stride is None:
         stride = kernel_size


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 APIs 

### Describe
<!-- Describe what this PR does -->
Paddle2ONNX同学反馈，需要使用mask作为index，这里应该为int32类型。并且，pooling静态图的mask均为int32类型
