### PR TITLE
reuse ConvNormActivation in some vision models

### DIFF
--- a/python/paddle/vision/models/inceptionv3.py
+++ b/python/paddle/vision/models/inceptionv3.py
@@ -31,7 +31,7 @@ __all__ = []
 
 model_urls = {
     "inception_v3":
-    ("https://bj.bcebos.com/v1/ai-studio-online/37bdfacc03a3478d807287da1433c27c3b4cb5094aca4ff78e1738fa5ddd45c0",
+    ("https://paddle-hapi.bj.bcebos.com/models/inception_v3.pdparams",
      "649a4547c3243e8b59c656f41fe330b8")
 }
 

--- a/python/paddle/vision/models/inceptionv3.py
+++ b/python/paddle/vision/models/inceptionv3.py
@@ -19,75 +19,60 @@ from __future__ import print_function
 import math
 import paddle
 import paddle.nn as nn
-from paddle.nn import Conv2D, BatchNorm, Linear, Dropout
+from paddle.nn import Linear, Dropout
 from paddle.nn import AdaptiveAvgPool2D, MaxPool2D, AvgPool2D
 from paddle.nn.initializer import Uniform
 from paddle.fluid.param_attr import ParamAttr
 
 from paddle.utils.download import get_weights_path_from_url
+from ..ops import ConvNormActivation
 
 __all__ = []
 
 model_urls = {
     "inception_v3":
-    ("https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/legendary_models/InceptionV3_pretrained.pdparams",
-     "e4d0905a818f6bb7946e881777a8a935")
+    ("https://bj.bcebos.com/v1/ai-studio-online/37bdfacc03a3478d807287da1433c27c3b4cb5094aca4ff78e1738fa5ddd45c0",
+     "649a4547c3243e8b59c656f41fe330b8")
 }
-
-
-class ConvBNLayer(nn.Layer):
-    def __init__(self,
-                 num_channels,
-                 num_filters,
-                 filter_size,
-                 stride=1,
-                 padding=0,
-                 groups=1,
-                 act="relu"):
-        super().__init__()
-        self.act = act
-        self.conv = Conv2D(
-            in_channels=num_channels,
-            out_channels=num_filters,
-            kernel_size=filter_size,
-            stride=stride,
-            padding=padding,
-            groups=groups,
-            bias_attr=False)
-        self.bn = BatchNorm(num_filters)
-        self.relu = nn.ReLU()
-
-    def forward(self, x):
-        x = self.conv(x)
-        x = self.bn(x)
-        if self.act:
-            x = self.relu(x)
-        return x
 
 
 class InceptionStem(nn.Layer):
     def __init__(self):
         super().__init__()
-        self.conv_1a_3x3 = ConvBNLayer(
-            num_channels=3, num_filters=32, filter_size=3, stride=2, act="relu")
-        self.conv_2a_3x3 = ConvBNLayer(
-            num_channels=32,
-            num_filters=32,
-            filter_size=3,
+        self.conv_1a_3x3 = ConvNormActivation(
+            in_channels=3,
+            out_channels=32,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.conv_2a_3x3 = ConvNormActivation(
+            in_channels=32,
+            out_channels=32,
+            kernel_size=3,
             stride=1,
-            act="relu")
-        self.conv_2b_3x3 = ConvBNLayer(
-            num_channels=32,
-            num_filters=64,
-            filter_size=3,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.conv_2b_3x3 = ConvNormActivation(
+            in_channels=32,
+            out_channels=64,
+            kernel_size=3,
             padding=1,
-            act="relu")
+            activation_layer=nn.ReLU)
 
         self.max_pool = MaxPool2D(kernel_size=3, stride=2, padding=0)
-        self.conv_3b_1x1 = ConvBNLayer(
-            num_channels=64, num_filters=80, filter_size=1, act="relu")
-        self.conv_4a_3x3 = ConvBNLayer(
-            num_channels=80, num_filters=192, filter_size=3, act="relu")
+        self.conv_3b_1x1 = ConvNormActivation(
+            in_channels=64,
+            out_channels=80,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.conv_4a_3x3 = ConvNormActivation(
+            in_channels=80,
+            out_channels=192,
+            kernel_size=3,
+            padding=0,
+            activation_layer=nn.ReLU)
 
     def forward(self, x):
         x = self.conv_1a_3x3(x)
@@ -103,47 +88,53 @@ class InceptionStem(nn.Layer):
 class InceptionA(nn.Layer):
     def __init__(self, num_channels, pool_features):
         super().__init__()
-        self.branch1x1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=64,
-            filter_size=1,
-            act="relu")
-        self.branch5x5_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=48,
-            filter_size=1,
-            act="relu")
-        self.branch5x5_2 = ConvBNLayer(
-            num_channels=48,
-            num_filters=64,
-            filter_size=5,
-            padding=2,
-            act="relu")
+        self.branch1x1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=64,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
 
-        self.branch3x3dbl_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=64,
-            filter_size=1,
-            act="relu")
-        self.branch3x3dbl_2 = ConvBNLayer(
-            num_channels=64,
-            num_filters=96,
-            filter_size=3,
+        self.branch5x5_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=48,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch5x5_2 = ConvNormActivation(
+            in_channels=48,
+            out_channels=64,
+            kernel_size=5,
+            padding=2,
+            activation_layer=nn.ReLU)
+
+        self.branch3x3dbl_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=64,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch3x3dbl_2 = ConvNormActivation(
+            in_channels=64,
+            out_channels=96,
+            kernel_size=3,
             padding=1,
-            act="relu")
-        self.branch3x3dbl_3 = ConvBNLayer(
-            num_channels=96,
-            num_filters=96,
-            filter_size=3,
+            activation_layer=nn.ReLU)
+        self.branch3x3dbl_3 = ConvNormActivation(
+            in_channels=96,
+            out_channels=96,
+            kernel_size=3,
             padding=1,
-            act="relu")
+            activation_layer=nn.ReLU)
+
         self.branch_pool = AvgPool2D(
             kernel_size=3, stride=1, padding=1, exclusive=False)
-        self.branch_pool_conv = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=pool_features,
-            filter_size=1,
-            act="relu")
+        self.branch_pool_conv = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=pool_features,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
 
     def forward(self, x):
         branch1x1 = self.branch1x1(x)
