### PR TITLE
Replace fill zeros like by fill any like op

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -610,7 +610,7 @@ def _remove_no_grad_branch_(op_descs, no_grad_set):
         op_desc for op_desc in op_descs
         if not _op_can_be_removed_(op_desc, no_grad_set)
     ]
-    # Insert fill_zeros_like_op
+    # Insert fill_any_like_op
     to_insert = []
     for idx, op_desc in enumerate(op_descs):
         for arg in op_desc.input_arg_names():
@@ -620,7 +620,7 @@ def _remove_no_grad_branch_(op_descs, no_grad_set):
                 # the reason should be: arg can be input of another grad op
                 # and the op is a not-to-remove op
                 to_insert.append((_create_op_desc_(
-                    "fill_zeros_like", {"X": [x_in]}, {"Out": [arg]}, {}), idx))
+                    "fill_any_like", {"X": [x_in]}, {"Out": [arg]}, {'value': 0}), idx))
 
     list([op_descs.insert(p[1], p[0]) for p in reversed(to_insert)])
 

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -620,7 +620,8 @@ def _remove_no_grad_branch_(op_descs, no_grad_set):
                 # the reason should be: arg can be input of another grad op
                 # and the op is a not-to-remove op
                 to_insert.append((_create_op_desc_(
-                    "fill_any_like", {"X": [x_in]}, {"Out": [arg]}, {'value': 0, "dtype": core.VarDesc.VarType.FP32}), idx))
+                    "fill_any_like", {"X": [x_in]}, {"Out": [arg]},
+                    {'value': 0, "dtype": core.VarDesc.VarType.FP32}), idx))
 
     list([op_descs.insert(p[1], p[0]) for p in reversed(to_insert)])
 

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -620,7 +620,7 @@ def _remove_no_grad_branch_(op_descs, no_grad_set):
                 # the reason should be: arg can be input of another grad op
                 # and the op is a not-to-remove op
                 to_insert.append((_create_op_desc_(
-                    "fill_any_like", {"X": [x_in]}, {"Out": [arg]}, {'value': 0}), idx))
+                    "fill_any_like", {"X": [x_in]}, {"Out": [arg]}, {'value': 0, "dtype": core.VarDesc.VarType.FP32}), idx))
 
     list([op_descs.insert(p[1], p[0]) for p in reversed(to_insert)])
 

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1593,7 +1593,11 @@ def zeros_like(x, out=None):
             'zeros_like')
 
     helper.append_op(
-        type='fill_zeros_like', inputs={'X': [x]}, outputs={'Out': [out]})
+        type='fill_any_like',
+        inputs={'X': [x]},
+        attrs={'value': 0,
+               "dtype": x.dtype},
+        outputs={'Out': [out]})
     out.stop_gradient = True
     return out
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Replace fill zeros like by fill any like op

fill_zeros_like和fill_zeros_like2都是废弃op了，和fill_any_like op功能重复，框架内只有两处的使用fill_zeros_like的，没有使用fill_zeros_like2的，将仅有的两处替换为使用fill_any_like，后续希望移除这两个重复的op，并且也不会迁移到phi中