### PR TITLE
Increase test_export_deploy_model tolerance for broadwell CPU

### DIFF
--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -783,7 +783,7 @@ class TestModelFunction(unittest.TestCase):
                                   feed={feed_target_names[0]: tensor_img},
                                   fetch_list=fetch_targets)
                 np.testing.assert_allclose(
-                    results, ori_results, rtol=1e-5, atol=1e-7)
+                    results, ori_results, rtol=1e-5, atol=1e-6)
 
             paddle.enable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
`test_model` unit test is failed on Broadwell CPU. Increase tolerance to pass on Broadwell CPU.