### PR TITLE
Fix bug for prepare phi OP

### DIFF
--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -186,11 +186,10 @@ PreparedOp PrepareImpl(const NameVarMap<VarType>& ins,
               << " | kernel key: " << pt_kernel_key
               << " | kernel: " << pt_kernel;
 
-      if (platform::is_cpu_place(expected_kernel_key.place_)) {
-        auto* cpu_ctx = pool.Get(paddle::platform::CPUPlace());
-        return PreparedOp(op, ctx, expected_kernel_key, pt_kernel_signature,
-                          pt_kernel, cpu_ctx);
+      if (expected_kernel_key.place_ != place) {
+        dev_ctx = pool.Get(expected_kernel_key.place_);
       }
+
       // TODO(chenweihang): using CPUKernel when miss device kernel case
       return PreparedOp(op, ctx, expected_kernel_key, pt_kernel_signature,
                         pt_kernel, dev_ctx);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
PR #38979 adds some [codes](https://github.com/PaddlePaddle/Paddle/pull/38979/files#diff-7b3d497f2efe0d31a006f288eb6035340d52fbfda2144bab4647e7674b1cd8e3R176) in _prepared_operatoer.cc_ that reacquires a CPU DeviceContext from the DeviceContextPool when the _expected_kernel_key.place__ is CPU place. This cannot handle all situations. When the _expected_kernel_key.place__ is GPU place and the place parameter for _PreparedImpl_ is CPU place, the DeviceContext also need to be reacquired, or a CPU DeviceContext will pass to a GPU kernel. 
This bug is triggered after moving Compare OPs to phi in PR #39970 , which causes a random segmentation fault in case _test_where.py_ in CE:
![image](https://user-images.githubusercontent.com/17673696/156160316-dc060ad7-791f-4f39-8560-00baa2b911ec.png)
![image](https://user-images.githubusercontent.com/17673696/156160367-d6fc219b-527f-484e-8e0f-e4760e35d028.png)

This PR fixes this bug.