### PR TITLE
Fix unsqueeze op get wrong output shape in compile time infer shape.

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2554,7 +2554,8 @@ void UnfoldInferMeta(const MetaTensor& x,
 void UnsqueezeInferMeta(const MetaTensor& x,
                         const ScalarArray& axes,
                         MetaTensor* xshape,
-                        MetaTensor* out) {
+                        MetaTensor* out,
+                        MetaConfig config) {
   const auto& x_dims = x.dims();
   // Validity Check: input tensor dims (<6).
   PADDLE_ENFORCE_LE(x_dims.size(),
@@ -2563,7 +2564,13 @@ void UnsqueezeInferMeta(const MetaTensor& x,
                         "Invalid "
                         "dimensions, the rank of Input(X) "
                         "should be in the range of [1, 6] (Eigen limit)"));
-  if (!axes.GetData().empty()) {
+  if (!config.is_runtime && axes.FromTensor()) {
+    // compile time infershape.  set all elements to -1.
+    int output_size = x.dims().size() + axes.GetData().size();
+    std::vector<int64_t> vec_out_dims(output_size, -1);
+    out->set_dtype(x.dtype());
+    out->set_dims(phi::make_ddim(vec_out_dims));
+  } else if (!axes.GetData().empty()) {
     std::vector<int32_t> tmp;
     tmp.reserve(axes.GetData().size());
     std::for_each(axes.GetData().begin(),
@@ -2574,7 +2581,9 @@ void UnsqueezeInferMeta(const MetaTensor& x,
     if (x_dims[0] == out_dims[0]) {
       out->share_lod(x);
     }
+    out->set_dtype(x.dtype());
   }
+  // set xshape dims.
   std::vector<int64_t> xshape_dims(x_dims.size() + 1);
   xshape_dims[0] = 0;
   for (int i = 0; i < x_dims.size(); ++i) {
@@ -2582,7 +2591,6 @@ void UnsqueezeInferMeta(const MetaTensor& x,
   }
   xshape->set_dims(phi::make_ddim(xshape_dims));
   xshape->share_lod(x);
-  out->set_dtype(x.dtype());
   xshape->set_dtype(x.dtype());
 }
 

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -363,7 +363,8 @@ void UnfoldInferMeta(const MetaTensor& x,
 void UnsqueezeInferMeta(const MetaTensor& x,
                         const ScalarArray& axes,
                         MetaTensor* xshape,
-                        MetaTensor* out);
+                        MetaTensor* out,
+                        MetaConfig config = MetaConfig());
 
 void OneHotRawInferMeta(const MetaTensor& x,
                         int32_t depth,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix unsqueeze op get wrong output shape in compile time infer shape.
```
 from __future__ import print_function                                                                                                                                       
                               
 import numpy as np            
 import os
 import unittest               
  
 import paddle                 
 import paddle.fluid as fluid  
 import paddle.fluid.core as core
 import paddle.fluid.layers as layers
 import paddle.fluid.framework as framework
 from paddle.fluid.backward import append_backward
 from paddle.fluid.framework import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard
  
  
 def check(shape, axis, compile_result, runtime_result):
     paddle.set_device('cpu')  
     paddle.enable_static()    
     main_prg, startup_prg = Program(), Program()
     with program_guard(main_prg, startup_prg):
         var_a = paddle.static.data(name='a', shape=shape, dtype='float32')
         var_b = paddle.static.data(name='b', shape=np.array(axis).shape, dtype='int64')
         var_a.stop_gradient = False     
         var_c = paddle.unsqueeze(var_a, var_b)
         print("CompileTimeShape:", var_c.shape)
         assert var_c.shape == compile_result, var_c.shape
         exe = paddle.static.Executor()  
         exe.run(startup_prg)
         out = exe.run(main_prg,         
                       feed={'a': np.random.rand(*shape).astype('float32'), 
                             'b': np.array(axis)},           
                       fetch_list=[var_c])             
         print("RuntimeShape", out[0].shape)
         assert out[0].shape == runtime_result, out[0].shape 
 
 check([2,2], [0], (-1, -1, -1), (1, 2, 2))
 check([2,2], [1], (-1, -1, -1), (2, 1, 2))
 check([2,2], [0, 0], (-1, -1, -1, -1), (1, 1, 2, 2))
```