### PR TITLE
Fix output dtype of elementwise_div

### DIFF
--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -266,7 +266,7 @@ def monkey_patch_math_varbase():
 
             if op_type == 'elementwise_div' and self.dtype in _supported_int_dtype_:
                 self = astype(self, 'float32')
-                other_var = astype(self, 'float32')
+                other_var = astype(other_var, 'float32')
 
             # 4. calculation
             axis = -1

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -220,8 +220,6 @@ def monkey_patch_math_varbase():
                 pass
 
             # 2. create varbase for scalar
-            if op_type == 'elementwise_div' and self.dtype in _supported_int_dtype_:
-                self = astype(self, 'float32')
             lhs_dtype = self.dtype
             if _in_eager_mode():
                 other_var_should_be = core.eager.Tensor
@@ -265,6 +263,10 @@ def monkey_patch_math_varbase():
                 tmp = self
                 self = other_var
                 other_var = tmp
+
+            if op_type == 'elementwise_div' and self.dtype in _supported_int_dtype_:
+                self = astype(self, 'float32')
+                other_var = astype(self, 'float32')
 
             # 4. calculation
             axis = -1

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -220,6 +220,8 @@ def monkey_patch_math_varbase():
                 pass
 
             # 2. create varbase for scalar
+            if op_type == 'elementwise_div' and self.dtype in _supported_int_dtype_:
+                self = astype(self, 'float32')
             lhs_dtype = self.dtype
             if _in_eager_mode():
                 other_var_should_be = core.eager.Tensor


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

整数除法结果还是整数：
```python
import paddle

a = paddle.to_tensor([327])
b = paddle.to_tensor([80])
a / b
'''
Tensor(shape=[1], dtype=int64, place=CUDAPlace(0), stop_gradient=True,
       [4])
'''
```
修复后结果为浮点数：
```python
import paddle

a = paddle.to_tensor([327])
b = paddle.to_tensor([80])
a / b
'''
Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
       [4.08750010])
'''
```
