### PR TITLE
fix dynamic link bug on mac ipython environment

### DIFF
--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -535,6 +535,11 @@ PADDLE_DEFINE_EXPORTED_double(
     "you should set FLAGS_local_exe_sub_scope_limit=-1. "
     "The default value is 256 MBytes.");
 
+PADDLE_DEFINE_EXPORTED_bool(
+    reader_queue_speed_test_mode, false,
+    "If set true, the queue.pop will only get data from queue but not "
+    "remove the data from queue for speed testing");
+
 /**
  * MKLDNN related FLAG
  * Name: use_mkldnn

--- a/paddle/fluid/pybind/reader_py.cc
+++ b/paddle/fluid/pybind/reader_py.cc
@@ -32,10 +32,7 @@
 #include "paddle/phi/core/ddim.h"
 #include "pybind11/stl.h"
 
-PADDLE_DEFINE_EXPORTED_bool(
-    reader_queue_speed_test_mode, false,
-    "If set true, the queue.pop will only get data from queue but not "
-    "remove the data from queue for speed testing");
+DECLARE_bool(reader_queue_speed_test_mode);
 
 // disable auto conversion to list in Python
 PYBIND11_MAKE_OPAQUE(paddle::framework::LoDTensorArray);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

修复`FLAGS_reader_queue_speed_test_mode`动态链接的问题，当前该flag是放到动态库paddle_pybind.so的源文件里，**编译成动态库**，在部分mac 的 ipython环境下 import paddle时会报错：**该符号既被动态链接，也被静态链接**

![infoflow 2022-04-11 14-48-42](https://user-images.githubusercontent.com/52485244/162680505-33e98a9d-5da3-4bd4-8d90-e6df7080ca5b.png)

因此将其挪动位置，**放在静态库里编译**，解决上述问题。
