### PR TITLE
Fix dim problem of getitem

### DIFF
--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -311,11 +311,9 @@ def _getitem_impl_(var, item):
     slice_info = SliceInfo()
 
     for dim, slice_item in enumerate(item):
-        if is_integer_or_scalar_tensor(slice_item) and not is_bool_tensor(
-                slice_item):
-            if isinstance(slice_item,
-                          int) and var.shape[dim] is not None and var.shape[
-                              dim] >= 0 and slice_item >= var.shape[dim]:
+        if isinstance(slice_item, int):
+            if var.shape[dim] is not None and var.shape[
+                    dim] >= 0 and slice_item >= var.shape[dim]:
                 # For python, if users write a, b = var, the __getitem__
                 # method will iterate through 0, 1, 2 ... until __getitem__
                 # throws an IndexError, then stop. The var[0], var[1] will


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Fix dim problem of getitem.

```
mask_logit = paddle.ones([1, 10, 10])
index = paddle.arange(1).cast('int32')
mask_out = mask_logit[index]
```
The shape of mask_out expect be [1, 10, 10], but result is [10, 10] before the PR.