### PR TITLE
Support heterogeneous tensor kernel in yaml

### DIFF
--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -904,10 +904,8 @@ def monkey_patch_varbase():
                     #[1, 2, 3, 4, 5]
         """
 
-        if self.is_sparse_coo():
-            return _C_ops.final_state_sparse_coo_values(self)
-        elif self.is_sparse_csr():
-            return _C_ops.final_state_sparse_csr_values(self)
+        if self.is_sparse_coo() or self.is_sparse_csr():
+            return _C_ops.final_state_sparse_values(self)
         else:
             raise ValueError(
                 "only SparseCooTensor and SparseCsrTensor have method values")

--- a/python/paddle/sparse/functional/unary.py
+++ b/python/paddle/sparse/functional/unary.py
@@ -47,10 +47,8 @@ def relu(x, name=None):
 
     assert in_dynamic_mode(), "Currently, Sparse API only support dynamic mode"
 
-    if x.is_sparse_coo():
-        return _C_ops.final_state_sparse_coo_relu(x)
-    elif x.is_sparse_csr():
-        return _C_ops.final_state_sparse_csr_relu(x)
+    if x.is_sparse_coo() or x.is_sparse_csr():
+        return _C_ops.final_state_sparse_relu(x)
     else:
         raise ValueError(
             "Currently, sparse.relu only support the input of SparseCooTensor or SparseCsrTensor"
@@ -87,10 +85,8 @@ def tanh(x, name=None):
 
     assert in_dynamic_mode(), "Currently, Sparse API only support dynamic mode"
 
-    if x.is_sparse_coo():
-        return _C_ops.final_state_sparse_coo_tanh(x)
-    elif x.is_sparse_csr():
-        return _C_ops.final_state_sparse_csr_tanh(x)
+    if x.is_sparse_coo() or x.is_sparse_csr():
+        return _C_ops.final_state_sparse_tanh(x)
     else:
         raise ValueError(
             "Currently, sparse.tanh only support the input of SparseCooTensor or SparseCsrTensor"
@@ -127,10 +123,8 @@ def sqrt(x, name=None):
 
     assert in_dynamic_mode(), "Currently, Sparse API only support dynamic mode"
 
-    if x.is_sparse_coo():
-        return _C_ops.final_state_sparse_coo_sqrt(x)
-    elif x.is_sparse_csr():
-        return _C_ops.final_state_sparse_csr_sqrt(x)
+    if x.is_sparse_coo() or x.is_sparse_csr():
+        return _C_ops.final_state_sparse_sqrt(x)
     else:
         raise ValueError(
             "Currently, sparse.sqrt only support the input of SparseCooTensor or SparseCsrTensor"
@@ -167,10 +161,8 @@ def sin(x, name=None):
 
     assert in_dynamic_mode(), "Currently, Sparse API only support dynamic mode"
 
-    if x.is_sparse_coo():
-        return _C_ops.final_state_sparse_coo_sin(x)
-    elif x.is_sparse_csr():
-        return _C_ops.final_state_sparse_csr_sin(x)
+    if x.is_sparse_coo() or x.is_sparse_csr():
+        return _C_ops.final_state_sparse_sin(x)
     else:
         raise ValueError(
             "Currently, sparse.sin only support the input of SparseCooTensor or SparseCsrTensor"

--- a/python/paddle/utils/code_gen/sparse_api.yaml
+++ b/python/paddle/utils/code_gen/sparse_api.yaml
@@ -1,128 +1,98 @@
 - api : conv3d
   args : (Tensor x, Tensor kernel, int[] paddings, int[] dilations, int[] strides, int groups, bool subm)
-  output : Tensor(out@SparseCooTensor), Tensor(rulebook@DenseTensor)
+  output : Tensor(out), Tensor(rulebook)
   kernel :
-    func : sparse_conv3d
+    func : sparse_conv3d{sparse_coo, dense -> sparse_coo, dense}
     layout : x
   intermediate : rulebook
   backward : conv3d_grad
 
-- api : coo_relu
-  args : (Tensor x)
-  output : Tensor(out@SparseCooTensor)
-  kernel :
-    func : sparse_coo_relu
-    layout : x
-  backward : sparse_coo_relu_grad
-
-- api : coo_sin
-  args : (Tensor x)
-  output : Tensor(out@SparseCooTensor)
-  kernel :
-    func : sparse_coo_sin
-    layout : x
-  backward : sparse_coo_sin_grad
-
-- api : coo_sqrt
-  args : (Tensor x)
-  output : Tensor(out@SparseCooTensor)
-  kernel :
-    func : sparse_coo_sqrt
-    layout : x
-  backward : sparse_coo_sqrt_grad
-
-- api : coo_tanh
-  args : (Tensor x)
-  output : Tensor(out@SparseCooTensor)
-  kernel :
-    func : sparse_coo_tanh
-    layout : x
-  backward : sparse_coo_tanh_grad
-
 - api : coo_to_dense
   args : (Tensor x)
-  output : Tensor(out@DenseTensor)
+  output : Tensor(out)
   invoke : to_dense_impl(x)
   backward : coo_to_dense_grad
 
-- api : coo_values
-  args : (Tensor x)
-  output : Tensor(out@DenseTensor)
-  kernel :
-    func : coo_values
-    layout : x
-  backward : coo_values_grad
-
 - api : create_sparse_coo_tensor
   args : (Tensor values, Tensor indices, IntArray dense_shape)
-  output : Tensor(out@SparseCooTensor)
+  output : Tensor(out)
   kernel :
-    func : sparse_coo_tensor
+    func : sparse_coo_tensor{dense, dense -> sparse_coo}
     layout : values
     data_type : values
   backward : create_sparse_coo_tensor_grad
 
-- api : csr_relu
-  args : (Tensor x)
-  output : Tensor(out@SparseCsrTensor)
-  kernel :
-    func : sparse_csr_relu
-    layout : x
-
-- api : csr_sin
-  args : (Tensor x)
-  output : Tensor(out@SparseCsrTensor)
-  kernel :
-    func : sparse_csr_sin
-    layout : x
-
-- api : csr_sqrt
-  args : (Tensor x)
-  output : Tensor(out@SparseCsrTensor)
-  kernel :
-    func : sparse_csr_sqrt
-    layout : x
-
-- api : csr_tanh
-  args : (Tensor x)
-  output : Tensor(out@SparseCsrTensor)
-  kernel :
-    func : sparse_csr_tanh
-    layout : x
-
-- api : csr_values
-  args : (Tensor x)
-  output : Tensor(out@DenseTensor)
-  kernel :
-    func : csr_values
-    layout : x
-
 - api : dense_to_coo
   args : (Tensor x, int64_t sparse_dim)
-  output : Tensor(out@SparseCooTensor)
+  output : Tensor(out)
   invoke : to_sparse_coo_impl(x, sparse_dim)
   backward : dense_to_coo_grad
 
+- api : relu
+  args : (Tensor x)
+  output : Tensor(out)
+  kernel :
+    func : sparse_coo_relu{sparse_coo -> sparse_coo},
+           sparse_csr_relu{sparse_csr -> sparse_csr}
+    layout : x
+  backward : relu_grad
+
+- api : sin
+  args : (Tensor x)
+  output : Tensor(out@SparseCooTensor)
+  kernel :
+    func : sparse_coo_sin {sparse_coo -> sparse_coo},
+           sparse_csr_sin {sparse_csr -> sparse_csr}
+    layout : x
+  backward : sin_grad
+
+- api : sqrt
+  args : (Tensor x)
+  output : Tensor(out)
+  kernel :
+    func : sparse_coo_sqrt{sparse_coo -> sparse_coo},
+           sparse_csr_sqrt{sparse_csr -> sparse_csr}
+    layout : x
+  backward : sqrt_grad
+
+- api : tanh
+  args : (Tensor x)
+  output : Tensor(out)
+  kernel :
+    func : sparse_coo_tanh{sparse_coo -> sparse_coo},
+           sparse_csr_tanh{sparse_csr -> sparse_csr}
+    layout : x
+  backward : tanh_grad
+
 - api : to_dense
   args : (Tensor x)
-  output : Tensor(out@DenseTensor)
+  output : Tensor(out)
   invoke : to_dense_impl(x)
 
 - api : to_sparse_coo
   args : (Tensor x, int64_t sparse_dim)
-  output : Tensor(out@SparseCooTensor)
+  output : Tensor(out)
   invoke : to_sparse_coo_impl(x, sparse_dim)
 
 - api : to_sparse_csr
   args : (Tensor x)
-  output : Tensor(out@SparseCsrTensor)
+  output : Tensor(out)
   invoke : to_sparse_csr_impl(x)
+
+- api : values
+  args : (Tensor x)
+  output : Tensor(out)
+  kernel :
+    func : coo_values{sparse_coo -> dense},
+           csr_values{sparse_csr -> dense}
+    layout : x
+  backward : values_grad
 
 - api: maxpool
   args : (Tensor x, int[] kernel_sizes, int[] paddings, int[] dilations, int[] strides)
-  output : Tensor(out@SparseCooTensor), Tensor(rulebook@DenseTensor)
+  output : Tensor(out), Tensor(rulebook)
   kernel :
-    func : sparse_maxpool
+    func : sparse_maxpool{sparse_coo -> sparse_coo, dense}
     layout : x
   intermediate : rulebook
   backward : sparse_maxpool_grad

--- a/python/paddle/utils/code_gen/sparse_bw_api.yaml
+++ b/python/paddle/utils/code_gen/sparse_bw_api.yaml
@@ -1,68 +1,68 @@
 - backward_api : conv3d_grad
   forward : conv3d (Tensor x, Tensor kernel, int[] paddings, int[] dilations, int[] strides, int groups, bool subm) -> Tensor(out@SparseCooTensor), Tensor(rulebook@DenseTensor)
   args : (Tensor x, Tensor kernel, Tensor rulebook, Tensor out_grad, int[] paddings, int[] dilations, int[] strides, int groups, bool subm)
-  output : Tensor(x_grad@SparseCooTensor), Tensor(kernel_grad@DenseTensor)
+  output : Tensor(x_grad), Tensor(kernel_grad)
   kernel :
-    func : sparse_conv3d_grad
+    func : sparse_conv3d_grad{sparse_coo, dense, dense, sparse_coo -> sparse_coo, dense}
 
 - backward_api : coo_to_dense_grad
-  forward : coo_to_dense(Tensor x) -> Tensor(out@DenseTensor)
+  forward : coo_to_dense(Tensor x) -> Tensor(out)
   args : (Tensor x, Tensor out_grad)
-  output : Tensor(x_grad@SparseCooTensor)
+  output : Tensor(x_grad)
   kernel :
-    func : sparse_coo_to_dense_grad
-
-- backward_api : coo_values_grad
-  forward : coo_values(Tensor x) -> Tensor(out@DenseTensor)
-  args : (Tensor x, Tensor out_grad)
-  output : Tensor(x_grad@SparseCooTensor)
-  kernel :
-    func : coo_values_grad
+    func : sparse_coo_to_dense_grad{sparse_coo, dense-> sparse_coo}
 
 - backward_api : create_sparse_coo_tensor_grad
-  forward : create_sparse_coo_tensor(Tensor values, Tensor indices, IntArray dense_shape) -> Tensor(out@SparseCooTensor)
+  forward : create_sparse_coo_tensor(Tensor values, Tensor indices, IntArray dense_shape) -> Tensor(out)
   args : (Tensor indices, Tensor out_grad)
-  output : Tensor(values_grad@DenseTensor)
+  output : Tensor(values_grad)
   kernel :
-    func : sparse_coo_tensor_grad
+    func : sparse_coo_tensor_grad{dense, sparse_coo -> dense}
 
 - backward_api : dense_to_coo_grad
-  forward : dense_to_coo(Tensor x, int64_t sparse_dim) -> Tensor(out@SparseCooTensor)
+  forward : dense_to_coo(Tensor x, int64_t sparse_dim) -> Tensor(out)
   args : (Tensor out_grad)
-  output : Tensor(x_grad@DenseTensor)
+  output : Tensor(x_grad)
   invoke : to_dense_impl(out_grad)
 
-- backward_api : sparse_coo_relu_grad
-  forward : sparse_coo_relu(Tensor x) -> Tensor(out@SparseCooTensor)
+- backward_api : relu_grad
+  forward : relu(Tensor x) -> Tensor(out)
   args : (Tensor out, Tensor out_grad)
-  output : Tensor(x_grad@SparseCooTensor)
+  output : Tensor(x_grad)
   kernel :
-    func : sparse_coo_relu_grad
+    func : sparse_coo_relu_grad {sparse_coo, sparse_coo -> sparse_coo}
 
-- backward_api : sparse_coo_sin_grad
-  forward : sparse_coo_sin(Tensor x) -> Tensor(out@SparseCooTensor)
+- backward_api : sin_grad
+  forward : sin(Tensor x) -> Tensor(out)
   args : (Tensor x, Tensor out_grad)
-  output : Tensor(x_grad@SparseCooTensor)
+  output : Tensor(x_grad)
   kernel :
-    func : sparse_coo_sin_grad
-
-- backward_api : sparse_coo_sqrt_grad
-  forward : sparse_coo_sqrt(Tensor x) -> Tensor(out@SparseCooTensor)
-  args : (Tensor out, Tensor out_grad)
-  output : Tensor(x_grad@SparseCooTensor)
-  kernel :
-    func : sparse_coo_sqrt_grad
-
-- backward_api : sparse_coo_tanh_grad
-  forward : sparse_coo_tanh(Tensor x) -> Tensor(out@SparseCooTensor)
-  args : (Tensor out, Tensor out_grad)
-  output : Tensor(x_grad@SparseCooTensor)
-  kernel :
-    func : sparse_coo_tanh_grad
+    func : sparse_coo_sin_grad {sparse_coo, sparse_coo -> sparse_coo}
 
 - backward_api : sparse_maxpool_grad
-  forward : sparse_maxpool(Tensor x, int[] kernel_sizes, int[] paddings, int[] dilations, int[] strides) -> Tensor(out@SparseCooTensor), Tensor(rulebook@DenseTensor)
+  forward : sparse_maxpool(Tensor x, int[] kernel_sizes, int[] paddings, int[] dilations, int[] strides) -> Tensor(out), Tensor(rulebook)
   args : (Tensor x, Tensor rulebook, Tensor out, Tensor out_grad, int[] kernel_sizes)
-  output : Tensor(x_grad@SparseCooTensor)
+  output : Tensor(x_grad)
   kernel :
-    func : sparse_maxpool_grad
+    func : sparse_maxpool_grad {sparse_coo, dense, sparse_coo, sparse_coo -> sparse_coo}
+
+- backward_api : sqrt_grad
+  forward : sqrt(Tensor x) -> Tensor(out)
+  args : (Tensor out, Tensor out_grad)
+  output : Tensor(x_grad)
+  kernel :
+    func : sparse_coo_sqrt_grad {sparse_coo, sparse_coo -> sparse_coo}
+
+- backward_api : tanh_grad
+  forward : tanh(Tensor x) -> Tensor(out)
+  args : (Tensor out, Tensor out_grad)
+  output : Tensor(x_grad)
+  kernel :
+    func : sparse_coo_tanh_grad {sparse_coo, sparse_coo -> sparse_coo}
+
+- backward_api : values_grad
+  forward : coo_values(Tensor x) -> Tensor(out)
+  args : (Tensor x, Tensor out_grad)
+  output : Tensor(x_grad)
+  kernel :
+    func : coo_values_grad{sparse_coo, dense-> sparse_coo}

--- a/python/paddle/utils/code_gen/sparse_bw_api_gen.py
+++ b/python/paddle/utils/code_gen/sparse_bw_api_gen.py
@@ -35,7 +35,7 @@ class SparseBackwardAPI(SparseAPI, BackwardAPI):
         return BackwardAPI.get_return_type(self)
 
     def gene_return_code(self):
-        return ""
+        return "return;"
 
     def gene_api_declaration(self):
         return SparseAPI.gene_api_declaration(self)
@@ -54,6 +54,11 @@ class SparseBackwardAPI(SparseAPI, BackwardAPI):
         kernel_output = ""
         output_names = []
         output_create = ""
+        output_type_map = {
+            'dense': 'TensorType::DENSE_TENSOR',
+            'sparse_coo': 'TensorType::SPARSE_COO',
+            'sparse_csr': 'TensorType::SPARSE_CSR'
+        }
 
         if len(output_type_list) == 1:
             kernel_output = 'kernel_out'
@@ -62,7 +67,7 @@ class SparseBackwardAPI(SparseAPI, BackwardAPI):
                 0]] if inplace_flag and self.inplace_map is not None and self.outputs[
                     'names'][0] in self.inplace_map else ""
             output_create = f"""
