### PR TITLE
[XPUPS]modify xpu_kp.cmake with HETERPS&PSLIB

### DIFF
--- a/cmake/xpu_kp.cmake
+++ b/cmake/xpu_kp.cmake
@@ -122,11 +122,11 @@ macro(compile_kernel COMPILE_ARGS)
   string(REPLACE ";" " " XPU_CXX_DEFINES "${XPU_CXX_DEFINES}" )
   separate_arguments(XPU_CXX_DEFINES UNIX_COMMAND "${XPU_CXX_DEFINES}")
 
-  set(ABI_VERSION, "")
+  set(ABI_VERSION "")
   if(WITH_HETERPS AND WITH_PSLIB)
-    set(ABI_VERSION, "-D_GLIBCXX_USE_CXX11_ABI=0")
+    set(ABI_VERSION "-D_GLIBCXX_USE_CXX11_ABI=0")
   else()
-    set(ABI_VERSION, "-D_GLIBCXX_USE_CXX11_ABI=1")
+    set(ABI_VERSION "-D_GLIBCXX_USE_CXX11_ABI=1")
   endif()
   add_custom_command(
     OUTPUT

--- a/cmake/xpu_kp.cmake
+++ b/cmake/xpu_kp.cmake
@@ -162,7 +162,7 @@ macro(compile_kernel COMPILE_ARGS)
     COMMAND
     ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 ${ABI_VERSION} ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
         -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu
-        --xpu-host-only -c -v
+        --xpu-host-only -c -v 
     WORKING_DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS

--- a/cmake/xpu_kp.cmake
+++ b/cmake/xpu_kp.cmake
@@ -130,9 +130,15 @@ macro(compile_kernel COMPILE_ARGS)
     COMMAND
 	  ${CMAKE_COMMAND} -E copy ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu
     COMMAND
-    ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS}  ${XPU_CXX_INCLUDES} 
-       -I.  -o kernel_build/${kernel_name}.bin.o.sec kernel_build/${kernel_name}.xpu
-        --xpu-device-only -c -v 
+    if(WITH_HETERPS AND WITH_PSLIB)
+      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS}  ${XPU_CXX_INCLUDES} 
+         -I.  -o kernel_build/${kernel_name}.bin.o.sec kernel_build/${kernel_name}.xpu
+          --xpu-device-only -c -v 
+    else()
+      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS}  ${XPU_CXX_INCLUDES} 
+         -I.  -o kernel_build/${kernel_name}.bin.o.sec kernel_build/${kernel_name}.xpu
+          --xpu-device-only -c -v 
+    endif()
     COMMAND
       ${XTDK_DIR}/bin/xpu2-elfconv kernel_build/${kernel_name}.bin.o.sec  kernel_build/${kernel_name}.bin.o ${XPU_CLANG} --sysroot=${CXX_DIR}
     WORKING_DIRECTORY
@@ -153,9 +159,15 @@ macro(compile_kernel COMPILE_ARGS)
     COMMAND
 	  ${CMAKE_COMMAND} -E copy ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu
     COMMAND
-    ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
-        -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu
-        --xpu-host-only -c -v 
+    if(WITH_HETERPS AND WITH_PSLIB)
+      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
+          -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu
+          --xpu-host-only -c -v
+    else()
+      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
+          -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu
+          --xpu-host-only -c -v
+    endif()
     WORKING_DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS

--- a/cmake/xpu_kp.cmake
+++ b/cmake/xpu_kp.cmake
@@ -122,6 +122,13 @@ macro(compile_kernel COMPILE_ARGS)
   string(REPLACE ";" " " XPU_CXX_DEFINES "${XPU_CXX_DEFINES}" )
   separate_arguments(XPU_CXX_DEFINES UNIX_COMMAND "${XPU_CXX_DEFINES}")
 
+
+  set(ABI_VERSION, "")
+  if(WITH_HETERPS AND WITH_PSLIB)
+    set(ABI_VERSION, "-D_GLIBCXX_USE_CXX11_ABI=0")
+  else()
+    set(ABI_VERSION, "-D_GLIBCXX_USE_CXX11_ABI=1")
+  endif()
   add_custom_command(
     OUTPUT
       kernel_build/${kernel_name}.bin.o
@@ -130,15 +137,9 @@ macro(compile_kernel COMPILE_ARGS)
     COMMAND
 	  ${CMAKE_COMMAND} -E copy ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu
     COMMAND
-    if(WITH_HETERPS AND WITH_PSLIB)
-      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS}  ${XPU_CXX_INCLUDES} 
-         -I.  -o kernel_build/${kernel_name}.bin.o.sec kernel_build/${kernel_name}.xpu
-          --xpu-device-only -c -v 
-    else()
-      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS}  ${XPU_CXX_INCLUDES} 
-         -I.  -o kernel_build/${kernel_name}.bin.o.sec kernel_build/${kernel_name}.xpu
-          --xpu-device-only -c -v 
-    endif()
+    ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 ${ABI_VERSION} ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS}  ${XPU_CXX_INCLUDES} 
+       -I.  -o kernel_build/${kernel_name}.bin.o.sec kernel_build/${kernel_name}.xpu
+        --xpu-device-only -c -v 
     COMMAND
       ${XTDK_DIR}/bin/xpu2-elfconv kernel_build/${kernel_name}.bin.o.sec  kernel_build/${kernel_name}.bin.o ${XPU_CLANG} --sysroot=${CXX_DIR}
     WORKING_DIRECTORY
@@ -159,15 +160,9 @@ macro(compile_kernel COMPILE_ARGS)
     COMMAND
 	  ${CMAKE_COMMAND} -E copy ${kernel_path}/${kernel_name}.kps kernel_build/${kernel_name}.xpu
     COMMAND
-    if(WITH_HETERPS AND WITH_PSLIB)
-      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
-          -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu
-          --xpu-host-only -c -v
-    else()
-      ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1 ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
-          -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu
-          --xpu-host-only -c -v
-    endif()
+    ${XPU_CLANG} --sysroot=${CXX_DIR}  -std=c++11 ${ABI_VERSION} ${OPT_LEVEL} -fno-builtin -mcpu=xpu2  -fPIC ${XPU_CXX_DEFINES}  ${XPU_CXX_FLAGS} ${XPU_CXX_INCLUDES} 
+        -I.  -o kernel_build/${kernel_name}.host.o kernel_build/${kernel_name}.xpu
+        --xpu-host-only -c -v
     WORKING_DIRECTORY
       ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS

--- a/cmake/xpu_kp.cmake
+++ b/cmake/xpu_kp.cmake
@@ -122,7 +122,6 @@ macro(compile_kernel COMPILE_ARGS)
   string(REPLACE ";" " " XPU_CXX_DEFINES "${XPU_CXX_DEFINES}" )
   separate_arguments(XPU_CXX_DEFINES UNIX_COMMAND "${XPU_CXX_DEFINES}")
 
-
   set(ABI_VERSION, "")
   if(WITH_HETERPS AND WITH_PSLIB)
     set(ABI_VERSION, "-D_GLIBCXX_USE_CXX11_ABI=0")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
this pr modify ABI version to keep consistent with Paddle main framework when HETERPS=ON&PSLIB=ON