### PR TITLE
fix summary trainable_params bug

### DIFF
--- a/python/paddle/hapi/model_summary.py
+++ b/python/paddle/hapi/model_summary.py
@@ -301,14 +301,18 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
             else:
                 layer_state_dict = layer.state_dict()
 
+            summary[m_key]["trainable_params"] = 0
+            trainable_flag = False
             for k, v in layer_state_dict.items():
                 params += np.prod(v.shape)
 
                 try:
                     if (getattr(getattr(layer, k), 'trainable')) and (
                             not getattr(getattr(layer, k), 'stop_gradient')):
+                        summary[m_key]["trainable_params"] += np.prod(v.shape)
                         summary[m_key]["trainable"] = True
-                    else:
+                        trainable_flag = True
+                    elif not trainable_flag:
                         summary[m_key]["trainable"] = False
                 except:
                     summary[m_key]["trainable"] = True
@@ -427,7 +431,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
 
         if "trainable" in summary[layer]:
             if summary[layer]["trainable"] == True:
-                trainable_params += summary[layer]["nb_params"]
+                trainable_params += summary[layer]["trainable_params"]
         summary_str += line_new + "\n"
 
     def _get_input_size(input_size, size):

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -90,7 +90,26 @@ class ModelOutter(paddle.nn.Layer):
         return y, 3
 
 
-class LeNetListInput(LeNetDygraph):
+class LeNetListInput(paddle.nn.Layer):
+    def __init__(self, num_classes=10):
+        super(LeNetListInput, self).__init__()
+        self.num_classes = num_classes
+        self.cov = Conv2D(1, 6, 3, stride=1, padding=1)
+        for param in self.cov.parameters():
+            param.trainable = False
+        self.features = Sequential(
+            self.cov,
+            ReLU(),
+            paddle.fluid.dygraph.Pool2D(2, 'max', 2),
+            Conv2D(
+                6, 16, 5, stride=1, padding=0),
+            ReLU(),
+            paddle.fluid.dygraph.Pool2D(2, 'max', 2))
+
+        if num_classes > 0:
+            self.fc = Sequential(
+                Linear(400, 120), Linear(120, 84), Linear(84, 10))
+
     def forward(self, inputs):
         x = inputs[0]
         x = self.features(x)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
Some network layers contain both trainable parameters and non-trainable parameters. This PR fixes that paddle.summary could only record the parameters of the entire layer as trainable or non-trainable parameters, resulting in incorrect calculation of trainable parameters.

Example:
.. code-block:: python

    import paddle
    import paddle.nn as nn
    
    class LeNet(nn.Layer):
        def __init__(self, num_classes=10):
            super(LeNet, self).__init__()
            self.num_classes = num_classes
            self.features = nn.Sequential(
                nn.Conv2D(1, 6, 3, stride=1, padding=1),
                nn.BatchNorm2D(6),
                nn.ReLU(),
                nn.MaxPool2D(2, 2),
                nn.Conv2D(6, 16, 5, stride=1, padding=0),
                nn.ReLU(),
                nn.MaxPool2D(2, 2))
    
            if num_classes > 0:
                self.fc = nn.Sequential(
                    nn.Linear(400, 120),
                    nn.Linear(120, 84),
                    nn.Linear(84, 10))

        def forward(self, inputs):
            x = self.features(inputs)
    
            if self.num_classes > 0:
                x = paddle.flatten(x, 1)
                x = self.fc(x)
            return x
    
    lenet = LeNet()
    status = lenet.state_dict()
    params_info = paddle.summary(lenet, (1, 1, 28, 28))
    print(params_info)

previous incorrect output :
<img width="550" alt="image" src="https://user-images.githubusercontent.com/79366697/168716225-bacb074a-e8fd-4b26-9fba-748aab6693ce.png">

correct output :
<img width="567" alt="image" src="https://user-images.githubusercontent.com/79366697/168716301-13c944d0-a3c2-490e-909b-0fd83045e305.png">


Corresponding issue https://github.com/PaddlePaddle/Paddle/issues/40057
