### PR TITLE
fix compile bug of windows cuda11.5

### DIFF
--- a/paddle/phi/kernels/funcs/activation_functor.h
+++ b/paddle/phi/kernels/funcs/activation_functor.h
@@ -1878,12 +1878,17 @@ struct CudaCosGradFunctor : public BaseActivationFunctor<T> {
 
 template <typename T>
 struct CudaExpFunctor : public BaseActivationFunctor<T> {
-  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+  // exp(x) = expf(x)
+  __device__ __forceinline__ T operator()(const T x) const {
+    return static_cast<T>(expf(static_cast<float>(x)));
+  }
+};
 
+template <>
+struct CudaExpFunctor<double> : public BaseActivationFunctor<double> {
   // exp(x) = exp(x)
-  __device__ __forceinline__ T operator()(const T arg_x) const {
-    MPType x = static_cast<MPType>(arg_x);
-    return static_cast<T>(exp(x));
+  __device__ __forceinline__ double operator()(const double x) const {
+    return exp(x);
   }
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

修复CUDA11.5的编译bug，在注册int、int64的kernel时，CUDA11.5的编译器无法正确重载到 CUDA函数`expf`：https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html#group__CUDA__MATH__SINGLE ，
因此这里改为进行显式调用。