### PR TITLE
[cherry-pick] Fix the race condition in cumsum operator (#42205)

### DIFF
--- a/paddle/phi/kernels/gpu/cumsum_kernel.cu
+++ b/paddle/phi/kernels/gpu/cumsum_kernel.cu
@@ -39,14 +39,12 @@ __device__ void BlockReverse(
   int tx = threadIdx.x;
 
   int offset = tx;
-  int in_index = src_base + offset;
-  if (offset >= valid_item) {
-    sh_mem[offset] = 0;
-  } else {
-    int sh_mem_index = BLOCK_SIZE - offset - 1;
-    T data = idata[in_index];
-    sh_mem[sh_mem_index] = data;
+  T src_data = 0;
+  int src_offset = BLOCK_SIZE - offset - 1;
+  if (src_offset < valid_item) {
+    src_data = idata[src_base + src_offset];
   }
+  sh_mem[offset] = src_data;
 
   __syncthreads();
   int out_index = dst_base - offset;


### PR DESCRIPTION
### PR types
Bug fixes
### PR changes
OPs 

### Describe
The reason is that the BlockReverse function in cumsum_op has race condition.
This PR modifies part of codes to avoid hazard.Followed by the issue https://github.com/PaddlePaddle/Paddle/issues/41932,

cherry-pick from the PR https://github.com/PaddlePaddle/Paddle/pull/42205
