### PR TITLE
【CI】support py3.6 in windows-ci pipeline

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -88,7 +88,6 @@ set UPLOAD_TP_FILE=OFF
 rem ------initialize set git config------
 git config --global core.longpaths true
 
-set PYTHON_ROOT=C:\Python36
 rem ------initialize the python environment------
 set PYTHON_EXECUTABLE=%PYTHON_ROOT%\python.exe
 set PATH=%PYTHON_ROOT%\Scripts;%PYTHON_ROOT%;%PATH%

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -88,7 +88,7 @@ set UPLOAD_TP_FILE=OFF
 rem ------initialize set git config------
 git config --global core.longpaths true
 
-
+set PYTHON_ROOT=C:\Python36
 rem ------initialize the python environment------
 set PYTHON_EXECUTABLE=%PYTHON_ROOT%\python.exe
 set PATH=%PYTHON_ROOT%\Scripts;%PYTHON_ROOT%;%PATH%

--- a/python/paddle/fluid/tests/unittests/test_corr.py
+++ b/python/paddle/fluid/tests/unittests/test_corr.py
@@ -24,7 +24,7 @@ np_minor_version = int((np.__version__).split('.')[1])
 
 
 def numpy_corr(np_arr, rowvar=True, dtype='float64'):
-    # np.corrcoef support parameter since 1.20
+    # np.corrcoef support parameter 'dtype' since 1.20
     if np_minor_version < 20:
         return np.corrcoef(np_arr, rowvar=rowvar)
     return np.corrcoef(np_arr, rowvar=rowvar, dtype=dtype)

--- a/python/paddle/fluid/tests/unittests/test_corr.py
+++ b/python/paddle/fluid/tests/unittests/test_corr.py
@@ -18,9 +18,15 @@ import numpy as np
 import six
 import paddle
 import warnings
+import sys
+
+np_minor_version = int((np.__version__).split('.')[1])
 
 
 def numpy_corr(np_arr, rowvar=True, dtype='float64'):
+    # np.corrcoef support parameter since 1.20
+    if np_minor_version < 20:
+        return np.corrcoef(np_arr, rowvar=rowvar)
     return np.corrcoef(np_arr, rowvar=rowvar, dtype=dtype)
 
 

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -1,3 +1,4 @@
+pynacl==1.4.0 ; python_version == "3.6"
 PyGithub
 coverage==5.5
 pycrypto ; platform_system != "Windows"

--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -8,7 +8,8 @@ hypothesis
 opencv-python<=4.2.0.32
 visualdl
 paddle2onnx>=0.8.2
-scipy>=1.6
+scipy>=1.6; python_version >= "3.7"
+scipy>=1.5; python_version == "3.6"
 prettytable
 distro
-numpy>=1.20,<1.22
+numpy>=1.20,<1.22; python_version >= "3.7"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
We want to change python version to 3.6 in one of three windows ci pipeline, to check py3.6 problem. There are some limit:

- Unittests of fft need scipy version greater equal 1.6, since it need scipy.fft.rfftn support norm of backward and forward. And because of another factor, these unittests only run in windows-openblas CI. So this CI cant transfer to python3.6.
- The highest version of numpy spported by python3.6 is 1.19.5, see #38307.
- numpy.[corrcoef](https://numpy.org/doc/stable/reference/generated/numpy.corrcoef.html?highlight=corrcoef#numpy.corrcoef) support parameter dtype since 1.20.