### PR TITLE
[Phi] Fix bug of kernel backend selecting in C++ API

### DIFF
--- a/paddle/phi/api/lib/kernel_dispatch.cc
+++ b/paddle/phi/api/lib/kernel_dispatch.cc
@@ -25,16 +25,19 @@ namespace experimental {
 namespace detail {
 
 BackendSet GetTensorBackendSet(const phi::TensorBase& t) {
-  BackendSet backend_set(phi::TransToPhiBackend(t.place()));
-  switch (t.layout()) {
-    case DataLayout::MKLDNN:
-      backend_set = backend_set | BackendSet(Backend::MKLDNN);
-      break;
-    default:
-      // do nothing
-      break;
+  if (t.initialized()) {
+    BackendSet backend_set(phi::TransToPhiBackend(t.place()));
+    switch (t.layout()) {
+      case DataLayout::MKLDNN:
+        backend_set = backend_set | BackendSet(Backend::MKLDNN);
+        break;
+      default:
+        // do nothing
+        break;
+    }
+    return backend_set;
   }
-  return backend_set;
+  return BackendSet(Backend::UNDEFINED);
 }
 
 std::size_t CountLeadingZeros(uint64_t val) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复C++ API中kernel的backend选择逻辑问题。
原先输入的Tensor为未初始化时，在解析到该Tensor时会引发报错，修复后在C++ API中选择kernel时会跳过对该Tensor的place信息的处理。