### PR TITLE
support speedyspeech model on xpu. test=kunlun

### DIFF
--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -509,6 +509,14 @@ static void OpBaseRunImpl(const framework::OperatorBase& op,
     prepared_op.Run(*tmp_ins_ptr, outs, attrs, default_attrs);
   }
 
+  if (std::getenv("XPU_PADDLE_SYNC") != nullptr) {
+  	if (platform::is_xpu_place(place)) {
+		int r = xpu_wait();
+		PADDLE_ENFORCE_EQ(r,0,platform::errors::InvalidArgument(
+					"not initialized.[",op.Type()));
+	}
+  }
+
   VLOG(4) << LayerDebugString(op.Type(), ins, outs);
 
   // set the output var


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
1.changes layer.cc to fix loss value is nan bugs.
2.change batch_norm_op_xpu.cc to support NHWC data format of batch_norm operator in speedyspeech model training.
3.change conv_op_xpu.cc to support NHWC data format of conv operator in speedyspeech model training. 
support speedyspeech model traing and fix loss value is nan bugs in training.