### PR TITLE
fix index_select kernel configuration error where input numel is 0

### DIFF
--- a/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
@@ -85,6 +85,9 @@ void IndexSelectGradKernel(const Context& ctx,
                         phi::DataType::INT64));
 
   int64_t numel = x_grad->numel();
+  if (numel == 0) {
+    return;
+  }
   int64_t index_nums = index.numel();
   int64_t out_nums = out_grad.numel();
 

--- a/paddle/phi/kernels/gpu/index_select_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_kernel.cu
@@ -72,6 +72,9 @@ void IndexSelectKernel(const Context& ctx,
   T* out_data = ctx.template Alloc<T>(output);
 
   int64_t numel = output->numel();
+  if (numel == 0) {
+    return;
+  }
   auto stream = ctx.stream();
 
   unsigned int block_dim = PADDLE_CUDA_NUM_THREADS;


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
 OPs

### Describe

For index_select, if the numel() of input x is 0, launching the kernel raises a error as bellow:
```
import paddle
data = paddle.empty((0, 7), dtype='float32')
index = paddle.to_tensor([0, 1], dtype='int32')
out = paddle.index_select(data, index, axis=-1)
```

![image](https://user-images.githubusercontent.com/22235422/161536436-ea8741a0-a784-4868-8f7d-a0fd0dc9f8f9.png)

After we fix this bug, the output can be computed correctly:

![image](https://user-images.githubusercontent.com/22235422/161536672-ada5ea7f-2935-447d-9b3f-03bf60468395.png)
