### PR TITLE
updated paddle_bfloat to v0.1.7

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,5 +5,5 @@ Pillow
 six
 decorator
 astor
-paddle_bfloat==0.1.2
+paddle_bfloat==0.1.7
 opt_einsum==3.3.0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Updating `paddle_bfloat` package to v0.1.7 is needed because some of v0.1.2's wheels are broken and PyPi doesn't allow replacing existing wheels because of security reasons, so creating a new version was needed to fix that. In v0.1.7 every wheel was compiled with oldest numpy supported by that wheel's python version to remove errors like `RuntimeError: module compiled against API version 0xf but this version of numpy is 0xe` which was caused by compiling wheels with too recent numpy version.
Also some new functionality inside python was added in v0.1.7. Now we can use bfloat16 datatype as a string and numpy will recognize it, so for example we can do:
`array= np.array([1, 2, 3], dtype="bfloat16")`
instead of
`array= np.array([1, 2, 3], dtype=bfloat16)`

Currently paddle_bfloat supports following combinations of python/numpy:
|Python version|Numpy versions|
|-----|-----|
|3.6  | 1.13.0-1.19.5|
|3.7  | 1.14.5-1.21.6|
|3.8  | 1.17.3+|
|3.9  | 1.19.3+|
|3.10| 1.22.0+ |

Currently following combination of wheels are uploaded:
For all pythons in range 3.6-3.10:
- linux: x86_64 and i686 with tag manylinux1
- other linuxes: s390x, ppc64le and aarch64 are supported with tag manylinux2014
- macos: standard wheels
- windows: both 64 and 32 bit versions are supported
Additionally for macos with python versions 3.8, 3.9 and 3.10 arm64 and universal wheels are supported as well.

All tags for version 0.1.7 can are available here: https://pypi.org/project/paddle-bfloat/0.1.7/#files