### PR TITLE
Print memory peak message for UT

### DIFF
--- a/paddle/fluid/memory/stats.h
+++ b/paddle/fluid/memory/stats.h
@@ -107,7 +107,7 @@ void StatUpdate(const std::string& stat_type, int dev_id, int64_t increment);
     break
 
 #define MEMORY_STAT_FUNC(item, id, func, ...)                         \
-  ({                                                                  \
+  [&] {                                                               \
     paddle::memory::StatBase* stat = nullptr;                         \
     switch (id) {                                                     \
       MEMORY_STAT_FUNC_SWITHCH_CASE(item, 0);                         \
@@ -133,8 +133,8 @@ void StatUpdate(const std::string& stat_type, int dev_id, int64_t increment);
             id));                                                     \
         break;                                                        \
     }                                                                 \
-    stat->func(__VA_ARGS__);                                          \
-  })
+    return stat->func(__VA_ARGS__);                                   \
+  }()
 
 #define MEMORY_STAT_CURRENT_VALUE(item, id) \
   MEMORY_STAT_FUNC(item, id, GetCurrentValue)

--- a/paddle/fluid/memory/stats.h
+++ b/paddle/fluid/memory/stats.h
@@ -107,7 +107,7 @@ void StatUpdate(const std::string& stat_type, int dev_id, int64_t increment);
     break
 
 #define MEMORY_STAT_FUNC(item, id, func, ...)                         \
-  do {                                                                \
+  ({                                                                  \
     paddle::memory::StatBase* stat = nullptr;                         \
     switch (id) {                                                     \
       MEMORY_STAT_FUNC_SWITHCH_CASE(item, 0);                         \
@@ -134,7 +134,7 @@ void StatUpdate(const std::string& stat_type, int dev_id, int64_t increment);
         break;                                                        \
     }                                                                 \
     stat->func(__VA_ARGS__);                                          \
-  } while (0)
+  })
 
 #define MEMORY_STAT_CURRENT_VALUE(item, id) \
   MEMORY_STAT_FUNC(item, id, GetCurrentValue)

