### PR TITLE
fix auc instag

### DIFF
--- a/paddle/fluid/operators/metrics/auc_op.cc
+++ b/paddle/fluid/operators/metrics/auc_op.cc
@@ -25,6 +25,8 @@ class AucOp : public framework::OperatorWithKernel {
   void InferShape(framework::InferShapeContext *ctx) const override {
     OP_INOUT_CHECK(ctx->HasInput("Predict"), "Input", "Predict", "Auc");
     OP_INOUT_CHECK(ctx->HasInput("Label"), "Input", "Label", "Auc");
+    OP_INOUT_CHECK(ctx->HasInput("InsTagWeight"), "Input", "InsTagWeight",
+                   "Auc");
     auto predict_width = ctx->GetInputDim("Predict")[1];
     if (ctx->IsRuntime()) {
       PADDLE_ENFORCE_LE(predict_width, 2,
@@ -34,11 +36,15 @@ class AucOp : public framework::OperatorWithKernel {
     }
     auto predict_height = ctx->GetInputDim("Predict")[0];
     auto label_height = ctx->GetInputDim("Label")[0];
+    auto ins_tag_height = ctx->GetInputDim("InsTagWeight")[0];
 
     if (ctx->IsRuntime()) {
       PADDLE_ENFORCE_EQ(predict_height, label_height,
                         platform::errors::InvalidArgument(
                             "Out and Label should have same height."));
+      PADDLE_ENFORCE_EQ(ins_tag_height, label_height,
+                        platform::errors::InvalidArgument(
+                            "InsTagWeight and Label should have same height."));
     }
 
     int num_pred_buckets = ctx->Attrs().Get<int>("num_thresholds") + 1;
@@ -83,7 +89,8 @@ class AucOpMaker : public framework::OpProtoAndCheckerMaker {
     AddInput("Label",
              "A 2D int tensor indicating the label of the training data. "
              "shape: [batch_size, 1]");
-
+    AddInput("InsTagWeight",
+             "(Tensor) instag weight, 1 means real data, 0 means false data");
     // TODO(typhoonzero): support weight input
     AddInput("StatPos", "Statistic value when label = 1");
     AddInput("StatNeg", "Statistic value when label = 0");

--- a/paddle/fluid/operators/metrics/auc_op.cc
+++ b/paddle/fluid/operators/metrics/auc_op.cc
@@ -36,15 +36,11 @@ class AucOp : public framework::OperatorWithKernel {
     }
     auto predict_height = ctx->GetInputDim("Predict")[0];
     auto label_height = ctx->GetInputDim("Label")[0];
-    auto ins_tag_height = ctx->GetInputDim("InsTagWeight")[0];
 
     if (ctx->IsRuntime()) {
       PADDLE_ENFORCE_EQ(predict_height, label_height,
                         platform::errors::InvalidArgument(
                             "Out and Label should have same height."));
-      PADDLE_ENFORCE_EQ(ins_tag_height, label_height,
-                        platform::errors::InvalidArgument(
-                            "InsTagWeight and Label should have same height."));
     }
 
     int num_pred_buckets = ctx->Attrs().Get<int>("num_thresholds") + 1;
@@ -89,11 +85,11 @@ class AucOpMaker : public framework::OpProtoAndCheckerMaker {
     AddInput("Label",
              "A 2D int tensor indicating the label of the training data. "
              "shape: [batch_size, 1]");
-    AddInput("InsTagWeight",
-             "(Tensor) instag weight, 1 means real data, 0 means false data");
     // TODO(typhoonzero): support weight input
     AddInput("StatPos", "Statistic value when label = 1");
     AddInput("StatNeg", "Statistic value when label = 0");
+    AddInput("InsTagWeight",
+             "(Tensor) instag weight, 1 means real data, 0 means false data");
 
     AddOutput("AUC",
               "A scalar representing the "

--- a/paddle/fluid/operators/metrics/auc_op.h
+++ b/paddle/fluid/operators/metrics/auc_op.h
@@ -65,6 +65,8 @@ class AucKernel : public framework::OpKernel<T> {
               (slide_steps > 0 ? 1 : 0)) *
                  sizeof(int64_t));
     }
+
+    // when calculate global_auc && is fake data, just do nothing
     if (slide_steps == 0 && is_fake_data) {
       return;
     }

--- a/paddle/fluid/operators/metrics/auc_op.h
+++ b/paddle/fluid/operators/metrics/auc_op.h
@@ -30,7 +30,11 @@ class AucKernel : public framework::OpKernel<T> {
     auto *predict = ctx.Input<Tensor>("Predict");
     auto *label = ctx.Input<Tensor>("Label");
     auto *ins_tag_weight = ctx.Input<Tensor>("InsTagWeight");
-
+    const auto *ins_tag_weight_value = ins_tag_weight->data<float>();
+    bool is_fake_data = 0;
+    if (ins_tag_weight_value[0] == 0) {
+      is_fake_data = 1;
+    }
     int num_thresholds = ctx.Attr<int>("num_thresholds");
     int slide_steps = ctx.Attr<int>("slide_steps");
 
@@ -61,8 +65,11 @@ class AucKernel : public framework::OpKernel<T> {
               (slide_steps > 0 ? 1 : 0)) *
                  sizeof(int64_t));
     }
+    if (slide_steps == 0 && is_fake_data) {
+      return;
+    }
     statAuc(label, predict, num_thresholds, slide_steps, origin_stat_pos,
-            origin_stat_neg, ins_tag_weight);
+            origin_stat_neg, is_fake_data);
 
     int sum_offset = slide_steps * (num_thresholds + 1);
     calcAuc(origin_stat_pos + sum_offset, origin_stat_neg + sum_offset,
@@ -83,12 +90,11 @@ class AucKernel : public framework::OpKernel<T> {
                              const framework::Tensor *predict,
                              const int num_thresholds, const int slide_steps,
                              int64_t *origin_stat_pos, int64_t *origin_stat_neg,
-                             const framework::Tensor *ins_tag_weight) {
+                             const bool is_fake_data) {
     size_t batch_size = predict->dims()[0];
     size_t inference_width = predict->dims()[1];
     const T *inference_data = predict->data<T>();
     const auto *label_data = label->data<int64_t>();
-    const auto *ins_tag_weight_value = ins_tag_weight->data<float>();
     const int bucket_length = num_thresholds + 1;
     if (slide_steps == 0) {
       for (size_t i = 0; i < batch_size; i++) {
@@ -104,9 +110,9 @@ class AucKernel : public framework::OpKernel<T> {
                               "The predict data must gather or equal 0."));
 
         uint32_t binIdx = static_cast<uint32_t>(predict_data * num_thresholds);
-        if (label_data[i] > 0 && ins_tag_weight_value[i] > 0.0) {
+        if (label_data[i] > 0) {
           origin_stat_pos[binIdx] += 1;
-        } else if (label_data[i] == 0 && ins_tag_weight_value[i] > 0.0) {
+        } else if (label_data[i] == 0) {
           origin_stat_neg[binIdx] += 1;
         }
       }
@@ -144,17 +150,19 @@ class AucKernel : public framework::OpKernel<T> {
                             "The predict data must gather or equal 0."));
 
       uint32_t binIdx = static_cast<uint32_t>(predict_data * num_thresholds);
-      if (label_data[i] > 0 && ins_tag_weight_value[i] > 0.0) {
+      if (label_data[i] > 0) {
         origin_stat_pos[cur_step_begin + binIdx] += 1;
-      } else if (label_data[i] == 0 && ins_tag_weight_value[i] > 0.0) {
+      } else if (label_data[i] == 0) {
         origin_stat_neg[cur_step_begin + binIdx] += 1;
       }
     }
-    for (int i = 0; i < bucket_length; ++i) {
-      origin_stat_pos[sum_step_begin + i] +=
-          origin_stat_pos[cur_step_begin + i];
-      origin_stat_neg[sum_step_begin + i] +=
-          origin_stat_neg[cur_step_begin + i];
+    if (!is_fake_data) {
+      for (int i = 0; i < bucket_length; ++i) {
+        origin_stat_pos[sum_step_begin + i] +=
+            origin_stat_pos[cur_step_begin + i];
+        origin_stat_neg[sum_step_begin + i] +=
+            origin_stat_neg[cur_step_begin + i];
+      }
     }
   }
 

--- a/python/paddle/fluid/layers/metric_op.py
+++ b/python/paddle/fluid/layers/metric_op.py
@@ -24,6 +24,7 @@ from ..framework import Variable, in_dygraph_mode, _varbase_creator
 from .. import core
 from ..param_attr import ParamAttr
 from . import nn
+from . import tensor
 from ..data_feeder import check_variable_and_dtype
 
 __all__ = ['accuracy', 'auc']
@@ -178,16 +179,18 @@ def auc(input,
     helper = LayerHelper("auc", **locals())
 
     if ins_tag_weight is None:
-        ins_tag_weight = helper.create_global_variable(
-            dtype='float', shape=label.shape)
-        helper.set_variable_initializer(
-            ins_tag_weight, Constant(
-                value=1.0, force_cpu=False))
+        ins_tag_weight = tensor.fill_constant_batch_size_like(
+            input=label, shape=[-1, 1], dtype="float32", value=1.0)
+        #ins_tag_weight = helper.create_global_variable(
+        #    dtype='float', shape=label.shape)
+        #helper.set_variable_initializer(
+        #    ins_tag_weight, Constant(
+        #        value=1.0, force_cpu=False))
 
     check_variable_and_dtype(input, 'input', ['float32', 'float64'], 'auc')
     check_variable_and_dtype(label, 'label', ['int32', 'int64'], 'auc')
-    check_variable_and_dtype(label, 'ins_tag_weight', ['float32', 'float64'],
-                             'auc')
+    check_variable_and_dtype(ins_tag_weight, 'ins_tag_weight',
+                             ['float32', 'float64'], 'auc')
     auc_out = helper.create_variable_for_type_inference(dtype="float64")
     batch_auc_out = helper.create_variable_for_type_inference(dtype="float64")
     # make tp, tn, fp, fn persistable, so that can accumulate all batches.

--- a/python/paddle/fluid/layers/metric_op.py
+++ b/python/paddle/fluid/layers/metric_op.py
@@ -175,11 +175,11 @@ def auc(input,
             print(output)
             #[array([0.5])]
     """
-
     helper = LayerHelper("auc", **locals())
 
     if ins_tag_weight is None:
-        ins_tag_weight = label
+        ins_tag_weight = helper.create_global_variable(
+            dtype='float', shape=label.shape)
         helper.set_variable_initializer(
             ins_tag_weight, Constant(
                 value=1.0, force_cpu=False))

--- a/python/paddle/fluid/layers/metric_op.py
+++ b/python/paddle/fluid/layers/metric_op.py
@@ -183,8 +183,8 @@ def auc(input,
     helper = LayerHelper("auc", **locals())
 
     if ins_tag_weight is None:
-        ins_tag_weight = tensor.fill_constant_batch_size_like(
-            input=label, shape=[-1, 1], dtype="float32", value=1.0)
+        ins_tag_weight = tensor.fill_constant(
+            shape=[1, 1], dtype="float32", value=1.0)
 
     check_variable_and_dtype(input, 'input', ['float32', 'float64'], 'auc')
     check_variable_and_dtype(label, 'label', ['int32', 'int64'], 'auc')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes 

### PR changes
OPs 

### Describe
背景介绍：如下图，当不存在tag2的数据时，目前的策略是填充‘0值假数据’，这导致了计算auc等指标时，包含了假数据，干扰真实指标。

![image](https://user-images.githubusercontent.com/41941775/159460402-4e52cbcf-d7b9-4db0-9f6f-74b2ad36981b.png)

解决方案：加入了InsTagWeight属性，用来判别多任务中的真假数据，如果为真数据ins_tag_weight为全1值。
