### PR TITLE
Fix compile error on CUDA 11.6

### DIFF
--- a/paddle/phi/kernels/funcs/mode.h
+++ b/paddle/phi/kernels/funcs/mode.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(__NVCC__) || defined(__HIPCC__)
 #include <thrust/device_vector.h>
 #include <thrust/execution_policy.h>
 #include <thrust/extrema.h>
@@ -143,7 +143,7 @@ static void ModeAssign(const Type& input_height,
   }
 }
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(__NVCC__) || defined(__HIPCC__)
 template <typename T>
 static void GetModebySort(const phi::GPUContext& dev_ctx,
                           const DenseTensor* input_tensor,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix compile error on CUDA 11.6.
```
[ 31%] Building CXX object paddle/phi/kernels/CMakeFiles/mode_grad_kernel_cpu.dir/cpu/mode_grad_kernel.cc.o

In file included from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/cuda/detail/util.h:36,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/cuda/detail/internal/copy_cross_system.h:41,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/cuda/detail/copy.h:100,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/detail/adl/copy.h:42,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/copy.inl:22,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/copy.h:90,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/allocator/copy_construct_range.inl:21,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/allocator/copy_construct_range.h:45,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/contiguous_storage.inl:23,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/contiguous_storage.h:234,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/vector_base.h:30,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/device_vector.h:26,
                 from /data2/zengjinle/Paddle_dev/Paddle_for_ngc/paddle/phi/kernels/funcs/mode.h:18,
                 from /data2/zengjinle/Paddle_dev/Paddle_for_ngc/paddle/phi/kernels/cpu/mode_kernel.cc:19:
/usr/local/cuda/targets/x86_64-linux/include/cub/detail/device_synchronize.cuh:33: error: ignoring #pragma nv_exec_check_disable  [-Werror=unknown-pragmas]
 #pragma nv_exec_check_disable
 
cc1plus: all warnings being treated as errors
make[2]: *** [paddle/phi/kernels/CMakeFiles/mode_kernel_cpu.dir/build.make:63: paddle/phi/kernels/CMakeFiles/mode_kernel_cpu.dir/cpu/mode_kernel.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:34137: paddle/phi/kernels/CMakeFiles/mode_kernel_cpu.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
In file included from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/cuda/detail/util.h:36,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/cuda/detail/internal/copy_cross_system.h:41,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/cuda/detail/copy.h:100,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/system/detail/adl/copy.h:42,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/copy.inl:22,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/copy.h:90,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/allocator/copy_construct_range.inl:21,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/allocator/copy_construct_range.h:45,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/contiguous_storage.inl:23,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/contiguous_storage.h:234,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/detail/vector_base.h:30,
                 from /usr/local/cuda/targets/x86_64-linux/include/thrust/device_vector.h:26,
                 from /data2/zengjinle/Paddle_dev/Paddle_for_ngc/paddle/phi/kernels/funcs/mode.h:18,
                 from /data2/zengjinle/Paddle_dev/Paddle_for_ngc/paddle/phi/kernels/cpu/mode_grad_kernel.cc:20:
/usr/local/cuda/targets/x86_64-linux/include/cub/detail/device_synchronize.cuh:33: error: ignoring #pragma nv_exec_check_disable  [-Werror=unknown-pragmas]
 #pragma nv_exec_check_disable
 
cc1plus: all warnings being treated as errors
make[2]: *** [paddle/phi/kernels/CMakeFiles/mode_grad_kernel_cpu.dir/build.make:63: paddle/phi/kernels/CMakeFiles/mode_grad_kernel_cpu.dir/cpu/mode_grad_kernel.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:93552: paddle/phi/kernels/CMakeFiles/mode_grad_kernel_cpu.dir/all] Error 2
```