@@ -164,29 +155,34 @@ class InceptionA(nn.Layer):
 class InceptionB(nn.Layer):
     def __init__(self, num_channels):
         super().__init__()
-        self.branch3x3 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=384,
-            filter_size=3,
+        self.branch3x3 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=384,
+            kernel_size=3,
             stride=2,
-            act="relu")
-        self.branch3x3dbl_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=64,
-            filter_size=1,
-            act="relu")
-        self.branch3x3dbl_2 = ConvBNLayer(
-            num_channels=64,
-            num_filters=96,
-            filter_size=3,
+            padding=0,
+            activation_layer=nn.ReLU)
+
+        self.branch3x3dbl_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=64,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch3x3dbl_2 = ConvNormActivation(
+            in_channels=64,
+            out_channels=96,
+            kernel_size=3,
             padding=1,
-            act="relu")
-        self.branch3x3dbl_3 = ConvBNLayer(
-            num_channels=96,
-            num_filters=96,
-            filter_size=3,
+            activation_layer=nn.ReLU)
+        self.branch3x3dbl_3 = ConvNormActivation(
+            in_channels=96,
+            out_channels=96,
+            kernel_size=3,
             stride=2,
-            act="relu")
+            padding=0,
+            activation_layer=nn.ReLU)
+
         self.branch_pool = MaxPool2D(kernel_size=3, stride=2)
 
     def forward(self, x):
@@ -206,70 +202,74 @@ class InceptionB(nn.Layer):
 class InceptionC(nn.Layer):
     def __init__(self, num_channels, channels_7x7):
         super().__init__()
-        self.branch1x1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=192,
-            filter_size=1,
-            act="relu")
+        self.branch1x1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=192,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
 
-        self.branch7x7_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=channels_7x7,
-            filter_size=1,
+        self.branch7x7_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=channels_7x7,
+            kernel_size=1,
             stride=1,
-            act="relu")
-        self.branch7x7_2 = ConvBNLayer(
-            num_channels=channels_7x7,
-            num_filters=channels_7x7,
-            filter_size=(1, 7),
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch7x7_2 = ConvNormActivation(
+            in_channels=channels_7x7,
+            out_channels=channels_7x7,
+            kernel_size=(1, 7),
             stride=1,
             padding=(0, 3),
-            act="relu")
-        self.branch7x7_3 = ConvBNLayer(
-            num_channels=channels_7x7,
-            num_filters=192,
-            filter_size=(7, 1),
+            activation_layer=nn.ReLU)
+        self.branch7x7_3 = ConvNormActivation(
+            in_channels=channels_7x7,
+            out_channels=192,
+            kernel_size=(7, 1),
             stride=1,
             padding=(3, 0),
-            act="relu")
+            activation_layer=nn.ReLU)
 
-        self.branch7x7dbl_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=channels_7x7,
-            filter_size=1,
-            act="relu")
-        self.branch7x7dbl_2 = ConvBNLayer(
-            num_channels=channels_7x7,
-            num_filters=channels_7x7,
-            filter_size=(7, 1),
+        self.branch7x7dbl_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=channels_7x7,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch7x7dbl_2 = ConvNormActivation(
+            in_channels=channels_7x7,
+            out_channels=channels_7x7,
+            kernel_size=(7, 1),
             padding=(3, 0),
-            act="relu")
-        self.branch7x7dbl_3 = ConvBNLayer(
-            num_channels=channels_7x7,
-            num_filters=channels_7x7,
-            filter_size=(1, 7),
+            activation_layer=nn.ReLU)
+        self.branch7x7dbl_3 = ConvNormActivation(
+            in_channels=channels_7x7,
+            out_channels=channels_7x7,
+            kernel_size=(1, 7),
             padding=(0, 3),
-            act="relu")
-        self.branch7x7dbl_4 = ConvBNLayer(
-            num_channels=channels_7x7,
-            num_filters=channels_7x7,
-            filter_size=(7, 1),
+            activation_layer=nn.ReLU)
+        self.branch7x7dbl_4 = ConvNormActivation(
+            in_channels=channels_7x7,
+            out_channels=channels_7x7,
+            kernel_size=(7, 1),
             padding=(3, 0),
-            act="relu")
-        self.branch7x7dbl_5 = ConvBNLayer(
-            num_channels=channels_7x7,
-            num_filters=192,
-            filter_size=(1, 7),
+            activation_layer=nn.ReLU)
+        self.branch7x7dbl_5 = ConvNormActivation(
+            in_channels=channels_7x7,
+            out_channels=192,
+            kernel_size=(1, 7),
             padding=(0, 3),
-            act="relu")
+            activation_layer=nn.ReLU)
 
         self.branch_pool = AvgPool2D(
             kernel_size=3, stride=1, padding=1, exclusive=False)
-        self.branch_pool_conv = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=192,
-            filter_size=1,
-            act="relu")
+        self.branch_pool_conv = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=192,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
 
     def forward(self, x):
         branch1x1 = self.branch1x1(x)
