### PR TITLE
[Paddle Inference] fix flatten_op flatten_contiguous_range_op: use IShuffleLayer(reshape)

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
@@ -33,95 +33,49 @@ class FlattenContiguousRangeOpConverter : public OpConverter {
     framework::OpDesc op_desc(op, nullptr);
     // Declare inputs
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
-    int dims = input->getDimensions().nbDims;
+    auto dims = input->getDimensions();
     int start_axis = BOOST_GET_CONST(int, op_desc.GetAttr("start_axis"));
     int stop_axis = BOOST_GET_CONST(int, op_desc.GetAttr("stop_axis"));
 
     nvinfer1::IShuffleLayer* layer = nullptr;
     if (!engine_->with_dynamic_shape()) {
-      if (start_axis < 0) start_axis += dims + 1;
-      if (stop_axis < 0) stop_axis += dims + 1;
-      int dim_prod = 1;
-      nvinfer1::Dims flatten_dim;
-      flatten_dim.nbDims = dims - (stop_axis - start_axis);
-      for (int i = 0, j = 0; i < dims; ++i) {
-        if (start_axis <= i + 1 && i + 1 <= stop_axis) {
-          int dim_i = input->getDimensions().d[i];
-          PADDLE_ENFORCE_GT(dim_i, 0, platform::errors::InvalidArgument(
-                                          "flatten_contiguous_range input dim "
-                                          "should be > 0, but got %d.",
-                                          dim_i));
-          dim_prod *= dim_i;
-          if (i + 1 == stop_axis) {
-            flatten_dim.d[j++] = dim_prod;
-          }
-        } else {
-          flatten_dim.d[j++] = input->getDimensions().d[i];
-        }
+      if (start_axis < 0) {
+        start_axis += dims.nbDims + 1;
       }
-      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-      layer->setReshapeDimensions(flatten_dim);
-    } else {
-      if (start_axis < 0) start_axis += dims;
-      if (stop_axis < 0) stop_axis += dims;
-      auto* shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
-      auto* shape_layer_itensor = shape_layer->getOutput(0);
-
-      nvinfer1::Dims start_dim, size_dim, stride_dim;
-      start_dim.nbDims = 1;
-      size_dim.nbDims = 1;
-      stride_dim.nbDims = 1;
-      start_dim.d[0] = start_axis;
-      size_dim.d[0] = stop_axis - start_axis + 1;
-      stride_dim.d[0] = 1;
-      auto* slice_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Slice, *shape_layer_itensor, start_dim,
-                               size_dim, stride_dim);
-      uint32_t reduce_dim = 1;
-      auto* reduce_prod_layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Reduce, *(slice_layer->getOutput(0)),
-          nvinfer1::ReduceOperation::kPROD, reduce_dim, true);
-
-      nvinfer1::ITensor* input_shape = nullptr;
-      if (start_axis == 0 && stop_axis == dims - 1) {
-        input_shape = reduce_prod_layer->getOutput(0);
+      if (start_axis == 0) {
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "The flatten_contiguous_range'start_axis must != 0, when use "
+            "static shape mode."));
       } else {
-        std::vector<nvinfer1::ITensor*> itensors;
-        if (start_axis > 0) {
-          nvinfer1::Dims left_start_dim, left_size_dim, left_stride_dim;
-          left_start_dim.nbDims = 1;
-          left_size_dim.nbDims = 1;
-          left_stride_dim.nbDims = 1;
-          left_start_dim.d[0] = 0;
-          left_size_dim.d[0] = start_axis;
-          left_stride_dim.d[0] = 1;
-          auto* slice_layer_left = TRT_ENGINE_ADD_LAYER(
-              engine_, Slice, *shape_layer_itensor, left_start_dim,
-              left_size_dim, left_stride_dim);
-          itensors.push_back(slice_layer_left->getOutput(0));
-        }
-        itensors.push_back(reduce_prod_layer->getOutput(0));
-        if (stop_axis < dims - 1) {
-          nvinfer1::Dims right_start_dim, right_size_dim, right_stride_dim;
-          right_start_dim.nbDims = 1;
-          right_size_dim.nbDims = 1;
-          right_stride_dim.nbDims = 1;
-          right_start_dim.d[0] = stop_axis + 1;
-          right_size_dim.d[0] = dims - stop_axis - 1;
-          right_stride_dim.d[0] = 1;
-          auto* slice_layer_right = TRT_ENGINE_ADD_LAYER(
-              engine_, Slice, *shape_layer_itensor, right_start_dim,
-              right_size_dim, right_stride_dim);
-          itensors.push_back(slice_layer_right->getOutput(0));
-        }
-        auto* concat_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, Concatenation, itensors.data(), itensors.size());
-        concat_layer->setAxis(0);
-        input_shape = concat_layer->getOutput(0);
+        start_axis--;
       }
