### PR TITLE
OneDNN md-in-tensor refactoring part 2: Second batch of changes for md-in-tensor

### DIFF
--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -107,8 +107,7 @@ void eltwise_forward(const framework::ExecutionContext &ctx,
       astream, {{DNNL_ARG_FROM, *src_memory_p}, {DNNL_ARG_TO, *dst_memory_p}});
   astream.wait();
 
-  out->set_layout(DataLayout::kMKLDNN);
-  out->set_format(GetMKLDNNFormat(*dst_memory_p));
+  out->set_mem_desc(dst_memory_p->get_desc());
 }
 
 template <typename T>
@@ -136,8 +135,7 @@ void eltwise_grad(const framework::ExecutionContext &ctx,
                                   {DNNL_ARG_DIFF_SRC, *diff_src_memory_p}});
   astream.wait();
 
-  dx->set_layout(DataLayout::kMKLDNN);
-  dx->set_format(GetMKLDNNFormat(*diff_src_memory_p));
+  dx->set_mem_desc(diff_src_memory_p->get_desc());
 }
 
 template <typename T>
@@ -165,8 +163,7 @@ void eltwise_grad_use_out(const framework::ExecutionContext &ctx,
                                   {DNNL_ARG_DIFF_SRC, *diff_src_memory_p}});
   astream.wait();
 
-  dx->set_layout(DataLayout::kMKLDNN);
-  dx->set_format(GetMKLDNNFormat(*diff_src_memory_p));
+  dx->set_mem_desc(diff_src_memory_p->get_desc());
 }
 
 template <typename T, dnnl::algorithm algorithm>
@@ -347,6 +344,7 @@ namespace ops = paddle::operators;
 
 FOR_EACH_MKLDNN_KERNEL_FUNCTOR(REGISTER_ACTIVATION_MKLDNN_KERNEL);
 
+// round eltwise primitive doesn't support BF16, nor does it support grad
 REGISTER_ACTIVATION_MKLDNN_KERNEL_FWD_ONLY(round, RoundMKLDNNFunctor);
 
 namespace ops = paddle::operators;

--- a/paddle/fluid/operators/mkldnn/clip_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/clip_mkldnn_op.cc
@@ -46,8 +46,7 @@ class ClipMKLDNNKernel : public paddle::framework::OpKernel<T> {
                                     {DNNL_ARG_TO, *dst_memory_p}});
     astream.wait();
 
-    out->set_layout(paddle::framework::DataLayout::kMKLDNN);
-    out->set_format(paddle::platform::GetMKLDNNFormat(*dst_memory_p));
+    out->set_mem_desc(dst_memory_p->get_desc());
   }
 };
 
@@ -83,8 +82,7 @@ class ClipGradMKLDNNKernel : public paddle::framework::OpKernel<T> {
                                     {DNNL_ARG_DIFF_SRC, *diff_src_memory_p}});
     astream.wait();
 
-    dx->set_layout(paddle::framework::DataLayout::kMKLDNN);
-    dx->set_format(paddle::platform::GetMKLDNNFormat(*diff_dst_memory_p));
+    dx->set_mem_desc(diff_dst_memory_p->get_desc());
   }
 };
 

--- a/paddle/fluid/operators/mkldnn/gaussian_random_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/gaussian_random_mkldnn_op.cc
@@ -16,7 +16,7 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/generator.h"
 #include "paddle/fluid/operators/fill_constant_op.h"