@@ -296,40 +296,46 @@ class InceptionC(nn.Layer):
 class InceptionD(nn.Layer):
     def __init__(self, num_channels):
         super().__init__()
-        self.branch3x3_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=192,
-            filter_size=1,
-            act="relu")
-        self.branch3x3_2 = ConvBNLayer(
-            num_channels=192,
-            num_filters=320,
-            filter_size=3,
+        self.branch3x3_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=192,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch3x3_2 = ConvNormActivation(
+            in_channels=192,
+            out_channels=320,
+            kernel_size=3,
             stride=2,
-            act="relu")
-        self.branch7x7x3_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=192,
-            filter_size=1,
-            act="relu")
-        self.branch7x7x3_2 = ConvBNLayer(
-            num_channels=192,
-            num_filters=192,
-            filter_size=(1, 7),
+            padding=0,
+            activation_layer=nn.ReLU)
+
+        self.branch7x7x3_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=192,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch7x7x3_2 = ConvNormActivation(
+            in_channels=192,
+            out_channels=192,
+            kernel_size=(1, 7),
             padding=(0, 3),
-            act="relu")
-        self.branch7x7x3_3 = ConvBNLayer(
-            num_channels=192,
-            num_filters=192,
-            filter_size=(7, 1),
+            activation_layer=nn.ReLU)
+        self.branch7x7x3_3 = ConvNormActivation(
+            in_channels=192,
+            out_channels=192,
+            kernel_size=(7, 1),
             padding=(3, 0),
-            act="relu")
-        self.branch7x7x3_4 = ConvBNLayer(
-            num_channels=192,
-            num_filters=192,
-            filter_size=3,
+            activation_layer=nn.ReLU)
+        self.branch7x7x3_4 = ConvNormActivation(
+            in_channels=192,
+            out_channels=192,
+            kernel_size=3,
             stride=2,
-            act="relu")
+            padding=0,
+            activation_layer=nn.ReLU)
+
         self.branch_pool = MaxPool2D(kernel_size=3, stride=2)
 
     def forward(self, x):
@@ -350,59 +356,64 @@ class InceptionD(nn.Layer):
 class InceptionE(nn.Layer):
     def __init__(self, num_channels):
         super().__init__()
-        self.branch1x1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=320,
-            filter_size=1,
-            act="relu")
-        self.branch3x3_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=384,
-            filter_size=1,
-            act="relu")
-        self.branch3x3_2a = ConvBNLayer(
-            num_channels=384,
-            num_filters=384,
-            filter_size=(1, 3),
+        self.branch1x1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=320,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch3x3_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=384,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch3x3_2a = ConvNormActivation(
+            in_channels=384,
+            out_channels=384,
+            kernel_size=(1, 3),
             padding=(0, 1),
-            act="relu")
-        self.branch3x3_2b = ConvBNLayer(
-            num_channels=384,
-            num_filters=384,
-            filter_size=(3, 1),
+            activation_layer=nn.ReLU)
+        self.branch3x3_2b = ConvNormActivation(
+            in_channels=384,
+            out_channels=384,
+            kernel_size=(3, 1),
             padding=(1, 0),
-            act="relu")
+            activation_layer=nn.ReLU)
 
-        self.branch3x3dbl_1 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=448,
-            filter_size=1,
-            act="relu")
-        self.branch3x3dbl_2 = ConvBNLayer(
-            num_channels=448,
-            num_filters=384,
-            filter_size=3,
+        self.branch3x3dbl_1 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=448,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
+        self.branch3x3dbl_2 = ConvNormActivation(
+            in_channels=448,
+            out_channels=384,
+            kernel_size=3,
             padding=1,
-            act="relu")
-        self.branch3x3dbl_3a = ConvBNLayer(
-            num_channels=384,
-            num_filters=384,
-            filter_size=(1, 3),
+            activation_layer=nn.ReLU)
+        self.branch3x3dbl_3a = ConvNormActivation(
+            in_channels=384,
+            out_channels=384,
+            kernel_size=(1, 3),
             padding=(0, 1),
-            act="relu")
-        self.branch3x3dbl_3b = ConvBNLayer(
-            num_channels=384,
-            num_filters=384,
-            filter_size=(3, 1),
+            activation_layer=nn.ReLU)
+        self.branch3x3dbl_3b = ConvNormActivation(
+            in_channels=384,
+            out_channels=384,
+            kernel_size=(3, 1),
             padding=(1, 0),
-            act="relu")
+            activation_layer=nn.ReLU)
+
         self.branch_pool = AvgPool2D(
             kernel_size=3, stride=1, padding=1, exclusive=False)
-        self.branch_pool_conv = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=192,
-            filter_size=1,
-            act="relu")
+        self.branch_pool_conv = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=192,
+            kernel_size=1,
+            padding=0,
+            activation_layer=nn.ReLU)
 
     def forward(self, x):
         branch1x1 = self.branch1x1(x)

