### PR TITLE
Fix dimension error in static mode.

### DIFF
--- a/python/paddle/signal.py
+++ b/python/paddle/signal.py
@@ -383,7 +383,7 @@ def stft(x,
     out = out.transpose(perm=[0, 2, 1])  # (batch, n_fft, num_frames)
 
     if x_rank == 1:
-        out.squeeze_(0)
+        out = out.squeeze(0)
 
     return out
 
@@ -574,6 +574,6 @@ def istft(x,
     out = out / window_envelop
 
     if x_rank == 2:
-        out.squeeze_(0)
+        out = out.squeeze(0)
 
     return out


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
paddle.signal.stft静态图计算结果shape有误

```
import paddle
from paddle.signal import stft
import numpy as np
import torch

# n_fft = 4
# print(n_fft//4)
# x_data = np.arange(4).astype('float64')
x_data = np.random.rand(4, )
# x_data = np.exp(3j * np.pi * np.arange(7) / 7)
x = paddle.to_tensor(x_data)
y1 = stft(x, 4, onesided=False)
print(y1)

paddle.enable_static()
main_program, startup_program = paddle.static.Program(), paddle.static.Program()
with paddle.utils.unique_name.guard():
    with paddle.static.program_guard(main_program=main_program, startup_program=startup_program):
        data0 = paddle.static.data(name='s0', shape=(4, ), dtype="float64")
        feed = {"s0": x_data}
        out = stft(data0, 4, onesided=False)
        exe = paddle.static.Executor()
        exe.run(startup_program)
        static_res = exe.run(main_program, feed=feed, fetch_list=[out])
paddle.disable_static()
print(static_res[0].shape)
```
文档描述有误：
![image](https://user-images.githubusercontent.com/6836917/211757749-d339e5a3-aead-46c3-83fc-513b6976c174.png)