### PR TITLE
Optimize perf of reduce by changing reduce mode

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -473,7 +473,7 @@ struct ReduceConfig {
     } else if (reduce_rank == 1) {
       reduce_type = static_cast<int>(ReduceType::kReduceHigherDim);
       if ((rank == 3 && not_higher) ||
-          reduce_dim[0] >= max_reduce_num_for_higher) {
+          x_dim[reduce_dim[0]] >= max_reduce_num_for_higher) {
         reduce_type = static_cast<int>(ReduceType::kReduceAny);
       }
     } else {

--- a/paddle/phi/kernels/funcs/reduce_function.h
+++ b/paddle/phi/kernels/funcs/reduce_function.h
@@ -466,12 +466,14 @@ struct ReduceConfig {
     int device_id = paddle::platform::GetCurrentDeviceId();
     int max_grid_z = phi::backends::gpu::GetGpuMaxGridDimSize(device_id)[2];
     bool not_higher = x_dim[0] >= max_grid_z;
+    constexpr int max_reduce_num_for_higher = 2048;
 #endif
     if (reduce_last_dim && (reduce_rank == 1)) {
       reduce_type = static_cast<int>(ReduceType::kReduceLastDim);
     } else if (reduce_rank == 1) {
       reduce_type = static_cast<int>(ReduceType::kReduceHigherDim);
-      if (rank == 3 && not_higher) {
+      if ((rank == 3 && not_higher) ||
+          reduce_dim[0] >= max_reduce_num_for_higher) {
         reduce_type = static_cast<int>(ReduceType::kReduceAny);
       }
     } else {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Optimize perf of reduce by changing reduce mode
 For config[10201, 50], axis=0, the gpu time from **380+us** to **30+us**, speedup is **10x**.