### PR TITLE
[Phi] fix the bug when compile phi in infrt ci

### DIFF
--- a/paddle/phi/kernels/CMakeLists.txt
+++ b/paddle/phi/kernels/CMakeLists.txt
@@ -62,7 +62,7 @@ kernel_library(triangular_solve_grad_kernel DEPS ${COMMON_KERNEL_DEPS} matrix_re
 kernel_library(rnn_kernel DEPS ${COMMON_KERNEL_DEPS} concat_and_split_functor lstm_compute gru_compute)
 kernel_library(rnn_grad_kernel DEPS ${COMMON_KERNEL_DEPS} concat_and_split_functor lstm_compute gru_compute)
 kernel_library(warpctc_kernel DEPS ${COMMON_KERNEL_DEPS} phi_dynload_warpctc sequence_padding sequence_scale)
-kernel_library(warpctc_grad_kernel DEPS ${COMMON_KERNEL_DEPS} sequence_padding sequence_scale)
+kernel_library(warpctc_grad_kernel DEPS ${COMMON_KERNEL_DEPS} phi_dynload_warpctc sequence_padding sequence_scale)
 
 # 4. auto parse and build kernel targets by cmake
 register_kernels(EXCLUDES ${COMMON_BAISC_KERNELS} ${MANUAL_BUILD_KERNELS} DEPS ${COMMON_KERNEL_DEPS} ${COMMON_BAISC_KERNELS} )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

当在infrt ci中编译paddle_python时，有一定概率报错。
<img width="1160" alt="85868a09179a617183b5b96c44c0f653" src="https://user-images.githubusercontent.com/78149749/162607656-5b5509a3-03f3-4744-9096-d1a5f2b42ac0.png">
报错信息显示是在编译 ```paddle/phi/kernels/warpctc_grad_kernel.cc```找不到文件```warpctc/include/ctc.h```。
定位发现```warpctc/include/ctc.h```是第三方库```warpctc```库的编译产出。

<img width="1143" alt="59bad24a3ea4c4473f50137df7da9f2f" src="https://user-images.githubusercontent.com/78149749/162607821-60ce005e-57dc-44e8-b818-b1ea36ac334f.png">

观看cmakelist.txt文件可知， warpctc_grad_kernel并没有添加到warpctc的依赖。
多线程编译时，如果先编译了其它依赖了warpctc的模块，比如截图中显示的warpctc_kernel。 则ctc.h会被生成，编译不会报错。
但如果先编译了warpctc_grad_kernel， 则就会报找不到ctc.h的错误。

改pr给warpctc_grad_kernel添加了对warpctc的依赖。对此问题予以修复。