### PR TITLE
Unify utils naming style

### DIFF
--- a/paddle/fluid/framework/infershape_utils.cc
+++ b/paddle/fluid/framework/infershape_utils.cc
@@ -320,7 +320,7 @@ void CompatInferMetaContext::EmplaceBackOutput(CompatMetaTensor output) {
 }
 
 void CompatInferMetaContext::EmplaceBackInputs(
-    paddle::SmallVector<CompatMetaTensor, phi::kInputSmallVectorSize> inputs) {
+    paddle::small_vector<CompatMetaTensor, phi::kInputSmallVectorSize> inputs) {
   int index = compat_inputs_.size();
   input_range_.emplace_back(std::pair<int, int>(index, index + inputs.size()));
   compat_inputs_.insert(compat_inputs_.end(),
@@ -329,7 +329,7 @@ void CompatInferMetaContext::EmplaceBackInputs(
 }
 
 void CompatInferMetaContext::EmplaceBackOutputs(
-    paddle::SmallVector<CompatMetaTensor, phi::kOutputSmallVectorSize>
+    paddle::small_vector<CompatMetaTensor, phi::kOutputSmallVectorSize>
         outputs) {
   int index = compat_outputs_.size();
   output_range_.emplace_back(
@@ -428,7 +428,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
         infer_meta_context.EmplaceBackInput(
             std::move(CompatMetaTensor(input_var[0], ctx->IsRuntime())));
       } else {
-        paddle::SmallVector<CompatMetaTensor, phi::kInputSmallVectorSize>
+        paddle::small_vector<CompatMetaTensor, phi::kInputSmallVectorSize>
             inputs;
         for (const auto& in : input_var) {
           inputs.emplace_back(
@@ -689,7 +689,7 @@ CompatInferMetaContext BuildInferMetaContext(InferShapeContext* ctx,
         infer_meta_context.EmplaceBackOutput(
             std::move(CompatMetaTensor(output_var[0], ctx->IsRuntime())));
       } else {
-        paddle::SmallVector<CompatMetaTensor, phi::kOutputSmallVectorSize>
+        paddle::small_vector<CompatMetaTensor, phi::kOutputSmallVectorSize>
             outputs;
         for (const auto& out : output_var) {
           if (ctx->IsRuntime()) {

--- a/paddle/fluid/framework/infershape_utils.h
+++ b/paddle/fluid/framework/infershape_utils.h
@@ -100,9 +100,10 @@ class CompatInferMetaContext : public phi::InferMetaContext {
   void EmplaceBackOutput(CompatMetaTensor output);
 
   void EmplaceBackInputs(
-      paddle::SmallVector<CompatMetaTensor, phi::kInputSmallVectorSize> inputs);
+      paddle::small_vector<CompatMetaTensor, phi::kInputSmallVectorSize>
+          inputs);
   void EmplaceBackOutputs(
-      paddle::SmallVector<CompatMetaTensor, phi::kOutputSmallVectorSize>
+      paddle::small_vector<CompatMetaTensor, phi::kOutputSmallVectorSize>
           outputs);
 
   const phi::MetaTensor& InputAt(size_t idx) const override;
@@ -121,9 +122,9 @@ class CompatInferMetaContext : public phi::InferMetaContext {
   virtual ~CompatInferMetaContext() = default;
 
  private:
-  paddle::SmallVector<CompatMetaTensor, phi::kInputSmallVectorSize>
+  paddle::small_vector<CompatMetaTensor, phi::kInputSmallVectorSize>
       compat_inputs_;
-  paddle::SmallVector<CompatMetaTensor, phi::kOutputSmallVectorSize>
+  paddle::small_vector<CompatMetaTensor, phi::kOutputSmallVectorSize>
       compat_outputs_;
 };
 

--- a/paddle/fluid/framework/new_executor/new_executor_defs.cc
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.cc
@@ -328,21 +328,21 @@ bool InterpretercoreInferShapeContext::IsRunMKLDNNKernel() const {
 }
 
 // TODO(paddle-dev): Can this be template?
-paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize>
+paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize>
 InterpretercoreInferShapeContext::GetInputVarPtrs(
     const std::string& name) const {
   const std::vector<Variable*>& vars = InputVars(name);
-  paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize> res;
+  paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize> res;
   res.reserve(vars.size());
   res.insert(res.begin(), vars.begin(), vars.end());
   return res;
 }
 
-paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
+paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
 InterpretercoreInferShapeContext::GetOutputVarPtrs(
     const std::string& name) const {
   const std::vector<Variable*>& vars = OutputVars(name);
-  paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize> res;
+  paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize> res;
   res.reserve(vars.size());
   res.insert(res.begin(), vars.begin(), vars.end());
   return res;

--- a/paddle/fluid/framework/new_executor/new_executor_defs.h
+++ b/paddle/fluid/framework/new_executor/new_executor_defs.h
@@ -90,10 +90,10 @@ class InterpretercoreInferShapeContext : public InferShapeContext {
   bool IsRunMKLDNNKernel() const override;
 
   // TODO(paddle-dev): Can this be template?
-  paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize>
+  paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize>
   GetInputVarPtrs(const std::string& name) const override;
 
-  paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
+  paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
   GetOutputVarPtrs(const std::string& name) const override;
 
   DDim GetInputDim(const std::string& name) const override;

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -202,10 +202,10 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     }
   }
 
-  paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize>
+  paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize>
   GetInputVarPtrs(const std::string &name) const override {
     const std::vector<std::string> arg_names = Inputs(name);
-    paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize> res;
+    paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize> res;
     res.reserve(arg_names.size());
     std::transform(arg_names.begin(), arg_names.end(), std::back_inserter(res),
                    [this](const std::string &name) {
@@ -214,10 +214,10 @@ class CompileTimeInferShapeContext : public InferShapeContext {
     return res;
   }
 
-  paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
+  paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
   GetOutputVarPtrs(const std::string &name) const override {
     const std::vector<std::string> arg_names = Outputs(name);
-    paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize> res;
+    paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize> res;
     res.reserve(arg_names.size());
     std::transform(arg_names.begin(), arg_names.end(), std::back_inserter(res),
                    [this](const std::string &name) {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -946,19 +946,19 @@ class RuntimeInferShapeContext : public InferShapeContext {
   }
 
   // TODO(paddle-dev): Can this be template?
-  paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize>
+  paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize>
   GetInputVarPtrs(const std::string& name) const override {
     const std::vector<Variable*>& vars = InputVars(name);
-    paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize> res;
+    paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize> res;
     res.reserve(vars.size());
     res.insert(res.begin(), vars.begin(), vars.end());
     return res;
   }
 
-  paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
+  paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
   GetOutputVarPtrs(const std::string& name) const override {
     const std::vector<Variable*>& vars = OutputVars(name);
-    paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize> res;
+    paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize> res;
     res.reserve(vars.size());
     res.insert(res.begin(), vars.begin(), vars.end());
     return res;
@@ -2340,7 +2340,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
         tensor_in = &(var->Get<phi::SelectedRows>());
         pt_kernel_context->EmplaceBackInputWithoutSetRange(tensor_in);
       } else if (var->IsType<framework::LoDTensorArray>()) {
-        paddle::SmallVector<const phi::TensorBase*> tensor_vector;
+        paddle::small_vector<const phi::TensorBase*> tensor_vector;
         auto& tensor_array = var->Get<framework::LoDTensorArray>();
         for (auto& t : tensor_array) {
           tensor_vector.emplace_back(&t);
@@ -2389,7 +2389,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
           tensor_out = var->template GetMutable<phi::SelectedRows>();
           pt_kernel_context->EmplaceBackOutputWithoutSetRange(tensor_out);
         } else if (var->template IsType<framework::LoDTensorArray>()) {
-          paddle::SmallVector<phi::TensorBase*> tensor_vector;
+          paddle::small_vector<phi::TensorBase*> tensor_vector;
           auto* tensor_array =
               var->template GetMutable<framework::LoDTensorArray>();
           // Note: If the input LoDTensorArray size is 0, the output

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -333,8 +333,8 @@ class ExecutionContext {
     return it->second;
   }
 
-  virtual paddle::SmallVector<const std::string*> InNameList() const {
-    paddle::SmallVector<const std::string*> vec_temp;
+  virtual paddle::small_vector<const std::string*> InNameList() const {
+    paddle::small_vector<const std::string*> vec_temp;
     vec_temp.reserve(ctx_.inputs.size());
 
     for (auto& input : ctx_.inputs) {

--- a/paddle/fluid/framework/phi_utils.cc
+++ b/paddle/fluid/framework/phi_utils.cc
@@ -41,9 +41,9 @@ class KernelArgsNameMakerByOpProto : public KernelArgsNameMaker {
 
   ~KernelArgsNameMakerByOpProto() {}
 
-  const paddle::SmallVector<const char*>& GetInputArgsNames() override;
-  const paddle::SmallVector<const char*>& GetOutputArgsNames() override;
-  const paddle::SmallVector<const char*>& GetAttrsArgsNames() override;
+  const paddle::small_vector<const char*>& GetInputArgsNames() override;
+  const paddle::small_vector<const char*>& GetOutputArgsNames() override;
+  const paddle::small_vector<const char*>& GetAttrsArgsNames() override;
 
   phi::KernelSignature GetKernelSignature();
 
@@ -53,9 +53,9 @@ class KernelArgsNameMakerByOpProto : public KernelArgsNameMaker {
  private:
   const framework::proto::OpProto* op_proto_;
 
-  paddle::SmallVector<const char*> input_names_;
-  paddle::SmallVector<const char*> output_names_;
-  paddle::SmallVector<const char*> attr_names_;
+  paddle::small_vector<const char*> input_names_;
+  paddle::small_vector<const char*> output_names_;
+  paddle::small_vector<const char*> attr_names_;
 };
 
 OpKernelType TransPhiKernelKeyToOpKernelType(const phi::KernelKey& kernel_key) {
@@ -149,7 +149,7 @@ phi::KernelKey FallBackToCpu(const OpKernelType& expected_kernel_key,
   return phi::KernelKey();
 }
 
-const paddle::SmallVector<const char*>&
+const paddle::small_vector<const char*>&
 KernelArgsNameMakerByOpProto::GetInputArgsNames() {
   for (int i = 0; i < op_proto_->inputs_size(); ++i) {
     auto& in = op_proto_->inputs()[i];
@@ -174,7 +174,7 @@ KernelArgsNameMakerByOpProto::GetInputArgsNames() {
   return input_names_;
 }
 
-const paddle::SmallVector<const char*>&
+const paddle::small_vector<const char*>&
 KernelArgsNameMakerByOpProto::GetOutputArgsNames() {
   for (int i = 0; i < op_proto_->outputs_size(); ++i) {
     auto& out = op_proto_->outputs()[i];
@@ -194,7 +194,7 @@ KernelArgsNameMakerByOpProto::GetOutputArgsNames() {
   return output_names_;
 }
 
-const paddle::SmallVector<const char*>&
+const paddle::small_vector<const char*>&
 KernelArgsNameMakerByOpProto::GetAttrsArgsNames() {
   for (int i = 0; i < op_proto_->attrs_size(); ++i) {
     auto& attr = op_proto_->attrs()[i];

--- a/paddle/fluid/framework/phi_utils.h
+++ b/paddle/fluid/framework/phi_utils.h
@@ -53,9 +53,9 @@ phi::KernelKey FallBackToCpu(const OpKernelType& expected_kernel_key,
 class KernelArgsNameMaker {
  public:
   virtual ~KernelArgsNameMaker() {}
-  virtual const paddle::SmallVector<const char*>& GetInputArgsNames() = 0;
-  virtual const paddle::SmallVector<const char*>& GetOutputArgsNames() = 0;
-  virtual const paddle::SmallVector<const char*>& GetAttrsArgsNames() = 0;
+  virtual const paddle::small_vector<const char*>& GetInputArgsNames() = 0;
+  virtual const paddle::small_vector<const char*>& GetOutputArgsNames() = 0;
+  virtual const paddle::small_vector<const char*>& GetAttrsArgsNames() = 0;
 };
 
 void InitDefaultKernelSignatureMap();

--- a/paddle/fluid/framework/shape_inference.h
+++ b/paddle/fluid/framework/shape_inference.h
@@ -108,9 +108,9 @@ class InferShapeContext {
 
   virtual bool IsRunMKLDNNKernel() const = 0;
 
-  virtual paddle::SmallVector<InferShapeVarPtr, phi::kInputSmallVectorSize>
+  virtual paddle::small_vector<InferShapeVarPtr, phi::kInputSmallVectorSize>
   GetInputVarPtrs(const std::string &name) const = 0;
-  virtual paddle::SmallVector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
+  virtual paddle::small_vector<InferShapeVarPtr, phi::kOutputSmallVectorSize>
   GetOutputVarPtrs(const std::string &name) const = 0;
 
   virtual const phi::ArgumentMappingFn *GetPhiArgumentMappingFn() const = 0;

--- a/paddle/fluid/imperative/execution_context.h
+++ b/paddle/fluid/imperative/execution_context.h
@@ -117,8 +117,8 @@ class DygraphExecutionContext : public framework::ExecutionContext {
     return it->second;
   }
 
-  paddle::SmallVector<const std::string*> InNameList() const override {
-    paddle::SmallVector<const std::string*> vec_temp;
+  paddle::small_vector<const std::string*> InNameList() const override {
+    paddle::small_vector<const std::string*> vec_temp;
     vec_temp.reserve(var_map_in_.size());
 
     for (auto& v : var_map_in_) {

--- a/paddle/fluid/imperative/infer_shape_context.h
+++ b/paddle/fluid/imperative/infer_shape_context.h
@@ -239,9 +239,10 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
             (op_kernel_type_->data_layout_ == framework::DataLayout::kMKLDNN));
   }
 
-  paddle::SmallVector<framework::InferShapeVarPtr, phi::kInputSmallVectorSize>
+  paddle::small_vector<framework::InferShapeVarPtr, phi::kInputSmallVectorSize>
   GetInputVarPtrs(const std::string& name) const override {
-    paddle::SmallVector<framework::InferShapeVarPtr, phi::kInputSmallVectorSize>
+    paddle::small_vector<framework::InferShapeVarPtr,
+                         phi::kInputSmallVectorSize>
         res;
     auto it = var_map_in_->find(name);
     PADDLE_ENFORCE_NE(
@@ -253,10 +254,10 @@ class DygraphInferShapeContext : public framework::InferShapeContext {
     return res;
   }
 
-  paddle::SmallVector<framework::InferShapeVarPtr, phi::kOutputSmallVectorSize>
+  paddle::small_vector<framework::InferShapeVarPtr, phi::kOutputSmallVectorSize>
   GetOutputVarPtrs(const std::string& name) const override {
-    paddle::SmallVector<framework::InferShapeVarPtr,
-                        phi::kOutputSmallVectorSize>
+    paddle::small_vector<framework::InferShapeVarPtr,
+                         phi::kOutputSmallVectorSize>
         res;
     auto it = var_map_out_->find(name);
     PADDLE_ENFORCE_NE(

--- a/paddle/fluid/imperative/prepared_operator.h
+++ b/paddle/fluid/imperative/prepared_operator.h
@@ -311,7 +311,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
         tensor_in = &(var.template Get<phi::SelectedRows>());
         kernel_ctx->EmplaceBackInputWithoutSetRange(tensor_in);
       } else if (var.template IsType<framework::LoDTensorArray>()) {
-        paddle::SmallVector<const phi::TensorBase*> tensor_vector;
+        paddle::small_vector<const phi::TensorBase*> tensor_vector;
         auto& tensor_array = var.template Get<framework::LoDTensorArray>();
         for (auto& t : tensor_array) {
           tensor_vector.emplace_back(&t);
@@ -357,7 +357,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
           tensor_out = var->template GetMutable<phi::SelectedRows>();
           kernel_ctx->EmplaceBackOutputWithoutSetRange(tensor_out);
         } else if (var->template IsType<framework::LoDTensorArray>()) {
-          paddle::SmallVector<phi::TensorBase*> tensor_vector;
+          paddle::small_vector<phi::TensorBase*> tensor_vector;
           auto* tensor_array =
               var->template GetMutable<framework::LoDTensorArray>();
           for (auto& t : *tensor_array) {

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -2028,35 +2028,35 @@ void BindImperative(py::module *m_ptr) {
                  *(imperative::AmpOperators::Instance().GetMutableAllowOps()),
                  *(imperative::AmpOperators::Instance().GetMutableBlockOps()));
            })
-      .def(
-          "_get_kernel_signature",
-          [](imperative::Tracer &self, const std::string &type,
-             const PyNameVarBaseMap &ins, const PyNameVarBaseMap &outs,
-             framework::AttributeMap attrs) {
-            // TODO(xiongkun): move this function outside of tracer.
-            auto ins_map = ConvertToNameTensorMap(ins);
-            auto outs_map = ConvertToNameTensorMap(outs);
-            {
-              auto input_to_vector =
-                  [](paddle::SmallVector<const char *> &vec) {
-                    return std::vector<std::string>(vec.begin(), vec.end());
-                  };
-              auto output_to_vector =
-                  [](paddle::SmallVector<const char *> &vec) {
-                    return std::vector<std::string>(vec.begin(), vec.end());
-                  };
-              auto attr_to_vector = [](paddle::SmallVector<const char *> &vec) {
-                return std::vector<std::string>(vec.begin(), vec.end());
-              };
-              auto ret = self.GetExpectedKernelSignature(type, ins_map,
-                                                         outs_map, attrs);
-              auto kernelsig_ins = input_to_vector(ret.input_names);
-              auto kernelsig_attrs = attr_to_vector(ret.attr_names);
-              auto kernelsig_outs = output_to_vector(ret.output_names);
-              return std::make_tuple(kernelsig_ins, kernelsig_attrs,
-                                     kernelsig_outs);
-            }
-          })
+      .def("_get_kernel_signature",
+           [](imperative::Tracer &self, const std::string &type,
+              const PyNameVarBaseMap &ins, const PyNameVarBaseMap &outs,
+              framework::AttributeMap attrs) {
+             // TODO(xiongkun): move this function outside of tracer.
+             auto ins_map = ConvertToNameTensorMap(ins);
+             auto outs_map = ConvertToNameTensorMap(outs);
+             {
+               auto input_to_vector =
+                   [](paddle::small_vector<const char *> &vec) {
+                     return std::vector<std::string>(vec.begin(), vec.end());
+                   };
+               auto output_to_vector =
+                   [](paddle::small_vector<const char *> &vec) {
+                     return std::vector<std::string>(vec.begin(), vec.end());
+                   };
+               auto attr_to_vector =
+                   [](paddle::small_vector<const char *> &vec) {
+                     return std::vector<std::string>(vec.begin(), vec.end());
+                   };
+               auto ret = self.GetExpectedKernelSignature(type, ins_map,
+                                                          outs_map, attrs);
+               auto kernelsig_ins = input_to_vector(ret.input_names);
+               auto kernelsig_attrs = attr_to_vector(ret.attr_names);
+               auto kernelsig_outs = output_to_vector(ret.output_names);
+               return std::make_tuple(kernelsig_ins, kernelsig_attrs,
+                                      kernelsig_outs);
+             }
+           })
       .def("trace",
            [](imperative::Tracer &self, const std::string &type,
               const PyNameVarBaseMap &ins, const PyNameVarBaseMap &outs,

--- a/paddle/infrt/dialect/phi/pass/kernel_op_desc.cc
+++ b/paddle/infrt/dialect/phi/pass/kernel_op_desc.cc
@@ -93,9 +93,9 @@ std::vector<PhiKernelDesc> GetCandidateKernels(
     phi_kernel_desc.input_types.clear();
     phi_kernel_desc.output_types.clear();
     phi::KernelArgsDef args_def = kernel_key_map.at(kernel_key).args_def();
-    const paddle::SmallVector<phi::TensorArgDef, phi::kInputSmallVectorSize>&
+    const paddle::small_vector<phi::TensorArgDef, phi::kInputSmallVectorSize>&
         input_arg = args_def.input_defs();
-    const paddle::SmallVector<phi::TensorArgDef, phi::kOutputSmallVectorSize>&
+    const paddle::small_vector<phi::TensorArgDef, phi::kOutputSmallVectorSize>&
         output_arg = args_def.output_defs();
     for (auto tensor_arg : input_arg) {
       phi_kernel_desc.input_types.emplace_back(ConvertPlaceFromPhi(tensor_arg));

--- a/paddle/phi/core/compat/arg_map_context.h
+++ b/paddle/phi/core/compat/arg_map_context.h
@@ -27,30 +27,30 @@ limitations under the License. */
 namespace phi {
 
 // tuple(input_names, attr_names, output_names)
-using KernelArgsTuple = std::tuple<paddle::SmallVector<const char*>,
-                                   paddle::SmallVector<const char*>,
-                                   paddle::SmallVector<const char*>>;
+using KernelArgsTuple = std::tuple<paddle::small_vector<const char*>,
+                                   paddle::small_vector<const char*>,
+                                   paddle::small_vector<const char*>>;
 
 struct KernelSignature {
   const char* name;
-  paddle::SmallVector<const char*> input_names;
-  paddle::SmallVector<const char*> attr_names;
-  paddle::SmallVector<const char*> output_names;
+  paddle::small_vector<const char*> input_names;
+  paddle::small_vector<const char*> attr_names;
+  paddle::small_vector<const char*> output_names;
 
   KernelSignature() = default;
 
   KernelSignature(const char* kernel_name,
-                  paddle::SmallVector<const char*>&& inputs,
-                  paddle::SmallVector<const char*>&& attrs,
-                  paddle::SmallVector<const char*>&& outputs)
+                  paddle::small_vector<const char*>&& inputs,
+                  paddle::small_vector<const char*>&& attrs,
+                  paddle::small_vector<const char*>&& outputs)
       : name(kernel_name),
         input_names(std::move(inputs)),
         attr_names(std::move(attrs)),
         output_names(std::move(outputs)) {}
   KernelSignature(const char* kernel_name,
-                  const paddle::SmallVector<const char*>& inputs,
-                  const paddle::SmallVector<const char*>& attrs,
-                  const paddle::SmallVector<const char*>& outputs)
+                  const paddle::small_vector<const char*>& inputs,
+                  const paddle::small_vector<const char*>& attrs,
+                  const paddle::small_vector<const char*>& outputs)
       : name(kernel_name),
         input_names(inputs),
         attr_names(attrs),

--- a/paddle/phi/core/infermeta_utils.cc
+++ b/paddle/phi/core/infermeta_utils.cc
@@ -35,7 +35,7 @@ void InferMetaContext::EmplaceBackAttr(Attribute attr) {
 }
 
 void InferMetaContext::EmplaceBackInputs(
-    paddle::SmallVector<MetaTensor, phi::kInputSmallVectorSize> inputs) {
+    paddle::small_vector<MetaTensor, phi::kInputSmallVectorSize> inputs) {
   int index = inputs_.size();
   input_range_.emplace_back(std::pair<int, int>(index, index + inputs.size()));
   inputs_.insert(inputs_.end(),
@@ -43,7 +43,7 @@ void InferMetaContext::EmplaceBackInputs(
                  std::make_move_iterator(inputs.end()));
 }
 void InferMetaContext::EmplaceBackOutputs(
-    paddle::SmallVector<MetaTensor, phi::kOutputSmallVectorSize> outputs) {
+    paddle::small_vector<MetaTensor, phi::kOutputSmallVectorSize> outputs) {
   int index = outputs_.size();
   output_range_.emplace_back(
       std::pair<int, int>(index, index + outputs.size()));

--- a/paddle/phi/core/infermeta_utils.h
+++ b/paddle/phi/core/infermeta_utils.h
@@ -45,9 +45,9 @@ class InferMetaContext {
   void EmplaceBackAttr(Attribute attr);
 
   void EmplaceBackInputs(
-      paddle::SmallVector<MetaTensor, phi::kInputSmallVectorSize> inputs);
+      paddle::small_vector<MetaTensor, phi::kInputSmallVectorSize> inputs);
   void EmplaceBackOutputs(
-      paddle::SmallVector<MetaTensor, phi::kOutputSmallVectorSize> outputs);
+      paddle::small_vector<MetaTensor, phi::kOutputSmallVectorSize> outputs);
 
   virtual const MetaTensor& InputAt(size_t idx) const;
   virtual paddle::optional<const MetaTensor&> OptionalInputAt(size_t idx) const;
@@ -72,16 +72,16 @@ class InferMetaContext {
  protected:
   MetaConfig config_;
 
-  paddle::SmallVector<Attribute, kAttrSmallVectorSize> attrs_;
+  paddle::small_vector<Attribute, kAttrSmallVectorSize> attrs_;
 
-  paddle::SmallVector<std::pair<int, int>, phi::kInputSmallVectorSize>
+  paddle::small_vector<std::pair<int, int>, phi::kInputSmallVectorSize>
       input_range_;
-  paddle::SmallVector<std::pair<int, int>, phi::kOutputSmallVectorSize>
+  paddle::small_vector<std::pair<int, int>, phi::kOutputSmallVectorSize>
       output_range_;
 
  private:
-  paddle::SmallVector<MetaTensor, phi::kInputSmallVectorSize> inputs_;
-  paddle::SmallVector<MetaTensor, phi::kOutputSmallVectorSize> outputs_;
+  paddle::small_vector<MetaTensor, phi::kInputSmallVectorSize> inputs_;
+  paddle::small_vector<MetaTensor, phi::kOutputSmallVectorSize> outputs_;
 };
 
 #define PD_INFER_META(...) \

--- a/paddle/phi/core/kernel_context.cc
+++ b/paddle/phi/core/kernel_context.cc
@@ -28,7 +28,7 @@ void KernelContext::EmplaceBackInputWithoutSetRange(const TensorBase* input) {
 }
 
 void KernelContext::EmplaceBackInputs(
-    paddle::SmallVector<const TensorBase*> inputs) {
+    paddle::small_vector<const TensorBase*> inputs) {
   int index = inputs_.size();
   // Record the start and end index of the input
   input_range_.emplace_back(std::pair<int, int>(index, index + inputs.size()));
@@ -38,7 +38,7 @@ void KernelContext::EmplaceBackInputs(
 }
 
 void KernelContext::EmplaceBackInputsWithoutSetRange(
-    paddle::SmallVector<const TensorBase*> inputs) {
+    paddle::small_vector<const TensorBase*> inputs) {
   inputs_.insert(inputs_.end(),
                  std::make_move_iterator(inputs.begin()),
                  std::make_move_iterator(inputs.end()));
@@ -56,7 +56,7 @@ void KernelContext::EmplaceBackOutputWithoutSetRange(TensorBase* output) {
 }
 
 void KernelContext::EmplaceBackOutputs(
-    paddle::SmallVector<TensorBase*> outputs) {
+    paddle::small_vector<TensorBase*> outputs) {
   int index = outputs_.size();
   // Record the start and end index of the input
   output_range_.emplace_back(
@@ -67,7 +67,7 @@ void KernelContext::EmplaceBackOutputs(
 }
 
 void KernelContext::EmplaceBackOutputsWithoutSetRange(
-    paddle::SmallVector<TensorBase*> outputs) {
+    paddle::small_vector<TensorBase*> outputs) {
   outputs_.insert(outputs_.end(),
                   std::make_move_iterator(outputs.begin()),
                   std::make_move_iterator(outputs.end()));

--- a/paddle/phi/core/kernel_context.h
+++ b/paddle/phi/core/kernel_context.h
@@ -51,19 +51,19 @@ class KernelContext {
 
   void EmplaceBackInputWithoutSetRange(const TensorBase* input);
 
-  void EmplaceBackInputs(paddle::SmallVector<const TensorBase*> inputs);
+  void EmplaceBackInputs(paddle::small_vector<const TensorBase*> inputs);
 
   void EmplaceBackInputsWithoutSetRange(
-      paddle::SmallVector<const TensorBase*> inputs);
+      paddle::small_vector<const TensorBase*> inputs);
 
   void EmplaceBackOutput(TensorBase* output);
 
   void EmplaceBackOutputWithoutSetRange(TensorBase* output);
 
-  void EmplaceBackOutputs(paddle::SmallVector<TensorBase*> outputs);
+  void EmplaceBackOutputs(paddle::small_vector<TensorBase*> outputs);
 
   void EmplaceBackOutputsWithoutSetRange(
-      paddle::SmallVector<TensorBase*> outputs);
+      paddle::small_vector<TensorBase*> outputs);
 
   void EmplaceBackAttr(Attribute attr);
 
@@ -138,12 +138,12 @@ class KernelContext {
  private:
   DeviceContext* dev_ctx_;
 
-  paddle::SmallVector<const TensorBase*> inputs_;
-  paddle::SmallVector<TensorBase*> outputs_;
-  paddle::SmallVector<Attribute, kAttrSmallVectorSize> attrs_;
+  paddle::small_vector<const TensorBase*> inputs_;
+  paddle::small_vector<TensorBase*> outputs_;
+  paddle::small_vector<Attribute, kAttrSmallVectorSize> attrs_;
 
-  paddle::SmallVector<std::pair<int, int>, kInputSmallVectorSize> input_range_;
-  paddle::SmallVector<std::pair<int, int>, kOutputSmallVectorSize>
+  paddle::small_vector<std::pair<int, int>, kInputSmallVectorSize> input_range_;
+  paddle::small_vector<std::pair<int, int>, kOutputSmallVectorSize>
       output_range_;
 };
 

--- a/paddle/phi/core/kernel_factory.h
+++ b/paddle/phi/core/kernel_factory.h
@@ -151,37 +151,38 @@ class KernelArgsDef {
     attribute_defs_.emplace_back(AttributeArgDef(type_index));
   }
 
-  const paddle::SmallVector<TensorArgDef, kInputSmallVectorSize>& input_defs()
+  const paddle::small_vector<TensorArgDef, kInputSmallVectorSize>& input_defs()
       const {
     return input_defs_;
   }
 
-  const paddle::SmallVector<TensorArgDef, kOutputSmallVectorSize>& output_defs()
-      const {
+  const paddle::small_vector<TensorArgDef, kOutputSmallVectorSize>&
+  output_defs() const {
     return output_defs_;
   }
 
-  const paddle::SmallVector<AttributeArgDef, kAttrSmallVectorSize>&
+  const paddle::small_vector<AttributeArgDef, kAttrSmallVectorSize>&
   attribute_defs() const {
     return attribute_defs_;
   }
 
-  paddle::SmallVector<TensorArgDef, kInputSmallVectorSize>& input_defs() {
+  paddle::small_vector<TensorArgDef, kInputSmallVectorSize>& input_defs() {
     return input_defs_;
   }
 
-  paddle::SmallVector<TensorArgDef, kOutputSmallVectorSize>& output_defs() {
+  paddle::small_vector<TensorArgDef, kOutputSmallVectorSize>& output_defs() {
     return output_defs_;
   }
 
-  paddle::SmallVector<AttributeArgDef, kAttrSmallVectorSize>& attribute_defs() {
+  paddle::small_vector<AttributeArgDef, kAttrSmallVectorSize>&
+  attribute_defs() {
     return attribute_defs_;
   }
 
  private:
-  paddle::SmallVector<TensorArgDef, kInputSmallVectorSize> input_defs_{{}};
-  paddle::SmallVector<TensorArgDef, kOutputSmallVectorSize> output_defs_{{}};
-  paddle::SmallVector<AttributeArgDef, kAttrSmallVectorSize> attribute_defs_{
+  paddle::small_vector<TensorArgDef, kInputSmallVectorSize> input_defs_{{}};
+  paddle::small_vector<TensorArgDef, kOutputSmallVectorSize> output_defs_{{}};
+  paddle::small_vector<AttributeArgDef, kAttrSmallVectorSize> attribute_defs_{
       {}};
 };
 

--- a/paddle/phi/ops/compat/adam_sig.cc
+++ b/paddle/phi/ops/compat/adam_sig.cc
@@ -19,22 +19,22 @@
 namespace phi {
 
 KernelSignature AdamOpArgumentMapping(const ArgumentMappingContext& ctx) {
-  paddle::SmallVector<const char*> in_names = {"Param",
-                                               "Grad",
-                                               "LearningRate",
-                                               "Moment1",
-                                               "Moment2",
-                                               "Beta1Pow",
-                                               "Beta2Pow",
-                                               "MasterParam",
-                                               "SkipUpdate"};
-  paddle::SmallVector<const char*> out_names = {"ParamOut",
-                                                "Moment1Out",
-                                                "Moment2Out",
-                                                "Beta1PowOut",
-                                                "Beta2PowOut",
-                                                "MasterParamOut"};
-  paddle::SmallVector<const char*> attr_names;
+  paddle::small_vector<const char*> in_names = {"Param",
+                                                "Grad",
+                                                "LearningRate",
+                                                "Moment1",
+                                                "Moment2",
+                                                "Beta1Pow",
+                                                "Beta2Pow",
+                                                "MasterParam",
+                                                "SkipUpdate"};
+  paddle::small_vector<const char*> out_names = {"ParamOut",
+                                                 "Moment1Out",
+                                                 "Moment2Out",
+                                                 "Beta1PowOut",
+                                                 "Beta2PowOut",
+                                                 "MasterParamOut"};
+  paddle::small_vector<const char*> attr_names;
 
   attr_names.emplace_back(ctx.HasInput("Beta1Tensor") ? "Beta1Tensor"
                                                       : "beta1");

--- a/paddle/phi/ops/compat/adamw_sig.cc
+++ b/paddle/phi/ops/compat/adamw_sig.cc
@@ -19,22 +19,22 @@
 namespace phi {
 
 KernelSignature AdamwOpArgumentMapping(const ArgumentMappingContext& ctx) {
-  paddle::SmallVector<const char*> in_names = {"Param",
-                                               "Grad",
-                                               "LearningRate",
-                                               "Moment1",
-                                               "Moment2",
-                                               "Beta1Pow",
-                                               "Beta2Pow",
-                                               "MasterParam",
-                                               "SkipUpdate"};
-  paddle::SmallVector<const char*> out_names = {"ParamOut",
-                                                "Moment1Out",
-                                                "Moment2Out",
-                                                "Beta1PowOut",
-                                                "Beta2PowOut",
-                                                "MasterParamOut"};
-  paddle::SmallVector<const char*> attr_names;
+  paddle::small_vector<const char*> in_names = {"Param",
+                                                "Grad",
+                                                "LearningRate",
+                                                "Moment1",
+                                                "Moment2",
+                                                "Beta1Pow",
+                                                "Beta2Pow",
+                                                "MasterParam",
+                                                "SkipUpdate"};
+  paddle::small_vector<const char*> out_names = {"ParamOut",
+                                                 "Moment1Out",
+                                                 "Moment2Out",
+                                                 "Beta1PowOut",
+                                                 "Beta2PowOut",
+                                                 "MasterParamOut"};
+  paddle::small_vector<const char*> attr_names;
 
   attr_names.emplace_back(ctx.HasInput("Beta1Tensor") ? "Beta1Tensor"
                                                       : "beta1");

--- a/paddle/phi/ops/compat/clip_sig.cc
+++ b/paddle/phi/ops/compat/clip_sig.cc
@@ -18,7 +18,7 @@
 namespace phi {
 
 KernelSignature ClipOpArgumentMapping(const ArgumentMappingContext& ctx) {
-  paddle::SmallVector<std::string, kAttrSmallVectorSize> attr_names;
+  paddle::small_vector<std::string, kAttrSmallVectorSize> attr_names;
   attr_names.emplace_back(ctx.HasInput("Min") ? "Min" : "min");
   attr_names.emplace_back(ctx.HasInput("Max") ? "Max" : "max");
   if (ctx.IsDenseTensorInput("X")) {

--- a/paddle/phi/ops/compat/strided_slice_sig.cc
+++ b/paddle/phi/ops/compat/strided_slice_sig.cc
@@ -48,14 +48,14 @@ KernelSignature StridedSliceOpArgumentMapping(
                  ? (use_attr_strides ? "strides" : "StridesTensorList")
                  : "strides");
 
-  paddle::SmallVector<const char*> inputs = {"Input"};
-  paddle::SmallVector<const char*> attrs = {"axes",
-                                            starts_key,
-                                            ends_key,
-                                            strides_key,
-                                            "infer_flags",
-                                            "decrease_axis"};
-  paddle::SmallVector<const char*> outputs = {"Out"};
+  paddle::small_vector<const char*> inputs = {"Input"};
+  paddle::small_vector<const char*> attrs = {"axes",
+                                             starts_key,
+                                             ends_key,
+                                             strides_key,
+                                             "infer_flags",
+                                             "decrease_axis"};
+  paddle::small_vector<const char*> outputs = {"Out"};
 
   const char* kernel_name;
   if (ctx.IsDenseTensorVectorInput("Input")) {
@@ -97,14 +97,14 @@ KernelSignature StridedSliceGradOpArgumentMapping(
                  ? (use_attr_strides ? "strides" : "StridesTensorList")
                  : "strides");
 
-  paddle::SmallVector<const char*> inputs = {"Input", "Out@GRAD"};
-  paddle::SmallVector<const char*> attrs = {"axes",
-                                            starts_key,
-                                            ends_key,
-                                            strides_key,
-                                            "infer_flags",
-                                            "decrease_axis"};
-  paddle::SmallVector<const char*> outputs = {"Input@GRAD"};
+  paddle::small_vector<const char*> inputs = {"Input", "Out@GRAD"};
+  paddle::small_vector<const char*> attrs = {"axes",
+                                             starts_key,
+                                             ends_key,
+                                             strides_key,
+                                             "infer_flags",
+                                             "decrease_axis"};
+  paddle::small_vector<const char*> outputs = {"Input@GRAD"};
 
   const char* kernel_name;
   if (ctx.IsDenseTensorVectorInput("Input")) {

--- a/paddle/phi/tests/core/test_meta_fn_utils.cc
+++ b/paddle/phi/tests/core/test_meta_fn_utils.cc
@@ -68,7 +68,7 @@ TEST(MetaFnFactory, SplitInferMetaFn) {
 
   phi::DenseTensor dense_out1;
   phi::DenseTensor dense_out2;
-  paddle::SmallVector<phi::MetaTensor, kOutputSmallVectorSize> out;
+  paddle::small_vector<phi::MetaTensor, kOutputSmallVectorSize> out;
   out.emplace_back(phi::MetaTensor(&dense_out1));
   out.emplace_back(phi::MetaTensor(&dense_out2));
 

--- a/paddle/utils/array_ref.h
+++ b/paddle/utils/array_ref.h
@@ -1,11 +1,11 @@
-// This file copy from llvm/ADT/array_ref.h, version: 12.0.0
+// This file copy from llvm/ADT/ArrayRef.h, version: 12.0.0
 // Modified the following points
 // 1. remove hash_value functions
 // 2. replace with the llvm::NoneType with paddle::none_t
 // 3. remove drop_while, drop_until, take_while, take_until methods
 // 4. change ArrayRef to array_ref to unify naming style of utils
 
-//===- array_ref.h - Array Reference Wrapper ---------------------*- C++
+//===- ArrayRef.h - Array Reference Wrapper ---------------------*- C++
 //-*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/paddle/utils/array_ref.h
+++ b/paddle/utils/array_ref.h
@@ -1,10 +1,12 @@
-// This file copy from llvm/ADT/ArrayRef.h, version: 12.0.0
+// This file copy from llvm/ADT/array_ref.h, version: 12.0.0
 // Modified the following points
 // 1. remove hash_value functions
 // 2. replace with the llvm::NoneType with paddle::none_t
 // 3. remove drop_while, drop_until, take_while, take_until methods
+// 4. change ArrayRef to array_ref to unify naming style of utils
 
-//===- ArrayRef.h - Array Reference Wrapper ---------------------*- C++ -*-===//
+//===- array_ref.h - Array Reference Wrapper ---------------------*- C++
+//-*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -29,19 +31,19 @@
 
 namespace paddle {
 
-/// ArrayRef - Represent a constant reference to an array (0 or more elements
+/// array_ref - Represent a constant reference to an array (0 or more elements
 /// consecutively in memory), i.e. a start pointer and a length.  It allows
 /// various APIs to take consecutive elements easily and conveniently.
 ///
 /// This class does not own the underlying data, it is expected to be used in
 /// situations where the data resides in some other buffer, whose lifetime
-/// extends past that of the ArrayRef. For this reason, it is not in general
-/// safe to store an ArrayRef.
+/// extends past that of the array_ref. For this reason, it is not in general
+/// safe to store an array_ref.
 ///
 /// This is intended to be trivially copyable, so it should be passed by
 /// value.
 template <typename T>
-class ArrayRef {
+class array_ref {
  public:
   using iterator = const T *;
   using const_iterator = const T *;
@@ -59,81 +61,81 @@ class ArrayRef {
   /// @name Constructors
   /// @{
 
-  /// Construct an empty ArrayRef.
-  /*implicit*/ ArrayRef() = default;
+  /// Construct an empty array_ref.
+  /*implicit*/ array_ref() = default;
 
-  /// Construct an empty ArrayRef from None.
-  /*implicit*/ ArrayRef(none_t) {}
+  /// Construct an empty array_ref from None.
+  /*implicit*/ array_ref(none_t) {}
 
-  /// Construct an ArrayRef from a single element.
-  /*implicit*/ ArrayRef(const T &OneElt) : Data(&OneElt), Length(1) {}
+  /// Construct an array_ref from a single element.
+  /*implicit*/ array_ref(const T &OneElt) : Data(&OneElt), Length(1) {}
 
-  /// Construct an ArrayRef from a pointer and length.
-  /*implicit*/ ArrayRef(const T *data, size_t length)
+  /// Construct an array_ref from a pointer and length.
+  /*implicit*/ array_ref(const T *data, size_t length)
       : Data(data), Length(length) {}
 
-  /// Construct an ArrayRef from a range.
-  ArrayRef(const T *begin, const T *end) : Data(begin), Length(end - begin) {}
+  /// Construct an array_ref from a range.
+  array_ref(const T *begin, const T *end) : Data(begin), Length(end - begin) {}
 
-  /// Construct an ArrayRef from a SmallVector. This is templated in order to
-  /// avoid instantiating SmallVectorTemplateCommon<T> whenever we
-  /// copy-construct an ArrayRef.
+  /// Construct an array_ref from a small_vector. This is templated in order to
+  /// avoid instantiating small_vector_template_common<T> whenever we
+  /// copy-construct an array_ref.
   template <typename U>
-  /*implicit*/ ArrayRef(const SmallVectorTemplateCommon<T, U> &Vec)
+  /*implicit*/ array_ref(const small_vector_template_common<T, U> &Vec)
       : Data(Vec.data()), Length(Vec.size()) {}
 
-  /// Construct an ArrayRef from a std::vector.
+  /// Construct an array_ref from a std::vector.
   template <typename A>
-  /*implicit*/ ArrayRef(const std::vector<T, A> &Vec)
+  /*implicit*/ array_ref(const std::vector<T, A> &Vec)
       : Data(Vec.data()), Length(Vec.size()) {}
 
-  /// Construct an ArrayRef from a std::array
+  /// Construct an array_ref from a std::array
   template <size_t N>
-  /*implicit*/ constexpr ArrayRef(const std::array<T, N> &Arr)
+  /*implicit*/ constexpr array_ref(const std::array<T, N> &Arr)
       : Data(Arr.data()), Length(N) {}
 
-  /// Construct an ArrayRef from a C array.
+  /// Construct an array_ref from a C array.
   template <size_t N>
-  /*implicit*/ constexpr ArrayRef(const T (&Arr)[N]) : Data(Arr), Length(N) {}
+  /*implicit*/ constexpr array_ref(const T (&Arr)[N]) : Data(Arr), Length(N) {}
 
-/// Construct an ArrayRef from a std::initializer_list.
+/// Construct an array_ref from a std::initializer_list.
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 9
 // Disable gcc's warning in this constructor as it generates an enormous
 // amount
-// of messages. Anyone using ArrayRef should already be aware of the fact that
+// of messages. Anyone using array_ref should already be aware of the fact that
 // it does not do lifetime extension.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winit-list-lifetime"
 #endif
-  /*implicit*/ ArrayRef(const std::initializer_list<T> &Vec)
+  /*implicit*/ array_ref(const std::initializer_list<T> &Vec)
       : Data(Vec.begin() == Vec.end() ? (T *)nullptr : Vec.begin()),
         Length(Vec.size()) {}
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 9
 #pragma GCC diagnostic pop
 #endif
 
-  /// Construct an ArrayRef<const T*> from ArrayRef<T*>. This uses SFINAE to
+  /// Construct an array_ref<const T*> from array_ref<T*>. This uses SFINAE to
   /// ensure that only ArrayRefs of pointers can be converted.
   template <typename U>
-  ArrayRef(const ArrayRef<U *> &A,
-           std::enable_if_t<std::is_convertible<U *const *, T const *>::value>
-               * = nullptr)
+  array_ref(const array_ref<U *> &A,
+            std::enable_if_t<std::is_convertible<U *const *, T const *>::value>
+                * = nullptr)
       : Data(A.data()), Length(A.size()) {}
 
-  /// Construct an ArrayRef<const T*> from a SmallVector<T*>. This is
-  /// templated in order to avoid instantiating SmallVectorTemplateCommon<T>
-  /// whenever we copy-construct an ArrayRef.
+  /// Construct an array_ref<const T*> from a small_vector<T*>. This is
+  /// templated in order to avoid instantiating small_vector_template_common<T>
+  /// whenever we copy-construct an array_ref.
   template <typename U, typename DummyT>
-  /*implicit*/ ArrayRef(
-      const SmallVectorTemplateCommon<U *, DummyT> &Vec,
+  /*implicit*/ array_ref(
+      const small_vector_template_common<U *, DummyT> &Vec,
       std::enable_if_t<std::is_convertible<U *const *, T const *>::value> * =
           nullptr)
       : Data(Vec.data()), Length(Vec.size()) {}
 
-  /// Construct an ArrayRef<const T*> from std::vector<T*>. This uses SFINAE
+  /// Construct an array_ref<const T*> from std::vector<T*>. This uses SFINAE
   /// to ensure that only vectors of pointers can be converted.
   template <typename U, typename A>
-  ArrayRef(
+  array_ref(
       const std::vector<U *, A> &Vec,
       std::enable_if_t<std::is_convertible<U *const *, T const *>::value> * = 0)
       : Data(Vec.data()), Length(Vec.size()) {}
@@ -168,50 +170,50 @@ class ArrayRef {
     return Data[Length - 1];
   }
 
-  // copy - Allocate copy in Allocator and return ArrayRef<T> to it.
+  // copy - Allocate copy in Allocator and return array_ref<T> to it.
   template <typename Allocator>
-  ArrayRef<T> copy(Allocator &A) {
+  array_ref<T> copy(Allocator &A) {
     T *Buff = A.template Allocate<T>(Length);
     std::uninitialized_copy(begin(), end(), Buff);
-    return ArrayRef<T>(Buff, Length);
+    return array_ref<T>(Buff, Length);
   }
 
   /// equals - Check for element-wise equality.
-  bool equals(ArrayRef RHS) const {
+  bool equals(array_ref RHS) const {
     if (Length != RHS.Length) return false;
     return std::equal(begin(), end(), RHS.begin());
   }
 
   /// slice(n, m) - Chop off the first N elements of the array, and keep M
   /// elements in the array.
-  ArrayRef<T> slice(size_t N, size_t M) const {
+  array_ref<T> slice(size_t N, size_t M) const {
     assert(N + M <= size() && "Invalid specifier");
-    return ArrayRef<T>(data() + N, M);
+    return array_ref<T>(data() + N, M);
   }
 
   /// slice(n) - Chop off the first N elements of the array.
-  ArrayRef<T> slice(size_t N) const { return slice(N, size() - N); }
+  array_ref<T> slice(size_t N) const { return slice(N, size() - N); }
 
   /// Drop the first \p N elements of the array.
-  ArrayRef<T> drop_front(size_t N = 1) const {
+  array_ref<T> drop_front(size_t N = 1) const {
     assert(size() >= N && "Dropping more elements than exist");
     return slice(N, size() - N);
   }
 
   /// Drop the last \p N elements of the array.
-  ArrayRef<T> drop_back(size_t N = 1) const {
+  array_ref<T> drop_back(size_t N = 1) const {
     assert(size() >= N && "Dropping more elements than exist");
     return slice(0, size() - N);
   }
 
   /// Return a copy of *this with only the first \p N elements.
-  ArrayRef<T> take_front(size_t N = 1) const {
+  array_ref<T> take_front(size_t N = 1) const {
     if (N >= size()) return *this;
     return drop_back(size() - N);
   }
 
   /// Return a copy of *this with only the last \p N elements.
-  ArrayRef<T> take_back(size_t N = 1) const {
+  array_ref<T> take_back(size_t N = 1) const {
     if (N >= size()) return *this;
     return drop_front(size() - N);
   }
@@ -229,7 +231,7 @@ class ArrayRef {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  std::enable_if_t<std::is_same<U, T>::value, ArrayRef<T>> &operator=(
+  std::enable_if_t<std::is_same<U, T>::value, array_ref<T>> &operator=(
       U &&Temporary) = delete;
 
   /// Disallow accidental assignment from a temporary.
@@ -237,7 +239,7 @@ class ArrayRef {
   /// The declaration here is extra complicated so that "arrayRef = {}"
   /// continues to select the move assignment operator.
   template <typename U>
-  std::enable_if_t<std::is_same<U, T>::value, ArrayRef<T>> &operator=(
+  std::enable_if_t<std::is_same<U, T>::value, array_ref<T>> &operator=(
       std::initializer_list<U>) = delete;
 
   /// @}
@@ -255,90 +257,90 @@ class ArrayRef {
   /// @}
 };
 
-/// @name ArrayRef Convenience constructors
+/// @name array_ref Convenience constructors
 /// @{
 
-/// Construct an ArrayRef from a single element.
+/// Construct an array_ref from a single element.
 template <typename T>
-ArrayRef<T> makeArrayRef(const T &OneElt) {
+array_ref<T> make_array_ref(const T &OneElt) {
   return OneElt;
 }
 
-/// Construct an ArrayRef from a pointer and length.
+/// Construct an array_ref from a pointer and length.
 template <typename T>
-ArrayRef<T> makeArrayRef(const T *data, size_t length) {
-  return ArrayRef<T>(data, length);
+array_ref<T> make_array_ref(const T *data, size_t length) {
+  return array_ref<T>(data, length);
 }
 
-/// Construct an ArrayRef from a range.
+/// Construct an array_ref from a range.
 template <typename T>
-ArrayRef<T> makeArrayRef(const T *begin, const T *end) {
-  return ArrayRef<T>(begin, end);
+array_ref<T> make_array_ref(const T *begin, const T *end) {
+  return array_ref<T>(begin, end);
 }
 
-/// Construct an ArrayRef from a SmallVector.
+/// Construct an array_ref from a small_vector.
 template <typename T>
-ArrayRef<T> makeArrayRef(const SmallVectorImpl<T> &Vec) {
+array_ref<T> make_array_ref(const small_vector_impl<T> &Vec) {
   return Vec;
 }
 
-/// Construct an ArrayRef from a SmallVector.
+/// Construct an array_ref from a small_vector.
 template <typename T, unsigned N>
-ArrayRef<T> makeArrayRef(const SmallVector<T, N> &Vec) {
+array_ref<T> make_array_ref(const small_vector<T, N> &Vec) {
   return Vec;
 }
 
-/// Construct an ArrayRef from a std::vector.
+/// Construct an array_ref from a std::vector.
 template <typename T>
-ArrayRef<T> makeArrayRef(const std::vector<T> &Vec) {
+array_ref<T> make_array_ref(const std::vector<T> &Vec) {
   return Vec;
 }
 
-/// Construct an ArrayRef from a std::array.
+/// Construct an array_ref from a std::array.
 template <typename T, std::size_t N>
-ArrayRef<T> makeArrayRef(const std::array<T, N> &Arr) {
+array_ref<T> make_array_ref(const std::array<T, N> &Arr) {
   return Arr;
 }
 
-/// Construct an ArrayRef from an ArrayRef (no-op) (const)
+/// Construct an array_ref from an array_ref (no-op) (const)
 template <typename T>
-ArrayRef<T> makeArrayRef(const ArrayRef<T> &Vec) {
+array_ref<T> make_array_ref(const array_ref<T> &Vec) {
   return Vec;
 }
 
-/// Construct an ArrayRef from an ArrayRef (no-op)
+/// Construct an array_ref from an array_ref (no-op)
 template <typename T>
-ArrayRef<T> &makeArrayRef(ArrayRef<T> &Vec) {
+array_ref<T> &make_array_ref(array_ref<T> &Vec) {
   return Vec;
 }
 
-/// Construct an ArrayRef from a C array.
+/// Construct an array_ref from a C array.
 template <typename T, size_t N>
-ArrayRef<T> makeArrayRef(const T (&Arr)[N]) {
-  return ArrayRef<T>(Arr);
+array_ref<T> make_array_ref(const T (&Arr)[N]) {
+  return array_ref<T>(Arr);
 }
 
 /// @}
-/// @name ArrayRef Comparison Operators
+/// @name array_ref Comparison Operators
 /// @{
 
 template <typename T>
-inline bool operator==(ArrayRef<T> LHS, ArrayRef<T> RHS) {
+inline bool operator==(array_ref<T> LHS, array_ref<T> RHS) {
   return LHS.equals(RHS);
 }
 
 template <typename T>
-inline bool operator==(SmallVectorImpl<T> &LHS, ArrayRef<T> RHS) {
-  return ArrayRef<T>(LHS).equals(RHS);
+inline bool operator==(small_vector_impl<T> &LHS, array_ref<T> RHS) {
+  return array_ref<T>(LHS).equals(RHS);
 }
 
 template <typename T>
-inline bool operator!=(ArrayRef<T> LHS, ArrayRef<T> RHS) {
+inline bool operator!=(array_ref<T> LHS, array_ref<T> RHS) {
   return !(LHS == RHS);
 }
 
 template <typename T>
-inline bool operator!=(SmallVectorImpl<T> &LHS, ArrayRef<T> RHS) {
+inline bool operator!=(small_vector_impl<T> &LHS, array_ref<T> RHS) {
   return !(LHS == RHS);
 }
 

--- a/paddle/utils/array_ref_test.cc
+++ b/paddle/utils/array_ref_test.cc
@@ -21,53 +21,53 @@
 #include "gtest/gtest.h"
 
 TEST(array_ref, array_ref) {
-  paddle::ArrayRef<int> a;
+  paddle::array_ref<int> a;
   CHECK_EQ(a.size(), size_t(0));
   CHECK_EQ(a.data(), static_cast<int*>(nullptr));
 
-  paddle::ArrayRef<int> b(paddle::none);
+  paddle::array_ref<int> b(paddle::none);
   CHECK_EQ(b.size(), size_t(0));
   CHECK_EQ(b.data(), static_cast<int*>(nullptr));
 
   int v = 1;
-  paddle::ArrayRef<int> c(v);
+  paddle::array_ref<int> c(v);
   CHECK_EQ(c.size(), size_t(1));
   CHECK_EQ(c.data(), &v);
-  CHECK_EQ(c.equals(paddle::makeArrayRef(v)), true);
+  CHECK_EQ(c.equals(paddle::make_array_ref(v)), true);
 
   int v1[5] = {1, 2, 3, 4, 5};
-  paddle::ArrayRef<int> d(v1, 5);
+  paddle::array_ref<int> d(v1, 5);
   CHECK_EQ(d.size(), size_t(5));
   CHECK_EQ(d.data(), v1);
-  CHECK_EQ(d.equals(paddle::makeArrayRef(v1, 5)), true);
+  CHECK_EQ(d.equals(paddle::make_array_ref(v1, 5)), true);
 
-  paddle::ArrayRef<int> e(&v1[0], &v1[4]);
+  paddle::array_ref<int> e(&v1[0], &v1[4]);
   CHECK_EQ(e.size(), size_t(4));
   CHECK_EQ(e.data(), v1);
-  CHECK_EQ(e.equals(paddle::makeArrayRef(&v1[0], &v1[4])), true);
+  CHECK_EQ(e.equals(paddle::make_array_ref(&v1[0], &v1[4])), true);
 
-  paddle::SmallVector<int, 3> small_vector{1, 2, 3};
-  paddle::ArrayRef<int> f(small_vector);
+  paddle::small_vector<int, 3> small_vector{1, 2, 3};
+  paddle::array_ref<int> f(small_vector);
   CHECK_EQ(f.size(), size_t(3));
   CHECK_EQ(f.data(), small_vector.data());
-  CHECK_EQ(f.equals(paddle::makeArrayRef(small_vector)), true);
+  CHECK_EQ(f.equals(paddle::make_array_ref(small_vector)), true);
 
   std::vector<int> vector{1, 2, 3};
-  paddle::ArrayRef<int> g(vector);
+  paddle::array_ref<int> g(vector);
   CHECK_EQ(g.size(), size_t(3));
   CHECK_EQ(g.data(), vector.data());
-  CHECK_EQ(g.equals(paddle::makeArrayRef(vector)), true);
+  CHECK_EQ(g.equals(paddle::make_array_ref(vector)), true);
 
   std::initializer_list<int> list = {1, 2, 3};
-  paddle::ArrayRef<int> h(list);
+  paddle::array_ref<int> h(list);
   CHECK_EQ(h.size(), size_t(3));
   CHECK_EQ(h.data(), list.begin());
 
-  paddle::ArrayRef<int> i(h);
+  paddle::array_ref<int> i(h);
   CHECK_EQ(i.size(), size_t(3));
   CHECK_EQ(i.data(), list.begin());
   CHECK_EQ(i.equals(h), true);
-  CHECK_EQ(i.equals(paddle::makeArrayRef(h)), true);
+  CHECK_EQ(i.equals(paddle::make_array_ref(h)), true);
 
   auto slice = i.slice(1, 2);
   CHECK_EQ(slice.size(), size_t(2));
@@ -78,7 +78,7 @@ TEST(array_ref, array_ref) {
   CHECK_EQ(drop.size(), size_t(1));
   CHECK_EQ(drop[0], 3);
 
-  paddle::ArrayRef<int> nums = {1, 2, 3, 4, 5, 6, 7, 8};
+  paddle::array_ref<int> nums = {1, 2, 3, 4, 5, 6, 7, 8};
   auto front = nums.take_front(3);
   CHECK_EQ(front.size(), size_t(3));
   for (size_t i = 0; i < 3; ++i) {

--- a/paddle/utils/small_vector.h
+++ b/paddle/utils/small_vector.h
@@ -5,6 +5,7 @@
 // 3. add at(index) method for small vector
 // 4. wrap the call to max and min with parenthesis to prevent the macro
 // expansion to fix the build error on windows platform
+// 5. change SmallVector to small_vector to unify naming style of utils
 
 //===- llvm/ADT/SmallVector.h - 'Normally small' vectors --------*- C++ -*-===//
 //
@@ -79,13 +80,13 @@ iterator_range<T> make_range(std::pair<T, T> p) {
 /// This is all the stuff common to all SmallVectors.
 ///
 /// The template parameter specifies the type which should be used to hold the
-/// Size and Capacity of the SmallVector, so it can be adjusted.
-/// Using 32 bit size is desirable to shrink the size of the SmallVector.
-/// Using 64 bit size is desirable for cases like SmallVector<char>, where a
+/// Size and Capacity of the small_vector, so it can be adjusted.
+/// Using 32 bit size is desirable to shrink the size of the small_vector.
+/// Using 64 bit size is desirable for cases like small_vector<char>, where a
 /// 32 bit size would limit the vector to ~4GB. SmallVectors are used for
 /// buffering bitcode output - which can exceed 4GB.
 template <class Size_T>
-class SmallVectorBase {
+class small_vector_base {
  protected:
   void *BeginX;
   Size_T Size = 0, Capacity;
@@ -95,8 +96,8 @@ class SmallVectorBase {
     return (std::numeric_limits<Size_T>::max)();
   }
 
-  SmallVectorBase() = delete;
-  SmallVectorBase(void *FirstEl, size_t TotalCapacity)
+  small_vector_base() = delete;
+  small_vector_base(void *FirstEl, size_t TotalCapacity)
       : BeginX(FirstEl), Capacity(TotalCapacity) {}
 
   /// This is a helper for \a grow() that's out of line to reduce code
@@ -139,22 +140,23 @@ using SmallVectorSizeType =
 /// Figure out the offset of the first element.
 template <class T, typename = void>
 struct SmallVectorAlignmentAndSize {
-  alignas(SmallVectorBase<SmallVectorSizeType<T>>) char Base[sizeof(
-      SmallVectorBase<SmallVectorSizeType<T>>)];
+  alignas(small_vector_base<SmallVectorSizeType<T>>) char Base[sizeof(
+      small_vector_base<SmallVectorSizeType<T>>)];
   alignas(T) char FirstEl[sizeof(T)];
 };
 
-/// This is the part of SmallVectorTemplateBase which does not depend on whether
-/// the type T is a POD. The extra dummy template argument is used by ArrayRef
+/// This is the part of small_vector_template_base which does not depend on
+/// whether
+/// the type T is a POD. The extra dummy template argument is used by array_ref
 /// to avoid unnecessarily requiring T to be complete.
 template <typename T, typename = void>
-class SmallVectorTemplateCommon
-    : public SmallVectorBase<SmallVectorSizeType<T>> {
-  using Base = SmallVectorBase<SmallVectorSizeType<T>>;
+class small_vector_template_common
+    : public small_vector_base<SmallVectorSizeType<T>> {
+  using Base = small_vector_base<SmallVectorSizeType<T>>;
 
   /// Find the address of the first element.  For this pointer math to be valid
   /// with small-size of 0 for T with lots of alignment, it's important that
-  /// SmallVectorStorage is properly-aligned even for small-size of 0.
+  /// small_vector_storage is properly-aligned even for small-size of 0.
   void *getFirstEl() const {
     return const_cast<void *>(reinterpret_cast<const void *>(
         reinterpret_cast<const char *>(this) +
@@ -163,7 +165,7 @@ class SmallVectorTemplateCommon
   // Space after 'FirstEl' is clobbered, do not add any instance vars after it.
 
  protected:
-  SmallVectorTemplateCommon(size_t Size) : Base(getFirstEl(), Size) {}
+  small_vector_template_common(size_t Size) : Base(getFirstEl(), Size) {}
 
   void grow_pod(size_t MinSize, size_t TSize) {
     Base::grow_pod(getFirstEl(), MinSize, TSize);
@@ -358,7 +360,7 @@ class SmallVectorTemplateCommon
   }
 };
 
-/// SmallVectorTemplateBase<TriviallyCopyable = false> - This is where we put
+/// small_vector_template_base<TriviallyCopyable = false> - This is where we put
 /// method implementations that are designed to work with non-trivial T's.
 ///
 /// We approximate is_trivially_copyable with trivial move/copy construction and
@@ -370,14 +372,15 @@ template <typename T,
           bool = (std::is_trivially_copy_constructible<T>::value) &&
                  (std::is_trivially_move_constructible<T>::value) &&
                  std::is_trivially_destructible<T>::value>
-class SmallVectorTemplateBase : public SmallVectorTemplateCommon<T> {
-  friend class SmallVectorTemplateCommon<T>;
+class small_vector_template_base : public small_vector_template_common<T> {
+  friend class small_vector_template_common<T>;
 
  protected:
   static constexpr bool TakesParamByValue = false;
   using ValueParamT = const T &;
 
-  SmallVectorTemplateBase(size_t Size) : SmallVectorTemplateCommon<T>(Size) {}
+  small_vector_template_base(size_t Size)
+      : small_vector_template_common<T>(Size) {}
 
   static void destroy_range(T *S, T *E) {
     while (S != E) {
@@ -410,7 +413,7 @@ class SmallVectorTemplateBase : public SmallVectorTemplateCommon<T> {
   /// in \p NewCapacity. This is the first section of \a grow().
   T *mallocForGrow(size_t MinSize, size_t &NewCapacity) {
     return static_cast<T *>(
-        SmallVectorBase<SmallVectorSizeType<T>>::mallocForGrow(
+        small_vector_base<SmallVectorSizeType<T>>::mallocForGrow(
             MinSize, sizeof(T), NewCapacity));
   }
 
@@ -480,7 +483,7 @@ class SmallVectorTemplateBase : public SmallVectorTemplateCommon<T> {
 
 // Define this out-of-line to dissuade the C++ compiler from inlining it.
 template <typename T, bool TriviallyCopyable>
-void SmallVectorTemplateBase<T, TriviallyCopyable>::grow(size_t MinSize) {
+void small_vector_template_base<T, TriviallyCopyable>::grow(size_t MinSize) {
   size_t NewCapacity;
   T *NewElts = mallocForGrow(MinSize, NewCapacity);
   moveElementsForGrow(NewElts);
@@ -489,7 +492,7 @@ void SmallVectorTemplateBase<T, TriviallyCopyable>::grow(size_t MinSize) {
 
 // Define this out-of-line to dissuade the C++ compiler from inlining it.
 template <typename T, bool TriviallyCopyable>
-void SmallVectorTemplateBase<T, TriviallyCopyable>::moveElementsForGrow(
+void small_vector_template_base<T, TriviallyCopyable>::moveElementsForGrow(
     T *NewElts) {
   // Move the elements over.
   this->uninitialized_move(this->begin(), this->end(), NewElts);
@@ -500,7 +503,7 @@ void SmallVectorTemplateBase<T, TriviallyCopyable>::moveElementsForGrow(
 
 // Define this out-of-line to dissuade the C++ compiler from inlining it.
 template <typename T, bool TriviallyCopyable>
-void SmallVectorTemplateBase<T, TriviallyCopyable>::takeAllocationForGrow(
+void small_vector_template_base<T, TriviallyCopyable>::takeAllocationForGrow(
     T *NewElts, size_t NewCapacity) {
   // If this wasn't grown from the inline copy, deallocate the old space.
   if (!this->isSmall()) free(this->begin());
@@ -509,13 +512,14 @@ void SmallVectorTemplateBase<T, TriviallyCopyable>::takeAllocationForGrow(
   this->Capacity = NewCapacity;
 }
 
-/// SmallVectorTemplateBase<TriviallyCopyable = true> - This is where we put
+/// small_vector_template_base<TriviallyCopyable = true> - This is where we put
 /// method implementations that are designed to work with trivially copyable
 /// T's. This allows using memcpy in place of copy/move construction and
 /// skipping destruction.
 template <typename T>
-class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
-  friend class SmallVectorTemplateCommon<T>;
+class small_vector_template_base<T, true>
+    : public small_vector_template_common<T> {
+  friend class small_vector_template_common<T>;
 
  protected:
   /// True if it's cheap enough to take parameters by value. Doing so avoids
@@ -527,7 +531,8 @@ class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
   using ValueParamT =
       typename std::conditional<TakesParamByValue, T, const T &>::type;
 
-  SmallVectorTemplateBase(size_t Size) : SmallVectorTemplateCommon<T>(Size) {}
+  small_vector_template_base(size_t Size)
+      : small_vector_template_common<T>(Size) {}
 
   // No need to do a destroy loop for POD's.
   static void destroy_range(T *, T *) {}
@@ -557,7 +562,7 @@ class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
       T2 *Dest,
       std::enable_if_t<std::is_same<typename std::remove_const<T1>::type,
                                     T2>::value> * = nullptr) {
-    // Use memcpy for PODs iterated by pointers (which includes SmallVector
+    // Use memcpy for PODs iterated by pointers (which includes small_vector
     // iterators): std::uninitialized_copy optimizes to memmove, but we can
     // use memcpy here. Note that I and E are iterators and thus might be
     // invalid for memcpy if they are equal.
@@ -612,11 +617,11 @@ class SmallVectorTemplateBase<T, true> : public SmallVectorTemplateCommon<T> {
   void pop_back() { this->set_size(this->size() - 1); }
 };
 
-/// This class consists of common code factored out of the SmallVector class to
-/// reduce code duplication based on the SmallVector 'N' template parameter.
+/// This class consists of common code factored out of the small_vector class to
+/// reduce code duplication based on the small_vector 'N' template parameter.
 template <typename T>
-class SmallVectorImpl : public SmallVectorTemplateBase<T> {
-  using SuperClass = SmallVectorTemplateBase<T>;
+class small_vector_impl : public small_vector_template_base<T> {
+  using SuperClass = small_vector_template_base<T>;
 
  public:
   using iterator = typename SuperClass::iterator;
@@ -625,16 +630,16 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
   using size_type = typename SuperClass::size_type;
 
  protected:
-  using SmallVectorTemplateBase<T>::TakesParamByValue;
+  using small_vector_template_base<T>::TakesParamByValue;
   using ValueParamT = typename SuperClass::ValueParamT;
 
   // Default ctor - Initialize to empty.
-  explicit SmallVectorImpl(unsigned N) : SmallVectorTemplateBase<T>(N) {}
+  explicit small_vector_impl(unsigned N) : small_vector_template_base<T>(N) {}
 
  public:
-  SmallVectorImpl(const SmallVectorImpl &) = delete;
+  small_vector_impl(const small_vector_impl &) = delete;
 
-  ~SmallVectorImpl() {
+  ~small_vector_impl() {
     // Subclass has already destructed this vector's elements.
     // If this wasn't grown from the inline copy, deallocate the old space.
     if (!this->isSmall()) free(this->begin());
@@ -695,9 +700,9 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
     return Result;
   }
 
-  void swap(SmallVectorImpl &RHS);
+  void swap(small_vector_impl &RHS);
 
-  /// Add the specified range to the end of the SmallVector.
+  /// Add the specified range to the end of the small_vector.
   template <typename in_iter,
             typename = std::enable_if_t<std::is_convertible<
                 typename std::iterator_traits<in_iter>::iterator_category,
@@ -719,7 +724,7 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
 
   void append(std::initializer_list<T> IL) { append(IL.begin(), IL.end()); }
 
-  void append(const SmallVectorImpl &RHS) { append(RHS.begin(), RHS.end()); }
+  void append(const small_vector_impl &RHS) { append(RHS.begin(), RHS.end()); }
 
   void assign(size_type NumElts, ValueParamT Elt) {
     // Note that Elt could be an internal reference.
@@ -755,7 +760,7 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
     append(IL);
   }
 
-  void assign(const SmallVectorImpl &RHS) { assign(RHS.begin(), RHS.end()); }
+  void assign(const small_vector_impl &RHS) { assign(RHS.begin(), RHS.end()); }
 
   iterator erase(const_iterator CI) {
     // Just cast away constness because this is a non-const member function.
@@ -976,24 +981,26 @@ class SmallVectorImpl : public SmallVectorTemplateBase<T> {
     return this->back();
   }
 
-  SmallVectorImpl &operator=(const SmallVectorImpl &RHS);
+  small_vector_impl &operator=(const small_vector_impl &RHS);
 
-  SmallVectorImpl &operator=(SmallVectorImpl &&RHS);
+  small_vector_impl &operator=(small_vector_impl &&RHS);
 
-  bool operator==(const SmallVectorImpl &RHS) const {
+  bool operator==(const small_vector_impl &RHS) const {
     if (this->size() != RHS.size()) return false;
     return std::equal(this->begin(), this->end(), RHS.begin());
   }
-  bool operator!=(const SmallVectorImpl &RHS) const { return !(*this == RHS); }
+  bool operator!=(const small_vector_impl &RHS) const {
+    return !(*this == RHS);
+  }
 
-  bool operator<(const SmallVectorImpl &RHS) const {
+  bool operator<(const small_vector_impl &RHS) const {
     return std::lexicographical_compare(
         this->begin(), this->end(), RHS.begin(), RHS.end());
   }
 };
 
 template <typename T>
-void SmallVectorImpl<T>::swap(SmallVectorImpl<T> &RHS) {
+void small_vector_impl<T>::swap(small_vector_impl<T> &RHS) {
   if (this == &RHS) return;
 
   // We can only avoid copying elements if neither vector is small.
@@ -1028,8 +1035,8 @@ void SmallVectorImpl<T>::swap(SmallVectorImpl<T> &RHS) {
 }
 
 template <typename T>
-SmallVectorImpl<T> &SmallVectorImpl<T>::operator=(
-    const SmallVectorImpl<T> &RHS) {
+small_vector_impl<T> &small_vector_impl<T>::operator=(
+    const small_vector_impl<T> &RHS) {
   // Avoid self-assignment.
   if (this == &RHS) return *this;
 
@@ -1076,7 +1083,8 @@ SmallVectorImpl<T> &SmallVectorImpl<T>::operator=(
 }
 
 template <typename T>
-SmallVectorImpl<T> &SmallVectorImpl<T>::operator=(SmallVectorImpl<T> &&RHS) {
+small_vector_impl<T> &small_vector_impl<T>::operator=(
+    small_vector_impl<T> &&RHS) {
   // Avoid self-assignment.
   if (this == &RHS) return *this;
 
@@ -1135,38 +1143,38 @@ SmallVectorImpl<T> &SmallVectorImpl<T>::operator=(SmallVectorImpl<T> &&RHS) {
   return *this;
 }
 
-/// Storage for the SmallVector elements.  This is specialized for the N=0 case
+/// Storage for the small_vector elements.  This is specialized for the N=0 case
 /// to avoid allocating unnecessary storage.
 template <typename T, unsigned N>
-struct SmallVectorStorage {
+struct small_vector_storage {
   alignas(T) char InlineElts[N * sizeof(T)];
 };
 
 /// We need the storage to be properly aligned even for small-size of 0 so that
-/// the pointer math in \a SmallVectorTemplateCommon::getFirstEl() is
+/// the pointer math in \a small_vector_template_common::getFirstEl() is
 /// well-defined.
 template <typename T>
-struct alignas(T) SmallVectorStorage<T, 0> {};
+struct alignas(T) small_vector_storage<T, 0> {};
 
-/// Forward declaration of SmallVector so that
+/// Forward declaration of small_vector so that
 /// calculateSmallVectorDefaultInlinedElements can reference
-/// `sizeof(SmallVector<T, 0>)`.
+/// `sizeof(small_vector<T, 0>)`.
 template <typename T, unsigned N>
-class SmallVector;
+class small_vector;
 
 /// Helper class for calculating the default number of inline elements for
-/// `SmallVector<T>`.
+/// `small_vector<T>`.
 ///
 /// This should be migrated to a constexpr function when our minimum
 /// compiler support is enough for multi-statement constexpr functions.
 template <typename T>
 struct CalculateSmallVectorDefaultInlinedElements {
   // Parameter controlling the default number of inlined elements
-  // for `SmallVector<T>`.
+  // for `small_vector<T>`.
   //
   // The default number of inlined elements ensures that
   // 1. There is at least one inlined element.
-  // 2. `sizeof(SmallVector<T>) <= kPreferredSmallVectorSizeof` unless
+  // 2. `sizeof(small_vector<T>) <= kPreferredSmallVectorSizeof` unless
   // it contradicts 1.
   static constexpr size_t kPreferredSmallVectorSizeof = 64;
 
@@ -1175,14 +1183,14 @@ struct CalculateSmallVectorDefaultInlinedElements {
   // Because our policy guarantees at least one inlined element, it is possible
   // for an arbitrarily large inlined element to allocate an arbitrarily large
   // amount of inline storage. We generally consider it an antipattern for a
-  // SmallVector to allocate an excessive amount of inline storage, so we want
+  // small_vector to allocate an excessive amount of inline storage, so we want
   // to call attention to these cases and make sure that users are making an
   // intentional decision if they request a lot of inline storage.
   //
   // We want this assertion to trigger in pathological cases, but otherwise
   // not be too easy to hit. To accomplish that, the cutoff is actually somewhat
   // larger than kPreferredSmallVectorSizeof (otherwise,
-  // `SmallVector<SmallVector<T>>` would be one easy way to trip it, and that
+  // `small_vector<small_vector<T>>` would be one easy way to trip it, and that
   // pattern seems useful in practice).
   //
   // One wrinkle is that this assertion is in theory non-portable, since
@@ -1195,14 +1203,14 @@ struct CalculateSmallVectorDefaultInlinedElements {
   static_assert(
       sizeof(T) <= 256,
       "You are trying to use a default number of inlined elements for "
-      "`SmallVector<T>` but `sizeof(T)` is really big! Please use an "
-      "explicit number of inlined elements with `SmallVector<T, N>` to make "
+      "`small_vector<T>` but `sizeof(T)` is really big! Please use an "
+      "explicit number of inlined elements with `small_vector<T, N>` to make "
       "sure you really want that much inline storage.");
 
   // Discount the size of the header itself when calculating the maximum inline
   // bytes.
   static constexpr size_t PreferredInlineBytes =
-      kPreferredSmallVectorSizeof - sizeof(SmallVector<T, 0>);
+      kPreferredSmallVectorSizeof - sizeof(small_vector<T, 0>);
   static constexpr size_t NumElementsThatFit = PreferredInlineBytes / sizeof(T);
   static constexpr size_t value =
       NumElementsThatFit == 0 ? 1 : NumElementsThatFit;
@@ -1216,27 +1224,27 @@ struct CalculateSmallVectorDefaultInlinedElements {
 ///
 /// \note
 /// In the absence of a well-motivated choice for the number of inlined
-/// elements \p N, it is recommended to use \c SmallVector<T> (that is,
+/// elements \p N, it is recommended to use \c small_vector<T> (that is,
 /// omitting the \p N). This will choose a default number of inlined elements
 /// reasonable for allocation on the stack (for example, trying to keep \c
-/// sizeof(SmallVector<T>) around 64 bytes).
+/// sizeof(small_vector<T>) around 64 bytes).
 ///
 /// \warning This does not attempt to be exception safe.
 ///
 /// \see https://llvm.org/docs/ProgrammersManual.html#llvm-adt-smallvector-h
 template <typename T,
           unsigned N = CalculateSmallVectorDefaultInlinedElements<T>::value>
-class SmallVector : public SmallVectorImpl<T>, SmallVectorStorage<T, N> {
+class small_vector : public small_vector_impl<T>, small_vector_storage<T, N> {
  public:
-  SmallVector() : SmallVectorImpl<T>(N) {}
+  small_vector() : small_vector_impl<T>(N) {}
 
-  ~SmallVector() {
+  ~small_vector() {
     // Destroy the constructed elements in the vector.
     this->destroy_range(this->begin(), this->end());
   }
 
-  explicit SmallVector(size_t Size, const T &Value = T())
-      : SmallVectorImpl<T>(N) {
+  explicit small_vector(size_t Size, const T &Value = T())
+      : small_vector_impl<T>(N) {
     this->assign(Size, Value);
   }
 
@@ -1244,65 +1252,65 @@ class SmallVector : public SmallVectorImpl<T>, SmallVectorStorage<T, N> {
             typename = std::enable_if_t<std::is_convertible<
                 typename std::iterator_traits<ItTy>::iterator_category,
                 std::input_iterator_tag>::value>>
-  SmallVector(ItTy S, ItTy E) : SmallVectorImpl<T>(N) {
+  small_vector(ItTy S, ItTy E) : small_vector_impl<T>(N) {
     this->append(S, E);
   }
 
   template <typename RangeTy>
-  explicit SmallVector(const iterator_range<RangeTy> &R)
-      : SmallVectorImpl<T>(N) {
+  explicit small_vector(const iterator_range<RangeTy> &R)
+      : small_vector_impl<T>(N) {
     this->append(R.begin(), R.end());
   }
 
-  SmallVector(std::initializer_list<T> IL) : SmallVectorImpl<T>(N) {
+  small_vector(std::initializer_list<T> IL) : small_vector_impl<T>(N) {
     this->assign(IL);
   }
 
-  SmallVector(const SmallVector &RHS) : SmallVectorImpl<T>(N) {
-    if (!RHS.empty()) SmallVectorImpl<T>::operator=(RHS);
+  small_vector(const small_vector &RHS) : small_vector_impl<T>(N) {
+    if (!RHS.empty()) small_vector_impl<T>::operator=(RHS);
   }
 
-  SmallVector &operator=(const SmallVector &RHS) {
-    SmallVectorImpl<T>::operator=(RHS);
+  small_vector &operator=(const small_vector &RHS) {
+    small_vector_impl<T>::operator=(RHS);
     return *this;
   }
 
-  SmallVector(SmallVector &&RHS) : SmallVectorImpl<T>(N) {
-    if (!RHS.empty()) SmallVectorImpl<T>::operator=(::std::move(RHS));
+  small_vector(small_vector &&RHS) : small_vector_impl<T>(N) {
+    if (!RHS.empty()) small_vector_impl<T>::operator=(::std::move(RHS));
   }
 
-  SmallVector(SmallVectorImpl<T> &&RHS) : SmallVectorImpl<T>(N) {
-    if (!RHS.empty()) SmallVectorImpl<T>::operator=(::std::move(RHS));
+  small_vector(small_vector_impl<T> &&RHS) : small_vector_impl<T>(N) {
+    if (!RHS.empty()) small_vector_impl<T>::operator=(::std::move(RHS));
   }
 
-  SmallVector &operator=(SmallVector &&RHS) {
-    SmallVectorImpl<T>::operator=(::std::move(RHS));
+  small_vector &operator=(small_vector &&RHS) {
+    small_vector_impl<T>::operator=(::std::move(RHS));
     return *this;
   }
 
-  SmallVector &operator=(SmallVectorImpl<T> &&RHS) {
-    SmallVectorImpl<T>::operator=(::std::move(RHS));
+  small_vector &operator=(small_vector_impl<T> &&RHS) {
+    small_vector_impl<T>::operator=(::std::move(RHS));
     return *this;
   }
 
-  SmallVector &operator=(std::initializer_list<T> IL) {
+  small_vector &operator=(std::initializer_list<T> IL) {
     this->assign(IL);
     return *this;
   }
 };
 
 template <typename T, unsigned N>
-inline size_t capacity_in_bytes(const SmallVector<T, N> &X) {
+inline size_t capacity_in_bytes(const small_vector<T, N> &X) {
   return X.capacity_in_bytes();
 }
 
 /// Given a range of type R, iterate the entire range and return a
-/// SmallVector with elements of the vector.  This is useful, for example,
+/// small_vector with elements of the vector.  This is useful, for example,
 /// when you want to iterate a range and then sort the results.
 template <unsigned Size, typename R>
-SmallVector<typename std::remove_const<typename std::remove_reference<
-                decltype(*std::begin(std::declval<R &>()))>::type>::type,
-            Size>
+small_vector<typename std::remove_const<typename std::remove_reference<
+                 decltype(*std::begin(std::declval<R &>()))>::type>::type,
+             Size>
 to_vector(R &&Range) {
   return {std::begin(Range), std::end(Range)};
 }
@@ -1352,22 +1360,22 @@ struct Struct32B {
   alignas(32) void *X;
 };
 }
-static_assert(sizeof(SmallVector<void *, 0>) ==
+static_assert(sizeof(small_vector<void *, 0>) ==
                   sizeof(unsigned) * 2 + sizeof(void *),
-              "wasted space in SmallVector size 0");
-static_assert(alignof(SmallVector<Struct16B, 0>) >= alignof(Struct16B),
+              "wasted space in small_vector size 0");
+static_assert(alignof(small_vector<Struct16B, 0>) >= alignof(Struct16B),
               "wrong alignment for 16-byte aligned T");
-static_assert(alignof(SmallVector<Struct32B, 0>) >= alignof(Struct32B),
+static_assert(alignof(small_vector<Struct32B, 0>) >= alignof(Struct32B),
               "wrong alignment for 32-byte aligned T");
-static_assert(sizeof(SmallVector<Struct16B, 0>) >= alignof(Struct16B),
+static_assert(sizeof(small_vector<Struct16B, 0>) >= alignof(Struct16B),
               "missing padding for 16-byte aligned T");
-static_assert(sizeof(SmallVector<Struct32B, 0>) >= alignof(Struct32B),
+static_assert(sizeof(small_vector<Struct32B, 0>) >= alignof(Struct32B),
               "missing padding for 32-byte aligned T");
-static_assert(sizeof(SmallVector<void *, 1>) ==
+static_assert(sizeof(small_vector<void *, 1>) ==
                   sizeof(unsigned) * 2 + sizeof(void *) * 2,
-              "wasted space in SmallVector size 1");
+              "wasted space in small_vector size 1");
 
-static_assert(sizeof(SmallVector<char, 0>) ==
+static_assert(sizeof(small_vector<char, 0>) ==
                   sizeof(void *) * 2 + sizeof(void *),
               "1 byte elements have word-sized type for size and capacity");
 
@@ -1375,7 +1383,7 @@ static_assert(sizeof(SmallVector<char, 0>) ==
 /// std::length_error or calls report_fatal_error.
 static void report_size_overflow(size_t MinSize, size_t MaxSize);
 static void report_size_overflow(size_t MinSize, size_t MaxSize) {
-  std::string Reason = "SmallVector unable to grow. Requested capacity (" +
+  std::string Reason = "small_vector unable to grow. Requested capacity (" +
                        std::to_string(MinSize) +
                        ") is larger than maximum value for size type (" +
                        std::to_string(MaxSize) + ")";
@@ -1387,7 +1395,7 @@ static void report_size_overflow(size_t MinSize, size_t MaxSize) {
 static void report_at_maximum_capacity(size_t MaxSize);
 static void report_at_maximum_capacity(size_t MaxSize) {
   std::string Reason =
-      "SmallVector capacity unable to grow. Already at maximum size " +
+      "small_vector capacity unable to grow. Already at maximum size " +
       std::to_string(MaxSize);
   throw std::length_error(Reason);
 }
@@ -1415,18 +1423,18 @@ static size_t getNewCapacity(size_t MinSize, size_t TSize, size_t OldCapacity) {
 
 // Note: Moving this function into the header may cause performance regression.
 template <class Size_T>
-void *SmallVectorBase<Size_T>::mallocForGrow(size_t MinSize,
-                                             size_t TSize,
-                                             size_t &NewCapacity) {
+void *small_vector_base<Size_T>::mallocForGrow(size_t MinSize,
+                                               size_t TSize,
+                                               size_t &NewCapacity) {
   NewCapacity = getNewCapacity<Size_T>(MinSize, TSize, this->capacity());
   return safe_malloc(NewCapacity * TSize);
 }
 
 // Note: Moving this function into the header may cause performance regression.
 template <class Size_T>
-void SmallVectorBase<Size_T>::grow_pod(void *FirstEl,
-                                       size_t MinSize,
-                                       size_t TSize) {
+void small_vector_base<Size_T>::grow_pod(void *FirstEl,
+                                         size_t MinSize,
+                                         size_t TSize) {
   size_t NewCapacity = getNewCapacity<Size_T>(MinSize, TSize, this->capacity());
   void *NewElts;
   if (BeginX == FirstEl) {
@@ -1443,38 +1451,38 @@ void SmallVectorBase<Size_T>::grow_pod(void *FirstEl,
   this->Capacity = NewCapacity;
 }
 
-template class paddle::SmallVectorBase<uint32_t>;
+template class paddle::small_vector_base<uint32_t>;
 
 // Disable the uint64_t instantiation for 32-bit builds.
 // Both uint32_t and uint64_t instantiations are needed for 64-bit builds.
 // This instantiation will never be used in 32-bit builds, and will cause
 // warnings when sizeof(Size_T) > sizeof(size_t).
 #if SIZE_MAX > UINT32_MAX
-template class paddle::SmallVectorBase<uint64_t>;
+template class paddle::small_vector_base<uint64_t>;
 
 // Assertions to ensure this #if stays in sync with SmallVectorSizeType.
 static_assert(sizeof(SmallVectorSizeType<char>) == sizeof(uint64_t),
-              "Expected SmallVectorBase<uint64_t> variant to be in use.");
+              "Expected small_vector_base<uint64_t> variant to be in use.");
 #else
 static_assert(sizeof(SmallVectorSizeType<char>) == sizeof(uint32_t),
-              "Expected SmallVectorBase<uint32_t> variant to be in use.");
+              "Expected small_vector_base<uint32_t> variant to be in use.");
 #endif
 
 }  // namespace paddle
 
 namespace std {
 
-/// Implement std::swap in terms of SmallVector swap.
+/// Implement std::swap in terms of small_vector swap.
 template <typename T>
-inline void swap(paddle::SmallVectorImpl<T> &LHS,
-                 paddle::SmallVectorImpl<T> &RHS) {
+inline void swap(paddle::small_vector_impl<T> &LHS,
+                 paddle::small_vector_impl<T> &RHS) {
   LHS.swap(RHS);
 }
 
-/// Implement std::swap in terms of SmallVector swap.
+/// Implement std::swap in terms of small_vector swap.
 template <typename T, unsigned N>
-inline void swap(paddle::SmallVector<T, N> &LHS,
-                 paddle::SmallVector<T, N> &RHS) {
+inline void swap(paddle::small_vector<T, N> &LHS,
+                 paddle::small_vector<T, N> &RHS) {
   LHS.swap(RHS);
 }
 

--- a/paddle/utils/small_vector_test.cc
+++ b/paddle/utils/small_vector_test.cc
@@ -21,7 +21,7 @@
 #include "gtest/gtest.h"
 
 template <typename T, unsigned N>
-static std::vector<T> ToStdVector(const paddle::SmallVector<T, N> &vec) {
+static std::vector<T> ToStdVector(const paddle::small_vector<T, N> &vec) {
   std::vector<T> std_vec;
   std_vec.reserve(vec.size());
   for (size_t i = 0; i < vec.size(); ++i) {
@@ -35,7 +35,7 @@ void SmallVectorCheck(size_t n) {
   std::srand(std::time(nullptr));
 
   std::vector<int> std_vec;
-  paddle::SmallVector<int, N> vec;
+  paddle::small_vector<int, N> vec;
 
   for (size_t i = 0; i < n; ++i) {
     int value = rand();  // NOLINT


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Unify utils naming style

统一paddle/utils下组件的命名风格：

- SmallVector -> small_vector
- ArrayRef -> array_ref

utils下其他组件都是小写+下划线命名风格：any, variant, flat_hash_map, optional等