### PR TITLE
Add kernel sparse_mask_helper; sparse_coo_tensor_grad

### DIFF
--- a/paddle/phi/kernels/funcs/sparse/common_shape.h
+++ b/paddle/phi/kernels/funcs/sparse/common_shape.h
@@ -40,6 +40,33 @@ inline const DDim InferDenseDims(const DDim& x_dims,
   return values_dims;
 }
 
+template <typename IntT>
+inline IntT HOSTDEVICE IndicesToIndex(const IntT* indices,
+                                      const IntT* sparse_offsets,
+                                      const int64_t non_zero_num,
+                                      const int64_t sparse_dim,
+                                      const int i) {
+  IntT index = 0;
+  for (IntT j = 0; j < sparse_dim; j++) {
+    index += indices[j * non_zero_num + i] * sparse_offsets[j];
+  }
+  return index;
+}
+
+// 1. indices.dims().size() == 2
+template <typename IntT>
+inline const void CalcOffsetsPerDim(const DenseTensor& indices,
+                                    const DDim& dims,
+                                    std::vector<IntT>* offsets) {
+  const DDim& indices_dims = indices.dims();
+  const IntT sparse_dim = indices_dims[0];
+  IntT offset = 1;
+  for (IntT i = sparse_dim - 1; i >= 0; i--) {
+    (*offsets)[i] = offset;
+    offset *= dims[i];
+  }
+}
+
 }  // namespace sparse
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/sparse/common_shape.h
+++ b/paddle/phi/kernels/funcs/sparse/common_shape.h
@@ -69,11 +69,9 @@ inline void HOSTDEVICE FlattenIndices(const IntT* indices,
 
 // 1. indices.dims().size() == 2
 template <typename IntT>
-inline void CalcOffsetsPerDim(const DenseTensor& indices,
-                              const DDim& dims,
+inline void CalcOffsetsPerDim(const DDim& dims,
+                              const int64_t sparse_dim,
                               std::vector<IntT>* offsets) {
-  const DDim& indices_dims = indices.dims();
-  const IntT sparse_dim = indices_dims[0];
   IntT offset = 1;
   for (IntT i = sparse_dim - 1; i >= 0; i--) {
     (*offsets)[i] = offset;

--- a/paddle/phi/kernels/funcs/sparse/common_shape.h
+++ b/paddle/phi/kernels/funcs/sparse/common_shape.h
@@ -53,6 +53,20 @@ inline const IntT HOSTDEVICE IndicesToIndex(const IntT* indices,
   return index;
 }
 
+template <typename IntT>
+inline void HOSTDEVICE FlattenIndices(const IntT* indices,
+                                      const IntT* sparse_offsets,
+                                      const int64_t non_zero_num,
+                                      const int64_t sparse_dim,
+                                      const int start,
+                                      const int stride,
+                                      IntT* out) {
+  for (int i = start; i < non_zero_num; i += stride) {
+    out[i] =
+        IndicesToIndex(indices, sparse_offsets, non_zero_num, sparse_dim, i);
+  }
+}
+
 // 1. indices.dims().size() == 2
 template <typename IntT>
 inline void CalcOffsetsPerDim(const DenseTensor& indices,

--- a/paddle/phi/kernels/funcs/sparse/common_shape.h
+++ b/paddle/phi/kernels/funcs/sparse/common_shape.h
@@ -41,11 +41,11 @@ inline const DDim InferDenseDims(const DDim& x_dims,
 }
 
 template <typename IntT>
-inline IntT HOSTDEVICE IndicesToIndex(const IntT* indices,
-                                      const IntT* sparse_offsets,
-                                      const int64_t non_zero_num,
-                                      const int64_t sparse_dim,
-                                      const int i) {
+inline const IntT HOSTDEVICE IndicesToIndex(const IntT* indices,
+                                            const IntT* sparse_offsets,
+                                            const int64_t non_zero_num,
+                                            const int64_t sparse_dim,
+                                            const int i) {
   IntT index = 0;
   for (IntT j = 0; j < sparse_dim; j++) {
     index += indices[j * non_zero_num + i] * sparse_offsets[j];
@@ -55,9 +55,9 @@ inline IntT HOSTDEVICE IndicesToIndex(const IntT* indices,
 
 // 1. indices.dims().size() == 2
 template <typename IntT>
-inline const void CalcOffsetsPerDim(const DenseTensor& indices,
-                                    const DDim& dims,
-                                    std::vector<IntT>* offsets) {
+inline void CalcOffsetsPerDim(const DenseTensor& indices,
+                              const DDim& dims,
+                              std::vector<IntT>* offsets) {
   const DDim& indices_dims = indices.dims();
   const IntT sparse_dim = indices_dims[0];
   IntT offset = 1;

--- a/paddle/phi/kernels/sparse/cpu/sparse_mask_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/sparse_mask_kernel.cc
@@ -55,6 +55,10 @@ void SparseMaskCPUKernel(const CPUContext& dev_ctx,
   const IntT* indices_ptr = indices.data<IntT>();
 
   std::vector<IntT> out_indexs(non_zero_num), sparse_offsets(sparse_dim);
+
+  phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
+      dims, sparse_dim, &sparse_offsets);
+
   for (int64_t i = 0; i < non_zero_num; i++) {
     int64_t index = phi::funcs::sparse::IndicesToIndex<IntT>(
         indices_ptr, sparse_offsets.data(), non_zero_num, sparse_dim, i);
@@ -95,7 +99,7 @@ void SparseMaskHelperCPUKernel(const CPUContext& dev_ctx,
   std::vector<IntT> sparse_offsets(sparse_dim), x_indexs(x.nnz()),
       mask_indexs(mask_indices.dims()[1]);
   phi::funcs::sparse::CalcOffsetsPerDim<IntT>(
-      x.non_zero_indices(), x.dims(), &sparse_offsets);
+      x.dims(), sparse_dim, &sparse_offsets);
 
   phi::funcs::sparse::FlattenIndices(x.non_zero_indices().data<IntT>(),
                                      sparse_offsets.data(),

--- a/paddle/phi/kernels/sparse/cpu/sparse_utils_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/sparse_utils_kernel.cc
@@ -394,3 +394,15 @@ PD_REGISTER_KERNEL(csr_values,
                    int64_t) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }
+
+PD_REGISTER_KERNEL(sparse_coo_tensor,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::sparse::SparseCooTensorKernel,
+                   float,
+                   double,
+                   phi::dtype::float16,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t) {}

--- a/paddle/phi/kernels/sparse/gpu/sparse_mask_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/sparse_mask_kernel.cu
@@ -193,8 +193,7 @@ void SparseMaskHelperGPUKernel(const GPUContext& dev_ctx,
   IntT* bound_out_ptr = bound_out.data<IntT>();
 
   // 1. calc the offsets of per dim
-  phi::funcs::sparse::CalcOffsetsPerDim(
-      x.non_zero_indices(), x.dims(), &sparse_offsets);
+  phi::funcs::sparse::CalcOffsetsPerDim(x.dims(), sparse_dim, &sparse_offsets);
   // 2. copy sparse_offsets to device
   phi::backends::gpu::GpuMemcpyAsync(d_sparse_offsets.data<IntT>(),
                                      sparse_offsets.data(),

--- a/paddle/phi/kernels/sparse/gpu/sparse_mask_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/sparse_mask_kernel.cu
@@ -130,10 +130,14 @@ __global__ void FlattenIndicesKernel(const IntT* indices,
                                      const int64_t non_zero_num,
                                      const int64_t sparse_dim,
                                      IntT* out) {
-  CUDA_KERNEL_LOOP_TYPE(i, non_zero_num, int64_t) {
-    out[i] = phi::funcs::sparse::IndicesToIndex<IntT>(
-        indices, sparse_offsets, non_zero_num, sparse_dim, i);
-  }
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  phi::funcs::sparse::FlattenIndices<IntT>(indices,
+                                           sparse_offsets,
+                                           non_zero_num,
+                                           sparse_dim,
+                                           tid,
+                                           gridDim.x * blockDim.x,
+                                           out);
 }
 
 template <typename T, typename IntT>

--- a/paddle/phi/kernels/sparse/gpu/sparse_mask_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/sparse_mask_kernel.cu
@@ -124,6 +124,7 @@ void SparseMaskKernel(const Context& dev_ctx,
       }));
 }
 
+// TODO(zhangkaihuo): Use an op to realize the function of FlattenIndices
 template <typename IntT>
 __global__ void FlattenIndicesKernel(const IntT* indices,
                                      const IntT* sparse_offsets,

--- a/paddle/phi/kernels/sparse/gpu/sparse_utils_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/sparse_utils_kernel.cu
@@ -665,3 +665,15 @@ PD_REGISTER_KERNEL(csr_values,
                    int64_t) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }
+
+PD_REGISTER_KERNEL(sparse_coo_tensor,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::sparse::SparseCooTensorKernel,
+                   float,
+                   double,
+                   phi::dtype::float16,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t) {}

--- a/paddle/phi/kernels/sparse/sparse_mask_kernel.h
+++ b/paddle/phi/kernels/sparse/sparse_mask_kernel.h
@@ -26,5 +26,11 @@ void SparseMaskKernel(const Context& dev_ctx,
                       const SparseCooTensor& mask,
                       SparseCooTensor* out);
 
+template <typename T, typename Context>
+void SparseMaskHelperKernel(const Context& dev_ctx,
+                            const SparseCooTensor& x,
+                            const DenseTensor& mask_indices,
+                            DenseTensor* out);
+
 }  // namespace sparse
 }  // namespace phi

--- a/paddle/phi/kernels/sparse/sparse_utils_grad_kernel.cc
+++ b/paddle/phi/kernels/sparse/sparse_utils_grad_kernel.cc
@@ -66,6 +66,19 @@ PD_REGISTER_KERNEL(sparse_coo_to_dense_grad,
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }
 
+PD_REGISTER_KERNEL(sparse_coo_tensor_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::sparse::SparseCooTensorGradKernel,
+                   float,
+                   double,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t) {
+  kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
+}
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 PD_REGISTER_KERNEL(coo_values_grad,
                    GPU,
@@ -94,5 +107,17 @@ PD_REGISTER_KERNEL(sparse_coo_to_dense_grad,
                    int,
                    int64_t) {
   kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
+}
+PD_REGISTER_KERNEL(sparse_coo_tensor_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::sparse::SparseCooTensorGradKernel,
+                   float,
+                   double,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t) {
+  kernel->InputAt(1).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }
 #endif

--- a/paddle/phi/kernels/sparse/sparse_utils_grad_kernel.cc
+++ b/paddle/phi/kernels/sparse/sparse_utils_grad_kernel.cc
@@ -76,7 +76,7 @@ PD_REGISTER_KERNEL(sparse_coo_tensor_grad,
                    int16_t,
                    int,
                    int64_t) {
-  kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
+  kernel->InputAt(1).SetDataLayout(phi::DataLayout::SPARSE_COO);
 }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)

--- a/paddle/phi/kernels/sparse/sparse_utils_grad_kernel.h
+++ b/paddle/phi/kernels/sparse/sparse_utils_grad_kernel.h
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/sparse_coo_tensor.h"
+#include "paddle/phi/kernels/sparse/sparse_mask_kernel.h"
 
 namespace phi {
 namespace sparse {
@@ -31,6 +32,14 @@ void SparseCooToDenseGradKernel(const Context& dev_ctx,
                                 const SparseCooTensor& x,
                                 const DenseTensor& out_grad,
                                 SparseCooTensor* x_grad);
+
+template <typename T, typename Context>
+void SparseCooTensorGradKernel(const Context& dev_ctx,
+                               const DenseTensor& indices,
+                               const SparseCooTensor& out_grad,
+                               DenseTensor* values_grad) {
+  SparseMaskHelperKernel<T, Context>(dev_ctx, out_grad, indices, values_grad);
+}
 
 }  // namespace sparse
 }  // namespace phi

--- a/paddle/phi/kernels/sparse/sparse_utils_kernel.h
+++ b/paddle/phi/kernels/sparse/sparse_utils_kernel.h
@@ -150,8 +150,8 @@ void CsrValuesKernel(const Context& dev_ctx,
 
 template <typename T, typename Context>
 void SparseCooTensorKernel(const Context& dev_ctx,
-                           const DenseTensor& indices,
                            const DenseTensor& values,
+                           const DenseTensor& indices,
                            const IntArray& dense_shape,
                            SparseCooTensor* out) {
   *out =

--- a/paddle/phi/kernels/sparse/sparse_utils_kernel.h
+++ b/paddle/phi/kernels/sparse/sparse_utils_kernel.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include "paddle/phi/api/lib/utils/storage.h"
+#include "paddle/phi/common/int_array.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/sparse_coo_tensor.h"
 #include "paddle/phi/core/sparse_csr_tensor.h"
@@ -145,6 +146,17 @@ void CsrValuesKernel(const Context& dev_ctx,
                      const SparseCsrTensor& x,
                      DenseTensor* out) {
   *out = x.non_zero_elements();
+}
+
+template <typename T, typename Context>
+void SparseCooTensorKernel(const Context& dev_ctx,
+                           const DenseTensor& indices,
+                           const DenseTensor& values,
+                           const IntArray& dense_shape,
+                           SparseCooTensor* out) {
+  *out =
+      SparseCooTensor(indices, values, phi::make_ddim(dense_shape.GetData()));
+  // TODO(zhangkaihuo): sort and merge the dumplicate indices
 }
 
 }  // namespace sparse

--- a/python/paddle/fluid/tests/unittests/test_sparse_utils_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sparse_utils_op.py
@@ -186,6 +186,27 @@ class TestSparseConvert(unittest.TestCase):
             values_tensor.backward(paddle.to_tensor(out_grad))
             assert np.array_equal(out_grad, sparse_x.grad.values().numpy())
 
+    def test_sparse_coo_tensor_grad(self):
+        with _test_eager_guard():
+            indices = [[0, 1], [0, 1]]
+            values = [1, 2]
+            indices = paddle.to_tensor(indices, dtype='int32')
+            values = paddle.to_tensor(
+                values, dtype='float32', stop_gradient=False)
+            sparse_x = paddle.sparse.sparse_coo_tensor(
+                indices, values, shape=[2, 2], stop_gradient=False)
+            print(sparse_x)
+            grad_indices = [[0, 1], [1, 0]]
+            grad_values = [2, 3]
+            grad_indices = paddle.to_tensor(grad_indices, dtype='int32')
+            grad_values = paddle.to_tensor(grad_values, dtype='float32')
+            sparse_out_grad = paddle.sparse.sparse_coo_tensor(
+                grad_indices, grad_values, shape=[2, 2])
+            sparse_x.backward(sparse_out_grad)
+            print(sparse_x.grad)
+            print(values.grad)
+            print(indices.grad)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/sparse/creation.py
+++ b/python/paddle/sparse/creation.py
@@ -107,7 +107,9 @@ def sparse_coo_tensor(indices,
     values = _handle_dtype(values, dtype)
     if shape is None:
         shape = _infer_dense_shape(indices)
-    return core.eager.sparse_coo_tensor(indices, values, shape, stop_gradient)
+#return core.eager.sparse_coo_tensor(indices, values, shape, stop_gradient)
+    return _C_ops.final_state_sparse_create_sparse_coo_tensor(indices, values,
+                                                              shape)
 
 
 #TODO: need to support shape is None

--- a/python/paddle/utils/code_gen/sparse_api.yaml
+++ b/python/paddle/utils/code_gen/sparse_api.yaml
@@ -22,7 +22,7 @@
   backward : coo_values_grad
 
 - api : create_sparse_coo_tensor
-  args : (Tensor indices, Tensor values, IntArray dense_shape)
+  args : (Tensor values, Tensor indices, IntArray dense_shape)
   output : Tensor(out@SparseCooTensor)
   kernel :
     func : sparse_coo_tensor

--- a/python/paddle/utils/code_gen/sparse_api.yaml
+++ b/python/paddle/utils/code_gen/sparse_api.yaml
@@ -21,6 +21,14 @@
     layout : x
   backward : coo_values_grad
 
+- api : create_sparse_coo_tensor
+  args : (Tensor indices, Tensor values, IntArray dense_shape)
+  output : Tensor(out@SparseCooTensor)
+  kernel :
+    func : sparse_coo_tensor
+    layout : values
+  backward : create_sparse_coo_tensor_grad
+
 - api : csr_values
   args : (Tensor x)
   output : Tensor(out@DenseTensor)

--- a/python/paddle/utils/code_gen/sparse_bw_api.yaml
+++ b/python/paddle/utils/code_gen/sparse_bw_api.yaml
@@ -20,7 +20,7 @@
     func : coo_values_grad
 
 - backward_api : create_sparse_coo_tensor_grad
-  forward : create_sparse_coo_tensor(Tensor indices, Tensor values, IntArray dense_shape) -> Tensor(out@SparseCooTensor)
+  forward : create_sparse_coo_tensor(Tensor values, Tensor indices, IntArray dense_shape) -> Tensor(out@SparseCooTensor)
   args : (Tensor indices, Tensor out_grad)
   output : Tensor(values_grad@DenseTensor)
   kernel :

--- a/python/paddle/utils/code_gen/sparse_bw_api.yaml
+++ b/python/paddle/utils/code_gen/sparse_bw_api.yaml
@@ -19,6 +19,13 @@
   kernel :
     func : coo_values_grad
 
+- backward_api : create_sparse_coo_tensor_grad
+  forward : create_sparse_coo_tensor(Tensor indices, Tensor values, IntArray dense_shape) -> Tensor(out@SparseCooTensor)
+  args : (Tensor indices, Tensor out_grad)
+  output : Tensor(values_grad@DenseTensor)
+  kernel :
+    func : sparse_coo_tensor_grad
+
 - backward_api : dense_to_coo_grad
   forward : dense_to_coo(Tensor x, int64_t sparse_dim) -> Tensor(out@SparseCooTensor)
   args : (Tensor out_grad)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. 添加SparseMaskHelperKernel
 - 使用输入的mask_indices对输入x进行过滤
 - 如果mask_indices在x的indices中存在，则把对应的values保留下来，否则为0.
 - 输出mask后的DenseTensor
3. 为sparse_coo_tensor添加反向逻辑

支持中间构造SparseCooTensor，例子：
```
import paddle
from paddle.fluid.framework import _test_eager_guard

with _test_eager_guard():
  a = paddle.to_tensor([1,2], stop_gradient=False)
  b = paddle.to_tensor([1, 0], stop_gradient=False)
  values = a + b
  indices = paddle.to_tensor([[0, 1][ 0, 1]], dtype='int32')
  #如果sparse_coo_tensor()是纯前向的，就不能反向传播到a和b
  sparse_x = paddle.sparse.sparse_coo_tensor(indices, values, shape=[2,2], stop_gradient=False)
  relu = paddle.sparse.ReLU()
  sparse_out = relu(sparse_x)
  sparse_out.backward(sparse_out)
```