### PR TITLE
add int8 for cast op

### DIFF
--- a/paddle/fluid/operators/cast_op.cc
+++ b/paddle/fluid/operators/cast_op.cc
@@ -156,7 +156,7 @@ REGISTER_OP_CPU_KERNEL(
     ops::CastOpKernel<CPU, double>, ops::CastOpKernel<CPU, int>,
     ops::CastOpKernel<CPU, int64_t>, ops::CastOpKernel<CPU, int>,
     ops::CastOpKernel<CPU, int16_t>, ops::CastOpKernel<CPU, bool>,
-    ops::CastOpKernel<CPU, uint8_t>,
+    ops::CastOpKernel<CPU, uint8_t>, ops::CastOpKernel<CPU, int8_t>,
     ops::CastOpKernel<CPU, paddle::platform::float16>,
     ops::CastOpKernel<CPU, paddle::platform::bfloat16>,
     ops::CastOpKernel<CPU, paddle::platform::complex<float>>,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
add int8 support for cast op (cpu kernel)