### PR TITLE
Enable fuse of conv and gelu oneDNN pass test for NHWC

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
@@ -157,7 +157,7 @@ ConvActivationFusePass::ConvActivationFusePass() {
       // IsStringIn({"NHWC", "NCHW"}) MobileNetV2 has no this attribute
       .AddAttr("data_format")
       .IsOptional()
-      .IsStringIn({"NCHW", "AnyLayout"})
+      .IsStringIn({"NCHW", "AnyLayout", "NHWC"})
       .End();
 
   AddOpCompat(OpCompat("relu"))

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_conv_gelu_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_conv_gelu_fuse_pass.py
@@ -31,10 +31,6 @@ class TestConvGeluMkldnnFusePass(PassAutoScanTest):
             program_config.ops[i].attrs
             for i in range(len(program_config.ops))
         ]
-        # If the problem has been fixed, the judgment 
-        # needs to be deleted!!!
-        if attrs[0]['data_format'] == "NHWC":
-            return False
 
         return True
 
@@ -108,18 +104,18 @@ class TestConvGeluMkldnnFusePass(PassAutoScanTest):
         config = self.create_inference_config(use_mkldnn=True)
         yield config, ["conv2d"], (1e-5, 1e-5)
 
-    # If the problem has been fixed, the judgment 
-    # needs to be deleted!!!
-    def add_ignore_pass_case(self):
-        def teller1(program_config, predictor_config):
-            if program_config.ops[0].attrs['data_format'] == "NHWC":
-                return True
-            return False
-
-        self.add_ignore_check_case(
-            teller1, SkipReasons.PASS_ACCURACY_ERROR,
-            "The output format of conv2d is wrong when data_format attribute is NHWC"
-        )
+#    # If the problem has been fixed, the judgment 
+#    # needs to be deleted!!!
+#    def add_ignore_pass_case(self):
+#        def teller1(program_config, predictor_config):
+#            if program_config.ops[0].attrs['data_format'] == "NHWC":
+#                return True
+#            return False
+#
+#        self.add_ignore_check_case(
+#            teller1, SkipReasons.PASS_ACCURACY_ERROR,
+#            "The output format of conv2d is wrong when data_format attribute is NHWC"
+#        )
 
     def test(self):
         self.run_and_statis(quant=False, passes=["conv_gelu_mkldnn_fuse_pass"])

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_conv_gelu_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_conv_gelu_fuse_pass.py
@@ -104,19 +104,6 @@ class TestConvGeluMkldnnFusePass(PassAutoScanTest):
         config = self.create_inference_config(use_mkldnn=True)
         yield config, ["conv2d"], (1e-5, 1e-5)
 
-#    # If the problem has been fixed, the judgment 
-#    # needs to be deleted!!!
-#    def add_ignore_pass_case(self):
-#        def teller1(program_config, predictor_config):
-#            if program_config.ops[0].attrs['data_format'] == "NHWC":
-#                return True
-#            return False
-#
-#        self.add_ignore_check_case(
-#            teller1, SkipReasons.PASS_ACCURACY_ERROR,
-#            "The output format of conv2d is wrong when data_format attribute is NHWC"
-#        )
-
     def test(self):
         self.run_and_statis(quant=False, passes=["conv_gelu_mkldnn_fuse_pass"])
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
This enable pass of conv + gelu to work with NHWC data_format
