### PR TITLE
fix device_id bug for final_state op in multiprocess testcase

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
@@ -195,6 +195,16 @@ FORWARD_FUNCTION_TEMPLATE = \
     
     // Get Input AutoGradMeta
 {}
+    // Set Device Id
+    auto place = egr::Controller::Instance().GetExpectedPlace();
+    if (paddle::platform::is_gpu_place(place)) {{
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+      phi::backends::gpu::SetDeviceId(place.device);
+#else
+      PADDLE_THROW(paddle::platform::errors::PreconditionNotMet(
+        "PaddlePaddle should compile with GPU if use CUDAPlace."));
+#endif
+    }}
     // Forward API Call
 {}
     // Get Outputs
@@ -285,6 +295,7 @@ FORWARD_CC_FILE_TEMPLATE = \
 #include "paddle/fluid/platform/profiler/event_tracing.h"
 #include "paddle/fluid/eager/amp_utils.h"
 #include "paddle/fluid/eager/eager_amp_auto_cast.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 
 {}
 {}

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -387,7 +387,9 @@ void Tracer::SetExpectedPlace(platform::Place place) {
   expected_place_ = place;
   if (platform::is_gpu_place(place)) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    platform::SetDeviceId(place.device);
+    if (place.device) {
+      platform::SetDeviceId(place.device);
+    }
 #else
     PADDLE_THROW(platform::errors::PreconditionNotMet(
         "PaddlePaddle should compile with GPU if use CUDAPlace."));

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -385,6 +385,14 @@ void Tracer::TraceOp(const std::string& type, const NameTensorMap& ins,
 
 void Tracer::SetExpectedPlace(platform::Place place) {
   expected_place_ = place;
+  if (platform::is_gpu_place(place)) {
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+    platform::SetDeviceId(place.device);
+#else
+    PADDLE_THROW(platform::errors::PreconditionNotMet(
+        "PaddlePaddle should compile with GPU if use CUDAPlace."));
+#endif
+  }
 }
 
 bool Tracer::ComputeRequiredGrad(const NameVarBaseMap& ins,

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -385,16 +385,6 @@ void Tracer::TraceOp(const std::string& type, const NameTensorMap& ins,
 
 void Tracer::SetExpectedPlace(platform::Place place) {
   expected_place_ = place;
-  if (platform::is_gpu_place(place)) {
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    if (place.device) {
-      platform::SetDeviceId(place.device);
-    }
-#else
-    PADDLE_THROW(platform::errors::PreconditionNotMet(
-        "PaddlePaddle should compile with GPU if use CUDAPlace."));
-#endif
-  }
 }
 
 bool Tracer::ComputeRequiredGrad(const NameVarBaseMap& ins,

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -270,7 +270,10 @@ def monkey_patch_math_varbase():
 
             # 4. calculation
             axis = -1
-            math_op = getattr(_C_ops, op_type)
+            if framework._in_eager_mode_ and op_type == 'elementwise_add':
+                math_op = getattr(_C_ops, 'final_state_add')
+            else:
+                math_op = getattr(_C_ops, op_type)
             return math_op(self, other_var, 'axis', axis)
 
         comment = OpProtoHolder.instance().get_op_proto(op_type).comment

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -103,9 +103,7 @@ class TestInplace(unittest.TestCase):
 
             var_b[1:2] = 3  # var_b is modified inplace before using it
 
-            var_c = paddle.add(
-                var_b,
-                var_b)  # Here, the grad op of sum doesn't use the value of var_b
+            var_c = var_b + var_b  # Here, the grad op of sum doesn't use the value of var_b
             loss = var_c.sum()
 
             var_b[1:2] = 3  # var_b is modified inplace after using it


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

- 问题
在分布式多进程单测`test_eager_dist_api.py`里，如果使用最终态op，在GetDeviceContextByBackend获取设备时报错。

- 原因
在分布式多进程场景下，gpu1的子进程执行时，使用GetCurrentDeviceId获取到的设备是place0，但是预期获得的应该是place1，导致DeviceContextPool没法Get到相应place。

- 解决方法
新动态图执行kernel前，需要使用SetDeviceId事先指定place.device。

