### PR TITLE
[CustomDevice] fix exit order

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -227,7 +227,9 @@ if core.is_compiled_with_npu():
     atexit.register(core.npu_finalize)
 # NOTE(Aurelius84): clean up ExecutorCacheInfo in advance manually.
 atexit.register(core.clear_executor_cache)
+
 # NOTE(Aganlengzi): clean up KernelFactory in advance manually.
-atexit.register(core.clear_kernel_factory)
 # NOTE(wangran16): clean up DeviceManger in advance manually.
+# Keep clear_kernel_factory running before clear_device_manager
 atexit.register(core.clear_device_manager)
+atexit.register(core.clear_kernel_factory)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Keep clear_kernel_factory runs before clear_device_manager, and the order of execution and registration is reversed.
related: https://github.com/PaddlePaddle/Paddle/pull/40504 https://github.com/PaddlePaddle/Paddle/pull/40414
