### PR TITLE
fix ctr_metric_bundle for instag

### DIFF
--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -23,6 +23,7 @@ from paddle.fluid.initializer import Normal, Constant
 from paddle.fluid.framework import Variable
 from paddle.fluid.param_attr import ParamAttr
 from paddle.fluid.layers import nn
+from paddle.fluid.layers import tensor
 
 __all__ = ['ctr_metric_bundle']
 
@@ -193,7 +194,11 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
                 "Y": [local_ins_num]},
         outputs={"Out": [local_ins_num]})
 
+    #if data is fake, return 0
     if ins_tag_weight[0] == 0:
-        local_q = 0
-        local_ins_num = 0
+        for var in [local_q, local_ins_num]:
+            helper.set_variable_initializer(
+                var, Constant(
+                    value=0.0, force_cpu=True))
+
     return local_sqrerr, local_abserr, local_prob, local_q, local_pos_num, local_ins_num

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -27,7 +27,7 @@ from paddle.fluid.layers import nn
 __all__ = ['ctr_metric_bundle']
 
 
-def ctr_metric_bundle(input, label):
+def ctr_metric_bundle(input, label, ins_tag_weight=None):
     """
     ctr related metric layer
 
@@ -48,6 +48,9 @@ def ctr_metric_bundle(input, label):
                          Variable indicates the probability of each label.
         label(Variable): A 2D int Variable indicating the label of the training
                          data. The height is batch size and width is always 1.
+        ins_tag_weight(Variable): A 2D int Variable indicating the ins_tag_weight of the training
+                         data. 1 means real data, 0 means fake data. 
+                         A LoDTensor or Tensor with type float32,float64.
 
     Returns:
         local_sqrerr(Variable): Local sum of squared error
@@ -61,9 +64,14 @@ def ctr_metric_bundle(input, label):
             import paddle.fluid as fluid
             data = fluid.layers.data(name="data", shape=[32, 32], dtype="float32")
             label = fluid.layers.data(name="label", shape=[1], dtype="int32")
+            ins_tag_weight = fluid.layers.data(name="ins_tag_weight", shape=[1], dtype="float32")
             predict = fluid.layers.sigmoid(fluid.layers.fc(input=data, size=1))
             auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label)
     """
+    if ins_tag_weight is None:
+        ins_tag_weight = tensor.fill_constant_batch_size_like(
+            input=label, shape=[-1, 1], dtype="float32", value=1.0)
+
     assert input.shape == label.shape
     helper = LayerHelper("ctr_metric_bundle", **locals())
 
@@ -185,4 +193,7 @@ def ctr_metric_bundle(input, label):
                 "Y": [local_ins_num]},
         outputs={"Out": [local_ins_num]})
 
+    if ins_tag_weight[0] == 0:
+        local_q = 0
+        local_ins_num = 0
     return local_sqrerr, local_abserr, local_prob, local_q, local_pos_num, local_ins_num

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -66,7 +66,7 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
             label = fluid.layers.data(name="label", shape=[1], dtype="int32")
             ins_tag_weight = fluid.layers.data(name="ins_tag_weight", shape=[1], dtype="float32")
             predict = fluid.layers.sigmoid(fluid.layers.fc(input=data, size=1))
-            auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label)
+            auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label, ins_tag_weight=ins_tag_weight)
     """
     if ins_tag_weight is None:
         ins_tag_weight = tensor.fill_constant_batch_size_like(

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -70,8 +70,8 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
             auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label, ins_tag_weight=ins_tag_weight)
     """
     if ins_tag_weight is None:
-        ins_tag_weight = tensor.fill_constant_batch_size_like(
-            input=label, shape=[-1, 1], dtype="float32", value=1.0)
+        ins_tag_weight = tensor.fill_constant(
+            shape=[1, 1], dtype="float32", value=1.0)
 
     assert input.shape == label.shape
     helper = LayerHelper("ctr_metric_bundle", **locals())

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -195,7 +195,7 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
         outputs={"Out": [local_ins_num]})
 
     #if data is fake, return 0
-    ins_tag_weight_np = ins_tag_weight.to_string()
+    ins_tag_weight_np = ins_tag_weight.to_string(False, False)
     if ins_tag_weight_np[0] == '0':
         local_ins_num = tensor.fill_constant_batch_size_like(
             input=local_ins_num,

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -195,7 +195,8 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
         outputs={"Out": [local_ins_num]})
 
     #if data is fake, return 0
