### PR TITLE
Polish kernel type string format

### DIFF
--- a/paddle/fluid/framework/op_kernel_type.h
+++ b/paddle/fluid/framework/op_kernel_type.h
@@ -82,9 +82,9 @@ class OpKernelType {
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const OpKernelType& kernel_key) {
-  os << "data_type[" << kernel_key.data_type_ << "]:data_layout["
-     << kernel_key.data_layout_ << "]:place[" << kernel_key.place_
-     << "]:library_type[" << kernel_key.library_type_ << "]";
+  os << "{data_type[" << kernel_key.data_type_ << "]; data_layout["
+     << kernel_key.data_layout_ << "]; place[" << kernel_key.place_
+     << "]; library_type[" << kernel_key.library_type_ << "]}";
   return os;
 }
 

--- a/paddle/fluid/framework/op_kernel_type_test.cc
+++ b/paddle/fluid/framework/op_kernel_type_test.cc
@@ -27,16 +27,15 @@ TEST(OpKernelType, ToString) {
                               LibraryType::kCUDNN);
 
   ASSERT_EQ(paddle::framework::KernelTypeToString(op_kernel_type),
-            "data_type[float]:data_layout[NCHW]:place[Place(cpu)]:library_type["
-            "CUDNN]");
+            "{data_type[float]; data_layout[NCHW]; place[Place(cpu)]; "
+            "library_type[CUDNN]}");
 
   using CUDAPlace = paddle::platform::CUDAPlace;
   OpKernelType op_kernel_type2(DataType::FP16, CUDAPlace(0), DataLayout::kNCHW,
                                LibraryType::kCUDNN);
   ASSERT_EQ(paddle::framework::KernelTypeToString(op_kernel_type2),
-            "data_type[::paddle::platform::float16]:data_layout[NCHW]:place["
-            "Place(gpu:0)]:library_"
-            "type[CUDNN]");
+            "{data_type[::paddle::platform::float16]; data_layout[NCHW]; "
+            "place[Place(gpu:0)]; library_type[CUDNN]}");
 }
 
 TEST(OpKernelType, Hash) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

研发管理平台依赖KernelType str做一些分析和统计工作，之前用”:“分割类型容易误判，例如place中含有“:”，命名空间也有”:“，因此这里改为分号

修改前：`data_type[float]:data_layout[NCHW]:place[Place(cpu)]:library_type[CUDNN]`

修改后：`{data_type[float]; data_layout[NCHW]; place[Place(cpu)]; library_type[CUDNN]}`