### PR TITLE
Add move construct for KernelSignature

### DIFF
--- a/paddle/phi/core/compat/arg_map_context.h
+++ b/paddle/phi/core/compat/arg_map_context.h
@@ -64,7 +64,7 @@ struct KernelSignature {
         attr_names(other.attr_names),
         output_names(other.output_names) {}
 
-  KernelSignature(KernelSignature&& other)
+  KernelSignature(KernelSignature&& other) noexcept
       : name(other.name),
         input_names(std::move(other.input_names)),
         attr_names(std::move(other.attr_names)),
@@ -78,7 +78,7 @@ struct KernelSignature {
     return *this;
   }
 
-  KernelSignature& operator=(KernelSignature&& other) {
+  KernelSignature& operator=(KernelSignature&& other) noexcept {
     name = other.name;
     input_names.swap(other.input_names);
     attr_names.swap(other.attr_names);

--- a/paddle/phi/core/compat/arg_map_context.h
+++ b/paddle/phi/core/compat/arg_map_context.h
@@ -63,11 +63,26 @@ struct KernelSignature {
         input_names(other.input_names),
         attr_names(other.attr_names),
         output_names(other.output_names) {}
+
+  KernelSignature(KernelSignature&& other)
+      : name(other.name),
+        input_names(std::move(other.input_names)),
+        attr_names(std::move(other.attr_names)),
+        output_names(std::move(other.output_names)) {}
+
   KernelSignature& operator=(const KernelSignature& other) {
     name = other.name;
     input_names = other.input_names;
     attr_names = other.attr_names;
     output_names = other.output_names;
+    return *this;
+  }
+
+  KernelSignature& operator=(KernelSignature&& other) {
+    name = other.name;
+    input_names.swap(other.input_names);
+    attr_names.swap(other.attr_names);
+    output_names.swap(other.output_names);
     return *this;
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
KernelSignature添加移动构造函数和移动赋值函数。