### PR TITLE
[Dy2St]Use `self`as a parameter of _hash_with_id function to avoid error caused by hash_id reuse

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_run_program_op.py
+++ b/python/paddle/fluid/tests/unittests/test_run_program_op.py
@@ -99,7 +99,7 @@ class RunProgramOpTest(unittest.TestCase):
     def prepare_attrs(self):
         return ('global_block', self.program_desc.block(0), 'start_op_index', 0,
                 'end_op_index', self.fwd_op_num, 'program_id',
-                _hash_with_id(self.program_desc))
+                _hash_with_id(self.program_desc, self))
 
     def get_param_grad_names(self):
         grad_names = []


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Use `self`as a parameter of _hash_with_id function to avoid error caused by hash_id reuse