### PR TITLE
[Cherry-pick KP] Add Logical/compare/bitwise registry & UT (#40802)

### DIFF
--- a/paddle/fluid/platform/device/xpu/xpu_op_kpfirst_list.h
+++ b/paddle/fluid/platform/device/xpu/xpu_op_kpfirst_list.h
@@ -59,6 +59,32 @@ XPUOpMap& get_kp_ops() {
       {"swish", XPUKernelSet({pOpKernelType(vartype::FP32, XPUPlace())})},
       {"thresholded_relu",
        XPUKernelSet({pOpKernelType(vartype::FP32, XPUPlace())})},
+      // bitwise logical & compare
+      {"bitwise_and", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace()),
+                                    pOpKernelType(vartype::BOOL, XPUPlace())})},
+      {"bitwise_or", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace()),
+                                   pOpKernelType(vartype::BOOL, XPUPlace())})},
+      {"bitwise_not", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace()),
+                                    pOpKernelType(vartype::BOOL, XPUPlace())})},
+      {"bitwise_xor", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace()),
+                                    pOpKernelType(vartype::BOOL, XPUPlace())})},
+
+      {"logical_and",
+       XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"logical_or", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"logical_not",
+       XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"logical_xor",
+       XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+
+      {"less_than", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"less_equal", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"greater_than",
+       XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"greater_equal",
+       XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"equal", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
+      {"not_equal", XPUKernelSet({pOpKernelType(vartype::INT32, XPUPlace())})},
   };
 
   return s_xpu_kp_kernels;

--- a/paddle/phi/common/backend.h
+++ b/paddle/phi/common/backend.h
@@ -159,7 +159,14 @@ inline Backend StringToBackend(const char* backend_cstr) {
   } else if (s == std::string("GPUDNN")) {
     return Backend::GPUDNN;
   } else if (s == std::string("KPS")) {
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+    // NOTE(chenweihang) KPS is not yet a complete backend, and it still needs
+    // to be converted
+    // to GPU in the GPU environment
+    return Backend::GPU;
+#else
     return Backend::KPS;
+#endif
   } else if (s == std::string("IPU")) {
     return Backend::IPU;
   } else {

--- a/paddle/phi/kernels/gpu/reduce.h
+++ b/paddle/phi/kernels/gpu/reduce.h
@@ -15,7 +15,8 @@
 #pragma once
 
 // CUDA and HIP use same api
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP) || \
+    defined(PADDLE_WITH_XPU_KP)
 
 #include "paddle/phi/kernels/funcs/reduce_function.h"
 

--- a/paddle/phi/kernels/kps/bitwise_kernel.cu
+++ b/paddle/phi/kernels/kps/bitwise_kernel.cu
@@ -14,7 +14,12 @@ limitations under the License. */
 
 #include "paddle/phi/kernels/bitwise_kernel.h"
 
+#ifdef PADDLE_WITH_XPU_KP
+#include "paddle/phi/backends/xpu/xpu_context.h"
+#else
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#endif
+
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/bitwise_functors.h"
 #include "paddle/phi/kernels/funcs/broadcast_function.h"
@@ -53,8 +58,19 @@ void BitwiseNotKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
+#ifdef PADDLE_WITH_XPU_KP
+PD_REGISTER_KERNEL(
+    bitwise_and, KPS, ALL_LAYOUT, phi::BitwiseAndKernel, int, bool) {}
+PD_REGISTER_KERNEL(
+    bitwise_or, KPS, ALL_LAYOUT, phi::BitwiseOrKernel, int, bool) {}
+PD_REGISTER_KERNEL(
+    bitwise_xor, KPS, ALL_LAYOUT, phi::BitwiseXorKernel, int, bool) {}
+PD_REGISTER_KERNEL(
+    bitwise_not, KPS, ALL_LAYOUT, phi::BitwiseNotKernel, int, bool) {}
+
+#else
 PD_REGISTER_KERNEL(bitwise_and,
-                   GPU,
+                   KPS,
                    ALL_LAYOUT,
                    phi::BitwiseAndKernel,
                    bool,
@@ -65,7 +81,7 @@ PD_REGISTER_KERNEL(bitwise_and,
                    int64_t) {}
 
 PD_REGISTER_KERNEL(bitwise_or,
-                   GPU,
+                   KPS,
                    ALL_LAYOUT,
                    phi::BitwiseOrKernel,
                    bool,
@@ -76,7 +92,7 @@ PD_REGISTER_KERNEL(bitwise_or,
                    int64_t) {}
 
 PD_REGISTER_KERNEL(bitwise_xor,
-                   GPU,
+                   KPS,
                    ALL_LAYOUT,
                    phi::BitwiseXorKernel,
                    bool,
@@ -87,7 +103,7 @@ PD_REGISTER_KERNEL(bitwise_xor,
                    int64_t) {}
 
 PD_REGISTER_KERNEL(bitwise_not,
-                   GPU,
+                   KPS,
                    ALL_LAYOUT,
                    phi::BitwiseNotKernel,
                    bool,
@@ -96,3 +112,5 @@ PD_REGISTER_KERNEL(bitwise_not,
                    int16_t,
                    int,
                    int64_t) {}
+
+#endif

--- a/paddle/phi/kernels/kps/logical_kernel.cu
+++ b/paddle/phi/kernels/kps/logical_kernel.cu
@@ -10,11 +10,15 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
+// limitation
 
 #include "paddle/phi/kernels/logical_kernel.h"
-
+#ifdef PADDLE_WITH_XPU_KP
+#include "paddle/phi/backends/xpu/xpu_context.h"
+#else
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#endif
+
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/broadcast_function.h"
 #include "paddle/phi/kernels/funcs/logical_functor.h"
@@ -59,9 +63,15 @@ void LogicalNotKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
+#ifdef PADDLE_WITH_XPU_KP
+PD_REGISTER_KERNEL(logical_and, KPS, ALL_LAYOUT, phi::LogicalAndKernel, int) {}
+PD_REGISTER_KERNEL(logical_Or, KPS, ALL_LAYOUT, phi::LogicalOrKernel, int) {}
+PD_REGISTER_KERNEL(logical_Not, KPS, ALL_LAYOUT, phi::LogicalNotKernel, int) {}
+PD_REGISTER_KERNEL(logical_Xor, KPS, ALL_LAYOUT, phi::LogicalXorKernel, int) {}
+#else
 #define REGISTER_LOGICAL_CUDA_KERNEL(logical_and, func_type) \
   PD_REGISTER_KERNEL(logical_and,                            \
-                     GPU,                                    \
+                     KPS,                                    \
                      ALL_LAYOUT,                             \
                      phi::Logical##func_type##Kernel,        \
                      float,                                  \
@@ -76,3 +86,4 @@ REGISTER_LOGICAL_CUDA_KERNEL(logical_and, And)
 REGISTER_LOGICAL_CUDA_KERNEL(logical_or, Or)
 REGISTER_LOGICAL_CUDA_KERNEL(logical_not, Not)
 REGISTER_LOGICAL_CUDA_KERNEL(logical_xor, Xor)
+#endif

--- a/paddle/phi/kernels/primitive/helper_primitives.h
+++ b/paddle/phi/kernels/primitive/helper_primitives.h
@@ -23,7 +23,7 @@ struct dim3 {
   int y;
   int z;
 
-  explicit inline dim3(int split_x, int split_y = 1, int split_z = 1) {
+  explicit inline dim3(int split_x = 1, int split_y = 1, int split_z = 1) {
     x = split_x;
     y = split_y;
     z = split_z;

--- a/paddle/phi/tests/common/test_backend.cc
+++ b/paddle/phi/tests/common/test_backend.cc
@@ -64,7 +64,11 @@ TEST(Backend, StringToBackend) {
   EXPECT_EQ(phi::Backend::NPU, pexp::StringToBackend("NPU"));
   EXPECT_EQ(phi::Backend::MKLDNN, pexp::StringToBackend("MKLDNN"));
   EXPECT_EQ(phi::Backend::GPUDNN, pexp::StringToBackend("GPUDNN"));
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  EXPECT_EQ(phi::Backend::GPU, pexp::StringToBackend("KPS"));
+#else
   EXPECT_EQ(phi::Backend::KPS, pexp::StringToBackend("KPS"));
+#endif
   EXPECT_EQ(static_cast<phi::Backend>(
                 static_cast<size_t>(phi::Backend::NUM_BACKENDS) + 1),
             pexp::StringToBackend("CustomBackend"));

--- a/python/paddle/fluid/tests/unittests/xpu/test_bitwise_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_bitwise_op_xpu.py
@@ -1,10 +1,10 @@
-#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,25 +27,25 @@ from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types,
 paddle.enable_static()
 
 
-################## TEST OP: logical_and ##################
-class XPUTestLogicalAnd(XPUOpTestWrapper):
+################## TEST OP: BitwiseAnd ##################
+class XPUTestBitwiseAnd(XPUOpTestWrapper):
     def __init__(self):
-        self.op_name = 'logical_and'
+        self.op_name = 'bitwise_and'
 
-    class XPUTestLogicalAndBase(XPUOpTest):
+    class XPUTestBitwiseAndBase(XPUOpTest):
         def setUp(self):
             self.place = paddle.XPUPlace(0)
             self.init_case()
             self.set_case()
 
         def set_case(self):
-            self.op_type = 'logical_and'
+            self.op_type = 'bitwise_and'
 
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype)
             y = np.random.randint(
                 self.low, self.high, self.y_shape, dtype=self.dtype)
-            out = np.logical_and(x, y)
+            out = np.bitwise_and(x, y)
 
             self.attrs = {'use_xpu': True}
             self.inputs = {
@@ -67,7 +67,7 @@ class XPUTestLogicalAnd(XPUOpTestWrapper):
         def test_check_grad(self):
             pass
 
-    class XPUTestLogicalAndCase1(XPUTestLogicalAndBase):
+    class XPUTestBitwiseAndCase1(XPUTestBitwiseAndBase):
         def init_case(self):
             self.dtype = np.int32
             self.x_shape = [4, 5]
@@ -75,31 +75,47 @@ class XPUTestLogicalAnd(XPUOpTestWrapper):
             self.low = -100
             self.high = 100
 
+    class XPUTestBitwiseAndCase2(XPUTestBitwiseAndBase):
+        def init_case(self):
+            self.dtype = np.int32
+            self.x_shape = [2, 3, 4, 5]
+            self.y_shape = [4, 1]
+            self.low = -100
+            self.high = 100
 
-support_types = get_xpu_op_support_types('logical_and')
+    class XPUTestBitwiseAndCase3(XPUTestBitwiseAndBase):
+        def init_case(self):
+            self.dtype = np.int32
+            self.x_shape = [2, 3, 4, 5]
+            self.y_shape = [2, 3, 4, 5]
+            self.low = 0
+            self.high = 100
+
+
+support_types = get_xpu_op_support_types('bitwise_and')
 for stype in support_types:
-    create_test_class(globals(), XPUTestLogicalAnd, stype)
+    create_test_class(globals(), XPUTestBitwiseAnd, stype)
 
 
-################## TEST OP: logical_or ##################
-class XPUTestLogicalOr(XPUOpTestWrapper):
+################## TEST OP: BitwiseOr ##################
+class XPUTestBitwiseOr(XPUOpTestWrapper):
     def __init__(self):
-        self.op_name = 'logical_or'
+        self.op_name = 'bitwise_or'
 
-    class XPUTestLogicalOrBase(XPUOpTest):
+    class XPUTestBitwiseOrBase(XPUOpTest):
         def setUp(self):
             self.place = paddle.XPUPlace(0)
             self.init_case()
             self.set_case()
 
         def set_case(self):
-            self.op_type = 'logical_or'
+            self.op_type = 'bitwise_or'
 
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype)
             y = np.random.randint(
                 self.low, self.high, self.y_shape, dtype=self.dtype)
-            out = np.logical_or(x, y)
+            out = np.bitwise_or(x, y)
 
             self.attrs = {'use_xpu': True}
             self.inputs = {
@@ -121,7 +137,7 @@ class XPUTestLogicalOr(XPUOpTestWrapper):
         def test_check_grad(self):
             pass
 
-    class XPUTestLogicalOrCase1(XPUTestLogicalOrBase):
+    class XPUTestBitwiseOrCase1(XPUTestBitwiseOrBase):
         def init_case(self):
             self.dtype = np.int32
             self.x_shape = [4, 5]
@@ -129,31 +145,47 @@ class XPUTestLogicalOr(XPUOpTestWrapper):
             self.low = -100
             self.high = 100
 
+    class XPUTestBitwiseOrCase2(XPUTestBitwiseOrBase):
+        def init_case(self):
+            self.dtype = np.int32
+            self.x_shape = [2, 3, 4, 5]
+            self.y_shape = [4, 1]
+            self.low = -100
+            self.high = 100
 
-support_types = get_xpu_op_support_types('logical_or')
+    class XPUTestBitwiseOrCase3(XPUTestBitwiseOrBase):
+        def init_case(self):
+            self.dtype = np.int32
+            self.x_shape = [2, 3, 4, 5]
+            self.y_shape = [2, 3, 4, 5]
+            self.low = 0
+            self.high = 100
+
+
+support_types = get_xpu_op_support_types('bitwise_or')
 for stype in support_types:
-    create_test_class(globals(), XPUTestLogicalOr, stype)
+    create_test_class(globals(), XPUTestBitwiseOr, stype)
 
 
-################## TEST OP: logical_xor ##################
-class XPUTestLogicalXor(XPUOpTestWrapper):
+################## TEST OP: BitwiseXor ##################
+class XPUTestBitwiseXor(XPUOpTestWrapper):
     def __init__(self):
-        self.op_name = 'logical_xor'
+        self.op_name = 'bitwise_xor'
 
-    class XPUTestLogicalXorBase(XPUOpTest):
+    class XPUTestBitwiseXorBase(XPUOpTest):
         def setUp(self):
             self.place = paddle.XPUPlace(0)
             self.init_case()
             self.set_case()
 
         def set_case(self):
-            self.op_type = 'logical_xor'
+            self.op_type = 'bitwise_xor'
 
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype)
             y = np.random.randint(
                 self.low, self.high, self.y_shape, dtype=self.dtype)
-            out = np.logical_xor(x, y)
+            out = np.bitwise_xor(x, y)
 
             self.attrs = {'use_xpu': True}
             self.inputs = {
@@ -163,7 +195,7 @@ class XPUTestLogicalXor(XPUOpTestWrapper):
             self.outputs = {'Out': out}
 
         def init_case(self):
-            self.dtype = np.int64
+            self.dtype = np.int32
             self.x_shape = [2, 3, 4, 5]
             self.y_shape = [2, 3, 4, 5]
             self.low = -100
@@ -175,7 +207,7 @@ class XPUTestLogicalXor(XPUOpTestWrapper):
         def test_check_grad(self):
             pass
 
-    class XPUTestLogicalXorCase1(XPUTestLogicalXorBase):
+    class XPUTestBitwiseXorCase1(XPUTestBitwiseXorBase):
         def init_case(self):
             self.dtype = np.int32
             self.x_shape = [4, 5]
@@ -183,29 +215,45 @@ class XPUTestLogicalXor(XPUOpTestWrapper):
             self.low = -100
             self.high = 100
 
+    class XPUTestBitwiseXorCase2(XPUTestBitwiseXorBase):
+        def init_case(self):
+            self.dtype = np.int32
+            self.x_shape = [2, 3, 4, 5]
+            self.y_shape = [4, 1]
+            self.low = -100
+            self.high = 100
 
-support_types = get_xpu_op_support_types('logical_xor')
+    class XPUTestBitwiseXorCase3(XPUTestBitwiseXorBase):
+        def init_case(self):
+            self.dtype = np.int32
+            self.x_shape = [2, 3, 4, 5]
+            self.y_shape = [2, 3, 4, 5]
+            self.low = 0
+            self.high = 100
+
+
+support_types = get_xpu_op_support_types('bitwise_xor')
 for stype in support_types:
-    create_test_class(globals(), XPUTestLogicalXor, stype)
+    create_test_class(globals(), XPUTestBitwiseXor, stype)
 
 
-##################  TEST OP: LogicalNot ##################
-class XPUTestLogicalNot(XPUOpTestWrapper):
+##################  TEST OP: BitwiseNot ##################
+class XPUTestBitwiseNot(XPUOpTestWrapper):
     def __init__(self):
-        self.op_name = 'logical_not'
+        self.op_name = 'bitwise_not'
 
-    class XPUTestLogicalNotBase(XPUOpTest):
+    class XPUTestBitwiseNotBase(XPUOpTest):
         def setUp(self):
             self.place = paddle.XPUPlace(0)
             self.init_case()
             self.set_case()
 
         def set_case(self):
-            self.op_type = 'logical_not'
+            self.op_type = 'bitwise_not'
 
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype)
-            out = np.logical_not(x)
+            out = np.bitwise_not(x)
 
             self.attrs = {'use_xpu': True}
             self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
@@ -223,10 +271,30 @@ class XPUTestLogicalNot(XPUOpTestWrapper):
         def test_check_grad(self):
             pass
 
+    class XPUTestBitwiseNotBool(XPUTestBitwiseNotBase):
+        def setUp(self):
+            self.place = paddle.XPUPlace(0)
+            self.init_case()
+            self.set_case()
 
-support_types = get_xpu_op_support_types('logical_not')
+        def set_case(self):
+            self.op_type = 'bitwise_not'
+
+            x = np.random.choice([True, False], self.x_shape)
+            out = np.bitwise_not(x)
+
+            self.attrs = {'use_xpu': True}
+            self.inputs = {'X': x}
+            self.outputs = {'Out': out}
+
+        def init_case(self):
+            self.dtype = np.bool
+            self.x_shape = [2, 3, 4, 5]
+
+
+support_types = get_xpu_op_support_types('bitwise_not')
 for stype in support_types:
-    create_test_class(globals(), XPUTestLogicalNot, stype)
+    create_test_class(globals(), XPUTestBitwiseNot, stype)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/xpu/test_compare_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_compare_op_xpu.py
@@ -65,7 +65,7 @@ def create_test_class(op_type, typename, callback):
     globals()[cls_name] = Cls
 
 
-for _type_name in {'float32', 'int32', 'int64'}:
+for _type_name in {'int32'}:
     if _type_name == 'float64' and core.is_compiled_with_rocm():
         _type_name = 'float32'
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry-pick from [Paddle#40802](https://github.com/PaddlePaddle/Paddle/pull/40802)

- 添加了elementwise类中logical（4个）、compare（6个）和bitwise（4个） 共15个op在xpu上kp注册和单测

- 陈威行 @chenwhql  提供了 phi下KP的完善 Co-authored-by: Chen Weihang <chenweihang@baidu.com>

- 在xpu-kp环境中单测通过，执行符合预期，效果：
- bitwise_op 在xpu上注册kp kernel成功

<img width="1440" alt="截屏2022-04-21 21 07 05" src="https://user-images.githubusercontent.com/18277990/164464644-98f6c52f-32c7-4454-89ca-99006598666b.png">



<img width="307" alt="截屏2022-04-02 13 05 32" src="https://user-images.githubusercontent.com/18277990/161367292-dbdada6f-6174-4160-b315-34522cbcf972.png">

- logical_op
<img width="1440" alt="截屏2022-04-02 12 35 33" src="https://user-images.githubusercontent.com/18277990/161366488-cf077b12-ea3b-43df-a9b5-c483c5b80922.png">
<img width="1438" alt="截屏2022-04-02 12 35 48" src="https://user-images.githubusercontent.com/18277990/161366489-9f93fbae-359f-46a3-afb6-c145baa4a9d4.png">
<img width="1440" alt="截屏2022-04-02 12 36 16" src="https://user-images.githubusercontent.com/18277990/161366491-aae45b92-8829-4d78-9508-4a15d140f0e2.png">
<img width="1439" alt="截屏2022-04-02 12 37 11" src="https://user-images.githubusercontent.com/18277990/161366493-da852eee-4883-4b25-81ad-d11e511e01c8.png">

<img width="306" alt="截屏2022-04-02 13 07 30" src="https://user-images.githubusercontent.com/18277990/161367351-b133b093-eabf-437f-b66f-0a99f0284050.png">

- compare_op 在xpu上注册kp kernel成功

<img width="1157" alt="截屏2022-04-21 21 18 15" src="https://user-images.githubusercontent.com/18277990/164466674-d028ee07-3a28-4793-ab94-08243467d9cd.png">


<img width="308" alt="截屏2022-04-02 13 05 15" src="https://user-images.githubusercontent.com/18277990/161367299-8065653e-a015-413f-9c14-3d5bc5344b2d.png">


结果符合预期