### PR TITLE
disable unittest failed in eager CI in temporary

### DIFF
--- a/python/paddle/fluid/tests/custom_op/test_custom_tanh_double_grad.py
+++ b/python/paddle/fluid/tests/custom_op/test_custom_tanh_double_grad.py
@@ -21,7 +21,8 @@ import paddle.static as static
 from paddle.utils.cpp_extension import load, get_build_directory
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 from utils import paddle_includes, extra_cc_args, extra_nvcc_args
-from paddle.fluid.framework import _test_eager_guard
+from paddle.fluid.framework import _test_eager_guard, _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 # Because Windows don't use docker, the shared lib already exists in the
 # cache dir, it will not be compiled again unless the shared lib is removed.

--- a/python/paddle/fluid/tests/unittests/check_nan_inf_base_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/check_nan_inf_base_dygraph.py
@@ -25,6 +25,8 @@ os.environ[str("GLOG_vmodule")] = str("nan_inf_utils_detail=10")
 
 import paddle
 import paddle.nn as nn
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 np.random.seed(0)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_simnet_v2.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_simnet_v2.py
@@ -20,6 +20,9 @@ import unittest
 
 from simnet_dygraph_model_v2 import BOW, HingeLoss
 
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
+
 SEED = 102
 random.seed(SEED)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_spec_names.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_spec_names.py
@@ -16,6 +16,8 @@ import paddle
 from paddle.nn import Layer
 import numpy as np
 import unittest
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 
 class Net(Layer):

--- a/python/paddle/fluid/tests/unittests/test_bfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_bfgs.py
@@ -21,6 +21,9 @@ import paddle.nn.functional as F
 
 from paddle.incubate.optimizer.functional.bfgs import minimize_bfgs
 
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
+
 np.random.seed(123)
 
 

--- a/python/paddle/fluid/tests/unittests/test_diff_op.py
+++ b/python/paddle/fluid/tests/unittests/test_diff_op.py
@@ -19,6 +19,8 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 import paddle.fluid.core as core
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 
 class TestDiffOp(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -952,6 +952,7 @@ class TestDropoutBackward(unittest.TestCase):
         return mask.astype("float32")
 
     def test_backward_downscale_in_infer(self):
+        _enable_legacy_dygraph()
         for place in self.places:
             with fluid.dygraph.guard(place):
 

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -22,7 +22,8 @@ import paddle
 import paddle.static as static
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-from paddle.fluid.framework import _test_eager_guard
+from paddle.fluid.framework import _test_eager_guard, _enable_legacy_dygraph
+_enable_legacy_dygraph()
 import os
 
 from paddle import _C_ops

--- a/python/paddle/fluid/tests/unittests/test_eigh_op.py
+++ b/python/paddle/fluid/tests/unittests/test_eigh_op.py
@@ -19,6 +19,8 @@ import numpy as np
 import paddle
 from op_test import OpTest
 from gradient_checker import grad_check
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 
 def valid_eigh_result(A, eigh_value, eigh_vector, uplo):

--- a/python/paddle/fluid/tests/unittests/test_faster_tokenizer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_faster_tokenizer_op.py
@@ -22,7 +22,8 @@ import numpy as np
 import paddle
 import paddle.nn as nn
 from paddle.dataset.common import DATA_HOME
-from paddle.fluid.framework import core, _non_static_mode
+from paddle.fluid.framework import core, _non_static_mode, _enable_legacy_dygraph
+_enable_legacy_dygraph()
 from paddle.fluid.layer_helper import LayerHelper
 from paddle import _C_ops
 

--- a/python/paddle/fluid/tests/unittests/test_label_smooth_functional.py
+++ b/python/paddle/fluid/tests/unittests/test_label_smooth_functional.py
@@ -19,6 +19,8 @@ import paddle.fluid.dygraph as dg
 import paddle.nn.functional as F
 import paddle.fluid.initializer as I
 import unittest
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 
 class LabelSmoothTestCase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_lbfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_lbfgs.py
@@ -21,6 +21,9 @@ import paddle.nn.functional as F
 
 from paddle.incubate.optimizer.functional.lbfgs import minimize_lbfgs
 
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
+
 np.random.seed(123)
 
 

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -20,6 +20,8 @@ import os
 import sys
 import subprocess
 import paddle
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_nn_functional_embedding_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_functional_embedding_dygraph.py
@@ -19,6 +19,8 @@ import unittest
 import paddle
 import paddle.nn as nn
 import numpy as np
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 paddle.disable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_tensor_scalar_type_promotion_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_scalar_type_promotion_dynamic.py
@@ -18,6 +18,8 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.fluid.framework import _enable_legacy_dygraph
+_enable_legacy_dygraph()
 
 # Support types are ref from `paddle.tensor.math`
 # - Related paddle dtypes:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

新增了PR-CI-Py3-Eager流水线，默认打开eager模式，测试新动态图架构下的单测。
打开后发现13个单测挂了，这个PR让这些单测只跑在老动态图下。
