### PR TITLE
cut off relation between xk and initial_position's graph

### DIFF
--- a/python/paddle/incubate/optimizer/functional/bfgs.py
+++ b/python/paddle/incubate/optimizer/functional/bfgs.py
@@ -126,8 +126,8 @@ def minimize_bfgs(objective_func,
         check_initial_inverse_hessian_estimate(initial_inverse_hessian_estimate)
 
     Hk = paddle.assign(initial_inverse_hessian_estimate)
-    # use assign to create new tensor rather than =, or xk will share memory and grad with initial_position
-    xk = paddle.assign(initial_position)
+    # use detach and assign to create new tensor rather than =, or xk will share memory and grad with initial_position
+    xk = paddle.assign(initial_position.detach())
 
     value, g1 = _value_and_gradient(objective_func, xk)
     num_func_calls = paddle.full(shape=[1], fill_value=1, dtype='int64')

--- a/python/paddle/incubate/optimizer/functional/bfgs.py
+++ b/python/paddle/incubate/optimizer/functional/bfgs.py
@@ -126,7 +126,8 @@ def minimize_bfgs(objective_func,
         check_initial_inverse_hessian_estimate(initial_inverse_hessian_estimate)
 
     Hk = paddle.assign(initial_inverse_hessian_estimate)
-    xk = initial_position
+    # use assign to create new tensor rather than =, or xk will share memory and grad with initial_position
+    xk = paddle.assign(initial_position.detach)
 
     value, g1 = _value_and_gradient(objective_func, xk)
     num_func_calls = paddle.full(shape=[1], fill_value=1, dtype='int64')

--- a/python/paddle/incubate/optimizer/functional/bfgs.py
+++ b/python/paddle/incubate/optimizer/functional/bfgs.py
@@ -127,7 +127,7 @@ def minimize_bfgs(objective_func,
 
     Hk = paddle.assign(initial_inverse_hessian_estimate)
     # use assign to create new tensor rather than =, or xk will share memory and grad with initial_position
-    xk = paddle.assign(initial_position.detach)
+    xk = paddle.assign(initial_position)
 
     value, g1 = _value_and_gradient(objective_func, xk)
     num_func_calls = paddle.full(shape=[1], fill_value=1, dtype='int64')

--- a/python/paddle/incubate/optimizer/functional/lbfgs.py
+++ b/python/paddle/incubate/optimizer/functional/lbfgs.py
@@ -113,7 +113,8 @@ def minimize_lbfgs(objective_func,
         check_initial_inverse_hessian_estimate(initial_inverse_hessian_estimate)
         H0 = initial_inverse_hessian_estimate
 
-    xk = initial_position
+    # use assign to create new tensor rather than =, or xk will share memory and grad with initial_position
+    xk = paddle.assign(initial_position.detach)
     value, g1 = _value_and_gradient(objective_func, xk)
 
     k = paddle.full(shape=[1], fill_value=0, dtype='int64')

--- a/python/paddle/incubate/optimizer/functional/lbfgs.py
+++ b/python/paddle/incubate/optimizer/functional/lbfgs.py
@@ -113,8 +113,8 @@ def minimize_lbfgs(objective_func,
         check_initial_inverse_hessian_estimate(initial_inverse_hessian_estimate)
         H0 = initial_inverse_hessian_estimate
 
-    # use assign to create new tensor rather than =, or xk will share memory and grad with initial_position
-    xk = paddle.assign(initial_position)
+    # use detach and assign to create new tensor rather than =, or xk will share memory and grad with initial_position
+    xk = paddle.assign(initial_position.detach())
     value, g1 = _value_and_gradient(objective_func, xk)
 
     k = paddle.full(shape=[1], fill_value=0, dtype='int64')

--- a/python/paddle/incubate/optimizer/functional/lbfgs.py
+++ b/python/paddle/incubate/optimizer/functional/lbfgs.py
@@ -114,7 +114,7 @@ def minimize_lbfgs(objective_func,
         H0 = initial_inverse_hessian_estimate
 
     # use assign to create new tensor rather than =, or xk will share memory and grad with initial_position
-    xk = paddle.assign(initial_position.detach)
+    xk = paddle.assign(initial_position)
     value, g1 = _value_and_gradient(objective_func, xk)
 
     k = paddle.full(shape=[1], fill_value=0, dtype='int64')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

cut off relation between xk and initial_position's graph. Note, if initial_position comes from a graph, paddle.assign(initial_position) will cause error of "set gradient op twice"
![a9c5ae4d1303c102cf2cd75cfdeb9469](https://user-images.githubusercontent.com/51314274/161558275-f1b8eeed-8263-443b-b270-ddac848e579d.png)