-#include "paddle/fluid/platform/mkldnn_helper.h"
+#include "paddle/fluid/platform/mkldnn_reuse.h"
 
 namespace paddle {
 namespace operators {
@@ -42,8 +42,13 @@ class GaussianMKLDNNKernel : public paddle::framework::OpKernel<T> {
       data[i] = dist(*engine);
     }
 
-    tensor->set_layout(DataLayout::kMKLDNN);
-    tensor->set_format(platform::GetPlainMKLDNNFormat(tensor->dims().size()));
+    dnnl::memory::desc out_mem_desc(
+        phi::vectorize(tensor->dims()),
+        framework::ToMKLDNNDataType(
+            framework::TransToProtoVarType(tensor->dtype())),
+        platform::GetPlainMKLDNNFormat(tensor->dims().size()));
+
+    tensor->set_mem_desc(out_mem_desc);
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/interpolate_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/interpolate_mkldnn_op.cc
@@ -34,17 +34,14 @@ class InterpolateMKLDNNHandler
  public:
   InterpolateMKLDNNHandler(const dnnl::algorithm algo,
                            const dnnl::engine engine, platform::Place cpu_place,
-                           const Tensor* x, Tensor* z)
+                           const Tensor* x, Tensor* out)
       : platform::MKLDNNHandlerNoCachingT<T, dnnl::resampling_forward>(
             engine, cpu_place) {
-    const auto src_x_tz = phi::vectorize(x->dims());
-    const auto dst_tz = phi::vectorize(z->dims());
-    const auto src_md = dnnl::memory::desc(
-        src_x_tz, platform::MKLDNNGetDataType<T>(), x->format());
+    const auto dst_tz = phi::vectorize(out->dims());
     const auto dst_md = memory::desc(dst_tz, platform::MKLDNNGetDataType<T>(),
                                      MKLDNNMemoryFormat::any);
     this->AcquireForwardPrimitiveDescriptor(dnnl::prop_kind::forward_inference,
-                                            algo, src_md, dst_md);
+                                            algo, x->mem_desc(), dst_md);
   }
 };
 
@@ -133,7 +130,7 @@ class InterpolateMKLDNNKernel : public framework::OpKernel<T> {
     const auto& mkldnn_engine = dev_ctx.GetEngine();
 
     const auto* x = ctx.Input<Tensor>("X");
-    auto* z = ctx.Output<Tensor>("Out");
+    auto* out = ctx.Output<Tensor>("Out");
 
     const auto interp_method = ctx.Attr<std::string>("interp_method");
     const dnnl::algorithm algo = (interp_method == "nearest")
@@ -142,13 +139,13 @@ class InterpolateMKLDNNKernel : public framework::OpKernel<T> {
 
     const auto out_dims_vec = ComputeOutputShape(ctx);
     framework::DDim dim_out = phi::make_ddim(out_dims_vec);
-    z->Resize(dim_out);
+    out->Resize(dim_out);
 
     InterpolateMKLDNNHandler<T> handler(algo, mkldnn_engine, ctx.GetPlace(), x,
-                                        z);
+                                        out);
 
     auto src_memory_p = handler.AcquireSrcMemory(x);
-    auto dst_memory_p = handler.AcquireDstMemory(z);
+    auto dst_memory_p = handler.AcquireDstMemory(out);
 
     auto resampling_prim = handler.AcquireForwardPrimitive();
     const std::unordered_map<int, dnnl::memory> args = {
@@ -158,8 +155,7 @@ class InterpolateMKLDNNKernel : public framework::OpKernel<T> {
     resampling_prim->execute(astream, args);
     astream.wait();
 
-    z->set_layout(DataLayout::kMKLDNN);
-    z->set_format(platform::GetMKLDNNFormat(*dst_memory_p));
+    out->set_mem_desc(dst_memory_p->get_desc());
   }
 };
 

--- a/paddle/fluid/operators/mkldnn/layer_norm_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/layer_norm_mkldnn_op.cc
@@ -25,22 +25,21 @@ class LayerNormMKLDNNHandler : public platform::MKLDNNHandlerNoCachingT<
  public:
   LayerNormMKLDNNHandler(const std::vector<int64_t>& dims, const float& epsilon,
                          const dnnl::normalization_flags& flags,
-                         const bool& is_test, const MKLDNNMemoryFormat fmt,
+                         const bool& is_test, const Tensor* x,
                          const dnnl::engine engine, platform::Place cpu_place)
       : platform::MKLDNNHandlerNoCachingT<T, dnnl::layer_normalization_forward>(
             engine, cpu_place) {
-    auto md = dnnl::memory::desc(dims, platform::MKLDNNGetDataType<T>(), fmt);
     if (!is_test) {
       // TODO(grygielski) Delete forcing stats_md after DNNL 1.2 is introduced
       auto stats_md = dnnl::memory::desc(
           {begin(dims), end(dims) - 1}, platform::MKLDNNGetDataType<float>(),
-          platform::MKLDNNFormatForSize(dims.size() - 1,
-                                        MKLDNNMemoryFormat::nchw));
+          platform::GetPlainMKLDNNFormat(dims.size() - 1));
       this->AcquireForwardPrimitiveDescriptor(dnnl::prop_kind::forward_training,
-                                              md, stats_md, epsilon, flags);
+                                              x->mem_desc(), stats_md, epsilon,
+                                              flags);
     } else {
       this->AcquireForwardPrimitiveDescriptor(
-          dnnl::prop_kind::forward_inference, md, epsilon, flags);
+          dnnl::prop_kind::forward_inference, x->mem_desc(), epsilon, flags);
     }
   }
 
