### PR TITLE
Correct MultipleQuantizeSquash

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -45,6 +45,7 @@ void LogCannotQuantizeOp(Node* op, const char* details = nullptr) {
          << " (type: " << op->Op()->Type() << ", id: " << op->id() << ").";
   if (details) msg_ss << " " << details;
   PrettyLogDetail(msg_ss.str().c_str());
+  op->Op()->SetAttr("mkldnn_data_type", std::string("float32"));
 }
 
 void LogScaleIsMissingForVarName(const std::string& name) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

This fixed the problem with running the yolov3_darknet model. 

This PR corrects MultipleQuantizeSquash in `cpu_quantize_squash_pass.cc`. 
It turned out that this mechanism didn't support the situation when under one input name are many inputs (eg. concat, sum). 
Before new inputs for the next operators were created, now we just updating the next operator input. 

Moreover, I added setting `mkldnn_data_type` to float32 if the operator is not quantised, because before even if the operator wasn't quantized this attribute was set to int8. 
