### PR TITLE
Fix sync_bn error in fp16 amp-o2

### DIFF
--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -171,7 +171,7 @@ def pure_fp16_initialize(models):
             if (layer._dtype == 'float16') or isinstance(
                     layer, (paddle.nn.BatchNorm, paddle.nn.BatchNorm1D,
                             paddle.nn.BatchNorm2D, paddle.nn.BatchNorm3D,
-                            paddle.nn.LayerNorm)):
+                            paddle.nn.LayerNorm, paddle.nn.SyncBatchNorm)):
                 continue
             layer._to_impl(dtype='float16', include_sublayers=False)
     return models


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
sync_batch_nrom 在 fp16 混合精度训练模式下，仅输入x可以转换为fp16，其余参数保持为fp32，在fp16 amp-o2模式下，amp.decorate做网络参数转换时需跳过SyncBatchNorm。