### PR TITLE
fix yolo_loss return value in dygraph mode

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_yolov3_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_yolov3_loss_op.py
@@ -305,6 +305,7 @@ class TestYolov3LossDygraph(unittest.TestCase):
             use_label_smooth=True,
             scale_x_y=1.)
         assert loss is not None
+        assert loss.shape == [2]
         paddle.enable_static()
 
 

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -195,7 +195,7 @@ def yolo_loss(x,
     """
 
     if in_dygraph_mode() and gt_score is None:
-        loss = _C_ops.yolov3_loss(
+        loss, _, _ = _C_ops.yolov3_loss(
             x, gt_box, gt_label, 'anchors', anchors, 'anchor_mask', anchor_mask,
             'class_num', class_num, 'ignore_thresh', ignore_thresh,
             'downsample_ratio', downsample_ratio, 'use_label_smooth',


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
fix return value of `paddle.vision.ops.yolo_loss` in dygraph mode
fix  https://github.com/PaddlePaddle/Paddle/issues/40145
