### PR TITLE
[ROCm] fix compile error on DTK21.10, test=develop

### DIFF
--- a/paddle/phi/backends/gpu/forwards.h
+++ b/paddle/phi/backends/gpu/forwards.h
@@ -77,10 +77,8 @@ using ncclComm_t = struct ncclComm *;
 
 using hipDevice_t = int;
 using hipCtx_t = struct ihipCtx_t *;
-using hipModule_t = struct ihipModule_t *;
 using hipStream_t = struct ihipStream_t *;
 using hipEvent_t = struct ihipEvent_t *;
-using hipFunction_t = struct ihipModuleSymbol_t *;
 
 // Forward declaration of MIOpen types.
 using miopenHandle_t = struct miopenHandle *;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

Fix compiling error with dtk21.10, error log as following:

```log
In file included from /workspace/Paddle/paddle/phi/backends/gpu/rocm/rocm_info.cc:16:
In file included from /workspace/Paddle/paddle/phi/backends/gpu/gpu_info.h:21:
In file included from /workspace/Paddle/paddle/phi/backends/gpu/gpu_types.h:23:
In file included from /workspace/Paddle/paddle/phi/backends/dynload/miopen.h:18:
In file included from /opt/dtk-21.10.1/miopen/include/miopen/miopen.h:48:
In file included from /opt/dtk-21.10.1/hip/include/hip/hip_runtime_api.h:389:
/opt/dtk-21.10.1/hip/include/hip/hsa_detail/hip_runtime_api.h:83:39: error: type alias redefinition with different types ('struct ihipModuleInternal_st *' vs 'struct ihipModule_t *')
typedef struct ihipModuleInternal_st* hipModule_t;
                                      ^
/workspace/Paddle/paddle/phi/backends/gpu/forwards.h:80:7: note: previous definition is here
using hipModule_t = struct ihipModule_t *;
      ^
In file included from /workspace/Paddle/paddle/phi/backends/gpu/rocm/rocm_info.cc:16:
In file included from /workspace/Paddle/paddle/phi/backends/gpu/gpu_info.h:21:
In file included from /workspace/Paddle/paddle/phi/backends/gpu/gpu_types.h:23:
In file included from /workspace/Paddle/paddle/phi/backends/dynload/miopen.h:18:
In file included from /opt/dtk-21.10.1/miopen/include/miopen/miopen.h:48:
In file included from /opt/dtk-21.10.1/hip/include/hip/hip_runtime_api.h:389:
/opt/dtk-21.10.1/hip/include/hip/hsa_detail/hip_runtime_api.h:85:41: error: type alias redefinition with different types ('struct ihipFunctionInternal_st *' vs 'struct ihipModuleSymbol_t *')
typedef struct ihipFunctionInternal_st* hipFunction_t;
                                        ^
/workspace/Paddle/paddle/phi/backends/gpu/forwards.h:83:7: note: previous definition is here
using hipFunction_t = struct ihipModuleSymbol_t *;
```

