### PR TITLE
Fix operator== for float16

### DIFF
--- a/paddle/fluid/framework/custom_kernel_test.cc
+++ b/paddle/fluid/framework/custom_kernel_test.cc
@@ -73,7 +73,7 @@ void FakeDot(const paddle::CPUContext& dev_ctx, const paddle::Tensor& x,
   assert(fake_attr_float == 2);
   assert(fake_attr_double == 3);
   assert(fake_attr_int64 == 4);
-  assert(fake_attr_f16 == 5);
+  assert(fake_attr_f16 == pten::dtype::float16(5));
   assert(fake_attr_dtype == pten::DataType::UINT32);
   assert(fake_attr_int64_vec.size() == 0);
   assert(fake_attr_int_vec.size() == 0);


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix a compilation error:
```
[ 90%] Building CXX object paddle/fluid/framework/CMakeFiles/custom_kernel_test.dir/custom_kernel_test.cc.o
In file included from /usr/include/c++/8/cassert:44,
                 from $HOME/dev/paddle/paddle/pten/core/utils/type_registry.h:17,
                 from $HOME/dev/paddle/paddle/pten/core/tensor_base.h:23,
                 from $HOME/dev/paddle/paddle/pten/core/dense_tensor.h:19,
                 from $HOME/dev/paddle/paddle/fluid/framework/tensor.h:33,
                 from $HOME/dev/paddle/paddle/fluid/framework/lod_tensor.h:25,
                 from $HOME/dev/paddle/paddle/pten/api/lib/utils/tensor_utils.h:19,
                 from $HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:27:
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc: In function ‘void custom_kernel::FakeDot(const paddle::CPUContext&, const Tensor&, const Tensor&, const std::vector<paddle::experimental::Tensor>&, bool, int, float, double, int64_t, pten::dtype::float16, pten::DataType, const Scalar&, const ScalarArray&, const std::vector<long int>&, const std::vector<int>&, paddle::Tensor*, std::vector<paddle::experimental::Tensor*>)’:
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:76:24: error: ambiguous overload for ‘operator==’ (operand types are ‘pten::dtype::float16’ and ‘int’)
   assert(fake_attr_f16 == 5);
          ~~~~~~~~~~~~~~^~~~
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:76:24: note: candidate: ‘operator==(double, int)’ <built-in>
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:76:24: note: candidate: ‘operator==(long unsigned int, int)’ <built-in>
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:76:24: note: candidate: ‘operator==(long int, int)’ <built-in>
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:76:24: note: candidate: ‘operator==(unsigned int, int)’ <built-in>
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:76:24: note: candidate: ‘operator==(int, int)’ <built-in>
$HOME/dev/paddle/paddle/fluid/framework/custom_kernel_test.cc:76:24: note: candidate: ‘operator==(float, int)’ <built-in>
make[2]: *** [paddle/fluid/framework/CMakeFiles/custom_kernel_test.dir/build.make:63: paddle/fluid/framework/CMakeFiles/custom_kernel_test.dir/custom_kernel_test.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:27512: paddle/fluid/framework/CMakeFiles/custom_kernel_test.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
