### PR TITLE
Add Coverage build size check

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2931,9 +2931,10 @@ function check_coverage_build() {
 
     rm -f build_size
     curl -O https://paddle-docker-tar.bj.bcebos.com/paddle_ci_index/build_size
-    dev_coverage_build_size=`cat build_size`
+    dev_coverage_build_size=`cat build_size|sed 's#G##g'`
+    pr_coverage_build_size=`echo $buildSize|sed 's#G##g'`
 
-    diff_coverage_build_size=`echo $(($buildSize - $dev_coverage_build_size))`
+    diff_coverage_build_size=`echo $(($pr_coverage_build_size - $dev_coverage_build_size))`
 
     set +x
     if [ ${diff_coverage_build_size} -gt 3 ]; then

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2939,12 +2939,12 @@ function check_coverage_build() {
     set +x
     if [ ${diff_coverage_build_size} -gt 3 ]; then
        approval_line=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
-       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 29832297 6836917`
+       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 29832297 6836917 43953930`
        echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
        if [ "${APPROVALS}" == "FALSE" ]; then
            echo "=========================================================================================="
-           echo "This PR make the release paddlepaddle coverage build size growth exceeds 3 G, Please explain why your PR exceeds 3G to ext_ppee@baidu.com."
-           echo "Then you must have one RD (tianshuo78520a (Recommend) or luotao1) approval for this PR\n"
+           echo "This PR make the release paddlepaddle coverage build size growth exceeds 3 G, please explain why your PR exceeds 3G to ext_ppee@baidu.com."
+           echo "Then you must have one RD (tianshuo78520a (Recommend) or luotao1 or phlrain) approval for this PR\n"
            echo "=========================================================================================="
            exit 6
        fi

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2939,12 +2939,12 @@ function check_coverage_build() {
     set +x
     if [ ${diff_coverage_build_size} -gt 3 ]; then
        approval_line=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
-       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 22334008 22361972`
+       APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 29832297 6836917`
        echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
        if [ "${APPROVALS}" == "FALSE" ]; then
            echo "=========================================================================================="
-           echo "This PR make the release paddlepaddle coverage build size growth exceeds 3 G."
-           echo "Then you must have one RD (jim19930609 (Recommend) or JiabinYang) approval for this PR\n"
+           echo "This PR make the release paddlepaddle coverage build size growth exceeds 3 G, Please explain why your PR exceeds 3G to ext_ppee@baidu.com."
+           echo "Then you must have one RD (tianshuo78520a (Recommend) or luotao1) approval for this PR\n"
            echo "=========================================================================================="
            exit 6
        fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
添加Coverage CI Build目录监控
    2.16号、3.7号两天因为Coverage任务的Build目录太大，导致两天Coverage任务全部失败。为避免CI大面积挂，工程效率上线监控Coverage Build目录功能，会拿当前PR和每天晚上3点develop，编译的Coverage Build目录进行比较，超过3G则需要邮件发送ext_ppee@baidu.com 进行说明增长原因，由tianshuo78520a、luotao1、phlrain其中一人approval 才能通过。 监控PR：https://github.com/PaddlePaddle/Paddle/pull/40749