### PR TITLE
delete PADDLE_WITH_TESTING in memory_block_desc

### DIFF
--- a/paddle/fluid/memory/detail/memory_block_desc.cc
+++ b/paddle/fluid/memory/detail/memory_block_desc.cc
@@ -62,18 +62,12 @@ inline size_t hash(const MemoryBlock::Desc& metadata, size_t initial_seed) {
 }  // namespace
 
 void MemoryBlock::Desc::UpdateGuards() {
-#ifdef PADDLE_WITH_TESTING
   guard_begin = hash(*this, 1);
   guard_end = hash(*this, 2);
-#endif
 }
 
 bool MemoryBlock::Desc::CheckGuards() const {
-#ifdef PADDLE_WITH_TESTING
   return guard_begin == hash(*this, 1) && guard_end == hash(*this, 2);
-#else
-  return true;
-#endif
 }
 
 }  // namespace detail

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -31,6 +31,8 @@ from .framework import disable_signal_handler  # noqa: F401
 from .framework import get_flags  # noqa: F401
 from .framework import set_flags  # noqa: F401
 
+set_flags({'FLAGS_allocator_strategy': 'naive_best_fit'})
+
 from .framework import disable_static  # noqa: F401
 from .framework import enable_static  # noqa: F401
 from .framework import in_dynamic_mode  # noqa: F401

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -31,8 +31,6 @@ from .framework import disable_signal_handler  # noqa: F401
 from .framework import get_flags  # noqa: F401
 from .framework import set_flags  # noqa: F401
 
-set_flags({'FLAGS_allocator_strategy': 'naive_best_fit'})
-
 from .framework import disable_static  # noqa: F401
 from .framework import enable_static  # noqa: F401
 from .framework import in_dynamic_mode  # noqa: F401


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

NV希望WITH_TESTING编译选项打开和关闭时，代码的行为保持一致。
`memory_block_desc`中存在WITH_TESTING选项打开后，代码行为不一致的情况，原因是将hash耗时过程放到了WITH_TESTING中测试，发布包是不包括该hash过程。
这个PR把WITH_TESTING条件删掉了，并测试了约70种配置的动态图模型的性能、21种配置的静态图模型的性能。从性能数据来看，该PR对性能没有明显影响。
