### PR TITLE
[Eager Hook] Support eager hook_for_layer

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -342,7 +342,7 @@ class Layer(object):
                 import paddle
                 import numpy as np
 
-                # the forward_post_hook change the input of the layer: input = input * 2
+                # the forward_pre_hook change the input of the layer: input = input * 2
                 def forward_pre_hook(layer, input):
                     # user can use layer and input for information statistis tasks
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_hook_for_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_hook_for_layer.py
@@ -118,7 +118,7 @@ class Test_Forward_Hook(unittest.TestCase):
                 self.assertTrue(
                     np.array_equal(outs_pre_hook.numpy(), outs_origin.numpy()))
 
-                # register forward_posst_hook
+                # register forward_post_hook
                 forward_post_hook_handle1 = simplenet.register_forward_post_hook(
                     forward_post_hook1)
                 outs_forward_hook = simplenet(input, y)

--- a/python/paddle/fluid/tests/unittests/test_imperative_hook_for_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_hook_for_layer.py
@@ -25,9 +25,13 @@ import paddle.fluid.core as core
 import paddle.fluid.dygraph.base as base
 
 from test_imperative_lod_tensor_to_selected_rows import SimpleNet
+from paddle.fluid.framework import _test_eager_guard
 
 call_forward_hook = False
 call_forward_pre_hook = False
+
+call_forward_hook_eager = False
+call_forward_pre_hook_eager = False
 
 
 def forward_hook(layer, input, output):
@@ -38,6 +42,16 @@ def forward_hook(layer, input, output):
 def forward_pre_hook(layer, input):
     global call_forward_pre_hook
     call_forward_pre_hook = True
+
+
+def eager_forward_hook(layer, input, output):
+    global call_forward_hook_eager
+    call_forward_hook_eager = True
+
+
+def eager_forward_pre_hook(layer, input):
+    global call_forward_pre_hook_eager
+    call_forward_pre_hook_eager = True
 
 
 def forward_hook1(layer, input, output):
@@ -119,6 +133,70 @@ class Test_Forward_Hook(unittest.TestCase):
                     np.array_equal(outs_forward_hook.numpy(),
                                    outs_origin.numpy()))
 
+        for place in places:
+            with fluid.dygraph.guard(place):
+                with _test_eager_guard():
+                    fluid.default_startup_program().random_seed = seed
+                    fluid.default_main_program().random_seed = seed
+                    fluid.set_flags({'FLAGS_sort_sum_gradient': True})
+
+                    input_word = np.array(
+                        [0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7,
+                         8]).reshape(6, 3).astype('int64')
+                    input_word1 = input_word * 2
+                    input_word = input_word.reshape((-1, 3, 1))
+                    input_word1 = input_word1.reshape((-1, 3, 1))
+                    y_data = np.array(
+                        [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8,
+                         9]).reshape(6, 3).astype('int64')
+                    y_data = y_data.reshape((-1, 1))
+
+                    input = base.to_variable(input_word)
+                    input1 = base.to_variable(input_word1)
+                    y = base.to_variable(y_data)
+
+                    simplenet = SimpleNet(
+                        hidden_size=20,
+                        vocab_size=32,
+                        num_steps=3,
+                        init_scale=0.1,
+                        is_sparse=False,
+                        dtype="float32")
+
+                    # origin, don't register any hook
+                    outs_origin = simplenet(input, y)
+                    outs_origin1 = simplenet(input1, y)
+
+                    # register forward_pre_hook
+                    forward_pre_hook_handle1 = simplenet.register_forward_pre_hook(
+                        forward_pre_hook1)
+                    outs_pre_hook = simplenet(input, y)
+                    self.assertTrue(
+                        np.array_equal(outs_pre_hook.numpy(),
+                                       outs_origin1.numpy()))
+
+                    # remove forward_pre_hook
+                    forward_pre_hook_handle1.remove()
+                    outs_pre_hook = simplenet(input, y)
+                    self.assertTrue(
+                        np.array_equal(outs_pre_hook.numpy(),
+                                       outs_origin.numpy()))
+
+                    # register forward_hook
+                    forward_hook_handle1 = simplenet.register_forward_post_hook(
+                        forward_hook1)
+                    outs_forward_hook = simplenet(input, y)
+                    self.assertTrue(
+                        np.array_equal(outs_forward_hook.numpy(),
+                                       outs_origin.numpy() * 2))
+
+                    # remove forward_hook
+                    forward_hook_handle1.remove()
+                    outs_forward_hook = simplenet(input, y)
+                    self.assertTrue(
+                        np.array_equal(outs_forward_hook.numpy(),
+                                       outs_origin.numpy()))
+
     # test forward_pre_hook and forward_hook that don't have return value
     def test_forward_hook(self):
         seed = 90
