### PR TITLE
[Paddle-TRT] Test only trt group norm

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_group_norm_op.py
@@ -28,25 +28,14 @@ class TRTGroupNormTest(InferencePassTest):
         with fluid.program_guard(self.main_program, self.startup_program):
             data = fluid.data(
                 name="data", shape=[-1, 512, 12, 12], dtype="float32")
-            relu_out = fluid.layers.relu(data)
-            relu6_out = fluid.layers.relu6(relu_out)
-            tanh_out = fluid.layers.tanh(relu6_out)
-            conv_out = fluid.layers.conv2d(
-                input=tanh_out,
-                num_filters=512,
-                filter_size=3,
-                groups=1,
-                padding=[1, 1],
-                bias_attr=False,
-                act=None)
-            out = self.append_group_norm(conv_out)
+            out = self.append_group_norm(data)
 
         self.feeds = {
             "data": np.random.random([1, 512, 12, 12]).astype("float32"),
         }
         self.enable_trt = True
         self.trt_parameters = TRTGroupNormTest.TensorRTParam(
-            1 << 30, 32, 1, AnalysisConfig.Precision.Float32, False, False)
+            1 << 30, 1, 1, AnalysisConfig.Precision.Float32, False, False)
         self.dynamic_shape_params = TRTGroupNormTest.DynamicShapeParam({
             'data': [1, 512, 12, 12]
         }, {'data': [1, 512, 12, 12]}, {'data': [1, 512, 12, 12]}, False)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
1. Unit test should cover only the specific feature, so `test_trt_group_norm_op.py` should only test the `trt_group_norm` without other ops. If it is important to test the combination of `relu` + `relu6` + `tanh` + `conv2d` + `group_norm`, we could add another unit test.
2. The random input batch size is only 1, set the `max_batch_size` to 1