-      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-      layer->setInput(1, *input_shape);
+
+      if (stop_axis < 0) {
+        stop_axis += dims.nbDims + 1;
+      }
+      if (stop_axis == 0) {
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "The flatten_contiguous_range'stop_axis must != 0, when use static "
+            "shape mode."));
+      } else {
+        stop_axis--;
+      }
+    } else {
+      if (start_axis < 0) {
+        start_axis += dims.nbDims;
+      }
+      if (stop_axis < 0) {
+        stop_axis += dims.nbDims;
+      }
     }
+    nvinfer1::Dims flatten_dim;
+    flatten_dim.nbDims = dims.nbDims - (stop_axis - start_axis);
+    for (int i = 0; i < flatten_dim.nbDims; i++) {
+      flatten_dim.d[i] = 0;
+    }
+    flatten_dim.d[start_axis] = -1;
+    layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+    layer->setReshapeDimensions(flatten_dim);
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "flatten_contiguous_range", {output_name},
                              test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_contiguous_range_op.cc
@@ -33,49 +33,95 @@ class FlattenContiguousRangeOpConverter : public OpConverter {
     framework::OpDesc op_desc(op, nullptr);
     // Declare inputs
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
-    auto dims = input->getDimensions();
+    int dims = input->getDimensions().nbDims;
     int start_axis = BOOST_GET_CONST(int, op_desc.GetAttr("start_axis"));
     int stop_axis = BOOST_GET_CONST(int, op_desc.GetAttr("stop_axis"));
 
     nvinfer1::IShuffleLayer* layer = nullptr;
     if (!engine_->with_dynamic_shape()) {
-      if (start_axis < 0) {
-        start_axis += dims.nbDims + 1;
+      if (start_axis < 0) start_axis += dims + 1;
+      if (stop_axis < 0) stop_axis += dims + 1;
+      int dim_prod = 1;
+      nvinfer1::Dims flatten_dim;
+      flatten_dim.nbDims = dims - (stop_axis - start_axis);
+      for (int i = 0, j = 0; i < dims; ++i) {
+        if (start_axis <= i + 1 && i + 1 <= stop_axis) {
+          int dim_i = input->getDimensions().d[i];
+          PADDLE_ENFORCE_GT(dim_i, 0, platform::errors::InvalidArgument(
+                                          "flatten_contiguous_range input dim "
+                                          "should be > 0, but got %d.",
+                                          dim_i));
+          dim_prod *= dim_i;
+          if (i + 1 == stop_axis) {
+            flatten_dim.d[j++] = dim_prod;
+          }
+        } else {
+          flatten_dim.d[j++] = input->getDimensions().d[i];
+        }
       }
-      if (start_axis == 0) {
-        PADDLE_THROW(platform::errors::InvalidArgument(
-            "The flatten_contiguous_range'start_axis must != 0, when use "
-            "static shape mode."));
-      } else {
-        start_axis--;
-      }
-
-      if (stop_axis < 0) {
-        stop_axis += dims.nbDims + 1;
-      }
-      if (stop_axis == 0) {
-        PADDLE_THROW(platform::errors::InvalidArgument(
-            "The flatten_contiguous_range'stop_axis must != 0, when use static "
-            "shape mode."));
-      } else {
-        stop_axis--;
-      }
+      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+      layer->setReshapeDimensions(flatten_dim);
     } else {
-      if (start_axis < 0) {
-        start_axis += dims.nbDims;
+      if (start_axis < 0) start_axis += dims;
+      if (stop_axis < 0) stop_axis += dims;
+      auto* shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
+      auto* shape_layer_itensor = shape_layer->getOutput(0);
+
+      nvinfer1::Dims start_dim, size_dim, stride_dim;
+      start_dim.nbDims = 1;
+      size_dim.nbDims = 1;
+      stride_dim.nbDims = 1;
+      start_dim.d[0] = start_axis;
+      size_dim.d[0] = stop_axis - start_axis + 1;
+      stride_dim.d[0] = 1;
+      auto* slice_layer =
+          TRT_ENGINE_ADD_LAYER(engine_, Slice, *shape_layer_itensor, start_dim,
+                               size_dim, stride_dim);
+      uint32_t reduce_dim = 1;
+      auto* reduce_prod_layer = TRT_ENGINE_ADD_LAYER(
+          engine_, Reduce, *(slice_layer->getOutput(0)),
+          nvinfer1::ReduceOperation::kPROD, reduce_dim, true);
+
+      nvinfer1::ITensor* input_shape = nullptr;
+      if (start_axis == 0 && stop_axis == dims - 1) {
+        input_shape = reduce_prod_layer->getOutput(0);
+      } else {
+        std::vector<nvinfer1::ITensor*> itensors;
+        if (start_axis > 0) {
+          nvinfer1::Dims left_start_dim, left_size_dim, left_stride_dim;
+          left_start_dim.nbDims = 1;
+          left_size_dim.nbDims = 1;
+          left_stride_dim.nbDims = 1;
+          left_start_dim.d[0] = 0;
+          left_size_dim.d[0] = start_axis;
+          left_stride_dim.d[0] = 1;
+          auto* slice_layer_left = TRT_ENGINE_ADD_LAYER(
+              engine_, Slice, *shape_layer_itensor, left_start_dim,
+              left_size_dim, left_stride_dim);
+          itensors.push_back(slice_layer_left->getOutput(0));
+        }
+        itensors.push_back(reduce_prod_layer->getOutput(0));
+        if (stop_axis < dims - 1) {
+          nvinfer1::Dims right_start_dim, right_size_dim, right_stride_dim;
+          right_start_dim.nbDims = 1;
+          right_size_dim.nbDims = 1;
+          right_stride_dim.nbDims = 1;
+          right_start_dim.d[0] = stop_axis + 1;
+          right_size_dim.d[0] = dims - stop_axis - 1;
+          right_stride_dim.d[0] = 1;
+          auto* slice_layer_right = TRT_ENGINE_ADD_LAYER(
+              engine_, Slice, *shape_layer_itensor, right_start_dim,
+              right_size_dim, right_stride_dim);
+          itensors.push_back(slice_layer_right->getOutput(0));
+        }
+        auto* concat_layer = TRT_ENGINE_ADD_LAYER(
+            engine_, Concatenation, itensors.data(), itensors.size());
+        concat_layer->setAxis(0);
+        input_shape = concat_layer->getOutput(0);
       }
-      if (stop_axis < 0) {
-        stop_axis += dims.nbDims;
-      }
+      layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+      layer->setInput(1, *input_shape);
     }
-    nvinfer1::Dims flatten_dim;
-    flatten_dim.nbDims = dims.nbDims - (stop_axis - start_axis);
-    for (int i = 0; i < flatten_dim.nbDims; i++) {
-      flatten_dim.d[i] = 0;
-    }
-    flatten_dim.d[start_axis] = -1;
-    layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-    layer->setReshapeDimensions(flatten_dim);
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "flatten_contiguous_range", {output_name},
                              test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/flatten_op.cc
@@ -34,57 +34,48 @@ class FlattenOpConverter : public OpConverter {
     framework::OpDesc op_desc(op, nullptr);
     // Declare inputs
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
-    int dims = input->getDimensions().nbDims;
+    auto dims = input->getDimensions();
+    int start_axis = BOOST_GET_CONST(int, op_desc.GetAttr("axis"));
+    int stop_axis = dims.nbDims - 1;
     nvinfer1::IShuffleLayer* layer = nullptr;
     if (!engine_->with_dynamic_shape()) {
-      int dim_prod = 1;
-      for (int i = 0; i < dims; i++) {
-        int dim_i = input->getDimensions().d[i];
-        PADDLE_ENFORCE_GT(
-            dim_i, 0,
-            platform::errors::InvalidArgument(
-                "flatten input dim should be > 0, but got %d.", dim_i));
-        dim_prod *= dim_i;
+      if (dims.nbDims <= 1) {
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "On TRT static shape, flatten input dims should > 1."));
       }
+      if (start_axis < 0) {
+        start_axis += dims.nbDims + 1;
+      }
+      if (start_axis == 0) {
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "The flatten'start_axis must != 0, when use static shape mode."));
+      } else {
+        start_axis--;
+      }
+
       nvinfer1::Dims flatten_dim;
-      flatten_dim.nbDims = 1;
-      flatten_dim.d[0] = dim_prod;
+      flatten_dim.nbDims = dims.nbDims - (stop_axis - start_axis);
+      for (int i = 0; i < flatten_dim.nbDims; i++) {
+        flatten_dim.d[i] = 0;
+      }
+      flatten_dim.d[start_axis] = 1;
+      for (int i = start_axis; i <= stop_axis; i++) {
+        flatten_dim.d[start_axis] *= dims.d[i];
+      }
       layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
       layer->setReshapeDimensions(flatten_dim);
     } else {
-      auto* shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
-      nvinfer1::Dims start_dim, size_dim, stride_dim;
-      start_dim.nbDims = 1;
-      size_dim.nbDims = 1;
-      stride_dim.nbDims = 1;
-      start_dim.d[0] = 1;
-      size_dim.d[0] = dims - 1;
-      stride_dim.d[0] = 1;
-      auto* slice_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Slice, *(shape_layer->getOutput(0)),
-                               start_dim, size_dim, stride_dim);
-      uint32_t reduce_dim = 1;
-      auto* reduce_prod_layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Reduce, *(slice_layer->getOutput(0)),
-          nvinfer1::ReduceOperation::kPROD, reduce_dim, true);
-      int32_t* constant_weight_data = new int32_t[1];
-      constant_weight_data[0] = -1;
-      TensorRTEngine::Weight constant_weight{
-          nvinfer1::DataType::kINT32, static_cast<void*>(constant_weight_data),
-          1};
-      nvinfer1::Dims constant_dims;
-      constant_dims.nbDims = 1;
-      constant_dims.d[0] = 1;
-      auto* constant_layer = TRT_ENGINE_ADD_LAYER(
-          engine_, Constant, constant_dims, constant_weight.get());
-      std::vector<nvinfer1::ITensor*> itensors;
-      itensors.push_back(constant_layer->getOutput(0));
-      itensors.push_back(reduce_prod_layer->getOutput(0));
-      auto* concat_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Concatenation, itensors.data(), 2);
-      concat_layer->setAxis(0);
+      if (start_axis < 0) {
+        start_axis += dims.nbDims;
+      }
+      nvinfer1::Dims flatten_dim;
+      flatten_dim.nbDims = dims.nbDims - (stop_axis - start_axis);
+      for (int i = 0; i < flatten_dim.nbDims; i++) {
+        flatten_dim.d[i] = 0;
+      }
+      flatten_dim.d[start_axis] = -1;
       layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-      layer->setInput(1, *(concat_layer->getOutput(0)));
