### PR TITLE
add data_type support for phi embedding op.

### DIFF
--- a/paddle/phi/kernels/gpu/embedding_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/embedding_grad_kernel.cu
@@ -130,9 +130,11 @@ void EmbeddingGradKernel(const Context& ctx,
     functor.template apply<int>();
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
+  } else if (input.dtype() == phi::DataType::INT16) {
+    functor.template apply<int16_t>();
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
-        "emebdding input only support int32 and int64"));
+        "emebdding input only support int16, int32 and int64"));
   }
 }
 
@@ -233,9 +235,10 @@ void EmbeddingSparseGradKernel(const Context& ctx,
     functor.template apply<int>();
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
-  } else {
+  } else if (input.dtype() == phi::DataType::INT16) {
+    functor.template apply<int16_t>();
     PADDLE_THROW(phi::errors::Unimplemented(
-        "emebdding input only support int32 and int64"));
+        "emebdding input only support int16, int32 and int64"));
   }
 }
 

--- a/paddle/phi/kernels/gpu/embedding_kernel.cu
+++ b/paddle/phi/kernels/gpu/embedding_kernel.cu
@@ -109,9 +109,11 @@ void EmbeddingKernel(const Context &ctx,
     functor.template apply<int32_t>();
   } else if (input.dtype() == phi::DataType::INT64) {
     functor.template apply<int64_t>();
+  } else if (input.dtype() == phi::DataType::INT16) {
+    functor.template apply<int16_t>();
   } else {
     PADDLE_THROW(phi::errors::Unimplemented(
-        "emebdding input only support int32 and int64"));
+        "emebdding input only support int16, int32 and int64"));
   }
 }
 


### PR DESCRIPTION
### PR types
Function optimization 

### PR changes
OPs

### Describe
Add int16 type support for the index of the phi embedding op. This can be used in MLPerf BERT model.