### PR TITLE
fix eager_gen generate node bug

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
@@ -1255,7 +1255,7 @@ class DygraphNodeGenerator(DygraphFunctionGeneratorBase):
             if num_outputs == 1:
                 get_tensor_str = f"auto& {transformed_tensor_name} = grad_api_result;"
             else:
-                get_tensor_str = f"auto& {transformed_tensor_name} = grad_api_result[{fwd_position}];"
+                get_tensor_str = f"auto& {transformed_tensor_name} = grad_api_result[{grad_api_position}];"
             get_outputs_str += get_tensor_str + "\n"
 
         # Prepare for Node Creation if Necessary

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -325,8 +325,6 @@ class TestDygraphInplaceFlatten(TestDygraphInplace):
         return var.flatten_()
 
 
-"""
-# TODO: need to fix bug
 class TestDygraphInplaceScatter(TestDygraphInplace):
     def init_data(self):
         self.input_var_numpy = np.array([[1, 1], [2, 2], [3, 3]])
@@ -345,7 +343,6 @@ class TestDygraphInplaceScatter(TestDygraphInplace):
             [[1, 1], [2, 2], [3, 3], [4, 4]], dtype='float32')
 
         return paddle.scatter_(var, index, updates, overwrite=False)
-"""
 
 
 class TestDygraphInplaceElu(TestDygraphInplace):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

修复动态图最终态生成`node.cc`报错的问题：如下图，红框中应该为`grad_api_result[1]`：
![图片](https://user-images.githubusercontent.com/26408901/160832062-2dd72629-c66e-4705-a5f8-79a7415887de.png)

