### PR TITLE
make variable 'gradient_merge_cond' local

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding_optimizer.py
@@ -1621,13 +1621,8 @@ class ShardingOptimizer(MetaOptimizerBase):
             persistable=True,
             force_cpu=True)
 
-        cond_var = layers.create_global_var(
-            name="gradient_merge_cond",
-            shape=[1],
-            value=bool(0),
-            dtype='bool',
-            persistable=False,
-            force_cpu=True)
+        cond_var = main_block.create_var(
+            name="gradient_merge_cond", shape=[1], dtype='bool')
 
         with device_guard("cpu"):
             # step_var = (step_var + 1) % k_step

--- a/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
+++ b/python/paddle/distributed/passes/auto_parallel_gradient_merge.py
@@ -107,13 +107,8 @@ def _get_gm_cond_var(main_program, k_steps, dist_context):
         force_cpu=True)
     set_var_dist_attr(dist_context, step_var, [-1], world_process_group.ranks)
 
-    cond_var = layers.create_global_var(
-        name="gradient_merge_cond",
-        shape=[1],
-        value=bool(0),
-        dtype='bool',
-        persistable=False,
-        force_cpu=True)
+    cond_var = main_block.create_var(
+        name="gradient_merge_cond", shape=[1], dtype='bool')
     set_var_dist_attr(dist_context, cond_var, [-1], world_process_group.ranks)
 
     with device_guard("cpu"):

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -7098,13 +7098,8 @@ class GradientMergeOptimizer(object):
             persistable=True,
             force_cpu=True)
 
-        cond_var = layers.create_global_var(
-            name="gradient_merge_cond",
-            shape=[1],
-            value=bool(0),
-            dtype='bool',
-            persistable=False,
-            force_cpu=True)
+        cond_var = main_block.create_var(
+            name="gradient_merge_cond", shape=[1], dtype='bool')
 
         with device_guard("cpu"):
             # step_var = (step_var + 1) % k_step


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
make variable 'gradient_merge_cond' local

The variable 'gradient_merge_cond' is created `global`, and it is set persistable in startup program but not persistable in main program, which may cause Error in executor.

startup program
<img width="840" alt="38 persist trainable pars •0 K 6 LOO_ TENSOR  SMape (32, 128) etyseffloat32) step arodlenk (Fa 1se)" src="https://user-images.githubusercontent.com/6888866/161207267-3f8ffb2a-9c1a-44e9-bce6-b4b09eb4d92a.png">

main program
<img width="811" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/6888866/161207283-be68fc8d-5edd-4ec1-bd98-57e2e4b2bcef.png">

This PR make 'gradient_merge_cond' a local variable, since it is not needed to be initialized in startup program.