### PR TITLE
fix bug of inplace fill_ and zero_ API

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/eager_generator.cc
+++ b/paddle/fluid/eager/auto_code_generator/eager_generator.cc
@@ -1824,7 +1824,7 @@ static std::pair<std::string, std::string> GenerateForwardFunctionContents(
           // Bump inplace version of inplace tensor.
           auto inplace_input_name = inplace_map[output_name];
           const char* FWD_OUT_TENSOR_TEMPLATE =
-              "  egr::EagerUtils::ModifyInplaceInput(outs[\"%s\"][0], &%s);\n"
+              "  egr::EagerUtils::GetOutput(outs[\"%s\"][0], &%s);\n"
               "  %s.bump_inplace_version();\n"
               "  VLOG(3) << \"Tensor(\" << %s.name() << \") uses Inplace "
               "Strategy.\";\n";

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -271,27 +271,6 @@ void EagerUtils::HandleViewBetweenInputAndOutput(
   }
 }
 
-void EagerUtils::ModifyInplaceInput(
-    const std::shared_ptr<EagerVariable>& inplace_variable,
-    paddle::experimental::Tensor* inplace_tensor) {
-  // Only modify the meta information of the inplace tensor, because
-  // EagerVariable cannot modify Tensor's meta information after inplace
-  // op (such as ``reshape``) is executed.
-  PADDLE_ENFORCE_NOT_NULL(inplace_tensor,
-                          paddle::platform::errors::Fatal(
-                              "Inplace Tensor is null and cannot be modified. "
-                              "We are tring to Modify Inplace Input from its "
-                              "shared_ptr, this error may indicate the inplace "
-                              " input is nullptr"));
-  if (phi::DenseTensor::classof(inplace_variable->GetTensorBase().get())) {
-    phi::DenseTensor* variable_dense_tensor =
-        static_cast<phi::DenseTensor*>(inplace_variable->GetTensorBase().get());
-    phi::DenseTensor* tensor_dense_tensor =
-        static_cast<phi::DenseTensor*>(inplace_tensor->impl().get());
-    tensor_dense_tensor->set_meta(variable_dense_tensor->meta());
-  }
-}
-
 std::vector<paddle::experimental::Tensor> EagerUtils::GetOutputs(
     const std::vector<std::shared_ptr<EagerVariable>>& outs) {
   std::vector<paddle::experimental::Tensor> res;

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -203,9 +203,6 @@ class EagerUtils {
   static std::vector<std::shared_ptr<EagerVariable>> CreateVars(
       const size_t num);
   // Construct Tensor From var
-  static void ModifyInplaceInput(
-      const std::shared_ptr<EagerVariable>& inplace_variable,
-      paddle::experimental::Tensor* inplace_tensor);
   static std::vector<paddle::experimental::Tensor> GetOutputs(
       const std::vector<std::shared_ptr<EagerVariable>>& outs);
   static paddle::experimental::Tensor GetOutput(

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -171,6 +171,12 @@ def _test_eager_guard(place=None):
     if not _already_patch_eager_tensor:
         monkey_patch_varbase()
         monkey_patch_math_varbase()
+
+        # Ugly setting
+        from paddle.tensor.manipulation import fill_, zero_
+        setattr(core.eager.Tensor, 'fill_', fill_)
+        setattr(core.eager.Tensor, 'zero_', zero_)
+
         _already_patch_eager_tensor = True
     try:
         yield

--- a/python/paddle/fluid/tests/unittests/test_tensor_fill_.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_fill_.py
@@ -17,13 +17,14 @@ import unittest
 import numpy as np
 import six
 import paddle
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TensorFill_Test(unittest.TestCase):
     def setUp(self):
         self.shape = [32, 32]
 
-    def test_tensor_fill_true(self):
+    def func_test_tensor_fill_true(self):
         typelist = ['float32', 'float64', 'int32', 'int64', 'float16']
         places = [fluid.CPUPlace()]
         if fluid.core.is_compiled_with_cuda():
@@ -46,7 +47,12 @@ class TensorFill_Test(unittest.TestCase):
                 tensor.fill_(var)  #var type is basic type in typelist
                 self.assertEqual((tensor.numpy() == target).all(), True)
 
-    def test_tensor_fill_backward(self):
+    def test_tensor_fill_true(self):
+        with _test_eager_guard():
+            self.func_test_tensor_fill_true()
+        self.func_test_tensor_fill_true()
+
+    def func_test_tensor_fill_backward(self):
         typelist = ['float32']
         places = [fluid.CPUPlace()]
         if fluid.core.is_compiled_with_cuda():
@@ -71,12 +77,22 @@ class TensorFill_Test(unittest.TestCase):
 
                 self.assertEqual((y.grad.numpy() == 0).all().item(), True)
 
-    def test_errors(self):
+    def test_tensor_fill_backward(self):
+        with _test_eager_guard():
+            self.func_test_tensor_fill_backward()
+        self.func_test_tensor_fill_backward()
+
+    def func_test_errors(self):
         def test_list():
             x = paddle.to_tensor([2, 3, 4])
             x.fill_([1])
 
         self.assertRaises(TypeError, test_list)
+
+    def test_errors(self):
+        with _test_eager_guard():
+            self.func_test_errors()
+        self.func_test_errors()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_tensor_zero_.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_zero_.py
@@ -17,13 +17,14 @@ import unittest
 import numpy as np
 import six
 import paddle
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TensorFill_Test(unittest.TestCase):
     def setUp(self):
         self.shape = [32, 32]
 
-    def test_tensor_fill_true(self):
+    def func_test_tensor_fill_true(self):
         typelist = ['float32', 'float64', 'int32', 'int64', 'float16']
         places = [fluid.CPUPlace()]
         if fluid.core.is_compiled_with_cuda():
@@ -40,6 +41,11 @@ class TensorFill_Test(unittest.TestCase):
 
                 tensor.zero_()
                 self.assertEqual((tensor.numpy() == target).all().item(), True)
+
+    def test_tensor_fill_true(self):
+        with _test_eager_guard():
+            self.func_test_tensor_fill_true()
+        self.func_test_tensor_fill_true()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

对于`fill_`和`zero_` inplace API，输入在`CUDAPinned` Place上时，输出会被拷贝到`CUDA` Place上。
- 原inplace逻辑
使用`ModifyInplaceInput`只将输出的`meta`信息赋值给输入，输入的`impl`信息还是输入Tensor。
导致对上述场景，输出为`CUDAPinned`Place上的值。与老动态图行为不一致。
- 修复后逻辑
使用`GetOutput`，将输出的`impl`信息整个赋给输入。这样输入的TensorBase也变成了输出。
将会输出`CUDA`Place上的值。