### PR TITLE
Speedup SetDeviceId

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cuda_info.cc
+++ b/paddle/phi/backends/gpu/cuda/cuda_info.cc
@@ -232,6 +232,10 @@ const gpuDeviceProp &GetDeviceProperties(int id) {
 }
 
 void SetDeviceId(int id) {
+  // cudaGetDevice is faster than cudaSetDevice
+  int prev_id = GetCurrentDeviceId();
+  if (prev_id == id) return;
+
   // TODO(qijun): find a better way to cache the cuda device count
   PADDLE_ENFORCE_LT(
       id,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Speedup SetDeviceId.
如下代码测试，cudaGetDevice比cudaSetDevice快。Op Run里面，每次需要运行SetDeviceID，由于set device后一般不会变，先查询当前device_id，如果等于需要设置的device_id，则不用再set device了，以此来加速。
|  | cudaGetDevice(ms) | cudaSetDevice(ms) |
| -- | -- | -- |
| A100 | 74 | 120 |
| V100 | 36 | 50 |
| A30 | 35 | 61 |
``` c++
#include <stdio.h>
#include <chrono>
#include <cuda_runtime.h>

class Timer {
 public:
  void tic() { tic_time = std::chrono::high_resolution_clock::now(); }
  double toc() {
    std::chrono::high_resolution_clock::time_point toc_time =
        std::chrono::high_resolution_clock::now();
    std::chrono::duration<double> time_elapse =
        std::chrono::duration_cast<std::chrono::duration<double>>(toc_time -
                                                                  tic_time);
    double time_elapse_in_ms =
        static_cast<double>(time_elapse.count()) * 1000.0;
    return time_elapse_in_ms;
  }

 private:
  std::chrono::high_resolution_clock::time_point tic_time;
};


int main() {
  int id = -1;
  int warmup = 20;
  int count = 1000000;
  Timer timer;

  for (int i = 0; i < warmup; ++i) {
    cudaGetDevice(&id);
  }
  timer.tic();
  for (int i = 0; i < count; ++i) {
    cudaGetDevice(&id);
  }
  printf("cudaGetDevice time=%f ms\n", timer.toc());

  id = 0;
  for (int i = 0; i < warmup; ++i) {
    cudaSetDevice(id);
  }
  timer.tic();
  for (int i = 0; i < count; ++i) {
    cudaSetDevice(id);
  }
  printf("cudaSetDevice time=%f ms\n", timer.toc());

  return 0;
}
```