### PR TITLE
add depend when doing fuse_all_optimizer on program

### DIFF
--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.cc
@@ -622,6 +622,23 @@ void FuseOptimizerOpPass::InsertInputAndOutputForFusedOpNode(
   }
 
   outputs.insert(out_dep_vars.begin(), out_dep_vars.end());
+
+  auto nodes_to_string =
+      [](std::unordered_set<ir::Node *> nodes) -> std::string {
+    std::stringstream ss;
+    for (auto n : nodes) {
+      if (n->IsVar()) {
+        ss << n->Name() << " ";
+      }
+    }
+    return ss.str();
+  };
+
+  VLOG(4) << "add inputs to " << fused_opt_node->Op()->Type() << ": "
+          << nodes_to_string(inputs);
+  VLOG(4) << "add outputs to " << fused_opt_node->Op()->Type() << ": "
+          << nodes_to_string(outputs);
+
   fused_opt_node->inputs.insert(fused_opt_node->inputs.begin(), inputs.begin(),
                                 inputs.end());
   fused_opt_node->outputs.insert(fused_opt_node->outputs.begin(),

--- a/paddle/fluid/operators/controlflow/depend_op.cc
+++ b/paddle/fluid/operators/controlflow/depend_op.cc
@@ -1,0 +1,91 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+
+namespace paddle {
+namespace framework {
+class OpDesc;
+class Scope;
+template <typename T>
+class EmptyGradOpMaker;
+}  // namespace framework
+namespace imperative {
+class OpBase;
+}  // namespace imperative
+}  // namespace paddle
+
+namespace paddle {
+namespace operators {
+
+class DependOp : public framework::OperatorBase {
+ public:
+  DependOp(const std::string &type, const framework::VariableNameMap &inputs,
+           const framework::VariableNameMap &outputs,
+           const framework::AttributeMap &attrs)
+      : OperatorBase(type, inputs, outputs, attrs) {}
+
+ private:
+  void RunImpl(const framework::Scope &scope,
+               const platform::Place &place) const override {
+    // NOTE(zhiqiu): depend op has empty compute, and it
+    // can be skiped in the executor.
+    OP_INOUT_CHECK(HasInputs("X"), "Input", "X", "Feed");
+    OP_INOUT_CHECK(HasOutputs("Out"), "Output", "Out", "Feed");
+
+    auto x_name = Input("X");
+    auto out_name = Output("Out");
+    PADDLE_ENFORCE_EQ(x_name, out_name,
+                      platform::errors::PreconditionNotMet(
+                          "Input(X) and Output(Out) varibale should be the "
+                          "same, but got Input is %s and Output is %s.",
+                          x_name, out_name));
+    return;
+  }
+};
+
+class DependOpProtoMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "Tensor, the dependence is added for.");
+    AddInput("Dep", "The tensors that should be generated before X.")
+        .AsDuplicable();
+    AddOutput("Out", "Tensor, the same as input X");
+    AddComment(R"DOC(
+Depend Operator, allows to add explicit dependency between tensors.
+For example, given two ops:
+b = opA(a)
+y = opB(x)
+
+if tensor b and tensor x has some inner dependency, for example, x share data with b,
+we need to add explicit dependency for x <- b, otherwise the these two operators may 
+be executed parellel in static graph. We can use depend op as below,
+
+b = opA(a)
+x = depend(x, b)
+y = opB(x)
+
+)DOC");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+REGISTER_OPERATOR(
+    depend, paddle::operators::DependOp,
+    paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
+    paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>,
+    paddle::operators::DependOpProtoMaker);

--- a/python/paddle/fluid/tests/unittests/test_apply_pass_to_program.py
+++ b/python/paddle/fluid/tests/unittests/test_apply_pass_to_program.py
@@ -114,6 +114,7 @@ class TestIRPassBase(unittest.TestCase):
         # fused all optimizer pass requires this
         if paddle.is_compiled_with_cuda():
             self.assertTrue(global_block_contains_op(main, "coalesce_tensor"))
+            self.assertTrue(global_block_contains_op(main, "depend"))
         self.assertTrue(
             global_block_contains_op(main, "fused_elemwise_add_activation"))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add depend when doing fuse_all_optimizer on program

If `fuse_all_optimizer` is applied to a program, it rewrites the program with fused tensors as below,
```
fused_grads = coalesce_tensor(grad0, grad1, ...)
fused_params = coalesce_tensor(param0, param1, ...)
...
grad0 = grad_op0(...)
grad1 = grad_op1(...)
...
fused_params = adam(fused_params, fused_grads, ...)
```

If the operators in the program are executed op-by-op, it is ok.
However, it the program is executed by an Executor that may run op parallel, the `adam` and `grad_op0`, `grad_op1` may run in any order since there are no explicit dependencies. And it is wrong.

This PR adds explicit dependency in that case, by adding an empty `depend` op. 

```
fused_grads = coalesce_tensor(grad0, grad1, ...)
fused_params = coalesce_tensor(param0, param1, ...)
...
grad0 = grad_op0(...)
grad1 = grad_op1(...)
...
fused_params = depend(fused_params, grad0, grad1, ...)
fused_params = adam(fused_params, fused_grads, ...)
```