### PR TITLE
[tensorrt]fix tensorrt teller

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1016,29 +1016,8 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
       auto* y_var_desc = block->FindVar(desc.Input("Y")[0]);
       const auto x_shape = x_var_desc->GetShape();
       const auto y_shape = y_var_desc->GetShape();
-      if (x_var_desc->Persistable()) {
-        return false;
-      }
-      if (x_shape.size() == 1 && !with_dynamic_shape) {
-        return false;
-      }
-      if (y_var_desc->Persistable()) {
-        if (y_shape.size() != 1 || y_shape.size() != x_shape.size() ||
-            y_shape.size() != x_shape.size() - 1) {
-          return false;
-        } else if (y_shape.size() == x_shape.size()) {
-          if (y_shape[0] != 1) {
-            return false;
-          }
-          if (y_shape[1] != x_shape[1]) {
-            return false;
-          }
-        } else if (y_shape.size() == x_shape.size() - 1) {
-          if (y_shape[0] != x_shape[1]) {
-            return false;
-          }
-        }
-      } else if (y_shape.size() == 1 && !with_dynamic_shape) {
+      if (x_shape.size() == 1 && y_shape.size() == 1) {
+        VLOG(3) << "Now trt may not support two 1d tensor elementwise op.";
         return false;
       }
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复和完善op_teller:
1. elementwise
（1）静态 shape 下过滤一维非权重输入
（2）仅支持x、y都是var，或者 x 是var，y是 权重的情况
（3）y是权重时，不支持 broatcast
2. conv_transpose 不支持非 0 的output_padding 属性
3. reshape 静态 shape 下过滤一维非权重输入