### PR TITLE
Fix PD_INFER_DECL redefine

### DIFF
--- a/paddle/fluid/inference/api/paddle_infer_declare.h
+++ b/paddle/fluid/inference/api/paddle_infer_declare.h
@@ -23,5 +23,7 @@
 #endif  // PADDLE_DLL_INFERENCE
 #endif  // PD_INFER_DECL
 #else
+#ifndef PD_INFER_DECL
 #define PD_INFER_DECL __attribute__((visibility("default")))
+#endif  // PD_INFER_DECL
 #endif  // _WIN32


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix potential redefinition of `PD_INFER_DECL` in platforms other than WIN32.
Signed-off-by: KernelErr <me@lirui.tech>