+      layer->setReshapeDimensions(flatten_dim);
     }
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "flatten", {output_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -546,8 +546,8 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
           return false;
         }
         if (dims <= 1) {
-          VLOG(3) << "On TRT static shape, flatten_contiguous_range input dims "
-                     "should > 1 ";
+          VLOG(3) << "TRT flatten_contiguous_range input dims should > 1 "
+                     "in static_shape mode ";
           return false;
         }
         for (int i = start_axis; i <= stop_axis; ++i) {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -499,16 +499,37 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
         return false;
       }
     }
-    if (op_type == "flatten2" || op_type == "flatten") {
+    if (op_type == "flatten") {
       if (!desc.HasAttr("axis")) {
+        VLOG(3) << "flatten need attribute: axis.";
         return false;
       } else {
+        if (with_dynamic_shape) {
 #if IS_TRT_VERSION_GE(7130)
 #else
-        if (with_dynamic_shape) return false;
+          VLOG(3) << "Flatten_op'dynamic shape need TensorRt version > 7.1 ";
+          return false;
 #endif
-        int axis = BOOST_GET_CONST(int, desc.GetAttr("axis"));
-        if (axis != 1) return false;
+        } else {
+          auto x_var_name = desc.Input("X")[0];
+          auto* block = desc.Block();
+          auto* x_var_desc = block->FindVar(x_var_name);
+          const auto x_shape = x_var_desc->GetShape();
+          int dims = x_shape.size();
+          int axis = BOOST_GET_CONST(int, desc.GetAttr("axis"));
+          if (axis < 0) {
+            axis += dims;
+          }
+          if (axis == 0) {
+            VLOG(3) << "TRT flatten_op not support the "
+                       "batch-dimension being changed in static_shape mode";
+            return false;
+          }
+          if (dims <= 1) {
+            VLOG(3) << "On TRT static shape, flatten input dims should > 1 ";
+            return false;
+          }
+        }
       }
     }
     if (op_type == "flatten_contiguous_range") {
@@ -529,16 +550,19 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
         if (start_axis < 0) start_axis += dims;
         if (start_axis == 0) {
           VLOG(3) << "TRT flatten_contiguous_range not support the "
-                     "batch-dimension being changed";
+                     "batch-dimension being changed in static_shape mode";
           return false;
         }
         if (stop_axis < 0) stop_axis += dims;
-        for (int i = start_axis; i <= stop_axis; ++i) {
-          if (x_shape[i] < 0) {
-            VLOG(3) << "On TRT static shape,flatten_contiguous_range input dim "
-                       "should be > 0";
-            return false;
-          }
+        if (stop_axis == 0) {
+          VLOG(3) << "TRT flatten_contiguous_range not support the "
+                     "batch-dimension being changed in static_shape mode";
+          return false;
+        }
+        if (dims <= 1) {
+          VLOG(3) << "On TRT static shape, flatten_contiguous_range input dims "
+                     "should > 1 ";
+          return false;
         }
       }
     }

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_flatten.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_flatten.py
@@ -75,7 +75,7 @@ class TrtConvertFlattenTest_dim_2(TrtLayerAutoScanTest):
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
             ver = paddle_infer.get_trt_compile_version()
-            if ver[0] * 1000 + ver[1] * 100 + ver[0] * 10 >= 7130:
+            if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 >= 7130:
                 if attrs[0]['axis'] == 1:
                     return 1, 2
                 else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix flatten_op flatten_contiguous_range_op: use IShuffleLayer(reshape)