### PR TITLE
[NPU] fix no allocator error

### DIFF
--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -219,6 +219,12 @@ class AllocatorFacadePrivate {
         }
         InitNaiveBestFitCUDAPinnedAllocator();
 #endif
+#ifdef PADDLE_WITH_ASCEND_CL
+        for (int dev_id = 0; dev_id < platform::GetNPUDeviceCount(); ++dev_id) {
+          InitNaiveBestFitNPUAllocator(platform::NPUPlace(dev_id));
+        }
+        InitNaiveBestFitNPUPinnedAllocator();
+#endif
 #ifdef PADDLE_WITH_XPU
         for (int dev_id = 0; dev_id < platform::GetXPUDeviceCount(); ++dev_id) {
           InitNaiveBestFitXPUAllocator(platform::XPUPlace(dev_id));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix NPU no allocator error when compiled with ON_INFER=OFF, where allocator_strategy is `auto_growth` but no allocator is provided, using NaiveBestFit allocator before split NPU out.
<img width="1141" alt="c1aae30b54b3fdc0fd71967571c01a3b" src="https://user-images.githubusercontent.com/5997715/158819477-17ed6323-3aca-4770-a932-d6027de946be.png">

