### PR TITLE
[cherry-pick] add a inner loop for index_select_grad_init() in index_select op when dealing with large-shape data

### DIFF
--- a/paddle/phi/kernels/gpu/index_select_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_kernel.cu
@@ -32,7 +32,7 @@ __global__ void index_select_cuda_kernel(const T* input,
                                          int64_t stride,
                                          int64_t size,
                                          int64_t delta) {
-  CUDA_KERNEL_LOOP(idx, N) {
+  CUDA_KERNEL_LOOP_TYPE(idx, N, int64_t) {
     int64_t pre_idx = idx / (stride * size);
     int64_t dim_idx = idx % (stride * size) / stride;
     IndexT src_dim_idx = index[dim_idx];


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
 OPs

### Describe
cherry-pick https://github.com/PaddlePaddle/Paddle/pull/41563
For index_select op, the function index_select_grad_init will not work on part of data whose number exceeds the loop number, so we add a inner loop by replacing for() with CUDA_KERNEL_LOOP.