### PR TITLE
fix false positive warning of gcc>=9

### DIFF
--- a/paddle/utils/variant.h
+++ b/paddle/utils/variant.h
@@ -13,6 +13,10 @@
 
 #pragma once
 
+// gcc >= 9 has a bug that creates a false positive warning.
+// Reference:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92145
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89381
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 9
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
Fix a false positive warning of gcc >= 9 introduced in https://github.com/PaddlePaddle/Paddle/pull/42139