### PR TITLE
fix tensorrt dla int8 problem

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -90,7 +90,9 @@ void TensorRTEngine::FreezeNetwork() {
 
   bool enable_int8 = (precision_ == AnalysisConfig::Precision::kInt8);
   if (enable_int8) {
-    infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kFP16);
+    if (!use_dla_) {
+      infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kFP16);
+    }
     infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kINT8);
 
     if (calibrator_) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Describe
<!-- Describe what this PR does --> Solve the problem that Jetson DLA int8 accuracy does not take effect
