### PR TITLE
fix gcc warning of cast-function-type

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -163,7 +163,6 @@ if(NOT APPLE)
         set(COMMON_FLAGS
                 ${COMMON_FLAGS}
                 -Wno-format-truncation # Warning in boost gcc 8.2
-                -Wno-error=cast-function-type # Warning in boost gcc 8.2
                 -Wno-error=parentheses # Warning in boost gcc 8.2
                 -Wno-error=catch-value # Warning in boost gcc 8.2
                 -Wno-error=nonnull-compare # Warning in boost gcc 8.2

--- a/paddle/fluid/pybind/fleet_py.cc
+++ b/paddle/fluid/pybind/fleet_py.cc
@@ -60,11 +60,7 @@ void BindDistFleetWrapper(py::module* m) {
       .def("load_model", &FleetWrapper::LoadModel)
       .def("load_one_table", &FleetWrapper::LoadModelOneTable)
       .def("init_server", &FleetWrapper::InitServer)
-      .def("run_server",
-           (uint64_t (FleetWrapper::*)(void)) & FleetWrapper::RunServer)
-      .def("run_server", (uint64_t (FleetWrapper::*)(          // NOLINT
-                             const std::string&, uint32_t)) &  // NOLINT
-                             FleetWrapper::RunServer)
+      .def("run_server", &FleetWrapper::RunServer)
       .def("init_worker", &FleetWrapper::InitWorker)
       .def("push_dense_params", &FleetWrapper::PushDenseParamSync)
       .def("pull_dense_params", &FleetWrapper::PullDenseVarsSync)

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -765,10 +765,7 @@ void BindMkldnnQuantizerConfig(py::module *m) {
              return;
            })
       .def("set_quant_batch_size", &MkldnnQuantizerConfig::SetWarmupBatchSize)
-      .def(
-          "set_enabled_op_types",
-          (void (MkldnnQuantizerConfig::*)(std::unordered_set<std::string> &)) &
-              MkldnnQuantizerConfig::SetEnabledOpTypes);
+      .def("set_enabled_op_types", &MkldnnQuantizerConfig::SetEnabledOpTypes);
 }
 #endif
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- fix code that contains gcc warning of cast-function-type
- remove `-Wno-error=cast-function-type` in gcc flags

ps. it seems the related code is not used in paddle, maybe we should clean it directly