### PR TITLE
[Pten] Remove setting output in executor

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2097,8 +2097,8 @@ void OperatorWithKernel::BuildPtenKernelContext(
 
       experimental::ResetTensorDtypeAndLayoutByArgDef(tensor_out,
                                                       output_defs.at(i));
-      SetAllocationForOutputTenosr(
-          tensor_out, pten::TransToPtenPlace(output_defs.at(i).backend));
+      // SetAllocationForOutputTenosr(
+      //     tensor_out, pten::TransToPtenPlace(output_defs.at(i).backend));
 
       pt_kernel_context->EmplaceBackOutputWithoutSetRange(tensor_out);
     }

--- a/paddle/fluid/imperative/prepared_operator.h
+++ b/paddle/fluid/imperative/prepared_operator.h
@@ -326,8 +326,8 @@ void BuildDygraphPtenKernelContext(
 
       experimental::ResetTensorDtypeAndLayoutByArgDef(tensor_out,
                                                       output_defs.at(i));
-      framework::SetAllocationForOutputTenosr(
-          tensor_out, pten::TransToPtenPlace(output_defs.at(i).backend));
+      // framework::SetAllocationForOutputTenosr(
+      //     tensor_out, pten::TransToPtenPlace(output_defs.at(i).backend));
 
       kernel_ctx->EmplaceBackOutputWithoutSetRange(tensor_out);
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
移除动静态图执行过程中在调用kernel前对output的dtype，layout已经alloc的设置
