### PR TITLE
[cherry-pick] Add get profiler from config (#41532)

### DIFF
--- a/python/paddle/profiler/profiler.py
+++ b/python/paddle/profiler/profiler.py
@@ -18,6 +18,8 @@ import datetime
 from enum import Enum
 from typing import Any, Callable, Iterable, Optional, Union
 from warnings import warn
+import importlib
+import json
 
 import paddle
 from paddle.fluid.core import (_Profiler, _ProfilerResult, ProfilerOptions,
@@ -741,3 +743,73 @@ class Profiler:
                     op_detail=op_detail,
                     thread_sep=thread_sep,
                     time_unit=time_unit))
+
+
+def get_profiler(config_path):
+    try:
+        with open(config_path, 'r') as filehandle:
+            config_dict = json.load(filehandle)
+    except Exception as e:
+        print('Load config file for profiler error: {}'.format(e))
+        print('Use default parameters instead.')
+        return Profiler()
+    translated_config_dict = {}
+    if "targets" in config_dict:
+        try:
+            translated_config_dict['targets'] = []
+            for target in config_dict['targets']:
+                if target.lower() == "cpu":
+                    translated_config_dict['targets'].append(ProfilerTarget.CPU)
+                elif target.lower() == 'gpu':
+                    translated_config_dict['targets'].append(ProfilerTarget.GPU)
+        except:
+            print('Set targets parameter error, use default parameter instead.')
+            translated_config_dict['targets'] = None
+    if "scheduler" in config_dict:
+        try:
+            if isinstance(config_dict['scheduler'], dict):
+                for key, value in config_dict['scheduler'].items():
+                    module_path = value['module']
+                    use_direct = value['use_direct']
+                    module = importlib.import_module(module_path)
+                    method = getattr(module, key)
+                    if not use_direct:
+                        translated_config_dict['scheduler'] = method(
+                            *value['args'], **value['kwargs'])
+                    else:
+                        translated_config_dict['scheduler'] = method
+            else:
+                translated_config_dict['scheduler'] = [
+                    config_dict['scheduler'][0], config_dict['scheduler'][1]
+                ]
+
+        except:
+            print(
+                'Set scheduler parameter error, use default parameter instead.')
+            translated_config_dict['scheduler'] = None
+    if "on_trace_ready" in config_dict:
+        try:
+            if isinstance(config_dict['on_trace_ready'], dict):
+                for key, value in config_dict['on_trace_ready'].items():
+                    module_path = value['module']
+                    use_direct = value['use_direct']
+                    module = importlib.import_module(module_path)
+                    method = getattr(module, key)
+                    if not use_direct:
+                        translated_config_dict['on_trace_ready'] = method(
+                            *value['args'], **value['kwargs'])
+                    else:
+                        translated_config_dict['on_trace_ready'] = method
+        except:
+            print(
+                'Set on_trace_ready parameter error, use default parameter instead.'
+            )
+            translated_config_dict['on_trace_ready'] = None
+    if "timer_only" in config_dict:
+        if isinstance(config_dict['timer_only'], bool):
+            translated_config_dict['timer_only'] = config_dict['timer_only']
+        else:
+            print(
+                'Set timer_only parameter error, use default parameter instead.')
+
+    return Profiler(**translated_config_dict)

--- a/python/paddle/profiler/profiler_statistic.py
+++ b/python/paddle/profiler/profiler_statistic.py
@@ -695,6 +695,16 @@ def _build_table(statistic_data,
         cpu_type_time[TracerEventType.Communication] = sum_ranges(
             statistic_data.distributed_summary.cpu_communication_range)
 
+    for event_type in [
+            TracerEventType.Dataloader, TracerEventType.Forward,
+            TracerEventType.Backward, TracerEventType.Optimization
+    ]:
+        event_type_name = str(event_type).split('.')[1]
+        if event_type in cpu_call_times and event_type_name in statistic_data.event_summary.model_perspective_items:
+            cpu_call_times[
+                event_type] = statistic_data.event_summary.model_perspective_items[
+                    event_type_name].call
+
     gpu_time_range = collections.defaultdict(list)
     for device_id, device_time_ranges in statistic_data.time_range_summary.GPUTimeRange.items(
     ):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
加入从序列化的json配置文件中自动生成Profiler
json格式类似如下：
{
"targets": ["CPU", "GPU"],
"scheduler": [3,4],
"on_trace_ready": {
"export_chrome_tracing":{
"module": "paddle.profiler",
"use_direct": false,
"args": [],
"kwargs": {
"dir_name": "testdebug/"
}
}
},
"timer_only": true
}