### PR TITLE
为 Paddle 新增 corrcoef(皮尔逊积矩相关系数) API #40332

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -2990,3 +2990,44 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
         singular_values = paddle.static.data(name='singular_values', shape=[0])
 
     return solution, residuals, rank, singular_values
+
+
+def corrcoef(x, rowvar=True, ddof=True, name=None):
+    """
+    Estimate the corrcoef matrix of the input variables, given data and weights.
+    A corrcoef matrix is a square matrix, indicate the corrcoef of each pair variables in the input matrix.
+    For example, for an N-dimensional samples X=[x1,x2,…xN]T, then the corrcoef matrix 
+    element Cij is the corrcoef of xi and xj. The element Cii is 1.0.
+    Parameters:
+        x(Tensor): A N-D(N<=2) Tensor containing multiple variables and observations. By default, each row of x represents a variable. Also see rowvar below.
+        rowvar(Bool, optional): If rowvar is True (default), then each row represents a variable, with observations in the columns. Default: True
+        ddof(Bool, optional): If ddof=True will return the unbiased estimate, and ddof=False will return the simple average. Default: True
+        name(str, optional): Name of the output. Default is None. It's used to print debug info for developers. Details: :ref:`api_guide_Name`
+    Returns:
+        Tensor: The corrcoef matrix Tensor of the variables.
+    Examples:
+    .. code-block:: python
+        import paddle
+        x = paddle.rand((3,4))
+        paddle.linalg.corrcoef(x)
+        '''
+        Tensor(shape=[3, 3], dtype=float64, place=CUDAPlace(0), stop_gradient=True,
+            [[ 1.        ,  0.06972050, -0.46672094],
+                [ 0.06972050,  1.        ,  0.34793886],
+                [-0.46672094,  0.34793886,  1.        ]])
+        '''
+    """
+    if len(x.shape) > 2 or len(x.shape) < 1:
+        raise ValueError(
+            "Input(x) only support N-D (1<=N<=2) tensor in corrcoef, but received "
+            "length of Input(input) is %s." % len(x.shape))
+    check_variable_and_dtype(x, 'dtype', ['float32', 'float64'], 'corrcoef')
+
+    x_cov = paddle.linalg.cov(x, rowvar = rowvar, ddof = ddof, name = name)
+    if x_cov.shape == []:
+        corr = paddle.to_tensor([1], dtype = x.dtype)
+    else:
+        x_div = paddle.mm(paddle.diag(x_cov).reshape([-1, 1]), paddle.diag(x_cov).reshape([1, -1])) ** 0.5
+        corr = paddle.divide(x_cov, x_div)
+
+    return corr


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
为 Paddle 新增 corrcoef(皮尔逊积矩相关系数) API #40332