### PR TITLE
Fix for failing CI for log_softmax OneDNN kernel

### DIFF
--- a/paddle/fluid/operators/mkldnn/log_softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/log_softmax_mkldnn_op.cc
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#include "paddle/fluid/operators/softmax_op.h"
 #include "paddle/fluid/platform/mkldnn_reuse.h"
 
 namespace paddle {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix for failing CI for log_softmax OneDNN kernel
