### PR TITLE
[Dy2Stat]Modify all jit.save path into tempfile under dygraph_to_static directory

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_container.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_container.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import paddle
 import unittest
 import numpy as np
+import tempfile
 
 
 class BufferLayers(paddle.nn.Layer):
@@ -66,11 +68,15 @@ class TestSequential(unittest.TestCase):
     def setUp(self):
         paddle.set_device('cpu')
         self.seed = 2021
+        self.temp_dir = tempfile.TemporaryDirectory()
         self._init_config()
 
     def _init_config(self):
         self.net = SequentialNet(BufferLayers, 10, 3)
-        self.model_path = './sequential_net'
+        self.model_path = os.path.join(self.temp_dir.name, 'sequential_net')
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
 
     def _init_seed(self):
         paddle.seed(self.seed)
@@ -108,7 +114,8 @@ class TestSequential(unittest.TestCase):
 class TestNestSequential(TestSequential):
     def _init_config(self):
         self.net = NestSequentialNet()
-        self.model_path = './nested_sequential_net'
+        self.model_path = os.path.join(self.temp_dir.name,
+                                       'nested_sequential_net')
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_for_enumerate.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_for_enumerate.py
@@ -16,6 +16,8 @@ from __future__ import print_function
 
 import numpy as np
 import unittest
+import os
+import tempfile
 
 import paddle
 import paddle.fluid as fluid
