### PR TITLE
[FixBug]Fix bugs when use save_combine op

### DIFF
--- a/paddle/fluid/operators/save_combine_op.cc
+++ b/paddle/fluid/operators/save_combine_op.cc
@@ -38,7 +38,8 @@ class SaveCombineOp : public framework::OperatorWithKernel {
   framework::OpKernelType GetKernelTypeForVar(
       const std::string& var_name, const Tensor& tensor,
       const framework::OpKernelType& expected_kernel_type) const override {
-    return expected_kernel_type;
+    return framework::OpKernelType(expected_kernel_type.data_type_,
+                                   tensor.place());
   }
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复了save_combine的一个bug，该bug发生主要是由于在调用save_combine op的时候，传入的是GPU的Tensor却调用的CPU的Kernel导致，报错如下：
![4508b9f6f233f3ab8971ffc59d337b30](https://user-images.githubusercontent.com/29249150/156315686-82f36732-faf9-4f11-87e6-4f2930ee94b6.jpg)
