### PR TITLE
Fix DistributedFusedLamb alignment bug

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_distributed_fused_lamb_op_with_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_distributed_fused_lamb_op_with_clip.py
@@ -72,7 +72,7 @@ class TestDistributedFusedLambWithClip(unittest.TestCase):
     def test_1(self):
         run_test(clip_after_allreduce=True, max_global_norm=0.01)
 
-    def _test_2(self):
+    def test_2(self):
         run_test(clip_after_allreduce=False, max_global_norm=0.01)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix the bug that the numel of the fused tensor inside `DistributedFusedLamb` op should be a factor of `alignment * nranks` instead of `lcm(alignment, nranks)`.