### PR TITLE
[Phi] Fix XPU OP segmentation Fault problem

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1215,16 +1215,15 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
     bool is_xpu_unsupport =
         paddle::platform::is_xpu_place(kernel_type_->place_) &&
             !paddle::platform::is_xpu_support_op(type_, *kernel_type_.get()) ||
-        paddle::platform::is_in_xpu_black_list(type_)
+        paddle::platform::is_in_xpu_black_list(type_);
 #endif
-            if (pt_kernel_->IsValid()
+    if (pt_kernel_->IsValid()
 #ifdef PADDLE_WITH_XPU
-                && !is_xpu_unsupport
+        && !is_xpu_unsupport
 #endif
-                ) {
+        ) {
       run_pten_kernel_ = true;
-    }
-    else {  // NOLINT
+    } else {
       auto& all_op_kernels = AllOpKernels();
       auto kernels_iter = all_op_kernels.find(type_);
       if (kernels_iter == all_op_kernels.end() ||

--- a/paddle/phi/core/compat/convert_utils.cc
+++ b/paddle/phi/core/compat/convert_utils.cc
@@ -30,6 +30,8 @@ Backend TransToPtenBackend(const phi::Place& place) {
     return Backend::CPU;
   } else if (place.GetType() == phi::AllocationType::GPU) {
     return Backend::GPU;
+  } else if (place.GetType() == phi::AllocationType::XPU) {
+    return Backend::XPU;
   } else if (place.GetType() == phi::AllocationType::CUSTOM) {
     return static_cast<Backend>(
         static_cast<size_t>(Backend::NUM_BACKENDS) +


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
段错误是因为dst_ptr是一个shm_open+mmap映射的内存地址，没有写的权限，导致std::memcpy报了段错误。但根本原因是reshape_op不应该fallback到CPU上执行，应该在XPU上执行，这个是后端backend少了XPU的转换逻辑，导致xpu的kernel没有找到导致的