### PR TITLE
the `defaults` in FullArgSpec may be `None`, found in #40408 ; test=document_fix 

### DIFF
--- a/tools/check_api_compatible.py
+++ b/tools/check_api_compatible.py
@@ -75,7 +75,7 @@ def check_compatible(old_api_spec, new_api_spec):
 
 def check_compatible_str(old_api_spec_str, new_api_spec_str):
     patArgSpec = re.compile(
-        r'args=(.*), varargs=.*defaults=\((.*)\), kwonlyargs=.*')
+        r'args=(.*), varargs=.*defaults=(None|\((.*)\)), kwonlyargs=.*')
     mo_o = patArgSpec.search(old_api_spec_str)
     mo_n = patArgSpec.search(new_api_spec_str)
     if not (mo_o and mo_n):
@@ -86,8 +86,10 @@ def check_compatible_str(old_api_spec_str, new_api_spec_str):
 
     args_o = eval(mo_o.group(1))
     args_n = eval(mo_n.group(1))
-    defaults_o = mo_o.group(2).split(', ')
-    defaults_n = mo_n.group(2).split(', ')
+    defaults_o = mo_o.group(2) if mo_o.group(3) is None else mo_o.group(3)
+    defaults_n = mo_n.group(2) if mo_n.group(3) is None else mo_n.group(3)
+    defaults_o = defaults_o.split(', ') if defaults_o else []
+    defaults_n = defaults_n.split(', ') if defaults_n else []
     return _check_compatible(args_o, args_n, defaults_o, defaults_n)
 
 

--- a/tools/test_check_api_compatible.py
+++ b/tools/test_check_api_compatible.py
@@ -105,6 +105,11 @@ class Test_check_compatible_str(unittest.TestCase):
         argspec_o = self.argspec_str_o
         self.assertFalse(check_compatible_str(argspec_o, argspec_n))
 
+    def test_args_defaults_None(self):
+        argspec_o = """inspect.FullArgSpec(args=['filename'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={'filename': <class 'str'>})"""
+        argspec_n = """inspect.FullArgSpec(args=['filename'], varargs=None, varkw=None, defaults=None, kwonlyargs=[], kwonlydefaults=None, annotations={'filename': <class 'str'>})"""
+        self.assertTrue(check_compatible_str(argspec_o, argspec_n))
+
 
 class Test_read_argspec_from_file(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
The `defaults` in `FullArgSpec` is found been 'None' in #40408, Static-Check pipeline crashed here.
