### PR TITLE
fix PIL sample mode deprecated warning

### DIFF
--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -33,12 +33,12 @@ else:
     Iterable = collections.abc.Iterable
 
 _pil_interp_from_str = {
-    'nearest': Image.NEAREST,
-    'bilinear': Image.BILINEAR,
-    'bicubic': Image.BICUBIC,
-    'box': Image.BOX,
-    'lanczos': Image.LANCZOS,
-    'hamming': Image.HAMMING
+    'nearest': Image.Resampling.NEAREST,
+    'bilinear': Image.Resampling.BILINEAR,
+    'bicubic': Image.Resampling.BICUBIC,
+    'box': Image.Resampling.BOX,
+    'lanczos': Image.Resampling.LANCZOS,
+    'hamming': Image.Resampling.HAMMING
 }
 
 __all__ = []

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -32,14 +32,25 @@ else:
     Sequence = collections.abc.Sequence
     Iterable = collections.abc.Iterable
 
-_pil_interp_from_str = {
-    'nearest': Image.Resampling.NEAREST,
-    'bilinear': Image.Resampling.BILINEAR,
-    'bicubic': Image.Resampling.BICUBIC,
-    'box': Image.Resampling.BOX,
-    'lanczos': Image.Resampling.LANCZOS,
-    'hamming': Image.Resampling.HAMMING
-}
+try:
+    # PIL version >= "9.1.0"
+    _pil_interp_from_str = {
+        'nearest': Image.Resampling.NEAREST,
+        'bilinear': Image.Resampling.BILINEAR,
+        'bicubic': Image.Resampling.BICUBIC,
+        'box': Image.Resampling.BOX,
+        'lanczos': Image.Resampling.LANCZOS,
+        'hamming': Image.Resampling.HAMMING
+    }
+except:
+    _pil_interp_from_str = {
+        'nearest': Image.NEAREST,
+        'bilinear': Image.BILINEAR,
+        'bicubic': Image.BICUBIC,
+        'box': Image.BOX,
+        'lanczos': Image.LANCZOS,
+        'hamming': Image.HAMMING
+    }
 
 __all__ = []
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Use Image.Resampling instead of Image. to eliminate deprecation warning.
![image](https://user-images.githubusercontent.com/50691816/165426820-6c80c370-1aed-4ff3-8dcf-d9466f65fe62.png)

