### PR TITLE
[PHI] Replace PD_THROW to PADDLE_THROW in Scalar and ScalarArray

### DIFF
--- a/paddle/phi/common/scalar.h
+++ b/paddle/phi/common/scalar.h
@@ -17,8 +17,8 @@ limitations under the License. */
 #include <cstdint>
 #include <limits>
 
-#include "paddle/phi/api/ext/exception.h"
 #include "paddle/phi/api/include/tensor.h"
+#include "paddle/phi/core/enforce.h"
 namespace paddle {
 namespace experimental {
 
@@ -104,11 +104,12 @@ class ScalarBase {
   // The Tensor must have one dim
   ScalarBase(const T& tensor) : dtype_(tensor.dtype()) {  // NOLINT
     is_from_tensor_ = true;
-    PD_CHECK(
-        tensor.numel() == 1,
-        "The Scalar only supports Tensor with 1 element, but now Tensor has `",
+    PADDLE_ENFORCE_EQ(
         tensor.numel(),
-        "` element.");
+        1,
+        phi::errors::InvalidArgument("The Scalar only supports Tensor with 1 "
+                                     "element, but now Tensor has %d element.",
+                                     tensor.numel()));
     switch (dtype_) {
       case DataType::FLOAT32:
         data_.f32 = tensor.template data<float>()[0];
@@ -147,7 +148,8 @@ class ScalarBase {
         data_.c128 = tensor.template data<complex128>()[0];
         break;
       default:
-        PD_THROW("Invalid tensor data type `", dtype_, "`.");
+        PADDLE_THROW(phi::errors::InvalidArgument(
+            "Invalid tensor data type : %s.", dtype_));
     }
   }
 
@@ -190,7 +192,8 @@ class ScalarBase {
       case DataType::COMPLEX128:
         return static_cast<RT>(data_.c128);
       default:
-        PD_THROW("Invalid enum scalar data type `", dtype_, "`.");
+        PADDLE_THROW(phi::errors::InvalidArgument(
+            "Invalid enum scalar data type : %s.", dtype_));
     }
   }
 

--- a/paddle/phi/common/scalar_array.h
+++ b/paddle/phi/common/scalar_array.h
@@ -14,8 +14,8 @@ limitations under the License. */
 
 #pragma once
 
-#include "paddle/phi/api/ext/exception.h"
 #include "paddle/phi/api/include/tensor.h"
+#include "paddle/phi/core/enforce.h"
 
 namespace paddle {
 namespace experimental {
@@ -60,12 +60,10 @@ class ScalarArrayBase {
         AssignData(tensor.template data<int64_t>(), n);
         break;
       default:
-        PD_THROW(
-            "Data type error. Currently, The data type of ScalarArrayBase "
-            "only supports Tensor with int32 and int64, "
-            "but now received `",
-            tensor.dtype(),
-            "`.");
+        PADDLE_THROW(phi::errors::InvalidArgument(
+            "Data type error. Currently, The data type of ScalarArrayBase only "
+            "supports Tensor with int32 and int64, but now received %s.",
+            tensor.dtype()));
     }
   }
 
@@ -83,12 +81,10 @@ class ScalarArrayBase {
           array_.push_back(*tensor_list[i].template data<int64_t>());
           break;
         default:
-          PD_THROW(
+          PADDLE_THROW(phi::errors::InvalidArgument(
               "Data type error. Currently, The data type of ScalarArrayBase "
-              "only supports Tensor with int32 and int64, "
-              "but now received `",
-              data_type,
-              "`.");
+              "only supports Tensor with int32 and int64, but now received %s.",
+              data_type));
       }
     }
   }
@@ -109,7 +105,8 @@ class ScalarArrayBase {
         array_.push_back(static_cast<int64_t>(value_data[i]));
       }
     } else {
-      PD_THROW("The input data pointer is null.");
+      PADDLE_THROW(
+          phi::errors::InvalidArgument("The input data pointer is null."));
     }
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
将Scalar 和 ScalarArray中的PD_THROW替换为PADDLE_THROW