### PR TITLE
Fix bug for UT test_calc_gradient

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_calc_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_calc_gradient.py
@@ -122,15 +122,16 @@ class TestDoubleGradient(unittest.TestCase):
         return start_prog, main_prog, [grad_x, jvp]
 
     def test_calc_gradient(self):
-        start_prog, main_prog, fetch_list = self.build_program()
-        exe = paddle.static.Executor()
-        exe.run(start_prog)
-        ans = exe.run(main_prog,
-                      feed={'x': np.ones([2, 2]).astype(np.float32)},
-                      fetch_list=fetch_list)
-        self.assertEqual(len(ans), 2)
-        self.assertListEqual(ans[0].tolist(), [[0., 0.], [0., 0.]])
-        self.assertListEqual(ans[1].tolist(), [[2., 2.], [2., 2.]])
+        with paddle.fluid.scope_guard(paddle.static.Scope()):
+            start_prog, main_prog, fetch_list = self.build_program()
+            exe = paddle.static.Executor()
+            exe.run(start_prog)
+            ans = exe.run(main_prog,
+                          feed={'x': np.ones([2, 2]).astype(np.float32)},
+                          fetch_list=fetch_list)
+            self.assertEqual(len(ans), 2)
+            self.assertListEqual(ans[0].tolist(), [[0., 0.], [0., 0.]])
+            self.assertListEqual(ans[1].tolist(), [[2., 2.], [2., 2.]])
 
 
 class TestDoubleGradient2(unittest.TestCase):
@@ -158,15 +159,16 @@ class TestDoubleGradient2(unittest.TestCase):
         return start_prog, main_prog, [grad_x, jvp]
 
     def test_calc_gradient(self):
-        start_prog, main_prog, fetch_list = self.build_program()
-        exe = paddle.static.Executor()
-        exe.run(start_prog)
-        ans = exe.run(main_prog,
-                      feed={'x': np.ones([2, 2]).astype(np.float32)},
-                      fetch_list=fetch_list)
-        self.assertEqual(len(ans), 2)
-        self.assertListEqual(ans[0].tolist(), [[0., 0.], [0., 0.]])
-        self.assertListEqual(ans[1].tolist(), [[5., 5.], [5., 5.]])
+        with paddle.fluid.scope_guard(paddle.static.Scope()):
+            start_prog, main_prog, fetch_list = self.build_program()
+            exe = paddle.static.Executor()
+            exe.run(start_prog)
+            ans = exe.run(main_prog,
+                          feed={'x': np.ones([2, 2]).astype(np.float32)},
+                          fetch_list=fetch_list)
+            self.assertEqual(len(ans), 2)
+            self.assertListEqual(ans[0].tolist(), [[0., 0.], [0., 0.]])
+            self.assertListEqual(ans[1].tolist(), [[5., 5.], [5., 5.]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
Scope records the mapping between variable names and variables, if **_scope_guard_** is not invoked, all variables and variable names are recorded in the default global scope, and the variables with the same name will overwrite each other. To avoid overwriting, the scope should be switched in test_calc_gradient.  