### PR TITLE
[Eager]Fix EagerTensor _copy_to memory overlapping problem

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -363,12 +363,33 @@ static PyObject* tensor_method__is_dense_tensor_hold_allocation(
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
+static void IncreaseTensorReferenceCountUntilCopyComplete(
+    const paddle::experimental::Tensor& tensor, const platform::Place& place) {
+  auto place_ = platform::is_gpu_place(place) ? place : tensor.place();
+
+  auto tracer = egr::Controller::Instance().GetCurrentTracer();
+  auto gc = tracer->MutableGarbageCollectorIfNotExists(place_);
+
+  // Note(dev): This is an empty callback, the only way is to "reference"
+  // inner memory Holder, so it will not be destructed until the kernels
+  // launched at current stream of given place is finished, such as
+  // CUDAPinned Mem -> CUDA by cudamemcpyAsync.
+  auto callback = [tensor, place_]() {
+    VLOG(3) << "Run callback of Tensor:" << tensor.name() << " at place "
+            << place_;
+  };
+  gc->DirectClearCallback(callback);
+}
+
 static PyObject* tensor_method__copy_to(TensorObject* self, PyObject* args,
                                         PyObject* kwargs) {
   EAGER_TRY
   auto place = CastPyArg2Place(PyTuple_GET_ITEM(args, 0), 0);
   bool blocking = CastPyArg2AttrBoolean(PyTuple_GET_ITEM(args, 1), 1);
   auto cp_tensor = self->tensor.copy_to(place, blocking);
+  if (!blocking) {
+    IncreaseTensorReferenceCountUntilCopyComplete(self->tensor, place);
+  }
   egr::EagerUtils::autograd_meta(&cp_tensor)->SetStopGradient(true);
   egr::EagerUtils::autograd_meta(&cp_tensor)
       ->SetPersistable(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

### What's New?
在模型推广新动态图时，发现部分模型在GPU上 Eval阶段出现精度与老动态图存在较大diff问题。初步定位发现，是输入给model的数据在存在随机的被篡改行为。此PR修复了此问题

如下图：
![0549a28fbf4a879e0c13961fe4fcf044](https://user-images.githubusercontent.com/9301846/167762118-1c3786cd-3d1e-4b88-ba7a-df98f1ed44a8.jpg)

### 问题定位
经过逐步摸排发现，从dataloader出来的pinned place上数据是正确的，但经过`batch[0] = paddle.to_tensor(batch[0])`之后数据出现随机错误，且发生在相邻的两个batch之间，**总是batch的数据区的末尾部分被篡改了**

数据表现如下图：
![57789e276e09a667d767824405fe7553](https://user-images.githubusercontent.com/9301846/167762374-84af693e-e070-47b1-8446-f9e77e3f06c9.jpg)
<img width="1364" alt="b50b1af9174b05d8d701226496683d35" src="https://user-images.githubusercontent.com/9301846/167762378-3e7aeafc-182c-4e91-9378-5928f09f3402.png">

是因为，to_tensor底层调用的是CudaMemCpyAsync，在blocking=False时，是一个stream上异步行为。当pinned place的Tensor被析构时，此cpy行为可能正在发生。导致Pinned Mem被下一个batch给重用了（因为提前被GC，标记为可用）

### 解决方案
当blocking=False时，需要以添加callback的形式，给src_tenso的引用计数+1，告知框架侧的GC，此Pinned Mem在cpy行为未完成之前，此内存是不可重用的。