-    if ins_tag_weight[0] == 0:
+    ins_tag_weight_np = ins_tag_weight.to_string()
+    if ins_tag_weight_np[0] == '0':
         local_ins_num = tensor.fill_constant_batch_size_like(
             input=local_ins_num,
             shape=local_ins_num.shape,

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -196,9 +196,12 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
 
     #if data is fake, return 0
     if ins_tag_weight[0] == 0:
-        for var in [local_q, local_ins_num]:
-            helper.set_variable_initializer(
-                var, Constant(
-                    value=0.0, force_cpu=True))
+        local_ins_num = tensor.fill_constant_batch_size_like(
+            input=local_ins_num,
+            shape=local_ins_num.shape,
+            dtype="float32",
+            value=0.0)
+        local_q = tensor.fill_constant_batch_size_like(
+            input=local_q, shape=local_q.shape, dtype="float32", value=0.0)
 
     return local_sqrerr, local_abserr, local_prob, local_q, local_pos_num, local_ins_num

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -195,14 +195,15 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
         outputs={"Out": [local_ins_num]})
 
     #if data is fake, return 0
-    ins_tag_weight_np = ins_tag_weight.to_string(False, False)
-    if ins_tag_weight_np[0] == '0':
-        local_ins_num = tensor.fill_constant_batch_size_like(
-            input=local_ins_num,
-            shape=local_ins_num.shape,
-            dtype="float32",
-            value=0.0)
-        local_q = tensor.fill_constant_batch_size_like(
-            input=local_q, shape=local_q.shape, dtype="float32", value=0.0)
+    helper.append_op(
+        type="elementwise_mul",
+        inputs={"X": [ins_tag_weight],
+                "Y": [local_ins_num]},
+        outputs={"Out": [local_ins_num]})
+    helper.append_op(
+        type="elementwise_mul",
+        inputs={"X": [ins_tag_weight],
+                "Y": [local_q]},
+        outputs={"Out": [local_q]})
 
     return local_sqrerr, local_abserr, local_prob, local_q, local_pos_num, local_ins_num

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -155,6 +155,16 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
         type="sigmoid",
         inputs={"X": [input]},
         outputs={"Out": [tmp_res_sigmoid]})
+
+    #if data is fake, return 0
+    axis = helper.kwargs.get('axis', 0)
+    helper.append_op(
+        type="elementwise_mul",
+        inputs={"X": [tmp_res_sigmoid],
+                "Y": [ins_tag_weight]},
+        outputs={"Out": [tmp_res_sigmoid]},
+        attrs={'axis': axis})
+
     helper.append_op(
         type="reduce_sum",
         inputs={"X": [tmp_res_sigmoid]},
@@ -188,22 +198,20 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
         type="reduce_sum",
         inputs={"X": [tmp_ones]},
         outputs={"Out": [batch_ins_num]})
+
+    #if data is fake, return 0
+    axis = helper.kwargs.get('axis', 0)
+    helper.append_op(
+        type="elementwise_mul",
+        inputs={"X": [batch_ins_num],
+                "Y": [ins_tag_weight]},
+        outputs={"Out": [batch_ins_num]},
+        attrs={'axis': axis})
+
     helper.append_op(
         type="elementwise_add",
         inputs={"X": [batch_ins_num],
                 "Y": [local_ins_num]},
         outputs={"Out": [local_ins_num]})
-
-    #if data is fake, return 0
-    helper.append_op(
-        type="elementwise_mul",
-        inputs={"X": [ins_tag_weight],
-                "Y": [local_ins_num]},
-        outputs={"Out": [local_ins_num]})
-    helper.append_op(
-        type="elementwise_mul",
-        inputs={"X": [ins_tag_weight],
-                "Y": [local_q]},
-        outputs={"Out": [local_q]})
 
     return local_sqrerr, local_abserr, local_prob, local_q, local_pos_num, local_ins_num

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -24,7 +24,6 @@ from paddle.fluid.framework import Variable
 from paddle.fluid.param_attr import ParamAttr
 from paddle.fluid.layers import nn
 from paddle.fluid.layers import tensor
-from paddle.fluid.layers import Print
 
 __all__ = ['ctr_metric_bundle']
 
@@ -65,8 +64,8 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
 
             import paddle.fluid as fluid
             data = fluid.layers.data(name="data", shape=[32, 32], dtype="float32")
-            label = fluid.layers.data(name="label", shape=[1], dtype="int32")
-            ins_tag_weight = fluid.layers.data(name="ins_tag_weight", shape=[1], dtype="float32")
+            label = fluid.layers.data(name="label", shape=[-1, 1], dtype="int32")
+            ins_tag_weight = fluid.layers.data(name="ins_tag_weight", shape=[-1, 1], dtype="float32")
             predict = fluid.layers.sigmoid(fluid.layers.fc(input=data, size=1))
             auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label, ins_tag_weight=ins_tag_weight)
     """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
 APIs 

### Describe
背景介绍：如下图，当不存在tag2的数据时，目前的策略是填充‘0值假数据’，这导致了计算MSE, RMSE等指标时，包含了假数据，干扰真实指标。

![image](https://user-images.githubusercontent.com/41941775/159460402-4e52cbcf-d7b9-4db0-9f6f-74b2ad36981b.png)

解决方案：在ctr_metric_bundle里加入了ins_tag_weight属性，用来判别多任务中的真假数据，如果为真数据ins_tag_weight为全1值。