### PR TITLE
Add NHWC format to Paddle-TRT

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv2d_nhwc.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv2d_nhwc.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest, SkipReasons
+from program_config import TensorConfig, ProgramConfig
+import numpy as np
+import unittest
+import itertools
+import paddle.inference as paddle_infer
+from functools import partial
+from typing import Optional, List, Callable, Dict, Any, Set
+import time
+from program_config import create_fake_model, create_quant_model
+import os
+import shutil
+
+
+class TrtConvertConv2dTest(TrtLayerAutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        inputs = program_config.inputs
+        weights = program_config.weights
+        attrs = [
+            program_config.ops[i].attrs
+            for i in range(len(program_config.ops))
+        ]
+
+        if inputs['input_data'].shape[3] != weights['conv2d_weight'].shape[
+                1] * attrs[0]['groups']:
+            return False
+        ver = paddle_infer.get_trt_compile_version()
+        if ver[0] * 1000 + ver[1] * 100 + ver[0] * 10 < 7000:
+            if attrs[0]['padding_algorithm'] == 'SAME' and (
+                    attrs[0]['strides'][0] > 1 or attrs[0]['strides'][1] > 1):
+                return False
+
+        return True
+
+    def sample_program_configs(self):
+        self.trt_param.workspace_size = 1073741824
+
+        def generate_input1(batch, attrs: List[Dict[str, Any]]):
+            return np.ones(
+                [batch, 64, 64, 3 * attrs[0]['groups']]).astype(np.float32)
+
+        def generate_weight1(attrs: List[Dict[str, Any]]):
+            return np.random.random([24, 3, 3, 3]).astype(np.float32)
+
+        batch_list = [1, 4]
+        strides_list = [[1, 1], [2, 2], [1, 2]]
+        paddings_list = [[0, 3], [1, 2, 3, 4]]
+        groups_list = [1, 3]
+        padding_altorithm_list = ['EXPLICIT', 'SAME', 'VALID']
+        dilations_list = [[1, 1], [2, 2], [1, 2]]
+        data_format_list = ['NHWC']
+
+        combination = [
+            batch_list, strides_list, paddings_list, groups_list,
+            padding_altorithm_list, dilations_list, data_format_list
+        ]
+        for batch, strides, paddings, groups, padding_algorithm, dilations, data_format in itertools.product(
+                *combination):
+            dics = [{
+                "data_fromat": data_format,
+                "dilations": dilations,
+                "padding_algorithm": padding_algorithm,
+                "groups": groups,
+                "paddings": paddings,
+                "strides": strides,
+                "data_format": data_format
+            }, {}]
+
+            ops_config = [{
+                "op_type": "conv2d",
+                "op_inputs": {
+                    "Input": ["input_data"],
+                    "Filter": ["conv2d_weight"]
+                },
+                "op_outputs": {
+                    "Output": ["conv_output_data"]
+                },
+                "op_attrs": dics[0]
+            }, {
+                "op_type": "relu",
+                "op_inputs": {
+                    "X": ["conv_output_data"]
+                },
+                "op_outputs": {
+                    "Out": ["output_data"]
+                },
+                "op_attrs": dics[1]
+            }]
+
+            ops = self.generate_op_config(ops_config)
+
+            program_config = ProgramConfig(
+                ops=ops,
+                weights={
+                    "conv2d_weight":
+                    TensorConfig(data_gen=partial(generate_weight1, dics))
+                },
+                inputs={
+                    "input_data": TensorConfig(data_gen=partial(generate_input1,
+                                                                batch, dics))
+                },
+                outputs=["output_data"])
+
+            yield program_config
+
+    def sample_predictor_configs(
+            self, program_config) -> (paddle_infer.Config, List[int], float):
+        def generate_dynamic_shape(attrs):
+            self.dynamic_shape.min_input_shape = {
+                "input_data": [1, 32, 32, 3 * attrs[0]['groups']],
+                "output_data": [1, 32, 32, 24]
+            }
+            self.dynamic_shape.max_input_shape = {
+                "input_data": [4, 64, 64, 3 * attrs[0]['groups']],
+                "output_data": [4, 64, 64, 24]
+            }
+            self.dynamic_shape.opt_input_shape = {
+                "input_data": [1, 64, 64, 3 * attrs[0]['groups']],
+                "output_data": [1, 64, 64, 24]
+            }
+
+        def clear_dynamic_shape():
+            self.dynamic_shape.min_input_shape = {}
+            self.dynamic_shape.max_input_shape = {}
+            self.dynamic_shape.opt_input_shape = {}
+
+        def generate_trt_nodes_num(attrs, dynamic_shape):
+            return 1, 2
+
+        attrs = [
+            program_config.ops[i].attrs
+            for i in range(len(program_config.ops))
+        ]
+
+        # for static_shape
+        clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False), (1e-5, 1e-5)
+        self.trt_param.precision = paddle_infer.PrecisionType.Int8
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False), (1e-5, 1e-5)
+
+        # for dynamic_shape
+        generate_dynamic_shape(attrs)
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(attrs,
+                                                                     True), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True), (1e-5, 1e-5)
+        self.trt_param.precision = paddle_infer.PrecisionType.Int8
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True), (1e-5, 1e-5)
+
+    def test(self):
+        self.run_test()
+
+    # Paddle raw OP fake_channel_wise_dequantize_abs_max dose not support NHWC data format.
+    # GPU (baseline) will lead to an error (incorrect channel size).
+    # Paddle-TRT will convert IR pattern quant->conv2d->dequant to conv2d (with attr InScale), so it can work.
+    # Hence, we only test whether Paddle-TRT can successfully work or not.
+    def test_quant(self):
+        status = True
+        np.random.seed(int(time.strftime("%W")))
+        run_flags = []
+        for prog_config in self.sample_program_configs():
+            # In CI, only run 30% cases
+            if np.random.rand() < self.num_percent_cases:
+                run_flags.append(True)
+            else:
+                run_flags.append(False)
+        np.random.seed(1024)
+        for prog_config, run_flags in zip(self.sample_program_configs(),
+                                          run_flags):
+            if not run_flags:
+                continue
+
+            # if program is invalid, we should skip that cases.
+            if not self.is_program_valid(prog_config):
+                continue
+            model, params = create_fake_model(prog_config)
+            model, params = create_quant_model(model, params)
+            feed_data = {}
+            for name, tensor_config in prog_config.inputs.items():
+                feed_data[name] = {
+                    'data': tensor_config.data,
+                    'lod': tensor_config.lod
+                }
+            for pred_config, nodes_num, threshold in self.sample_predictor_configs(
+                    prog_config):
+                if os.path.exists(self.trt_cache_dir):
+                    shutil.rmtree(self.trt_cache_dir)
+
+                if pred_config.tensorrt_precision_mode(
+                ) != paddle_infer.PrecisionType.Int8:
+                    continue
+
+                try:
+                    pred_config_deserialize = paddle_infer.Config(pred_config)
+                    self.run_test_config(model, params, prog_config,
+                                         pred_config, feed_data)
+                    self.assert_op_size(nodes_num[0], nodes_num[1])
+                    # deserialize test
+                    if nodes_num[0] > 0:
+                        self.run_test_config(model, params, prog_config,
+                                             pred_config_deserialize, feed_data)
+                except Exception as e:
+                    self.fail_log(
+                        str(prog_config) + ' vs ' + self.inference_config_str(
+                            pred_config) +
+                        '\033[1;31m \nERROR INFO: {}\033[0m'.format(str(e)))
+                    status = False
+                    continue
+                self.success_log('RUN ' + str(prog_config) + ' with ' +
+                                 self.inference_config_str(pred_config))
+
+        self.assertTrue(status)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_nhwc_convert.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_nhwc_convert.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import shutil
+import six
+import paddle
+import numpy as np
+import paddle.nn as nn
+import paddle.fluid as fluid
+import paddle.static as static
+import paddle.inference as inference
+from paddle.fluid import global_scope
+from paddle.fluid.core import AnalysisConfig
+
+paddle.enable_static()
+
+
+class SimpleNet(nn.Layer):
+    def __init__(self):
+        super(SimpleNet, self).__init__()
+        self.conv1 = nn.Conv2D(
+            in_channels=4,
+            out_channels=4,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+            data_format='NHWC')
+        self.relu1 = nn.ReLU()
+        self.conv2 = nn.Conv2D(
+            in_channels=4,
+            out_channels=2,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+            data_format='NHWC')
+        self.relu2 = nn.ReLU()
+        self.conv3 = nn.Conv2D(
+            in_channels=2,
+            out_channels=1,
+            kernel_size=3,
+            stride=2,
+            padding=0,
+            data_format='NHWC')
+        self.relu3 = nn.ReLU()
+        self.flatten = nn.Flatten()
+        self.fc = nn.Linear(729, 10)
+        self.softmax = nn.Softmax()
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.relu1(x)
+        x = self.conv2(x)
+        x = self.relu2(x)
+        x = self.conv3(x)
+        x = self.relu3(x)
+        x = self.flatten(x)
+        x = self.fc(x)
+        x = self.softmax(x)
+        return x
+
+
+class TRTNHWCConvertTest(unittest.TestCase):
+    def setUp(self):
+        self.place = paddle.CUDAPlace(0)
+        self.path = './inference_pass/nhwc_convert/infer_model'
+
+    def create_model(self):
+        image = static.data(
+            name='img', shape=[None, 224, 224, 4], dtype='float32')
+        label = static.data(name='label', shape=[None, 1], dtype='float32')
+        predict = SimpleNet()(image)
+        loss = paddle.nn.functional.cross_entropy(predict, label)
+        avg_loss = paddle.tensor.stat.mean(loss)
+        exe = paddle.static.Executor(self.place)
+        exe.run(paddle.static.default_startup_program())
+        paddle.static.save_inference_model(self.path, [image], [predict], exe)
+
+    def create_predictor(self):
+        config = paddle.inference.Config(self.path + '.pdmodel',
+                                         self.path + '.pdiparams')
+        config.enable_memory_optim()
+        config.enable_use_gpu(100, 0)
+        config.enable_tensorrt_engine(
+            workspace_size=1 << 30,
+            max_batch_size=1,
+            min_subgraph_size=3,
+            precision_mode=inference.PrecisionType.Float32,
+            use_static=False,
+            use_calib_mode=False)
+        predictor = inference.create_predictor(config)
+        return predictor
+
+    def infer(self, predictor, img):
+        input_names = predictor.get_input_names()
+        for i, name in enumerate(input_names):
+            input_tensor = predictor.get_input_handle(name)
+            input_tensor.reshape(img[i].shape)
+            input_tensor.copy_from_cpu(img[i].copy())
+        predictor.run()
+        results = []
+        output_names = predictor.get_output_names()
+        for i, name in enumerate(output_names):
+            output_tensor = predictor.get_output_handle(name)
+            output_data = output_tensor.copy_to_cpu()
+            results.append(output_data)
+        return results
+
+    def test_nhwc_convert(self):
+        self.create_model()
+        predictor = self.create_predictor()
+        img = np.ones((1, 224, 224, 4), dtype=np.float32)
+        result = self.infer(predictor, img=[img])
+
+    def tearDown(self):
+        shutil.rmtree('./inference_pass/nhwc_convert/')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Make Paddle-TRT support NHWC model
1. Add function `IsSubgraphNHWCConvert` to validate a TRT subgraph is NHWC data format
2. Add function `NHWCUpdateBeforeConvert` to add shuffle layer to the input and rename input/output variable name
3. Add function `NHWCUpdateAfterConvert` to add shuffle layer to the output
4. Add UT `test_trt_nhwc_convert.py` to check nhwc converter works correctly
5. Modify prelu op to make alpha transposed if data format is NHWC
6. Add UT `test_trt_convert_conv2d_nhwc.py` to check the functionality and output correctness of nhwc conv2d