--- a/python/paddle/vision/models/mobilenetv1.py
+++ b/python/paddle/vision/models/mobilenetv1.py
@@ -22,7 +22,7 @@ __all__ = []
 
 model_urls = {
     'mobilenetv1_1.0':
-    ('https://bj.bcebos.com/v1/ai-studio-online/e4780dbc69e44e88af956736840ecf31a74a91dcbff64ede8e311fffcd99b64f',
+    ('https://paddle-hapi.bj.bcebos.com/models/mobilenetv1_1.0.pdparams',
      '3033ab1975b1670bef51545feb65fc45')
 }
 

--- a/python/paddle/vision/models/mobilenetv1.py
+++ b/python/paddle/vision/models/mobilenetv1.py
@@ -94,9 +94,15 @@ class MobileNetV1(nn.Layer):
     Examples:
         .. code-block:: python
 
+            import paddle
             from paddle.vision.models import MobileNetV1
 
             model = MobileNetV1()
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
 
     def __init__(self, scale=1.0, num_classes=1000, with_pool=True):
@@ -257,6 +263,7 @@ def mobilenet_v1(pretrained=False, scale=1.0, **kwargs):
     Examples:
         .. code-block:: python
 
+            import paddle
             from paddle.vision.models import mobilenet_v1
 
             # build model
@@ -266,7 +273,12 @@ def mobilenet_v1(pretrained=False, scale=1.0, **kwargs):
             # model = mobilenet_v1(pretrained=True)
 
             # build mobilenet v1 with scale=0.5
-            model = mobilenet_v1(scale=0.5)
+            model_scale = mobilenet_v1(scale=0.5)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
     model = _mobilenet(
         'mobilenetv1_' + str(scale), pretrained, scale=scale, **kwargs)

--- a/python/paddle/vision/models/mobilenetv1.py
+++ b/python/paddle/vision/models/mobilenetv1.py
@@ -16,43 +16,15 @@ import paddle
 import paddle.nn as nn
 
 from paddle.utils.download import get_weights_path_from_url
+from ..ops import ConvNormActivation
 
 __all__ = []
 
 model_urls = {
     'mobilenetv1_1.0':
-    ('https://paddle-hapi.bj.bcebos.com/models/mobilenet_v1_x1.0.pdparams',
-     '42a154c2f26f86e7457d6daded114e8c')
+    ('https://bj.bcebos.com/v1/ai-studio-online/e4780dbc69e44e88af956736840ecf31a74a91dcbff64ede8e311fffcd99b64f',
+     '3033ab1975b1670bef51545feb65fc45')
 }
-
-
-class ConvBNLayer(nn.Layer):
-    def __init__(self,
-                 in_channels,
-                 out_channels,
-                 kernel_size,
-                 stride,
-                 padding,
-                 num_groups=1):
-        super(ConvBNLayer, self).__init__()
-
-        self._conv = nn.Conv2D(
-            in_channels,
-            out_channels,
-            kernel_size,
-            stride=stride,
-            padding=padding,
-            groups=num_groups,
-            bias_attr=False)
-
-        self._norm_layer = nn.BatchNorm2D(out_channels)
-        self._act = nn.ReLU()
-
-    def forward(self, x):
-        x = self._conv(x)
-        x = self._norm_layer(x)
-        x = self._act(x)
-        return x
 
 
 class DepthwiseSeparable(nn.Layer):
@@ -60,15 +32,15 @@ class DepthwiseSeparable(nn.Layer):
                  stride, scale):
         super(DepthwiseSeparable, self).__init__()
 
-        self._depthwise_conv = ConvBNLayer(
+        self._depthwise_conv = ConvNormActivation(
             in_channels,
             int(out_channels1 * scale),
             kernel_size=3,
             stride=stride,
             padding=1,
-            num_groups=int(num_groups * scale))
+            groups=int(num_groups * scale))
 
