### PR TITLE
[Cherry-pick, Eager] Fix test_imperative_optimizer_v2 eager mode global issue (#41…

### DIFF
--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -1360,6 +1360,8 @@ class ReduceOnPlateau(LRScheduler):
         if not _in_legacy_dygraph():
             tmp = core.eager.Tensor
         else:
+            # need to declarate explicitly
+            from paddle.framework import VarBase as Tensor
             tmp = Tensor
         # loss must be float, numpy.ndarray or 1-D Tensor with shape [1]
         if isinstance(metrics, (tmp, numpy.ndarray)):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
由于 python/paddle/__init__.py 里面的 如下逻辑只会执行一次
![image](https://user-images.githubusercontent.com/87417304/162682984-f4c47feb-79a5-4b4d-8b0b-8ef255ea4ae9.png)

如果 framework 中开启全局 eager，
那么如果单测存在 with _test_eager_mode(): ，执行最后是会 enable_legacy_dygraph 的(即切换了老动态图)。但是 from paddle import Tensor 引入的 Tensor 依然是 core.eager.Tensor，那么一些单测就会出现问题（老动态图不使用 core.eager.Tensor）。
需要如下显式声明
![image](https://user-images.githubusercontent.com/87417304/162683309-c628e043-720f-41c5-a61c-216288558b1e.png)


