### PR TITLE
[Cherry-pick, Eager] Fix multiprocessing eager mode global issue (#41645)

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_paddle_multiprocessing.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_multiprocessing.py
@@ -19,13 +19,16 @@ import unittest
 import time
 import paddle
 import paddle.incubate.multiprocessing as mp
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, in_dygraph_mode
+from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, in_dygraph_mode, _enable_legacy_dygraph
 
 REPEAT = 20
 HAS_SHM_FILES = os.path.isdir('/dev/shm')
 
 
 def fill_tensor(queue, event):
+    # make sure run in legacy dygraph
+    if in_dygraph_mode():
+        _enable_legacy_dygraph()
     data = queue.get()
     with paddle.no_grad():
         data[0][:] = 5


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
由于 python/paddle/__init__.py 里面的 如下逻辑只会执行一次
![image](https://user-images.githubusercontent.com/87417304/162682984-f4c47feb-79a5-4b4d-8b0b-8ef255ea4ae9.png)

如果 framework 中开启全局 eager，
那么如果单测存在 with _test_eager_mode(): ，执行最后是会 enable_legacy_dygraph 的(即切换了老动态图)。但是 from paddle import Tensor 引入的 Tensor 依然是 core.eager.Tensor，那么一些单测就会出现问题（老动态图不使用 core.eager.Tensor）。
需要如下显式声明
![image](https://user-images.githubusercontent.com/87417304/162683309-c628e043-720f-41c5-a61c-216288558b1e.png)


