### PR TITLE
move trunc_op's infer shape

### DIFF
--- a/paddle/fluid/operators/trunc_op.cc
+++ b/paddle/fluid/operators/trunc_op.cc
@@ -21,14 +21,6 @@ namespace operators {
 class TruncOp : public framework::OperatorWithKernel {
  public:
   using framework::OperatorWithKernel::OperatorWithKernel;
-
-  void InferShape(framework::InferShapeContext *ctx) const override {
-    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "trunc");
-    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "trunc");
-    auto input_dims = ctx->GetInputDim("X");
-    ctx->SetOutputDim("Out", input_dims);
-    ctx->ShareLoD("X", /*->*/ "Out");
-  }
 };
 
 class TruncOpMaker : public framework::OpProtoAndCheckerMaker {
@@ -47,16 +39,6 @@ $$out = trunc(x)$$
 class TruncGradOp : public framework::OperatorWithKernel {
  public:
   using framework::OperatorWithKernel::OperatorWithKernel;
-
-  void InferShape(framework::InferShapeContext *ctx) const override {
-    OP_INOUT_CHECK(ctx->HasInput(framework::GradVarName("Out")), "Input",
-                   framework::GradVarName("Out"), "TruncGrad");
-    OP_INOUT_CHECK(ctx->HasOutput(framework::GradVarName("X")), "Output",
-                   framework::GradVarName("X"), "TruncGrad");
-
-    auto dout_dims = ctx->GetInputDim(framework::GradVarName("Out"));
-    ctx->SetOutputDim(framework::GradVarName("X"), dout_dims);
-  }
 };
 
 template <typename T>
@@ -76,8 +58,15 @@ class TruncGradOpMaker : public framework::SingleGradOpMaker<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
+
+DELCARE_INFER_SHAPE_FUNCTOR(trunc, TruncInferShapeFunctor,
+                            PT_INFER_META(pten::TruncInferMeta));
+
 REGISTER_OPERATOR(trunc, ops::TruncOp, ops::TruncOpMaker,
                   ops::TruncGradOpMaker<paddle::framework::OpDesc>,
-                  ops::TruncGradOpMaker<paddle::imperative::OpBase>);
+                  ops::TruncGradOpMaker<paddle::imperative::OpBase>,
+                  TruncInferShapeFunctor);
 
-REGISTER_OPERATOR(trunc_grad, ops::TruncGradOp);
+DELCARE_INFER_SHAPE_FUNCTOR(trunc_grad, TruncGradInferShapeFunctor,
+                            PT_INFER_META(pten::TruncGradInferMeta));
+REGISTER_OPERATOR(trunc_grad, ops::TruncGradOp, TruncGradInferShapeFunctor);

--- a/paddle/pten/infermeta/backward.cc
+++ b/paddle/pten/infermeta/backward.cc
@@ -28,4 +28,17 @@ void GeneralBinaryGradInferMeta(const MetaTensor& x,
   }
 }
 
+void TruncGradInferMeta(const MetaTensor& out_grad, MetaTensor* in_grad) {
+  PADDLE_ENFORCE_NOT_NULL(
+      out_grad,
+      pten::errors::InvalidArgument(
+          "The Input(out_grad) of TruncGradOp should not be null."));
+  PADDLE_ENFORCE_NOT_NULL(
+      in_grad,
+      pten::errors::InvalidArgument(
+          "The Output(in_grad) of TruncGradOp should not be null."));
+  auto dout_dims = out_grad.dims();
+  in_grad->set_dims(dout_dims);
+}
+
 }  // namespace pten

--- a/paddle/pten/infermeta/backward.h
+++ b/paddle/pten/infermeta/backward.h
@@ -25,4 +25,6 @@ void GeneralBinaryGradInferMeta(const MetaTensor& x,
                                 MetaTensor* dx,
                                 MetaTensor* dy);
 
+void TruncGradInferMeta(const MetaTensor& out_grad, MetaTensor* in_grad);
+
 }  // namespace pten

--- a/paddle/pten/infermeta/unary.cc
+++ b/paddle/pten/infermeta/unary.cc
@@ -499,4 +499,17 @@ void TraceInferMeta(
   out->set_dims(framework::make_ddim(sizes));
 }
 
+void TruncInferMeta(const MetaTensor& x, MetaTensor* out) {
+  PADDLE_ENFORCE_NOT_NULL(x,
+                          pten::errors::InvalidArgument(
+                              "The Input(x) of TruncOp should not be null."));
+  PADDLE_ENFORCE_NOT_NULL(
+      out,
+      pten::errors::InvalidArgument(
+          "The Output(out) of TruncOp should not be null."));
+  auto input_dims = x.dims();
+  out->set_dims(input_dims);
+  out->share_lod(x);
+}
+
 }  // namespace pten

--- a/paddle/pten/infermeta/unary.h
+++ b/paddle/pten/infermeta/unary.h
@@ -84,4 +84,6 @@ void SplitInferMeta(const MetaTensor& x_meta,
 void TraceInferMeta(
     const MetaTensor& x, int offset, int axis1, int axis2, MetaTensor* out);
 
+void TruncInferMeta(const MetaTensor& x, MetaTensor* out);
+
 }  // namespace pten


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
move trunc_op's infer shape to pten