### PR TITLE
Refactor code auto-gene for no_need_buffer

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
@@ -334,10 +334,10 @@ class FunctionGeneratorBase:
             self.inplace_map[key] = val
 
     def ParseNoNeedBuffer(self):
-        forward_api_contents = self.forward_api_contents
+        grad_api_contents = self.grad_api_contents
 
-        if 'no_need_buffer' in forward_api_contents.keys():
-            no_need_buffer_str = forward_api_contents['no_need_buffer']
+        if 'no_need_buffer' in grad_api_contents.keys():
+            no_need_buffer_str = grad_api_contents['no_need_buffer']
             for name in no_need_buffer_str.split(","):
                 name = name.strip()
                 name = RemoveSpecialSymbolsInName(name)

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,7 +56,7 @@ def ParseArguments():
 ########################
 SET_PLAIN_TENSOR_WRAPPER_TEMPLATE = \
 """
-   void SetTensorWrapper{}(const paddle::experimental::Tensor& {}, bool full_reserved) {{     
+   void SetTensorWrapper{}(const paddle::experimental::Tensor& {}, bool full_reserved) {{
      {} = egr::TensorWrapper({}, full_reserved, {});
    }}
 """
@@ -121,19 +121,19 @@ NODE_DECLARATION_TEMPLATE = \
       virtual std::vector<std::vector<paddle::experimental::Tensor>> operator()(
           std::vector<std::vector<paddle::experimental::Tensor>>& grads, bool create_graph = false) override;
       std::string name() override {{ return \" {} \"; }}
-      
+
       void ClearTensorWrappers() override {{
           {}
         is_tensor_wrappers_cleared = true;
       }}
-      
+
       // SetTensorWrapperX, SetTensorWrapperY, ...
       {}
       // SetAttributes
       {}
 
       bool IsTensorWrappersCleared() override {{
-          return is_tensor_wrappers_cleared;  
+          return is_tensor_wrappers_cleared;
       }}
      private:
       // TensorWrappers
@@ -187,7 +187,7 @@ NODE_CREATION_TEMPLATE = \
 {}
         if(require_any_grad) {{
             egr::EagerUtils::PassStopGradient({});
-            
+
             // Node Construction
 {}
             // SetAttributes
@@ -377,7 +377,7 @@ class DygraphSingleFunctionGenerator(FunctionGeneratorBase):
         #self.forward_outputs_position_map
         #self.optional_inputs
         #self.no_need_buffers
-        #self.intermediate_outputs   
+        #self.intermediate_outputs
         #self.inplace_map
         FunctionGeneratorBase.__init__(self, forward_api_contents, namespace)
 
@@ -989,7 +989,7 @@ class DygraphSingleFunctionGenerator(FunctionGeneratorBase):
                 bump_inplace_version_str += BUMP_INPLACE_VERSION_TEMPLATE.format(
                     inplace_name, inplace_name)
 
-        # Node Construction        
+        # Node Construction
         num_backward_inputs = len(forward_outputs_position_map.keys())
         num_backward_outputs = len(forward_inputs_position_map.keys())
         grad_node_name = GetGradNodeName(forward_api_name)

--- a/paddle/phi/api/lib/CMakeLists.txt
+++ b/paddle/phi/api/lib/CMakeLists.txt
@@ -169,7 +169,7 @@ cc_library(api_custom_impl SRCS api_custom_impl.cc DEPS phi_tensor_raw phi kerne
 cc_library(sparse_api_custom_impl SRCS sparse_api_custom_impl.cc DEPS phi_tensor_raw phi kernel_dispatch api_gen_utils phi_data_transform)
 
 cc_library(phi_function_api SRCS ${api_source_file} DEPS phi_tensor_raw phi kernel_dispatch api_gen_utils phi_data_transform api_custom_impl)
-cc_library(phi_bw_function_api SRCS ${bw_api_source_file} DEPS phi_tensor_raw phi kernel_dispatch api_gen_utils backward_infermeta phi_data_transform phi_function_api api_custom_impl)
+cc_library(phi_bw_function_api SRCS ${bw_api_source_file} DEPS phi_tensor_raw phi kernel_dispatch api_gen_utils backward_infermeta phi_data_transform phi_function_api api_custom_impl global_utils)
 cc_library(sparse_api SRCS ${sparse_api_source_file} DEPS phi_tensor_raw phi kernel_dispatch api_gen_utils sparse_api_custom_impl)
 cc_library(sparse_bw_api SRCS ${sparse_bw_api_source_file} DEPS phi_tensor_raw phi kernel_dispatch api_gen_utils sparse_api sparse_api_custom_impl)
 cc_library(phi_dygraph_api SRCS ${dygraph_api_source_file} DEPS phi_tensor_raw phi kernel_dispatch api_gen_utils phi_data_transform phi_function_api sparse_api)

--- a/python/paddle/utils/code_gen/api_base.py
+++ b/python/paddle/utils/code_gen/api_base.py
@@ -325,7 +325,7 @@ PADDLE_API {self.gene_return_type_code()} {self.get_api_func_name() + '_'}({self
 
             else:
                 backend_args = [
-                    ele.strip() for ele in kernel['backend'].split(',')
+                    ele.strip() for ele in self.kernel['backend'].split(',')
                 ]
                 backend_select_code = f"""
   kernel_backend = ParseBackend({", ".join(backend_args)});

--- a/python/paddle/utils/code_gen/backward.yaml
+++ b/python/paddle/utils/code_gen/backward.yaml
@@ -213,6 +213,7 @@
     param : [x, y]
   kernel :
     func : where_grad
+  no_need_buffer : condition, x, y, out_grad
 
 # - backward_api : huber_loss_grad
 #   forward : huber_loss (Tensor input, Tensor label, float delta) -> Tensor(out), Tensor(residual)

--- a/python/paddle/utils/code_gen/backward.yaml
+++ b/python/paddle/utils/code_gen/backward.yaml
@@ -213,7 +213,6 @@
     param : [x, y]
   kernel :
     func : where_grad
-  no_need_buffer : condition, x, y, out_grad
 
 # - backward_api : huber_loss_grad
 #   forward : huber_loss (Tensor input, Tensor label, float delta) -> Tensor(out), Tensor(residual)

--- a/python/paddle/utils/code_gen/backward_api_gen.py
+++ b/python/paddle/utils/code_gen/backward_api_gen.py
@@ -24,6 +24,7 @@ class BackwardAPI(BaseAPI):
     def __init__(self, backward_item_yaml):
         super(BackwardAPI, self).__init__(backward_item_yaml)
         self.check_args(backward_item_yaml['forward'])
+        self.no_need_buffer = self.parse_no_need_buffer(backward_item_yaml)
 
     def get_api_name(self, api_item_yaml):
         return api_item_yaml['backward_api']
@@ -40,6 +41,15 @@ class BackwardAPI(BaseAPI):
             api, result.group('args'))
 
         return api, fw_inputs, fw_attrs, outputs
+
+    def parse_no_need_buffer(self, api_item_yaml):
+        no_need_buffer = []
+        if 'no_need_buffer' in api_item_yaml:
+            no_need_buffer = [
+                item.strip()
+                for item in api_item_yaml['no_need_buffer'].split(',')
+            ]
+        return no_need_buffer
 
     def check_args(self, forward_config):
         # parse the forward and backward config
@@ -66,6 +76,19 @@ class BackwardAPI(BaseAPI):
         assert len(self.outputs['types']) <= len(fw_inputs['names']), \
             f"{self.api} : Output error: The number of outputs should be less then the number of inputs of forward api. \
              Please check the output of {self.api} in yaml."
+
+    def gene_kernel_backend_select(self):
+        all_no_need_buffer = True
+        for in_name in self.inputs['names']:
+            if in_name not in self.no_need_buffer:
+                all_no_need_buffer = False
+
+        if all_no_need_buffer:
+            return """
+  kernel_backend = ParseBackend(egr::Controller::Instance().GetExpectedPlace());
+"""
+        else:
+            return super.gene_kernel_backend_select()
 
     def get_return_type(self, out_type_list):
         return out_type_list[0] if len(

--- a/python/paddle/utils/code_gen/backward_api_gen.py
+++ b/python/paddle/utils/code_gen/backward_api_gen.py
@@ -88,7 +88,7 @@ class BackwardAPI(BaseAPI):
   kernel_backend = ParseBackend(egr::Controller::Instance().GetExpectedPlace());
 """
         else:
-            return super.gene_kernel_backend_select()
+            return super().gene_kernel_backend_select()
 
     def get_return_type(self, out_type_list):
         return out_type_list[0] if len(
@@ -177,6 +177,7 @@ def source_include(header_file_path):
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/infermeta/backward.h"
 
+#include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/platform/profiler/event_tracing.h"
 """
 

--- a/python/paddle/utils/code_gen/sparse_bw_api_gen.py
+++ b/python/paddle/utils/code_gen/sparse_bw_api_gen.py
@@ -28,6 +28,9 @@ class SparseBackwardAPI(SparseAPI, BackwardAPI):
     def get_api_func_name(self):
         return self.api
 
+    def gene_kernel_backend_select(self):
+        return BackwardAPI.gene_kernel_backend_select(self)
+
     def get_return_type(self, out_type_list):
         return BackwardAPI.get_return_type(self, out_type_list)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
对no_need_buffer相关的代码自动生成逻辑进行了调整

- no_need_buffer由前向yaml文件改为在反向yaml文件中配置
- 如果反向API所有的输入Tensor都为no_need_buffer，则kernel的backend由全局默认Place决定