--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -143,7 +143,11 @@ class RecordedGpuMallocHelper {
 
  public:
   ~RecordedGpuMallocHelper() {
-    VLOG(0) << "[CI] Memory message : peak memory = " << peak_size_;
+#ifdef PADDLE_WITH_TESTING
+    std::cout << "[CI] GPU " << dev_id_
+              << " memory message : peak memory use = " << peak_size_
+              << std::endl;
+#endif
   }
 
   static RecordedGpuMallocHelper *Instance(int dev_id) {

--- a/paddle/fluid/platform/device/gpu/gpu_info.cc
+++ b/paddle/fluid/platform/device/gpu/gpu_info.cc
@@ -142,14 +142,6 @@ class RecordedGpuMallocHelper {
   DISABLE_COPY_AND_ASSIGN(RecordedGpuMallocHelper);
 
  public:
-  ~RecordedGpuMallocHelper() {
-#ifdef PADDLE_WITH_TESTING
-    std::cout << "[CI] GPU " << dev_id_
-              << " memory message : peak memory use = " << peak_size_
-              << std::endl;
-#endif
-  }
-
   static RecordedGpuMallocHelper *Instance(int dev_id) {
     std::call_once(once_flag_, [] {
       int dev_cnt = GetGPUDeviceCount();
@@ -203,7 +195,6 @@ class RecordedGpuMallocHelper {
 #endif
     if (result == gpuSuccess) {
       cur_size_.fetch_add(size);
-      peak_size_ = std::max(cur_size_.load(), peak_size_);
       STAT_INT_ADD("STAT_gpu" + std::to_string(dev_id_) + "_mem_size", size);
       MEMORY_STAT_UPDATE(Reserved, dev_id_, size);
 
@@ -331,7 +322,6 @@ class RecordedGpuMallocHelper {
   const int dev_id_;
   const uint64_t limit_size_;
   std::atomic<uint64_t> cur_size_{0};
-  uint64_t peak_size_{0};
 
   mutable std::unique_ptr<std::mutex> mtx_;
 

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -106,9 +106,6 @@ namespace phi {
 class ErrorSummary;
 }  // namespace phi
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-DECLARE_int64(gpu_allocator_retry_time);
-#endif
 DECLARE_int32(call_stack_level);
 
 namespace paddle {
@@ -539,7 +536,7 @@ inline void retry_sleep(unsigned milliseconds) {
         ::paddle::platform::details::ExternalApiType<                   \
             __CUDA_STATUS_TYPE__>::kSuccess;                            \
     while (UNLIKELY(__cond__ != __success_type__) && retry_count < 5) { \
-      paddle::platform::retry_sleep(FLAGS_gpu_allocator_retry_time);    \
+      paddle::platform::retry_sleep(10000);                             \
       __cond__ = (COND);                                                \
       ++retry_count;                                                    \
     }                                                                   \
@@ -727,7 +724,7 @@ inline void retry_sleep(unsigned millisecond) {
         ::paddle::platform::details::ExternalApiType<                   \
             __CUDA_STATUS_TYPE__>::kSuccess;                            \
     while (UNLIKELY(__cond__ != __success_type__) && retry_count < 5) { \
-      ::paddle::platform::retry_sleep(FLAGS_gpu_allocator_retry_time);  \
+      ::paddle::platform::retry_sleep(10000);                           \
       __cond__ = (COND);                                                \
       ++retry_count;                                                    \
     }                                                                   \

--- a/paddle/testing/CMakeLists.txt
+++ b/paddle/testing/CMakeLists.txt
@@ -1,5 +1,11 @@
 # for paddle test case
 
 if(WITH_TESTING)
-  cc_library(paddle_gtest_main SRCS paddle_gtest_main.cc DEPS init device_context memory gtest gflags proto_desc phi_utils)
+  set(paddle_gtest_main_deps device_context gtest gflags init memory phi_utils proto_desc)
+
+  if (WITH_GPU OR WITH_ROCM)
+    list(APPEND paddle_gtest_main_deps gpu_info)
+  endif()
+
+  cc_library(paddle_gtest_main SRCS paddle_gtest_main.cc DEPS ${paddle_gtest_main_deps})
 endif()

--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -97,10 +97,10 @@ int main(int argc, char** argv) {
 
 #ifdef PADDLE_WITH_CUDA
   std::cout << std::endl
-            << "=========GPU Memory Use (Bytes)=========" << std::endl;
+            << "========GPU Memory Usage (Bytes)========" << std::endl;
   for (int dev_id = 0; dev_id < paddle::platform::GetGPUDeviceCount();
        ++dev_id) {
-    int64_t peak_value = MEMORY_STAT_PEAK_VALUE(Reserved, dev_id);
+    int64_t peak_value = paddle::memory::StatGetPeakValue("Reserved", dev_id);
     std::cout << "[max memory reserved] gpu " << dev_id << " : " << peak_value
               << std::endl;
   }

--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -91,6 +91,7 @@ int main(int argc, char** argv) {
   ::GFLAGS_NAMESPACE::ParseCommandLineFlags(
       &new_argc, &new_argv_address, false);
   paddle::framework::InitDevices();
+  paddle::framework::InitDefaultKernelSignatureMap();
 
   int ret = RUN_ALL_TESTS();
 

--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
             << "========GPU Memory Usage (Bytes)========" << std::endl;
   for (int dev_id = 0; dev_id < paddle::platform::GetGPUDeviceCount();
        ++dev_id) {
-    int64_t peak_value = paddle::memory::StatGetPeakValue("Reserved", dev_id);
+    int64_t peak_value = MEMORY_STAT_PEAK_VALUE(Reserved, dev_id);
     std::cout << "[max memory reserved] gpu " << dev_id << " : " << peak_value
               << std::endl;
   }

--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "gflags/gflags.h"
 #include "gtest/gtest.h"
+#include "paddle/fluid/framework/phi_utils.h"
 #include "paddle/fluid/memory/allocation/allocator_strategy.h"
 #include "paddle/fluid/platform/device/npu/npu_info.h"
 #include "paddle/fluid/platform/flags.h"
@@ -96,9 +97,11 @@ int main(int argc, char** argv) {
 #ifdef PADDLE_WITH_CUDA
   std::cout << std::endl
             << "=========GPU Memory Use (Bytes)=========" << std::endl;
-  for (int i = 0; i < paddle::platform::GetGPUDeviceCount(); ++i) {
-    std::cout << "[max memory reserved] gpu " << i << " : "
-              << MEMORY_STAT_PEAK_VALUE(Allocated, i) << std::endl;
+  for (int dev_id = 0; dev_id < paddle::platform::GetGPUDeviceCount();
+       ++dev_id) {
+    int64_t peak_value = MEMORY_STAT_PEAK_VALUE(Reserved, dev_id);
+    std::cout << "[max memory reserved] gpu " << dev_id << " : " << peak_value
+              << std::endl;
   }
   std::cout << "========================================" << std::endl;
 #endif

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -20,6 +20,7 @@ import sys
 import paddle
 import paddle.fluid as fluid
 import importlib
+import paddle.fluid.core as core
 from six.moves import cStringIO
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
@@ -45,6 +46,16 @@ def main():
                     module = importlib.import_module(module_name)
                     tests = test_loader.loadTestsFromModule(module)
                     res = unittest.TextTestRunner(stream=buffer).run(tests)
+
+                    if core.is_compiled_with_cuda():
+                        print("\n=========GPU Memory Use (Bytes)=========")
+                        dev_count = core.get_cuda_device_count()
+                        for dev_id in range(dev_count):
+                            print(
+                                f"[max memory reserved] gpu {dev_id} : {paddle.device.cuda.max_memory_reserved(dev_id)}"
+                            )
+                        print("========================================")
+
                     if not res.wasSuccessful():
                         some_test_failed = True
                         print(

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -29,6 +29,10 @@ import static_mode_white_list
 
 def main():
     sys.path.append(os.getcwd())
+    if core.is_compiled_with_cuda() or core.is_compiled_with_rocm():
+        if (os.getenv('FLAGS_enable_gpu_memory_usage_log') == None):
+            os.environ['FLAGS_enable_gpu_memory_usage_log'] = 'true'
+
     some_test_failed = False
     for module_name in sys.argv[1:]:
         flag_need_static_mode = False
@@ -46,15 +50,6 @@ def main():
                     module = importlib.import_module(module_name)
                     tests = test_loader.loadTestsFromModule(module)
                     res = unittest.TextTestRunner(stream=buffer).run(tests)
-
-                    if core.is_compiled_with_cuda():
-                        print("\n========GPU Memory Usage (Bytes)========")
-                        dev_count = core.get_cuda_device_count()
-                        for dev_id in range(dev_count):
-                            print(
-                                f"[max memory reserved] gpu {dev_id} : {paddle.device.cuda.max_memory_reserved(dev_id)}"
-                            )
-                        print("========================================")
 
                     if not res.wasSuccessful():
                         some_test_failed = True

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -48,7 +48,7 @@ def main():
                     res = unittest.TextTestRunner(stream=buffer).run(tests)
 
                     if core.is_compiled_with_cuda():
-                        print("\n=========GPU Memory Use (Bytes)=========")
+                        print("\n========GPU Memory Usage (Bytes)========")
                         dev_count = core.get_cuda_device_count()
                         for dev_id in range(dev_count):
                             print(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
在单测运行结束时打印显存占用峰值信息：
![image](https://user-images.githubusercontent.com/17673696/165699621-46bbb0a7-4869-4301-b2b1-4c1b365ab26b.png)

此信息供CI流水线监控单测的显存占用情况，同时也方便RD在本地进行单元测试时了解单测的显存使用情况，后续将考虑据此在CI上拦截显存占用过多的新增单测。

是否打印信息可通过FLAGS_enable_gpu_memory_usage_log环境变量设置，目前全局默认关闭，但在test_runner.py和paddle_gtest_main.cc中会自动开启。