### PR TITLE
Optimize the finding of max workspace size.

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -276,11 +276,12 @@ struct SearchAlgorithm<cudnnConvolutionFwdAlgoPerf_t> {
                 args.handle, args.idesc.desc(), args.wdesc.desc(),
                 args.cdesc.desc(), args.odesc.desc(),
                 static_cast<cudnnConvolutionFwdAlgo_t>(algo), &workspace_size);
-        if (status == CUDNN_STATUS_SUCCESS) {
+        if (status == CUDNN_STATUS_SUCCESS &&
+            workspace_size <= workspace_size_limit) {
           max_workspace_size = std::max(workspace_size, max_workspace_size);
         }
       }
-      return std::min(max_workspace_size, workspace_size_limit);
+      return max_workspace_size;
     } else {
       return workspace_size_limit;
     }
@@ -425,11 +426,12 @@ struct SearchAlgorithm<cudnnConvolutionBwdDataAlgoPerf_t> {
                 args.cdesc.desc(), args.idesc.desc(),
                 static_cast<cudnnConvolutionBwdDataAlgo_t>(algo),
                 &workspace_size);
-        if (status == CUDNN_STATUS_SUCCESS) {
+        if (status == CUDNN_STATUS_SUCCESS &&
+            workspace_size <= workspace_size_limit) {
           max_workspace_size = std::max(workspace_size, max_workspace_size);
         }
       }
-      return std::min(max_workspace_size, workspace_size_limit);
+      return max_workspace_size;
     } else {
       return workspace_size_limit;
     }
@@ -588,11 +590,12 @@ struct SearchAlgorithm<cudnnConvolutionBwdFilterAlgoPerf_t> {
                 args.cdesc.desc(), args.wdesc.desc(),
                 static_cast<cudnnConvolutionBwdFilterAlgo_t>(algo),
                 &workspace_size);
-        if (status == CUDNN_STATUS_SUCCESS) {
+        if (status == CUDNN_STATUS_SUCCESS &&
+            workspace_size <= workspace_size_limit) {
           max_workspace_size = std::max(workspace_size, max_workspace_size);
         }
       }
-      return std::min(max_workspace_size, workspace_size_limit);
+      return max_workspace_size;
     } else {
       return workspace_size_limit;
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
优化Conv中，最大workspace_size的设置逻辑。当所有算法所需最大workspace_size > workspace_size_limit，选择使用次大的算法实际所需的workspace_size，而不是直接使用workspace_size_limit。