### PR TITLE
[PTen] Move stream into pten, remove stream.h dependency

### DIFF
--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -28,7 +28,7 @@ limitations under the License. */
 #include "paddle/fluid/platform/device_context.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/place.h"
-#include "paddle/fluid/platform/stream/stream.h"
+#include "paddle/pten/core/stream.h"
 
 #include "paddle/pten/core/dense_tensor.h"
 

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -907,7 +907,7 @@ uint64_t AllocatorFacade::Release(const platform::Place& place) {
 }
 
 std::shared_ptr<pten::Allocation> AllocatorFacade::AllocShared(
-    const platform::Place& place, size_t size, const platform::Stream& stream) {
+    const platform::Place& place, size_t size, const pten::Stream& stream) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   PADDLE_ENFORCE_EQ(
       FLAGS_use_stream_safe_cuda_allocator, true,
@@ -932,7 +932,7 @@ std::shared_ptr<pten::Allocation> AllocatorFacade::AllocShared(
 
 bool AllocatorFacade::InSameStream(
     const std::shared_ptr<pten::Allocation>& allocation,
-    const platform::Stream& stream) {
+    const pten::Stream& stream) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   PADDLE_ENFORCE_EQ(
       FLAGS_use_stream_safe_cuda_allocator, true,

--- a/paddle/fluid/memory/allocation/allocator_facade.h
+++ b/paddle/fluid/memory/allocation/allocator_facade.h
@@ -22,7 +22,7 @@
 #include "paddle/fluid/platform/device/gpu/gpu_info.h"
 #endif
 #include "paddle/fluid/platform/place.h"
-#include "paddle/fluid/platform/stream/stream.h"
+#include "paddle/pten/core/stream.h"
 
 namespace paddle {
 namespace memory {
@@ -71,13 +71,13 @@ class AllocatorFacade {
 
   std::shared_ptr<Allocation> AllocShared(const platform::Place& place,
                                           size_t size,
-                                          const platform::Stream& stream);
+                                          const pten::Stream& stream);
 
   bool InSameStream(const std::shared_ptr<Allocation>& allocation,
-                    const platform::Stream& stream);
+                    const pten::Stream& stream);
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  // TODO(zhiqiu): change gpuStream_t to platform::Stream if needed.
+  // TODO(zhiqiu): change gpuStream_t to pten::Stream if needed.
   AllocationPtr Alloc(const platform::Place& place, size_t size,
                       const gpuStream_t& stream);
   uint64_t Release(const platform::CUDAPlace& place, const gpuStream_t& stream);

--- a/paddle/fluid/memory/malloc.cc
+++ b/paddle/fluid/memory/malloc.cc
@@ -16,7 +16,7 @@ limitations under the License. */
 
 #include "paddle/fluid/memory/allocation/allocator_facade.h"
 #include "paddle/fluid/platform/place.h"
-#include "paddle/fluid/platform/stream/stream.h"
+#include "paddle/pten/core/stream.h"
 
 namespace paddle {
 namespace memory {
@@ -36,13 +36,13 @@ uint64_t Release(const platform::Place& place) {
 
 std::shared_ptr<Allocation> AllocShared(const platform::Place& place,
                                         size_t size,
-                                        const platform::Stream& stream) {
+                                        const pten::Stream& stream) {
   return allocation::AllocatorFacade::Instance().AllocShared(place, size,
                                                              stream);
 }
 
 bool InSameStream(const std::shared_ptr<Allocation>& allocation,
-                  const platform::Stream& stream) {
+                  const pten::Stream& stream) {
   return allocation::AllocatorFacade::Instance().InSameStream(allocation,
                                                               stream);
 }

--- a/paddle/fluid/memory/malloc.h
+++ b/paddle/fluid/memory/malloc.h
@@ -18,8 +18,8 @@ limitations under the License. */
 
 #include "paddle/fluid/memory/allocation/allocator.h"
 #include "paddle/fluid/platform/place.h"
-#include "paddle/fluid/platform/stream/stream.h"
 #include "paddle/pten/core/device_context.h"
+#include "paddle/pten/core/stream.h"
 
 namespace paddle {
 namespace memory {
@@ -39,10 +39,10 @@ extern uint64_t Release(const platform::Place& place);
 
 extern std::shared_ptr<Allocation> AllocShared(const platform::Place& place,
                                                size_t size,
-                                               const platform::Stream& stream);
+                                               const pten::Stream& stream);
 
 extern bool InSameStream(const std::shared_ptr<Allocation>& allocation,
-                         const platform::Stream& stream);
+                         const pten::Stream& stream);
 
 extern void* GetBasePtr(const std::shared_ptr<Allocation>& allocation);
 

--- a/paddle/fluid/memory/stream_safe_cuda_alloc_test.cu
+++ b/paddle/fluid/memory/stream_safe_cuda_alloc_test.cu
@@ -30,7 +30,7 @@
 #include "paddle/fluid/platform/cuda_graph_with_memory_pool.h"
 #include "paddle/fluid/platform/device/gpu/gpu_info.h"
 #include "paddle/fluid/platform/device_context.h"
-#include "paddle/fluid/platform/stream/stream.h"
+#include "paddle/pten/core/stream.h"
 
 namespace paddle {
 namespace memory {
@@ -70,9 +70,9 @@ class StreamSafeCUDAAllocTest : public ::testing::Test {
       PADDLE_ENFORCE_GPU_SUCCESS(hipStreamCreate(&stream));
 #endif
 
-      std::shared_ptr<Allocation> allocation = AllocShared(
-          place_, workspace_size_,
-          platform::Stream(reinterpret_cast<platform::StreamId>(stream)));
+      std::shared_ptr<Allocation> allocation =
+          AllocShared(place_, workspace_size_,
+                      pten::Stream(reinterpret_cast<pten::StreamId>(stream)));
 #ifdef PADDLE_WITH_CUDA
       PADDLE_ENFORCE_GPU_SUCCESS(
           cudaMemset(allocation->ptr(), 0, allocation->size()));
@@ -286,9 +286,9 @@ TEST(StreamSafeCUDAAllocInterfaceTest, GetStreamInterfaceTest) {
   PADDLE_ENFORCE_GPU_SUCCESS(hipStreamCreate(&new_stream));
 #endif
 
-  std::shared_ptr<Allocation> allocation_new_stream = AllocShared(
-      place, alloc_size,
-      platform::Stream(reinterpret_cast<platform::StreamId>(new_stream)));
+  std::shared_ptr<Allocation> allocation_new_stream =
+      AllocShared(place, alloc_size,
+                  pten::Stream(reinterpret_cast<pten::StreamId>(new_stream)));
   EXPECT_EQ(GetStream(allocation_new_stream), new_stream);
 
 #ifdef PADDLE_WITH_CUDA
@@ -315,10 +315,10 @@ TEST(StreamSafeCUDAAllocInterfaceTest, CUDAGraphExceptionTest) {
   EXPECT_THROW(Release(place), paddle::platform::EnforceNotMet);
   EXPECT_THROW(allocation::AllocatorFacade::Instance().GetAllocator(place),
                paddle::platform::EnforceNotMet);
-  EXPECT_THROW(AllocShared(place, alloc_size,
-                           platform::Stream(
-                               reinterpret_cast<platform::StreamId>(nullptr))),
-               paddle::platform::EnforceNotMet);
+  EXPECT_THROW(
+      AllocShared(place, alloc_size,
+                  pten::Stream(reinterpret_cast<pten::StreamId>(nullptr))),
+      paddle::platform::EnforceNotMet);
   EXPECT_THROW(Alloc(place, alloc_size, nullptr),
                paddle::platform::EnforceNotMet);
   EXPECT_THROW(Release(place, nullptr), paddle::platform::EnforceNotMet);

--- a/paddle/fluid/operators/memcpy_h2d_op.h
+++ b/paddle/fluid/operators/memcpy_h2d_op.h
@@ -15,7 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/var_type.h"
 #include "paddle/fluid/platform/device_context.h"
-#include "paddle/fluid/platform/stream/stream.h"
+#include "paddle/pten/core/stream.h"
 
 namespace pten {
 class DenseTensor;
@@ -47,7 +47,7 @@ class MemcpyH2DFunctor {
 #endif
     out_tensor.mutable_data(
         dev_ctx_.GetPlace(), lod_tensor.type(),
-        platform::Stream(reinterpret_cast<platform::StreamId>(stream)));
+        pten::Stream(reinterpret_cast<pten::StreamId>(stream)));
 
     if (dst_place_type_ == 0 || dst_place_type_ == 1) {
       framework::TensorCopy(lod_tensor, dev_ctx_.GetPlace(), dev_ctx_,

--- a/paddle/pten/core/dense_tensor.h
+++ b/paddle/pten/core/dense_tensor.h
@@ -16,12 +16,12 @@ limitations under the License. */
 
 #include "paddle/pten/core/allocator.h"
 #include "paddle/pten/core/storage.h"
+#include "paddle/pten/core/stream.h"
 #include "paddle/pten/core/tensor_base.h"
 #include "paddle/pten/core/tensor_meta.h"
 
 // See Note [ Why still include the fluid headers? ]
 #include "paddle/fluid/framework/data_type.h"
-#include "paddle/fluid/platform/stream/stream.h"
 
 /* @jim19930609: Move to MKLDNN_Tensor in the future
     */

--- a/paddle/pten/core/dense_tensor.inl
+++ b/paddle/pten/core/dense_tensor.inl
@@ -76,7 +76,7 @@ void* mutable_data(const paddle::platform::Place& place,
 
 void* mutable_data(const paddle::platform::Place& place,
                     paddle::framework::proto::VarType::Type type,
-                    const paddle::platform::Stream& stream);
+                    const pten::Stream& stream);
 
 /* @jim19930609: Remove dependency on protobuf after Tensor Unification.
 */

--- a/paddle/pten/core/dense_tensor_impl.cc
+++ b/paddle/pten/core/dense_tensor_impl.cc
@@ -144,7 +144,7 @@ void* DenseTensor::mutable_data(const paddle::platform::Place& place,
 
 void* DenseTensor::mutable_data(const paddle::platform::Place& place,
                                 paddle::framework::proto::VarType::Type type,
-                                const paddle::platform::Stream& stream) {
+                                const pten::Stream& stream) {
   set_type(type);
   PADDLE_ENFORCE_GE(
       numel(),

--- a/paddle/pten/core/stream.h
+++ b/paddle/pten/core/stream.h
@@ -17,8 +17,7 @@ limitations under the License. */
 #include <cstdint>
 #include <memory>
 
-namespace paddle {
-namespace platform {
+namespace pten {
 
 using StreamId = uint64_t;
 class Stream final {
@@ -30,5 +29,4 @@ class Stream final {
   StreamId id_;
 };
 
-}  // namespace platform
-}  // namespace paddle
+}  // namespace pten


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[PTen] Move stream into pten, remove stream.h depend

pten/core目录需要解耦对fluid头文件的依赖，将stream.h移动到pten 