### PR TITLE
Add Tensor._ptr() method in pybind

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -758,6 +758,10 @@ PYBIND11_MODULE(core_noavx, m) {
   framework_tensor
       .def("__array__",
            [](framework::Tensor &self) { return TensorToPyArray(self); })
+      .def("_ptr",
+           [](const framework::Tensor &self) {
+             return reinterpret_cast<uintptr_t>(self.data());
+           })
       .def("_is_initialized",
            [](const framework::Tensor &self) { return self.IsInitialized(); })
       .def("_get_dims",

--- a/python/paddle/fluid/tests/unittests/test_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor.py
@@ -21,6 +21,14 @@ import numpy
 import numbers
 
 
+class TestTensorPtr(unittest.TestCase):
+    def test_tensor_ptr(self):
+        t = core.Tensor()
+        np_arr = numpy.zeros([2, 3])
+        t.set(np_arr, core.CPUPlace())
+        self.assertGreater(t._ptr(), 0)
+
+
 class TestTensor(unittest.TestCase):
     def setUp(self):
         self.support_dtypes = [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Add `Tensor._ptr()` method in pybind.