### PR TITLE
[cherry-pick] Fix old dygraph record event

### DIFF
--- a/paddle/fluid/imperative/partial_grad_engine.cc
+++ b/paddle/fluid/imperative/partial_grad_engine.cc
@@ -826,6 +826,8 @@ std::vector<std::shared_ptr<VarBase>> PartialGradTask::Run() {
 }
 
 void PartialGradTask::RunEachOp(OpBase *op) {
+  platform::RecordEvent op_type_record_event(
+      op->Type() + " grad trace_op", platform::TracerEventType::Operator, 1);
   // Prepare new inputs
   NameVarMap<VarBase> tmp_ins;
   for (auto &input_pair : op->GetInsMap()) {
@@ -908,7 +910,6 @@ void PartialGradTask::RunEachOp(OpBase *op) {
   // Run op
   OpBase::Run(op->InnerOp(), tmp_ins, tmp_outs, op->Attrs(),
               op->DefaultAttrsMap(), op->place());
-
   if (create_graph_) {
     auto double_grad_node =
         CreateGradOpNode(op->InnerOp(), tmp_ins, tmp_outs, op->Attrs(),

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -313,7 +313,7 @@ void Tracer::TraceOpImpl(const std::string& type,
 
   {
     platform::RecordEvent node_creation_record_event(
-        type + " node_creation", platform::TracerEventType::Operator, 1);
+        type + " node_creation", platform::TracerEventType::OperatorInner, 1);
 
     if (ComputeRequiredGrad(new_ins, outs, trace_backward)) {
       PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/platform/profiler/chrometracing_logger.cc
+++ b/paddle/fluid/platform/profiler/chrometracing_logger.cc
@@ -325,7 +325,7 @@ void ChromeTracingLogger::HandleTypeKernel(
     "name": "%s[%s]", "pid": %lld, "tid": %lld,
     "ts": %lld, "dur": %.3f,
     "ph": "X", "cat": "%s", 
-    "cname": "rail_animation",
+    "cname": "cq_build_failed",
     "args": {
       "start_time": "%.3f us",
       "end_time": "%.3f us",
@@ -376,7 +376,7 @@ void ChromeTracingLogger::HandleTypeMemcpy(
     "name": "%s[%s]", "pid": %lld, "tid": %lld,
     "ts": %lld, "dur": %.3f,
     "ph": "X", "cat": "%s", 
-    "cname": "rail_animation",
+    "cname": "cq_build_failed",
     "args": {
       "start_time": "%.3f us",
       "end_time": "%.3f us",
@@ -411,7 +411,7 @@ void ChromeTracingLogger::HandleTypeMemset(
     "name": "%s[%s]", "pid": %lld, "tid": %lld,
     "ts": %lld, "dur": %.3f,
     "ph": "X", "cat": "%s", 
-    "cname": "rail_animation",
+    "cname": "cq_build_failed",
     "args": {
       "start_time": "%.3f us",
       "end_time": "%.3f us",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. 旧的动态图，grad node的打点没有了，现在补充上
2. 更改了一下device event在chrome tracing上的配色