### PR TITLE
Implement AutoTuneStatus class for Kernel Auto Tune

### DIFF
--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -390,7 +390,6 @@ static void PerformBackwardInplace(const std::string& op_type,
 }
 
 void BasicEngine::Execute() {
-  phi::autotune::SwitchAutoTune::Instance().UpdateAutoTuneStatus();
   platform::RecordEvent backward_record_event(
       "backward", platform::TracerEventType::Operator, 1);
 
@@ -647,6 +646,8 @@ void BasicEngine::Execute() {
   Clear();
 
   VLOG(1) << "Backward op number: " << op_num;
+
+  phi::autotune::SwitchAutoTune::Instance().UpdateAutoTuneStatus();
 }
 
 void BasicEngine::Clear() {

--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -30,6 +30,7 @@
 #include "paddle/fluid/imperative/op_base.h"
 #include "paddle/fluid/imperative/tracer.h"
 #include "paddle/fluid/platform/profiler.h"
+#include "paddle/phi/kernels/autotune/switch_autotune.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 
 DECLARE_bool(sort_sum_gradient);
@@ -389,6 +390,7 @@ static void PerformBackwardInplace(const std::string& op_type,
 }
 
 void BasicEngine::Execute() {
+  phi::autotune::SwitchAutoTune::Instance().UpdateAutoTuneStatus();
   platform::RecordEvent backward_record_event(
       "backward", platform::TracerEventType::Operator, 1);
 

--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -647,7 +647,7 @@ void BasicEngine::Execute() {
 
   VLOG(1) << "Backward op number: " << op_num;
 
-  phi::autotune::SwitchAutoTune::Instance().UpdateAutoTuneStatus();
+  phi::autotune::AutoTuneStatus::Instance().Update();
 }
 
 void BasicEngine::Clear() {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4422,23 +4422,22 @@ All parameter, weight, gradient are variables in Paddle.
 #endif
 
   m.def("enable_autotune", [] {
-    return phi::autotune::SwitchAutoTune::Instance().EnableAutoTune();
+    return phi::autotune::AutoTuneStatus::Instance().EnableAutoTune();
   });
 
   m.def("disable_autotune", [] {
-    return phi::autotune::SwitchAutoTune::Instance().DisableAutoTune();
+    return phi::autotune::AutoTuneStatus::Instance().DisableAutoTune();
   });
 
-  m.def("update_autotune_status", [] {
-    return phi::autotune::SwitchAutoTune::Instance().UpdateAutoTuneStatus();
-  });
+  m.def("update_autotune_status",
+        [] { return phi::autotune::AutoTuneStatus::Instance().Update(); });
 
   m.def("autotune_status", [] {
     phi::autotune::AutoTuneCache::Instance().UpdateStatus();
     py::dict res;
     res["use_autotune"] =
-        phi::autotune::SwitchAutoTune::Instance().UseAutoTune();
-    res["step_id"] = phi::autotune::SwitchAutoTune::Instance().StepID();
+        phi::autotune::AutoTuneStatus::Instance().UseAutoTune();
+    res["step_id"] = phi::autotune::AutoTuneStatus::Instance().StepID();
     res["cache_size"] = phi::autotune::AutoTuneCache::Instance().Size();
     res["cache_hit_rate"] =
         phi::autotune::AutoTuneCache::Instance().CacheHitRate();

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4429,6 +4429,11 @@ All parameter, weight, gradient are variables in Paddle.
     return phi::autotune::AutoTuneStatus::Instance().DisableAutoTune();
   });
 
+  m.def("autotune_range", [](int64_t start, int64_t stop) {
+    return phi::autotune::AutoTuneStatus::Instance().SetAutoTuneRange(start,
+                                                                      stop);
+  });
+
   m.def("update_autotune_status",
         [] { return phi::autotune::AutoTuneStatus::Instance().Update(); });
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4429,14 +4429,19 @@ All parameter, weight, gradient are variables in Paddle.
     return phi::autotune::SwitchAutoTune::Instance().DisableAutoTune();
   });
 
-  m.def("auto_tune_status", [] {
+  m.def("update_autotune_status", [] {
+    return phi::autotune::SwitchAutoTune::Instance().UpdateAutoTuneStatus();
+  });
+
+  m.def("autotune_status", [] {
+    phi::autotune::AutoTuneCache::Instance().UpdateStatus();
     py::dict res;
     res["use_autotune"] =
         phi::autotune::SwitchAutoTune::Instance().UseAutoTune();
     res["step_id"] = phi::autotune::SwitchAutoTune::Instance().StepID();
     res["cache_size"] = phi::autotune::AutoTuneCache::Instance().Size();
     res["cache_hit_rate"] =
-        phi::autotune::AutoTuneCache::Instance().AutoTuneCacheHitRate();
+        phi::autotune::AutoTuneCache::Instance().CacheHitRate();
     return res;
   });
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -168,6 +168,7 @@ limitations under the License. */
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/phi/api/ext/op_meta_info.h"
+#include "paddle/phi/kernels/autotune/cache.h"
 #include "paddle/phi/kernels/autotune/switch_autotune.h"
 #include "pybind11/stl.h"
 
@@ -4423,8 +4424,20 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("enable_autotune", [] {
     return phi::autotune::SwitchAutoTune::Instance().EnableAutoTune();
   });
+
   m.def("disable_autotune", [] {
     return phi::autotune::SwitchAutoTune::Instance().DisableAutoTune();
+  });
+
+  m.def("auto_tune_status", [] {
+    py::dict res;
+    res["use_autotune"] =
+        phi::autotune::SwitchAutoTune::Instance().UseAutoTune();
+    res["step_id"] = phi::autotune::SwitchAutoTune::Instance().StepID();
+    res["cache_size"] = phi::autotune::AutoTuneCache::Instance().Size();
+    res["cache_hit_rate"] =
+        phi::autotune::AutoTuneCache::Instance().AutoTuneCacheHitRate();
+    return res;
   });
 
   BindFleetWrapper(&m);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -168,6 +168,7 @@ limitations under the License. */
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/phi/api/ext/op_meta_info.h"
+#include "paddle/phi/kernels/autotune/switch_autotune.h"
 #include "pybind11/stl.h"
 
 DECLARE_bool(use_mkldnn);
@@ -4418,6 +4419,13 @@ All parameter, weight, gradient are variables in Paddle.
       .def("disable_pattern", &platform::ipu::IpuStrategy::DisablePattern)
       .def("is_pattern_enabled", &platform::ipu::IpuStrategy::IsPatternEnabled);
 #endif
+
+  m.def("enable_autotune", [] {
+    return phi::autotune::SwitchAutoTune::Instance().EnableAutoTune();
+  });
+  m.def("disable_autotune", [] {
+    return phi::autotune::SwitchAutoTune::Instance().DisableAutoTune();
+  });
 
   BindFleetWrapper(&m);
   BindIO(&m);

--- a/paddle/phi/kernels/autotune/CMakeLists.txt
+++ b/paddle/phi/kernels/autotune/CMakeLists.txt
@@ -6,4 +6,6 @@ elseif (WITH_ROCM)
     hip_test(auto_tune_test SRCS auto_tune_test.cu DEPS gtest)
 endif()
 
-cc_test(cache_test SRCS cache_test.cc DEPS gtest)
+cc_library(cache SRCS cache.cc DEPS)
+
+cc_test(cache_test SRCS cache_test.cc DEPS gtest cache)

--- a/paddle/phi/kernels/autotune/cache.cc
+++ b/paddle/phi/kernels/autotune/cache.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/autotune/cache.h"
+
+namespace phi {
+namespace autotune {
+
+// Define the cache key of operator
+size_t ConvKey(const std::vector<int64_t>& x_dims,
+               const std::vector<int64_t>& w_dims,
+               const std::vector<int>& strides,
+               const std::vector<int>& paddings,
+               const std::vector<int>& dilations,
+               phi::DataType dtype) {
+  return GetKey(x_dims,
+                w_dims,
+                strides,
+                paddings,
+                dilations,
+                static_cast<int64_t>(dtype));
+}
+
+}  // namespace autotune
+}  // namespace phi

--- a/paddle/phi/kernels/autotune/cache.h
+++ b/paddle/phi/kernels/autotune/cache.h
@@ -64,14 +64,7 @@ size_t ConvKey(const std::vector<int64_t>& x_dims,
                const std::vector<int>& strides,
                const std::vector<int>& paddings,
                const std::vector<int>& dilations,
-               phi::DataType dtype) {
-  return GetKey(x_dims,
-                w_dims,
-                strides,
-                paddings,
-                dilations,
-                static_cast<int64_t>(dtype));
-}
+               phi::DataType dtype);
 
 template <typename AlgorithmT>
 class AlgorithmsCache {

--- a/paddle/phi/kernels/autotune/cache.h
+++ b/paddle/phi/kernels/autotune/cache.h
@@ -111,7 +111,24 @@ class AlgorithmsCache {
     return cache_hit_rate;
   }
 
-  int64_t Size() { return hash_.size(); }
+  int64_t GetCacheMisses() { return cache_misses_ }
+
+  int64_t GetCacheHits() { return cache_hits_; }
+
+  // Define the cache key of operator
+  size_t ConvKey(const std::vector<int64_t>& x_dims,
+                 const std::vector<int64_t>& w_dims,
+                 const std::vector<int>& strides,
+                 const std::vector<int>& paddings,
+                 const std::vector<int>& dilations,
+                 phi::DataType dtype) {
+    return GetKey(x_dims,
+                  w_dims,
+                  strides,
+                  paddings,
+                  dilations,
+                  static_cast<int64_t>(dtype));
+  }
 
  private:
   std::unordered_map<size_t, AlgorithmT> hash_;
@@ -120,42 +137,67 @@ class AlgorithmsCache {
   int64_t cache_misses_ = 0;
 };
 
-// AlgorithmsConfigKey -> AlgorithmsID
-using AlgorithmsConfigKeyMap = AlgorithmsCache<int64_t>;
-// AlgorithmsType -> AlgorithmsCache
-using AlgorithmsTypeMap =
-    std::unordered_map<std::string, AlgorithmsConfigKeyMap>;
-
 class AutoTuneCache {
  public:
-  static AutoTuneCache& Instance() {
-    static AutoTuneCache autotune_cache;
+  // AlgoType->KernelCache
+  AutoTuneCacheBase& AutoTuneCacheBase::Instance() {
+    static AutoTuneCacheBase autotune_cache;
     return autotune_cache;
   }
 
-  AlgorithmsConfigKeyMap& RegisterOrGet(const std::string& algo_type) {
-    std::lock_guard<std::mutex> lock(*autotune_cache_mutex_);
-    if (auto_tune_map_.find(algo_type) == auto_tune_map_.end()) {
-      AlgorithmsConfigKeyMap cache;
-      auto_tune_map_[algo_type] = cache;
+  AlgorithmsCache GetOrRegisterAlgoCache(const std::string& name) {
+    std::lock_guard<std::mutex> lock(autotune_cache_mutex_);
+    if (auto_tune_map_.find(name) == auto_tune_map_.end()) {
+      AlgorithmsCache cache;
+      auto_tune_map_[name] = cache;
+    } else {
+      return auto_tune_map_[name];
     }
-    return auto_tune_map_[algo_type];
   }
 
-  // The number of total config cached
-  int64_t Size() {
-    int64_t total = 0;
+  float AutoTuneCacheHitRate() const {
+    std::lock_guard<std::mutex> lock(autotune_cache_mutex_);
+    int64_t total_cache_hits = 0;
+    int64_t total_cache_misses = 0;
+    // update CacheHitRate for each AlgoType
     for (auto& v : auto_tune_map_) {
-      VLOG(3) << v.first << " " << v.second.Size();
-      total += v.second.Size();
+      cache_hit_rate = v.second.CacheHitRate();
+      cache_hit_rate_map_[v.first] = cache_hit_rate;
+      VLOG(3) << "Cache Hit Rate: " << cache_hit_rate_map_[v.first] << " "
+              << cache_hit_rate;
+      total_cache_hits += v.second.GetCacheHits();
+      total_cache_hits += v.second.GetCacheMisses();
     }
-    return total;
+    float total_cache_hit_rate =
+        static_cast<float>(total_cache_hits) /
+        static_cast<float>(total_cache_misses + total_cache_hits);
+    return total_cache_hit_rate;
+  }
+
+  float AutoTuneStepCacheRate() const {
+    std::lock_guard<std::mutex> lock(autotune_cache_mutex_);
+    // update CacheHitRate for each AlgoType
+    for (auto& v : auto_tune_map_) {
+      cache_hit_rate = v.second.CacheHitRate();
+      cache_hit_rate_map_[v.first] = cache_hit_rate;
+      VLOG(3) << "Cache Hit Rate: " << cache_hit_rate_map_[v.first] << " "
+              << cache_hit_rate;
+      total_cache_hits += v.second.GetCacheHits();
+      total_cache_hits += v.second.GetCacheMisses();
+    }
+    float total_cache_hit_rate =
+        static_cast<float>(total_cache_hits) /
+        static_cast<float>(total_cache_misses + total_cache_hits);
+    return total_cache_hit_rate;
   }
 
  private:
-  AutoTuneCache() : autotune_cache_mutex_(new std::mutex()) {}
-  AlgorithmsTypeMap auto_tune_map_;
-  std::shared_ptr<std::mutex> autotune_cache_mutex_;
+  AutoTuneCache() = default;
+  std::unordered_map<std::string, AlgorithmsCache> auto_tune_map_;
+  std::unordered_map<std::string, float> cache_hit_rate_map_;
+  std::mutex autotune_cache_mutex_;
+  int64_t total_cache_hits = 0;
+  int64_t total_cache_misses = 0;
 };
 
 }  // namespace autotune

--- a/paddle/phi/kernels/autotune/cache.h
+++ b/paddle/phi/kernels/autotune/cache.h
@@ -155,49 +155,10 @@ class AutoTuneCache {
     }
   }
 
-  float AutoTuneCacheHitRate() const {
-    std::lock_guard<std::mutex> lock(autotune_cache_mutex_);
-    int64_t total_cache_hits = 0;
-    int64_t total_cache_misses = 0;
-    // update CacheHitRate for each AlgoType
-    for (auto& v : auto_tune_map_) {
-      cache_hit_rate = v.second.CacheHitRate();
-      cache_hit_rate_map_[v.first] = cache_hit_rate;
-      VLOG(3) << "Cache Hit Rate: " << cache_hit_rate_map_[v.first] << " "
-              << cache_hit_rate;
-      total_cache_hits += v.second.GetCacheHits();
-      total_cache_hits += v.second.GetCacheMisses();
-    }
-    float total_cache_hit_rate =
-        static_cast<float>(total_cache_hits) /
-        static_cast<float>(total_cache_misses + total_cache_hits);
-    return total_cache_hit_rate;
-  }
-
-  float AutoTuneStepCacheRate() const {
-    std::lock_guard<std::mutex> lock(autotune_cache_mutex_);
-    // update CacheHitRate for each AlgoType
-    for (auto& v : auto_tune_map_) {
-      cache_hit_rate = v.second.CacheHitRate();
-      cache_hit_rate_map_[v.first] = cache_hit_rate;
-      VLOG(3) << "Cache Hit Rate: " << cache_hit_rate_map_[v.first] << " "
-              << cache_hit_rate;
-      total_cache_hits += v.second.GetCacheHits();
-      total_cache_hits += v.second.GetCacheMisses();
-    }
-    float total_cache_hit_rate =
-        static_cast<float>(total_cache_hits) /
-        static_cast<float>(total_cache_misses + total_cache_hits);
-    return total_cache_hit_rate;
-  }
-
  private:
   AutoTuneCache() = default;
   std::unordered_map<std::string, AlgorithmsCache> auto_tune_map_;
-  std::unordered_map<std::string, float> cache_hit_rate_map_;
   std::mutex autotune_cache_mutex_;
-  int64_t total_cache_hits = 0;
-  int64_t total_cache_misses = 0;
 };
 
 }  // namespace autotune

--- a/paddle/phi/kernels/autotune/cache.h
+++ b/paddle/phi/kernels/autotune/cache.h
@@ -104,14 +104,21 @@ class AlgorithmsCache {
     hash_[key] = algo;
   }
 
+  int64_t CacheMisses() const { return cache_misses_; }
+
+  int64_t CacheHits() const { return cache_hits_; }
+
   float CacheHitRate() const {
     int64_t num_accesses = cache_hits_ + cache_misses_;
-    float cache_hit_rate =
-        static_cast<float>(cache_hits_) / static_cast<float>(num_accesses);
+    float cache_hit_rate = 0.;
+    if (num_accesses != 0) {
+      cache_hit_rate =
+          static_cast<float>(cache_hits_) / static_cast<float>(num_accesses);
+    }
     return cache_hit_rate;
   }
 
-  int64_t Size() { return hash_.size(); }
+  int64_t Size() const { return hash_.size(); }
 
  private:
   std::unordered_map<size_t, AlgorithmT> hash_;
@@ -143,13 +150,31 @@ class AutoTuneCache {
   }
 
   // The number of total config cached
-  int64_t Size() {
+  int64_t Size() const {
     int64_t total = 0;
     for (auto& v : auto_tune_map_) {
       VLOG(3) << v.first << " " << v.second.Size();
       total += v.second.Size();
     }
     return total;
+  }
+
+  float AutoTuneCacheHitRate() const {
+    int64_t total_cache_hits = 0;
+    int64_t total_cache_misses = 0;
+    float total_cache_hit_rate = 0.;
+    for (auto& v : auto_tune_map_) {
+      total_cache_hits += v.second.CacheHits();
+      total_cache_misses += v.second.CacheMisses();
+    }
+
+    int64_t total_num_accesses = total_cache_hits + total_cache_misses;
+    if (total_num_accesses != 0) {
+      total_cache_hit_rate = static_cast<float>(total_cache_hits) /
+                             static_cast<float>(total_num_accesses);
+    }
+
+    return total_cache_hit_rate;
   }
 
  private:

--- a/paddle/phi/kernels/autotune/cache_test.cc
+++ b/paddle/phi/kernels/autotune/cache_test.cc
@@ -21,9 +21,9 @@
 enum ConvAlgos { GEMMKernel = 0, CuDNNKernel_1 = 1, CuDNNKernel_2 = 2 };
 
 TEST(AlgosCache, AlgosCache) {
-  auto autotune_cache = phi::autotune::AutoTuneCache::Instance();
-  auto& cache = autotune_cache.RegisterOrGet("conv_fw");
-
+  auto cache = phi::autotune::AutoTuneCache::Instance().GetOrRegisterAlgoCache(
+      "conv_fw");
+  phi::autotune::AlgorithmsCache<std::function<void()>> cache;
   std::vector<int64_t> x_shape = {4, 224, 224, 3};
   std::vector<int64_t> w_shape = {32, 3, 3, 3};
   std::vector<int> paddings = {0, 0};

--- a/paddle/phi/kernels/autotune/cache_test.cc
+++ b/paddle/phi/kernels/autotune/cache_test.cc
@@ -46,11 +46,15 @@ TEST(AlgosCache, AlgosCache) {
   EXPECT_EQ(cache.Find(key), false);
   cache.Set(key, ConvAlgos::CuDNNKernel_1);
   EXPECT_EQ(cache.Size(), 2);
+  EXPECT_EQ(cache.CacheHits(), 1);
+  EXPECT_EQ(cache.CacheMisses(), 2);
 
   float cache_hit_rate = static_cast<float>(1) / static_cast<float>(3);
   EXPECT_LT(std::abs(cache_hit_rate - cache.CacheHitRate()), 1e-5);
 
   autotune_cache.UpdateStatus();
   EXPECT_EQ(autotune_cache.Size(), 2);
+  EXPECT_EQ(autotune_cache.CacheHits(), 1);
+  EXPECT_EQ(autotune_cache.CacheMisses(), 2);
   EXPECT_LT(std::abs(cache_hit_rate - autotune_cache.CacheHitRate()), 1e-5);
 }

--- a/paddle/phi/kernels/autotune/cache_test.cc
+++ b/paddle/phi/kernels/autotune/cache_test.cc
@@ -21,9 +21,9 @@
 enum ConvAlgos { GEMMKernel = 0, CuDNNKernel_1 = 1, CuDNNKernel_2 = 2 };
 
 TEST(AlgosCache, AlgosCache) {
-  auto cache = phi::autotune::AutoTuneCache::Instance().GetOrRegisterAlgoCache(
-      "conv_fw");
-  phi::autotune::AlgorithmsCache<std::function<void()>> cache;
+  auto autotune_cache = phi::autotune::AutoTuneCache::Instance();
+  auto& cache = autotune_cache.RegisterOrGet("conv_fw");
+
   std::vector<int64_t> x_shape = {4, 224, 224, 3};
   std::vector<int64_t> w_shape = {32, 3, 3, 3};
   std::vector<int> paddings = {0, 0};

--- a/paddle/phi/kernels/autotune/cache_test.cc
+++ b/paddle/phi/kernels/autotune/cache_test.cc
@@ -46,8 +46,11 @@ TEST(AlgosCache, AlgosCache) {
   EXPECT_EQ(cache.Find(key), false);
   cache.Set(key, ConvAlgos::CuDNNKernel_1);
   EXPECT_EQ(cache.Size(), 2);
-  EXPECT_EQ(autotune_cache.Size(), 2);
 
   float cache_hit_rate = static_cast<float>(1) / static_cast<float>(3);
   EXPECT_LT(std::abs(cache_hit_rate - cache.CacheHitRate()), 1e-5);
+
+  autotune_cache.UpdateStatus();
+  EXPECT_EQ(autotune_cache.Size(), 2);
+  EXPECT_LT(std::abs(cache_hit_rate - autotune_cache.CacheHitRate()), 1e-5);
 }

--- a/paddle/phi/kernels/autotune/switch_autotune.h
+++ b/paddle/phi/kernels/autotune/switch_autotune.h
@@ -26,7 +26,7 @@ class SwitchAutoTune {
     return switch_autotune;
   }
 
-  bool IfAutoTune() { return enable_autotune_; }
+  bool UseAutoTune() { return enable_autotune_; }
 
   void UpdateAutoTuneStatus() {
     current_steps_id_ += 1;
@@ -40,8 +40,7 @@ class SwitchAutoTune {
                current_steps_id_ <
                    auto_tune_start_step_id_ + auto_tune_steps_) {
       enable_autotune_ = true;
-      VLOG(3) << "Current Step ID: " << current_steps_id_
-              << " AutoTune Status: Cache Hit Rate: "
+      VLOG(3) << "Current Step ID: " << current_steps_id_ << " Cache Hit Rate: "
               << AutoTuneCache::Instance().AutoTuneCacheHitRate()
               << " Cache Size: " << AutoTuneCache::Instance().Size();
     } else {
@@ -55,11 +54,13 @@ class SwitchAutoTune {
 
   void DisableAutoTune() { enable_autotune_ = false; }
 
+  int64_t StepID() { return current_steps_id_; }
+
  private:
   SwitchAutoTune() = default;
   int64_t auto_tune_start_step_id_ = 0;
   int64_t auto_tune_steps_ = 10;
-  int64_t current_steps_id_ = 0;
+  int64_t current_steps_id_ = -1;
   bool enable_autotune_ = true;
 };
 

--- a/paddle/phi/kernels/autotune/switch_autotune.h
+++ b/paddle/phi/kernels/autotune/switch_autotune.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "glog/logging.h"
+
+namespace phi {
+namespace autotune {
+
+class SwitchAutoTune {
+ public:
+  SwitchAutoTune& SwitchAutoTune::Instance() {
+    static SwitchAutoTune switch_autotune;
+    return switch_autotune;
+  }
+
+  bool IfAutoTune() { return enable_autotune_; }
+
+  void UpdateAutoTuneStatus() {
+    current_steps_id_ += 1;
+    if (current_step < auto_tune_start_step_id_) {
+      return;
+    } else if (current_steps_id_ >= auto_tune_start_step_id_ &&
+               current_steps_id_ < current_steps_id_ + auto_tune_steps_) {
+      enable_autotune_ = true;
+      float current_step_cache_misses_rate =
+          AutoTuneCache::Instance().AutoTuneCacheHitRate();
+    } else if (current_steps_id_ == current_steps_id_ + auto_tune_steps_) {
+      float total_cache_hit_rate =
+          AutoTuneCache::Instance().AutoTuneCacheHitRate();
+      VLOG(3) << "Current step id: " << current_steps_id_;
+    } else {
+      return;
+    }
+  }
+
+  void SetAutoTuneSteps(int steps) { auto_tune_steps_ = steps; }
+
+  void EnableAutoTune() { enable_autotune_ = true; }
+
+  void DisableAutoTune() { enable_autotune_ = false; }
+
+ private:
+  SwitchAutoTune() = default;
+  int64_t auto_tune_start_step_id_ = 0;
+  int64_t auto_tune_steps_ = 10;
+  int64_t current_steps_id_ = 0;
+  bool enable_autotune_ = false;
+  float step_cache_misses_rate = 1.;
+};
+
+}  // namespace autotune
+}  // namespace phi

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1285,7 +1285,7 @@ class Executor(object):
 
         """
         try:
-            return self._run_impl(
+            res = self._run_impl(
                 program=program,
                 feed=feed,
                 fetch_list=fetch_list,
@@ -1296,6 +1296,8 @@ class Executor(object):
                 use_program_cache=use_program_cache,
                 use_prune=use_prune,
                 return_merged=return_merged)
+            core.update_autotune_status()
+            return res
         except Exception as e:
             six.reraise(*sys.exc_info())
 

--- a/python/paddle/fluid/tests/unittests/test_switch_autotune.py
+++ b/python/paddle/fluid/tests/unittests/test_switch_autotune.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import unittest
+
+
+class TestSwitchAutoTuneDyGraph(unittest.TestCase):
+    def dygraph_program(self):
+        x_var = paddle.uniform((2, 4, 8, 8), dtype='float32', min=-1., max=1.)
+        conv = paddle.nn.Conv2D(4, 6, (3, 3))
+        out = conv(x_var)
+        loss = paddle.mean(out)
+        adam = paddle.optimizer.Adam(
+            learning_rate=0.1, parameters=conv.parameters())
+        out.backward()
+        adam.step()
+        adam.clear_grad()
+
+    def test_enable_autotune(self):
+        paddle.fluid.core.enable_autotune()
+        for i in range(2):
+            self.dygraph_program()
+            status = paddle.fluid.core.auto_tune_status()
+            self.assertEqual(status["step_id"], i)
+            self.assertEqual(status["use_autotune"], True)
+            self.assertEqual(status["cache_size"], 0)
+            self.assertEqual(status["cache_hit_rate"], 0)
+
+    def test_disable_autotune(self):
+        paddle.fluid.core.disable_autotune()
+        status = paddle.fluid.core.auto_tune_status()
+        self.assertEqual(status["use_autotune"], False)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Describe
<!-- Describe what this PR does --> Implement AutoTuneStatus for Kernel Auto Tune 

**AutoTuneStatus的实现**

- 功能：记录运行的step，并且控制autotune的开/关，以及在调优时更新cache命中率等status
- use_autotune：该参数表示是否开启自动调优，即在该状态下，允许算子从候选算法中运行benchmark，进行最佳算法的选择。搜索过程可能具有较高代价
- auto_tune的step范围：目前默认从第0个step开始，进行10步的调优。这些调优option如有必要，可以添加python接口，以进行debug，或者允许用户自定义。目前未暴露python接口
- 静态shape和动态shape的处理：
  - 静态shape：模型每个step的shape是固定的，那么在调优步骤的前1个/多个，cache的size已经稳定，后续迭代均是从cache中查算法
  - 动态shape：模型每个step的shape不固定（shape变化范围广）。在调优步骤内，可能都会不断触发算法的搜索，cache持续增加。在调优步骤后 ，尽管已经关闭了autotune的开关，不允许进行算法搜索，但是cache的size或许较大，且多为无用cache。处理方式：
    - 本PR：记录了调优时每一步的cache命中率，在调优结束时，计算最近的几次平均命中率。如果命中率极低，清除cache。目前设置的选择容忍度极小，miss率为0.01以上，就清除。
    - 可能的改进方案：未来可以在动态shape下做一些实验，如果有必要，可以选择根据miss率去清除命中率较低的cache，保留部分cache

**细节问题**
- step_id：
  - **记录方式**：动态图在每一次backward结束时，更新step_id，静态图在exe.run时更新，但静态图首先要run一次startup_program，所以真实训练时，switch_autotune记录的step_id是比实际运行的多了1步的，也就是静态图下会少进行1步的autotune。
  - **准确度**：对动态图而言，如果一个模型（如StyleGAN模型）在1个step里，进行了2次forward、2次backward、2次optimizer，AutoTuneStatus是无法区分的，也就是会认为是2个step。而这样的多次forward和backward的周期，无从得知。

- 动态shape的判断：
  - **为什么不用历史的cache命中率？** 因为上文提到，1个step中可能会进行多次backward。历史命中率，是每一步累加的结果，固定调优的步数，1个step进行多次backward下的历史命中率可能会比只进行1次backward时低。因此使用历史命中率来进行阈值的确定可能是不稳定的。
  - **最近cache命中率为什么选择最后几步的均值而不是最近1次？** 动态shape下如果最后1个调优步骤，模型的shape恰好出现过，很容易判断错误。而最后几步的平均命中率则不太容易受到随机性的影响，除非连续几步都命中了之前出现过的shape。

**说明**
- 目前默认autotune的开关是关闭，待benchmark测试无问题，最终版本需要打开

