### PR TITLE
fix fused_multi_transformer compile failed in cuda arch < sm53

### DIFF
--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -534,6 +534,8 @@ template <typename T, int Dh, int THREADS_PER_KEY, int THREADS_PER_VALUE,
           int THREADS_PER_BLOCK>
 __global__ void masked_multihead_attention_kernel(
     Masked_multihead_attention_params<T> params) {
+#if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
+
   static_assert(Dh % THREADS_PER_KEY == 0, "");
   static_assert(Dh % THREADS_PER_VALUE == 0, "");
 
@@ -820,6 +822,9 @@ __global__ void masked_multihead_attention_kernel(
       printf("%f ", static_cast<float>(params.out[i]));
     printf("\n");
   }
+#endif
+#else
+  assert(false);
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix fused_multi_transformer compile failed in cuda arch < sm53
<img width="973" alt="image" src="https://user-images.githubusercontent.com/10208305/165462205-6c2ef4d5-c991-4085-8b06-dba9c6ff5c5a.png">
