### PR TITLE
Fix test_jit_save_load

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -382,7 +382,9 @@ class GradNodeRunProgram : public egr::GradNodeBase {
       x_grad_ptr.emplace_back(&i);
     }
     for (auto &i : params_grad) {
-      params_grad_ptr.emplace_back(&i);
+      if (i.defined()) {
+        params_grad_ptr.emplace_back(&i);
+      }
     }
 
     PADDLE_ENFORCE_EQ(hooked_grads[0].size(), fwd_out_names_.size(),

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -883,7 +883,7 @@ def _run_dygraph(instance, input, program_holder):
     # transform SelectedRows to LoDTensor forcibly, it may not
     # be user wanted result.
     for persistable_var in persistable_vars:
-        grad_var_name = var.name + core.grad_var_suffix()
+        grad_var_name = persistable_var.name + core.grad_var_suffix()
         grad_var = trace_program.block(0).find_var(cpt.to_bytes(grad_var_name))
         # NOTE: cannot find var desc maybe not problem, 
         # such as in batch_norm

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -37,7 +37,7 @@ from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTra
 from paddle.fluid.dygraph.io import TranslatedLayer, INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX, INFER_PARAMS_INFO_SUFFIX
 from paddle.fluid.dygraph.layers import Layer
 from paddle.fluid.executor import Executor, scope_guard
-from paddle.fluid.framework import Block, ParamBase, Program, Variable, Parameter
+from paddle.fluid.framework import Block, ParamBase, Program, Variable, Parameter, EagerParamBase
 from paddle.fluid.framework import _current_expected_place, _dygraph_guard, _dygraph_tracer
 from paddle.fluid.framework import dygraph_only, _non_static_mode
 from paddle.fluid.wrapped_decorator import wrap_decorator
@@ -921,7 +921,8 @@ def save(layer, path, input_spec=None, **configs):
                                     param_or_buffer.name]
                         extra_info_dict[
                             'stop_gradient'] = param_or_buffer.stop_gradient
-                        if isinstance(param_or_buffer, ParamBase):
+                        if isinstance(param_or_buffer,
+                                      (ParamBase, EagerParamBase)):
                             extra_info_dict[
                                 'trainable'] = param_or_buffer.trainable
                         extra_var_info[param_or_buffer.name] = extra_info_dict

--- a/python/paddle/fluid/dygraph/tracer.py
+++ b/python/paddle/fluid/dygraph/tracer.py
@@ -147,6 +147,13 @@ class Tracer(core.Tracer):
             attrs_list.append(v)
         returns = function_ptr(*arg_list, *attrs_list)
 
+        if type == 'load_combine':
+            assert len(outputs.keys()) == 1
+            key = list(outputs.keys())[0]
+            for j in range(len(returns)):
+                returns[j]._share_underline_tensor_to(outputs[key][j])
+            return
+
         if isinstance(returns, tuple):
             for i in range(len(op_returns)):
                 retname = op_returns[i]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 问题1：循环设置param_grad类型时，var.name应该修改为persistable_var.name。persistable_var.name才是正确的循环变量
![image](https://user-images.githubusercontent.com/23097963/160779318-71aee043-8f6d-4e43-b18e-a503ee278f00.png)

- 问题2：save param时，需要加入EagerParamBase的判断，保存下trainable信息
![image](https://user-images.githubusercontent.com/23097963/160779368-147149ff-fc0b-4f68-bd12-52e464321eaf.png)

- 问题3：\_load_persistable_vars时，会调通过trace_op调用load_combine OP，调用到eager_trace_op函数内时通过reconstruct_from_函数将load_combine OP返回的结果塞到原始的param内。由于load_combine OP返回的结果stop_gradient=True，但是reconstruct_from_未恢复原始的stop_gradient信息，导致stop_gradient信息错误。询问 @占略 后建议在 eager_trace_op 函数内加入了特判，调用load_combine OP时，调用_share_underline_tensor_to函数，只set impl其他不变。
![image](https://user-images.githubusercontent.com/23097963/160779424-c3f980da-0bc1-401b-aee4-ae9f23abb6c8.png)

- 问题4：未save之前param和program中一个param.stop_gradient=True，但是save后load的program中param应该是stop_gradient=True，却发现stop_gradient=False
为什么？因为在jit.save时，在save_inference_model函数中有下图中的逻辑，_remove_training_info函数会将stop_gradient信息移除。那么save下的program对应的param.stop_gradient=False，与原本的program不同了。
![image](https://user-images.githubusercontent.com/23097963/160779653-cbaefc52-daa2-49e5-a9e2-51967e89f304.png)
![image](https://user-images.githubusercontent.com/23097963/160779686-9627488a-9221-42bc-a0e2-e05abe18a64d.png)
在load program后会发现，load回来的param其stop_gradient=True，但是在program中却是False。那么在新run_program OP中，由于param_grad个数需要和param个数保持一直，我们在ConstructParamGradTensors时，对于StopGradient=True的param，塞了一个空的Tensor。后续在ShareTensorsFromScope逻辑调用的CheckOutputVarStatus函数中，会检查dst_tensor是否被初始化，由于是空的tesnor，导致报错
![image](https://user-images.githubusercontent.com/23097963/160779750-1c831996-494f-4816-89dc-c3c53014e302.png)
![image](https://user-images.githubusercontent.com/23097963/160779803-303b8657-e9b2-4bcc-bfac-3b384cc311f8.png)

