### PR TITLE
Fix cv2 import error and some issues for lamb

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -54,7 +54,10 @@ if six.PY3:
     if retcode != 0:
         cv2 = None
     else:
-        import cv2
+        try:
+            import cv2
+        except ImportError:
+            cv2 = None
 else:
     try:
         import cv2

--- a/python/paddle/incubate/optimizer/distributed_fused_lamb.py
+++ b/python/paddle/incubate/optimizer/distributed_fused_lamb.py
@@ -17,7 +17,7 @@ from paddle.fluid.framework import Variable
 from paddle.fluid.clip import ClipGradByGlobalNorm
 from paddle.fluid.initializer import Constant
 from paddle.fluid.layer_helper import LayerHelper
-from paddle.optimizer import Optimizer
+from paddle.fluid.optimizer import Optimizer
 from paddle.distributed import get_rank, get_world_size
 from paddle.fluid.executor import global_scope
 from paddle.fluid.framework import name_scope
@@ -42,11 +42,7 @@ class DistributedFusedLamb(Optimizer):
         assert not framework._non_static_mode(
         ), "DistributedFusedLamb does not support dygraph mode"
         super(DistributedFusedLamb, self).__init__(
-            learning_rate=learning_rate,
-            parameters=parameters,
-            weight_decay=None,
-            grad_clip=None,
-            name=name)
+            learning_rate=learning_rate, grad_clip=None, name=name)
 
         self._beta1 = beta1
         self._beta2 = beta2


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix `cv2` package import error like:
```
Traceback (most recent call last):
  File "run_pretrain.py", line 15, in <module>
    from init_env import get_context
  File "init_env.py", line 19, in <module>
    import paddle
  File "/opt/conda/lib/python3.8/site-packages/paddle/__init__.py", line 71, in <module>
    import paddle.dataset  # noqa: F401
  File "/opt/conda/lib/python3.8/site-packages/paddle/dataset/__init__.py", line 27, in <module>
    import paddle.dataset.flowers  # noqa: F401
  File "/opt/conda/lib/python3.8/site-packages/paddle/dataset/flowers.py", line 39, in <module>
    from paddle.dataset.image import load_image_bytes
  File "/opt/conda/lib/python3.8/site-packages/paddle/dataset/image.py", line 57, in <module>
    import cv2
  File "/opt/conda/lib/python3.8/site-packages/cv2/__init__.py", line 96, in <module>
    bootstrap()
  File "/opt/conda/lib/python3.8/site-packages/cv2/__init__.py", line 86, in bootstrap
    import cv2
ImportError: /usr/local/lib/libz.so.1: version `ZLIB_1.2.9' not found (required by /usr/lib/x86_64-linux-gnu/libpng16.so.16)
```

Support learning rate to be a `Variable` for `DistributedFusedLamb` optimizer.