### PR TITLE
Fix multi-threads predict bug of RNN OP

### DIFF
--- a/paddle/phi/kernels/cpu/rnn_kernel.cc
+++ b/paddle/phi/kernels/cpu/rnn_kernel.cc
@@ -832,11 +832,13 @@ void RnnKernel(const Context& dev_ctx,
                DenseTensor* dropout_state,
                std::vector<DenseTensor*> state,
                DenseTensor* reserve) {
-  if (dropout_state->IsInitialized()) {
-    if (dropout_state->numel() != out->numel()) dropout_state->clear();
+  if (!is_test) {
+    if (dropout_state->IsInitialized()) {
+      if (dropout_state->numel() != out->numel()) dropout_state->clear();
+    }
+    const auto& out_dim = out->dims();
+    Full<uint8_t>(dev_ctx, {out_dim.Get(), out_dim.size()}, 1, dropout_state);
   }
-  const auto& out_dim = out->dims();
-  Full<uint8_t>(dev_ctx, {out_dim.Get(), out_dim.size()}, 1, dropout_state);
 
   // init the output and allocate the memory
   dev_ctx.template Alloc<T>(out);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
This PR fix the bug of RNN OP which modify the persistable variable `DropoutState` in inference mode.