### PR TITLE
[NPU] minor changes for version control to support code without suffix

### DIFF
--- a/paddle/fluid/operators/fill_constant_op_npu.cc
+++ b/paddle/fluid/operators/fill_constant_op_npu.cc
@@ -65,7 +65,7 @@ class FillConstantNPUKernel : public framework::OpKernel<T> {
       tensor_value.mutable_data<T>({1}, ctx.GetPlace());
       FillNpuTensorWithConstant<T>(&tensor_value, value);
       NpuOpRunner runner;
-#if (CANN_VERSION_CODE >= 503003 && CANN_VERSION_CODE < 504001)
+#if (CANN_VERSION_CODE >= 503003 && CANN_VERSION_CODE < 504000)
       runner.SetType("FillD")
           .AddInput(tensor_value)
           .AddOutput(*out_var)

--- a/paddle/fluid/operators/set_value_op_npu.cc
+++ b/paddle/fluid/operators/set_value_op_npu.cc
@@ -178,7 +178,7 @@ class SetValueNPUKernel : public framework::OpKernel<T> {
         .AddInput(std::move(index_indices))
         .AddInput(val_temp)
         .AddOutput(out_temp)
-#if (CANN_VERSION_CODE >= 504001)
+#if (CANN_VERSION_CODE >= 504000)
         .AddAttrs({{"use_locking", false}})
 #endif
         .Run(stream);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
OPs

### Describe
For cann version 5.0.4(without any suffix), we can not get suffix like `.alpha001`, so it need be suffixed with 000 and get 504000 for numeric comparison, this PR make minor changes for known ops.

related: https://github.com/PaddlePaddle/Paddle/pull/39635
