### PR TITLE
get build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,15 @@ option(NEW_RELEASE_CUBIN   "PaddlePaddle next-level release strategy for pypi cu
 option(NEW_RELEASE_JIT   "PaddlePaddle next-level release strategy for backup jit package"             OFF)
 option(WITH_ASCEND_INT64 "Compile with int64 kernel for ascend NPU"    OFF)
 option(WITH_POCKETFFT    "Compile with pocketfft support"      ON)
+option(WITH_RECORD_BUILDTIME    "Compile PaddlePaddle with record all targets build time"       OFF)
+
+if(WITH_RECORD_BUILDTIME)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_CURRENT_SOURCE_DIR}/tools/get_build_time.sh")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CMAKE_CURRENT_SOURCE_DIR}/tools/get_build_time.sh")
+else()            
+    include(ccache) # set ccache for compilation ; if WITH_RECORD_BUILDTIME=ON can't use ccache
+endif()
+unset(WITH_RECORD_BUILDTIME CACHE)
 
 # PY_VERSION
 if(NOT PY_VERSION)
@@ -382,7 +391,6 @@ if(WITH_PROFILER)
     add_definitions(-DWITH_GPERFTOOLS)
 endif()
 
-include(ccache)             # set ccache for compilation
 include(util)               # set unittest and link libs
 include(version)            # set PADDLE_VERSION
 include(coveralls)          # set code coverage

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -2,7 +2,6 @@ if(NOT WITH_GPU)
     return()
 endif()
 
-
 if(WITH_NV_JETSON)
   add_definitions(-DWITH_NV_JETSON)
   set(paddle_known_gpu_archs "53 62 72")

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -239,6 +239,7 @@ function cmake_base() {
         -DON_INFER=${ON_INFER:-OFF}
         -DWITH_HETERPS=${WITH_HETERPS:-OFF}
         -DWITH_FLUID_ONLY=${WITH_FLUID_ONLY:-OFF} 
+        -DWITH_RECORD_BUILDTIME=${WITH_RECORD_BUILDTIME:-OFF}
         -DCUDA_ARCH_BIN="${CUDA_ARCH_BIN}"
     ========================================
 EOF
@@ -289,6 +290,7 @@ EOF
         -DWITH_HETERPS=${WITH_HETERPS:-OFF} \
         -DWITH_FLUID_ONLY=${WITH_FLUID_ONLY:-OFF} \
         -DCUDA_ARCH_BIN="${CUDA_ARCH_BIN}" \
+        -DWITH_RECORD_BUILDTIME=${WITH_RECORD_BUILDTIME:-OFF} \
         -DWITH_UNITY_BUILD=${WITH_UNITY_BUILD:-OFF};build_error=$?
     if [ "$build_error" != 0 ];then
         exit 7;
@@ -450,6 +452,14 @@ function cmake_gen_and_build() {
     [ -n "$startTime_firstBuild" ] && startTime_s=$startTime_firstBuild
     echo "Build Time: $[ $endTime_s - $startTime_s ]s"
     echo "ipipe_log_param_Build_Time: $[ $endTime_s - $startTime_s ]s" >> ${PADDLE_ROOT}/build/build_summary.txt
+}
+
+function get_build_time_file() {
+    python ${PADDLE_ROOT}/tools/analysis_build_time.py
+    cat ${PADDLE_ROOT}/tools/buildTime.txt
+    today=$(date "+%Y-%m-%d")
+    mkdir -p /paddle_targets_buildtime_record
+    cp ${PADDLE_ROOT}/tools/buildTime.txt /paddle_targets_buildtime_record/${today}-buildTime.txt
 }
 
 function build_mac() {
@@ -2483,6 +2493,10 @@ function build_pr_and_develop() {
     mkdir ${PADDLE_ROOT}/build/dev_whl && cp ${PADDLE_ROOT}/build/python/dist/*.whl ${PADDLE_ROOT}/build/dev_whl
 }
 
+function build_develop() {
+    #git checkout -b develop_base_pr upstream/$BRANCH
+    cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
+}
 
 function main() {
     local CMD=$1 
@@ -2493,7 +2507,12 @@ function main() {
         cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         ;;
       build_pr_dev)
-        build_pr_and_develop 
+        build_pr_and_develop
+        ;;
+      build_dev_test)
+        #build_develop
+        cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
+        get_build_time_file
         ;;
       build_and_check)
         set +e

--- a/tools/analysis_build_time.py
+++ b/tools/analysis_build_time.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+root_path = os.path.abspath(os.path.join(os.getcwd(), ".."))
+
+
+def strToSecond(strTime):
+    minute = int(strTime.split(':')[0])
+    second = int(strTime.split(':')[1].split('.')[0]) + 1
+    return minute * 60 + second
+
+
+def getUsefulBuildTimeFile(filename):
+    os.system(
+        "grep -Po -- '-o .*' %s | grep ' elapsed' | grep -P -v '0:00.* elapse' > %s/tools/analysis_build_time"
+        % (filename, root_path))
+    os.system(
+        "grep -v  -- '-o .*' %s |grep ' elapse' |  grep -P -v '0:00.* elapse' >> %s/tools/analysis_build_time"
+        % (filename, root_path))
+
+
+def analysisBuildTime():
+    filename = '%s/build/build-time' % root_path
+    getUsefulBuildTimeFile(filename)
+    os.system('rm -rf %s/tools/tempbuildTime.txt' % root_path)
+    with open('%s/tools/analysis_build_time' % root_path, 'r') as f:
+        lines = f.readlines()
+        for line in lines:
+            try:
+                line = line.strip()
+                if '-o ' in line:
+                    buildFile = line.split(', ')[0].split(' ')[1]
+                    buildTime = line.split(', ')[1].split('elapsed')[0].strip()
+                    secondTime = strToSecond(buildTime)
+                    os.system("echo %s, %s >> %s/tools/tempbuildTime.txt" %
+                              (buildFile, secondTime, root_path))
+                else:
+                    buildTime = line.split(', ')[1].split('elapsed')[0].strip()
+                    secondTime = strToSecond(buildTime)
+                    if secondTime > 30:
+                        os.system("echo %s, %s >> %s/tools/tempbuildTime.txt" %
+                                  (line, secondTime, root_path))
+            except ValueError:
+                print(line)
+    os.system(
+        'sort -n -k 2 -r %s/tools/tempbuildTime.txt > %s/tools/buildTime.txt' %
+        (root_path, root_path))
+
+
+analysisBuildTime()

--- a/tools/get_build_time.sh
+++ b/tools/get_build_time.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CUR_ROOT=$(dirname "$0")/..
+/usr/bin/time -f '%C, %E elapsed, %U user, %S sys' "$@" >> $CUR_ROOT/build/build-time 2>&1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
get all targets buildTime
1. 用编译参数WITH_RECORD_BUILDTIME 来表示是否开启记录targets的编译时间
2. 使用WITH_RECORD_BUILDTIME 时不能使用cache
3. 后面会日级别的产出targets的编译时间，并按时间倒序排列放在sugar上，sugar显示如下：
![image](https://user-images.githubusercontent.com/22937122/153544333-6c565d63-2bf3-4c0b-aef8-01e48f85d0d8.png)
4. 每日的结果存于bos：如https://paddle-docker-tar.bj.bcebos.com/paddle_targets_buildtime_record/2022-02-10-buildTime.txt 