### PR TITLE
[Bug fix] Fixed immutable op quantization when non-quantizable op exists in multiple followed ops

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1592,11 +1592,8 @@ PDNode *patterns::Transpose::operator()() {
                            ->AsOutput()
                            ->assert_is_op_output("transpose2", "Out");
 
-  auto next_op = pattern->NewNode(next_op_repr())->assert_is_op();
-
   prev_op->LinksTo({transpose_in});
   transpose_op->LinksFrom({transpose_in}).LinksTo({transpose_out});
-  next_op->LinksFrom({transpose_out});
   return transpose_out;
 }
 
@@ -1613,11 +1610,8 @@ PDNode *patterns::Reshape::operator()() {
                          ->AsOutput()
                          ->assert_is_op_output("reshape2", "Out");
 
-  auto next_op = pattern->NewNode(next_op_repr())->assert_is_op();
-
   prev_op->LinksTo({reshape_in});
   reshape_op->LinksFrom({reshape_in}).LinksTo({reshape_out});
-  next_op->LinksFrom({reshape_out});
   return reshape_out;
 }
 
@@ -1633,11 +1627,8 @@ PDNode *patterns::Slice::operator()() {
                        ->AsOutput()
                        ->assert_is_op_output("slice", "Out");
 
-  auto next_op = pattern->NewNode(next_op_repr())->assert_is_op();
-
   prev_op->LinksTo({slice_in});
   slice_op->LinksFrom({slice_in}).LinksTo({slice_out});
-  next_op->LinksFrom({slice_out});
   return slice_out;
 }
 
@@ -1658,12 +1649,9 @@ PDNode *patterns::NearestInterp::operator()() {
           ->assert_is_ops_output({"nearest_interp", "nearest_interp_v2"},
                                  "Out");
 
-  auto next_op = pattern->NewNode(next_op_repr())->assert_is_op();
-
   prev_op->LinksTo({nearest_interp_in});
   nearest_interp_op->LinksFrom({nearest_interp_in})
       .LinksTo({nearest_interp_out});
-  next_op->LinksFrom({nearest_interp_out});
   return nearest_interp_out;
 }
 

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -963,7 +963,6 @@ struct Transpose : public PatternBase {
   PATTERN_DECL_NODE(transpose_in);
   PATTERN_DECL_NODE(transpose_op);
   PATTERN_DECL_NODE(transpose_out);
-  PATTERN_DECL_NODE(next_op);
 };
 
 // Reshape op
@@ -978,7 +977,6 @@ struct Reshape : public PatternBase {
   PATTERN_DECL_NODE(reshape_in);
   PATTERN_DECL_NODE(reshape_op);
   PATTERN_DECL_NODE(reshape_out);
-  PATTERN_DECL_NODE(next_op);
 };
 // Slice op
 // Forward pass for slice.
@@ -992,7 +990,6 @@ struct Slice : public PatternBase {
   PATTERN_DECL_NODE(slice_in);
   PATTERN_DECL_NODE(slice_op);
   PATTERN_DECL_NODE(slice_out);
-  PATTERN_DECL_NODE(next_op);
 };
 
 // Nearest Interp op
@@ -1007,7 +1004,6 @@ struct NearestInterp : public PatternBase {
   PATTERN_DECL_NODE(nearest_interp_in);
   PATTERN_DECL_NODE(nearest_interp_op);
   PATTERN_DECL_NODE(nearest_interp_out);
-  PATTERN_DECL_NODE(next_op);
 };
 
 // Matmul op

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -265,14 +265,12 @@ bool CPUQuantizePass::IsOpDequantized(const Node* node) const {
 }
 
 bool CPUQuantizePass::IsOpQuantized(const Node* node) const {
-  // Check if all the following operators are quantized
-  for (auto output : node->outputs) {
-    if (!output->IsOp() ||
-        !(output->Op()->Type() == "quantize" ||
-          platform::HasOpINT8DataType(output->Op())))
-      return false;
-  }
-  return true;
+  // return true only if all of outputs are ops and their are either quantize or
+  // have int8 data type
+  return all_of(node->outputs.begin(), node->outputs.end(), [](Node* output) {
+    return (output->IsOp() && (output->Op()->Type() == "quantize" ||
+                               platform::HasOpINT8DataType(output->Op())));
+  });
 }
 
 void CPUQuantizePass::QuantizeConv(Graph* graph,

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
@@ -371,7 +371,7 @@ TEST(CpuQuantizePass, fusion_lstm) {
 }
 
 static const std::initializer_list<std::string> variable_names_immutable_ops = {
-    "a", "w1", "b", "c", "d"};
+    "a", "w1", "b", "c", "d", "e", "f", "g"};
 
 // a->Dequantize->b
 // b->Tested Op->c
@@ -417,10 +417,46 @@ void TestImmutableOpBetweenNonQuantizedOp(const std::string tested_op) {
            SCALE * S8_MAX);
 }
 
