### PR TITLE
[Pten]Support ScalarArray when transform InfershapeContext to InferMetaContext

### DIFF
--- a/paddle/fluid/framework/infershape_utils.cc
+++ b/paddle/fluid/framework/infershape_utils.cc
@@ -20,6 +20,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/framework.pb.h"
 #include "paddle/fluid/framework/pten_utils.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/pten/common/scalar_array.h"
 #include "paddle/pten/core/compat/arg_map_context.h"
 #include "paddle/pten/core/compat/convert_utils.h"
 #include "paddle/pten/core/compat/op_utils.h"
@@ -54,7 +55,12 @@ class InferShapeArgumentMappingContext : public pten::ArgumentMappingContext {
   }
 
   size_t InputSize(const std::string& name) const override {
-    return ctx_.Inputs(name).size();
+    if (ctx_.HasInputs(name)) {
+      return ctx_.Inputs(name).size();
+    } else if (ctx_.HasInput(name)) {
+      return 1;
+    }
+    return 0;
   }
 
   size_t OutputSize(const std::string& name) const override {
@@ -288,6 +294,15 @@ pten::InferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
   auto& attr_names = std::get<1>(signature.args);
   auto& output_names = std::get<2>(signature.args);
 
+  auto kernels = pten::KernelFactory::Instance().kernels().find(signature.name);
+  if (kernels == pten::KernelFactory::Instance().kernels().end()) {
+    PADDLE_THROW(
+        platform::errors::Unimplemented("Not find `%s` kernels when construct "
+                                        "InferMetaContext.",
+                                        signature.name));
+  }
+  auto attr_defs = kernels->second.cbegin()->second.args_def().attribute_defs();
+
   // TODO(chenweihang): support multiple inputs and outputs later
   pten::InferMetaContext infer_mete_context;
   for (auto& in_name : input_names) {
@@ -299,9 +314,56 @@ pten::InferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
     }
   }
 
+  for (auto& out_name : output_names) {
+    if (ctx->HasOutput(out_name)) {
+      infer_meta_context.EmplaceBackOutput(std::make_shared<CompatMetaTensor>(
+          ctx->GetOutputVarPtrs(out_name)[0], ctx->IsRuntime()));
+    } else {
+      infer_meta_context.EmplaceBackOutput({nullptr});
+    }
+  }
   auto attr_reader = ctx->Attrs();
-  for (auto& attr_name : attr_names) {
-    if (ctx->HasAttr(attr_name)) {
+  for (size_t i = 0; i < attr_names.size(); ++i) {
+    auto attr_name = attr_names[i];
+    if (attr_defs[i].type_index == std::type_index(typeid(pten::ScalarArray))) {
+      // When attr is a vector_tensor or tensor, transform it to ScalarArray
+      if (ctx->HasInputs(attr_name) || ctx->HasInput(attr_name)) {
+        const auto& infershape_inputs = ctx->GetInputVarPtrs(attr_name);
+        if (ctx->IsRuntime()) {
+          std::vector<Variable*> vars;
+          vars.reserve(infershape_inputs.size());
+          for (size_t i = 0; i < infershape_inputs.size(); i++) {
+            vars.push_back(BOOST_GET_CONST(Variable*, infershape_inputs[i]));
+          }
+
+          if (infershape_inputs.size() != 1) {
+            infer_meta_context.EmplaceBackAttr(
+                std::move(experimental::MakePtenScalarArrayFromVarList(vars)));
+          } else {
+            infer_meta_context.EmplaceBackAttr(
+                std::move(experimental::MakePtenScalarArrayFromVar(*vars[0])));
+          }
+        } else {
+          VLOG(6) << "Not in Runtime, the Attr( " << attr_name
+                  << ") ScalarArray value will be set empty";
+          infer_meta_context.EmplaceBackAttr(std::move(pten::ScalarArray()));
+        }
+      } else if (ctx->HasAttr(attr_name)) {
+        auto& attr = attr_reader.GetAttr(attr_name);
+        if (std::type_index(attr.type()) ==
+            std::type_index(typeid(std::vector<int32_t>))) {
+          infer_meta_context.EmplaceBackAttr(std::move(
+              pten::ScalarArray(BOOST_GET_CONST(std::vector<int32_t>, attr))));
+        } else {
+          PADDLE_THROW(platform::errors::Unimplemented(
+              "Unsupported cast op attribute `%s` to ScalarArray when "
+              "construct KernelContext.",
+              attr_name));
+        }
+      }
+
+    } else if (ctx->HasAttr(attr_name)) {
+      // Emplace Back Attr according to the type of attr.
       auto& attr = attr_reader.GetAttr(attr_name);
       if (std::type_index(attr.type()) == std::type_index(typeid(bool))) {
         infer_meta_context.EmplaceBackAttr(BOOST_GET_CONST(bool, attr));
@@ -345,17 +407,6 @@ pten::InferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
             "Unsupported attribute type is received when call "
             "InferShapeFunctor."));
       }
-    } else {
-      // do nothing
-    }
-  }
-
-  for (auto& out_name : output_names) {
-    if (ctx->HasOutput(out_name)) {
-      infer_meta_context.EmplaceBackOutput(std::make_shared<CompatMetaTensor>(
-          ctx->GetOutputVarPtrs(out_name)[0], ctx->IsRuntime()));
-    } else {
-      infer_meta_context.EmplaceBackOutput({nullptr});
     }
   }
 

