### PR TITLE
Fix a bug in IndexKernel out-of-memory

### DIFF
--- a/paddle/fluid/operators/index_impl.cu.h
+++ b/paddle/fluid/operators/index_impl.cu.h
@@ -45,7 +45,7 @@ __global__ void VectorizedIndexKernel(T *out, int numel, int main_offset,
                                             BLOCK_NUM_X * VecSize);
   }
   int num = numel - data_offset;
-  if (numel > 0) {
+  if (num > 0) {
     kps::InitWithDataIndex<int, VecSize, 1, 1>(&args[0], data_offset);
     kps::ElementwiseUnary<int, T, VecSize, 1, 1, Functor>(&result[0], &args[0],
                                                           func);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
修复IndexKernel 访存越界的问题，只在CE上有表现，复现方式 pytest -sv test_list_dygraph.py
bug现象： 
![2bda848aeb46442570b7e3c3917ffc5d](https://user-images.githubusercontent.com/51102941/155323091-10ccb1f7-e781-4cc3-96b6-f96fa3e12c11.jpg)
