### PR TITLE
[Eager] Fix multiprocessing eager mode global issue

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_paddle_multiprocessing.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_multiprocessing.py
@@ -19,13 +19,16 @@ import unittest
 import time
 import paddle
 import paddle.incubate.multiprocessing as mp
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, in_dygraph_mode
+from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, in_dygraph_mode, _enable_legacy_dygraph
 
 REPEAT = 20
 HAS_SHM_FILES = os.path.isdir('/dev/shm')
 
 
 def fill_tensor(queue, event):
+    # make sure run in legacy dygraph
+    if in_dygraph_mode():
+        _enable_legacy_dygraph()
     data = queue.get()
     with paddle.no_grad():
         data[0][:] = 5


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
 Others 

### PR changes
Others 

### Describe
如果全局开启 eager 模式，通过 with  _test_eager_guard() 调用结束后，会调用 enable_legacy_dygraph 切换到老动态图，但是随后 multiprocessing 开启的子 process 依然是在 eager 模式下的，因此需要在子 process 的 func 里面显式切换到老动态图，即显式地声明使用老动态图。
![image](https://user-images.githubusercontent.com/87417304/162709202-82062f37-84ad-480a-bd04-b57b0898678f.png)

