### PR TITLE
[PTen] Rename general grad infermeta func

### DIFF
--- a/paddle/fluid/operators/matmul_v2_op.cc
+++ b/paddle/fluid/operators/matmul_v2_op.cc
@@ -527,7 +527,7 @@ REGISTER_OPERATOR(matmul_v2, ops::MatMulV2Op, ops::MatMulV2OpMaker,
                   ops::MatMulV2GradOpMaker<paddle::imperative::OpBase>);
 
 DELCARE_INFER_SHAPE_FUNCTOR(matmul_v2_grad, MatMulV2GradInferShapeFunctor,
-                            PT_INFER_META(pten::MatmulGradInferMeta));
+                            PT_INFER_META(pten::GeneralBinaryGradInferMeta));
 REGISTER_OPERATOR(matmul_v2_grad, ops::MatMulV2OpGrad,
                   ops::MatMulV2OpDoubleGradMaker<paddle::framework::OpDesc>,
                   ops::MatMulV2OpDoubleGradMaker<paddle::imperative::OpBase>,

--- a/paddle/pten/infermeta/backward.cc
+++ b/paddle/pten/infermeta/backward.cc
@@ -16,12 +16,6 @@ limitations under the License. */
 
 namespace pten {
 
-void GeneralUnaryGradInferMeta(const MetaTensor& x, MetaTensor* dx) {
-  if (dx) {
-    dx->share_meta(x);
-  }
-}
-
 void GeneralBinaryGradInferMeta(const MetaTensor& x,
                                 const MetaTensor& y,
                                 MetaTensor* dx,

--- a/paddle/pten/infermeta/backward.cc
+++ b/paddle/pten/infermeta/backward.cc
@@ -16,13 +16,16 @@ limitations under the License. */
 
 namespace pten {
 
-void MatmulGradInferMeta(const MetaTensor& x,
-                         const MetaTensor& y,
-                         const MetaTensor& out_grad_meta,
-                         bool transpose_x,
-                         bool transpose_y,
-                         MetaTensor* dx,
-                         MetaTensor* dy) {
+void GeneralUnaryGradInferMeta(const MetaTensor& x, MetaTensor* dx) {
+  if (dx) {
+    dx->share_meta(x);
+  }
+}
+
+void GeneralBinaryGradInferMeta(const MetaTensor& x,
+                                const MetaTensor& y,
+                                MetaTensor* dx,
+                                MetaTensor* dy) {
   if (dx) {
     dx->share_meta(x);
   }

--- a/paddle/pten/infermeta/backward.h
+++ b/paddle/pten/infermeta/backward.h
@@ -20,12 +20,11 @@ limitations under the License. */
 
 namespace pten {
 
-void MatmulGradInferMeta(const MetaTensor& x,
-                         const MetaTensor& y,
-                         const MetaTensor& out_grad_meta,
-                         bool transpose_x,
-                         bool transpose_y,
-                         MetaTensor* dx,
-                         MetaTensor* dy);
+void GeneralUnaryGradInferMeta(const MetaTensor& x, MetaTensor* dx);
+
+void GeneralBinaryGradInferMeta(const MetaTensor& x,
+                                const MetaTensor& y,
+                                MetaTensor* dx,
+                                MetaTensor* dy);
 
 }  // namespace pten

--- a/paddle/pten/infermeta/backward.h
+++ b/paddle/pten/infermeta/backward.h
@@ -20,8 +20,6 @@ limitations under the License. */
 
 namespace pten {
 
-void GeneralUnaryGradInferMeta(const MetaTensor& x, MetaTensor* dx);
-
 void GeneralBinaryGradInferMeta(const MetaTensor& x,
                                 const MetaTensor& y,
                                 MetaTensor* dx,

--- a/python/paddle/utils/code_gen/backward.yaml
+++ b/python/paddle/utils/code_gen/backward.yaml
@@ -3,7 +3,8 @@
   args : (const Tensor& x, const Tensor& y, const Tensor& out_grad, bool transpose_x=false, bool transpose_y=false)
   output : Tensor(x_grad), Tensor(y_grad)
   infer_meta :
-    func : MatmulGradInferMeta
+    func : GeneralBinaryGradInferMeta
+    param : [x, y]
   kernel :
     func : matmul_grad
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[PTen] Rename general grad infermeta func

反向op的infershape一般比较简单，就是复用一下前向的infershape，这里更改下对应函数命名，后续有需要，可以复用