### PR TITLE
[Infrt] add ir for convert pd dilect to phi dialect. test=develop

### DIFF
--- a/paddle/infrt/dialect/infrt/infrt_ops.td
+++ b/paddle/infrt/dialect/infrt/infrt_ops.td
@@ -17,3 +17,10 @@ def Infrt_KernelOp : Infrt_Op<"kernel", [NoSideEffect]> {
                        OptionalAttr<DictionaryAttr>:$attrs);
   let results = (outs Variadic<AnyType>);
 }
+
+def Infrt_CvtTensorOp : Infrt_Op<"cvt_tensor", [NoSideEffect]> {
+  let summary = "convert tensor type op";
+  let description = [{convert tensor type op!}];
+  let arguments = (ins AnyType:$input);
+  let results = (outs AnyType:$output);
+}

--- a/paddle/infrt/dialect/phi/CMakeLists.txt
+++ b/paddle/infrt/dialect/phi/CMakeLists.txt
@@ -5,5 +5,8 @@ endif()
 add_subdirectory(ir)
 add_subdirectory(pass)
 
+add_executable(phi-ir-exec phi_ir_exec.cc)
+target_link_libraries(phi-ir-exec infrt)
+
 add_executable(phi-exec phi_exec.cc)
 target_link_libraries(phi-exec infrt)

--- a/paddle/infrt/dialect/phi/ir/infrt_phi_base.td
+++ b/paddle/infrt/dialect/phi/ir/infrt_phi_base.td
@@ -3,6 +3,7 @@
 
 include "mlir/IR/OpBase.td"
 include "paddle/infrt/dialect/infrt_base.td"
