### PR TITLE
【Hackathon + No.8】

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -210,6 +210,7 @@ from .tensor.math import square  # noqa: F401
 from .tensor.math import stanh  # noqa: F401
 from .tensor.math import sum  # noqa: F401
 from .tensor.math import nansum  # noqa: F401
+from .tensor.math import nanmean  # noqa: F401
 from .tensor.math import tanh  # noqa: F401
 from .tensor.math import tanh_  # noqa: F401
 from .tensor.math import add_n  # noqa: F401
@@ -542,6 +543,7 @@ __all__ = [  # noqa
            'not_equal',
            'sum',
            'nansum',
+           'nanmean',
            'tile',
            'greater_equal',
            'isfinite',

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -6948,8 +6948,8 @@ def _get_paddle_place(place):
             device_id = place_info_list[1]
             device_id = int(device_id)
             return core.CUDAPlace(device_id)
-            
-    # XPU   
+
+    # XPU
     avaliable_xpu_place = re.match(r'xpu:\d+', place)
     if avaliable_xpu_place:
         if not core.is_compiled_with_xpu():

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -6948,8 +6948,8 @@ def _get_paddle_place(place):
             device_id = place_info_list[1]
             device_id = int(device_id)
             return core.CUDAPlace(device_id)
-
-    # XPU
+            
+    # XPU   
     avaliable_xpu_place = re.match(r'xpu:\d+', place)
     if avaliable_xpu_place:
         if not core.is_compiled_with_xpu():

--- a/python/paddle/fluid/tests/unittests/text_nanmean_api.py
+++ b/python/paddle/fluid/tests/unittests/text_nanmean_api.py
@@ -44,7 +44,6 @@ class API_Test_Nanmean(unittest.TestCase):
             res = exe.run(train_program,
                           feed={'input': x},
                           fetch_list=[out1, out2, out3, out4])
-
             out1_np = np.array(res[0])
             out2_np = np.array(res[1])
             out3_np = np.array(res[2])

--- a/python/paddle/fluid/tests/unittests/text_nanmean_api.py
+++ b/python/paddle/fluid/tests/unittests/text_nanmean_api.py
@@ -1,0 +1,101 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid import Program, program_guard
+
+
+class API_Test_Nanmean(unittest.TestCase):
+    def test_static_graph(self):
+        paddle.enable_static()
+        startup_program = fluid.Program()
+        train_program = fluid.Program()
+        with fluid.program_guard(train_program, startup_program):
+            input = fluid.data(name='input', dtype='float32', shape=[2, 4])
+            out1 = paddle.nanmean(input)
+            out2 = paddle.nanmean(input, axis=0)
+            out3 = paddle.nanmean(input, axis=-1)
+            out4 = paddle.nanmean(input, axis=1, keepdim=True)
+            place = fluid.CPUPlace()
+            if fluid.core.is_compiled_with_cuda():
+                place = fluid.CUDAPlace(0)
+            exe = fluid.Executor(place)
+            exe.run(startup_program)
+
+            x = np.array([[float('nan'), 3, 5, 9],
+                          [1, 2, float('-nan'), 7]]).astype(np.float32)
+            res = exe.run(train_program,
+                          feed={'input': x},
+                          fetch_list=[out1, out2, out3, out4])
+
+            out1_np = np.array(res[0])
+            out2_np = np.array(res[1])
+            out3_np = np.array(res[2])
+            out4_np = np.array(res[3])
+            out1_ref = np.array([4.5]).astype(np.float32)
+            out2_ref = np.array([1, 2.5, 5, 8]).astype(np.float32)
+            out3_ref = np.array([5.6666665 ,3.3333333]).astype(np.float32)
+            out4_ref = np.array([[5.6666665], [3.3333333]]).astype(np.float32)
+
+            self.assertTrue(
+                (out1_np == out1_ref).all(),
+                msg='nanmean output is wrong, out =' + str(out1_np))
+            self.assertTrue(
+                (out2_np == out2_ref).all(),
+                msg='nanmean output is wrong, out =' + str(out2_np))
+            self.assertTrue(
+                (out3_np == out3_ref).all(),
+                msg='nanmean output is wrong, out =' + str(out3_np))
+            self.assertTrue(
+                (out4_np == out4_ref).all(),
+                msg='nanmean output is wrong, out =' + str(out4_np))
+
+    def test_error_api(self):
+        paddle.enable_static()
+
+        ## input dtype error
+        def run1():
+            input = fluid.data(name='input', dtype='float16', shape=[2, 3])
+            output = paddle.nanmean(input)
+
+        self.assertRaises(TypeError, run1)
+
+        ## axis type error
+        def run2():
+            input = fluid.data(name='input', dtype='float16', shape=[2, 3])
+            output = paddle.nanmean(input, axis=1.2)
+
+        self.assertRaises(TypeError, run2)
+
+    def test_dygraph(self):
+        x = np.array([[float('nan'), 3, 5, 9],
+                      [1, 2, float('-nan'), 7]]).astype(np.float32)
+        with fluid.dygraph.guard():
+            inputs = fluid.dygraph.to_variable(x)
+            out = paddle.nanmean(inputs)
+            out_ref = np.array([4.5]).astype(np.float32)
+
+            self.assertTrue(
+                (out.numpy() == out_ref).all(),
+                msg='nanmean output is wrong, out =' + str(out.numpy()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -334,6 +334,7 @@ tensor_method_func  = [ #noqa
            'stanh',
            'sum',
            'nansum',
+           'nanmean',
            'tanh',
            'tanh_',
            'add_n',

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -165,6 +165,7 @@ from .math import square  # noqa: F401
 from .math import stanh  # noqa: F401
 from .math import sum  # noqa: F401
 from .math import nansum  # noqa: F401
+from .math import nanmean #noqa: F401
 from .math import tanh  # noqa: F401
 from .math import tanh_  # noqa: F401
 from .math import add_n  # noqa: F401

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -966,6 +966,75 @@ def nansum(x, axis=None, dtype=None, keepdim=False, name=None):
     tmp_tensor = paddle.where(isnan(x), zero_tensor, x)
     return sum(tmp_tensor, axis, dtype, keepdim, name)
 
+def nanmean(x,axis=None,keepdim=None,name=None):
+    r"""
+    Compute the arithmetic mean along the specified axis, ignoring NaNs.
+
+    Args:
+        x (Tensor): The input Tensor with data type float32, float64.
+        axis (int|list|tuple, optional):The axis along which to perform mean
+            calculations. ``axis`` should be int, list(int) or tuple(int). If
+            ``axis`` is a list/tuple of dimension(s), mean is calculated along
+            all element(s) of ``axis`` . ``axis`` or element(s) of ``axis``
+            should be in range [-D, D), where D is the dimensions of ``x`` . If
+            ``axis`` or element(s) of ``axis`` is less than 0, it works the
+            same way as :math:`axis + D` . If ``axis`` is None, mean is
+            calculated over all elements of ``x``. Default is None.
+        keepdim (bool, optional): Whether to reserve the reduced dimension(s)
+            in the output Tensor. If ``keepdim`` is True, the dimensions of
+            the output Tensor is the same as ``x`` except in the reduced
+            dimensions(it is of size 1 in this case). Otherwise, the shape of
+            the output Tensor is squeezed in ``axis`` . Default is False.
+        name (str, optional): Name for the operation (optional, default is None).
+            For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Tensor, results of arithmetic mean along ``axis`` of ``x``, with the same data
+        type as ``x``.
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+            import numpy as np
+
+            # x is a Tensor with following elements:
+            #    [[nan, 0.3, 0.5, 0.9]
+            #     [0.1, 0.2, -nan, 0.7]]
+            # Each example is followed by the corresponding output tensor.
+            x = np.array([[float('nan'), 0.3, 0.5, 0.9],
+                            [0.1, 0.2, float('-nan'), 0.7]]).astype(np.float32)
+            x = paddle.to_tensor(x)
+
+            out1 = nanmean(x)                       #[0.45000002]                   
+            out2 = nanmean(x,axis=0)                #[0.1        0.25       0.5        0.79999995]
+            out3 = nanmean(x,axis=0,keepdim=True)   #[[0.1        0.25       0.5        0.79999995]]
+            out4 = nanmean(x,axis=1)                #[0.56666666 0.33333334]
+            out5 = nanmean(x,axis=1,keepdim=True)   #[[0.56666666]
+                                                    # [0.33333334]]
+            
+            # y is a Tensor with shape [2, 2, 2] and elements as below:
+            #      [[[1, nan], [3, 4]],
+            #      [[5, 6], [-nan, 8]]]
+            # Each example is followed by the corresponding output tensor.
+            y = np.array([[[1, float('nan')], [3, 4]], 
+                            [[5, 6], [float('-nan'), 8]]])
+            y = paddle.to_tensor(y)
+            out5 = paddle.nanmean(y, axis=[1, 2]) # [3. 6.]
+            out6 = paddle.nanmean(y, axis=[0, 1]) # [2.66666667 6.33333333]
+    """
+    if isinstance(axis, int):
+        axis = [axis]
+    if axis == None:
+        return paddle.mean(x[~paddle.isnan(x)], keepdim=keepdim,name=name)
+
+    tot = paddle.nansum(x,axis=axis,dtype=x.dtype,keepdim=keepdim,name=name)
+    cnt = paddle.sum( ~paddle.isnan(x) ,axis = axis,keepdim=keepdim )
+    avg = paddle.divide(tot,cnt.astype(tot.dtype))
+
+    return avg
+
+
 
 @templatedoc(op_type="sum")
 def add_n(inputs, name=None):
@@ -3798,6 +3867,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
         else:
             out = elementwise_sub(input_back, input_front, axis=axis)
         return out
+
     else:
         check_variable_and_dtype(x, 'x', ['float32', 'float64', 'bool', 'int32', 'int64'], 'diff')
         check_type(axis, 'axis', (int), 'diff')
@@ -3904,3 +3974,6 @@ def angle(x, name=None):
     outputs = {"Out": out}
     helper.append_op(type=op_type, inputs=inputs, outputs=outputs)
     return out
+
+
+

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1028,7 +1028,7 @@ def nanmean(x,axis=None,keepdim=None,name=None):
     if axis == None:
         return paddle.mean(x[~paddle.isnan(x)], keepdim=keepdim,name=name)
 
-    tot = paddle.nansum(x,axis=axis,dtype=x.dtype,keepdim=keepdim,name=name)
+    tot = paddle.nansum(x,axis=axis,keepdim=keepdim,name=name)
     cnt = paddle.sum( ~paddle.isnan(x) ,axis = axis,keepdim=keepdim )
     avg = paddle.divide(tot,cnt.astype(tot.dtype))
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -93,7 +93,7 @@ def mean(x, axis=None, keepdim=False, name=None):
 
     check_variable_and_dtype(x, 'x/input',
                              ['uint16', 'float16', 'float32', 'float64'],
-                             'mean/reduce_mean')
+                             'mean/reduce_mean' )
     check_type(axis, 'axis/dim', (int, list, tuple), 'mean/reduce_mean')
     if isinstance(axis, (list, tuple)):
         for item in axis:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types 
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

为 Paddle 新增 nanmean API

paddle.nanmean 扩展了 paddle.mean API 的功能，如果输入Tensor中有nan值， paddle.mean在计算中会将涉及nan值的结果都置为nan，而 paddle.nanmean 会跳过nan值。比如输入数据 x = [[nan, 1. , 2. ], [3. , 4. , 5. ]]，x.mean() 得到 [nan]，x.mean(0) 得到 [nan, 2.5, 3.5]，x.nanmean() 得到 [3.]，x.nanmean(0) 得到 [3., 2.5, 3.5]。此API需支持的调用路径为：paddle.nanmean 和 Tensor.nanmean 。