### PR TITLE
[IPU] split IPU related UTs for CI timeout on a phyical IPU

### DIFF
--- a/python/paddle/fluid/tests/unittests/ipu/test_conv_op_case1_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_conv_op_case1_ipu.py
@@ -1,0 +1,47 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_conv_op_ipu import TestBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestStride(TestBase):
+    def set_op_attrs(self):
+        super().set_op_attrs()
+        self.attrs['stride'] = [2, 3]
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestDilation(TestBase):
+    def set_op_attrs(self):
+        super().set_op_attrs()
+        self.attrs['dilation'] = [2, 2]
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestGroups(TestBase):
+    def set_op_attrs(self):
+        super().set_op_attrs()
+        self.attrs['groups'] = 3
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_conv_op_case2_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_conv_op_case2_ipu.py
@@ -1,0 +1,47 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_conv_op_ipu import TestBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestPadding1(TestBase):
+    def set_op_attrs(self):
+        super().set_op_attrs()
+        self.attrs['padding'] = 2
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestPadding2(TestBase):
+    def set_op_attrs(self):
+        super().set_op_attrs()
+        self.attrs['padding'] = [2, 3]
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestPadding3(TestBase):
+    def set_op_attrs(self):
+        super().set_op_attrs()
+        self.attrs['padding'] = [1, 2, 2, 3]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_conv_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_conv_op_ipu.py
@@ -132,41 +132,5 @@ class TestCase2_1(TestBase):
         self.attrs['filter_size'] = [3, 2]
 
 
