### PR TITLE
[Eager]Fix clear_gradient bug in optimizer

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -1112,8 +1112,7 @@ class Optimizer(object):
 
         if _in_eager_without_dygraph_check():
             for p in param_list:
-                clear_func = p._zero_grads if set_to_zero else p.clear_gradient
-                clear_func()
+                p.clear_gradient(set_to_zero)
         else:
             core.clear_gradients(param_list, set_to_zero)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
[Eager]Fix clear_gradient bug in optimizer

新动态图下的 EagerTensor.clear_gradient接口是支持set_zeros参数的，不需要调用p._zeros_grad接口。在叶子节点的梯度为SelectedRows类型时，_zeros_grad 接口会错误地修改Tensor类型为DenseTensor，导致GradAccumulate中CopyOrAdd 逻辑报错。