### PR TITLE
[Phi]fix split error when sections has 0 size and add test case

### DIFF
--- a/paddle/fluid/operators/strided_memcpy.h
+++ b/paddle/fluid/operators/strided_memcpy.h
@@ -134,7 +134,7 @@ inline void StridedMemcpyWithAxis0(
   for (size_t i = 0; i < outputs->size(); ++i) {
     auto out_stride = stride_numel(shape_refer[i]->dims());
     auto out = outputs->at(i);
-    if (out != nullptr) {
+    if (out != nullptr && out->initialized()) {
       StridedNumelCopyWithAxis<T>(dev_ctx, axis, out->data<T>(), out_stride,
                                   input.data<T>() + input_offset, in_stride,
                                   out_stride[axis]);

--- a/python/paddle/fluid/tests/unittests/test_split_op.py
+++ b/python/paddle/fluid/tests/unittests/test_split_op.py
@@ -458,6 +458,20 @@ class API_TestDygraphSplit(unittest.TestCase):
         self.assertTrue(np.allclose(ex_x1, x1_out))
         self.assertTrue(np.allclose(ex_x2, x2_out))
 
+    def test_axis_input_empty_section(self):
+        with fluid.dygraph.guard():
+            input_1 = np.random.random([4, 6, 6]).astype("int32")
+            # input is a variable which shape is [4, 6, 6]
+            input = paddle.to_tensor(input1)
+            x0, x1, x2 = paddle.split(input, num_or_sections=[2, 0, 2])
+            x0_out = x0.numpy()
+            x1_out = x1.numpy()
+            x2_out = x2.numpy()
+            ex_x0, ex_x1, ex_x2 = np.split(input_1, [2, 0, 2])
+        self.assertTrue(np.allclose(ex_x0, x0_out))
+        self.assertTrue(np.allclose(ex_x1, x1_out))
+        self.assertTrue(np.allclose(ex_x2, x2_out))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_split_op.py
+++ b/python/paddle/fluid/tests/unittests/test_split_op.py
@@ -458,16 +458,21 @@ class API_TestDygraphSplit(unittest.TestCase):
         self.assertTrue(np.allclose(ex_x1, x1_out))
         self.assertTrue(np.allclose(ex_x2, x2_out))
 
+
+class API_TestEmptySplit(unittest.TestCase):
     def test_axis_input_empty_section(self):
         with fluid.dygraph.guard():
-            input_1 = np.random.random([4, 6, 6]).astype("int32")
-            # input is a variable which shape is [4, 6, 6]
-            input = paddle.to_tensor(input1)
-            x0, x1, x2 = paddle.split(input, num_or_sections=[2, 0, 2])
+            input_1 = np.random.random([8, 6, 6]).astype("float32")
+            # input is a variable which shape is [8, 6, 6]
+            input = paddle.to_tensor(input_1)
+            x0, x1, x2 = paddle.split(input, num_or_sections=[5, 0, 3])
             x0_out = x0.numpy()
             x1_out = x1.numpy()
             x2_out = x2.numpy()
-            ex_x0, ex_x1, ex_x2 = np.split(input_1, [2, 0, 2])
+            ex_x0, ex_x1, ex_x2 = np.split(input_1, [
+                5,
+                5,
+            ])
         self.assertTrue(np.allclose(ex_x0, x0_out))
         self.assertTrue(np.allclose(ex_x1, x1_out))
         self.assertTrue(np.allclose(ex_x2, x2_out))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->


修复split kernel 在sections 存在为0的size 情况下，段错误的问题，并添加单测。
测试例子：
```
import paddle
x = paddle.to_tensor([13, 12, 9, 5, 2, 11, 10, 8, 3, 18, 15, 8, 11])
y = [5, 4, 0, 4]
z = paddle.split(x, y)
```

报错如下：
![image](https://user-images.githubusercontent.com/13469016/162935808-f34af8e0-5afd-4b8a-8d72-cefd33e9b02a.png)

修复后：
<img width="733" alt="image" src="https://user-images.githubusercontent.com/13469016/162935912-9d487033-e1e6-4060-b53f-68654bc00cd5.png">

