### PR TITLE
[ROCm] fix Managed Memory Alloc on HIP, test=develop

### DIFF
--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -493,7 +493,8 @@ class AllocatorFacadePrivate {
             "support allocating managed memory.\n"
             "If you don't actually need to use managed memory, please disable "
             "it with command `export FLAGS_use_cuda_managed_memory=false`.\n"
-            "Or you must use the gpu device that supports managed memory."));
+            "Or you must use the gpu device that supports managed memory.",
+            p.device));
       }
       return std::make_shared<CUDAManagedAllocator>(p);
     }

--- a/paddle/fluid/memory/cuda_managed_memory_test.cu
+++ b/paddle/fluid/memory/cuda_managed_memory_test.cu
@@ -128,8 +128,13 @@ TEST(ManagedMemoryTest, OversubscribeGPUMemoryTest) {
 }
 
 TEST(ManagedMemoryTest, OOMExceptionTest) {
+#ifdef PADDLE_WITH_CUDA
   EXPECT_THROW(Alloc(platform::CUDAPlace(0), size_t(1) << 60),
                memory::allocation::BadAlloc);
+#else  // Hygon DCU get hipDeviceAttributeManagedMemory to 0
+  EXPECT_THROW(Alloc(platform::CUDAPlace(0), size_t(1) << 60),
+               platform::EnforceNotMet);
+#endif
 }
 
 }  // namespace memory

--- a/paddle/fluid/memory/cuda_managed_memory_test.cu
+++ b/paddle/fluid/memory/cuda_managed_memory_test.cu
@@ -128,13 +128,11 @@ TEST(ManagedMemoryTest, OversubscribeGPUMemoryTest) {
 }
 
 TEST(ManagedMemoryTest, OOMExceptionTest) {
-#ifdef PADDLE_WITH_CUDA
+  if (!platform::IsGPUManagedMemorySupported(0)) {
+    return;
+  }
   EXPECT_THROW(Alloc(platform::CUDAPlace(0), size_t(1) << 60),
                memory::allocation::BadAlloc);
-#else  // Hygon DCU get hipDeviceAttributeManagedMemory to 0
-  EXPECT_THROW(Alloc(platform::CUDAPlace(0), size_t(1) << 60),
-               platform::EnforceNotMet);
-#endif
 }
 
 }  // namespace memory


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

Fix cuda_managed_memory_test failure on DCU.

1. DCU NOT support managed Memory now:
![image](https://user-images.githubusercontent.com/16605440/155488476-1791ef52-8e9e-4f8d-ad8f-5707ee9b892d.png)

2. Fix cuda_managed_memory_test  to handle Paddle enforce not met instead of badalloc

Related PR https://github.com/PaddlePaddle/Paddle/pull/39075


