### PR TITLE
[Cmake] Update libmct.cmake

### DIFF
--- a/cmake/external/libmct.cmake
+++ b/cmake/external/libmct.cmake
@@ -45,7 +45,7 @@ ExternalProject_Add(
     PREFIX                ${LIBMCT_PREFIX_DIR}
     DOWNLOAD_DIR          ${LIBMCT_DOWNLOAD_DIR}
     DOWNLOAD_COMMAND      wget --no-check-certificate ${LIBMCT_URL} -c -q -O ${LIBMCT_NAME}.tar.gz
-                          && tar zxvf ${LIBMCT_NAME}.tar.gz
+                          && tar --no-same-owner -zxvf ${LIBMCT_NAME}.tar.gz
     DOWNLOAD_NO_PROGRESS  1
     UPDATE_COMMAND        ""
     CMAKE_ARGS            -DCMAKE_INSTALL_PREFIX=${LIBMCT_INSTALL_ROOT}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix for some environment  Cannot change ownership Failed.
```c++
tar: libmct/include/mct/closed-hash-map.hpp: Cannot change ownership to uid 516, gid 516: Operation not permitted
```
