### PR TITLE
Optimize the onnxruntime code

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -23,7 +23,8 @@
 #include "paddle/fluid/platform/float16.h"
 #include "paddle/phi/core/allocator.h"
 #ifdef PADDLE_WITH_ONNXRUNTIME
-#include "paddle/fluid/inference/api/onnxruntime_predictor.h"
+#include "onnxruntime_c_api.h"    // NOLINT
+#include "onnxruntime_cxx_api.h"  // NOLINT
 #endif
 
 namespace paddle_infer {

--- a/paddle/fluid/inference/api/onnxruntime_predictor.cc
+++ b/paddle/fluid/inference/api/onnxruntime_predictor.cc
@@ -81,7 +81,7 @@ bool CheckConvertToONNX(const AnalysisConfig &config) {
 bool ONNXRuntimePredictor::Init() {
   VLOG(3) << "ONNXRuntime Predictor::init()";
 
-  // Now ONNXRuntime only suuport CPU
+  // Now ONNXRuntime only support CPU
   const char *device_name = config_.use_gpu() ? "Cuda" : "Cpu";
   if (config_.use_gpu()) {
     place_ = paddle::platform::CUDAPlace(config_.gpu_device_id());

--- a/paddle/fluid/inference/api/onnxruntime_predictor_tester.cc
+++ b/paddle/fluid/inference/api/onnxruntime_predictor_tester.cc
@@ -49,10 +49,6 @@ TEST(ONNXRuntimePredictor, onnxruntime_on) {
 
   ASSERT_TRUE(predictor);
   ASSERT_TRUE(!predictor->Clone());
-  ASSERT_TRUE(predictor->scope_);
-  ASSERT_TRUE(predictor->sub_scope_);
-  ASSERT_EQ(predictor->scope_->parent(), nullptr);
-  ASSERT_EQ(predictor->sub_scope_->parent(), predictor->scope_.get());
   // Dummy Input Data
   std::vector<int64_t> input_shape = {-1, 3, 224, 224};
   std::vector<float> input_data(1 * 3 * 224 * 224, 1.0);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->Others

### Describe
1. 修复zero_copy_tensor.cc文件include onnxruntime_predictor，导致需要依赖paddle2onnx问题
2. onnxruntime_predictor.cc文件注释拼写错误
3. 单测删除废弃的属性测试