--- a/paddle/fluid/framework/infershape_utils_test.cc
+++ b/paddle/fluid/framework/infershape_utils_test.cc
@@ -23,8 +23,11 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/operator.h"
 #include "paddle/fluid/framework/program_desc.h"
+#include "paddle/pten/backends/cpu/cpu_context.h"
 #include "paddle/pten/core/compat/op_utils.h"
+#include "paddle/pten/core/dense_tensor.h"
 #include "paddle/pten/core/infermeta_utils.h"
+#include "paddle/pten/core/kernel_registry.h"
 
 namespace paddle {
 namespace framework {
@@ -93,6 +96,17 @@ pten::KernelSignature InferShapeUtilsTestOpArgumentMapping(
       {});
 }
 
+template <typename T, typename Context>
+void InferShapeUtilsTestKernel(
+    const Context& dev_ctx, const pten::DenseTensor& x, bool attr1, int attr2,
+    int64_t attr3, float attr4, const std::string& attr5,
+    const std::vector<bool>& attr6, const std::vector<int>& attr7,
+    const std::vector<int64_t>& attr8, const std::vector<float>& attr9,
+    const std::vector<double>& attr10, const std::vector<std::string>& attr11,
+    pten::DenseTensor* out) {
+  VLOG(6) << "Come into InferShapeUtilsTestKernel";
+}
+
 }  // namespace framework
 }  // namespace paddle
 
@@ -103,6 +117,9 @@ REGISTER_OPERATOR(infer_shape_utils_test,
                   paddle::framework::InferShapeUtilsTestOp,
                   paddle::framework::InferShapeUtilsTestOpMaker,
                   InferShapeUtilsTestInferShapeFunctor);
+
+PT_REGISTER_KERNEL(infer_shape_utils_test, CPU, ALL_LAYOUT,
+                   paddle::framework::InferShapeUtilsTestKernel, int) {}
 
 TEST(InferShapeUtilsTest, ALL) {
   paddle::framework::ProgramDesc prog;

--- a/paddle/pten/core/infermeta_utils.h
+++ b/paddle/pten/core/infermeta_utils.h
@@ -27,7 +27,6 @@ limitations under the License. */
 #include "paddle/pten/core/type_defs.h"
 #include "paddle/utils/flat_hash_map.h"
 #include "paddle/utils/small_vector.h"
-
 namespace pten {
 
 class InferMetaContext {

--- a/paddle/pten/core/kernel_utils.h
+++ b/paddle/pten/core/kernel_utils.h
@@ -239,6 +239,10 @@ struct KernelImpl<Return (*)(DevCtx, Args...), kernel_fn> {
   PT_SPECIALIZE_KernelCallHelper_FOR_ATTRIBUTE(const ScalarArray&);
   PT_SPECIALIZE_KernelCallHelper_FOR_ATTRIBUTE(const std::vector<int>&);
   PT_SPECIALIZE_KernelCallHelper_FOR_ATTRIBUTE(const std::string&);
+  PT_SPECIALIZE_KernelCallHelper_FOR_ATTRIBUTE(const std::vector<bool>&);
+  PT_SPECIALIZE_KernelCallHelper_FOR_ATTRIBUTE(const std::vector<float>&);
+  PT_SPECIALIZE_KernelCallHelper_FOR_ATTRIBUTE(const std::vector<double>&);
+  PT_SPECIALIZE_KernelCallHelper_FOR_ATTRIBUTE(const std::vector<std::string>&);
 
   /* Output Helpers */
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
InferMeta支持ScalarArray转换