### PR TITLE
use fp32 compute type for cublasGemmStridedBatchedEx with fp16 input/output

### DIFF
--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -92,16 +92,16 @@ PADDLE_DEFINE_EXPORTED_bool(
  * CUDA related related FLAG
  * Name: FLAGS_gemm_use_half_precision_compute_type
  * Since Version: 2.4
- * Value Range: bool, default=false
+ * Value Range: bool, default=true
  * Example:
  * Note: whether to use fp16 compute type when the input and output is fp16,
  * faster but it may loss precision.
  */
 PADDLE_DEFINE_EXPORTED_bool(
-    gemm_use_half_precision_compute_type, false,
+    gemm_use_half_precision_compute_type, true,
     "Whether to use fp16 compute type when the input and output is fp16, "
-    "faster but it may loss precision in most case. If false, the compute "
-    "type will be set to fp32. Default is false.");
+    "faster but it may loss precision in most case. If true, the compute "
+    "type will be set to fp32. Default is true.");
 
 /**
  * CUDA related FLAG

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -89,6 +89,21 @@ PADDLE_DEFINE_EXPORTED_bool(
     "(RNNs).");
 
 /**
+ * CUDA related related FLAG
+ * Name: FLAGS_gemm_use_half_precision_compute_type
+ * Since Version: 2.4
+ * Value Range: bool, default=true
+ * Example:
+ * Note: whether to use fp16 compute type when the input and output is fp16,
+ * faster but it may loss precision.
+ */
+PADDLE_DEFINE_EXPORTED_bool(
+    gemm_use_half_precision_compute_type, true,
+    "Whether to use fp16 compute type when the input and output is fp16, "
+    "faster but it may loss precision. If false, the compute type will be "
+    "set to fp32. Default is True.");
+
+/**
  * CUDA related FLAG
  * Name: FLAGS_selected_gpus
  * Since Version: 1.3.0

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -92,16 +92,16 @@ PADDLE_DEFINE_EXPORTED_bool(
  * CUDA related related FLAG
  * Name: FLAGS_gemm_use_half_precision_compute_type
  * Since Version: 2.4
- * Value Range: bool, default=true
+ * Value Range: bool, default=false
  * Example:
  * Note: whether to use fp16 compute type when the input and output is fp16,
  * faster but it may loss precision.
  */
 PADDLE_DEFINE_EXPORTED_bool(
-    gemm_use_half_precision_compute_type, true,
+    gemm_use_half_precision_compute_type, false,
     "Whether to use fp16 compute type when the input and output is fp16, "
-    "faster but it may loss precision. If false, the compute type will be "
-    "set to fp32. Default is True.");
+    "faster but it may loss precision in most case. If false, the compute "
+    "type will be set to fp32. Default is false.");
 
 /**
  * CUDA related FLAG

--- a/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blas_impl.cu.h
@@ -2262,20 +2262,16 @@ void Blas<paddle::platform::CUDADeviceContext>::BatchedGEMM(
     auto fp = std::is_same<T, float>::value ? CUDA_R_32F : CUDA_R_16F;
     cudaDataType_t compute_type = fp;
 
-    void *a = nullptr;
-    void *b = nullptr;
-
+    float h_alpha = static_cast<float>(alpha);
+    float h_beta = static_cast<float>(beta);
+    void *a = static_cast<void *>(&h_alpha);
+    void *b = static_cast<void *>(&h_beta);
     // set ComputeType as CUDA_R_32F for fp16, for better accuracy
-    if (FLAGS_gemm_use_half_precision_compute_type == false &&
+    if (FLAGS_gemm_use_half_precision_compute_type == true &&
         std::is_same<T, phi::dtype::float16>::value) {
-      float h_alpha = static_cast<float>(alpha);
-      float h_beta = static_cast<float>(beta);
-      a = static_cast<void *>(&h_alpha);
-      b = static_cast<void *>(&h_beta);
-      compute_type = CUDA_R_32F;
-    } else {
       a = static_cast<void *>(&alpha);
       b = static_cast<void *>(&beta);
+      compute_type = CUDA_R_16F;
     }
 
     // set ComputeType as CUDA_R_32F for fp16 and fp32, for better accuracy
@@ -2374,22 +2370,18 @@ void Blas<phi::GPUContext>::BatchedGEMM(CBLAS_TRANSPOSE transA,
             << FLAGS_gemm_use_half_precision_compute_type;
 
     auto fp = std::is_same<T, float>::value ? CUDA_R_32F : CUDA_R_16F;
-    cudaDataType_t compute_type = fp;
+    cudaDataType_t compute_type = CUDA_R_32F;
 
-    void *a = nullptr;
-    void *b = nullptr;
-
+    float h_alpha = static_cast<float>(alpha);
+    float h_beta = static_cast<float>(beta);
+    void *a = static_cast<void *>(&h_alpha);
+    void *b = static_cast<void *>(&h_beta);
     // set ComputeType as CUDA_R_32F for fp16, for better accuracy
-    if (FLAGS_gemm_use_half_precision_compute_type == false &&
+    if (FLAGS_gemm_use_half_precision_compute_type == true &&
         std::is_same<T, phi::dtype::float16>::value) {
-      float h_alpha = static_cast<float>(alpha);
-      float h_beta = static_cast<float>(beta);
-      a = static_cast<void *>(&h_alpha);
-      b = static_cast<void *>(&h_beta);
-      compute_type = CUDA_R_32F;
-    } else {
       a = static_cast<void *>(&alpha);
       b = static_cast<void *>(&beta);
+      compute_type = CUDA_R_16F;
     }
 
     context_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {

--- a/python/paddle/fluid/tests/unittests/test_matmul_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_v2_op.py
@@ -495,6 +495,26 @@ class TestMatMulV2API(unittest.TestCase):
                     y = paddle.to_tensor(input_y)
                     result = paddle.matmul(x, y)
 
+    def test_compute_type_fp32(self):
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+            if core.is_float16_supported(place):
+                with fluid.dygraph.guard(place):
+                    input_x = np.random.random([2, 8, 16]).astype("float16")
+                    input_y = np.random.random([2, 16, 8]).astype("float16")
+                    for i in range(0, 16, 2):
+                        input_x[:, :, i] += 60000
+                        input_x[:, :, i + 1] -= 60000
+                    input_y[:, :, :] = 1.5
+
+                    x = paddle.to_tensor(input_x)
+                    y = paddle.to_tensor(input_y)
+                    result = paddle.matmul(x, y)
+                    result_np = np.matmul(input_x, input_y)
+                    self.assertTrue(paddle.isfinite(result)[0, 0, 0])
+                    self.assertTrue(np.isfinite(result_np)[0, 0, 0])
+                    self.assertTrue(np.array_equal(result_np, result.numpy()))
+
     def test_api_eager_dygraph(self):
         with _test_eager_guard():
             self.test_dygraph()

--- a/python/paddle/fluid/tests/unittests/test_matmul_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_v2_op.py
@@ -500,6 +500,9 @@ class TestMatMulV2API(unittest.TestCase):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
                 with fluid.dygraph.guard(place):
+                    paddle.set_flags({
+                        'FLAGS_gemm_use_half_precision_compute_type': False
+                    })
                     input_x = np.random.random([2, 8, 16]).astype("float16")
                     input_y = np.random.random([2, 16, 8]).astype("float16")
                     for i in range(0, 16, 2):
@@ -514,6 +517,35 @@ class TestMatMulV2API(unittest.TestCase):
                     self.assertTrue(paddle.isfinite(result)[0, 0, 0])
                     self.assertTrue(np.isfinite(result_np)[0, 0, 0])
                     self.assertTrue(np.array_equal(result_np, result.numpy()))
+                    paddle.set_flags({
+                        'FLAGS_gemm_use_half_precision_compute_type': True
+                    })
+
+    def test_compute_type_fp16_nan(self):
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+            if core.is_float16_supported(place):
+                with fluid.dygraph.guard(place):
+                    paddle.set_flags({
+                        'FLAGS_gemm_use_half_precision_compute_type': True
+                    })
+                    input_x = np.random.random([2, 8, 16]).astype("float16")
+                    input_y = np.random.random([2, 16, 8]).astype("float16")
+                    for i in range(0, 16, 2):
+                        input_x[:, :, i] += 60000
+                        input_x[:, :, i + 1] -= 60000
+                    input_y[:, :, :] = 1.5
+
+                    x = paddle.to_tensor(input_x)
+                    y = paddle.to_tensor(input_y)
+                    result = paddle.matmul(x, y)
+                    result_np = np.matmul(input_x, input_y)
+                    self.assertFalse(
+                        paddle.isfinite(result)[0, 0, 0])  # contains nan/inf
+                    self.assertTrue(np.isfinite(result_np)[0, 0, 0])
+                    paddle.set_flags({
+                        'FLAGS_gemm_use_half_precision_compute_type': False
+                    })
 
     def test_api_eager_dygraph(self):
         with _test_eager_guard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
use fp32 compute type for cublasGemmStridedBatchedEx with fp16 input/output for better accuracy

Add `FLAGS_gemm_use_half_precision_compute_type` to control this feature, default is True and uses fp16 compute type, which is consistent with the old behavior.

TODO: make `FLAGS_gemm_use_half_precision_compute_type`  default to `false`.

Note: 
1. Using fp16 compute type may result in some problems, for example, https://github.com/NVIDIA/FasterTransformer/issues/49. And, also see the case in unittest.
2. Using fp16 compute type may result in `nan/inf` in some `vit(vision transformer)` models.
3. Using fp32 compute type may decrease the training speed in some models. Users can set `FLAGS_gemm_use_half_precision_compute_type` to true if no `nan/inf` willl occur in these models.