### PR TITLE
[NPU] fix elementwise_div_grad for model PPO

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_div_op_npu.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op_npu.cc
@@ -118,20 +118,45 @@ class ElementwiseDivGradNPUKernel : public framework::OpKernel<T> {
     if (dy) {
       dy->mutable_data<T>(place);
 
-      Tensor neg_out(y->type());
-      neg_out.mutable_data<T>(y->dims(), place);
+      Tensor neg_out(out->type());
+      neg_out.mutable_data<T>(out->dims(), place);
       const auto& runner_neg_out = NpuOpRunner("Neg", {*out}, {neg_out}, {});
       runner_neg_out.Run(stream);
 
-      Tensor y_grad_w(y->type());
-      y_grad_w.mutable_data<T>(y->dims(), place);
-      const auto& runner_y_grad_w =
-          NpuOpRunner("Div", {neg_out, *y}, {y_grad_w}, {});
-      runner_y_grad_w.Run(stream);
+      Tensor tmp_mul(out->type());
+      tmp_mul.mutable_data<T>(out->dims(), place);
+      const auto& runner_mul =
+          NpuOpRunner("Mul", {neg_out, *dout}, {tmp_mul}, {});
+      runner_mul.Run(stream);
 
-      const auto& runner_y_grad =
-          NpuOpRunner("Mul", {y_grad_w, *dout}, {*dy}, {});
-      runner_y_grad.Run(stream);
+      if (dy->dims() != dout->dims()) {
+        Tensor reduced_tmp_mul(y->type());
+        reduced_tmp_mul.mutable_data<T>(y->dims(), place);
+
+        std::vector<int64_t> axes;
+        int64_t diff = dout->dims().size() - dy->dims().size();
+        for (int64_t i = 0; i < dout->dims().size(); ++i) {
+          if (i < diff) {
+            axes.push_back(i);
+            continue;
+          }
+          if (dout->dims()[i] > dy->dims()[i - diff]) {
+            axes.push_back(i);
+          }
+        }
+        const auto& runner_reduce =
+            NpuOpRunner("ReduceSumD", {tmp_mul}, {reduced_tmp_mul},
+                        {{"axes", axes}, {"keep_dims", false}});
+        runner_reduce.Run(stream);
+
+        const auto& runner_y_grad =
+            NpuOpRunner("Div", {reduced_tmp_mul, *y}, {*dy}, {});
+        runner_y_grad.Run(stream);
+      } else {
+        const auto& runner_y_grad =
+            NpuOpRunner("Div", {tmp_mul, *y}, {*dy}, {});
+        runner_y_grad.Run(stream);
+      }
     }
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
In PPO, npu elementwise_div_grad fails because invalid parameter for Neg CANN OP, here out and y are different in dims, need reducesum.
![5ed7f6725bcf6dae166c7a00d660b2dd](https://user-images.githubusercontent.com/5997715/166859419-6427491e-6962-4ff4-9202-1ac9791fee0b.png)
<img width="535" alt="image" src="https://user-images.githubusercontent.com/5997715/166859466-0e096518-e25c-4d71-8948-b76043f7a69d.png">

