### PR TITLE
fix FusedResidualDropoutBias nan in v100

### DIFF
--- a/paddle/fluid/operators/fused/fused_dropout_common.h
+++ b/paddle/fluid/operators/fused/fused_dropout_common.h
@@ -43,9 +43,17 @@ inline platform::GpuLaunchConfig Get1DBlocksAnd2DGrids(
     const platform::CUDADeviceContext &ctx, const uint32_t rows,
     const uint32_t cols, const int vec_size) {
   const uint32_t tmp_cols = cols / vec_size;
-  int threads = std::max(
-      static_cast<uint32_t>(32),
-      std::min(tmp_cols, static_cast<uint32_t>(ctx.GetMaxThreadsPerBlock())));
+  // NOTE(wangxi): We set max_block_size to 512, for `FusedResidualDropoutBias`
+  // needs too many register resources. If data_type is float16, CUDA
+  // error(701) will occur when block_size is 1024. Which error is
+  // 'cudaErrorLaunchOutOfResources', this indicates that a launch did not
+  // occur because it did not have appropriate resources.
+  // Of course, this kernel can be optimized later to reduce the use
+  // of registers.
+  int threads =
+      std::max(static_cast<uint32_t>(32),
+               std::min(tmp_cols, static_cast<uint32_t>(std::min(
+                                      ctx.GetMaxThreadsPerBlock(), 512))));
   const auto blocks_x =
       std::max(static_cast<uint32_t>(1), (tmp_cols + threads - 1) / threads);
   const auto blocks_y = std::max(static_cast<uint32_t>(1), rows);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#### 问题定位
在V100上测试千亿ERNIE，发现精度对不齐，具体定位发现`FusedResidualDropoutBias` kernel运算的结果不对。
再进一步定位，发现kernel实现没问题，不过在ERNIE千亿场景下，跑fp16启动kernel线程数会设置为1024，由于`FusedResidualDropoutBias`每个线程占用的寄存器数比较多，就出现了如下错误。
也就是launch kernel时，block使用的寄存器超过了限制，导致kernel未被launch，最终没有执行。训练精度出现问题
<img width="1349" alt="f21818dacc6a90ded7fb115e0d4ffd3a" src="https://user-images.githubusercontent.com/10208305/165671919-04d2b351-2845-4d4e-9a1f-37154fc62965.png">
#### 问题解决
先将最大线程数简单设置为512(这个值足够SM使用，理论应该不会影响性能，大部分场景可能256好一些)，来规避超出寄存器资源的问题。
当然后续可以对`FusedResidualDropoutBias`优化，减少线程对寄存器的使用。