### PR TITLE
refine amp for view op

### DIFF
--- a/paddle/fluid/imperative/amp_auto_cast.cc
+++ b/paddle/fluid/imperative/amp_auto_cast.cc
@@ -316,6 +316,10 @@ template <typename VarType>
 NameVarMap<VarType> AutoCastInputs(const std::string& op_type,
                                    const NameVarMap<VarType>& ins) {
   NameVarMap<VarType> new_ins(ins);
+  if (op_type == "reshape2" || op_type == "unsqueeze2" ||
+      op_type == "squeeze2" || op_type == "flatten_contiguous_range") {
+    return new_ins;
+  }
   if (AmpOperators::Instance().GetMutableAllowOps()->count(op_type)) {
     for (auto& pair : new_ins) {
       // NOTE(zhiqiu): batch_norm and layer_norm support only input x is fp16.
@@ -395,6 +399,10 @@ template <typename VarType>
 NameVarMap<VarType> CastPureFp16Inputs(const std::string& op_type,
                                        const NameVarMap<VarType>& ins) {
   NameVarMap<VarType> new_ins(ins);
+  if (op_type == "reshape2" || op_type == "unsqueeze2" ||
+      op_type == "squeeze2" || op_type == "flatten_contiguous_range") {
+    return new_ins;
+  }
   auto dst_type = framework::proto::VarType::FP16;
   if (AmpOperators::Instance().GetMutableUnsupportedFp16Ops()->count(op_type) ||
       AmpOperators::Instance().GetMutableBlockOps()->count(op_type)) {
@@ -440,6 +448,10 @@ template <typename VarType>
 NameVarMap<VarType> AutoCastBF16Inputs(const std::string& op_type,
                                        const NameVarMap<VarType>& ins) {
   NameVarMap<VarType> new_ins(ins);
+  if (op_type == "reshape2" || op_type == "unsqueeze2" ||
+      op_type == "squeeze2" || op_type == "flatten_contiguous_range") {
+    return new_ins;
+  }
   if (AmpOperators::Instance().GetMutableAllowOps()->count(op_type)) {
     for (auto& pair : new_ins) {
       VLOG(5) << "Op(" << op_type << "): Cast " << pair.first << " from "
@@ -490,6 +502,10 @@ template <typename VarType>
 NameVarMap<VarType> CastPureBf16Inputs(const std::string& op_type,
                                        const NameVarMap<VarType>& ins) {
   NameVarMap<VarType> new_ins(ins);
+  if (op_type == "reshape2" || op_type == "unsqueeze2" ||
+      op_type == "squeeze2" || op_type == "flatten_contiguous_range") {
+    return new_ins;
+  }
   auto dst_type = framework::proto::VarType::BF16;
   if (AmpOperators::Instance().GetMutableUnsupportedBf16Ops()->count(op_type) ||
       AmpOperators::Instance().GetMutableBlockOps()->count(op_type)) {

--- a/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_auto_mixed_precision.py
@@ -1126,6 +1126,35 @@ class TestLayerNormFp16(unittest.TestCase):
                 self.assertTrue(out.dtype == fluid.core.VarDesc.VarType.FP16)
 
 
+class TestAmpForViewOp(unittest.TestCase):
+    r''' View op of reshape, squeeze, unsqueeze, flatten_contiguous_range will skip amp.
+    '''
+
+    def test_reshape_op(self):
+        if fluid.is_compiled_with_cuda():
+            with fluid.dygraph.guard(fluid.CUDAPlace(0)):
+                x_1 = paddle.rand([2, 4, 6], dtype="float32")
+                with paddle.amp.auto_cast(level="O1", dtype="float16"):
+                    out_1 = paddle.reshape(x_1, [-1, 0, 3, 2])
+
+                x_2 = paddle.rand([2, 4, 6], dtype="float32")
+                with paddle.amp.auto_cast(level="O2", dtype="float16"):
+                    out_2 = paddle.reshape(x_2, [-1, 0, 3, 2])
+
+                x_3 = paddle.rand([2, 4, 6], dtype="float32")
+                with paddle.amp.auto_cast(level="O1", dtype="bfloat16"):
+                    out_3 = paddle.reshape(x_3, [-1, 0, 3, 2])
+
+                x_4 = paddle.rand([2, 4, 6], dtype="float32")
+                with paddle.amp.auto_cast(level="O2", dtype="bfloat16"):
+                    out_4 = paddle.reshape(x_4, [-1, 0, 3, 2])
+
+                self.assertTrue(out_1.dtype == fluid.core.VarDesc.VarType.FP32)
+                self.assertTrue(out_2.dtype == fluid.core.VarDesc.VarType.FP32)
+                self.assertTrue(out_3.dtype == fluid.core.VarDesc.VarType.FP32)
+                self.assertTrue(out_4.dtype == fluid.core.VarDesc.VarType.FP32)
+
+
 class TestBf16(unittest.TestCase):
     '''
     test amp for BF16 


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
view 机制的四个op跳过amp，包括：reshape、unsqueeze、squeeze、flatten
