### PR TITLE
[PHi] Skip kernel declare for cuda only kernel on rocm

### DIFF
--- a/cmake/pten.cmake
+++ b/cmake/pten.cmake
@@ -58,10 +58,15 @@ endfunction()
 function(kernel_declare TARGET_LIST)
     foreach(kernel_path ${TARGET_LIST})
         file(READ ${kernel_path} kernel_impl)
-        # TODO(chenweihang): rename PD_REGISTER_KERNEL to PD_REGISTER_KERNEL
-        # NOTE(chenweihang): now we don't recommend to use digit in kernel name
-        string(REGEX MATCH "(PD_REGISTER_KERNEL|PD_REGISTER_GENERAL_KERNEL)\\([ \t\r\n]*[a-z0-9_]*," first_registry "${kernel_impl}")
+        string(REGEX MATCH "(PD_REGISTER_KERNEL|PD_REGISTER_GENERAL_KERNEL)\\([ \t\r\n]*[a-z0-9_]*,[ \t\r\n\/]*[a-z0-9_]*" first_registry "${kernel_impl}")
         if (NOT first_registry STREQUAL "")
+            # some gpu kernel only can run on cuda, not support rocm, so we add this branch
+            if (WITH_ROCM)
+                string(FIND "${first_registry}" "cuda_only" pos)
+                if(pos GREATER 1)
+                    continue()
+                endif()
+            endif()
             # parse the first kernel name
             string(REPLACE "PD_REGISTER_KERNEL(" "" kernel_name "${first_registry}")
             string(REPLACE "PD_REGISTER_GENERAL_KERNEL(" "" kernel_name "${kernel_name}")

--- a/cmake/pten.cmake
+++ b/cmake/pten.cmake
@@ -72,6 +72,7 @@ function(kernel_declare TARGET_LIST)
             string(REPLACE "PD_REGISTER_GENERAL_KERNEL(" "" kernel_name "${kernel_name}")
             string(REPLACE "," "" kernel_name "${kernel_name}")
             string(REGEX REPLACE "[ \t\r\n]+" "" kernel_name "${kernel_name}")
+            string(REGEX REPLACE "//cuda_only" "" kernel_name "${kernel_name}")
             # append kernel declare into declarations.h
             # TODO(chenweihang): default declare ALL_LAYOUT for each kernel
             if (${kernel_path} MATCHES "./cpu\/")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[PHi] Skip kernel declare for cuda only kernel on rocm

有少数几个gpu kernel比较特殊，只能在cuda上运行，而不能在rocm上运行，但是kernel declare的逻辑是通过正则自动生成的，无法判断这种情况，为了处理这几个case，增加一个trick的处理规则，当kernel注册时增加`cuda_only`标记的时候，在rocm上会跳过其kernel declare的生成

写法示例如下，在kernel name后面用注释声明的`cuda_only`

```
PD_REGISTER_KERNEL(cholesky, // cuda_only
    GPU, ALL_LAYOUT, phi::CholeskyKernel, float, double) {}
```