### PR TITLE
Fix the implementation of fused_fast_ln_fwd_kernel in test mode

### DIFF
--- a/paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h
+++ b/paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h
@@ -298,9 +298,15 @@ __global__ __launch_bounds__(THREADS_PER_CTA) void fused_fast_ln_fwd_kernel(
     for (int it = 0, col = c; it < LDGS; it++) {
       phi::Store<T, VecSize>(
           x[it], residual_out_ptr + row * ELTS_PER_ROW + col * VecSize);
-      phi::Store<MaskType, VecSize>(
-          mask_vec[it], mask_out_ptr + row * ELTS_PER_ROW + col * VecSize);
       col += THREADS_PER_ROW;
+    }
+    if (!is_test) {
+#pragma unroll
+      for (int it = 0, col = c; it < LDGS; it++) {
+        phi::Store<MaskType, VecSize>(
+            mask_vec[it], mask_out_ptr + row * ELTS_PER_ROW + col * VecSize);
+        col += THREADS_PER_ROW;
+      }
     }
 
     U mu_local = 0.f;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix the implementation of fused_fast_ln_fwd_kernel in test mode.
Only in train mode, the `mask` should be stored out.