### PR TITLE
Polish reshape error message under @to_static

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6299,7 +6299,14 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
                 if dim_size == -1:
                     assert unk_dim_idx == -1, (
                         "Only one dimension value of 'shape' in reshape can "
-                        "be -1. But received shape[%d] is also -1." % dim_idx)
+                        "be -1. But received shape[%d] is also -1.\n"
+                        "\n\t# N = x.shape()[2]\t\t# N is an int. "
+                        "(NOT recommend under @to_static)\n\tN = paddle.shape(x)[2]\t\t"
+                        "# N is a Tensor. (Recommend)\n\tz = paddle.reshape([N, -1, 4])"
+                        "\t# z.shape is [-1, -1, 4]\n\n"
+                        "    If your target shape in Reshape represents dynamic shape, "
+                        "please turn it into a Tensor under @to_static. See above example for details."
+                        % dim_idx)
                     unk_dim_idx = dim_idx
                 elif dim_size == 0:
                     assert dim_idx < len(x.shape), (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

```
File "/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/nn.py", line 6308, in get_attr_shape
    "please turn it into a Tensor under @to_static. See above example for details." % dim_idx)

AssertionError: Only one dimension value of 'shape' in reshape can be -1. But received shape[2] is also -1.

    # N = x.shape()[2]              # N is an int. (NOT recommend under @to_static)
    N = paddle.shape(x)[2]          # N is a Tensor. (Recommend)
    z = paddle.reshape([N, -1, 4])  # z.shape is [-1, -1, 4]

If your target shape in Reshape represents dynamic shape,please turn it into a Tensor under @to_static. See above example for details.
```
