### PR TITLE
[Eager] Fix CastPyArg2scalar for max value of int64

### DIFF
--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -1058,7 +1058,7 @@ paddle::experimental::Scalar CastPyArg2Scalar(PyObject* obj,
     bool value = CastPyArg2Boolean(obj, op_type, arg_pos);
     return paddle::experimental::Scalar(value);
   } else if (PyLong_Check(obj)) {
-    int value = CastPyArg2Int(obj, op_type, arg_pos);
+    int64_t value = CastPyArg2Long(obj, op_type, arg_pos);
     return paddle::experimental::Scalar(value);
   } else if (PyFloat_Check(obj)) {
     float value = CastPyArg2Float(obj, op_type, arg_pos);

--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -153,7 +153,7 @@ void CastPyArg2AttrInt(PyObject* obj,
 int64_t CastPyArg2Long(PyObject* obj, const std::string& op_type,
                        ssize_t arg_pos) {
   if (PyObject_CheckLongOrToLong(&obj)) {
-    return (int64_t)PyLong_AsLong(obj);  // NOLINT
+    return (int64_t)PyLong_AsLongLong(obj);  // NOLINT
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "%s(): argument (position %d) must be "

--- a/python/paddle/fluid/tests/unittests/test_clip_op.py
+++ b/python/paddle/fluid/tests/unittests/test_clip_op.py
@@ -200,7 +200,7 @@ class TestClipAPI(unittest.TestCase):
             np.allclose(res11, (data * 10).astype(np.int64).clip(2, 8)))
         paddle.disable_static()
 
-    def test_clip_dygraph(self):
+    def func_clip_dygraph(self):
         paddle.disable_static()
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
@@ -233,9 +233,19 @@ class TestClipAPI(unittest.TestCase):
             np.allclose(out_5.numpy(), (data * 10).astype(np.int64).clip(2, 8)))
         self.assertTrue(np.allclose(out_6.numpy(), data.clip(0.2, 0.8)))
 
-    def test_eager(self):
+    def test_clip_dygraph(self):
         with _test_eager_guard():
-            self.test_clip_dygraph()
+            self.func_clip_dygraph()
+        self.func_clip_dygraph()
+
+    def test_clip_dygraph_default_max(self):
+        paddle.disable_static()
+        with _test_eager_guard():
+            x = paddle.to_tensor([1, 2, 3])
+            egr_out = paddle.clip(x, min=1)
+        x = paddle.to_tensor([1, 2, 3])
+        out = paddle.clip(x, min=1)
+        self.assertTrue(np.allclose(out.numpy(), egr_out.numpy()))
 
     def test_errors(self):
         paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/test_clip_op.py
+++ b/python/paddle/fluid/tests/unittests/test_clip_op.py
@@ -241,11 +241,21 @@ class TestClipAPI(unittest.TestCase):
     def test_clip_dygraph_default_max(self):
         paddle.disable_static()
         with _test_eager_guard():
-            x = paddle.to_tensor([1, 2, 3])
-            egr_out = paddle.clip(x, min=1)
-        x = paddle.to_tensor([1, 2, 3])
-        out = paddle.clip(x, min=1)
-        self.assertTrue(np.allclose(out.numpy(), egr_out.numpy()))
+            x_int32 = paddle.to_tensor([1, 2, 3], dtype="int32")
+            x_int64 = paddle.to_tensor([1, 2, 3], dtype="int64")
+            x_f32 = paddle.to_tensor([1, 2, 3], dtype="float32")
+            egr_out1 = paddle.clip(x_int32, min=1)
+            egr_out2 = paddle.clip(x_int64, min=1)
+            egr_out3 = paddle.clip(x_f32, min=1)
+        x_int32 = paddle.to_tensor([1, 2, 3], dtype="int32")
+        x_int64 = paddle.to_tensor([1, 2, 3], dtype="int64")
+        x_f32 = paddle.to_tensor([1, 2, 3], dtype="float32")
+        out1 = paddle.clip(x_int32, min=1)
+        out2 = paddle.clip(x_int64, min=1)
+        out3 = paddle.clip(x_f32, min=1)
+        self.assertTrue(np.allclose(out1.numpy(), egr_out1.numpy()))
+        self.assertTrue(np.allclose(out2.numpy(), egr_out2.numpy()))
+        self.assertTrue(np.allclose(out3.numpy(), egr_out3.numpy()))
 
     def test_errors(self):
         paddle.enable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
1. Fix CastPyArg2Scalar when input is the max value of int64.
