### PR TITLE
Add skip impl for dygraph check nan and inf & polish eager deps

### DIFF
--- a/paddle/fluid/eager/CMakeLists.txt
+++ b/paddle/fluid/eager/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(eager_deps phi_api phi_dygraph_api hook_utils tensor_utils utils global_utils backward phi_tensor tracer layer autograd_meta grad_node_info grad_tensor_holder accumulation_node custom_operator_node)
+set(eager_deps phi_api phi_dygraph_api hook_utils tensor_utils utils global_utils backward phi_tensor autograd_meta grad_node_info grad_tensor_holder accumulation_node custom_operator_node)
 
 set(fluid_deps tracer layer proto_desc operator op_registry variable_helper memcpy)
 set(generated_deps final_dygraph_function final_dygraph_node dygraph_function dygraph_node)

--- a/paddle/fluid/eager/amp_utils.h
+++ b/paddle/fluid/eager/amp_utils.h
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 #pragma once
+
 #include <string>
+
 #include "paddle/fluid/eager/api/utils/global_utils.h"
+#include "paddle/fluid/eager/grad_node_info.h"
 #include "paddle/fluid/imperative/amp_auto_cast.h"
 
 namespace egr {

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -21,7 +21,7 @@
 #include "paddle/phi/api/ext/op_meta_info.h"
 #include "paddle/utils/small_vector.h"
 namespace egr {
-constexpr size_t kSlotSmallVectorSize = 15U;
+
 class UniqueNameGenerator {
  public:
   explicit UniqueNameGenerator(std::string prefix = "") : prefix_(prefix) {}

--- a/paddle/fluid/eager/autograd_meta.h
+++ b/paddle/fluid/eager/autograd_meta.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/eager/grad_node_info.h"
 namespace egr {
 

--- a/paddle/fluid/eager/custom_operator/custom_operator_node.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_node.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/eager/custom_operator/custom_operator_node.h"
+#include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/framework/custom_operator.h"
 #include "paddle/fluid/framework/op_meta_info_helper.h"
 #include "paddle/phi/api/ext/op_meta_info.h"

--- a/paddle/fluid/eager/grad_node_info.h
+++ b/paddle/fluid/eager/grad_node_info.h
@@ -15,13 +15,20 @@
 #pragma once
 
 #include <memory>
+#include <utility>
 
-#include "paddle/fluid/eager/api/utils/global_utils.h"
-#include "paddle/fluid/eager/eager_tensor.h"
+#include "glog/logging.h"
+
 #include "paddle/fluid/eager/hooks.h"
-#include "paddle/phi/api/all.h"
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/api/include/tensor.h"
+#include "paddle/phi/core/tensor_meta.h"
+#include "paddle/utils/small_vector.h"
 
 namespace egr {
+
+constexpr size_t kSlotSmallVectorSize = 15U;
+
 /**
  * GradNodeBase is base class of all grad node, which is what should be used by
  * eager execution, we define most of backward autograd members here, and for

--- a/paddle/fluid/eager/pylayer/py_layer_node.h
+++ b/paddle/fluid/eager/pylayer/py_layer_node.h
@@ -20,7 +20,7 @@
 #include "paddle/fluid/eager/grad_node_info.h"
 #include "paddle/fluid/eager/hooks.h"
 #include "paddle/phi/core/compat/convert_utils.h"
-#include "paddle/phi/core/tensor_meta.h"
+#include "paddle/phi/core/dense_tensor.h"
 
 namespace egr {
 
@@ -76,7 +76,7 @@ class GradNodePyLayer : public GradNodeBase {
  private:
   PyObject* ctx_{nullptr};
   std::vector<std::vector<phi::DenseTensorMeta>> forward_outputs_meta_;
-  std::vector<std::vector<paddle::platform::Place>> forward_outputs_place_;
+  std::vector<std::vector<phi::Place>> forward_outputs_place_;
 };
 
 }  // namespace egr

--- a/paddle/fluid/eager/tests/data_structure_tests/accumulation_node_test.cc
+++ b/paddle/fluid/eager/tests/data_structure_tests/accumulation_node_test.cc
@@ -17,8 +17,6 @@
 #include "gtest/gtest.h"
 
 #include "paddle/fluid/eager/accumulation/accumulation_node.h"
-#include "paddle/fluid/eager/api/utils/hook_utils.h"
-#include "paddle/fluid/eager/eager_tensor.h"
 #include "paddle/fluid/eager/grad_node_info.h"
 #include "paddle/fluid/eager/grad_tensor_holder.h"
 #include "paddle/fluid/eager/hooks.h"

--- a/paddle/fluid/framework/details/CMakeLists.txt
+++ b/paddle/fluid/framework/details/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 
 if(WITH_GPU)
-    nv_library(nan_inf_utils SRCS nan_inf_utils_detail.cc nan_inf_utils_detail.cu DEPS framework_proto scope place)
+    nv_library(nan_inf_utils SRCS nan_inf_utils_detail.cc nan_inf_utils_detail.cu DEPS framework_proto scope place var_helper)
     nv_library(all_reduce_op_handle SRCS all_reduce_op_handle.cc DEPS op_handle_base scope lod_tensor ddim memory
             dynload_cuda variable_visitor)
     nv_library(fused_all_reduce_op_handle SRCS fused_all_reduce_op_handle.cc DEPS op_handle_base scope lod_tensor ddim memory

--- a/paddle/fluid/framework/details/nan_inf_utils.h
+++ b/paddle/fluid/framework/details/nan_inf_utils.h
@@ -41,18 +41,9 @@ void CheckOpHasNanOrInf(const framework::OperatorBase& op,
                         const platform::Place& place);
 
 template <typename VarType>
-void CheckOpHasNanOrInfInDygraph(const std::string& op_type,
+void CheckOpHasNanOrInfInDygraph(const framework::OperatorBase& op,
                                  const imperative::NameVarMap<VarType>& op_outs,
-                                 platform::Place place) {
-  for (const auto& pair : op_outs) {
-    for (const auto& ivar : pair.second) {
-      auto* var = ivar->MutableVar();
-      if (var == nullptr) continue;
-      CheckVarHasNanOrInf(op_type, paddle::imperative::GetNameFromVar(ivar),
-                          var, place);
-    }
-  }
-}
+                                 platform::Place place);
 
 #ifdef PADDLE_WITH_ASCEND_CL
 void NPUAllocAndClearFloatStatus(const framework::OperatorBase& op,

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -532,56 +532,6 @@ Tensor* GetMutableLoDTensorOrSelectedRowsValueFromVar(Variable* var) {
   }
 }
 
-bool ExecutionContext::HasInput(const std::string& name) const {
-  auto* var = InputVar(name);
-  return var != nullptr;
-}
-
-bool ExecutionContext::HasInputs(const std::string& name) const {
-  const auto& ins = ctx_.inputs;
-  auto it = ins.find(name);
-  if (it == ins.end() || it->second.empty()) {
-    return false;
-  }
-  for (const auto* input : it->second) {
-    if (input == nullptr) {
-      return false;
-    }
-  }
-  return true;
-}
-
-bool ExecutionContext::HasOutput(const std::string& name) const {
-  auto* var = OutputVar(name);
-  return var != nullptr;
-}
-
-const Variable* ExecutionContext::InputVar(const std::string& name) const {
-  LogVarUsageIfUnusedVarCheckEnabled(name);
-
-  auto it = ctx_.inputs.find(name);
-  if (it == ctx_.inputs.end()) return nullptr;
-
-  PADDLE_ENFORCE_LE(
-      it->second.size(), 1UL,
-      platform::errors::InvalidArgument(
-          "Operator %s's input %s should contain only one variable.",
-          op_.Type(), name));
-  return it->second.empty() ? nullptr : it->second[0];
-}
-
-Variable* ExecutionContext::OutputVar(const std::string& name) const {
-  auto it = ctx_.outputs.find(name);
-  if (it == ctx_.outputs.end()) return nullptr;
-
-  PADDLE_ENFORCE_LE(
-      it->second.size(), 1UL,
-      platform::errors::InvalidArgument(
-          "Operator %s's output %s should contain only one variable.",
-          op_.Type(), name));
-  return it->second.empty() ? nullptr : it->second[0];
-}
-
 template <>
 const std::vector<const Tensor*> ExecutionContext::MultiInput<Tensor>(
     const std::string& name) const {

--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -479,7 +479,7 @@ static void PreparedOpRunImpl(
 
   if (FLAGS_check_nan_inf) {
     framework::details::CheckOpHasNanOrInfInDygraph<VarType>(
-        op.Type(), outs, dev_ctx->GetPlace());
+        op, outs, dev_ctx->GetPlace());
   }
 
   if (FLAGS_benchmark) {
@@ -544,7 +544,7 @@ static void PreparedOpRunPtImpl(
 
   if (FLAGS_check_nan_inf) {
     framework::details::CheckOpHasNanOrInfInDygraph<VarType>(
-        op.Type(), outs, dev_ctx->GetPlace());
+        op, outs, dev_ctx->GetPlace());
   }
 
   if (FLAGS_benchmark) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Add skip impl for dygraph check nan and inf & polish eager deps

- 支持动态图的nan和inf check时根据环境变量跳过一些指定op或var
- debug过程中调整了一些eager的头文件关系，global_utils.h对fluid框架头文件依赖较多，而一些eager的头文件实际上不需要global_utils.h里面的类
- 将一些Execution的virtual member function移到头文件，否则会在单测link阶段报错
https://stackoverflow.com/questions/307352/g-undefined-reference-to-typeinfo