### PR TITLE
fix divide zero error when cpu only

### DIFF
--- a/python/paddle/profiler/profiler_statistic.py
+++ b/python/paddle/profiler/profiler_statistic.py
@@ -869,7 +869,7 @@ def _build_table(statistic_data,
             '{} / - / - / - / {}'.format(
                 format_time(
                     other_gpu_time, unit=time_unit),
-                format_ratio(float(other_gpu_time) / gpu_total_time))
+                format_ratio(float(other_gpu_time) / total_time))
         ]
         all_row_values.append(row_values)
         # Calculate the column width


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. 修复Profiler在仅开启CPU的情况下发生除0错误。