### PR TITLE
[bf16] change bf16 c++ print behavior

### DIFF
--- a/paddle/fluid/platform/bfloat16_test.cc
+++ b/paddle/fluid/platform/bfloat16_test.cc
@@ -132,7 +132,11 @@ TEST(bfloat16, floating) {
 
 TEST(bfloat16, print) {
   bfloat16 a = bfloat16(1.0f);
-  std::cout << a << std::endl;
+  std::cout << "a:" << a << std::endl;
+  std::stringstream ss1, ss2;
+  ss1 << a;
+  ss2 << 1.0f;
+  EXPECT_EQ(ss1.str(), ss2.str());
 }
 
 // CPU test

--- a/paddle/pten/common/bfloat16.h
+++ b/paddle/pten/common/bfloat16.h
@@ -82,7 +82,7 @@ struct PADDLE_ALIGN(2) bfloat16 {
 
 #if defined(PADDLE_CUDA_BF16)
   HOSTDEVICE inline explicit bfloat16(const __nv_bfloat16& val) {
-    x = *reinterpret_cast<const unsigned short*>(&val);
+    x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
   }
 #endif
 
@@ -93,7 +93,7 @@ struct PADDLE_ALIGN(2) bfloat16 {
 // Assignment operators
 #if defined(PADDLE_CUDA_BF16)
   HOSTDEVICE inline bfloat16& operator=(const __nv_bfloat16& val) {
-    x = *reinterpret_cast<const unsigned short*>(&val);
+    x = *reinterpret_cast<const unsigned short*>(&val);  // NOLINT
     return *this;
   }
 #endif
@@ -311,7 +311,7 @@ HOSTDEVICE inline bool(isfinite)(const bfloat16& a) {
 }
 
 inline std::ostream& operator<<(std::ostream& os, const bfloat16& a) {
-  os << a.x;
+  os << static_cast<float>(a);
   return os;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[bf16] change bf16 print behavior

Original implementation prints `bfloat` number as uint16, this PR changes to `float`.
For example, bfloat number 1.0f is printed as `16256` before, and `1` now.