-class TestCase3(TestBase):
-    def set_op_attrs(self):
-        super().set_op_attrs()
-        self.attrs['stride'] = [2, 3]
-
-
-class TestCase4(TestBase):
-    def set_op_attrs(self):
-        super().set_op_attrs()
-        self.attrs['dilation'] = [2, 2]
-
-
-class TestCase5(TestBase):
-    def set_op_attrs(self):
-        super().set_op_attrs()
-        self.attrs['groups'] = 3
-
-
-class TestCase6(TestBase):
-    def set_op_attrs(self):
-        super().set_op_attrs()
-        self.attrs['padding'] = 2
-
-
-class TestCase7(TestBase):
-    def set_op_attrs(self):
-        super().set_op_attrs()
-        self.attrs['padding'] = [2, 3]
-
-
-class TestCase8(TestBase):
-    def set_op_attrs(self):
-        super().set_op_attrs()
-        self.attrs['padding'] = [1, 2, 2, 3]
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_add_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_add_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_elemetwise_mul_op_ipu import TestElemetwiseOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestAdd(TestElemetwiseOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.elementwise_add
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_div_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_div_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_elemetwise_mul_op_ipu import TestElemetwiseOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestDiv(TestElemetwiseOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.elementwise_div
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_max_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_max_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_elemetwise_mul_op_ipu import TestElemetwiseOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestMax(TestElemetwiseOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.elementwise_max
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_min_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_min_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_elemetwise_mul_op_ipu import TestElemetwiseOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestMin(TestElemetwiseOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.elementwise_min
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_mod_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_mod_op_ipu.py
@@ -1,0 +1,36 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_elemetwise_mul_op_ipu import TestElemetwiseOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestMod(TestElemetwiseOpBase):
+    def set_atol(self):
+        self.atol = 1e-7
+        self.rtol = 1e-5
+        self.atol_fp16 = 1e-2
+        self.rtol_fp16 = 1e-3
+
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.elementwise_mod
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_mul_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_mul_op_ipu.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ from paddle.fluid.tests.unittests.ipu.op_test_ipu import (ExecutionMode,
 
 @unittest.skipIf(not paddle.is_compiled_with_ipu(),
                  "core is not compiled with IPU")
-class TestMul(IPUOpTest):
+class TestElemetwiseOpBase(IPUOpTest):
     def setUp(self):
         self.set_atol()
         self.set_training()
@@ -161,47 +161,6 @@ class TestMul(IPUOpTest):
         self.set_feed_attr()
         self.attrs = {"axis": 0}
         self.run_test_base()
-
-
-class TestAdd(TestMul):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_add
-
-
-class TestSub(TestMul):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_sub
-
-
-class TestDiv(TestMul):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_div
-
-
-class TestMin(TestMul):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_min
-
-
-class TestMax(TestMul):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_max
-
-
-class TestPow(TestMul):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_pow
-
-
-class TestMod(TestMul):
-    def set_atol(self):
-        self.atol = 1e-7
-        self.rtol = 1e-5
-        self.atol_fp16 = 1e-2
-        self.rtol_fp16 = 1e-3
-
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_mod
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_pow_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_pow_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_elemetwise_mul_op_ipu import TestElemetwiseOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestPow(TestElemetwiseOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.elementwise_pow
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_sub_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_sub_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_elemetwise_mul_op_ipu import TestElemetwiseOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestSub(TestElemetwiseOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.elementwise_sub
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_reduce_max_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_reduce_max_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_reduce_mean_op_ipu import TestReduceOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestMax(TestReduceOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.reduce_max
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_reduce_mean_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_reduce_mean_op_ipu.py
@@ -22,7 +22,7 @@ from paddle.fluid.tests.unittests.ipu.op_test_ipu import IPUOpTest, ExecutionMod
 
 @unittest.skipIf(not paddle.is_compiled_with_ipu(),
                  "core is not compiled with IPU")
-class TestMean(IPUOpTest):
+class TestReduceOpBase(IPUOpTest):
     def setUp(self):
         self.set_atol()
         self.set_training()
@@ -161,26 +161,6 @@ class TestMean(IPUOpTest):
         self.attrs['dim'] = [0, 1]
         self.attrs['keep_dim'] = True
         self.run_test_base()
-
-
-class TestMax(TestMean):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.reduce_max
-
-
-class TestMin(TestMean):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.reduce_min
-
-
-class TestProd(TestMean):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.reduce_prod
-
-
-class TestSum(TestMean):
-    def set_test_op(self):
-        self.op = paddle.fluid.layers.reduce_sum
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ipu/test_reduce_min_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_reduce_min_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_reduce_mean_op_ipu import TestReduceOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestMin(TestReduceOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.reduce_min
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_reduce_prod_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_reduce_prod_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_reduce_mean_op_ipu import TestReduceOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TestProd(TestReduceOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.reduce_prod
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_reduce_sum_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_reduce_sum_op_ipu.py
@@ -1,0 +1,30 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+import paddle.static
+from paddle.fluid.tests.unittests.ipu.test_reduce_mean_op_ipu import TestReduceOpBase
+
+
+@unittest.skipIf(not paddle.is_compiled_with_ipu(),
+                 "core is not compiled with IPU")
+class TesSum(TestReduceOpBase):
+    def set_test_op(self):
+        self.op = paddle.fluid.layers.reduce_sum
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_save_load_fp16_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_save_load_fp16_ipu.py
@@ -1,0 +1,58 @@
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import unittest
+
+from paddle.fluid.tests.unittests.ipu.test_save_load_ipu import TestBase, IPUOpTest
+
+
+@unittest.skipIf(IPUOpTest.use_ipumodel(), "skip for ipumodel")
+class TestSGDFP16(TestBase):
+    def set_op_attrs(self):
+        self.attrs = {}
+        self.attrs['steps'] = 100
+        self.attrs['save_at_step'] = 20
+        self.attrs['is_training'] = True
+        self.attrs['opt_type'] = 'sgd'
+        self.attrs['enable_fp16'] = True
+        self.attrs['model_path'] = tempfile.TemporaryDirectory()
+
+
+@unittest.skipIf(IPUOpTest.use_ipumodel(), "skip for ipumodel")
+class TestAdamFP16(TestBase):
+    def set_op_attrs(self):
+        self.attrs = {}
+        self.attrs['steps'] = 100
+        self.attrs['save_at_step'] = 20
+        self.attrs['is_training'] = True
+        self.attrs['opt_type'] = 'adam'
+        self.attrs['enable_fp16'] = True
+        self.attrs['model_path'] = tempfile.TemporaryDirectory()
+
+
+@unittest.skipIf(IPUOpTest.use_ipumodel(), "skip for ipumodel")
+class TestLambFP16(TestBase):
+    def set_op_attrs(self):
+        self.attrs = {}
+        self.attrs['steps'] = 100
+        self.attrs['save_at_step'] = 20
+        self.attrs['is_training'] = True
+        self.attrs['opt_type'] = 'lamb'
+        self.attrs['enable_fp16'] = True
+        self.attrs['model_path'] = tempfile.TemporaryDirectory()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ipu/test_save_load_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_save_load_ipu.py
@@ -157,41 +157,5 @@ class TestLamb(TestBase):
         self.attrs['model_path'] = tempfile.TemporaryDirectory()
 
 
-@unittest.skipIf(IPUOpTest.use_ipumodel(), "skip for ipumodel")
-class TestSGDFP16(TestBase):
-    def set_op_attrs(self):
-        self.attrs = {}
-        self.attrs['steps'] = 100
-        self.attrs['save_at_step'] = 20
-        self.attrs['is_training'] = True
-        self.attrs['opt_type'] = 'sgd'
-        self.attrs['enable_fp16'] = True
-        self.attrs['model_path'] = tempfile.TemporaryDirectory()
-
-
-@unittest.skipIf(IPUOpTest.use_ipumodel(), "skip for ipumodel")
-class TestAdamFP16(TestBase):
-    def set_op_attrs(self):
-        self.attrs = {}
-        self.attrs['steps'] = 100
-        self.attrs['save_at_step'] = 20
-        self.attrs['is_training'] = True
-        self.attrs['opt_type'] = 'adam'
-        self.attrs['enable_fp16'] = True
-        self.attrs['model_path'] = tempfile.TemporaryDirectory()
-
-
-@unittest.skipIf(IPUOpTest.use_ipumodel(), "skip for ipumodel")
-class TestLambFP16(TestBase):
-    def set_op_attrs(self):
-        self.attrs = {}
-        self.attrs['steps'] = 100
-        self.attrs['save_at_step'] = 20
-        self.attrs['is_training'] = True
-        self.attrs['opt_type'] = 'lamb'
-        self.attrs['enable_fp16'] = True
-        self.attrs['model_path'] = tempfile.TemporaryDirectory()
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
split BIG UTs to small files, so it won't get timeout when running CI on a phyical IPU.