### PR TITLE
[Dy2St]Refine AnnAssign in static_analysis

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
@@ -349,7 +349,11 @@ class StaticAnalysisVisitor(object):
             ret_type = {NodeVarType.type_from_annotation(node.annotation)}
             # if annotation and value(Constant) are diffent type, we use value type
             if node.value:
-                ret_type = self.node_to_wrapper_map[node.value].node_var_type
+                node_value_type = self.node_to_wrapper_map[
+                    node.value].node_var_type
+                if not (node_value_type &
+                        {NodeVarType.UNKNOWN, NodeVarType.STATEMENT}):
+                    ret_type = node_value_type
             if isinstance(node.target, gast.Name):
                 self.node_to_wrapper_map[node.target].node_var_type = ret_type
                 self.var_env.set_var_type(node.target.id, ret_type)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_static_analysis.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_static_analysis.py
@@ -147,6 +147,7 @@ result_var_type6 = {
 def func_to_test7(a: int, b: float, c: paddle.Tensor, d: float='diff'):
     a = True
     e, f = paddle.shape(c)
+    g: paddle.Tensor = len(c)
 
 
 result_var_type7 = {
@@ -155,7 +156,8 @@ result_var_type7 = {
     'c': {NodeVarType.TENSOR},
     'd': {NodeVarType.STRING},
     'e': {NodeVarType.PADDLE_RETURN_TYPES},
-    'f': {NodeVarType.PADDLE_RETURN_TYPES}
+    'f': {NodeVarType.PADDLE_RETURN_TYPES},
+    'g': {NodeVarType.TENSOR}
 }
 
 test_funcs = [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
之前在动转静中使用`a: int = b`类似的type hint语句时，如果static analysis模块分析出a的标注类型和b的类型不同，则会将a分析为b的类型，而不会使用标注的类型int。但是static analysis模块有时后会将b分析为unknow类型，导致a的类型也被分析为unknow，使得type hint失效。
```python
@paddle.jit.to_static
def func(x):
    a = []
    import pdb; pdb.set_trace()
    x = paddle.to_tensor(x)
    tmp: paddle.Tensor = len(x)
    for i in range(tmp):
        a.append(i)
```