-  auto kernel_out = {set_out_func}({self.outputs['names'][0].split('@')[0]}, {self.get_kernel_tensor_out_type(self.outputs['names'][0])});"""
+    auto kernel_out = {set_out_func}({self.outputs['names'][0]}, {output_type_map[output_type_list[0]]});"""
 
         elif len(output_type_list) > 1:
             output_create = ""
@@ -73,10 +78,10 @@ class SparseBackwardAPI(SparseAPI, BackwardAPI):
                 if inplace_flag and self.inplace_map is not None and self.outputs[
                         'names'][i] in self.inplace_map:
                     output_create = output_create + f"""
-  *{self.outputs['names'][i]} = {self.inplace_map[self.outputs['names'][i]]};"""
+    *{self.outputs['names'][i]} = {self.inplace_map[self.outputs['names'][i]]};"""
 
                 output_create = output_create + f"""
-  auto kernel_out_{i} = {set_out_func}({self.outputs['names'][i].split('@')[0]}, {self.get_kernel_tensor_out_type(self.outputs['names'][i])});"""
+    auto kernel_out_{i} = {set_out_func}({self.outputs['names'][i]}, {output_type_map[output_type_list[i]]});"""
 
             kernel_output = kernel_output[:-2]
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Yaml文件支持对Sparse异构Tensor的kernel分发进行配置。

更新后的配置规则以relu为例（主要调整在kernel的func配置项）：
```
- api : relu
  args : (Tensor x)
  output : Tensor(out)
  kernel :
    func : sparse_coo_relu{sparse_coo -> sparse_coo},
           sparse_csr_relu{sparse_csr -> sparse_csr}
    layout : x
  backward : relu_grad
```
调整后的配置机制需要为每个分发的计算kernel配置对应的输入输出Tensor类型（目前只支持`sparse_coo`, `sparse_csr`, `dense`三种）。如relu调用的`sparse_coo_relu` kernel输入输出都为`sparse_coo`，对应的配置为`sparse_coo_relu{sparse_coo -> sparse_coo}`,  `sparse_csr_relu`也是同理。`kernel:func`下配置的多个kernel间使用`,`进行分隔。

需要注意配置的输入输出Tensor类型需要与api的`args`和`output`中的输入输出Tensor一一对应。