### PR TITLE
Fix amp with optiontional api bug

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
@@ -801,7 +801,7 @@ class DygraphSingleFunctionGenerator(FunctionGeneratorBase):
                 if is_optional:
                     arg_str = f"const paddle::optional<const paddle::experimental::Tensor&> {name}"
                     amp_tensors_vector_optional_list.append(
-                        f"if ({name}.is)initialized() amp_tensors_vector.push_back({name}.get()));\n"
+                        f"if ({name}.is_initialized()) amp_tensors_vector.push_back({name}.get());\n"
                     )
                     amp_autocast_optional_list.append(
                         f"auto NEW_{name} = {name}.is_initialized() ? egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name) : {name};\n"


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
修复最终态api amp与optional类型tensor组合使用的代码bug.

optional 类 tensor 的amp逻辑如下：
```c++
// const paddle::optional<const paddle::experimental::Tensor&> prior_dist
if (egr::Controller::Instance().GetAMPLevel() != paddle::imperative::AmpLevel::O0) {
        ...
        if (prior_dist.get_ptr() != nullptr) amp_tensors_vector.push_back({ *(prior_dist.get_ptr()) });
        ...
        auto NEW_prior_dist = (prior_dist.get_ptr() != nullptr) ? paddle::make_optional<const paddle::experimental::Tensor&>(egr::EagerAmpAutoCast("prior_dist", *(prior_dist.get_ptr()), amp_dst_dtype, op_name)) : prior_dist;
       ...
    }
```