### PR TITLE
[Eager]Remove is_initialized() interface in experimental::Tensor

### DIFF
--- a/paddle/fluid/distributed/collective/reducer.cc
+++ b/paddle/fluid/distributed/collective/reducer.cc
@@ -398,7 +398,7 @@ void EagerReducer::InitializeDenseGroups(
                           "GRAD is SelectedRows",
                           tensor_name));
 
-    PADDLE_ENFORCE_EQ(tensor.is_initialized(), true,
+    PADDLE_ENFORCE_EQ(tensor.initialized(), true,
                       platform::errors::PreconditionNotMet(
                           "Tensor %s is not initialized.", tensor_name));
     const auto size = tensor.numel();
@@ -710,7 +710,7 @@ void EagerReducer::MarkGroupReady(size_t group_index) {
 
 bool EagerReducer::HasGrad(size_t var_index) {
   auto grad = egr::EagerUtils::mutable_grad(tensors_[var_index]);
-  if (grad && grad->is_initialized()) {
+  if (grad && grad->initialized()) {
     return true;
   } else {
     return false;

--- a/paddle/fluid/eager/grad_node_info.cc
+++ b/paddle/fluid/eager/grad_node_info.cc
@@ -125,7 +125,7 @@ void GradNodeBase::SetGradInMeta(const paddle::experimental::Tensor& fwd_out,
   auto& meta = metas[0];
   meta.SetStopGradient(fwd_out_meta->StopGradient());
 
-  if (!fwd_out.is_initialized()) {
+  if (!fwd_out.initialized()) {
     VLOG(6)
         << "Skip Configuring GradSlotMeta for uninitialized GradInput Tensor";
     return;
@@ -192,7 +192,7 @@ void GradNodeBase::SetGradInMeta(
       meta.SetStopGradient(fwd_out_meta->StopGradient());
     }
 
-    if (!fwd_out_tensor.is_initialized()) {
+    if (!fwd_out_tensor.initialized()) {
       VLOG(6)
           << "Skip Configuring GradSlotMeta for uninitialized GradInput Tensor";
       return;

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -114,7 +114,7 @@ static void ShareTensorsIntoScope(const std::vector<Tensor> &tensors,
                                   paddle::framework::Scope *scope) {
   for (size_t i = 0; i < tensors.size(); ++i) {
     auto name = tensors[i].name();
-    if (name == "Fake_var" || !tensors[i].is_initialized()) {
+    if (name == "Fake_var" || !tensors[i].initialized()) {
       continue;
     }
     auto *var = scope->Var(name);

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -446,7 +446,7 @@ void EagerUtils::FillZeroForEmptyGradInputs(
   for (size_t i = 0; i < in_grads->size(); i++) {
     for (size_t j = 0; j < (*in_grads)[i].size(); j++) {
       paddle::experimental::Tensor& grad = (*in_grads)[i][j];
-      if (!grad.is_initialized()) {
+      if (!grad.initialized()) {
         const GradSlotMeta& grad_in_meta = grad_in_metas[i][j];
         PADDLE_ENFORCE(
             grad_in_meta.HasTensorMeta(),

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -617,7 +617,7 @@ static PyObject* tensor__getitem_index_not_tensor(TensorObject* self,
   // if index is a list, list_select_flag will be true
   bool list_select_flag = false;
   PADDLE_ENFORCE_EQ(
-      self->tensor.is_initialized(), true,
+      self->tensor.initialized(), true,
       platform::errors::InvalidArgument(
           "tensor %s has not been initialized, we can only slice initialized "
           "tensor please init it first with numpy or other tensor.",
@@ -1146,7 +1146,7 @@ static PyObject* tensor__copy_gradient_from(TensorObject* self, PyObject* args,
                                             PyObject* kwargs) {
   EAGER_TRY
   auto src = CastPyArg2Tensor(PyTuple_GET_ITEM(args, 0), 0);
-  if (self->tensor.is_initialized()) {
+  if (self->tensor.initialized()) {
     PADDLE_ENFORCE_EQ(self->tensor.dtype(), src.dtype(),
                       platform::errors::PreconditionNotMet(
                           "Tensor %s has different data type with Tensor %s",

--- a/paddle/phi/api/include/tensor.h
+++ b/paddle/phi/api/include/tensor.h
@@ -461,15 +461,6 @@ class PADDLE_API Tensor final {
   bool initialized() const;
 
   /**
-   * @brief Determine whether Tensor is initialized.
-   * This is a deprecated method and may be removed in the future!
-   *
-   * @return true
-   * @return false
-   */
-  bool is_initialized() const;
-
-  /**
    * @brief Reset the Tensor implementation
    */
   void reset();

--- a/paddle/phi/api/lib/tensor.cc
+++ b/paddle/phi/api/lib/tensor.cc
@@ -340,13 +340,6 @@ bool Tensor::defined() const { return impl_ != nullptr; }
 
 bool Tensor::initialized() const { return defined() && impl_->initialized(); }
 
-bool Tensor::is_initialized() const {
-  LOG(WARNING) << "The `is_initialized` method is deprecated since version "
-                  "2.3, and will be removed in version 2.4! "
-                  "Please use `initialized` method instead.";
-  return defined() && impl_->initialized();
-}
-
 void Tensor::reset() { impl_.reset(); }
 
 /* Part 6: Operator overloading */

--- a/paddle/phi/api/lib/tensor_method.cc
+++ b/paddle/phi/api/lib/tensor_method.cc
@@ -73,7 +73,7 @@ Tensor::copy_to<phi::dtype::float16>(const Place &target_place) const;
 void Tensor::copy_(const Tensor &src,
                    const phi::Place &target_place,
                    bool blocking) {
-  if (!src.is_initialized()) {
+  if (!src.initialized()) {
     VLOG(8) << "Src is empty, skip copy";
     return;
   }
@@ -81,7 +81,7 @@ void Tensor::copy_(const Tensor &src,
   auto kernel_key_set = ParseKernelKeyByInputArgs(src);
   KernelType kernel_type = ParseKernelTypeByInputArgs(src);
   VLOG(3) << "Deep copy Tensor from " << src.name() << " to " << name();
-  if (is_initialized()) {
+  if (initialized()) {
     PADDLE_ENFORCE_EQ(dtype(),
                       src.dtype(),
                       phi::errors::PreconditionNotMet(

--- a/paddle/phi/tests/api/test_pten_tensor.cc
+++ b/paddle/phi/tests/api/test_pten_tensor.cc
@@ -200,9 +200,9 @@ void GroupTestDtype() {
 
 void TestInitilized() {
   experimental::Tensor test_tensor(paddle::PlaceType::kCPU, {1, 1});
-  CHECK(test_tensor.is_initialized() == true);
+  CHECK(test_tensor.initialized() == true);
   test_tensor.mutable_data<float>(paddle::PlaceType::kCPU);
-  CHECK(test_tensor.is_initialized() == true);
+  CHECK(test_tensor.initialized() == true);
   float* tensor_data = test_tensor.mutable_data<float>();
   for (int i = 0; i < test_tensor.size(); i++) {
     tensor_data[i] = 0.5;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Eager]Remove is_initialized() interface in experimental::Tensor