### PR TITLE
fix random timeout problem of unittest test_autograd_functional_dynamic

### DIFF
--- a/python/paddle/fluid/tests/unittests/autograd/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/autograd/CMakeLists.txt
@@ -6,5 +6,5 @@ foreach(TEST_OP ${TEST_OPS})
     py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${GC_ENVS})
 endforeach(TEST_OP)
 
-set_tests_properties(test_autograd_functional_dynamic PROPERTIES TIMEOUT 100)
-set_tests_properties(test_autograd_functional_static PROPERTIES TIMEOUT 100)
+set_tests_properties(test_autograd_functional_dynamic PROPERTIES TIMEOUT 160)
+set_tests_properties(test_autograd_functional_static PROPERTIES TIMEOUT 160)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The unittest `` test_autograd_functional_dynamic`` run timeout randomly, which will block the CI pipeline.  