### PR TITLE
[CustomDevice] move member variable to dense_tensor.h

### DIFF
--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -190,6 +190,25 @@ class DenseTensor : public TensorBase,
   std::shared_ptr<InplaceVersion> inplace_version_counter_{
       std::make_shared<InplaceVersion>()};
 
+/* @jim19930609: This is a hack
+In general, it is badly designed to fuse MKLDNN-specific objects into a
+generic Tensor.
+We temporarily leave them here to unblock Tensor Unification progress.
+In the final state, we should come up with a MKLDNN_Tensor and move the
+following codes there.
+*/
+#ifdef PADDLE_WITH_MKLDNN
+  /**
+   * @brief the detail format of memory block which have layout as kMKLDNN
+   *
+   * @note MKLDNN lib support various memory format like nchw, nhwc, nChw8C,
+   *       nChw16c, etc. For a MKLDNN memory block, layout will be set as
+   *       DataLayout::kMKLDNN meanwhile detail memory format will be kept in
+   *       this field.
+   */
+  dnnl::memory::format_tag format_ = dnnl::memory::format_tag::undef;
+#endif
+
 #ifndef PADDLE_WITH_CUSTOM_KERNEL
 #include "paddle/phi/core/dense_tensor.inl"
 #endif

--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -133,17 +133,6 @@ inline void set_format(const dnnl::memory::format_tag format) {
   format_ = format;
 }
 
-protected:
-/**
- * @brief the detail format of memory block which have layout as kMKLDNN
- *
- * @note MKLDNN lib support various memory format like nchw, nhwc, nChw8C,
- *       nChw16c, etc. For a MKLDNN memory block, layout will be set as
- *       DataLayout::kMKLDNN meanwhile detail memory format will be kept in
- *       this field.
- */
-
-dnnl::memory::format_tag format_ = dnnl::memory::format_tag::undef;
 #endif
 
 /* ------------------------------ */


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Move member variable `format_` to `dense_tensor.h` to avoid runtime problem:
Currently, outer users can only use `dense_tensor.h` for plugins since `dense_tensor.inl`(to be deleted in near future) is not published. So, compiled Paddle and plugins probably have inconsistent DenseTensor class because `format_` and then lead to runtime problem.
![04273eda296acd0b2177f6b59ae18a61](https://user-images.githubusercontent.com/5997715/162919848-3f002413-7243-4a88-9f51-97d5326558dc.jpg)

