### PR TITLE
optimize performance of lookup_table_v2_op

### DIFF
--- a/paddle/fluid/operators/lookup_table_v2_op.cu
+++ b/paddle/fluid/operators/lookup_table_v2_op.cu
@@ -21,19 +21,18 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 
-template <typename T, typename IdT, int BlockDimX, int BlockDimY, int GridDimX,
-          bool PaddingFlag>
+template <typename T, typename IdT, bool PaddingFlag>
 __global__ void LookupTableV2(T *output, const T *table, const IdT *ids,
                               const int64_t N, const int64_t K, const int64_t D,
                               const int64_t padding_idx) {
   int idx = threadIdx.x;
-  int idy = blockIdx.x + threadIdx.y * GridDimX;
+  int idy = blockIdx.x + threadIdx.y * gridDim.x;
 
   while (idy < K) {
     auto id = static_cast<int64_t>(ids[idy]);
     T *out = output + idy * D;
     const T *tab = table + id * D;
-    for (int i = idx; i < D; i += BlockDimX) {
+    for (int i = idx; i < D; i += blockDim.x) {
       if (PaddingFlag) {
         if (id == padding_idx)
           out[i] = static_cast<T>(0);
@@ -43,25 +42,29 @@ __global__ void LookupTableV2(T *output, const T *table, const IdT *ids,
         out[i] = tab[i];
       }
     }
-    idy += BlockDimY * GridDimX;
+    idy += blockDim.y * gridDim.x;
   }
 }
 
-template <typename T, typename IdT, int BlockDimX, int BlockDimY, int GridDimX>
+template <typename T, typename IdT>
 __global__ void LookupTableV2Grad(T *table, const T *output, const IdT *ids,
                                   const int64_t N, const int64_t K,
                                   const int64_t D) {
   int idx = threadIdx.x;
-  int idy = blockIdx.x + threadIdx.y * GridDimX;
+  int idy = blockIdx.x + threadIdx.y * gridDim.x;
 
   while (idy < K) {
     auto id = static_cast<int64_t>(ids[idy]);
     const T *out = output + idy * D;
     T *tab = table + id * D;
-    for (int i = idx; i < D; i += BlockDimX) {
+#ifdef PADDLE_WITH_CUDA
+    paddle::platform::VectorizedAtomicAddPerBlock(D, idx, blockDim.x, out, tab);
+#else
+    for (int i = idx; i < D; i += blockDim.x) {
       paddle::platform::CudaAtomicAdd(&tab[i], out[i]);
     }
-    idy += BlockDimY * GridDimX;
+#endif
+    idy += blockDim.y * gridDim.x;
   }
 }
 
@@ -81,8 +84,9 @@ struct LookupTableV2CUDAFunctor {
     size_t D = table_t->dims()[1];
     size_t K = ids_t_->numel();
 
+    const int gridx = 2 * context_.cuda_device_context().GetSMCount();
     dim3 threads(256, 4);
-    dim3 grids(80, 1);
+    dim3 grids(gridx, 1);
 
     const auto *table = table_t->template data<T>();
     const auto *ids = ids_t_->template data<IdT>();
@@ -90,10 +94,10 @@ struct LookupTableV2CUDAFunctor {
     auto stream = context_.cuda_device_context().stream();
 
     if (padding_idx == -1) {
-      LookupTableV2<T, IdT, 256, 4, 80, false><<<grids, threads, 0, stream>>>(
+      LookupTableV2<T, IdT, false><<<grids, threads, 0, stream>>>(
           output, table, ids, N, K, D, padding_idx);
     } else {
-      LookupTableV2<T, IdT, 256, 4, 80, true><<<grids, threads, 0, stream>>>(
+      LookupTableV2<T, IdT, true><<<grids, threads, 0, stream>>>(
           output, table, ids, N, K, D, padding_idx);
     }
   }
@@ -193,17 +197,22 @@ struct LookupTableV2GradCUDAFunctor {
       int D = d_table_t->dims()[1];
       int K = ids_t_->numel();
 
-      dim3 threads(128, 8);
-      dim3 grids(8, 1);
       const T *d_output = d_output_t->template data<T>();
       const auto *ids = ids_t_->template data<IdT>();
       T *d_table = d_table_t->mutable_data<T>(context_.GetPlace());
 
-      auto t = framework::EigenVector<T>::Flatten(*d_table_t);
-      t.device(*dev_ctx.eigen_device()) = t.constant(static_cast<T>(0));
+#ifdef PADDLE_WITH_HIP
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          hipMemsetAsync(d_table, 0, N * D * sizeof(T), dev_ctx.stream()));
+#else
+      PADDLE_ENFORCE_GPU_SUCCESS(
+          cudaMemsetAsync(d_table, 0, N * D * sizeof(T), dev_ctx.stream()));
+#endif
 
-      LookupTableV2Grad<T, IdT, 128, 8,
-                        8><<<grids, threads, 0, dev_ctx.stream()>>>(
+      const int gridx = 2 * dev_ctx.GetSMCount();
+      dim3 threads(128, 8);
+      dim3 grids(gridx, 1);
+      LookupTableV2Grad<T, IdT><<<grids, threads, 0, dev_ctx.stream()>>>(
           d_table, d_output, ids, N, K, D);
     }
   }

--- a/paddle/fluid/platform/device/gpu/gpu_primitives.h
+++ b/paddle/fluid/platform/device/gpu/gpu_primitives.h
@@ -190,19 +190,6 @@ __device__ __forceinline__ void fastAtomicAdd(T *arr, size_t index,
   CudaAtomicAdd(arr + index, value);
 }
 
-#if 0
-template <class T>
-__device__ __forceinline__ void fastAtomicAdd(T *arr, size_t index,
-                                              const size_t numel, T value,
-                                              bool fast_atomics = false) {
-  if (fast_atomics) {
-    fastSpecializedAtomicAdd(arr, index, numel, value);
-  } else {
-    CudaAtomicAdd(arr + index, value);
-  }
-}
-#endif
-
 #ifdef PADDLE_WITH_CUDA
 /*
  * One thead block deals with elementwise atomicAdd for vector of len.

--- a/paddle/fluid/platform/device/gpu/gpu_primitives.h
+++ b/paddle/fluid/platform/device/gpu/gpu_primitives.h
@@ -147,6 +147,107 @@ CUDA_ATOMIC_WRAPPER(Add, float16) {
   }
 }
 #endif
+
+// The performance of "atomicAdd(half* )" is bad, but for "atomicAdd(half2* )"
+// is good. So for fp16 type, we can use "atomicAdd(half2* )" to speed up.
+template <typename T, typename std::enable_if<std::is_same<
+                          platform::float16, T>::value>::type * = nullptr>
+__device__ __forceinline__ void fastAtomicAdd(T *tensor, size_t index,
+                                              const size_t numel, T value) {
+#if ((CUDA_VERSION < 10000) || \
+     (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)))
+  CudaAtomicAdd(reinterpret_cast<platform::float16 *>(tensor) + index,
+                static_cast<platform::float16>(value));
+#else
+  // whether the address is 32-byte aligned.
+  __half *target_addr = reinterpret_cast<__half *>(tensor + index);
+  bool aligned_half2 =
+      (reinterpret_cast<std::uintptr_t>(target_addr) % sizeof(__half2) == 0);
+
+  if (aligned_half2 && index < (numel - 1)) {
+    __half2 value2;
+    value2.x = *reinterpret_cast<__half *>(&value);
+    value2.y = __int2half_rz(0);
+    atomicAdd(reinterpret_cast<__half2 *>(target_addr), value2);
+
+  } else if (!aligned_half2 && index > 0) {
+    __half2 value2;
+    value2.x = __int2half_rz(0);
+    value2.y = *reinterpret_cast<__half *>(&value);
+    atomicAdd(reinterpret_cast<__half2 *>(target_addr - 1), value2);
+
+  } else {
+    atomicAdd(reinterpret_cast<__half *>(tensor) + index,
+              *reinterpret_cast<__half *>(&value));
+  }
+#endif
+}
+
+template <typename T, typename std::enable_if<!std::is_same<
+                          platform::float16, T>::value>::type * = nullptr>
+__device__ __forceinline__ void fastAtomicAdd(T *arr, size_t index,
+                                              const size_t numel, T value) {
+  CudaAtomicAdd(arr + index, value);
+}
+
+#if 0
+template <class T>
+__device__ __forceinline__ void fastAtomicAdd(T *arr, size_t index,
+                                              const size_t numel, T value,
+                                              bool fast_atomics = false) {
+  if (fast_atomics) {
+    fastSpecializedAtomicAdd(arr, index, numel, value);
+  } else {
+    CudaAtomicAdd(arr + index, value);
+  }
+}
+#endif
+
+#ifdef PADDLE_WITH_CUDA
+/*
+ * One thead block deals with elementwise atomicAdd for vector of len.
+ * @in: [x1, x2, x3, ...]
+ * @out:[y1+x1, y2+x2, y3+x3, ...]
+ * */
+template <typename T, typename std::enable_if<!std::is_same<
+                          platform::float16, T>::value>::type * = nullptr>
+__device__ __forceinline__ void VectorizedAtomicAddPerBlock(
+    const int64_t len, int tid, int threads_per_block, const T *in, T *out) {
+  for (int i = tid; i < len; i += threads_per_block) {
+    CudaAtomicAdd(&out[i], in[i]);
+  }
+}
+
+// Note: assume that len is even. If len is odd, call fastAtomicAdd directly.
+template <typename T, typename std::enable_if<std::is_same<
+                          platform::float16, T>::value>::type * = nullptr>
+__device__ __forceinline__ void VectorizedAtomicAddPerBlock(
+    const int64_t len, int tid, int threads_per_block, const T *in, T *out) {
+  int i = 0;
+  int loops = len / 2 * 2;
+
+  bool aligned_half2 =
+      (reinterpret_cast<std::uintptr_t>(out) % sizeof(__half2) == 0);
+
+  if (aligned_half2) {
+    for (i = tid * 2; i < loops; i += threads_per_block * 2) {
+      __half2 value2;
+      T value_1 = in[i];
+      T value_2 = in[i + 1];
+      value2.x = *reinterpret_cast<__half *>(&value_1);
+      value2.y = *reinterpret_cast<__half *>(&value_2);
+      atomicAdd(reinterpret_cast<__half2 *>(&out[i]), value2);
+    }
+    for (; i < len; i += threads_per_block) {
+      fastAtomicAdd(out, i, len, in[i]);
+    }
+  } else {
+    for (int i = tid; i < len; i += threads_per_block) {
+      fastAtomicAdd(out, i, len, in[i]);
+    }
+  }
+}
+#endif
 #endif
 
 CUDA_ATOMIC_WRAPPER(Add, complex<float>) {


### PR DESCRIPTION
### PR types
Performance optimization 

### PR changes
OPs

### Describe
Optimize the lookup_table_v2_op cuda implementation :
1. modifying block configs to improve parallelism and replacing eigen fill to memset operations.
2. Use vectorized half2 to accelerate lookup_table_v2_grad of fp16 type.  

Performance results:
 
weight type： fp32

前向：
#rows | 28672 | 14336 | 7168 | 3584 | 1792 | 896 | 448 | 224 | 112 | 56
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
每次平均时间（ns）： |   |   |   |   |   |   |   |   |   |  
torch | 388132.6945 | 198200.7055 | 102779.22 | 55352.4235 | 30584.144 | 18323.924 | 11965.79025 | 9187.1955 | 7767.1485 | 6862.596
paddle | 297181.339 | 151734.7933 | 80506.91075 | 44245.821 | 25124.6865 | 15403.02575 | 11295.889 | 7945.50275 | 7471.5335 | 7235.57725
paddle_opt | 196586.3 | 102349.4288 | 54887.281 | 31177.76275 | 19231.03625 | 12930.68825 | 8984.6565 | 7957.018 | 7522.75525 | 7291.37975
加速比： |   |   |   |   |   |   |   |   |   |  
nv/paddle | 1.306046658 | 1.306231097 | 1.276650899 | 1.251020373 | 1.217294552 | 1.189631459 | 1.059304872 | 1.156276171 | 1.039565506 | 0.948451763
nv/paddle_opt | 1.974362885 | 1.936510129 | 1.872550765 | 1.77538151 | 1.590353406 | 1.417088066 | 1.331802752 | 1.15460283 | 1.032487199 | 0.941193057
paddle/paddle_opt | 1.511709305 | 1.482517246 | 1.466768061 | 1.41914676 | 1.306465558 | 1.191199219 | 1.257242166 | 0.998552818 | 0.993191092 | 0.992346785

结论：优化后相比优化前快0.99-1.51x，相比竞品torch快0.94-1.97x。


反向：

#rows | 28672 | 14336 | 7168 | 3584 | 1792 | 896 | 448 | 224 | 112 | 56
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
每次平均时间（ns）： |   |   |   |   |   |   |   |   |   |  
诸多kernel | 1030748.672 | 800320.438 | 638265.6688 | 539160.6598 | 480192.4818 | 432415.758 | 407163.4263 | 395145.133 | 390088.3185 | 385025.1205
paddle | 2137766.472 | 1073019.323 | 544362.5275 | 274703.8445 | 139399.8438 | 73540.7325 | 39879.46975 | 24690.522 | 15014.83375 | 10034.43125
paddle_opt | 274375.2188 | 141527.2588 | 78582.06275 | 43410.83175 | 26401.143 | 15902.55775 | 12274.17275 | 10537.92 | 10016.00775 | 9673.0915
加速比： |   |   |   |   |   |   |   |   |   |  
nv/paddle | 0.482161492 | 0.745858365 | 1.172501112 | 1.962697904 | 3.444713199 | 5.87994902 | 10.20985055 | 16.00391976 | 25.98019565 | 38.37039797
nv/paddle_opt | 3.756711983 | 5.654885462 | 8.122281936 | 12.41995691 | 18.18832169 | 27.19158545 | 33.17237215 | 37.49745045 | 38.94648729 | 39.80372981
paddle/paddle_opt | 7.791397787 | 7.581714872 | 6.927312779 | 6.328002331 | 5.280068509 | 4.624459389 | 3.249055603 | 2.343016648 | 1.499083679 | 1.037355146

结论：优化后相比优化前快1.03-7.79x，相比竞品torch快3.75-39.8x。

weight type： fp16


config-0： | paddle | torch | paddle-opt | paddle/paddle-opt | torch/paddle-opt
-- | -- | -- | -- | -- | --
  | 8204884.6 | 126850.5498 | 24090.1035 | 340.59x | 5.26x

Note: config-0: table shape = [2, 768], index shape=[16*128] 

All #row from 56 to 28672: | paddle | torch | paddle-opt | paddle/paddle-opt | torch/paddle-opt
-- | -- | -- | -- | -- | --
  | 102822673.7 | 897208.361 | 226602.5423 | 453.75x | 3.95x


结论：优化后比优化前获得百倍以上加速；优化后比竞品在大部分case下快3x多。
