### PR TITLE
[custom kernel] fix static object de-initialize bug

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -728,6 +728,12 @@ PYBIND11_MODULE(core_noavx, m) {
            Args:
                lib[string]: the libarary, could be 'phi', 'fluid' and 'all'.
            )DOC");
+  // NOTE(Aganlengzi): KernelFactory static instance is initialized BEFORE
+  // plugins are loaded for custom kernels, but de-inialized AFTER them are
+  // unloaded. We need manually clear symbols stored in static instance in
+  // case for illegal memory access.
+  m.def("clear_kernel_factory",
+        []() { phi::KernelFactory::Instance().kernels().clear(); });
 
   // NOTE(zjl): ctest would load environment variables at the beginning even
   // though we have not `import paddle.fluid as fluid`. So we add this API

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -730,7 +730,7 @@ PYBIND11_MODULE(core_noavx, m) {
            )DOC");
 
   // NOTE(Aganlengzi): KernelFactory static instance is initialized BEFORE
-  // plugins are loaded for custom kernels, but de-initialized AFTER them are
+  // plugins are loaded for custom kernels, but de-initialized AFTER they are
   // unloaded. We need manually clear symbols(may contain plugins' symbols)
   // stored in this static instance to avoid illegal memory access.
   m.def("clear_kernel_factory",

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -728,10 +728,11 @@ PYBIND11_MODULE(core_noavx, m) {
            Args:
                lib[string]: the libarary, could be 'phi', 'fluid' and 'all'.
            )DOC");
+
   // NOTE(Aganlengzi): KernelFactory static instance is initialized BEFORE
-  // plugins are loaded for custom kernels, but de-inialized AFTER them are
-  // unloaded. We need manually clear symbols stored in static instance in
-  // case for illegal memory access.
+  // plugins are loaded for custom kernels, but de-initialized AFTER them are
+  // unloaded. We need manually clear symbols(may contain plugins' symbols)
+  // stored in this static instance to avoid illegal memory access.
   m.def("clear_kernel_factory",
         []() { phi::KernelFactory::Instance().kernels().clear(); });
 

--- a/paddle/phi/core/custom_kernel.cc
+++ b/paddle/phi/core/custom_kernel.cc
@@ -33,6 +33,10 @@ void CustomKernelMap::RegisterCustomKernel(const std::string& name,
 void CustomKernelMap::RegisterCustomKernels() {
   VLOG(3) << "Size of custom_kernel_map: " << kernels_.size();
 
+  if (kernels_.size() <= 0) {
+    LOG(INFO) << "No custom kernel info found in loaded lib(s).";
+    return;
+  }
   auto& kernels = KernelFactory::Instance().kernels();
   for (auto& pair : kernels_) {
     PADDLE_ENFORCE_NE(
@@ -60,9 +64,10 @@ void CustomKernelMap::RegisterCustomKernels() {
               << info_pair.first
               << "] to Paddle. It will be used like native ones.";
     }
-    kernels_[pair.first].clear();
   }
-  LOG(INFO) << "Successed in loading custom kernels.";
+  LOG(INFO) << "Successed in loading " << kernels_.size()
+            << " custom kernel(s) from loaded lib(s), will be "
+            << "used like native ones.";
   kernels_.clear();
 }
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -226,3 +226,5 @@ if core.is_compiled_with_npu():
     atexit.register(core.npu_finalize)
 # NOTE(Aurelius84): clean up ExecutorCacheInfo in advance manually.
 atexit.register(core.clear_executor_cache)
+# NOTE(Aganlengzi): clean up KernelFactory in advance manually.
+atexit.register(core.clear_kernel_factory)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
1.Fix bug caused by static objects de-initialize order:
KernelFactory static instance is initialized BEFORE plugins are loaded for custom kernels, but de-initialized AFTER them are unloaded. We need manually clear symbols(may contain plugins' symbols) stored in this static instance to avoid illegal memory access.
2.Refine log info.