@@ -532,12 +534,20 @@ class TestForOriginalTuple(TestTransformForOriginalList):
 
 
 class TestForZip(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
     def test_for_zip_error(self):
         with self.assertRaises(RuntimeError):
-            paddle.jit.save(for_zip_error, './for_zip_error')
+            model_path = os.path.join(self.temp_dir.name, 'for_zip_error')
+            paddle.jit.save(for_zip_error, model_path)
 
     def test_for_zip(self):
-        paddle.jit.save(for_zip, './for_zip')
+        model_path = os.path.join(self.temp_dir.name, 'for_zip')
+        paddle.jit.save(for_zip, model_path)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_grad.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_grad.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 import numpy as np
 import paddle
 import unittest
+import os
+import tempfile
 
 
 class GradLayer(paddle.nn.Layer):
@@ -88,8 +90,15 @@ class TestGradLinear(TestGrad):
         self.func = GradLinearLayer()
         self.x = paddle.ones(shape=[10, 2, 5], dtype='float32')
         self.x.stop_gradient = False
-        self.infer_model_path = "double_grad_infer_model"
-        self.train_model_path = "double_grad_train_model"
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.infer_model_path = os.path.join(self.temp_dir.name,
+                                             'double_grad_infer_model')
+        self.train_model_path = os.path.join(self.temp_dir.name,
+                                             'double_grad_train_model')
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
 
     def test_save_infer_program(self):
         input_spec = [
@@ -113,7 +122,7 @@ class TestGradLinear(TestGrad):
             avg_loss = paddle.mean(paddle.abs(out - 1))
             avg_loss.backward()
             optimizer.minimize(avg_loss)
-            print(self.x.grad.mean())
+
             self.func.clear_gradients()
 
         paddle.jit.save(self.func, self.train_model_path)
@@ -129,8 +138,15 @@ class TestNoGradLinear(TestGradLinear):
         self.func = NoGradLinearLayer()
         self.x = paddle.ones(shape=[10, 2, 5], dtype='float32')
         self.x.stop_gradient = False
-        self.infer_model_path = "no_grad_infer_model"
-        self.train_model_path = "no_grad_train_model"
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.infer_model_path = os.path.join(self.temp_dir.name,
+                                             'no_grad_infer_model')
+        self.train_model_path = os.path.join(self.temp_dir.name,
+                                             'no_grad_train_model')
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
@@ -19,6 +19,7 @@ import numpy as np
 import unittest
 
 import os
+import tempfile
 os.environ["CUDA_VISIBLE_DEVICES"] = "2"
 
 import paddle
@@ -406,11 +407,6 @@ class Args(object):
     base_learning_rate = 0.01
     bigru_num = 2
     print_steps = 1
-    model_save_dir = "./inference"
-    model_save_prefix = "./inference/lac"
-    model_filename = "lac" + INFER_MODEL_SUFFIX
-    params_filename = "lac" + INFER_PARAMS_SUFFIX
-    dy_param_path = "./lac_dy_param"
 
 
 def get_random_input_data(batch_size, vocab_size, num_labels, max_seq_len=64):
@@ -458,84 +454,86 @@ def create_dataloader(reader, place):
     return data_loader
 
 
-def do_train(args, to_static):
-    program_translator.enable(to_static)
-    place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
-    ) else fluid.CPUPlace()
-    with fluid.dygraph.guard(place):
-        paddle.seed(SEED)
-        paddle.framework.random._manual_program_seed(SEED)
-
-        reader = get_random_input_data(args.batch_size, args.vocab_size,
-                                       args.num_labels)
-        train_loader = create_dataloader(reader, place)
-
-        model = LexNet(args)
-        optimizer = fluid.optimizer.AdamOptimizer(
-            learning_rate=args.base_learning_rate,
-            parameter_list=model.parameters())
-        chunk_eval = ChunkEval(
-            int(math.ceil((args.num_labels - 1) / 2.0)), "IOB")
-
-        step = 0
-        chunk_evaluator = fluid.metrics.ChunkEvaluator()
-        chunk_evaluator.reset()
-
-        loss_data = []
-        for epoch_id in range(args.epoch):
-            for batch in train_loader():
-                words, targets, length = batch
-                start_time = time.time()
-                avg_cost, crf_decode = model(words, targets, length)
-                loss_data.append(avg_cost.numpy()[0])
-
-                # backward and optimization
-                avg_cost.backward()
-                optimizer.minimize(avg_cost)
-                model.clear_gradients()
-                end_time = time.time()
-
-                if step % args.print_steps == 0:
-                    (precision, recall, f1_score, num_infer_chunks,
-                     num_label_chunks, num_correct_chunks) = chunk_eval(
-                         input=crf_decode, label=targets, seq_length=length)
-                    outputs = [avg_cost, precision, recall, f1_score]
-                    avg_cost, precision, recall, f1_score = [
-                        np.mean(x.numpy()) for x in outputs
-                    ]
-
-                    print(
-                        "[train] step = %d, loss = %f, P: %f, R: %f, F1: %f, elapsed time %f"
-                        % (step, avg_cost, precision, recall, f1_score,
-                           end_time - start_time))
-
-                step += 1
-        # save inference model
-        if to_static:
-            fluid.dygraph.jit.save(
-                layer=model,
-                path=args.model_save_prefix,
-                input_spec=[input_specs[0], input_specs[-1]],
-                output_spec=[crf_decode])
-        else:
-            fluid.dygraph.save_dygraph(model.state_dict(), args.dy_param_path)
-
-        return np.array(loss_data)
-
-
 class TestLACModel(unittest.TestCase):
     def setUp(self):
         self.args = Args()
         self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.model_save_dir = os.path.join(self.temp_dir.name, 'inference')
+        self.model_save_prefix = os.path.join(self.model_save_dir, 'lac')
+        self.model_filename = "lac" + INFER_MODEL_SUFFIX
+        self.params_filename = "lac" + INFER_PARAMS_SUFFIX
+        self.dy_param_path = os.path.join(self.temp_dir.name, 'lac_dy_param')
 
-    def train(self, to_static):
-        out = do_train(self.args, to_static)
-        return out
+    def train(self, args, to_static):
+        program_translator.enable(to_static)
+        place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.dygraph.guard(place):
+            paddle.seed(SEED)
+            paddle.framework.random._manual_program_seed(SEED)
+
+            reader = get_random_input_data(args.batch_size, args.vocab_size,
+                                           args.num_labels)
+            train_loader = create_dataloader(reader, place)
+
+            model = LexNet(args)
+            optimizer = fluid.optimizer.AdamOptimizer(
+                learning_rate=args.base_learning_rate,
+                parameter_list=model.parameters())
+            chunk_eval = ChunkEval(
+                int(math.ceil((args.num_labels - 1) / 2.0)), "IOB")
+
+            step = 0
+            chunk_evaluator = fluid.metrics.ChunkEvaluator()
+            chunk_evaluator.reset()
+
+            loss_data = []
+            for epoch_id in range(args.epoch):
+                for batch in train_loader():
+                    words, targets, length = batch
+                    start_time = time.time()
+                    avg_cost, crf_decode = model(words, targets, length)
+                    loss_data.append(avg_cost.numpy()[0])
+
+                    # backward and optimization
+                    avg_cost.backward()
+                    optimizer.minimize(avg_cost)
+                    model.clear_gradients()
+                    end_time = time.time()
+
+                    if step % args.print_steps == 0:
+                        (precision, recall, f1_score, num_infer_chunks,
+                         num_label_chunks, num_correct_chunks) = chunk_eval(
+                             input=crf_decode, label=targets, seq_length=length)
+                        outputs = [avg_cost, precision, recall, f1_score]
+                        avg_cost, precision, recall, f1_score = [
+                            np.mean(x.numpy()) for x in outputs
+                        ]
+
+                        print(
+                            "[train] step = %d, loss = %f, P: %f, R: %f, F1: %f, elapsed time %f"
+                            % (step, avg_cost, precision, recall, f1_score,
+                               end_time - start_time))
+
+                    step += 1
+            # save inference model
+            if to_static:
+                fluid.dygraph.jit.save(
+                    layer=model,
+                    path=self.model_save_prefix,
+                    input_spec=[input_specs[0], input_specs[-1]],
+                    output_spec=[crf_decode])
+            else:
+                fluid.dygraph.save_dygraph(model.state_dict(),
+                                           self.dy_param_path)
+
+            return np.array(loss_data)
 
     def test_train(self):
-        st_out = self.train(to_static=True)
-        dy_out = self.train(to_static=False)
+        st_out = self.train(self.args, to_static=True)
+        dy_out = self.train(self.args, to_static=False)
         self.assertTrue(
             np.allclose(dy_out, st_out),
             msg="dygraph output:\n{},\nstatic output:\n {}.".format(dy_out,
@@ -565,8 +563,7 @@ class TestLACModel(unittest.TestCase):
         with fluid.dygraph.guard(self.place):
             model = LexNet(self.args)
             # load dygraph trained parameters
-            model_dict, _ = fluid.load_dygraph(self.args.dy_param_path +
-                                               ".pdparams")
+            model_dict, _ = fluid.load_dygraph(self.dy_param_path + ".pdparams")
             model.set_dict(model_dict)
             model.eval()
 
@@ -585,10 +582,10 @@ class TestLACModel(unittest.TestCase):
         # load inference model
         [inference_program, feed_target_names,
          fetch_targets] = fluid.io.load_inference_model(
-             self.args.model_save_dir,
+             self.model_save_dir,
              executor=exe,
-             model_filename=self.args.model_filename,
-             params_filename=self.args.params_filename)
+             model_filename=self.model_filename,
+             params_filename=self.params_filename)
 
         words, targets, length = batch
         pred_res = exe.run(
@@ -601,7 +598,7 @@ class TestLACModel(unittest.TestCase):
     def predict_dygraph_jit(self, batch):
         words, targets, length = batch
         with fluid.dygraph.guard(self.place):
-            model = fluid.dygraph.jit.load(self.args.model_save_prefix)
+            model = fluid.dygraph.jit.load(self.model_save_prefix)
             model.eval()
 
             pred_res = model(to_variable(words), to_variable(length))

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_layer_hook.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_layer_hook.py
@@ -14,8 +14,9 @@
 
 import unittest
 import paddle
-
+import os
 import numpy as np
+import tempfile
 
 
 def forward_post_hook1(layer, input, output):
@@ -54,7 +55,11 @@ class TestNestLayerHook(unittest.TestCase):
     def setUp(self):
         paddle.seed(2022)
         self.x = paddle.randn([4, 10])
-        self.path = "./net_hook"
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.temp_dir.name, 'net_hook')
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
 
     def train_net(self, to_static=False):
         paddle.seed(2022)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist.py
@@ -15,6 +15,8 @@
 from __future__ import print_function
 
 import unittest
+import os
+import tempfile
 from time import time
 
 import numpy as np
@@ -134,6 +136,10 @@ class TestMNIST(unittest.TestCase):
             paddle.dataset.mnist.train(),
             batch_size=self.batch_size,
             drop_last=True)
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
 
 
 class TestMNISTWithToStatic(TestMNIST):
@@ -227,9 +233,10 @@ class TestMNISTWithToStatic(TestMNIST):
 
     def check_jit_save_load(self, model, inputs, input_spec, to_static, gt_out):
         if to_static:
-            infer_model_path = "./test_mnist_inference_model_by_jit_save"
-            model_save_dir = "./inference"
-            model_save_prefix = "./inference/mnist"
+            infer_model_path = os.path.join(
+                self.temp_dir.name, 'test_mnist_inference_model_by_jit_save')
+            model_save_dir = os.path.join(self.temp_dir.name, 'inference')
+            model_save_prefix = os.path.join(model_save_dir, 'mnist')
             model_filename = "mnist" + INFER_MODEL_SUFFIX
             params_filename = "mnist" + INFER_PARAMS_SUFFIX
             fluid.dygraph.jit.save(

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
 import time
 import numpy as np
 import paddle
@@ -439,11 +441,11 @@ class Args(object):
     train_step = 10
     place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
     ) else fluid.CPUPlace()
-    model_save_dir = "./inference"
-    model_save_prefix = "./inference/" + model
-    model_filename = model + INFER_MODEL_SUFFIX
-    params_filename = model + INFER_PARAMS_SUFFIX
-    dy_state_dict_save_path = model + ".dygraph"
+    model_save_dir = None
+    model_save_prefix = None
+    model_filename = None
+    params_filename = None
+    dy_state_dict_save_path = None
 
 
 def train_mobilenet(args, to_static):
@@ -571,13 +573,21 @@ def predict_analysis_inference(args, data):
 class TestMobileNet(unittest.TestCase):
     def setUp(self):
         self.args = Args()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.args.model_save_dir = os.path.join(self.temp_dir.name,
+                                                "./inference")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
 
     def train(self, model_name, to_static):
         self.args.model = model_name
-        self.args.model_save_prefix = "./inference/" + model_name
+        self.args.model_save_prefix = os.path.join(self.temp_dir.name,
+                                                   "./inference/" + model_name)
         self.args.model_filename = model_name + INFER_MODEL_SUFFIX
         self.args.params_filename = model_name + INFER_PARAMS_SUFFIX
-        self.args.dy_state_dict_save_path = model_name + ".dygraph"
+        self.args.dy_state_dict_save_path = os.path.join(
+            self.temp_dir.name, model_name + ".dygraph")
         out = train_mobilenet(self.args, to_static)
         return out
 
@@ -590,10 +600,12 @@ class TestMobileNet(unittest.TestCase):
 
     def assert_same_predict(self, model_name):
         self.args.model = model_name
-        self.args.model_save_prefix = "./inference/" + model_name
+        self.args.model_save_prefix = os.path.join(self.temp_dir.name,
+                                                   "./inference/" + model_name)
         self.args.model_filename = model_name + INFER_MODEL_SUFFIX
         self.args.params_filename = model_name + INFER_PARAMS_SUFFIX
-        self.args.dy_state_dict_save_path = model_name + ".dygraph"
+        self.args.dy_state_dict_save_path = os.path.join(
+            self.temp_dir.name, model_name + ".dygraph")
         local_random = np.random.RandomState(SEED)
         image = local_random.random_sample([1, 3, 224, 224]).astype('float32')
         dy_pre = predict_dygraph(self.args, image)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_v2.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet_v2.py
@@ -19,6 +19,7 @@ os.environ["FLAGS_enable_eager_mode"] = "0"
 import math
 import time
 import unittest
+import tempfile
 
 import numpy as np
 
@@ -37,11 +38,6 @@ epoch_num = 1
 place = paddle.CUDAPlace(0) if paddle.is_compiled_with_cuda() \
     else paddle.CPUPlace()
 
-MODEL_SAVE_DIR = "./inference"
-MODEL_SAVE_PREFIX = "./inference/resnet_v2"
-MODEL_FILENAME = "resnet_v2" + paddle.fluid.dygraph.io.INFER_MODEL_SUFFIX
-PARAMS_FILENAME = "resnet_v2" + paddle.fluid.dygraph.io.INFER_PARAMS_SUFFIX
-DY_STATE_DICT_SAVE_PATH = "./resnet_v2.dygraph"
 program_translator = paddle.jit.ProgramTranslator()
 
 if paddle.is_compiled_with_cuda():
@@ -210,133 +206,145 @@ def reader_decorator(reader):
     return __reader__
 
 
-def train(to_static):
-    """
-    Tests model decorated by `dygraph_to_static_output` in static mode. For users, the model is defined in dygraph mode and trained in static mode.
-    """
-    paddle.disable_static(place)
-    np.random.seed(SEED)
-    paddle.seed(SEED)
-    paddle.framework.random._manual_program_seed(SEED)
-
-    train_reader = paddle.batch(
-        reader_decorator(paddle.dataset.flowers.train(use_xmap=False)),
-        batch_size=batch_size,
-        drop_last=True)
-    data_loader = paddle.io.DataLoader.from_generator(capacity=5, iterable=True)
-    data_loader.set_sample_list_generator(train_reader)
-
-    resnet = ResNet()
-    optimizer = optimizer_setting(parameter_list=resnet.parameters())
-
-    for epoch in range(epoch_num):
-        total_loss = 0.0
-        total_acc1 = 0.0
-        total_acc5 = 0.0
-        total_sample = 0
-
-        for batch_id, data in enumerate(data_loader()):
-            start_time = time.time()
-            img, label = data
-
-            pred = resnet(img)
-            loss = paddle.nn.functional.cross_entropy(input=pred, label=label)
-            avg_loss = paddle.mean(x=loss)
-            acc_top1 = paddle.metric.accuracy(input=pred, label=label, k=1)
-            acc_top5 = paddle.metric.accuracy(input=pred, label=label, k=5)
-
-            avg_loss.backward()
-            optimizer.minimize(avg_loss)
-            resnet.clear_gradients()
-
-            total_loss += avg_loss
-            total_acc1 += acc_top1
-            total_acc5 += acc_top5
-            total_sample += 1
-
-            end_time = time.time()
-            if batch_id % 2 == 0:
-                print( "epoch %d | batch step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, time %f" % \
-                    ( epoch, batch_id, total_loss.numpy() / total_sample, \
-                        total_acc1.numpy() / total_sample, total_acc5.numpy() / total_sample, end_time-start_time))
-            if batch_id == 10:
-                if to_static:
-                    paddle.jit.save(resnet, MODEL_SAVE_PREFIX)
-                else:
-                    paddle.fluid.dygraph.save_dygraph(resnet.state_dict(),
-                                                      DY_STATE_DICT_SAVE_PATH)
-                    # avoid dataloader throw abort signaal
-                data_loader._reset()
-                break
-    paddle.enable_static()
-
-    return total_loss.numpy()
-
-
-def predict_dygraph(data):
-    program_translator.enable(False)
-    paddle.disable_static(place)
-    resnet = ResNet()
-
-    model_dict, _ = paddle.fluid.dygraph.load_dygraph(DY_STATE_DICT_SAVE_PATH)
-    resnet.set_dict(model_dict)
-    resnet.eval()
-
-    pred_res = resnet(
-        paddle.to_tensor(
-            data=data, dtype=None, place=None, stop_gradient=True))
-
-    ret = pred_res.numpy()
-    paddle.enable_static()
-    return ret
-
-
-def predict_static(data):
-    exe = paddle.static.Executor(place)
-    [inference_program, feed_target_names,
-     fetch_targets] = paddle.static.load_inference_model(
-         MODEL_SAVE_DIR,
-         executor=exe,
-         model_filename=MODEL_FILENAME,
-         params_filename=PARAMS_FILENAME)
-
-    pred_res = exe.run(inference_program,
-                       feed={feed_target_names[0]: data},
-                       fetch_list=fetch_targets)
-
-    return pred_res[0]
-
-
-def predict_dygraph_jit(data):
-    paddle.disable_static(place)
-    resnet = paddle.jit.load(MODEL_SAVE_PREFIX)
-    resnet.eval()
-
-    pred_res = resnet(data)
-
-    ret = pred_res.numpy()
-    paddle.enable_static()
-    return ret
-
-
-def predict_analysis_inference(data):
-    output = PredictorTools(MODEL_SAVE_DIR, MODEL_FILENAME, PARAMS_FILENAME,
-                            [data])
-    out = output()
-    return out
-
-
 class TestResnet(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+        self.model_save_dir = os.path.join(self.temp_dir.name, "./inference")
+        self.model_save_prefix = os.path.join(self.temp_dir.name,
+                                              "./inference/resnet_v2")
+        self.model_filename = "resnet_v2" + paddle.fluid.dygraph.io.INFER_MODEL_SUFFIX
+        self.params_filename = "resnet_v2" + paddle.fluid.dygraph.io.INFER_PARAMS_SUFFIX
+        self.dy_state_dict_save_path = os.path.join(self.temp_dir.name,
+                                                    "./resnet_v2.dygraph")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def do_train(self, to_static):
+        """
+        Tests model decorated by `dygraph_to_static_output` in static mode. For users, the model is defined in dygraph mode and trained in static mode.
+        """
+        paddle.disable_static(place)
+        np.random.seed(SEED)
+        paddle.seed(SEED)
+        paddle.framework.random._manual_program_seed(SEED)
+
+        train_reader = paddle.batch(
+            reader_decorator(paddle.dataset.flowers.train(use_xmap=False)),
+            batch_size=batch_size,
+            drop_last=True)
+        data_loader = paddle.io.DataLoader.from_generator(
+            capacity=5, iterable=True)
+        data_loader.set_sample_list_generator(train_reader)
+
+        resnet = ResNet()
+        optimizer = optimizer_setting(parameter_list=resnet.parameters())
+
+        for epoch in range(epoch_num):
+            total_loss = 0.0
+            total_acc1 = 0.0
+            total_acc5 = 0.0
+            total_sample = 0
+
+            for batch_id, data in enumerate(data_loader()):
+                start_time = time.time()
+                img, label = data
+
+                pred = resnet(img)
+                loss = paddle.nn.functional.cross_entropy(
+                    input=pred, label=label)
+                avg_loss = paddle.mean(x=loss)
+                acc_top1 = paddle.metric.accuracy(input=pred, label=label, k=1)
+                acc_top5 = paddle.metric.accuracy(input=pred, label=label, k=5)
+
+                avg_loss.backward()
+                optimizer.minimize(avg_loss)
+                resnet.clear_gradients()
+
+                total_loss += avg_loss
+                total_acc1 += acc_top1
+                total_acc5 += acc_top5
+                total_sample += 1
+
+                end_time = time.time()
+                if batch_id % 2 == 0:
+                    print( "epoch %d | batch step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, time %f" % \
+                        ( epoch, batch_id, total_loss.numpy() / total_sample, \
+                            total_acc1.numpy() / total_sample, total_acc5.numpy() / total_sample, end_time-start_time))
+                if batch_id == 10:
+                    if to_static:
+                        paddle.jit.save(resnet, self.model_save_prefix)
+                    else:
+                        paddle.fluid.dygraph.save_dygraph(
+                            resnet.state_dict(), self.dy_state_dict_save_path)
+                        # avoid dataloader throw abort signaal
+                    data_loader._reset()
+                    break
+        paddle.enable_static()
+
+        return total_loss.numpy()
+
+    def predict_dygraph(self, data):
+        program_translator.enable(False)
+        paddle.disable_static(place)
+        resnet = ResNet()
+
+        model_dict, _ = paddle.fluid.dygraph.load_dygraph(
+            self.dy_state_dict_save_path)
+        resnet.set_dict(model_dict)
+        resnet.eval()
+
+        pred_res = resnet(
+            paddle.to_tensor(
+                data=data, dtype=None, place=None, stop_gradient=True))
+
+        ret = pred_res.numpy()
+        paddle.enable_static()
+        return ret
+
+    def predict_static(self, data):
+        exe = paddle.static.Executor(place)
+        [inference_program, feed_target_names,
+         fetch_targets] = paddle.static.load_inference_model(
+             self.model_save_dir,
+             executor=exe,
+             model_filename=self.model_filename,
+             params_filename=self.params_filename)
+
+        pred_res = exe.run(inference_program,
+                           feed={feed_target_names[0]: data},
+                           fetch_list=fetch_targets)
+
+        return pred_res[0]
+
+    def predict_dygraph_jit(self, data):
+        paddle.disable_static(place)
+        resnet = paddle.jit.load(self.model_save_prefix)
+        resnet.eval()
+
+        pred_res = resnet(data)
+
+        ret = pred_res.numpy()
+        paddle.enable_static()
+        return ret
+
+    def predict_analysis_inference(self, data):
+        output = PredictorTools(self.model_save_dir, self.model_filename,
+                                self.params_filename, [data])
+        out = output()
+        return out
+
     def train(self, to_static):
         program_translator.enable(to_static)
-        return train(to_static)
+        return self.do_train(to_static)
 
     def verify_predict(self):
         image = np.random.random([1, 3, 224, 224]).astype('float32')
-        dy_pre = predict_dygraph(image)
-        st_pre = predict_static(image)
-        dy_jit_pre = predict_dygraph_jit(image)
-        predictor_pre = predict_analysis_inference(image)
+        dy_pre = self.predict_dygraph(image)
+        st_pre = self.predict_static(image)
+        dy_jit_pre = self.predict_dygraph_jit(image)
+        predictor_pre = self.predict_analysis_inference(image)
         self.assertTrue(
             np.allclose(dy_pre, st_pre),
             msg="dy_pre:\n {}\n, st_pre: \n{}.".format(dy_pre, st_pre))
@@ -361,7 +369,7 @@ class TestResnet(unittest.TestCase):
         paddle.fluid.set_flags({'FLAGS_use_mkldnn': True})
         try:
             if paddle.fluid.core.is_compiled_with_mkldnn():
-                train(to_static=True)
+                self.train(to_static=True)
         finally:
             paddle.fluid.set_flags({'FLAGS_use_mkldnn': False})
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_inference_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_inference_model.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import os
+import tempfile
 import unittest
 import numpy as np
 
@@ -48,6 +49,12 @@ class SimpleFcLayer(fluid.dygraph.Layer):
 
 
 class TestDyToStaticSaveInferenceModel(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
     def test_save_inference_model(self):
         fc_size = 20
         x_data = np.random.random((fc_size, fc_size)).astype('float32')
@@ -66,8 +73,10 @@ class TestDyToStaticSaveInferenceModel(unittest.TestCase):
                 adam.minimize(loss)
                 layer.clear_gradients()
             # test for saving model in dygraph.guard
-            infer_model_prefix = "./test_dy2stat_inference_in_guard/model"
-            infer_model_dir = "./test_dy2stat_inference_in_guard"
+            infer_model_prefix = os.path.join(
+                self.temp_dir.name, "test_dy2stat_inference_in_guard/model")
+            infer_model_dir = os.path.join(self.temp_dir.name,
+                                           "test_dy2stat_inference_in_guard")
             fluid.dygraph.jit.save(
                 layer=layer,
                 path=infer_model_prefix,
@@ -90,8 +99,10 @@ class TestDyToStaticSaveInferenceModel(unittest.TestCase):
 
         expected_persistable_vars = set([p.name for p in model.parameters()])
 
-        infer_model_prefix = "./test_dy2stat_inference/model"
-        infer_model_dir = "./test_dy2stat_inference"
+        infer_model_prefix = os.path.join(self.temp_dir.name,
+                                          "test_dy2stat_inference/model")
+        infer_model_dir = os.path.join(self.temp_dir.name,
+                                       "test_dy2stat_inference")
         model_filename = "model" + INFER_MODEL_SUFFIX
         params_filename = "model" + INFER_PARAMS_SUFFIX
         fluid.dygraph.jit.save(

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 from __future__ import print_function
-
+import os
+import tempfile
 import unittest
 import numpy as np
 
@@ -166,15 +167,20 @@ class TestSetValue(TestSliceWithoutControlFlow):
 
 
 class TestSetValueWithLayerAndSave(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.model_path = os.path.join(self.temp_dir.name,
+                                       "layer_use_set_value")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
     def test_set_value_with_save(self):
         prog_trans.enable(True)
         model = LayerWithSetValue(input_dim=10, hidden=1)
         x = paddle.full(shape=[5, 10], fill_value=5.0, dtype="float32")
         paddle.jit.save(
-            layer=model,
-            path="./layer_use_set_value",
-            input_spec=[x],
-            output_spec=None)
+            layer=model, path=self.model_path, input_spec=[x], output_spec=None)
 
 
 class TestSliceSupplementSpecialCase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_typing.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_typing.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import os
+import tempfile
 import paddle
 import unittest
 import numpy as np
@@ -72,11 +73,16 @@ class TestTyping(unittest.TestCase):
         self.x = paddle.randn([4, 16])
         self.spec = [paddle.static.InputSpec(shape=[None, 16], dtype='float32')]
 
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
     def build_net(self):
         return LinearNetWithTuple(self.in_num, self.out_num)
 
     def save_and_load(self, suffix=''):
-        path = './layer_typing_' + suffix
+        path = os.path.join(self.temp_dir.name, 'layer_typing_' + suffix)
         paddle.jit.save(self.net, path, input_spec=self.spec)
         return paddle.jit.load(path)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

动转静单测中包含一些模型导出的逻辑，为了更好的管理导出文件，此处用`tempfile`来管理此类文件，保证单测执行完之后所有的临时文件都会被正常的删除掉，避免占用磁盘文件。

此PR仅涉及单测修改，不涉及新功能。