@@ -83,7 +82,7 @@ class LayerNormMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto* x = ctx.Input<Tensor>("X");
     auto* scale = ctx.Input<Tensor>("Scale");
     auto* bias = ctx.Input<Tensor>("Bias");
-    auto* y = ctx.Output<Tensor>("Y");
+    auto* out = ctx.Output<Tensor>("Y");
 
     const float epsilon = ctx.Attr<float>("epsilon");
     const auto begin_norm_axis = ctx.Attr<int>("begin_norm_axis");
@@ -107,12 +106,11 @@ class LayerNormMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
       flags |= dnnl::normalization_flags::use_scale_shift;
     }
 
-    LayerNormMKLDNNHandler<T> handler(src_tz, epsilon, flags, is_test,
-                                      x->format(), mkldnn_engine,
-                                      ctx.GetPlace());
+    LayerNormMKLDNNHandler<T> handler(src_tz, epsilon, flags, is_test, x,
+                                      mkldnn_engine, ctx.GetPlace());
 
     auto src_memory = handler.AcquireSrcMemory(x);
-    auto dst_memory = handler.AcquireDstMemory(y);
+    auto dst_memory = handler.AcquireDstMemory(out);
 
     auto layer_norm_p = handler.AcquireForwardPrimitive();
 
@@ -140,8 +138,7 @@ class LayerNormMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     layer_norm_p->execute(astream, args);
     astream.wait();
 
-    y->set_layout(phi::DataLayout::kMKLDNN);
-    y->set_format(platform::GetMKLDNNFormat(*dst_memory));
+    out->set_mem_desc(dst_memory->get_desc());
   }
 };
 

--- a/paddle/fluid/operators/mkldnn/log_softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/log_softmax_mkldnn_op.cc
@@ -28,12 +28,8 @@ class LogSoftmaxMKLDNNHandler
                           const int axis)
       : platform::MKLDNNHandlerNoCachingT<T, dnnl::logsoftmax_forward>(
             mkldnn_engine, cpu_place) {
-    const auto logsoftmax_tz = phi::vectorize(x->dims());
-    const auto md = dnnl::memory::desc(
-        logsoftmax_tz, platform::MKLDNNGetDataType<T>(), x->format());
-
     this->AcquireForwardPrimitiveDescriptor(dnnl::prop_kind::forward_inference,
-                                            md, axis);
+                                            x->mem_desc(), axis);
   }
 };
 
@@ -63,8 +59,7 @@ class LogSoftmaxMKLDNNKernel : public framework::OpKernel<T> {
                                     {DNNL_ARG_DST, *dst_memory_p}});
     astream.wait();
 
