### PR TITLE
【chery-pick 2.3】fix bug of random compile fail

### DIFF
--- a/paddle/phi/kernels/autotune/CMakeLists.txt
+++ b/paddle/phi/kernels/autotune/CMakeLists.txt
@@ -6,6 +6,6 @@ elseif (WITH_ROCM)
     hip_test(auto_tune_test SRCS auto_tune_test.cu DEPS gtest)
 endif()
 
-cc_library(cache SRCS cache.cc DEPS)
+cc_library(cache SRCS cache.cc DEPS boost)
 
 cc_test(cache_test SRCS cache_test.cc DEPS gtest cache)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
【chery-pick #[41430](https://github.com/PaddlePaddle/Paddle/pull/41430)】fix bug of random compile failure, due to  incorrect  compile order of dependencies