### PR TITLE
[Cherry-pick, Eager] Support numpy.ndarry in CastNumpy2Scalar, fix test_bfgs.py (#42136)

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_bfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_bfgs.py
@@ -20,6 +20,7 @@ import paddle
 import paddle.nn.functional as F
 
 from paddle.incubate.optimizer.functional.bfgs import minimize_bfgs
+from paddle.fluid.framework import _test_eager_guard
 
 np.random.seed(123)
 
@@ -117,7 +118,7 @@ class TestBfgs(unittest.TestCase):
         results = test_static_graph(func, x0, dtype='float64')
         self.assertTrue(np.allclose(0.8, results[2]))
 
-    def test_rosenbrock(self):
+    def func_rosenbrock(self):
         # The Rosenbrock function is a standard optimization test case.
         a = np.random.random(size=[1]).astype('float32')
         minimum = [a.item(), (a**2).item()]
@@ -135,6 +136,11 @@ class TestBfgs(unittest.TestCase):
 
         results = test_dynamic_graph(func, x0)
         self.assertTrue(np.allclose(minimum, results[2]))
+
+    def test_rosenbrock(self):
+        with _test_eager_guard():
+            self.func_rosenbrock()
+        self.func_rosenbrock()
 
     def test_exception(self):
         def func(x):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Support numpy.ndarry in CastNumpy2Scalar and then support test_bfgs.py switch to eager mode.
