### PR TITLE
[Pten] move algorithm.h

### DIFF
--- a/paddle/fluid/operators/optimizers/adam_op.cu
+++ b/paddle/fluid/operators/optimizers/adam_op.cu
@@ -104,7 +104,7 @@ __global__ void SparseAdamCUDAKernelREG(
 
   for (; id < ndim; id += blockDim.x * gridDim.x) {
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_count, id / row_numel);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_count, id / row_numel);
     if (lazy_mode && row_idx < 0) {
       return;
     } else {

--- a/paddle/fluid/operators/optimizers/adam_op.h
+++ b/paddle/fluid/operators/optimizers/adam_op.h
@@ -21,10 +21,10 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/threadpool.h"
 #include "paddle/fluid/operators/jit/kernels.h"
-#include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/operators/math/selected_rows_functor.h"
 #include "paddle/fluid/platform/for_range.h"
 #include "paddle/fluid/platform/profiler.h"
+#include "paddle/pten/kernels/funcs/algorithm.h"
 
 namespace paddle {
 namespace operators {
@@ -279,7 +279,7 @@ class SparseAdamFunctor<T, GPUAdam, MT> {
 
   inline HOSTDEVICE void operator()(size_t i) const {
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
     if (lazy_mode_ && row_idx < 0) {
       return;
     } else {

--- a/paddle/fluid/operators/optimizers/adamw_op.cu
+++ b/paddle/fluid/operators/optimizers/adamw_op.cu
@@ -112,7 +112,7 @@ __global__ void SparseAdamWCUDAKernelREG(
 
   for (; id < ndim; id += blockDim.x * gridDim.x) {
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_count, id / row_numel);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_count, id / row_numel);
     if (lazy_mode && row_idx < 0) {
       return;
     } else {

--- a/paddle/fluid/operators/optimizers/adamw_op.h
+++ b/paddle/fluid/operators/optimizers/adamw_op.h
@@ -142,7 +142,7 @@ class SparseAdamWFunctor<T, GPUAdamW, MT> {
 
   inline HOSTDEVICE void operator()(size_t i) const {
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
     if (lazy_mode_ && row_idx < 0) {
       return;
     } else {

--- a/paddle/fluid/operators/optimizers/lamb_op.h
+++ b/paddle/fluid/operators/optimizers/lamb_op.h
@@ -19,10 +19,10 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/memory/buffer.h"
 #include "paddle/fluid/operators/amp/fp16_type_traits.h"
-#include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/operators/math/selected_rows_functor.h"
 #include "paddle/fluid/operators/math/squared_l2_norm.h"
 #include "paddle/fluid/platform/for_range.h"
+#include "paddle/pten/kernels/funcs/algorithm.h"
 #include "paddle/pten/kernels/funcs/eigen/extensions.h"
 
 namespace paddle {
@@ -233,7 +233,7 @@ struct SparseLambMomentREGUpdateFunctor {
   inline HOSTDEVICE void operator()(size_t i) const {
     if (skip_update_ && *skip_update_) return;
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
     T g = row_idx >= 0 ? grad_[row_idx * row_numel_ + i % row_numel_]
                        : static_cast<T>(0);
     update(i, g);
@@ -312,7 +312,7 @@ struct SparseLambMomentMENUpdateFunctor {
   inline HOSTDEVICE void operator()(size_t i) const {
     if (skip_update_ && *skip_update_) return;
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_count_, i / row_numel_);
     T g = row_idx >= 0 ? grad_[row_idx * row_numel_ + i % row_numel_]
                        : static_cast<T>(0);
     update(i, g);

--- a/paddle/fluid/operators/optimizers/momentum_op.h
+++ b/paddle/fluid/operators/optimizers/momentum_op.h
@@ -18,10 +18,10 @@ limitations under the License. */
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/amp/fp16_type_traits.h"
-#include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/operators/math/selected_rows_functor.h"
 #include "paddle/fluid/platform/float16.h"
 #include "paddle/fluid/platform/for_range.h"
+#include "paddle/pten/kernels/funcs/algorithm.h"
 
 namespace paddle {
 namespace operators {
@@ -345,7 +345,7 @@ class SparseMomentumFunctor<T, MT, UseNesterov> {
 
   inline HOSTDEVICE void operator()(size_t i) {
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_height_, i / row_numel_);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_height_, i / row_numel_);
     MT grad =
         row_idx >= 0
             ? static_cast<MT>(grad_[row_idx * row_numel_ + i % row_numel_]) *
@@ -418,7 +418,7 @@ class SparseMomentumFunctor<T, MT, NoNesterov> {
 
   inline HOSTDEVICE void operator()(size_t i) {
     auto row_idx =
-        math::BinarySearch<int64_t>(rows_, row_height_, i / row_numel_);
+        pten::funcs::BinarySearch<int64_t>(rows_, row_height_, i / row_numel_);
     MT grad =
         row_idx >= 0
             ? static_cast<MT>(grad_[row_idx * row_numel_ + i % row_numel_]) *

--- a/paddle/fluid/operators/optimizers/rmsprop_op.h
+++ b/paddle/fluid/operators/optimizers/rmsprop_op.h
@@ -16,9 +16,9 @@ limitations under the License. */
 #include <math.h>
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
-#include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/operators/math/selected_rows_functor.h"
 #include "paddle/fluid/platform/for_range.h"
+#include "paddle/pten/kernels/funcs/algorithm.h"
 
 namespace paddle {
 namespace operators {
@@ -42,7 +42,8 @@ struct SparseRmspropGradFunctor {
         row_count_(row_count) {}
 
   HOSTDEVICE inline T operator()(int64_t idx) const {
-    auto row_idx = math::BinarySearch(rows_, row_count_, idx / row_numel_);
+    auto row_idx =
+        pten::funcs::BinarySearch(rows_, row_count_, idx / row_numel_);
     return row_idx >= 0 ? grad_[row_idx * row_numel_ + idx % row_numel_] : 0;
   }
 

--- a/paddle/fluid/operators/optimizers/sparse_momentum_op.h
+++ b/paddle/fluid/operators/optimizers/sparse_momentum_op.h
@@ -20,7 +20,6 @@
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/amp/fp16_type_traits.h"
-#include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/platform/float16.h"
 #include "paddle/fluid/platform/for_range.h"
 

--- a/paddle/fluid/operators/searchsorted_op.h
+++ b/paddle/fluid/operators/searchsorted_op.h
@@ -19,9 +19,9 @@
 #include "paddle/fluid/framework/ddim.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/operator.h"
-#include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/for_range.h"
+#include "paddle/pten/kernels/funcs/algorithm.h"
 
 namespace paddle {
 namespace operators {
@@ -85,11 +85,11 @@ class GpuAndCpuSearchSortedCompute {
       out_data_[idx] = seq_size_;
     } else {
       if (right_) {
-        out_data_[idx] = static_cast<OutType>(
-            math::UpperBound<T1, T2>(sequence_ptr, seq_size_, *value_ptr));
+        out_data_[idx] = static_cast<OutType>(pten::funcs::UpperBound<T1, T2>(
+            sequence_ptr, seq_size_, *value_ptr));
       } else {
-        out_data_[idx] = static_cast<OutType>(
-            math::LowerBound<T1, T2>(sequence_ptr, seq_size_, *value_ptr));
+        out_data_[idx] = static_cast<OutType>(pten::funcs::LowerBound<T1, T2>(
+            sequence_ptr, seq_size_, *value_ptr));
       }
     }
   }

--- a/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
@@ -16,8 +16,8 @@
 
 #include <memory>
 #include "paddle/fluid/framework/op_registry.h"
-#include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/platform/for_range.h"
+#include "paddle/pten/kernels/funcs/algorithm.h"
 
 namespace paddle {
 namespace operators {
@@ -94,7 +94,7 @@ struct SequenceReverseFunctor {
 
   HOSTDEVICE void operator()(size_t idx_x) const {
     auto row_idx_x = idx_x / row_numel_;
-    auto lod_idx = math::UpperBound(lod_, lod_count_, row_idx_x);
+    auto lod_idx = pten::funcs::UpperBound(lod_, lod_count_, row_idx_x);
     auto row_idx_y = lod_[lod_idx - 1] + (lod_[lod_idx] - 1 - row_idx_x);
     auto idx_y = row_idx_y * row_numel_ + idx_x % row_numel_;
     y_[idx_y] = x_[idx_x];

--- a/paddle/pten/kernels/funcs/algorithm.h
+++ b/paddle/pten/kernels/funcs/algorithm.h
@@ -20,9 +20,8 @@
 
 #include "paddle/pten/core/hostdevice.h"
 
-namespace paddle {
-namespace operators {
-namespace math {
+namespace pten {
+namespace funcs {
 
 template <typename T>
 HOSTDEVICE inline int64_t BinarySearch(const T *x, int64_t num, const T &val) {
@@ -85,6 +84,5 @@ HOSTDEVICE inline size_t UpperBound(const T1 *x, size_t num, const T2 &val) {
 #endif  // @} End Group UpperBound
 }
 
-}  // namespace math
-}  // namespace operators
-}  // namespace paddle
+}  // namespace funcs
+}  // namespace pten


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Move paddle/operators/math/algorithm.h to paddle/pten/kernels/funcs and rename all references to symbols in it.