### PR TITLE
[Infrt] add method for automatically scanning  pass and kernel info

### DIFF
--- a/tools/infrt/print_kernel_pass_info.py
+++ b/tools/infrt/print_kernel_pass_info.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+import json
+
+skip_list = []
+
+
+def remove_grad_kernel(kernels):
+    clean_kernels = []
+    for kernel_ in kernels:
+        if (not "_grad" in kernel_):
+            clean_kernels.append(kernel_)
+    return clean_kernels
+
+
+CPU_KERNEL_REGISTER = "REGISTER_OP_CPU_KERNEL("
+GPU_KERNEL_REGISTER = "REGISTER_OP_CUDA_KERNEL("
+XPU_KERNEL_REGISTER = "REGISTER_OP_XPU_KERNEL("
+
+
+def get_compat_kernels_info(register):
+    kernels_info = {}
+    kernel_names = []
+    for dirpath, dirnames, filenames in os.walk("../../paddle/fluid/operators"):
+        for file_name in filenames:
+            if not ".cc" in file_name:
+                continue
+            with open(os.path.join(dirpath, file_name)) as f:
+                txt = f.readlines()
+                content = ""
+                registry = False
+                is_macro_defination = False
+                for line in txt:
+                    if line.strip().startswith("#define") and line.strip(
+                    ).endswith("\\"):
+                        is_macro_defination = True
+                        continue
+                    if is_macro_defination:
+                        if not line.strip().endswith("\\"):
+                            is_macro_defination = False
+                        continue
+
+                    if (register in line):
+                        content = ""
+                        registry = True
+                    if (registry):
+                        content += line
+                    if (registry and ";" in line):
+                        kernel_name = content.replace("\n", "").replace(
+                            " ", "").strip(register).split(",")
+                        registry = False
+                        kernel_names.append(kernel_name[0])
+    return remove_grad_kernel(kernel_names)
+
+
+def show_kernel_statistics(backend, kernels):
+    print("=== kernels statistics === ")
+    print("the number of " + backend + " kernels is: " + str(len(kernels)) +
+          "\n")
+    print(kernels)
+    print("\n")
+
+
+def show_pass_statistics(backend, passes):
+    print("=== Passes Statistics === ")
+    print("The number of " + backend + " passes is: " + str(len(passes)) + "\n")
+    print(passes)
+    print("\n")
+
+
+def get_passes_info(register):
+    pass_registry_func = ""
+    with open("../../paddle/fluid/inference/api/paddle_pass_builder.cc") as f:
+        txt = f.readlines()
+        stack = []
+        registry_fun_found = False
+        for line in txt:
+            if line.strip().startswith("//"):
+                continue
+            if register in line:
+                registry_fun_found = True
+            if (registry_fun_found):
+                pass_registry_func += line
+            if registry_fun_found:
+                for char in line:
+                    if char == "{":
+                        stack.append(char)
+                    if char == "}":
+                        stack.pop()
+            if len(stack) == 0:
+                registry_fun_found = False
+        pass_list = re.findall("\"(.+?)_pass\"", pass_registry_func)
+        return pass_list
+
+
+if __name__ == "__main__":
+    cpu_kernels = get_compat_kernels_info(CPU_KERNEL_REGISTER)
+    gpu_kernels = get_compat_kernels_info(GPU_KERNEL_REGISTER)
+    xpu_kernels = get_compat_kernels_info(XPU_KERNEL_REGISTER)
+    show_kernel_statistics("CPU", cpu_kernels)
+    show_kernel_statistics("GPU", gpu_kernels)
+    show_kernel_statistics("XPU", xpu_kernels)
+
+    cpu_passes = get_passes_info("CpuPassStrategy::CpuPassStrategy()")
+    gpu_passes = get_passes_info("GpuPassStrategy::GpuPassStrategy()")
+    show_pass_statistics("CPU", cpu_passes)
+    show_pass_statistics("GPU", gpu_passes)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
- scan and print kernel and pass info
``` shell
# .eg
=== kernels statistics ===
the number of CPU kernels is: 326

['nce', 'squeeze', 'squeeze2', 'bmm', 'expand', 'rank_attention', 'cvm', 'tree_conv', 'eig', 'isinf', 'isnan', 'isfinite', 'pad_constant_like', 'crop_tensor', 'class_center_sample', 'eigvalsh', 'lookup_table', 'instance_norm', 'rank_loss', 'pad2d', 'prroi_pool', 'lu_unpack', 'attention_lstm', 'tdm_sampler', 'repeat_interleave', 'squared_l2_norm', 'partial_sum', 'stack', 'mul', 'cos_sim', 'dirichlet', 'clip', 'inverse', 'uniform_random_batch_size_like', 'fake_quantize_abs_max', 'fake_quantize_dequantize_abs_max', 'fake_quantize_range_abs_max', 'fake_quantize_moving_average_abs_max', 'fake_quantize_dequantize_moving_average_abs_max', 'fake_channel_wise_quantize_abs_max', 'moving_average_abs_max_scale', 'fake_channel_wise_quantize_dequantize_abs_max', 'load_combine', 'lstm', 'meshgrid', 'unique_consecutive', 'lstm_unit', 'im2sequence', 'expand_as', 'inplace_abn', 'fused_softmax_mask_upper_triangle', 'complex', 'pull_box_extended_sparse', 'push_box_extended_sparse', 'var_conv_2d', 'add_position_encoding', 'edit_distance', 'ctc_align', 'chunk_eval', 'spp', 'clip_by_norm', 'lu', 'group_norm', 'dequantize_log', 'frame', 'bilinear_interp', 'nearest_interp', 'trilinear_interp', 'linear_interp', 'bicubic_interp', 'diag', 'range', 'bilinear_interp_v2', 'nearest_interp_v2', 'trilinear_interp_v2', 'linear_interp_v2', 'bicubic_interp_v2', 'hash', 'positive_negative_pair', 'affine_grid', 'deformable_conv_v1', 'as_complex', 'as_real', 'hinge_loss', 'lookup_table_dequant', 'deformable_psroi_pooling', 'correlation', 'fill_constant_batch_size_like', 'angle', 'graph_khop_sampler', 'conj', 'margin_rank_loss', 'fold', 'overlap_add', 'row_conv', 'l1_norm', 'sampling_id', 'dot', 'diag_embed', 'teacher_student_sigmoid_loss', 'p_norm', 'match_matrix_tensor', 'sum', 'py_layer', 'top_k', 'crf_decoding', 'mean', 'squared_l2_distance', 'renorm', 'detection_map', 'fsp', 'gru', 'marker', 'fc', 'data_norm', 'matmul', 'slogdeterminant', 'assign_value', 'strided_slice', 'unsqueeze', 'unsqueeze2', 'gru_unit', 'space_to_depth', 'coalesce_tensor', 'unstack', 'lstsq', 'temporal_shift', 'one_hot', 'number_count', 'lrn', 'nop', 'unpool', 'unpool3d', 'sample_logits', 'unique', 'mean_iou', 'beam_search', 'bpr_loss', 'fill_diagonal', 'transfer_dtype', 'crop', 'seed', 'softmax_with_cross_entropy', 'pyramid_hash', 'smooth_l1_loss', 'warpctc', 'solve', 'similarity_focus', 'lstmp', 'minus', 'svd', 'share_buffer', 'linear_chain_crf', 'cudnn_lstm', 'lookup_table_v2', 'random_crop', 'average_accumulates', 'fake_dequantize_max_abs', 'fake_channel_wise_dequantize_max_abs', 'dequantize_abs_max', 'gaussian_random_batch_size_like', 'fft_c2c', 'fft_r2c', 'fft_c2r', 'save_combine', 'exponential', 'slice', 'fill', 'filter_by_instag', 'logit', 'square', 'pow', 'exp', 'expm1', 'dgc_clip_by_norm', 'affine_channel', 'fused_softmax_mask', 'batch_fc', 'partial_concat', 'fill_zeros_like', 'fill_zeros_like2', 'lod_reset', 'shuffle_channel', 'flatten', 'flatten2', 'flatten_contiguous_range', 'save', 'unique_with_counts', 'margin_cross_entropy', 'conv_shift', 'fill_any', 'bilateral_slice', 'spectral_norm', 'fill_diagonal_tensor', 'eigvals', 'uniform_random_inplace', 'tdm_child', 'modified_huber_loss', 'merge_selected_rows', 'rnn', 'load', 'cross_entropy', 'cross_entropy2', 'shuffle_batch', 'center_loss', 'precision_recall', 'distributed_lookup_table', 'send_and_recv', 'distributed_push_sparse', 'fused_embedding_seq_pool', 'fusion_seqpool_concat', 'fusion_seqconv_eltadd_relu', 'fusion_gru', 'fusion_squared_mat_sub', 'fusion_lstm', 'fusion_seqexpand_concat_fc', 'fused_embedding_fc_lstm', 'fusion_seqpool_cvm_concat', 'fusion_repeated_fc_relu', 'fused_elemwise_activation', 'fused_elemwise_add_activation', 'sequence_expand', 'sequence_pad', 'sequence_topk_avg_pooling', 'sequence_softmax', 'sequence_expand_as', 'sequence_unpad', 'sequence_reshape', 'sequence_conv', 'sequence_concat', 'sequence_mask', 'sequence_enumerate', 'sequence_reverse', 'sequence_pool', 'sequence_scatter', 'sequence_slice', 'sequence_erase', 'box_clip', 'rpn_target_assign', 'retinanet_target_assign', 'generate_proposal_labels', 'mine_hard_examples', 'anchor_generator', 'box_coder', 'distribute_fpn_proposals', 'collect_fpn_proposals', 'roi_perspective_transform', 'generate_proposals_v2', 'sigmoid_focal_loss', 'density_prior_box', 'generate_mask_labels', 'box_decoder_and_assign', 'bipartite_match', 'multiclass_nms', 'multiclass_nms2', 'multiclass_nms3', 'retinanet_detection_output', 'matrix_nms', 'prior_box', 'polygon_box_transform', 'locality_aware_nms', 'target_assign', 'iou_similarity', 'generate_proposals', 'yolov3_loss', 'get_float_status', 'clear_float_status', 'alloc_float_status', 'check_finite_and_unscale', 'update_loss_scaling', 'faster_tokenizer', 'c_reducescatter', 'c_embedding', 'partial_allgather', 'c_allreduce_max', 'partial_recv', 'c_softmax_with_cross_entropy', 'barrier', 'c_reduce_max', 'c_scatter', 'alltoall', 'c_allgather', 'allreduce', 'c_identity', 'c_reduce_min', 'global_gather', 'c_split', 'partial_send', 'c_allreduce_min', 'recv_v2', 'c_concat', 'send_v2', 'c_broadcast', 'global_scatter', 'broadcast', 'reduce_amax', 'reduce_amin', 'logsumexp', 'elementwise_floordiv', 'elementwise_min', 'elementwise_mul', 'elementwise_pow', 'elementwise_max', 'grad_add', 'elementwise_mod', 'cinn_instruction_run', 'cinn_launch', 'dpsgd', 'decayed_adagrad', 'dgc_momentum', 'proximal_adagrad', 'lamb', 'lars_momentum', 'adamw', 'distributed_fused_lamb', 'sparse_momentum', 'rmsprop', 'merged_adam', 'distributed_fused_lamb_init', 'ftrl', 'momentum', 'adam', 'proximal_gd', 'adagrad', 'merged_momentum', 'pow2_decay_with_linear_warmup']

=== kernels statistics ===
the number of GPU kernels is: 76

['expand', 'merge_selected_rows', 'run_program', 'cudnn_lstm', 'cudnn_lstm', 'pad_constant_like', 'crop_tensor', 'rank_loss', 'squeeze', 'squeeze2', 'unsqueeze', 'unsqueeze2', 'fill_zeros_like', 'fill_zeros_like2', 'fill_any', 'meshgrid', 'fill_constant_batch_size_like', 'im2sequence', 'expand_as', 'fc', 'hinge_loss', 'l1_norm', 'mul', 'py_layer', 'matmul', 'lstm', 'coalesce_tensor', 'coalesce_tensor', 'inverse', 'fill', 'beam_search', 'flatten', 'flatten2', 'flatten_contiguous_range', 'nop', 'crop', 'minus', 'spp', 'slice', 'assign_value', 'unpool', 'unpool3d', 'gru', 'rnn', 'rnn', 'send_and_recv', 'distributed_push_sparse', 'distributed_lookup_table', 'fusion_transpose_flatten_concat', 'fusion_group', 'sequence_conv', 'sequence_concat', 'c_broadcast', 'broadcast', 'c_reducescatter', 'partial_send', 'c_concat', 'allreduce', 'c_scatter', 'global_scatter', 'c_sync_comm_stream', 'c_identity', 'recv_v2', 'barrier', 'partial_recv', 'partial_allgather', 'alltoall', 'global_gather', 'send_v2', 'c_allgather', 'c_sync_calc_stream', 'cinn_launch', 'cinn_instruction_run', 'ncclAllReduce', 'ncclBcast', 'ncclReduce']


=== kernels statistics ===
the number of XPU kernels is: 110

['gather_nd', 'concat', 'top_k_v2', 'split', 'batch_norm', 'where', 'softmax_with_cross_entropy', 'log_loss', 'sigmoid_cross_entropy_with_logits', 'mean', 'expand_v2', 'shape', 'rnn', 'sign', 'masked_select', 'conv2d_transpose', 'conv2d', 'depthwise_conv2d', 'clip_by_norm', 'squeeze', 'squeeze2', 'transpose', 'transpose2', 'layer_norm', 'range', 'load', 'tril_triu', 'scale', 'sum', 'lookup_table_v2', 'flatten', 'flatten2', 'flatten_contiguous_range', 'tanh', 'exp', 'log', 'pow', 'expand_as_v2', 'dropout', 'affine_channel', 'pool2d', 'uniform_random_inplace', 'one_hot_v2', 'top_k', 'arg_max', 'coalesce_tensor', 'uniform_random', 'fill_constant', 'deformable_conv', 'huber_loss', 'unsqueeze', 'unsqueeze2', 'gather', 'softmax', 'gelu', 'argsort', 'matmul_v2', 'truncated_gaussian_random', 'roi_align', 'clip', 'tile', 'mul', 'scatter', 'stack', 'cast', 'gaussian_random', 'bilinear_interp', 'nearest_interp', 'slice', 'matmul', 'one_hot', 'bilinear_interp_v2', 'nearest_interp_v2', 'label_smooth', 'fill_any_like', 'accuracy', 'sequence_conv', 'prior_box', 'iou_similarity', 'check_finite_and_unscale', 'update_loss_scaling', 'equal', 'not_equal', 'less_than', 'less_equal', 'greater_than', 'greater_equal', 'logical_and', 'logicalnot', 'logical_or', 'broadcast', 'reduce_max', 'reduce_mean', 'reduce_prod', 'reduce_sum', 'logsumexp', 'elementwise_pow', 'elementwise_div', 'elementwise_sub', 'elementwise_add', 'elementwise_floordiv', 'elementwise_max', 'elementwise_mul', 'elementwise_min', 'lamb', 'rmsprop', 'adamw', 'momentum', 'adam', 'sgd']

=== Passes Statistics ===
The number of CPU passes is: 26

['simplify_with_basic_ops', 'layer_norm_fuse', 'attention_lstm_fuse', 'seqconv_eltadd_relu_fuse', 'seqpool_cvm_concat_fuse', 'mul_lstm_fuse', 'fc_gru_fuse', 'mul_gru_fuse', 'seq_concat_fc_fuse', 'gpu_cpu_squeeze2_matmul_fuse', 'gpu_cpu_reshape2_matmul_fuse', 'gpu_cpu_flatten2_matmul_fuse', 'matmul_v2_scale_fuse', 'gpu_cpu_map_matmul_v2_to_mul', 'gpu_cpu_map_matmul_v2_to_matmul', 'matmul_scale_fuse', 'gpu_cpu_map_matmul_to_mul', 'fc_fuse', 'repeated_fc_relu_fuse', 'squared_mat_sub_fuse', 'conv_bn_fuse', 'conv_eltwiseadd_bn_fuse', 'conv_transpose_bn_fuse', 'conv_transpose_eltwiseadd_bn_fuse', 'is_test', 'runtime_context_cache']

=== Passes Statistics ===
The number of GPU passes is: 18

['is_test', 'simplify_with_basic_ops', 'conv_bn_fuse', 'conv_eltwiseadd_bn_fuse', 'embedding_eltwise_layernorm_fuse', 'gpu_cpu_squeeze2_matmul_fuse', 'gpu_cpu_reshape2_matmul_fuse', 'gpu_cpu_flatten2_matmul_fuse', 'gpu_cpu_map_matmul_v2_to_mul', 'gpu_cpu_map_matmul_v2_to_matmul', 'gpu_cpu_map_matmul_to_mul', 'fc_fuse', 'fc_elementwise_layernorm_fuse', 'conv_elementwise_add_act_fuse', 'conv_elementwise_add2_act_fuse', 'conv_elementwise_add_fuse', 'transpose_flatten_concat_fuse', 'runtime_context_cache']

```

#########################################