### PR TITLE
modify gpu memory strategy

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -772,12 +772,12 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
         gflags.push_back("--cudnn_deterministic=True");
       }
 
-// TODO(wilber): jetson tx2 may fail to run the model due to insufficient memory
-// under the native_best_fit strategy. Modify the default allocation strategy to
-// auto_growth. todo, find a more appropriate way to solve the problem.
-#ifdef WITH_NV_JETSON
+      // TODO(wilber): jetson tx2 may fail to run the model due to insufficient
+      // memory
+      // under the native_best_fit strategy. Modify the default allocation
+      // strategy to
+      // auto_growth. todo, find a more appropriate way to solve the problem.
       gflags.push_back("--allocator_strategy=auto_growth");
-#endif
 
       // TODO(Shixiaowei02): Add a mandatory scheme to use the thread local
       // allocator when multi-stream is enabled.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
 开启-DON_INFER=ON, naive_best_fit会让模型跑原生时显存爆满；
 将naive_best_fit改为auto_growth。