### PR TITLE
[KP]fix bug when TruncatedNormal cannot fall back in cpu

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1333,7 +1333,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 // NOTE(Liu-xiandong): Determine whether the selected kernel is valid
 // If not, use the kernel registered in fluid. And if the fluid do not
 // contains the related heterogeneous kernel, use phi CPU kernel.
-#if defined(PADDLE_WITH_XPU)  // && !defined(PADDLE_WITH_XPU_KP)
+#if defined(PADDLE_WITH_XPU)
     bool is_xpu_unsupport =
         paddle::platform::is_xpu_place(kernel_type_->place_) &&
             !paddle::platform::is_xpu_support_op(type_, *kernel_type_.get()) ||

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1333,7 +1333,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 // NOTE(Liu-xiandong): Determine whether the selected kernel is valid
 // If not, use the kernel registered in fluid. And if the fluid do not
 // contains the related heterogeneous kernel, use phi CPU kernel.
-#if defined(PADDLE_WITH_XPU) && !defined(PADDLE_WITH_XPU_KP)
+#if defined(PADDLE_WITH_XPU)  // && !defined(PADDLE_WITH_XPU_KP)
     bool is_xpu_unsupport =
         paddle::platform::is_xpu_place(kernel_type_->place_) &&
             !paddle::platform::is_xpu_support_op(type_, *kernel_type_.get()) ||
@@ -1373,7 +1373,10 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 #if defined(PADDLE_WITH_XPU) && !defined(PADDLE_WITH_XPU_KP)
           || is_xpu_unsupport
 #endif
-          ) {
+#if defined(PADDLE_WITH_XPU_KP)
+          || (is_xpu_unsupport && !is_xpu_kp_support)
+#endif
+              ) {
         auto pt_cpu_kernel_key =
             FallBackToCpu(*kernel_type_.get(), pt_kernel_key, *this);
         pt_kernel_.reset(

--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -268,9 +268,6 @@ PreparedOp PrepareImpl(const NameVarMap<VarType>& ins,
 #endif
           ) {
     if (phi::KernelFactory::Instance().HasCompatiblePhiKernel(op.Type())) {
-      VLOG(3) << "finding fluid kernel: " << op.Type()
-              << " for cpu code and the kernel_key is: " << expected_kernel_key;
-
       auto pt_cpu_kernel_key =
           FallBackToCpu(expected_kernel_key, pt_kernel_key, op);
       auto pt_cpu_kernel = phi::KernelFactory::Instance().SelectKernel(

--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -210,9 +210,6 @@ PreparedOp PrepareImpl(const NameVarMap<VarType>& ins,
     }
 #endif
 
-    VLOG(3) << "finding kernel: " << op.Type()
-            << " the kernel key is: " << expected_kernel_key;
-
     pt_kernel_key = TransOpKernelTypeToPhiKernelKey(expected_kernel_key);
     auto pt_kernel = phi::KernelFactory::Instance().SelectKernel(pt_kernel_name,
                                                                  pt_kernel_key);
@@ -270,9 +267,6 @@ PreparedOp PrepareImpl(const NameVarMap<VarType>& ins,
       || (is_xpu_unsupport && !is_xpu_kp_support)
 #endif
           ) {
-    VLOG(3) << "finding fluid kernel: " << op.Type()
-            << " for device code is failed: " << expected_kernel_key;
-
     if (phi::KernelFactory::Instance().HasCompatiblePhiKernel(op.Type())) {
       VLOG(3) << "finding fluid kernel: " << op.Type()
               << " for cpu code and the kernel_key is: " << expected_kernel_key;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 Others
### Describe
<!-- Describe what this PR does -->
fix bug when TruncatedNormal cannot fall back in cpu

bug描述：
XDNN中有OPTruncatedNormal，该op在fluid中正常注册。而目前的kernel调度逻辑是：
phi xpu -> fluid xpu -> phi cpu -> fluid cpu
当判断fluid xpu kernel是否存在时，
![image](https://user-images.githubusercontent.com/85323580/162431852-de920cf3-8ffc-420c-bd10-3ce5912970df.png)
没有进入这个if判断内部，因而跳过了phi cpu的选择逻辑直接走到 fluid cpu的逻辑内，但是由于fluid下面没有注册该CPU的kernel，代码显示不能找到相关kernel。

bug修复方式：
如果开启了XPU KP选项。fluid下面不支持该OP的XDNN kernel，也没有KP kernel，则直接进入到phi cpu选择逻辑。

本地测试：
测试代码；
![image](https://user-images.githubusercontent.com/85323580/162433588-ca210e16-eca2-492a-85aa-1ad2639b4677.png)
运行结果：
![image](https://user-images.githubusercontent.com/85323580/162433599-fde7721f-2bda-443d-bd02-ae90caaf2b29.png)

