### PR TITLE
Add -rf in xpu_kp.cmake when cp .kps to .xpu

### DIFF
--- a/cmake/xpu_kp.cmake
+++ b/cmake/xpu_kp.cmake
@@ -128,7 +128,7 @@ macro(compile_kernel COMPILE_ARGS)
     COMMAND
       ${CMAKE_COMMAND} -E make_directory kernel_build
     COMMAND
-      cp ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu
+      cp ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu -rf
     COMMAND
     ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS}  ${XPU_CXX_INCLUDES} 
        -I.  -o kernel_build/${kernel_name}.bin.o.sec kernel_build/${kernel_name}.xpu
@@ -151,7 +151,7 @@ macro(compile_kernel COMPILE_ARGS)
     COMMAND
       ${CMAKE_COMMAND} -E make_directory kernel_build
     COMMAND
-      cp ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu
+      cp ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu -rf
     COMMAND
     ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
         -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
Add -rf in xpu_kp.cmake when cp .kps to .xpu
重复编译会提示.xpu文件已存在的问题：
<img width="1064" alt="198d09a342f46c7a9e775d5557ee64dc" src="https://user-images.githubusercontent.com/51102941/160525396-797a9c04-44b7-495b-b5b2-d5069c4efacf.png">
