### PR TITLE
[cherry-pick][Performance]Add static inline for MakeReturnPyObject (#42334)

### DIFF
--- a/paddle/fluid/pybind/op_function.h
+++ b/paddle/fluid/pybind/op_function.h
@@ -177,7 +177,7 @@ static inline void HandleViewBetweenInputAndOutput(
   }
 }
 
-PyObject* MakeReturnPyObject(
+static inline PyObject* MakeReturnPyObject(
     const std::shared_ptr<paddle::imperative::VarBase>& out) {
   return ::pybind11::detail::type_caster_base<imperative::VarBase>::cast_holder(
              ::pybind11::detail::holder_helper<
@@ -186,7 +186,7 @@ PyObject* MakeReturnPyObject(
       .ptr();
 }
 
-PyObject* MakeReturnPyObject(
+static inline PyObject* MakeReturnPyObject(
     const std::vector<std::shared_ptr<imperative::VarBase>>& out) {
   PyObject* result = PyList_New((Py_ssize_t)out.size());
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[cherry-pick][Performance]Add static inline for MakeReturnPyObject (#42334)