### PR TITLE
Enabled FC of oneDNN for bert tester

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_bert_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_bert_tester.cc
@@ -156,6 +156,8 @@ void profile(bool use_mkldnn = false) {
 
   if (use_mkldnn) {
     config.EnableMKLDNN();
+    config.pass_builder()->AppendPass("fc_mkldnn_pass");
+    config.pass_builder()->AppendPass("fc_act_mkldnn_fuse_pass");
   }
 
   std::vector<std::vector<PaddleTensor>> outputs;


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
This PR is enabling FC of oneDNN for Bert tester. On CLX (Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz) it does improve performance of test_analyzer_bert by ~10% (from ~200 FPS to ~220 FPS). To reproduce you need to enable building of test_analyzer_bert  in https://github.com/PaddlePaddle/Paddle/blob/2f41f389228e48bab4b677a7f14248c39c67782f/paddle/fluid/inference/tests/api/CMakeLists.txt#L584-L586  by removing conditional building of test e.g. removing `if (WITH_GPU)` and corressponding `endif()`   Performance improvement is due to fact that fc oneDNN got fuses of various activations in particular gelu and tanh which is aplicable to BERT model
