### PR TITLE
Add ConditionalBlockGradInferVarType for cond_op

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
@@ -306,5 +306,35 @@ class TestListInForLoopWithSubscript(TestListWithoutControlFlow):
         self.input = np.random.random((3, 4)).astype('float32')
 
 
+class ListWithCondNet(paddle.nn.Layer):
+    def __init__(self):
+        super(ListWithCondNet, self).__init__()
+
+    @paddle.jit.to_static
+    def forward(self, x, index):
+        y = paddle.nn.functional.relu(x)
+        a = []
+
+        for i in y:
+            a.append(i)
+
+        if index > 0:
+            res = a[0] * a[0]
+        else:
+            res = a[-1] * a[-1]
+
+        z = a[-1] * res
+        return z
+
+
+class TestListWithCondGradInferVarType(unittest.TestCase):
+    def test_to_static(self):
+        net = ListWithCondNet()
+        x = paddle.to_tensor([2, 3, 4], dtype='float32')
+        index = paddle.to_tensor([1])
+        res = net(x, index)
+        self.assertEqual(res[0], 16.)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

修复了Cond_Grad_op当Input包含LoDTensorArray类型，且Input@GRAD存在时，编译期组网报错的问题。由于之前缺失了ConditionalBlockGradInferVarType，在backward.py的append_backward_vars时会默认标记Input@GRAD的所有类型均为Tensor类型，即会错误地把LoDTensorArray类型Variable变成Tensor，导致下游Op.infer_var_type时报错。