### PR TITLE
build_cinn_pass: fix bug because of output control var

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
@@ -375,7 +375,7 @@ std::unique_ptr<Graph> CreateNewSubGraph(const GraphNodeSet& cluster,
       const std::unordered_set<std::string>& ignore_names) {
     auto result = std::make_unique<std::vector<std::string>>();
     for (auto* node : nodes) {
-      if (ignore_names.count(node->Name())) {
+      if (!node->Var() || ignore_names.count(node->Name())) {
         continue;
       }
       result->emplace_back(node->Name());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
skip control variables in setting the output variables of a `cinn_launch` operator
