### PR TITLE
Implement AutotuneCache class

### DIFF
--- a/paddle/phi/kernels/autotune/cache.h
+++ b/paddle/phi/kernels/autotune/cache.h
@@ -118,5 +118,29 @@ class AlgorithmsCache {
   int64_t cache_misses_ = 0;
 };
 
+class AutoTuneCache {
+ public:
+  // AlgoType->KernelCache
+  AutoTuneCacheBase& AutoTuneCacheBase::Instance() {
+    static AutoTuneCacheBase autotune_cache;
+    return autotune_cache;
+  }
+
+  AlgorithmsCache GetOrRegisterAlgoCache(const std::string& name) {
+    std::lock_guard<std::mutex> lock(autotune_cache_mutex_);
+    if (auto_tune_map_.find(name) == auto_tune_map_.end()) {
+      AlgorithmsCache cache;
+      auto_tune_map_[name] = cache;
+    } else {
+      return auto_tune_map_[name];
+    }
+  }
+
+ private:
+  AutoTuneCache() = default;
+  std::unordered_map<std::string, AlgorithmsCache> auto_tune_map_;
+  std::mutex autotune_cache_mutex_;
+};
+
 }  // namespace autotune
 }  // namespace phi

--- a/paddle/phi/kernels/autotune/cache_test.cc
+++ b/paddle/phi/kernels/autotune/cache_test.cc
@@ -21,6 +21,8 @@
 void Algo() { VLOG(3) << "algo test"; }
 
 TEST(AlgosCache, AlgosCache) {
+  auto cache = phi::autotune::AutoTuneCache::Instance().GetOrRegisterAlgoCache(
+      "conv_fw");
   phi::autotune::AlgorithmsCache<std::function<void()>> cache;
   std::vector<int64_t> x_shape = {4, 224, 224, 3};
   std::vector<int64_t> w_shape = {32, 3, 3, 3};

--- a/paddle/phi/kernels/autotune/cache_test.cc
+++ b/paddle/phi/kernels/autotune/cache_test.cc
@@ -18,12 +18,12 @@
 #include <functional>
 #include "glog/logging.h"
 
-void Algo() { VLOG(3) << "algo test"; }
+enum ConvAlgos { GEMMKernel = 0, CuDNNKernel_1 = 1, CuDNNKernel_2 = 2 };
 
 TEST(AlgosCache, AlgosCache) {
-  auto cache = phi::autotune::AutoTuneCache::Instance().GetOrRegisterAlgoCache(
-      "conv_fw");
-  phi::autotune::AlgorithmsCache<std::function<void()>> cache;
+  auto autotune_cache = phi::autotune::AutoTuneCache::Instance();
+  auto& cache = autotune_cache.RegisterOrGet("conv_fw");
+
   std::vector<int64_t> x_shape = {4, 224, 224, 3};
   std::vector<int64_t> w_shape = {32, 3, 3, 3};
   std::vector<int> paddings = {0, 0};
@@ -31,17 +31,23 @@ TEST(AlgosCache, AlgosCache) {
   std::vector<int> dilations = {1, 1};
   phi::DataType dtype = paddle::experimental::CppTypeToDataType<float>::Type();
 
-  auto key =
-      cache.ConvKey(x_shape, w_shape, paddings, strides, dilations, dtype);
+  auto key = phi::autotune::ConvKey(
+      x_shape, w_shape, paddings, strides, dilations, dtype);
   EXPECT_EQ(cache.Find(key), false);
-  cache.Set(key, Algo);
+  cache.Set(key, ConvAlgos::GEMMKernel);
+  EXPECT_EQ(cache.Size(), 1);
   EXPECT_EQ(cache.Find(key), true);
   auto algo = cache.Get(key);
-  algo();
+  EXPECT_EQ(algo, ConvAlgos::GEMMKernel);
 
   x_shape = {4, 128, 128, 3};
-  key = cache.ConvKey(x_shape, w_shape, paddings, strides, dilations, dtype);
+  key = phi::autotune::ConvKey(
+      x_shape, w_shape, paddings, strides, dilations, dtype);
   EXPECT_EQ(cache.Find(key), false);
+  cache.Set(key, ConvAlgos::CuDNNKernel_1);
+  EXPECT_EQ(cache.Size(), 2);
+  EXPECT_EQ(autotune_cache.Size(), 2);
+
   float cache_hit_rate = static_cast<float>(1) / static_cast<float>(3);
   EXPECT_LT(std::abs(cache_hit_rate - cache.CacheHitRate()), 1e-5);
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Describe
<!-- Describe what this PR does --> Implement AutotuneCache class

AutoTuneCache为一个单例，保存所有autotune OP的算法cache，2层map：
- 外层：AlgoType -> AlgoConfigMap，使用conv_fw，conv_bw_data，conv_bw_filter等作为key，value是保存各种配置最佳算法的map
- 内层：即AlgoConfigMap，ConfigKey->AlgoID，key是根据具体配置参数生成的，value是算法ID