### PR TITLE
stride_slice don't support trt6

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -941,6 +941,11 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
     }
 
     if (op_type == "strided_slice") {
+#if !IS_TRT_VERSION_GE(7000)
+      VLOG(3)
+          << "strided_slice converter does not support trt versions below 7.0";
+      return false;
+#endif
       if (!with_dynamic_shape) {
         return false;
       }

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_strided_slice.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_strided_slice.py
@@ -103,6 +103,9 @@ class TrtConvertStridedSliceTest(TrtLayerAutoScanTest):
                 for x in attrs[0]["axes"]:
                     if x == 0:
                         return 0, 3
+            ver = paddle_infer.get_trt_compile_version()
+            if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 7000:
+                return 0, 3
             return 1, 2
 
         attrs = [


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
fix: stride_slice don't support trt6