### PR TITLE
fix sequential bug about key error

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -79,7 +79,7 @@ class Sequential(Layer):
                 name += len(self._sub_layers)
             elif name < -len(self._sub_layers):
                 raise IndexError('index {} is out of range'.format(name))
-            return self._sub_layers[str(name)]
+            return list(self._sub_layers.values())[name]
 
     def __setitem__(self, name, layer):
         assert isinstance(layer, Layer)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/Paddle/issues/39220 中反馈了Sequential的一个bug：
```
import paddle

layers = paddle.nn.Sequential()
for i in range(10):
    layers.add_sublayer('block'+str(i), paddle.nn.Linear(10, 10))
for layer in layers:
    print(layer)
```
会报KeyError
本PR修复了该bug