### PR TITLE
[Phi]fix pad3d infermeta bug

### DIFF
--- a/paddle/fluid/framework/infershape_utils.cc
+++ b/paddle/fluid/framework/infershape_utils.cc
@@ -397,6 +397,14 @@ phi::InferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
             for (size_t i = 0; i < tensor_dims.size(); ++i) {
               num_ele *= tensor_dims[i];
             }
+
+            if (num_ele <= 0) {
+              PADDLE_THROW(platform::errors::Unimplemented(
+                  "Invalid number for construct phi::ScalarArray, expected "
+                  "number > 0, but actually is %d. ",
+                  num_ele));
+            }
+
           } else {
             num_ele = vars.size();
           }

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -995,6 +995,7 @@ void Pad3dInferMeta(const MetaTensor& x,
     out_dims[1] = x_dim[1];
     out_dims[2] = x_dim[2];
     out_dims[3] = x_dim[3];
+    out_dims[4] = x_dim[4];
   } else {
     auto paddings = paddings_scalar_array.GetData();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

用户反馈case，https://github.com/PaddlePaddle/Paddle/pull/40701  PR会导致，动转静报MemoryError: std::bad_alloc 错误。
![image](https://user-images.githubusercontent.com/13469016/160390493-7a8e7e5c-ce0f-4f3c-9d22-9e97a7ee7271.png)

问题原因：

原来的InferShape中未对，out_dims的第5纬赋值。
<img width="638" alt="image" src="https://user-images.githubusercontent.com/13469016/160392262-f35373b7-0519-49c9-9767-a3314cdaeb4b.png">



导致迁移Pad3d 到Phi 后，BuildInferMetaContext函数中，在非运行时，vars[0]->GetShape()的结果异常，最终导致构建ScalarArray 参数错误。

具体异常代码片段如下：

```
          int64_t num_ele = 0;
          if (vars.size() == 1) {
            num_ele = 1;
            const auto& tensor_dims = vars[0]->GetShape();
            for (size_t i = 0; i < tensor_dims.size(); ++i) {
              num_ele *= tensor_dims[i];    // 这里tensor_dims[0] 为-1 了
            }
          } else {
            num_ele = vars.size();
          }
          phi::ScalarArray tensor_attr(std::vector<int32_t>(num_ele, -1));  // num_ele 为-1，导致std::bad_alloc 异常
```

修复方法：

添加out_dims[4] = x_dim[4];   后， vars[0]->GetShape() 结果为正确值 [6]。
同时，增加了对 ScalarArray 构建参数的合法性检查。