### PR TITLE
Fix dimension merge bug in broadcast

### DIFF
--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -37,8 +37,8 @@ struct DimensionsTransform {
   std::vector<DimVector> in_dims;
 
  private:
-  /* To compensate the lackage of input_tensors` dimension with input
-     variable 'axis' */
+  // To compensate the lackage of input_tensors` dimension with input
+  // variable 'axis'.
   void InputDimensionsExtend(int N, int axis) {
     for (auto &in_dim : in_dims) {
       int64_t in_idx = 0;
@@ -83,8 +83,8 @@ struct DimensionsTransform {
     std::reverse(out_dims.begin(), out_dims.end());
   }
 
-  /* Merge sequential dimension to shrink calculation cost for
-     offset computation in CUDA Kernel. */
+  // Merge sequential dimension to shrink calculation cost for
+  // offset computation in CUDA Kernel.
   template <typename MergeFunctor>
   __inline__ void MergeDimensions(MergeFunctor merge_func, int N) {
     auto VectorReorganise = [](DimVector *vec, int l_idx, int m_idx) {
@@ -123,8 +123,8 @@ struct DimensionsTransform {
     }
   }
 
-  /* To judge whether shape of any input tensors is sequential
-    1-value-dimensions, and metric the length of it. */
+  // To judge whether shape of any input tensors is sequential
+  // 1-value-dimensions, and metric the length of it.
   int GetSequentialOneDimLength(int *swap_index) {
     int index = 0;
     int max_one_length = 0;
@@ -176,11 +176,11 @@ struct DimensionsTransform {
     }
     InputDimensionsExtend(N, axis);
 
-    /* To Merge the dimensions of input_tensors while the consequtive
-       equal-dimensions appears. Example below :
-       in_1.shape = [2, 3, 4, 5]    in_1.shape = [2, 12, 5]
-       in_2.shape = [1, 3, 4, 5] -> in_2.shape = [1, 12, 5]
-       in_3.shape = [2, 3, 4, 1]    in_3.shape = [2, 12, 1] */
+    // To Merge the dimensions of input_tensors while the consequtive
+    // equal-dimensions appears. Example below :
+    //   in_1.shape = [2, 3, 4, 5]    in_1.shape = [2, 12, 5]
+    //   in_2.shape = [1, 3, 4, 5] -> in_2.shape = [1, 12, 5]
+    //   in_3.shape = [2, 3, 4, 1]    in_3.shape = [2, 12, 1]
     auto merge_sequential_dims = [](bool &equal,
                                     std::vector<DimVector> &in_dims,
                                     DimVector &out,
@@ -193,14 +193,14 @@ struct DimensionsTransform {
     MergeFunctor merge_ptr = merge_sequential_dims;
     MergeDimensions<MergeFunctor>(merge_ptr, N);
 
-    /* To Merge the dimension of input_tensors while the sequential
-       1-value-dimensions appears. Example below :
-        in_1.shape = [2, 1, 1, 5]    in_1.shape = [2,  1, 5]
-        in_2.shape = [2, 3, 4, 5] -> in_2.shape = [1, 12, 5]
-        in_3.shape = [2, 3, 4, 1]    in_3.shape = [2, 12, 1]
-      Caution: Once 1-value-dimensions appears, the corresponding
-      shape position of other input tensors must be same with the
-      output tensor`s shape, or incorrect merge may occur. */
+    // To Merge the dimension of input_tensors while the sequential
+    // 1-value-dimensions appears. Example below :
+    //   in_1.shape = [2, 1, 1, 5]    in_1.shape = [2,  1, 5]
+    //   in_2.shape = [2, 3, 4, 5] -> in_2.shape = [1, 12, 5]
+    //   in_3.shape = [2, 3, 4, 1]    in_3.shape = [2, 12, 1]
+    // Caution: Once 1-value-dimensions appears, the corresponding
+    // shape position of other input tensors must be same with the
+    // output tensor`s shape, or incorrect merge may occur.
     auto merge_sequential_one_dims = [](bool &equal,
                                         std::vector<DimVector> &in_dims,
                                         DimVector &out,

--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -37,7 +37,7 @@ struct DimensionsTransform {
   std::vector<DimVector> in_dims;
 
  private:
-  /* To compensate the lackage of input_tensors` dimension with input 
+  /* To compensate the lackage of input_tensors` dimension with input
      variable 'axis' */
   void InputDimensionsExtend(int N, int axis) {
     for (auto &in_dim : in_dims) {
@@ -83,7 +83,7 @@ struct DimensionsTransform {
     std::reverse(out_dims.begin(), out_dims.end());
   }
 
-  /* Merge sequential dimension to shrink calculation cost for 
+  /* Merge sequential dimension to shrink calculation cost for
      offset computation in CUDA Kernel. */
   template <typename MergeFunctor>
   __inline__ void MergeDimensions(MergeFunctor merge_func, int N) {
@@ -123,9 +123,9 @@ struct DimensionsTransform {
     }
   }
 
-  /* To judge whether shape of any input tensors is sequential 
-    1-value-dimensions, and metric the length of it.*/
-  int GetSequentialOneDimLength(int* swap_index) {
+  /* To judge whether shape of any input tensors is sequential
+    1-value-dimensions, and metric the length of it. */
+  int GetSequentialOneDimLength(int *swap_index) {
     int index = 0;
     int max_one_length = 0;
     for (int j = 0; j < N; ++j) {
@@ -144,11 +144,11 @@ struct DimensionsTransform {
           }
         }
       }
-      max_one_length = seq_one_length > max_one_length ?
-                       seq_one_length : max_one_length ;
+      max_one_length =
+          seq_one_length > max_one_length ? seq_one_length : max_one_length;
       index = seq_one_length > max_one_length ? j : index;
     }
-    
+
     if (max_one_length > 1) {
       std::swap(in_dims[0], in_dims[index]);
       *swap_index = index;
@@ -201,7 +201,6 @@ struct DimensionsTransform {
     // equal-dimensions appears.
     MergeFunctor merge_ptr = merge_sequential_dims;
     MergeDimensions<MergeFunctor>(merge_ptr, N);
-
 
     // To Merge the dimension of input_tensors while the sequential
     // 1-value-dimensions appears.

--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -31,13 +31,14 @@ struct DimensionsTransform {
   using DimVector = std::vector<int64_t>;
   typedef void (*MergeFunctor)(
       bool &, std::vector<DimVector> &, DimVector &, int, int);
+  int64_t N;
   int64_t dim_size;
   DimVector out_dims;
   std::vector<DimVector> in_dims;
 
  private:
-  // To compensate the lackage of input_tensors` dimension with input variable
-  // 'axis'
+  /* To compensate the lackage of input_tensors` dimension with input 
+     variable 'axis' */
   void InputDimensionsExtend(int N, int axis) {
     for (auto &in_dim : in_dims) {
       int64_t in_idx = 0;
@@ -82,6 +83,8 @@ struct DimensionsTransform {
     std::reverse(out_dims.begin(), out_dims.end());
   }
 
+  /* Merge sequential dimension to shrink calculation cost for 
+     offset computation in CUDA Kernel. */
   template <typename MergeFunctor>
   __inline__ void MergeDimensions(MergeFunctor merge_func, int N) {
     auto VectorReorganise = [](DimVector *vec, int l_idx, int m_idx) {
@@ -120,11 +123,44 @@ struct DimensionsTransform {
     }
   }
 
+  /* To judge whether shape of any input tensors is sequential 
+    1-value-dimensions, and metric the length of it.*/
+  int GetSequentialOneDimLength(int* swap_index) {
+    int index = 0;
+    int max_one_length = 0;
+    for (int j = 0; j < N; ++j) {
+      int seq_one_length = 0;
+      bool active_seq = false;
+
+      for (int i = 0; i < dim_size; ++i) {
+        if (!active_seq && in_dims[j][i] == 1) {
+          seq_one_length = 1;
+          active_seq = true;
+        } else if (active_seq) {
+          if (in_dims[j][i] == 1) {
+            seq_one_length++;
+          } else {
+            active_seq = false;
+          }
+        }
+      }
+      max_one_length = seq_one_length > max_one_length ?
+                       seq_one_length : max_one_length ;
+      index = seq_one_length > max_one_length ? j : index;
+    }
+    
+    if (max_one_length > 1) {
+      std::swap(in_dims[0], in_dims[index]);
+      *swap_index = index;
+    }
+    return max_one_length;
+  }
+
  public:
   explicit DimensionsTransform(const std::vector<const DenseTensor *> &ins,
                                const phi::DDim &dims,
                                int axis) {
-    const int N = std::max(static_cast<int>(ins.size()), 2);
+    N = std::max(static_cast<int>(ins.size()), 2);
     dim_size = dims.size();
     out_dims = phi::vectorize<int64_t>(dims);
     in_dims.resize(N);
@@ -157,7 +193,7 @@ struct DimensionsTransform {
       equal = in_dims[0][i] == 1;
       if (equal) {
         for (int j = 1; j < num; ++j) {
-          equal &= in_dims[j][i] == out[i];
+          equal &= (in_dims[j][i] == out[i]) || (in_dims[j][i] == 1);
         }
       }
     };
@@ -166,22 +202,16 @@ struct DimensionsTransform {
     MergeFunctor merge_ptr = merge_sequential_dims;
     MergeDimensions<MergeFunctor>(merge_ptr, N);
 
-    int min_idx = 0;
-    int min_val = std::accumulate(
-        in_dims[0].begin(), in_dims[0].end(), 1, std::multiplies<int64_t>());
-    for (int j = 1; j < N; ++j) {
-      int temp = std::accumulate(
-          in_dims[j].begin(), in_dims[j].end(), 1, std::multiplies<int64_t>());
-      min_val = min_val > temp ? temp : min_val;
-      min_idx = min_val == temp ? j : min_idx;
-    }
-    std::swap(in_dims[0], in_dims[min_idx]);
 
-    // To Merge the dimension of input_tensors while the consequtive
+    // To Merge the dimension of input_tensors while the sequential
     // 1-value-dimensions appears.
-    merge_ptr = merge_sequential_one_dims;
-    MergeDimensions<MergeFunctor>(merge_ptr, N);
-    std::swap(in_dims[min_idx], in_dims[0]);
+    int swap_idx = 0;
+    int max_one_length = GetSequentialOneDimLength(&swap_idx);
+    if (max_one_length > 1) {
+      merge_ptr = merge_sequential_one_dims;
+      MergeDimensions<MergeFunctor>(merge_ptr, N);
+      std::swap(in_dims[swap_idx], in_dims[0]);
+    }
   }
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- 原先用于判断**连续值为1的维度**函数的逻辑有漏洞，导致OP Benchmark内下述配置中的**维度合并**失效：
```
x(Variable)-dtype:float16,  shape:[32,   1,    1,128] 
y(Variable)-dtype:float16,  shape:[  1, 12, 128,     1]
```
预期合并后的维度应该如下所示，然而并未达成，导致Broadcast计算未能发挥最大效能。
```
x(Variable)-dtype:float16,  shape:[32,   1,   128] 
y(Variable)-dtype:float16,  shape:[   1, 1536,  1]
```

- 本PR完善了**连续值为1的维度**函数的判断逻辑，以`Add`计算为例，上述配置的性能提升效果如下：

|  Paddle_dev  |  本PR修改   |  Diff   | 竞品 |  较竞品差异 |
|   --   |  --   |  --   |   --   |  --   | 
|  40.711us  |  34.133us  |  提升19.27%  | 32.695us |  落后24.52%  -> 落后4.4%  | 
