### PR TITLE
[DO NOT REVIEW & DO NOT MERGE] Checking impact on CI not resetting data layout

### DIFF
--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -148,8 +148,8 @@ inline void ClearMKLDNNCache(const platform::Place& place,
     platform::MKLDNNDeviceContext* dev_ctx =
         (platform::MKLDNNDeviceContext*)pool.Get(place);
     dev_ctx->ResetBlobMap(ptr);
-    platform::MKLDNNDeviceContext::tls().set_cur_paddle_data_layout(
-        paddle::framework::DataLayout::kNCHW);
+//    platform::MKLDNNDeviceContext::tls().set_cur_paddle_data_layout(
+//        paddle::framework::DataLayout::kNCHW);
   }
 }
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others 

### Describe
Disable the resetting data layout to NCHW. This is needed in nested executors like in while or conditional ops.
