### PR TITLE
[Infrt] opt support input valid places by commondline.

### DIFF
--- a/paddle/infrt/dialect/infrt/common/types.h
+++ b/paddle/infrt/dialect/infrt/common/types.h
@@ -39,15 +39,12 @@ enum class PrecisionType : uint8_t {
 };
 
 struct Place {
-  TargetType target;
-  PrecisionType precision;
-  LayoutType layout;
+  TargetType target = TargetType::UNK;
+  PrecisionType precision = PrecisionType::UNK;
+  LayoutType layout = LayoutType::UNK;
   Place(TargetType tar, PrecisionType pre, LayoutType lay)
       : target(tar), precision(pre), layout(lay) {}
-  Place()
-      : target(TargetType::UNK),
-        precision(PrecisionType::UNK),
-        layout(LayoutType::UNK) {}
+  Place() = default;
 };
 
 llvm::Optional<TargetType> GetTargetType(llvm::StringRef key);

--- a/paddle/infrt/dialect/phi/pass/phi_op_convert_pass.h
+++ b/paddle/infrt/dialect/phi/pass/phi_op_convert_pass.h
@@ -23,6 +23,4 @@ namespace infrt {
  */
 std::unique_ptr<mlir::Pass> CreatePhiOpCvtPass(std::vector<Place> valid_places);
 
-std::unique_ptr<mlir::Pass> CreatePhiOpCvtPass();
-
 }  // namespace infrt

--- a/paddle/infrt/tests/dialect/phi/phi_pass.mlir
+++ b/paddle/infrt/tests/dialect/phi/phi_pass.mlir
@@ -1,4 +1,4 @@
-// RUN: infrtopt -phi-op-convert -infrt-op-fuse %s
+// RUN: infrtopt -phi-op-convert=valid-targets=CPU-FP32-NCHW -infrt-op-fuse %s
 
 // CHECK-LABEL: @ops
 func @ops(%a:!infrt.lod_tensor<?xf32,0>, %b:!infrt.lod_tensor<?xf32,0>) {

--- a/paddle/infrt/tests/dialect/phi/resnet50.mlir.in
+++ b/paddle/infrt/tests/dialect/phi/resnet50.mlir.in
@@ -444,7 +444,7 @@ module  {
     %387 = "pd.flatten_contiguous_range"(%386) {start_axis = 1 : si32, stop_axis = 3 : si32} : (!infrt.dense_tensor<CPU, FP32, NCHW>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
     %388 = "pd.matmul_v2"(%387, %245) {trans_x = false, trans_y = false} : (!infrt.dense_tensor<CPU, FP32, NCHW>, !infrt.dense_tensor<CPU, FP32, NCHW>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
     %389 = "pd.elementwise_add"(%388, %30) {axis = 1 : si32} : (!infrt.dense_tensor<CPU, FP32, NCHW>, !infrt.dense_tensor<CPU, FP32, NCHW>) -> !infrt.dense_tensor<CPU, FP32, NCHW>
-    infrt.return %270 : !infrt.dense_tensor<CPU, FP32, NCHW>
+    infrt.return %389 : !infrt.dense_tensor<CPU, FP32, NCHW>
   }
 
   func @main() {

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -2931,4 +2931,5 @@ void WhereIndexInferMeta(const MetaTensor& condition, MetaTensor* out) {
 }  // namespace phi
 
 PD_REGISTER_INFER_META_FN(copy_to, phi::CopyToInferMeta);
+PD_REGISTER_INFER_META_FN(flatten, phi::FlattenInferMeta);
 PD_REGISTER_INFER_META_FN(split, phi::SplitInferMeta);

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -201,7 +201,7 @@ fi
 # infrt needs to temporarily use LOG(FATAL) during the debugging period, and will replace it with standard error format in the future.
 NO_INFRT_FILES=`git diff --name-only upstream/develop | grep -v "tools/\|paddle/infrt/" || true`
 HAS_LOG_FATAL=`git diff -U0 upstream/$BRANCH $NO_INFRT_FILES |grep "^+" |grep -o -m 1 "LOG(FATAL)" || true`
-if [ ${HAS_LOG_FATAL} ] && [ "${GIT_PR_ID}" != "" ]; then
+if [ ${NO_INFRT_FILES} ] && [ ${HAS_LOG_FATAL} ] && [ "${GIT_PR_ID}" != "" ]; then
     echo_line="LOG(FATAL) is not recommended, because it will throw exception without standard stack information, so please use PADDLE_THROW macro here. If you have to use LOG(FATAL) here, please request chenwhql (Recommend), luotao1 or lanxianghit review and approve.\n"
     check_approval 1 6836917 47554610 22561442
 fi

--- a/tools/infrt/skipped_phi_api.json
+++ b/tools/infrt/skipped_phi_api.json
@@ -1,4 +1,4 @@
 {
-"phi_apis":["conj", "dropout", "expand_as", "flatten", "nll_loss", "psroi_pool", "roi_align", "roi_pool", "label_smooth"],
+"phi_apis":["conj", "dropout", "expand_as", "nll_loss", "psroi_pool", "roi_align", "roi_pool", "label_smooth"],
 "phi_kernels":["equal_all"]
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Docs

### Describe
<!-- Describe what this PR does -->

infrtopt支持通过命令行输入valid_targets 选项. 输入形式如下，多个valid_target通过逗号隔开。
使用样例：
```
infrtopt --phi-op-convert=valid-targets=CPU-FP32-NCHW,GPU-FP32-NCHW --infrt-op-fuse phi_pass.mlir
```