-    out->set_layout(framework::DataLayout::kMKLDNN);
-    out->set_format(x->format());
+    out->set_mem_desc(dst_memory_p->get_desc());
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/prelu_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/prelu_mkldnn_op.cc
@@ -41,9 +41,6 @@ class PReluMKLDNNHandler
             platform::CreateKey(dev_ctx, phi::vectorize(x->dims()),
                                 uniq_name)) {
     if (unlikely(!this->isCached())) {
-      auto x_md = memory::desc(phi::vectorize(x->dims()),
-                               MKLDNNGetDataType<T>(), x->format());
-
       auto weights_dims = phi::vectorize(weights->dims());
 
       // weights must have same size as X only for "element" case
@@ -59,30 +56,28 @@ class PReluMKLDNNHandler
                                      memory::format_tag::any);
 
       this->AcquireForwardPrimitiveDescriptor(dnnl::prop_kind::forward_training,
-                                              x_md, weights_md);
+                                              x->mem_desc(), weights_md);
       if (!is_test)
-        this->AcquireBackwardPrimitiveDescriptor(x_md, weights_md, x_md,
-                                                 weights_md);
+        this->AcquireBackwardPrimitiveDescriptor(x->mem_desc(), weights_md,
+                                                 x->mem_desc(), weights_md);
     }
   }
 
   std::shared_ptr<memory> AcquireWeightsMemoryPossiblyWithReorder(
-      const Tensor* input, const bool is_test) {
-    const T* input_data = input->data<T>();
+      const Tensor* weights, const bool is_test) {
+    const T* weights_data = weights->data<T>();
 
     // if weights are 1D, every format tag is correct, so we accept
     // format_tag::any's output and no reorder is needed
-    if (input->dims().size() == 1) {
+    if (weights->dims().size() == 1) {
       return this->AcquireMemoryFromPrimitive(this->fwd_pd_->weights_desc(),
-                                              to_void_cast<T>(input_data),
+                                              to_void_cast<T>(weights_data),
                                               "@alpha_mem_p");
     }
 
-    auto user_weights_md = memory::desc(
-        phi::vectorize(input->dims()), MKLDNNGetDataType<T>(), input->format());
     return this->AcquireMemoryWithReorder(
-        user_weights_md, this->fwd_pd_->weights_desc(),
-        to_void_cast<T>(input_data), "@alpha_mem_p", is_test);
+        weights->mem_desc(), this->fwd_pd_->weights_desc(),
+        to_void_cast<T>(weights_data), "@alpha_mem_p", is_test);
   }
 
   std::shared_ptr<memory> AcquireDiffWeightsMemory(Tensor* output) {
@@ -128,8 +123,7 @@ class PReluMKLDNNKernel : public framework::OpKernel<T> {
                                {DNNL_ARG_DST, *dst_memory_p}});
     astream.wait();
 
-    out->set_layout(framework::DataLayout::kMKLDNN);
-    out->set_format(GetMKLDNNFormat(*dst_memory_p));
+    out->set_mem_desc(dst_memory_p->get_desc());
   }
 };
 
@@ -174,8 +168,7 @@ class PReluGradMKLDNNKernel : public framework::OpKernel<T> {
                       {DNNL_ARG_DIFF_WEIGHTS, *diff_weights_memory_p}});
     astream.wait();
 
-    dx->set_layout(framework::DataLayout::kMKLDNN);
-    dx->set_format(GetMKLDNNFormat(*diff_src_memory_p));
+    dx->set_mem_desc(diff_src_memory_p->get_desc());
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/scale_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/scale_mkldnn_op.cc
@@ -54,8 +54,7 @@ class ScaleMKLDNNKernel : public framework::OpKernel<T> {
                                     {DNNL_ARG_TO, *dst_memory_p}});
     astream.wait();
 
