### PR TITLE
[Paddle Inference] Add dynamic_shape support for shuffle_channel.

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
@@ -39,25 +39,70 @@ class ShuffleChannelOpConverter : public OpConverter {
     // Declare inputs
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
     auto input_dims = input->getDimensions();
-
-    int c = input_dims.d[0];
-    int h = input_dims.d[1];
-    int w = input_dims.d[2];
+    auto output_name = op_desc.Output("Out")[0];
     int group = BOOST_GET_CONST(int, op_desc.GetAttr("group"));
 
-    auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-    nvinfer1::Dims4 reshape_dim(group, c / group, h, w);
-    layer->setReshapeDimensions(reshape_dim);
-    layer->setSecondTranspose({1, 0, 2, 3});
-    auto* output = layer->getOutput(0);
+    if (engine_->with_dynamic_shape()) {
+      auto* input_shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
+      auto* input_shape_tensor = input_shape_layer->getOutput(0);
+      auto* channel_index_tensor = Add1DConstantLayer(
+            1, output_name + "_channel_index_tensor_");
+      auto* channel_shape_tensor =
+            TRT_ENGINE_ADD_LAYER(engine_, Gather, *input_shape_tensor,
+                                  *channel_index_tensor, 0)
+                  ->getOutput(0);
+      auto* group_tensor = Add1DConstantLayer(
+            group, output_name + "_group_tensor_");
+      
+      auto* new_channel_shape_tensor = TRT_ENGINE_ADD_LAYER(
+            engine_, ElementWise, *channel_shape_tensor,
+            *group_tensor, nvinfer1::ElementWiseOperation::kDIV)->getOutput(0);
+      
+      std::vector<int32_t> shape_dim3 {0, 2, 3};
+      auto* shape_dim3_index_tensor = Add1DConstantLayer(
+            shape_dim3, output_name + "_shape_dim3_tensor_");
+      auto* shape_dim3_tensor =
+              TRT_ENGINE_ADD_LAYER(engine_, Gather, *input_shape_tensor,
+                                   *shape_dim3_index_tensor, 0)->getOutput(0);
 
-    auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
-    nvinfer1::Dims3 reshape_dim2(c, h, w);
-    reshape_layer->setReshapeDimensions(reshape_dim2);
+      std::vector<nvinfer1::ITensor*> itensors;
+      itensors.push_back(shape_dim3_tensor);
+      itensors.push_back(group_tensor);
+      itensors.push_back(new_channel_shape_tensor);
+      auto* reshape_tensor = TRT_ENGINE_ADD_LAYER(engine_, Concatenation, itensors.data(), itensors.size())->getOutput(0);
 
-    auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(reshape_layer, "shuffle_channel", {output_name},
+      auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *reshape_tensor);
+      nvinfer1::Permutation transpose_new_input{0, 3, 4, 1, 2};
+      reshape_layer->setSecondTranspose(transpose_new_input);
+
+      auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+      layer->setInput(1, *(reshape_layer->getOutput(0)));
+      nvinfer1::Permutation transpose_embed{0, 2, 1, 3, 4};
+      layer->setSecondTranspose(transpose_embed);
+      auto* output = layer->getOutput(0);
+      auto* output_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
+      output_layer->setInput(1, *input_shape_tensor);
+
+      RreplenishLayerAndOutput(output_layer, "shuffle_channel", {output_name},
                              test_mode);
+    } else {
+      int c = input_dims.d[0];
+      int h = input_dims.d[1];
+      int w = input_dims.d[2];
+
+      auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+      nvinfer1::Dims4 reshape_dim(group, c / group, h, w);
+      layer->setReshapeDimensions(reshape_dim);
+      layer->setSecondTranspose({1, 0, 2, 3});
+      auto* output = layer->getOutput(0);
+
+      auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
+      nvinfer1::Dims3 reshape_dim2(c, h, w);
+      reshape_layer->setReshapeDimensions(reshape_dim2);
+
+      RreplenishLayerAndOutput(reshape_layer, "shuffle_channel", {output_name},
+                              test_mode);
+    }
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -672,7 +672,7 @@ class TensorRTEngine {
 // them, and an macro like this is more extensible when underlying TensorRT
 // library add new layer supports.
 #define TRT_ENGINE_ADD_LAYER(engine__, layer__, ...) \
-  engine__->network()->add##layer__(__VA_ARGS__);
+  engine__->network()->add##layer__(__VA_ARGS__)
 
 class TRTEngineManager {
  public:

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1405,14 +1405,6 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
       }
     }
 
-    if (op_type == "shuffle_channel") {
-      if (with_dynamic_shape) {
-        VLOG(3) << "You are running the TRT Dynamic Shape mode, "
-                   "the shuffle_channel op does not support dynamic shape yet";
-        return false;
-      }
-    }
-
     if (op_type == "skip_layernorm") {
       if (!with_dynamic_shape) {
         VLOG(3) << "the skip_layernorm does not support static shape yet";

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -73,10 +73,7 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if dynamic_shape == True:
-                return 0, 3
-            else:
-                return 1, 2
+            return 1, 2
 
         attrs = [
             program_config.ops[i].attrs


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Add dynamic_shape support for shuffle_channel.