### PR TITLE
fix bug of missing boost when compile cache.cc

### DIFF
--- a/paddle/phi/kernels/autotune/CMakeLists.txt
+++ b/paddle/phi/kernels/autotune/CMakeLists.txt
@@ -6,6 +6,6 @@ elseif (WITH_ROCM)
     hip_test(auto_tune_test SRCS auto_tune_test.cu DEPS gtest)
 endif()
 
-cc_library(cache SRCS cache.cc DEPS)
+cc_library(cache SRCS cache.cc DEPS boost)
 
 cc_test(cache_test SRCS cache_test.cc DEPS gtest cache)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix bug of missing boost when compile cache.cc
![image](https://user-images.githubusercontent.com/51314274/161887936-410a7adc-599c-403d-8959-79bb80ffa2f1.png)