+// a->Dropout1->b
+// b->TestedOp1(not quantized)->c
+//    c->Dropout2->d
+//    c->TestedOp2(quantized)->e
+//        e->Pool2d1(quantized)->f
+//        e->Pool2d2(quantized)->g
+void TestImmutableOpWithManyOutputs(const std::string tested_op) {
+  ProgramDesc prog;
+  for (auto& v : variable_names_immutable_ops) {
+    prog.MutableBlock(0)->Var(v);
+  }
+
+  SetOp(&prog, "dropout", "Dropout1", {"a"}, {"b"}, true, "float32");
+  SetOp(&prog, tested_op, std::string(tested_op + "1"), {"b"}, {"c"}, true,
+        "int8");
+  SetOp(&prog, "dropout", "Dropout2", {"c"}, {"d"}, true, "float32");
+  SetOp(&prog, tested_op, std::string(tested_op + "2"), {"c"}, {"e"}, true,
+        "int8");
+  SetOp(&prog, "pool2d", "Pool2d1", {"e"}, {"f"}, true, "int8");
+  SetOp(&prog, "pool2d", "Pool2d2", {"e"}, {"g"}, true, "int8");
+
+  // 3 Quant + 3 IN + 3 DeQuant + 3 OUT
+  int added_nodes = 12;
+  std::unordered_map<std::string, int> expected_operators = {{tested_op, 2},
+                                                             {"dropout", 2},
+                                                             {"pool2d", 2},
+                                                             {"quantize", 3},
+                                                             {"dequantize", 3}};
+  MainTest(prog, variable_names_immutable_ops, expected_operators, added_nodes,
+           SCALE * S8_MAX);
+}
+
 TEST(CpuQuantizePass, reshape2) { TestImmutableOp("reshape2"); }
 
 TEST(CpuQuantizePass, reshape2BetweenNonQuantizedOp) {
   TestImmutableOpBetweenNonQuantizedOp("reshape2");
+}
+
+TEST(CpuQuantizePass, reshape2WithManyOutputs) {
+  TestImmutableOpWithManyOutputs("reshape2");
 }
 
 TEST(CpuQuantizePass, transpose2) { TestImmutableOp("transpose2"); }
@@ -429,10 +465,18 @@ TEST(CpuQuantizePass, transpose2BetweenNonQuantizedOp) {
   TestImmutableOpBetweenNonQuantizedOp("transpose2");
 }
 
+TEST(CpuQuantizePass, transpose2WithManyOutputs) {
+  TestImmutableOpWithManyOutputs("transpose2");
+}
+
 TEST(CpuQuantizePass, slice) { TestImmutableOp("slice"); }
 
 TEST(CpuQuantizePass, sliceBetweenNonQuantizedOp) {
   TestImmutableOpBetweenNonQuantizedOp("slice");
+}
+
+TEST(CpuQuantizePass, sliceWithManyOutputs) {
+  TestImmutableOpWithManyOutputs("slice");
 }
 
 TEST(CpuQuantizePass, nearestInterp) { TestImmutableOp("nearest_interp"); }
@@ -441,10 +485,18 @@ TEST(CpuQuantizePass, nearestInterpBetweenNonQuantizedOp) {
   TestImmutableOpBetweenNonQuantizedOp("nearest_interp");
 }
 
+TEST(CpuQuantizePass, nearestInterpWithManyOutputs) {
+  TestImmutableOpWithManyOutputs("nearest_interp");
+}
+
 TEST(CpuQuantizePass, nearestInterpV2) { TestImmutableOp("nearest_interp_v2"); }
 
 TEST(CpuQuantizePass, nearestInterpV2BetweenNonQuantizedOp) {
   TestImmutableOpBetweenNonQuantizedOp("nearest_interp_v2");
+}
+
+TEST(CpuQuantizePass, nearestInterpV2WithManyOutputs) {
+  TestImmutableOpWithManyOutputs("nearest_interp_v2");
 }
 
 static const std::initializer_list<std::string> variable_names_matmul = {

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
@@ -36,7 +36,7 @@ void SetOp(ProgramDesc* prog, const std::string& type, const std::string& name,
   op->SetType(type);
   op->SetAttr("use_mkldnn", use_mkldnn);
   op->SetAttr("name", name);
-  if (type != "dropout" || type != "quantize" || type != "dequantize") {
+  if (type != "dropout" && type != "quantize" && type != "dequantize") {
     op->SetAttr("mkldnn_data_type", mkldnn_data_type);
   }
 
@@ -418,11 +418,11 @@ void TestImmutableOpBetweenNonQuantizedOp(const std::string tested_op) {
 }
 
 // a->Dropout1->b
-// b->TestedOp1(not quantized)->c
+// b->TestedOp1(won't be quantized)->c
 //    c->Dropout2->d
-//    c->TestedOp2(quantized)->e
-//        e->Pool2d1(quantized)->f
-//        e->Pool2d2(quantized)->g
+//    c->TestedOp2(will be quantized)->e
+//        e->Pool2d1(will be quantized)->f
+//        e->Pool2d2(will be quantized)->g
 void TestImmutableOpWithManyOutputs(const std::string tested_op) {
   ProgramDesc prog;
   for (auto& v : variable_names_immutable_ops) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
This PR: 
- fixes problem for many output operators, 
- adds UT for the mentioned problem,
- adds missing descriptions for some logs in `cpu_quantize_pass`


There was a problem in quantizing the picodet_m_416_coco model. For operators such as reshape2, transpose2, slice, and nearest_interp/v2, it is necessary to check if there are quantized operators before or after the operator because quantizing these operators alone does not give you any speed up. So in `cpu_quantize_pass` we look for the pattern `prev_op`->`op`->`next_op` to check it. It turned out that the solution did not support a situation where there are not one but many operators after the op. This PR fixes that. 

