### PR TITLE
fix install python36: module 'paddle' has no attribute 'distributed'

### DIFF
--- a/python/paddle/distributed/ps/utils/public.py
+++ b/python/paddle/distributed/ps/utils/public.py
@@ -24,7 +24,6 @@ import six
 import paddle.fluid as fluid
 from paddle.fluid import core
 import paddle.fluid.framework as framework
-import paddle.distributed.fleet as fleet
 
 #logging.basicConfig(
 #    format='%(levelname)s - %(asctime)s - %(pathname)s: %(lineno)s - %(message)s', level=logging.INFO)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix install with python3.6:  module 'paddle' has no attribute 'distributed'