### PR TITLE
fix Tensor share memory in eager mode

### DIFF
--- a/python/paddle/fluid/dataloader/worker.py
+++ b/python/paddle/fluid/dataloader/worker.py
@@ -22,7 +22,7 @@ from collections import namedtuple
 from .. import core
 from .fetcher import _IterableDatasetFetcher, _MapDatasetFetcher
 from ..multiprocess_utils import _cleanup_mmap, CleanupFuncRegistrar, MP_STATUS_CHECK_INTERVAL
-from ..framework import _non_static_mode
+from ..framework import _non_static_mode, _in_eager_without_dygraph_check
 from .flat import _flatten_batch
 
 # NOTE: queue has a different name in python2 and python3
@@ -339,10 +339,16 @@ def _worker_loop(dataset, dataset_kind, indices_queue, out_queue, done_event,
                     out_queue.put((idx, batch, None))
                 batch, structure = _flatten_batch(batch)
                 if use_shared_memory:
+                    # NOTE: In eager mode, Tensor._share_memory has no
+                    # effect, fall back to _array_to_share_memory_tensor
+                    def tensor_share_memory(tensor):
+                        if _in_eager_without_dygraph_check():
+                            return core._array_to_share_memory_tensor(tensor)
+                        return tensor._share_memory()
                     tensor_list = [
                         core._array_to_share_memory_tensor(b)
-                        if isinstance(b, np.ndarray) else b._share_memory()
-                        for b in batch
+                        if isinstance(b, np.ndarray) \
+                        else tensor_share_memory(b) for b in batch
                     ]
                     out_queue.put((idx, tensor_list, structure))
                     core._remove_tensor_list_mmap_fds(tensor_list)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
`Tensor._share_memory` not work properly in eager mode, fall back to `_array_to_share_memory_tensor`
Eager mode Tensor does not implement `__getstate__` and `__setstate__` method for `py::pickle`, shared memory tensor cannot pass through `multiprocessing.Queue` in eager mode, change to use `_array_to_share_memory_tensor` instead, which recreate a new share memory `LoDTensor` for cross queue transmission

**Reproduction code**
```python
import sys
import time
import paddle
import numpy as np
import multiprocessing
from paddle.fluid.framework import _test_eager_guard

def foo(queue):
    a = paddle.to_tensor(np.random.random([2, 3]), place=paddle.CPUPlace())
    a = a._share_memory()
    queue.put(a)
    sys.stdout.flush()
    return

queue = multiprocessing.Queue()
process = multiprocessing.Process(target=foo, args=(queue,))
process.daemon = True
process.start()
time.sleep(1)
a = queue.get()
print(a)

with _test_eager_guard():
    queue = multiprocessing.Queue()
    process = multiprocessing.Process(target=foo, args=(queue,))
    process.daemon = True
    process.start()
    time.sleep(1)
    a = queue.get(timeout=1)
    print(a)
```