### PR TITLE
Support inplace addto for custom_fused_dense_grad

### DIFF
--- a/paddle/fluid/framework/ir/memory_optimize_pass/inplace_addto_op_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/inplace_addto_op_pass.cc
@@ -180,7 +180,8 @@ void InplaceAddToOpPass::Run(Graph *graph) const {
 
     // NOTE(zhiqiu): currently, only conv2d_grad supports addto strategy
     if (right_generated_op->Name() != "conv2d_grad" &&
-        right_generated_op->Name() != "resnet_unit_grad") {
+        right_generated_op->Name() != "resnet_unit_grad" && 
+	right_generated_op->Name() != "custom_fused_dense_grad") {
       continue;
     }
 

--- a/paddle/fluid/framework/ir/memory_optimize_pass/inplace_addto_op_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/inplace_addto_op_pass.cc
@@ -14,15 +14,11 @@
 
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 
 #include "glog/logging.h"
 #include "paddle/fluid/framework/ir/memory_optimize_pass/memory_reuse_pass.h"
 #include "paddle/fluid/framework/ir/pass.h"
 #include "paddle/fluid/platform/enforce.h"
-#include "paddle/fluid/string/string_helper.h"
-
-DECLARE_string(inplace_addto_external_ops);
 
 namespace paddle {
 namespace framework {
@@ -36,17 +32,6 @@ struct VarHandle;
 namespace paddle {
 namespace framework {
 namespace ir {
-
-static std::unordered_set<std::string> InplaceAddtoOpSet() {
-  std::unordered_set<std::string> inplace_addto_ops{
-      {"conv2d_grad", "resnet_unit_grad"}};
-  auto external_ops =
-      string::split_string(FLAGS_inplace_addto_external_ops, ",");
-  for (const auto &op : external_ops) {
-    inplace_addto_ops.insert(string::trim_spaces(op));
-  }
-  return inplace_addto_ops;
-}
 
 class Graph;
 
@@ -100,8 +85,6 @@ class InplaceAddToOpPass : public MemoryReusePass {
 };
 
 void InplaceAddToOpPass::Run(Graph *graph) const {
-  const auto inplace_addto_ops = InplaceAddtoOpSet();
-
   const auto &last_live_ops =
       Get<std::vector<LastLiveOpsOfVars>>(kLastLiveOpsOfVars);
 
@@ -195,8 +178,11 @@ void InplaceAddToOpPass::Run(Graph *graph) const {
     auto *out_generated_op = dynamic_cast<details::ComputationOpHandle *>(
         out_var_ptr->GeneratedOp());
 
-    // NOTE(zhiqiu): currently, only conv2d_grad supports addto strategy
-    if (inplace_addto_ops.count(right_generated_op->Name()) == 0) {
+    // FIXME(zengjinle): the "custom_fused_dense_grad" is only used for
+    // MLPerf temporarily. Replace it with the formal op type in the future.
+    if (right_generated_op->Name() != "conv2d_grad" &&
+        right_generated_op->Name() != "resnet_unit_grad" &&
+        right_generated_op->Name() != "custom_fused_dense_grad") {
       continue;
     }
 

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -773,3 +773,6 @@ DEFINE_bool(enable_ins_parser_file, false,
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 PADDLE_DEFINE_EXPORTED_bool(nccl_blocking_wait, false, "nccl blocking wait");
 #endif
+
+PADDLE_DEFINE_EXPORTED_string(inplace_addto_external_ops, "",
+                              "The external ops which support inplace addto.");

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -773,6 +773,3 @@ DEFINE_bool(enable_ins_parser_file, false,
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 PADDLE_DEFINE_EXPORTED_bool(nccl_blocking_wait, false, "nccl blocking wait");
 #endif
-
-PADDLE_DEFINE_EXPORTED_string(inplace_addto_external_ops, "",
-                              "The external ops which support inplace addto.");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
OPs

### Describe
Add inplace addto supporting for `custom_fused_dense_grad`. This is only used for MLPerf BERT optimization. It would be removed in the future.