### PR TITLE
Fix hang problem when some workers exited unexcepted 

### DIFF
--- a/paddle/fluid/distributed/store/tcp_store.h
+++ b/paddle/fluid/distributed/store/tcp_store.h
@@ -51,7 +51,9 @@ class MasterDaemon {
   std::unordered_map<std::string, std::vector<uint8_t>> _store;
   std::thread _background_thread{};
   int _nranks;
-  bool _stop = false;
+  bool _stop = false;  // all workers stopped
+  std::chrono::time_point<std::chrono::system_clock> _stop_time;
+  bool _has_stop = false;  // at least one worker stopped
 };
 
 class TCPServer {

--- a/paddle/fluid/distributed/store/tcp_store.h
+++ b/paddle/fluid/distributed/store/tcp_store.h
@@ -34,9 +34,11 @@ namespace detail {
 class MasterDaemon {
  public:
   static std::unique_ptr<MasterDaemon> start(SocketType listen_socket,
-                                             int nranks);
+                                             int nranks,
+                                             int stop_check_timeout);
   MasterDaemon() = delete;
-  explicit MasterDaemon(SocketType listen_socket, int nranks);
+  explicit MasterDaemon(SocketType listen_socket, int nranks,
+                        int stop_check_timeout);
   ~MasterDaemon();
 
  private:
@@ -51,6 +53,7 @@ class MasterDaemon {
   std::unordered_map<std::string, std::vector<uint8_t>> _store;
   std::thread _background_thread{};
   int _nranks;
+  int _stop_check_timeout;
   bool _stop = false;  // all workers stopped
   std::chrono::time_point<std::chrono::system_clock> _stop_time;
   bool _has_stop = false;  // at least one worker stopped
@@ -59,7 +62,8 @@ class MasterDaemon {
 class TCPServer {
  public:
   TCPServer() = default;
-  static std::unique_ptr<TCPServer> create(std::uint16_t port, int nranks);
+  static std::unique_ptr<TCPServer> create(std::uint16_t port, int nranks,
+                                           int stop_check_timeout);
 
  private:
   std::unique_ptr<MasterDaemon> _master_daemon;
@@ -95,7 +99,8 @@ class TCPStore : public Store {
   static constexpr std::uint16_t kDefaultPort = 6170;
   explicit TCPStore(std::string host, uint16_t port = kDefaultPort,
                     bool is_master = false, size_t num_workers = 1,
-                    std::chrono::seconds timeout = tcputils::kDefaultTimeout);
+                    std::chrono::seconds timeout = tcputils::kDefaultTimeout,
+                    int stop_check_timeout = 900);
 
   ~TCPStore();
 

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -833,3 +833,14 @@ PADDLE_DEFINE_EXPORTED_bool(nccl_blocking_wait, false, "nccl blocking wait");
  * Example:
  */
 PADDLE_DEFINE_EXPORTED_bool(use_autotune, false, "Whether enable autotune.");
+
+/**
+ * TCPStore related FLAG
+ * Name: FLAGS_stop_check_timeout
+ * Since Version: 2.4
+ * Value Range: int32, default=900
+ * Example:
+ */
+PADDLE_DEFINE_EXPORTED_int32(
+    stop_check_timeout, 900,
+    "Timeout value for check whether the master worker should stop or not.");

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -833,14 +833,3 @@ PADDLE_DEFINE_EXPORTED_bool(nccl_blocking_wait, false, "nccl blocking wait");
  * Example:
  */
 PADDLE_DEFINE_EXPORTED_bool(use_autotune, false, "Whether enable autotune.");
-
-/**
- * TCPStore related FLAG
- * Name: FLAGS_stop_check_timeout
- * Since Version: 2.4
- * Value Range: int32, default=900
- * Example:
- */
-PADDLE_DEFINE_EXPORTED_int32(
-    stop_check_timeout, 900,
-    "Timeout value for check whether the master worker should stop or not.");

--- a/paddle/fluid/pybind/communication.cc
+++ b/paddle/fluid/pybind/communication.cc
@@ -58,13 +58,16 @@ void BindTCPStore(py::module *m) {
 
   py::class_<TCPStore, std::shared_ptr<TCPStore>>(*m, "TCPStore", Store)
       .def(py::init([](std::string hostname, uint16_t port, bool is_master,
-                       size_t world_size, std::chrono::seconds timeout) {
+                       size_t world_size, std::chrono::seconds timeout,
+                       int stop_check_timeout) {
              return std::make_shared<TCPStore>(hostname, port, is_master,
-                                               world_size, timeout);
+                                               world_size, timeout,
+                                               stop_check_timeout);
            }),
            py::arg("hostname"), py::arg("port"), py::arg("is_master"),
            py::arg("world_size"),
            py::arg("timeout") = distributed::tcputils::kNoTimeout,
+           py::arg("stop_check_timeout") = 900,
            py::call_guard<py::gil_scoped_release>());
 }
 

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -233,8 +233,13 @@ def init_parallel_env():
         master_addr, master_port = endpoints.split(":")
         master_port = int(master_port)
         is_master = rank == 0
-        default_store = core.TCPStore(master_addr, master_port, is_master,
-                                      world_size)
+        stop_check_timeout = int(os.getenv("FLAGS_stop_check_timeout", "900"))
+        default_store = core.TCPStore(
+            master_addr,
+            master_port,
+            is_master,
+            world_size,
+            stop_check_timeout=stop_check_timeout)
         _set_default_store(default_store)
         pg = _new_process_group_impl(
             backend,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix hang problem when some workers exited unexcepted: the master worker wait for 15min (timeout) when some worker exited.
User can set timeout value by `export FLAGS_stop_check_timeout=xxx` in seconds.