### PR TITLE
[new-exec] do not use fast gc if stream safe allocator is not used

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -47,12 +47,17 @@ static constexpr size_t kHostNumThreads = 4;
 static constexpr size_t kDeviceNumThreads = 1;
 
 bool IsInterpretercoreFastGCEnabled() {
+  // NOTE(zhiqiu): why not use flag to decide stream_safe_allocator?
+  // FLAGS_use_stream_safe_allocator, FLAGS_use_system_allocator, and
+  // FLAGS_allocator_strategy may be changed, however, the
+  // AllocatorFacade::Instance() is initialized at the begining once.
+  // Especially in optest, the FLAGS_use_system_allocator is set to
+  // true and reset to false after the ut.
   static bool is_stream_safe_allocator_used =
       (std::dynamic_pointer_cast<memory::allocation::StreamSafeCUDAAllocator>(
            paddle::memory::allocation::AllocatorFacade::Instance().GetAllocator(
                platform::CUDAPlace(0))) != nullptr);
-  return FLAGS_fast_eager_deletion_mode &&
-         FLAGS_use_stream_safe_cuda_allocator && is_stream_safe_allocator_used;
+  return FLAGS_fast_eager_deletion_mode && is_stream_safe_allocator_used;
 }
 
 InterpreterCore::InterpreterCore(const platform::Place& place,

--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
@@ -23,7 +23,9 @@
 
 #ifdef PADDLE_WITH_CUDA
 #include <cuda_runtime.h>
-#else
+#endif
+
+#ifdef PADDLE_WITH_HIP
 #include <hip/hip_runtime.h>
 #endif
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[new-exec] do not use fast gc if stream safe allocator is not used

In new-executor, if fast gc is used while stream safe allocator is not, the following error raises.

<img width="887" alt="image" src="https://user-images.githubusercontent.com/6888866/159702756-df64aef6-4177-4f49-85fb-009468e456b6.png">