@@ -189,6 +267,70 @@ class Test_Forward_Hook(unittest.TestCase):
                 outs_remove_hook = simplenet(input, y)
                 self.assertFalse(call_forward_hook)
                 self.assertFalse(call_forward_pre_hook)
+
+        for place in places:
+            with fluid.dygraph.guard(place):
+                with _test_eager_guard():
+                    fluid.default_startup_program().random_seed = seed
+                    fluid.default_main_program().random_seed = seed
+                    fluid.set_flags({'FLAGS_sort_sum_gradient': True})
+
+                    global call_forward_hook_eager
+                    global call_forward_pre_hook_eager
+
+                    input_word = np.array(
+                        [0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6, 7,
+                         8]).reshape(6, 3).astype('int64')
+                    input_word = input_word.reshape((-1, 3, 1))
+                    y_data = np.array(
+                        [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8,
+                         9]).reshape(6, 3).astype('int64')
+                    y_data = y_data.reshape((-1, 1))
+
+                    input = base.to_variable(input_word)
+                    y = base.to_variable(y_data)
+
+                    simplenet = SimpleNet(
+                        hidden_size=20,
+                        vocab_size=32,
+                        num_steps=3,
+                        init_scale=0.1,
+                        is_sparse=False,
+                        dtype="float32")
+
+                    # origin, don't register any hook
+                    outs_origin = simplenet(input, y)
+                    self.assertFalse(call_forward_hook_eager)
+                    self.assertFalse(call_forward_pre_hook_eager)
+
+                    # register forward_hook and forward_pre_hook
+                    forward_hook_handle = simplenet.register_forward_post_hook(
+                        eager_forward_hook)
+                    forward_pre_hook_handle = simplenet.register_forward_pre_hook(
+                        eager_forward_pre_hook)
+                    outs_hook = simplenet(input, y)
+                    self.assertTrue(call_forward_hook_eager)
+                    self.assertTrue(call_forward_pre_hook_eager)
+
+                    outs_hook = simplenet(input, y)
+                    self.assertTrue(call_forward_hook_eager)
+                    self.assertTrue(call_forward_pre_hook_eager)
+
+                    # remove forward_hook
+                    forward_hook_handle.remove()
+                    call_forward_hook_eager = False
+                    call_forward_pre_hook_eager = False
+                    outs_remove_forward_hook = simplenet(input, y)
+                    self.assertFalse(call_forward_hook_eager)
+                    self.assertTrue(call_forward_pre_hook_eager)
+
+                    # remove forward_pre_hook
+                    forward_pre_hook_handle.remove()
+                    call_forward_hook_eager = False
+                    call_forward_pre_hook_eager = False
+                    outs_remove_hook = simplenet(input, y)
+                    self.assertFalse(call_forward_hook_eager)
+                    self.assertFalse(call_forward_pre_hook_eager)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR types
 New features

### PR changes
Others

### Describe
1. Support test_imperative_hook_for_layer with _test_eager_guard()
2. Polish the code, use "forward_post_hook" instead of "forward_hook",this will be more standardized.
