### PR TITLE
fix activation typo on xpu unittest. test=kunlun

### DIFF
--- a/python/paddle/fluid/tests/unittests/xpu/test_activation_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_activation_op_xpu.py
@@ -229,7 +229,7 @@ def gelu(x, approximate):
     return y_ref.astype(x.dtype)
 
 
-class XPUTestHardSwishGeluOP(XPUOpTestWrapper):
+class XPUTestHardSwishOP(XPUOpTestWrapper):
     def __init__(self):
         self.op_name = 'hard_swish'
         self.use_dynamic_create_class = False


### PR DESCRIPTION

### PR types
Bug fixes

### PR changes
Others

### Describe
之前的PR（#39677）里面有个typo。当时没触发，因为hard_swish没在xpu2_op_list.h里面。后来这个PR（#39586）把hard_swish加到了xpu2_op_list.h里面，就踩上了。
