### PR TITLE
Refine ignore_index >= 0 in cross_entropy loss

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1905,7 +1905,7 @@ def cross_entropy(input,
     if reduction == "sum":
         return paddle.sum(out, name=name)
     elif reduction == "mean":
-        if ignore_index != -100:
+        if ignore_index >= 0:
             out_sum = paddle.sum(out, name=name)
             # for each label[i],set 1 or 0, according to ignore_index
             # mask[i]=0, if label[i]==ignore_index


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
APIs

### Describe
Refine `paddle.nn.CrossEntropyLoss` when `ignore_index` is a negative number that is not equal to `-100` (for example, `ignore_index = -1`). This would reduce the operator number in the network.