### PR TITLE
split softmax gpu

### DIFF
--- a/paddle/fluid/operators/assign_pos_op.cu
+++ b/paddle/fluid/operators/assign_pos_op.cu
@@ -10,7 +10,11 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License. */
+limitations under the License.
+
+Referenced docs:
+    https://github.com/laekov/fastmoe/blob/master/cuda/local_exchange.cu
+*/
 
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/assign_pos_op.h"

--- a/paddle/fluid/operators/limit_by_capacity_op.cu
+++ b/paddle/fluid/operators/limit_by_capacity_op.cu
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// referenced docs:
+//    https://github.com/laekov/fastmoe/blob/master/cuda/balancing.cu
+
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/limit_by_capacity_op.h"
 #include "paddle/fluid/platform/device/gpu/gpu_primitives.h"

--- a/paddle/fluid/operators/number_count_op.cu
+++ b/paddle/fluid/operators/number_count_op.cu
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Referenced docs:
+//    https://github.com/laekov/fastmoe/blob/master/cuda/local_exchange.cu
+
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/number_count_op.h"
 #include "paddle/fluid/platform/device/gpu/gpu_primitives.h"

--- a/paddle/fluid/operators/prune_gate_by_capacity_op.cu
+++ b/paddle/fluid/operators/prune_gate_by_capacity_op.cu
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// referenced docs:
+//    https://github.com/laekov/fastmoe/blob/master/cuda/balancing.cu
+
 #include "paddle/fluid/operators/prune_gate_by_capacity_op.h"
 #include "paddle/fluid/platform/device/gpu/gpu_primitives.h"
 

--- a/python/paddle/incubate/distributed/models/moe/gate/base_gate.py
+++ b/python/paddle/incubate/distributed/models/moe/gate/base_gate.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#referenced docs:
+#   https://github.com/laekov/fastmoe/blob/master/fmoe/gates/base_gate.py
+
 import paddle.nn as nn
 
 

--- a/python/paddle/incubate/distributed/models/moe/gate/gshard_gate.py
+++ b/python/paddle/incubate/distributed/models/moe/gate/gshard_gate.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# referenced docs:
+#   https://github.com/laekov/fastmoe/blob/master/fmoe/gates/gshard_gate.py
+
 import math
 import paddle
 import paddle.nn.functional as F

--- a/python/paddle/incubate/distributed/models/moe/gate/naive_gate.py
+++ b/python/paddle/incubate/distributed/models/moe/gate/naive_gate.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# referenced docs:
+#   https://github.com/laekov/fastmoe/blob/master/fmoe/gates/naive_gate.py
+
 from .base_gate import BaseGate
 
 import paddle

--- a/python/paddle/incubate/distributed/models/moe/gate/switch_gate.py
+++ b/python/paddle/incubate/distributed/models/moe/gate/switch_gate.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# referenced docs:
+#   https://github.com/laekov/fastmoe/blob/master/fmoe/gates/switch_gate.py
+
 import math
 import paddle
 import paddle.nn as nn

--- a/python/paddle/incubate/distributed/models/moe/grad_clip.py
+++ b/python/paddle/incubate/distributed/models/moe/grad_clip.py
@@ -55,6 +55,10 @@ class ClipGradForMOEByGlobalNorm(ClipGradBase):
         ``need_clip`` of ``ClipGradyGlobalNorm`` HAS BEEN DEPRECATED since 2.0. 
         Please use ``need_clip`` in ``ParamAttr`` to speficiy the clip scope.
 
+    Reference:
+        https://github.com/laekov/fastmoe/blob/master/examples/megatron/clip-grad-v2.2.patch
+
+
     Args:
         clip_norm (float): The maximum norm value.
         is_expert_param_func (function): a function to decide whether a param should be put into moe_params_grads

--- a/python/paddle/incubate/distributed/models/moe/moe_layer.py
+++ b/python/paddle/incubate/distributed/models/moe/moe_layer.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# referenced docs:
+#   https://github.com/laekov/fastmoe/blob/master/fmoe/functions.py
+
 import collections
 import math
 

--- a/python/paddle/incubate/distributed/models/moe/utils.py
+++ b/python/paddle/incubate/distributed/models/moe/utils.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# referenced docs:
+#   https://github.com/laekov/fastmoe/blob/master/fmoe/functions.py
 from paddle.distributed.models.moe.utils import _number_count, _limit_by_capacity, _prune_gate_by_capacity, _assign_pos
 import paddle
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
support splitting softmax_with_cross_entropy batch according axis 0
splitting in forward pass:
export FLAGS_softmax_with_cross_entropy_mini_batch_size=512
splitting in backward pass:
export FLAGS_softmax_with_cross_grad_entropy_mini_batch_size=512

when either FLAGS_softmax_with_cross_entropy(_grad)_mini_batch_size is set 0 or no such a variable is setting，we won't splitting the batch in softmax_with_cross_entropy.
when this variable is larger than 0，we will seperate the whole batch into a few small batches
