### PR TITLE
move inplace_version_counter_ location

### DIFF
--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -171,6 +171,25 @@ class DenseTensor : public TensorBase,
   DenseTensorMeta meta_;
   std::shared_ptr<phi::Allocation> holder_;
 
+ public:
+  /* Temporarily put InplaceVersion inside DenseTensor.
+  Will move to AutogradMeta as soon as we switch to Eager Dygraph.
+  */
+  class InplaceVersion {
+   public:
+    bool IsUnique() const { return inplace_version_ == 0; }
+    void Bump() { ++inplace_version_; }
+    uint32_t CurrentVersion() const { return inplace_version_; }
+    void SetInplaceVersionToZero() { inplace_version_ = 0; }
+
+   private:
+    uint32_t inplace_version_{0};
+  };
+
+ protected:
+  std::shared_ptr<InplaceVersion> inplace_version_counter_{
+      std::make_shared<InplaceVersion>()};
+
 #ifndef PADDLE_WITH_CUSTOM_KERNEL
 #include "paddle/phi/core/dense_tensor.inl"
 #endif

--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -21,20 +21,6 @@ limitations under the License. */
     Will be adjusted/removed/moved in the near future
 */
 public:
-/* Temporarily put InplaceVersion inside DenseTensor.
-Will move to AutogradMeta as soon as we switch to Eager Dygraph.
-*/
-class InplaceVersion {
-public:
-  bool IsUnique() const { return inplace_version_ == 0; }
-  void Bump() { ++inplace_version_; }
-  uint32_t CurrentVersion() const { return inplace_version_; }
-  void SetInplaceVersionToZero() { inplace_version_ = 0; }
-
-private:
-  uint32_t inplace_version_{0};
-};
-
 /* @jim19930609: Remove dependency on protobuf after Tensor Unification.
 */
 explicit DenseTensor(paddle::experimental::DataType dtype);
@@ -130,9 +116,6 @@ DenseTensor Slice(int64_t begin_idx, int64_t end_idx) const;
 std::vector<DenseTensor> Split(int64_t split_size, int64_t axis) const;
 
 std::vector<DenseTensor> Chunk(int64_t chunks, int64_t axis) const;
-
-protected:
-std::shared_ptr<InplaceVersion> inplace_version_counter_{std::make_shared<InplaceVersion>()};
 
 /* @jim19930609: This is a hack
 In general, it is badly designed to fuse MKLDNN-specific objects into a


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
For outer users, `dense_tensor.h` will be used, but `dense_tensor.inl` can not be used. `dense_tensor.inl` contains necessary `inplace_version_counter_` for `phi::DenseTensor`, so move `inplace_version_counter_` into `dense_tensor.h` before it is moved as commented.
