### PR TITLE
Fix the race condition in cumsum operator

### DIFF
--- a/paddle/phi/kernels/gpu/cumsum_kernel.cu
+++ b/paddle/phi/kernels/gpu/cumsum_kernel.cu
@@ -39,13 +39,11 @@ __device__ void BlockReverse(
   int tx = threadIdx.x;
 
   int offset = tx;
-  int in_index = src_base + offset;
-  if (offset >= valid_item) {
-    sh_mem[offset] = 0;
+  int src_offset = BLOCK_SIZE - offset - 1;
+  if (src_offset < valid_item) {
+    sh_mem[offset] = idata[src_base + src_offset];
   } else {
-    int sh_mem_index = BLOCK_SIZE - offset - 1;
-    T data = idata[in_index];
-    sh_mem[sh_mem_index] = data;
+    sh_mem[offset] = 0;
   }
 
   __syncthreads();

--- a/paddle/phi/kernels/gpu/cumsum_kernel.cu
+++ b/paddle/phi/kernels/gpu/cumsum_kernel.cu
@@ -39,12 +39,12 @@ __device__ void BlockReverse(
   int tx = threadIdx.x;
 
   int offset = tx;
+  T src_data = 0;
   int src_offset = BLOCK_SIZE - offset - 1;
   if (src_offset < valid_item) {
-    sh_mem[offset] = idata[src_base + src_offset];
-  } else {
-    sh_mem[offset] = 0;
+    src_data = idata[src_base + src_offset];
   }
+  sh_mem[offset] = src_data;
 
   __syncthreads();
   int out_index = dst_base - offset;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Followed by the issue https://github.com/PaddlePaddle/Paddle/issues/41932, the cumsum UT failed on P100.

The reason is that the `BlockReverse` function in `cumsum_op` has race condition.
This PR modifies part of codes to avoid hazard.
