### PR TITLE
fix python3.10 compile bug on windows

### DIFF
--- a/paddle/fluid/pybind/bind_fleet_executor.h
+++ b/paddle/fluid/pybind/bind_fleet_executor.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 #include <pybind11/pybind11.h>
 
 namespace paddle {

--- a/paddle/fluid/pybind/compatible.h
+++ b/paddle/fluid/pybind/compatible.h
@@ -14,6 +14,10 @@
 
 #pragma once
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 #include <pybind11/pybind11.h>
 
 namespace paddle {

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -9,6 +9,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 // disable numpy compile error
+
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <Python.h>
 
 #include <string>

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -9,6 +9,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 // disable numpy compile error
+
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <Python.h>
 
 #include <string>

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -10,6 +10,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <Python.h>
 #include "paddle/phi/common/backend.h"
 #include "paddle/phi/common/data_type.h"

--- a/paddle/fluid/pybind/inference_api.h
+++ b/paddle/fluid/pybind/inference_api.h
@@ -14,6 +14,11 @@
 
 #pragma once
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <pybind11/pybind11.h>
 
 namespace paddle {

--- a/paddle/fluid/pybind/io.h
+++ b/paddle/fluid/pybind/io.h
@@ -14,6 +14,11 @@ limitations under the License. */
 
 #pragma once
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <Python.h>
 #include "paddle/fluid/pybind/pybind_boost_headers.h"
 

--- a/paddle/fluid/pybind/op_function_common.h
+++ b/paddle/fluid/pybind/op_function_common.h
@@ -14,6 +14,11 @@
 
 #pragma once
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 #include <pybind11/chrono.h>
 #include <pybind11/complex.h>
 #include <pybind11/functional.h>

--- a/paddle/fluid/pybind/protobuf.h
+++ b/paddle/fluid/pybind/protobuf.h
@@ -13,6 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 #include <Python.h>
 
 #include <fstream>

--- a/python/paddle/fluid/tests/unittests/cc_imp_py_test.cc
+++ b/python/paddle/fluid/tests/unittests/cc_imp_py_test.cc
@@ -50,7 +50,8 @@ TEST(CC, IMPORT_PY) {
   // 3. C/C++ Run Python file
   std::string file_name(cwd);
   file_name.append("/test_install_check.py");
-  FILE* fp = _Py_fopen(file_name.c_str(), "r+");
+  PyObject* obj = Py_BuildValue("s", file_name.c_str());
+  FILE* fp = _Py_fopen_obj(obj, "r+");
   ASSERT_TRUE(fp != NULL);
   ASSERT_FALSE(PyRun_SimpleFile(fp, file_name.c_str()));
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

**fix python3.10 compile bug on windows.**

This bug is same  with 
https://github.com/jpype-project/jpype/issues/1009

`ssize_t`、`_Py_fopen`  can not be used from python3.10 