### PR TITLE
fix padlde.Tensor in eager mode

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -48,7 +48,7 @@ from .framework.dtype import bfloat16  # noqa: F401
 from .framework.dtype import bool  # noqa: F401
 from .framework.dtype import complex64  # noqa: F401
 from .framework.dtype import complex128  # noqa: F401
-if fluid.framework._in_eager_mode_:
+if fluid.framework.in_dygraph_mode():
     Tensor = framework.core.eager.Tensor
 else:
     from .framework import VarBase as Tensor  # noqa: F401


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

`paddle/__init__.py`下定义的`Tensor`在新动态图下使用`core.eager.Tensor`。
新动态图模式的判断方式从`_in_eager_mode_`修改为`in_dygraph_mode()`。
