### PR TITLE
Fix the problem of slice infer shape in static graph mode

### DIFF
--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -306,8 +306,9 @@ def get_value_for_bool_tensor(var, item):
         return paddle.empty(var_shape, dtype=var.dtype)
 
     from .layers.control_flow import cond
-    return cond(item.any(), lambda: idx_not_empty(var, item),
-                lambda: idx_empty(var))
+    return cond(
+        paddle.logical_not(item.any()), lambda: idx_empty(var),
+        lambda: idx_not_empty(var, item))
 
 
 def _getitem_impl_(var, item):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复静态图下slice在使用bool索引时组网阶段输出结果维度为0的问题，预期结果应为-1。