-    out->set_layout(framework::DataLayout::kMKLDNN);
-    out->set_format(platform::GetMKLDNNFormat(*dst_memory_p));
+    out->set_mem_desc(dst_memory_p->get_desc());
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/shape_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/shape_mkldnn_op.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
-#include "paddle/fluid/platform/mkldnn_helper.h"
+#include "paddle/fluid/platform/mkldnn_reuse.h"
 
 namespace paddle {
 namespace operators {
@@ -40,9 +40,13 @@ class ShapeMKLDNNKernel : public framework::OpKernel<T> {
       out_data[i] = in_dims[i];
     }
 
-    auto* out = ctx.Output<Tensor>("Out");
-    out->set_layout(framework::DataLayout::kMKLDNN);
-    out->set_format(platform::GetPlainMKLDNNFormat(out->dims().size()));
+    dnnl::memory::desc out_mem_desc(
+        phi::vectorize(out_t->dims()),
+        framework::ToMKLDNNDataType(
+            framework::TransToProtoVarType(out_t->dtype())),
+        platform::GetPlainMKLDNNFormat(out_t->dims().size()));
+
+    out_t->set_mem_desc(out_mem_desc);
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/shuffle_channel_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/shuffle_channel_mkldnn_op.cc
@@ -29,11 +29,8 @@ class ShuffleChannelMKLDNNHandler
       : platform::MKLDNNHandlerNoCachingT<T, dnnl::shuffle_forward>(engine,
                                                                     cpu_place) {
     static constexpr int channel_axis = 1;
-    const auto md = dnnl::memory::desc(phi::vectorize(x->dims()),
-                                       MKLDNNGetDataType<T>(), x->format());
-
     this->AcquireForwardPrimitiveDescriptor(dnnl::prop_kind::forward_training,
-                                            md, channel_axis, group);
+                                            x->mem_desc(), channel_axis, group);
   }
 };
 
@@ -64,8 +61,7 @@ class ShuffleChannelMKLDNNKernel : public framework::OpKernel<T> {
                                  {DNNL_ARG_DST, *dst_memory_p}});
     astream.wait();
 
-    out->set_layout(framework::DataLayout::kMKLDNN);
-    out->set_format(x->format());
+    out->set_mem_desc(dst_memory_p->get_desc());
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/softplus_mkldnn_op.h
+++ b/paddle/fluid/operators/mkldnn/softplus_mkldnn_op.h
@@ -29,12 +29,11 @@ class SoftplusMKLDNNHandler
       : platform::MKLDNNHandlerNoCachingT<T, dnnl::binary>(engine,
                                                            ctx.GetPlace()) {
     auto x_tz = phi::vectorize(x->dims());
-    auto x_md =
-        dnnl::memory::desc(x_tz, platform::MKLDNNGetDataType<T>(), x->format());
 
     auto beta_tz = std::vector<int64_t>(x_tz.size(), 1);
-    auto beta_md = dnnl::memory::desc(beta_tz, platform::MKLDNNGetDataType<T>(),
-                                      x->format());
+    auto beta_md =
+        dnnl::memory::desc(beta_tz, platform::MKLDNNGetDataType<T>(),
+                           platform::GetPlainMKLDNNFormat(x_tz.size()));
 
     dnnl::post_ops post_ops;
     post_ops.append_eltwise(1.0f, dnnl::algorithm::eltwise_soft_relu, 0.0f,
@@ -50,7 +49,8 @@ class SoftplusMKLDNNHandler
     attrs.set_post_ops(post_ops);
 
     this->AcquireForwardPrimitiveDescriptor(attrs, dnnl::algorithm::binary_mul,
-                                            x_md, beta_md, x_md);
+                                            x->mem_desc(), beta_md,
+                                            x->mem_desc());
   }
 
   std::shared_ptr<dnnl::memory> AcquireBetaMemory(const float* beta) {
@@ -129,8 +129,7 @@ void custom_softplus_eltwise_forward(const framework::ExecutionContext& ctx) {
   binary_p->execute(astream, args);
   astream.wait();
 
-  out->set_layout(framework::DataLayout::kMKLDNN);
-  out->set_format(platform::GetMKLDNNFormat(*dst_memory_p));
+  out->set_mem_desc(dst_memory_p->get_desc());
 }
 }  // namespace operators
 }  // namespace paddle


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
Second part of md-in-tensor refactoring. This PR changes more mkldnn op's to use `mem_desc` variable instead of `format`. This refactoring is split into 3 PRs because PaddlePaddle has a limit of maximum 19 files changed without the need of an additional CI-Approval acceptance.