+include "mlir/Interfaces/InferTypeOpInterface.td"
 
 def PHI_Dialect : Dialect {
   let name = "phi";

--- a/paddle/infrt/dialect/phi/pass/kernel_op_desc.cc
+++ b/paddle/infrt/dialect/phi/pass/kernel_op_desc.cc
@@ -16,8 +16,10 @@
 #include <glog/logging.h>
 #include "paddle/phi/core/kernel_factory.h"
 #include "paddle/phi/core/kernel_registry.h"
-namespace infrt {
+#include "paddle/phi/kernels/declarations.h"
 
+namespace infrt {
+namespace {
 phi::Backend cvtTarget2Phi(TargetType target) {
   switch (target) {
     case TargetType::CPU:
@@ -124,19 +126,76 @@ Place cvtPlaceFromPhi(phi::TensorArgDef tensor_arg) {
                cvtLayoutFromPhi(tensor_arg.layout));
 }
 
+}  // namespace
+
+std::string getPhiTargetPrefix(TargetType target) {
+  switch (target) {
+    case TargetType::CPU:
+      return "phi_cpu.";
+    case TargetType::GPU:
+      return "phi_gpu.";
+    default:
+      LOG(FATAL) << "UnSupported target type !";
+      return std::string();
+  }
+}
+std::string getPhiPrecisionSuffix(PrecisionType precision) {
+  switch (precision) {
+    case PrecisionType::FLOAT32:
+      return ".float32";
+    case PrecisionType::FLOAT16:
+      return ".float16";
+    case PrecisionType::FLOAT64:
+      return ".float64";
+    case PrecisionType::UINT8:
+      return ".uint8";
+    case PrecisionType::INT8:
+      return ".int8";
+    case PrecisionType::INT16:
+      return ".int16";
+    case PrecisionType::INT32:
+      return ".int32";
+    case PrecisionType::INT64:
+      return ".int64";
+    case PrecisionType::COMPLEX64:
+      return ".complex64";
+    case PrecisionType::COMPLEX128:
+      return ".complex128";
+    case PrecisionType::BOOL:
+      return ".bool";
+    default:
+      LOG(FATAL) << "UnSupported precision type !";
+      return std::string();
+  }
+}
+std::string getPhiLayoutSuffix(LayoutType layout) {
+  switch (layout) {
+    case LayoutType::NCHW:
+      return ".nchw";
+    case LayoutType::NHWC:
+      return ".nhwc";
+    case LayoutType::ANY:
+      return ".any";
+    default:
+      LOG(FATAL) << "UnSupported layout type !";
+      return std::string();
+  }
+}
+
 std::vector<PhiKernelDesc> getCandidateKernels(
     std::string name, const std::vector<Place>& valid_palces) {
   std::vector<PhiKernelDesc> candidate_kernels;
   PhiKernelDesc phi_kernel_desc;
   phi::KernelKeyMap kernel_key_map =
       phi::KernelFactory::Instance().SelectKernelMap(name);
-  for (const Place& place : valid_palces) {
+  for (Place place : valid_palces) {
     phi::KernelKey kernel_key = cvtPlace2Phi(place);
     if (kernel_key_map.find(kernel_key) == kernel_key_map.end()) {
       kernel_key = phi::KernelKey(kernel_key.backend(),
                                   phi::DataLayout::ALL_LAYOUT,
                                   kernel_key.dtype());
       if (kernel_key_map.find(kernel_key) == kernel_key_map.end()) continue;
+      place.layout = LayoutType::ANY;
     }
     phi_kernel_desc.kernelType = place;
     phi_kernel_desc.inputsType.clear();

--- a/paddle/infrt/dialect/phi/pass/kernel_op_desc.h
+++ b/paddle/infrt/dialect/phi/pass/kernel_op_desc.h
@@ -26,6 +26,10 @@ struct PhiKernelDesc {
   Place kernelType;                // kernel place
 };
 
+std::string getPhiTargetPrefix(TargetType target);
+std::string getPhiPrecisionSuffix(PrecisionType precision);
+std::string getPhiLayoutSuffix(LayoutType layout);
+
 std::vector<PhiKernelDesc> getCandidateKernels(
     std::string name, const std::vector<Place>& valid_palces);
 

--- a/paddle/infrt/dialect/phi/pass/proto_arg_map_context.h
+++ b/paddle/infrt/dialect/phi/pass/proto_arg_map_context.h
@@ -20,7 +20,7 @@ limitations under the License. */
 #include "paddle/phi/core/compat/arg_map_context.h"
 
 namespace infrt {
-class ProtoArgumentMappingContext : public phi::ArgumentMappingContext {
+class ProtoArgumentMappingContext : public ::phi::ArgumentMappingContext {
  public:
   // only support op in pd dialect
   explicit ProtoArgumentMappingContext(mlir::Operation* op)

--- a/paddle/infrt/dialect/phi/phi_ir_exec.cc
+++ b/paddle/infrt/dialect/phi/phi_ir_exec.cc
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <llvm/Support/CommandLine.h>
+#include <mlir/Pass/PassManager.h>
+#include <iostream>
+#include <string>
+#include "paddle/infrt/common/global.h"
+#include "paddle/infrt/dialect/mlir_loader.h"
+#include "paddle/infrt/dialect/phi/pass/phi_op_cvt_pass.h"
+
+int main(int argc, char** argv) {
+  static llvm::cl::opt<std::string> input_file(
+      llvm::cl::Positional,
+      llvm::cl::desc("Specify input filename"),
+      llvm::cl::init("-"));
+
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  mlir::MLIRContext* context = infrt::Global::getMLIRContext();
+  auto module = infrt::dialect::LoadMlirFile(input_file.c_str(), context);
+  context->loadAllAvailableDialects();
+  module->dump();
+  mlir::PassManager pm(context);
+
+  mlir::OpPassManager& phi_pass_manager = pm.nest<mlir::FuncOp>();
+  std::vector<infrt::Place> valid_places = {{infrt::TargetType::CPU,
+                                             infrt::PrecisionType::FLOAT32,
+                                             infrt::LayoutType::NCHW}};
+  phi_pass_manager.addPass(std::make_unique<infrt::phiOpCvtPass>(valid_places));
+  if (mlir::failed(pm.run(*module))) {
+    std::cout << "\npass failed!\n" << std::endl;
+    return 4;
+  }
+  module->dump();
+  return 0;
+}

--- a/paddle/infrt/host_context/CMakeLists.txt
+++ b/paddle/infrt/host_context/CMakeLists.txt
@@ -12,6 +12,7 @@ gather_srcs(infrt_src SRCS
     function.cc
     mlir_function_executable.cc
     mlir_program_executor.cc
+    paddle_mlir.cc
     )
 
 cc_test_tiny(test_infrt_host_context_value SRCS value_test.cc DEPS infrt ${MLIR_IR_LIBS})
@@ -21,7 +22,7 @@ cc_test_tiny(test_infrt_op_executable SRCS op_executable_test.cc DEPS infrt ${ML
 cc_test_tiny(test_infrt_core_runtime SRCS core_runtime_test.cc DEPS infrt ${MLIR_IR_LIBS})
 cc_test_tiny(test_infrt_mlir_to_runtime_translate SRCS mlir_to_runtime_translate_test.cc DEPS infrt ${MLIR_IR_LIBS})
 
-add_executable(paddle-mlir-convert paddle_mlir.cc paddle_mlir_converter.cc)
+add_executable(paddle-mlir-convert paddle_mlir_converter.cc)
 target_link_libraries(paddle-mlir-convert infrt ${MLIR_IR_LIBS})
 add_executable(infrtexec mlir_exec.cc)
 target_link_libraries(infrtexec infrt ${MLIR_IR_LIBS})

--- a/paddle/infrt/pass/CMakeLists.txt
+++ b/paddle/infrt/pass/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(phi)

--- a/paddle/infrt/tests/CMakeLists.txt
+++ b/paddle/infrt/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 configure_file(lit.cfg.py.in "${CMAKE_SOURCE_DIR}/paddle/infrt/tests/lit.cfg.py")
 
 add_test(NAME test_infrt_by_lit COMMAND sh -c "lit -v ${CMAKE_SOURCE_DIR}/paddle/infrt/tests --filter-out \"disabled_*\""
-    DEPENDS infrtopt infrtexec)
+    DEPENDS infrtopt infrtexec phi-ir-exec)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/dialect/tensor/tensor_map.mlir.in ${CMAKE_CURRENT_SOURCE_DIR}/dialect/tensor/tensor_map.mlir)

--- a/paddle/infrt/tests/dialect/pten/pten_pass.mlir
+++ b/paddle/infrt/tests/dialect/pten/pten_pass.mlir
@@ -1,4 +1,4 @@
-// RUN: infrtopt %s | FileCheck %s
+// RUN: phi-ir-exec %s
 // CHECK-LABEL: @ops
 func @ops() {
   %a = pd.feed() {name="input0"} : !infrt.lod_tensor<?xf32,0>

--- a/paddle/infrt/tests/lit.cfg.py.in
+++ b/paddle/infrt/tests/lit.cfg.py.in
@@ -23,9 +23,10 @@ config.llvm_tools_dir = os.path.join(build_dir, "/third_party/install/llvm/lib")
 infrtopt_bin = os.path.join(build_dir, "paddle/infrt/dialect/")
 trtexec_bin = os.path.join(build_dir, "paddle/infrt/dialect/tensorrt/")
 infrtexec_bin = os.path.join(build_dir, "paddle/infrt/host_context/")
+phi_ir_exec_bin = os.path.join(build_dir, "paddle/infrt/dialect/phi")
 
 llvm_bin = os.path.join(build_dir, "third_party/install/llvm/bin/")
 config.environment['PATH'] = os.path.pathsep.join(
-    (infrtopt_bin, infrtexec_bin, trtexec_bin, llvm_bin, config.environment['PATH']))
+    (infrtopt_bin, infrtexec_bin, trtexec_bin, phi_ir_exec_bin, llvm_bin, config.environment['PATH']))
 
 config.suffixes = ['.mlir']

--- a/paddle/scripts/infrt_build.sh
+++ b/paddle/scripts/infrt_build.sh
@@ -92,7 +92,7 @@ function infrt_gen_and_build() {
         exit 7;
     fi
 
-    make -j ${parallel_number} infrt infrtopt infrtexec test_infrt_exec trt-exec phi-exec infrt_lib_dist paddle-mlir-convert;build_error=$?
+    make -j ${parallel_number} infrt infrtopt infrtexec test_infrt_exec trt-exec phi-ir-exec phi-exec infrt_lib_dist paddle-mlir-convert;build_error=$?
     if [ "$build_error" != 0 ];then
         exit 7;
     fi

--- a/tools/infrt/fake_models/multi_fc.py
+++ b/tools/infrt/fake_models/multi_fc.py
@@ -19,7 +19,6 @@ import sys, os
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid.backward import append_backward
 
 size = 2
 num_layers = 4

--- a/tools/infrt/generate_phi_kernel_dialect.py
+++ b/tools/infrt/generate_phi_kernel_dialect.py
@@ -16,7 +16,7 @@ import json
 import sys
 
 attr_type_converter = {"i": 'SI32Attr', "b": 'BoolAttr', "l": 'SI64Attr'}
-supported_kernels = ['sign', 'dot', 'digamma', 'conj']
+supported_kernels = ['sign', 'dot', 'digamma', 'conj', 'abs', 'add_raw']
 
 target_type_converter = {"CPU": "CPU", "GPU": "GPU"}
 layout_type_converter = {
@@ -66,7 +66,8 @@ def generate_attrs_info(op_name, attrs_info):
         'digamma': [],
         'lerp': [],
         'cast': ['out_dtype', 'in_dtype'],
-        'abs': []
+        'abs': [],
+        'add_raw': ['axis'],
     }
     attrs_args_ = ""
     if len(kernel_attrs_names[op_name]) == len(attrs_info):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->
添加了从pd dialect 到 phi dialect的转换 ir.
pd dialect 到 phi dialect转换分为两步： 
1.  pd dialect  --> infrt.kernel op   见 phiOpCvtPass::convertStage()
2.  infrt.kernel op --> phi dialect op 见 phiOpCvtPass::diapatchStage()


定义见： 
paddle/infrt/dialect/phi/pass/phi_op_cvt_pass.cc
执行：
Paddle/build/paddle/infrt/dialect/phi/phi-ir-exec Paddle/paddle/infrt/tests/dialect/phi/phi_pass.mlir
输入：
```mlir
module  {
  func @ops() {
    %0 = pd.feed() {name = "input0"} : !infrt.lod_tensor<?xf32, 0>
    %1 = pd.feed() {name = "input1"} : !infrt.lod_tensor<?xf32, 0>
    %2 = pd.feed() {name = "input3"} : !infrt.lod_tensor<3x4x9xf32, 0>
    %3 = "pd.elementwise_add"(%0, %1) {axis = 1 : si32} : (!infrt.lod_tensor<?xf32, 0>, !infrt.lod_tensor<?xf32, 0>) -> tensor<?xf32>
    %4 = "pd.abs"(%3) : (tensor<?xf32>) -> tensor<?xf32>
    "pd.fetch"(%4) {name = "output"} : (tensor<?xf32>) -> ()
  }
}
```
输出：
```mlir
module  {
  func @ops() {
    %0 = pd.feed() {name = "input0"} : !infrt.lod_tensor<?xf32, 0>
    %1 = pd.feed() {name = "input1"} : !infrt.lod_tensor<?xf32, 0>
    %2 = pd.feed() {name = "input3"} : !infrt.lod_tensor<3x4x9xf32, 0>
    %3 = "phi_dt.create_allocator.cpu"() : () -> !phi.CPU_Allocator
    %4 = "phi_dt.create_context.cpu"(%3) : (!phi.CPU_Allocator) -> !phi.CPU_Context
    %5 = "infrt.cvt_tensor"(%0) : (!infrt.lod_tensor<?xf32, 0>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
    %6 = "infrt.cvt_tensor"(%1) : (!infrt.lod_tensor<?xf32, 0>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
    %7 = "phi_cpu.add_raw.any.float32"(%4, %5, %6) {axis = 1 : si32} : (!phi.CPU_Context, !infrt.dense_tensor<CPU, FP32, NCHW>, !infrt.dense_tensor<CPU, FP32, NCHW>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
    %8 = "infrt.cvt_tensor"(%7) : (!infrt.dense_tensor<CPU, FP32, NCHW>) -> tensor<?xf32>
    %9 = "infrt.cvt_tensor"(%8) : (tensor<?xf32>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
    %10 = "phi_cpu.abs.any.float32"(%4, %9) : (!phi.CPU_Context, !infrt.dense_tensor<CPU, FP32, NCHW>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
    %11 = "infrt.cvt_tensor"(%10) : (!infrt.dense_tensor<CPU, FP32, NCHW>) -> tensor<?xf32>
    "pd.fetch"(%11) {name = "output"} : (tensor<?xf32>) -> ()
  }
}
```
Todo in next pr:
融合"infrt.cvt_tensor"算子.