### PR TITLE
[pten]add T, remove default value of DataType in DeviceContext::Alloc

### DIFF
--- a/paddle/pten/core/device_context.h
+++ b/paddle/pten/core/device_context.h
@@ -94,9 +94,7 @@ class DeviceContext {
   /**
    * @brief Allocate device memory for tensor.
    */
-  void* Alloc(TensorBase*,
-              DataType dtype = DataType::UNDEFINED,
-              size_t requested_size = 0) const;
+  void* Alloc(TensorBase*, DataType dtype, size_t requested_size = 0) const;
 
   template <typename T>
   T* Alloc(TensorBase* tensor, size_t requested_size = 0) const;

--- a/paddle/pten/core/device_context.h
+++ b/paddle/pten/core/device_context.h
@@ -103,7 +103,7 @@ class DeviceContext {
    * @brief Allocate host memory for tensor.
    */
   void* HostAlloc(TensorBase* tensor,
-                  DataType dtype = DataType::UNDEFINED,
+                  DataType dtype,
                   size_t requested_size = 0) const;
 
   template <typename T>

--- a/paddle/pten/kernels/cpu/copy_kernel.cc
+++ b/paddle/pten/kernels/cpu/copy_kernel.cc
@@ -37,7 +37,7 @@ void Copy(const Context& dev_ctx,
           << src_place;
 
   dst->Resize(src.dims());
-  auto* dst_ptr = dev_ctx.Alloc(dst);
+  auto* dst_ptr = dev_ctx.Alloc(dst, src.dtype());
 
   if (src_ptr == dst_ptr) {
     VLOG(3) << "Skip copy the same data async from " << src_place << " to "

--- a/paddle/pten/kernels/cpu/split_kernel.cc
+++ b/paddle/pten/kernels/cpu/split_kernel.cc
@@ -44,7 +44,7 @@ void SplitKernel(const Context& dev_ctx,
 
   std::vector<const DenseTensor*> shape_refer;
   for (size_t j = 0; j < outs.size(); ++j) {
-    dev_ctx.Alloc(outs[j]);
+    dev_ctx.template Alloc<T>(outs[j]);
     shape_refer.emplace_back(outs[j]);
   }
 

--- a/paddle/pten/kernels/gpu/split_kernel.cu
+++ b/paddle/pten/kernels/gpu/split_kernel.cu
@@ -43,7 +43,7 @@ void SplitKernel(const Context& dev_ctx,
 
   std::vector<const DenseTensor*> shape_refer;
   for (size_t j = 0; j < outs.size(); ++j) {
-    dev_ctx.Alloc(outs[j]);
+    dev_ctx.template Alloc<T>(outs[j]);
     shape_refer.emplace_back(outs[j]);
   }
 

--- a/paddle/pten/kernels/reshape_kernel.cc
+++ b/paddle/pten/kernels/reshape_kernel.cc
@@ -29,10 +29,10 @@ void ReshapeKernel(const Context& dev_ctx,
   MetaTensor meta_out(out);
   InferMetaFromVecValue(x, shape.GetData(), &meta_out);
   if (x.initialized() && x.Holder() == out->Holder()) {
-    dev_ctx.Alloc(out);
+    dev_ctx.Alloc(out, x.dtype());
     return;
   }
-  dev_ctx.Alloc(out);
+  dev_ctx.Alloc(out, x.dtype());
   // TODO(chenweihang): the output dims are overwrite after copying,
   // here we need to use copy method that only copy data
   auto dims = out->dims();

--- a/paddle/pten/kernels/xpu/copy_kernel.cc
+++ b/paddle/pten/kernels/xpu/copy_kernel.cc
@@ -30,7 +30,7 @@ void Copy(const Context& dev_ctx,
           bool blocking,
           DenseTensor* dst) {
   auto* src_ptr = src.data();
-  auto* dst_ptr = dev_ctx.Alloc(dst);
+  auto* dst_ptr = dev_ctx.Alloc(dst, src.dtype());
   const auto& src_place = src.place();
   const auto& dst_place = dst->place();
 


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add T to Alloc in split kernel.
Remove default value of DataType in DeviceContext::Alloc