### PR TITLE
Update dynamic_flops.py

### DIFF
--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -258,6 +258,8 @@ def dynamic_flops(model, inputs, custom_ops=None, print_detail=False):
 
     total_ops = 0
     total_params = 0
+    total_ops = paddle.to_tensor(total_ops, dtype=paddle.int64)
+    total_params = paddle.to_tensor(total_ops, dtype=paddle.int64)
     for m in model.sublayers():
         if len(list(m.children())) > 0:
             continue


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types

Function optimization

File name : /paddle/hapi/dynamic_flops.py

### PR changes

OPs

The type of a variable is converted from int32 to int64

### Describe

When calculating flops, since the type of total_ops parameter is int32, and flops is generally very large, it will exceed the range of int32, which leads to flops calculation errors, even a negative number. I changed this type to int64 to make the range of flops that can be calculated more big.