-        self._pointwise_conv = ConvBNLayer(
+        self._pointwise_conv = ConvNormActivation(
             int(out_channels1 * scale),
             int(out_channels2 * scale),
             kernel_size=1,
@@ -112,7 +84,7 @@ class MobileNetV1(nn.Layer):
         self.num_classes = num_classes
         self.with_pool = with_pool
 
-        self.conv1 = ConvBNLayer(
+        self.conv1 = ConvNormActivation(
             in_channels=3,
             out_channels=int(32 * scale),
             kernel_size=3,

--- a/python/paddle/vision/models/mobilenetv2.py
+++ b/python/paddle/vision/models/mobilenetv2.py
@@ -73,23 +73,30 @@ class InvertedResidual(nn.Layer):
 
 
 class MobileNetV2(nn.Layer):
+    """MobileNetV2 model from
+    `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
+
+    Args:
+        scale (float): scale of channels in each layer. Default: 1.0.
+        num_classes (int): output dim of last fc layer. If num_classes <=0, last fc layer 
+                            will not be defined. Default: 1000.
+        with_pool (bool): use pool before the last fc layer or not. Default: True.
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+            from paddle.vision.models import MobileNetV2
+
+            model = MobileNetV2()
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
+    """
+
     def __init__(self, scale=1.0, num_classes=1000, with_pool=True):
-        """MobileNetV2 model from
-        `"MobileNetV2: Inverted Residuals and Linear Bottlenecks" <https://arxiv.org/abs/1801.04381>`_.
-
-        Args:
-            scale (float): scale of channels in each layer. Default: 1.0.
-            num_classes (int): output dim of last fc layer. If num_classes <=0, last fc layer 
-                                will not be defined. Default: 1000.
-            with_pool (bool): use pool before the last fc layer or not. Default: True.
-
-        Examples:
-            .. code-block:: python
-
-                from paddle.vision.models import MobileNetV2
-
-                model = MobileNetV2()
-        """
         super(MobileNetV2, self).__init__()
         self.num_classes = num_classes
         self.with_pool = with_pool
@@ -187,6 +194,7 @@ def mobilenet_v2(pretrained=False, scale=1.0, **kwargs):
     Examples:
         .. code-block:: python
 
+            import paddle
             from paddle.vision.models import mobilenet_v2
 
             # build model
@@ -197,6 +205,11 @@ def mobilenet_v2(pretrained=False, scale=1.0, **kwargs):
 
             # build mobilenet v2 with scale=0.5
             model = mobilenet_v2(scale=0.5)
+
+            x = paddle.rand([1, 3, 224, 224])
+            out = model(x)
+
+            print(out.shape)
     """
     model = _mobilenet(
         'mobilenetv2_' + str(scale), pretrained, scale=scale, **kwargs)

--- a/python/paddle/vision/models/resnext.py
+++ b/python/paddle/vision/models/resnext.py
@@ -22,57 +22,34 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.fluid.param_attr import ParamAttr
-from paddle.nn import AdaptiveAvgPool2D, BatchNorm, Conv2D, Linear, MaxPool2D
+from paddle.nn import AdaptiveAvgPool2D, Linear, MaxPool2D
 from paddle.nn.initializer import Uniform
 from paddle.utils.download import get_weights_path_from_url
+
+from ..ops import ConvNormActivation
 
 __all__ = []
 
 model_urls = {
     'resnext50_32x4d':
-    ('https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNeXt50_32x4d_pretrained.pdparams',
-     'bf04add2f7fd22efcbe91511bcd1eebe'),
+    ('https://bj.bcebos.com/v1/ai-studio-online/1f199442185d4268859cbd72e9ea529ef346ac21a3ae40f5932b1749c10c6227',
+     'f848db2216597e5122b43b8e7c7f4832'),
     "resnext50_64x4d":
-    ('https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNeXt50_64x4d_pretrained.pdparams',
-     '46307df0e2d6d41d3b1c1d22b00abc69'),
+    ('https://bj.bcebos.com/v1/ai-studio-online/04236a150d9f4eeb9b1e39f0a06bbd87905ca78299ac463b806570a3788d83e9',
+     '8c077ffdab55d9fd7df6f2d314f60573'),
     'resnext101_32x4d':
-    ('https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNeXt101_32x4d_pretrained.pdparams',
-     '078ca145b3bea964ba0544303a43c36d'),
+    ('https://bj.bcebos.com/v1/ai-studio-online/265c31d967814419aaac0a66850c617c9f0f25f92ed94a3fbd29d2b938104289',
+     '4f9167fca54dd502810975a0b5555711'),
     'resnext101_64x4d':
-    ('https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNeXt101_64x4d_pretrained.pdparams',
-     '4edc0eb32d3cc5d80eff7cab32cd5c64'),
+    ('https://bj.bcebos.com/v1/ai-studio-online/3d60d063ce4447c8a172d81605796f6f3551017dd90e4fc5bcc27364b1cfbf1b',
+     'e24397a901f3ecbd3c5b7603c178a7e3'),
     'resnext152_32x4d':
-    ('https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNeXt152_32x4d_pretrained.pdparams',
-     '7971cc994d459af167c502366f866378'),
+    ('https://bj.bcebos.com/v1/ai-studio-online/29dcfbfcf4df46259f19de8e025879cc1c6a9af97ac840d48585136f84a4e4c0',
+     '6efb2388d62cfb9b2dca4bb58d299612'),
     'resnext152_64x4d':
-    ('https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ResNeXt152_64x4d_pretrained.pdparams',
-     '836943f03709efec364d486c57d132de'),
+    ('https://bj.bcebos.com/v1/ai-studio-online/8eb2937765154e78afbe9779a27ed9b37211dcb29ce94a5da12ef4ae1f3bae9b',
+     '7d2125a165c5678c9cb92f85ef6c287e'),
 }
-
-
-class ConvBNLayer(nn.Layer):
-    def __init__(self,
-                 num_channels,
-                 num_filters,
-                 filter_size,
-                 stride=1,
-                 groups=1,
-                 act=None):
-        super(ConvBNLayer, self).__init__()
-        self._conv = Conv2D(
-            in_channels=num_channels,
-            out_channels=num_filters,
-            kernel_size=filter_size,
-            stride=stride,
-            padding=(filter_size - 1) // 2,
-            groups=groups,
-            bias_attr=False)
-        self._batch_norm = BatchNorm(num_filters, act=act)
-
-    def forward(self, inputs):
-        x = self._conv(inputs)
-        x = self._batch_norm(x)
-        return x
 
 
 class BottleneckBlock(nn.Layer):
@@ -83,31 +60,32 @@ class BottleneckBlock(nn.Layer):
                  cardinality,
                  shortcut=True):
         super(BottleneckBlock, self).__init__()
-        self.conv0 = ConvBNLayer(
-            num_channels=num_channels,
-            num_filters=num_filters,
-            filter_size=1,
-            act='relu')
-        self.conv1 = ConvBNLayer(
-            num_channels=num_filters,
-            num_filters=num_filters,
-            filter_size=3,
+        self.conv0 = ConvNormActivation(
+            in_channels=num_channels,
+            out_channels=num_filters,
+            kernel_size=1,
+            activation_layer=nn.ReLU)
+        self.conv1 = ConvNormActivation(
+            in_channels=num_filters,
+            out_channels=num_filters,
+            kernel_size=3,
             groups=cardinality,
             stride=stride,
-            act='relu')
-        self.conv2 = ConvBNLayer(
-            num_channels=num_filters,
-            num_filters=num_filters * 2 if cardinality == 32 else num_filters,
-            filter_size=1,
-            act=None)
+            activation_layer=nn.ReLU)
+        self.conv2 = ConvNormActivation(
+            in_channels=num_filters,
+            out_channels=num_filters * 2 if cardinality == 32 else num_filters,
+            kernel_size=1,
+            activation_layer=None)
 
         if not shortcut:
-            self.short = ConvBNLayer(
-                num_channels=num_channels,
-                num_filters=num_filters * 2
+            self.short = ConvNormActivation(
+                in_channels=num_channels,
+                out_channels=num_filters * 2
                 if cardinality == 32 else num_filters,
-                filter_size=1,
-                stride=stride)
+                kernel_size=1,
+                stride=stride,
+                activation_layer=None)
 
         self.shortcut = shortcut
 
@@ -173,8 +151,12 @@ class ResNeXt(nn.Layer):
         num_filters = [128, 256, 512,
                        1024] if cardinality == 32 else [256, 512, 1024, 2048]
 
-        self.conv = ConvBNLayer(
-            num_channels=3, num_filters=64, filter_size=7, stride=2, act='relu')
+        self.conv = ConvNormActivation(
+            in_channels=3,
+            out_channels=64,
+            kernel_size=7,
+            stride=2,
+            activation_layer=nn.ReLU)
         self.pool2d_max = MaxPool2D(kernel_size=3, stride=2, padding=1)
 
         self.block_list = []

--- a/python/paddle/vision/models/shufflenetv2.py
+++ b/python/paddle/vision/models/shufflenetv2.py
@@ -27,25 +27,25 @@ __all__ = []
 
 model_urls = {
     "shufflenet_v2_x0_25": (
-        "https://bj.bcebos.com/v1/ai-studio-online/648cc351973b4233a016d158621a8e600568c6de97a14b469b2902676d939e6c",
+        "https://paddle-hapi.bj.bcebos.com/models/shufflenet_v2_x0_25.pdparams",
         "1e509b4c140eeb096bb16e214796d03b", ),
     "shufflenet_v2_x0_33": (
-        "https://bj.bcebos.com/v1/ai-studio-online/df83b6202b784a72b8486936333da529fca22335189e4b9e88b3e0bc9b7597b8",
+        "https://paddle-hapi.bj.bcebos.com/models/shufflenet_v2_x0_33.pdparams",
         "3d7b3ab0eaa5c0927ff1026d31b729bd", ),
     "shufflenet_v2_x0_5": (
-        "https://bj.bcebos.com/v1/ai-studio-online/ac3e4a06a3714939bed412307bafcc19193beff575dc48548b47b34d9ccbb3d8",
+        "https://paddle-hapi.bj.bcebos.com/models/shufflenet_v2_x0_5.pdparams",
         "5e5cee182a7793c4e4c73949b1a71bd4", ),
     "shufflenet_v2_x1_0": (
-        "https://bj.bcebos.com/v1/ai-studio-online/a20dfea65c614e8baeb6530dc1c84c3004cf2a09a96348938d0a14da9412bc05",
+        "https://paddle-hapi.bj.bcebos.com/models/shufflenet_v2_x1_0.pdparams",
         "122d42478b9e81eb49f8a9ede327b1a4", ),
     "shufflenet_v2_x1_5": (
-        "https://bj.bcebos.com/v1/ai-studio-online/d9f3eaf999d345c7bba7683bc6cc69d61881c3c37e45479bbf4dcf9ab132025d",
+        "https://paddle-hapi.bj.bcebos.com/models/shufflenet_v2_x1_5.pdparams",
         "faced5827380d73531d0ee027c67826d", ),
     "shufflenet_v2_x2_0": (
-        "https://bj.bcebos.com/v1/ai-studio-online/653d1228c8ca4274984d341111d0254fecdbf0954cfe4f85bc4bddd9545912e4",
+        "https://paddle-hapi.bj.bcebos.com/models/shufflenet_v2_x2_0.pdparams",
         "cd3dddcd8305e7bcd8ad14d1c69a5784", ),
     "shufflenet_v2_swish": (
-        "https://bj.bcebos.com/v1/ai-studio-online/cb7a029e746a423c9219d034c4dd834438945503157b4b41aa26f7cda62e1fc9",
+        "https://paddle-hapi.bj.bcebos.com/models/shufflenet_v2_swish.pdparams",
         "adde0aa3b023e5b0c94a68be1c394b84", ),
 }
 

--- a/python/paddle/vision/models/shufflenetv2.py
+++ b/python/paddle/vision/models/shufflenetv2.py
@@ -18,35 +18,48 @@ from __future__ import print_function
 
 import paddle
 import paddle.nn as nn
-from paddle.fluid.param_attr import ParamAttr
-from paddle.nn import AdaptiveAvgPool2D, BatchNorm, Conv2D, Linear, MaxPool2D
+from paddle.nn import AdaptiveAvgPool2D, Linear, MaxPool2D
 from paddle.utils.download import get_weights_path_from_url
+
+from ..ops import ConvNormActivation
 
 __all__ = []
 
 model_urls = {
     "shufflenet_v2_x0_25": (
-        "https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ShuffleNetV2_x0_25_pretrained.pdparams",
-        "e753404cbd95027759c5f56ecd6c9c4b", ),
+        "https://bj.bcebos.com/v1/ai-studio-online/648cc351973b4233a016d158621a8e600568c6de97a14b469b2902676d939e6c",
+        "1e509b4c140eeb096bb16e214796d03b", ),
     "shufflenet_v2_x0_33": (
-        "https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ShuffleNetV2_x0_33_pretrained.pdparams",
-        "776e3cf9a4923abdfce789c45b8fe1f2", ),
+        "https://bj.bcebos.com/v1/ai-studio-online/df83b6202b784a72b8486936333da529fca22335189e4b9e88b3e0bc9b7597b8",
+        "3d7b3ab0eaa5c0927ff1026d31b729bd", ),
     "shufflenet_v2_x0_5": (
-        "https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ShuffleNetV2_x0_5_pretrained.pdparams",
-        "e3649cf531566917e2969487d2bc6b60", ),
+        "https://bj.bcebos.com/v1/ai-studio-online/ac3e4a06a3714939bed412307bafcc19193beff575dc48548b47b34d9ccbb3d8",
+        "5e5cee182a7793c4e4c73949b1a71bd4", ),
     "shufflenet_v2_x1_0": (
-        "https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ShuffleNetV2_x1_0_pretrained.pdparams",
-        "7821c348ea34e58847c43a08a4ac0bdf", ),
+        "https://bj.bcebos.com/v1/ai-studio-online/a20dfea65c614e8baeb6530dc1c84c3004cf2a09a96348938d0a14da9412bc05",
+        "122d42478b9e81eb49f8a9ede327b1a4", ),
     "shufflenet_v2_x1_5": (
-        "https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ShuffleNetV2_x1_5_pretrained.pdparams",
-        "93a07fa557ab2d8803550f39e5b6c391", ),
+        "https://bj.bcebos.com/v1/ai-studio-online/d9f3eaf999d345c7bba7683bc6cc69d61881c3c37e45479bbf4dcf9ab132025d",
+        "faced5827380d73531d0ee027c67826d", ),
     "shufflenet_v2_x2_0": (
-        "https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ShuffleNetV2_x2_0_pretrained.pdparams",
-        "4ab1f622fd0d341e0f84b4e057797563", ),
+        "https://bj.bcebos.com/v1/ai-studio-online/653d1228c8ca4274984d341111d0254fecdbf0954cfe4f85bc4bddd9545912e4",
+        "cd3dddcd8305e7bcd8ad14d1c69a5784", ),
     "shufflenet_v2_swish": (
-        "https://paddle-imagenet-models-name.bj.bcebos.com/dygraph/ShuffleNetV2_swish_pretrained.pdparams",
-        "daff38b3df1b3748fccbb13cfdf02519", ),
+        "https://bj.bcebos.com/v1/ai-studio-online/cb7a029e746a423c9219d034c4dd834438945503157b4b41aa26f7cda62e1fc9",
+        "adde0aa3b023e5b0c94a68be1c394b84", ),
 }
+
+
+def create_activation_layer(act):
+    if act == "swish":
+        return nn.Swish
+    elif act == "relu":
+        return nn.ReLU
+    elif act is None:
+        return None
+    else:
+        raise RuntimeError(
+            "The activation function is not supported: {}".format(act))
 
 
 def channel_shuffle(x, groups):
@@ -65,61 +78,37 @@ def channel_shuffle(x, groups):
     return x
 
 
-class ConvBNLayer(nn.Layer):
+class InvertedResidual(nn.Layer):
     def __init__(self,
                  in_channels,
                  out_channels,
-                 kernel_size,
                  stride,
-                 padding,
-                 groups=1,
-                 act=None):
-        super(ConvBNLayer, self).__init__()
-        self._conv = Conv2D(
-            in_channels=in_channels,
-            out_channels=out_channels,
-            kernel_size=kernel_size,
-            stride=stride,
-            padding=padding,
-            groups=groups,
-            weight_attr=ParamAttr(initializer=nn.initializer.KaimingNormal()),
-            bias_attr=False, )
-
-        self._batch_norm = BatchNorm(out_channels, act=act)
-
-    def forward(self, inputs):
-        x = self._conv(inputs)
-        x = self._batch_norm(x)
-        return x
-
-
-class InvertedResidual(nn.Layer):
-    def __init__(self, in_channels, out_channels, stride, act="relu"):
+                 activation_layer=nn.ReLU):
         super(InvertedResidual, self).__init__()
-        self._conv_pw = ConvBNLayer(
+        self._conv_pw = ConvNormActivation(
             in_channels=in_channels // 2,
             out_channels=out_channels // 2,
             kernel_size=1,
             stride=1,
             padding=0,
             groups=1,
-            act=act)
-        self._conv_dw = ConvBNLayer(
+            activation_layer=activation_layer)
+        self._conv_dw = ConvNormActivation(
             in_channels=out_channels // 2,
             out_channels=out_channels // 2,
             kernel_size=3,
             stride=stride,
             padding=1,
             groups=out_channels // 2,
-            act=None)
-        self._conv_linear = ConvBNLayer(
+            activation_layer=None)
+        self._conv_linear = ConvNormActivation(
             in_channels=out_channels // 2,
             out_channels=out_channels // 2,
             kernel_size=1,
             stride=1,
             padding=0,
             groups=1,
-            act=act)
+            activation_layer=activation_layer)
 
     def forward(self, inputs):
         x1, x2 = paddle.split(
@@ -134,51 +123,55 @@ class InvertedResidual(nn.Layer):
 
 
 class InvertedResidualDS(nn.Layer):
-    def __init__(self, in_channels, out_channels, stride, act="relu"):
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 stride,
+                 activation_layer=nn.ReLU):
         super(InvertedResidualDS, self).__init__()
 
         # branch1
-        self._conv_dw_1 = ConvBNLayer(
+        self._conv_dw_1 = ConvNormActivation(
             in_channels=in_channels,
             out_channels=in_channels,
             kernel_size=3,
             stride=stride,
             padding=1,
             groups=in_channels,
-            act=None)
-        self._conv_linear_1 = ConvBNLayer(
+            activation_layer=None)
+        self._conv_linear_1 = ConvNormActivation(
             in_channels=in_channels,
             out_channels=out_channels // 2,
             kernel_size=1,
             stride=1,
             padding=0,
             groups=1,
-            act=act)
+            activation_layer=activation_layer)
         # branch2
-        self._conv_pw_2 = ConvBNLayer(
+        self._conv_pw_2 = ConvNormActivation(
             in_channels=in_channels,
             out_channels=out_channels // 2,
             kernel_size=1,
             stride=1,
             padding=0,
             groups=1,
-            act=act)
-        self._conv_dw_2 = ConvBNLayer(
+            activation_layer=activation_layer)
+        self._conv_dw_2 = ConvNormActivation(
             in_channels=out_channels // 2,
             out_channels=out_channels // 2,
             kernel_size=3,
             stride=stride,
             padding=1,
             groups=out_channels // 2,
-            act=None)
-        self._conv_linear_2 = ConvBNLayer(
+            activation_layer=None)
+        self._conv_linear_2 = ConvNormActivation(
             in_channels=out_channels // 2,
             out_channels=out_channels // 2,
             kernel_size=1,
             stride=1,
             padding=0,
             groups=1,
-            act=act)
+            activation_layer=activation_layer)
 
     def forward(self, inputs):
         x1 = self._conv_dw_1(inputs)
@@ -221,6 +214,7 @@ class ShuffleNetV2(nn.Layer):
         self.num_classes = num_classes
         self.with_pool = with_pool
         stage_repeats = [4, 8, 4]
+        activation_layer = create_activation_layer(act)
 
         if scale == 0.25:
             stage_out_channels = [-1, 24, 24, 48, 96, 512]
@@ -238,13 +232,13 @@ class ShuffleNetV2(nn.Layer):
             raise NotImplementedError("This scale size:[" + str(scale) +
                                       "] is not implemented!")
         # 1. conv1
-        self._conv1 = ConvBNLayer(
+        self._conv1 = ConvNormActivation(
             in_channels=3,
             out_channels=stage_out_channels[1],
             kernel_size=3,
             stride=2,
             padding=1,
-            act=act)
+            activation_layer=activation_layer)
         self._max_pool = MaxPool2D(kernel_size=3, stride=2, padding=1)
 
         # 2. bottleneck sequences
@@ -257,7 +251,7 @@ class ShuffleNetV2(nn.Layer):
                             in_channels=stage_out_channels[stage_id + 1],
                             out_channels=stage_out_channels[stage_id + 2],
                             stride=2,
-                            act=act),
+                            activation_layer=activation_layer),
                         name=str(stage_id + 2) + "_" + str(i + 1))
                 else:
                     block = self.add_sublayer(
@@ -265,17 +259,17 @@ class ShuffleNetV2(nn.Layer):
                             in_channels=stage_out_channels[stage_id + 2],
                             out_channels=stage_out_channels[stage_id + 2],
                             stride=1,
-                            act=act),
+                            activation_layer=activation_layer),
                         name=str(stage_id + 2) + "_" + str(i + 1))
                 self._block_list.append(block)
         # 3. last_conv
-        self._last_conv = ConvBNLayer(
+        self._last_conv = ConvNormActivation(
             in_channels=stage_out_channels[-2],
             out_channels=stage_out_channels[-1],
             kernel_size=1,
             stride=1,
             padding=0,
-            act=act)
+            activation_layer=activation_layer)
         # 4. pool
         if with_pool:
             self._pool2d_avg = AdaptiveAvgPool2D(1)

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -1335,13 +1335,13 @@ class ConvNormActivation(Sequential):
     Args:
         in_channels (int): Number of channels in the input image
         out_channels (int): Number of channels produced by the Convolution-Normalzation-Activation block
-        kernel_size: (int, optional): Size of the convolving kernel. Default: 3
-        stride (int, optional): Stride of the convolution. Default: 1
-        padding (int, tuple or str, optional): Padding added to all four sides of the input. Default: None,
+        kernel_size: (int|list|tuple, optional): Size of the convolving kernel. Default: 3
+        stride (int|list|tuple, optional): Stride of the convolution. Default: 1
+        padding (int|str|tuple|list, optional): Padding added to all four sides of the input. Default: None,
             in wich case it will calculated as ``padding = (kernel_size - 1) // 2 * dilation``
         groups (int, optional): Number of blocked connections from input channels to output channels. Default: 1
         norm_layer (Callable[..., paddle.nn.Layer], optional): Norm layer that will be stacked on top of the convolutiuon layer.
-            If ``None`` this layer wont be used. Default: ``paddle.nn.BatchNorm2d``
+            If ``None`` this layer wont be used. Default: ``paddle.nn.BatchNorm2D``
         activation_layer (Callable[..., paddle.nn.Layer], optional): Activation function which will be stacked on top of the normalization
             layer (if not ``None``), otherwise on top of the conv layer. If ``None`` this layer wont be used. Default: ``paddle.nn.ReLU``
         dilation (int): Spacing between kernel elements. Default: 1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

背景：https://github.com/PaddlePaddle/Paddle/pull/38653#discussion_r809349656

由于目前 `paddle.vision.models` 中很多模块中都单独实现了 `ConvBNLayer` 这一结构，因此我们完全可以将这一共有结构提取成一个单独的 Layer，此前在 #38653 中已经将该 Layer 提取到 `paddle.vision.ops.ConvNormActivation`，在本 PR 中将会在其余 5 个模型中复用该 Layer。

需要重构的网络如下：

- [x] inceptionv3.ConvBNLayer（1 个权重）
- [x] mobilenetv1.ConvBNLayer（1 个权重）
- [x] mobilenetv2.ConvBNLayer（无需更新权重）
- [x] ~~resnext.ConvBNLayer（6 个权重）~~
- [x] shufflenetv2.ConvBNLayer（7 个权重）

其中 mobilenetv2 中 ConvBNLayer 与 ConvNormActivation 实现方式一致（nn.Sequential），因此无需更新权重，但其余模型权重均需更新。

resnext 将会在 #40588 修改，原因见下面的 comments

全部模型更新后均重新测试了 performance，均未发生下降的问题，测试详情见：<https://aistudio.baidu.com/studio/project/partial/verify/3593768/f4038fdf8eb14cc698ca8dcccbcd363c>