### PR TITLE
[Paddle Inference] Add dynamic_shape support for shuffle_channel.

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/op_converter.h
+++ b/paddle/fluid/inference/tensorrt/convert/op_converter.h
@@ -292,6 +292,43 @@ class OpConverter {
     engine->ClearWeights();
   }
 
+  // Create and add 1D constant layer
+  nvinfer1::ITensor* Add1DConstantLayer(const std::vector<int>& data,
+                                        const std::string& weight_name) {
+    std::unique_ptr<framework::Tensor> tmp_tensor(new framework::Tensor());
+    int data_size = data.size();
+    tmp_tensor->Resize({data_size});
+    auto* tmp_data = tmp_tensor->mutable_data<int>(platform::CPUPlace());
+    for (int i = 0; i < data_size; i++) {
+      tmp_data[i] = data[i];
+    }
+    engine_->SetWeights(weight_name, std::move(tmp_tensor));
+
+    TensorRTEngine::Weight weight{nvinfer1::DataType::kINT32,
+                                  static_cast<void*>(tmp_data),
+                                  static_cast<size_t>(data_size)};
+    nvinfer1::Dims input_shape;
+    input_shape.nbDims = 1;
+    input_shape.d[0] = data_size;
+    auto const_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Constant, input_shape, weight.get());
+    return const_layer->getOutput(0);
+  }
+
+  nvinfer1::ITensor* Add1DConstantLayer(nvinfer1::Dims data,
+                                        const std::string& weight_name) {
+    std::vector<int> tmp_data;
+    for (int i = 0; i < data.nbDims; i++) tmp_data.push_back(data.d[i]);
+    return Add1DConstantLayer(tmp_data, weight_name);
+  }
+
+  nvinfer1::ITensor* Add1DConstantLayer(int32_t data,
+                                        const std::string& weight_name) {
+    std::vector<int> tmp_data;
+    tmp_data.push_back(data);
+    return Add1DConstantLayer(tmp_data, weight_name);
+  }
+
   void RreplenishLayerAndOutput(
       nvinfer1::ILayer* layer, const std::string& layer_type,
       const std::vector<std::string>& output_tensor_names,

--- a/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
@@ -42,6 +42,7 @@ class ShuffleChannelOpConverter : public OpConverter {
     auto output_name = op_desc.Output("Out")[0];
     int group = BOOST_GET_CONST(int, op_desc.GetAttr("group"));
 
+#if IS_TRT_VERSION_GE(8000)
     if (engine_->with_dynamic_shape()) {
       auto* input_shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
       auto* input_shape_tensor = input_shape_layer->getOutput(0);
@@ -92,7 +93,9 @@ class ShuffleChannelOpConverter : public OpConverter {
 
       RreplenishLayerAndOutput(output_layer, "shuffle_channel", {output_name},
                                test_mode);
-    } else {
+    }
+#endif
+    if (!engine_->with_dynamic_shape()) {
       int c = input_dims.d[0];
       int h = input_dims.d[1];
       int w = input_dims.d[2];

--- a/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/shuffle_channel_op.cc
@@ -39,25 +39,77 @@ class ShuffleChannelOpConverter : public OpConverter {
     // Declare inputs
     auto* input = engine_->GetITensor(op_desc.Input("X")[0]);
     auto input_dims = input->getDimensions();
-
-    int c = input_dims.d[0];
-    int h = input_dims.d[1];
-    int w = input_dims.d[2];
+    auto output_name = op_desc.Output("Out")[0];
     int group = BOOST_GET_CONST(int, op_desc.GetAttr("group"));
 
-    auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
-    nvinfer1::Dims4 reshape_dim(group, c / group, h, w);
-    layer->setReshapeDimensions(reshape_dim);
-    layer->setSecondTranspose({1, 0, 2, 3});
-    auto* output = layer->getOutput(0);
+    if (engine_->with_dynamic_shape()) {
+      auto* input_shape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shape, *input);
+      auto* input_shape_tensor = input_shape_layer->getOutput(0);
+      auto* channel_index_tensor =
+          Add1DConstantLayer(1, output_name + "_channel_index_tensor_");
+      auto* channel_shape_tensor =
+          TRT_ENGINE_ADD_LAYER(engine_, Gather, *input_shape_tensor,
+                               *channel_index_tensor, 0)
+              ->getOutput(0);
+      auto* group_tensor =
+          Add1DConstantLayer(group, output_name + "_group_tensor_");
 
-    auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
-    nvinfer1::Dims3 reshape_dim2(c, h, w);
-    reshape_layer->setReshapeDimensions(reshape_dim2);
+      auto* new_channel_shape_tensor =
+          TRT_ENGINE_ADD_LAYER(engine_, ElementWise, *channel_shape_tensor,
+                               *group_tensor,
+                               nvinfer1::ElementWiseOperation::kDIV)
+              ->getOutput(0);
 
-    auto output_name = op_desc.Output("Out")[0];
-    RreplenishLayerAndOutput(reshape_layer, "shuffle_channel", {output_name},
-                             test_mode);
+      std::vector<int32_t> shape_dim3{0, 2, 3};
+      auto* shape_dim3_index_tensor =
+          Add1DConstantLayer(shape_dim3, output_name + "_shape_dim3_tensor_");
+      auto* shape_dim3_tensor =
+          TRT_ENGINE_ADD_LAYER(engine_, Gather, *input_shape_tensor,
+                               *shape_dim3_index_tensor, 0)
+              ->getOutput(0);
+
+      std::vector<nvinfer1::ITensor*> itensors;
+      itensors.push_back(shape_dim3_tensor);
+      itensors.push_back(group_tensor);
+      itensors.push_back(new_channel_shape_tensor);
+      auto* reshape_tensor =
+          TRT_ENGINE_ADD_LAYER(engine_, Concatenation, itensors.data(),
+                               itensors.size())
+              ->getOutput(0);
+
+      auto* reshape_layer =
+          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *reshape_tensor);
+      nvinfer1::Permutation transpose_new_input{0, 3, 4, 1, 2};
+      reshape_layer->setSecondTranspose(transpose_new_input);
+
+      auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+      layer->setInput(1, *(reshape_layer->getOutput(0)));
+      nvinfer1::Permutation transpose_embed{0, 2, 1, 3, 4};
+      layer->setSecondTranspose(transpose_embed);
+      auto* output = layer->getOutput(0);
+      auto* output_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
+      output_layer->setInput(1, *input_shape_tensor);
+
+      RreplenishLayerAndOutput(output_layer, "shuffle_channel", {output_name},
+                               test_mode);
+    } else {
+      int c = input_dims.d[0];
+      int h = input_dims.d[1];
+      int w = input_dims.d[2];
+
+      auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input);
+      nvinfer1::Dims4 reshape_dim(group, c / group, h, w);
+      layer->setReshapeDimensions(reshape_dim);
+      layer->setSecondTranspose({1, 0, 2, 3});
+      auto* output = layer->getOutput(0);
+
+      auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *output);
+      nvinfer1::Dims3 reshape_dim2(c, h, w);
+      reshape_layer->setReshapeDimensions(reshape_dim2);
+
+      RreplenishLayerAndOutput(reshape_layer, "shuffle_channel", {output_name},
+                               test_mode);
+    }
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -672,7 +672,7 @@ class TensorRTEngine {
 // them, and an macro like this is more extensible when underlying TensorRT
 // library add new layer supports.
 #define TRT_ENGINE_ADD_LAYER(engine__, layer__, ...) \
-  engine__->network()->add##layer__(__VA_ARGS__);
+  engine__->network()->add##layer__(__VA_ARGS__)
 
 class TRTEngineManager {
  public:

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1388,6 +1388,16 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
       }
     }
 
+    if (op_type == "shuffle_channel") {
+#if !IS_TRT_VERSION_GE(8000)
+      if (with_dynamic_shape) {
+        VLOG(3) << "You are running the TRT Dynamic Shape mode, "
+                   "the shuffle_channel op does not support dynamic shape yet";
+        return false;
+      }
+#endif
+    }
+
     if (op_type == "skip_layernorm") {
       if (!with_dynamic_shape) {
         VLOG(3) << "the skip_layernorm does not support static shape yet";

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1388,14 +1388,6 @@ bool OpTeller::Tell(const framework::ir::Node* node, bool use_no_calib_int8,
       }
     }
 
-    if (op_type == "shuffle_channel") {
-      if (with_dynamic_shape) {
-        VLOG(3) << "You are running the TRT Dynamic Shape mode, "
-                   "the shuffle_channel op does not support dynamic shape yet";
-        return false;
-      }
-    }
-
     if (op_type == "skip_layernorm") {
       if (!with_dynamic_shape) {
         VLOG(3) << "the skip_layernorm does not support static shape yet";

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -73,7 +73,12 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            return 1, 2
+            ver = paddle_infer.get_trt_compile_version()
+            if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 8000:
+                if dynamic_shape == True:
+                    return 0, 3
+            else:
+                return 1, 2
 
         attrs = [
             program_config.ops[i].attrs

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -74,9 +74,9 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
             ver = paddle_infer.get_trt_compile_version()
-            if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 8000:
-                if dynamic_shape == True:
-                    return 0, 3
+            if ver[0] * 1000 + ver[1] * 100 + ver[
+                    2] * 10 < 8000 and dynamic_shape == True:
+                return 0, 3
             else:
                 return 1, 2
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -85,7 +85,6 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             for i in range(len(program_config.ops))
         ]
         self.trt_param.max_batch_size = 9
-
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -73,10 +73,7 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if dynamic_shape == True:
-                return 0, 3
-            else:
-                return 1, 2
+            return 1, 2
 
         attrs = [
             program_config.ops[i].attrs

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -85,6 +85,7 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             for i in range(len(program_config.ops))
         ]
         self.trt_param.max_batch_size = 9
+
         # for static_shape
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Add dynamic_shape support for shuffle_channel.