### PR TITLE
[Phi] Adjust the data transform behavior for Tensor with GPUPinned place

### DIFF
--- a/python/paddle/tests/test_async_read_write.py
+++ b/python/paddle/tests/test_async_read_write.py
@@ -96,7 +96,9 @@ class TestAsyncRead(unittest.TestCase):
         with _test_eager_guard():
             self.func_setUp()
             self.func_test_async_read_empty_offset_and_count()
+            self.func_setUp()
             self.func_test_async_read_success()
+            self.func_setUp()
             self.func_test_async_read_only_1dim()
         self.func_setUp()
         self.func_test_async_read_empty_offset_and_count()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
调整了输入Tensor在GPUPinned上时的data transform处理逻辑。

目前的data transform体系下，在GPUPinned的Tensor都会自动transfer到GPU上。如果一个输入Tensor在GPUPinned上且训练前反向都有使用的话，会在前反向分别进行一次data transform，如果传输的数据较多的话，对训练性能会产生明显的影响。

为了解决这里的性能问题，对在GPUPinned的Tensor的data transform行为进行了一些调整：
一个输入Tensor如果需要从GPUPinned拷贝到GPU进行计算时，会将其原先持有的GPUPinned的内存数据替换为新的GPU上的内存数据，即输入Tensor的内存发生了变化。
这种处理方式与data transform的设计理念有所违背，所以算是一个trick，后续如果有更好的方案可能会进行替换。