### PR TITLE
Fix numpy 1.20+ deprecation warnings

### DIFF
--- a/python/paddle/distributed/fleet/base/fleet_base.py
+++ b/python/paddle/distributed/fleet/base/fleet_base.py
@@ -1811,8 +1811,8 @@ class Fleet(object):
                     if (param._grad_ivar() is not None) and (
                         param._grad_ivar().dtype == core.VarDesc.VarType.FP32)
                 ]
-            temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
-            temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))
+            temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool_))
+            temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool_))
             if len(param_grads_fp16):
                 _C_ops.check_finite_and_unscale(param_grads_fp16, self._scale,
                                                 param_grads_fp16,

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_utils.py
@@ -200,8 +200,8 @@ def GroupShardedScaler(scaler):
                     else:
                         param_grads_fp32.append(param.grad)
 
-        temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
-        temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))
+        temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool_))
+        temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool_))
 
         device = "cpu" if optimizer.offload else "gpu"
         dev_id = 0 if device == "cpu" else int(

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_utils.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/sharding_utils.py
@@ -201,8 +201,8 @@ def ShardingScaler(scaler):
                     else:
                         param_grads_fp32.append(param.grad)
 
-        temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool))
-        temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool))
+        temp_found_inf_fp16 = to_variable(np.array([0]).astype(np.bool_))
+        temp_found_inf_fp32 = to_variable(np.array([0]).astype(np.bool_))
 
         device = "cpu" if optimizer.offload else "gpu"
         dev_id = 0 if device == "cpu" else int(

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -49,8 +49,8 @@ def convert_dtype(dtype):
             return _PADDLE_DTYPE_2_NUMPY_DTYPE[dtype]
     elif isinstance(dtype, type):
         if dtype in [
-                np.bool_, np.float16, np.uint16, np.float32, np.float64,
-                np.int8, np.int16, np.int32, np.int64, np.uint8, np.complex64,
+                bool, np.float16, np.uint16, np.float32, np.float64, np.int8,
+                np.int16, np.int32, np.int64, np.uint8, np.complex64,
                 np.complex128
         ]:
             return dtype.__name__

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -49,8 +49,8 @@ def convert_dtype(dtype):
             return _PADDLE_DTYPE_2_NUMPY_DTYPE[dtype]
     elif isinstance(dtype, type):
         if dtype in [
-                np.bool, np.float16, np.uint16, np.float32, np.float64, np.int8,
-                np.int16, np.int32, np.int64, np.uint8, np.complex64,
+                np.bool_, np.float16, np.uint16, np.float32, np.float64,
+                np.int8, np.int16, np.int32, np.int64, np.uint8, np.complex64,
                 np.complex128
         ]:
             return dtype.__name__

--- a/python/paddle/fluid/dygraph/amp/loss_scaler.py
+++ b/python/paddle/fluid/dygraph/amp/loss_scaler.py
@@ -129,11 +129,11 @@ class AmpScaler(object):
             self._decr_count = 0
             self._use_dynamic_loss_scaling = use_dynamic_loss_scaling
 
-            self._found_inf = to_variable(np.array([0]).astype(np.bool))
+            self._found_inf = to_variable(np.array([0]).astype(np.bool_))
             self._temp_found_inf_fp16 = to_variable(
-                np.array([0]).astype(np.bool))
+                np.array([0]).astype(np.bool_))
             self._temp_found_inf_fp32 = to_variable(
-                np.array([0]).astype(np.bool))
+                np.array([0]).astype(np.bool_))
             self._scale = to_variable(
                 np.array([self._init_loss_scaling]).astype(np.float32))
             self._cache_founf_inf = None

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -483,7 +483,7 @@ def _as_lodtensor(data, place, dtype=None):
             data = np.array([data]).astype(dtype)
         elif isinstance(data, (list, tuple)):
             data = np.array(data)
-            if data.dtype == np.object:
+            if data.dtype == np.object_:
                 raise TypeError(
                     "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
                     "this means the input data contains nested lists with different lengths. "

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1110,7 +1110,7 @@ def convert_np_dtype_to_dtype_(np_dtype):
         return core.VarDesc.VarType.INT16
     elif dtype == np.int64:
         return core.VarDesc.VarType.INT64
-    elif dtype == np.bool:
+    elif dtype == np.bool_:
         return core.VarDesc.VarType.BOOL
     elif dtype == np.uint16:
         # since there is still no support for bfloat16 in NumPy,

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12860,8 +12860,8 @@ def logical_or(x, y, out=None, name=None):
             import paddle
             import numpy as np
 
-            x_data = np.array([True, False], dtype=np.bool).reshape(2, 1)
-            y_data = np.array([True, False, True, False], dtype=np.bool).reshape(2, 2)
+            x_data = np.array([True, False], dtype=np.bool_).reshape(2, 1)
+            y_data = np.array([True, False, True, False], dtype=np.bool_).reshape(2, 2)
             x = paddle.to_tensor(x_data)
             y = paddle.to_tensor(y_data)
             res = paddle.logical_or(x, y)
@@ -12905,8 +12905,8 @@ def logical_xor(x, y, out=None, name=None):
             import paddle
             import numpy as np
 
-            x_data = np.array([True, False], dtype=np.bool).reshape([2, 1])
-            y_data = np.array([True, False, True, False], dtype=np.bool).reshape([2, 2])
+            x_data = np.array([True, False], dtype=np.bool_).reshape([2, 1])
+            y_data = np.array([True, False, True, False], dtype=np.bool_).reshape([2, 2])
             x = paddle.to_tensor(x_data)
             y = paddle.to_tensor(y_data)
             res = paddle.logical_xor(x, y)

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -145,7 +145,7 @@ class DataLoaderBase(object):
     @classmethod
     def _check_input_array(cls, item):
         arr = np.asarray(item)
-        if arr.dtype == np.object:
+        if arr.dtype == np.object_:
             raise TypeError(
                 "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
                 "this means the input data contains nested lists with different lengths. "

--- a/python/paddle/fluid/tests/unittests/fft/test_fft.py
+++ b/python/paddle/fluid/tests/unittests/fft/test_fft.py
@@ -44,8 +44,8 @@ def rand_x(dims=1,
            complex=False):
     shape = [np.random.randint(min_dim_len, max_dim_len) for i in range(dims)]
     if complex:
-        return np.random.randn(*shape).astype(
-            dtype) + 1.j * np.random.randn(*shape).astype(dtype)
+        return np.random.randn(
+            *shape).astype(dtype) + 1.j * np.random.randn(*shape).astype(dtype)
     else:
         return np.random.randn(*shape).astype(dtype)
 

--- a/python/paddle/fluid/tests/unittests/fft/test_fft.py
+++ b/python/paddle/fluid/tests/unittests/fft/test_fft.py
@@ -473,7 +473,7 @@ class TestIrfft2(unittest.TestCase):
 @parameterize((TEST_CASE_NAME, 'x', 'n', 'axis', 'norm', 'expect_exception'), [
     ('test_bool_input',
      (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-         np.bool8), None, -1, 'backward', NotImplementedError),
+         np.bool_), None, -1, 'backward', NotImplementedError),
     ('test_n_nagative', np.random.randn(4, 4, 4) +
      1j * np.random.randn(4, 4, 4), -1, -1, 'backward', ValueError),
     ('test_n_zero', np.random.randn(4, 4) + 1j * np.random.randn(4, 4), 0, -1,
@@ -543,7 +543,7 @@ class TestIrfftException(unittest.TestCase):
     (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm', 'expect_exception'),
     [('test_bool_input',
       (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-          np.bool8), None, (-2, -1), 'backward', NotImplementedError),
+          np.bool_), None, (-2, -1), 'backward', NotImplementedError),
      ('test_n_nagative',
       np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4), (-1, -2),
       (-2, -1), 'backward', ValueError),
@@ -625,7 +625,7 @@ class TestIrfft2Exception(unittest.TestCase):
     (TEST_CASE_NAME, 'x', 'n', 'axis', 'norm', 'expect_exception'),
     [('test_bool_input',
       (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-          np.bool8), None, (-2, -1), 'backward', NotImplementedError),
+          np.bool_), None, (-2, -1), 'backward', NotImplementedError),
      ('test_n_nagative',
       np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4), (-1, -2),
       (-2, -1), 'backward', ValueError),

--- a/python/paddle/fluid/tests/unittests/fft/test_fft_with_static_graph.py
+++ b/python/paddle/fluid/tests/unittests/fft/test_fft_with_static_graph.py
@@ -370,7 +370,7 @@ class TestIrfft2(unittest.TestCase):
                                          4), None, -1, 'backward', TypeError),
     ('test_bool_input',
      (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-         np.bool8), None, -1, 'backward', TypeError),
+         np.bool_), None, -1, 'backward', TypeError),
     ('test_n_nagative', np.random.randn(4, 4, 4) +
      1j * np.random.randn(4, 4, 4), -1, -1, 'backward', ValueError),
     ('test_n_zero', np.random.randn(4, 4) + 1j * np.random.randn(4, 4), 0, -1,
@@ -406,7 +406,7 @@ class TestHfftException(unittest.TestCase):
                                          4), None, -1, 'backward', TypeError),
     ('test_bool_input',
      (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-         np.bool8), None, -1, 'backward', TypeError),
+         np.bool_), None, -1, 'backward', TypeError),
     ('test_n_nagative', np.random.randn(4, 4, 4) +
      1j * np.random.randn(4, 4, 4), -1, -1, 'backward', ValueError),
     ('test_n_zero', np.random.randn(4, 4) + 1j * np.random.randn(4, 4), 0, -1,
@@ -444,7 +444,7 @@ class TestIrfftException(unittest.TestCase):
         4, 4, 4), None, None, 'backward', TypeError),
      ('test_bool_input',
       (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-          np.bool8), None, (-2, -1), 'backward', TypeError),
+          np.bool_), None, (-2, -1), 'backward', TypeError),
      ('test_n_nagative',
       np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4), (-1, -2),
       (-2, -1), 'backward', ValueError),
@@ -485,7 +485,7 @@ class TestHfft2Exception(unittest.TestCase):
         4, 4, 4), None, None, 'backward', TypeError),
      ('test_bool_input',
       (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-          np.bool8), None, (-2, -1), 'backward', TypeError),
+          np.bool_), None, (-2, -1), 'backward', TypeError),
      ('test_n_nagative',
       np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4), (-1, -2),
       (-2, -1), 'backward', ValueError),
@@ -526,7 +526,7 @@ class TestIrfft2Exception(unittest.TestCase):
         4, 4, 4), None, None, 'backward', TypeError),
      ('test_bool_input',
       (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)).astype(
-          np.bool8), None, (-2, -1), 'backward', TypeError),
+          np.bool_), None, (-2, -1), 'backward', TypeError),
      ('test_n_nagative',
       np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4), (-1, -2),
       (-2, -1), 'backward', ValueError),
@@ -568,7 +568,7 @@ class TestHfftnException(unittest.TestCase):
             4, 4, 4), None, None, 'backward', TypeError),
         #  ('test_bool_input',
         #                (np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4)
-        #                 ).astype(np.bool8), None, (-2, -1), 'backward', ValueError),
+        #                 ).astype(np.bool_), None, (-2, -1), 'backward', ValueError),
         ('test_n_nagative',
          np.random.randn(4, 4, 4) + 1j * np.random.randn(4, 4, 4), (-1, -2),
          (-2, -1), 'backward', ValueError),

--- a/python/paddle/fluid/tests/unittests/ipu/test_assign_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_assign_op_ipu.py
@@ -86,7 +86,7 @@ class TestAssignBoolValue(TestBase):
         self.feed_fp32 = {'in_0': data.astype(np.float32)}
         self.feed_fp16 = {'in_0': data.astype(np.float16)}
         data = np.random.choice([True, False], size=(2, 3, 1))
-        self.assign_bool = data.astype(np.bool)
+        self.assign_bool = data.astype(np.bool_)
 
     @IPUOpTest.static_graph
     def build_model(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_mul_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_mul_int8_mkldnn_op.py
@@ -64,7 +64,7 @@ class TestMKLDNNMulOpS8S8(OpTest):
 
         B_data = np.random.uniform(-127, 127, (5, 20)).astype(np.float32)
 
-        quant_B = np.round(B_data * self.scale_y[0]).astype(np.int)
+        quant_B = np.round(B_data * self.scale_y[0]).astype(np.int_)
         output = np.dot(A_data, quant_B)
 
         scale_output_shift = (self.scale_out) / \
@@ -136,7 +136,7 @@ class TestMKLDNNMulOpS8S8WithFlatten(TestMKLDNNMulOpS8S8):
         A_data_reshape = A_data.reshape(3 * 4, 4 * 3)
         B_data_reshape = B_data.reshape(2 * 6, 1 * 2 * 3)
 
-        quant_B = np.round(B_data_reshape * self.scale_y[0]).astype(np.int)
+        quant_B = np.round(B_data_reshape * self.scale_y[0]).astype(np.int_)
         output = np.dot(A_data_reshape, quant_B)
 
         scale_output_shift = (self.scale_out) / \

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_softmax_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_softmax_bf16_mkldnn_op.py
@@ -47,7 +47,7 @@ class TestSoftmaxMKLDNNOp(TestSoftmaxOp):
         self.shape = self.get_x_shape()
         self.axis = self.get_axis()
 
-        x = np.random.uniform(0.1, 1, self.shape).astype(np.float)
+        x = np.random.uniform(0.1, 1, self.shape).astype(np.float64)
         out = convert_float_to_uint16(
             np.apply_along_axis(stable_softmax, self.axis, x))
 

--- a/python/paddle/fluid/tests/unittests/npu/test_box_coder_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_box_coder_op_npu.py
@@ -193,7 +193,7 @@ class TestBoxCoderOp(OpTest):
         }
         if self.use_variance:
             self.attrs['variance'] = self.prior_box_var.astype(
-                np.float).flatten()
+                np.float64).flatten()
         if self.axis != 0:
             self.attrs['axis'] = self.axis
 

--- a/python/paddle/fluid/tests/unittests/npu/test_density_prior_box_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_density_prior_box_op_npu.py
@@ -84,7 +84,7 @@ class TestNpuDensityPriorBoxOp(OpTest):
         self.batch_size = 10
 
         self.variances = [0.1, 0.1, 0.2, 0.2]
-        self.variances = np.array(self.variances, dtype=np.float).flatten()
+        self.variances = np.array(self.variances, dtype=np.float64).flatten()
 
         self.clip = True
         self.num_priors = 0

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_zeros_like_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_zeros_like_op_npu.py
@@ -48,7 +48,7 @@ class TestFillZerosLikeOp(OpTest):
 class TestFillZerosLikeOpBool(TestFillZerosLikeOp):
 
     def init_dtype(self):
-        self.dtype = np.bool
+        self.dtype = np.bool_
 
 
 class TestFillZerosLikeOpFp16(TestFillZerosLikeOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
@@ -95,9 +95,9 @@ class TestNPUPriorBox(OpTest):
         self.set_min_max_aspect_ratios_order()
         self.real_aspect_ratios = [1, 2.0, 1.0 / 2.0, 3.0, 1.0 / 3.0]
         self.aspect_ratios = np.array(self.aspect_ratios,
-                                      dtype=np.float).flatten()
+                                      dtype=np.float64).flatten()
         self.variances = [0.1, 0.1, 0.2, 0.2]
-        self.variances = np.array(self.variances, dtype=np.float).flatten()
+        self.variances = np.array(self.variances, dtype=np.float64).flatten()
 
         self.clip = True
         self.num_priors = len(self.real_aspect_ratios) * len(self.min_sizes)

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_max_op_npu.py
@@ -106,7 +106,7 @@ class TestReduceMaxOpWithOutDtype_bool(TestNPUReduceMaxOp):
         }
         self.outputs = {
             'Out':
-            self.inputs['X'].max(axis=tuple(self.attrs['dim'])).astype(np.bool)
+            self.inputs['X'].max(axis=tuple(self.attrs['dim'])).astype(np.bool_)
         }
 
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_min_op_npu.py
@@ -106,7 +106,7 @@ class TestReduceMinOpWithOutDtype_bool(TestNPUReduceMinOp):
         }
         self.outputs = {
             'Out':
-            self.inputs['X'].min(axis=tuple(self.attrs['dim'])).astype(np.bool)
+            self.inputs['X'].min(axis=tuple(self.attrs['dim'])).astype(np.bool_)
         }
 
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
@@ -128,8 +128,9 @@ class TestNPUReduceProdWithOutDtype_bool(TestNPUReduceProd):
         self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
         self.attrs = {'dim': [0], 'out_dtype': int(core.VarDesc.VarType.BOOL)}
         self.outputs = {
-            'Out': self.inputs['X'].prod(
-                axis=tuple(self.attrs['dim'])).astype(np.bool_)
+            'Out':
+            self.inputs['X'].prod(axis=tuple(self.attrs['dim'])).astype(
+                np.bool_)
         }
 
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
@@ -128,8 +128,8 @@ class TestNPUReduceProdWithOutDtype_bool(TestNPUReduceProd):
         self.inputs = {'X': np.random.random((5, 6, 10)).astype(self.dtype)}
         self.attrs = {'dim': [0], 'out_dtype': int(core.VarDesc.VarType.BOOL)}
         self.outputs = {
-            'Out':
-            self.inputs['X'].prod(axis=tuple(self.attrs['dim'])).astype(np.bool)
+            'Out': self.inputs['X'].prod(
+                axis=tuple(self.attrs['dim'])).astype(np.bool_)
         }
 
 

--- a/python/paddle/fluid/tests/unittests/npu/test_size_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_size_op_npu.py
@@ -72,7 +72,7 @@ class TestSizeOp4(TestSizeOp):
 
     def config(self):
         self.shape = [2**10]
-        self.dtype = np.bool
+        self.dtype = np.bool_
 
 
 class TestSizeOp5(TestSizeOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
@@ -199,7 +199,7 @@ class TestNPUTrilTriu_bool(TestNPUTrilTriu):
         self.check_output_with_place(self.place)
 
     def init_dtype(self):
-        self.dtype = np.bool
+        self.dtype = np.bool_
 
     def initTestCase(self):
         self.real_op_type = np.random.choice(['triu', 'tril'])

--- a/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_min_op_npu.py
@@ -37,7 +37,7 @@ class TestUpdateLossScalingOpMinLossScalingBad(TestUpdateLossScalingOpBad):
 
         self.init()
         fluid.core.globals()['FLAGS_min_loss_scaling'] = 1639
-        found_inf = np.array([True], dtype=np.bool)
+        found_inf = np.array([True], dtype=np.bool_)
         x = np.random.random((1024, 1024)).astype(self.dtype)
         i = np.random.randint(0, 1024, 1)
         j = np.random.randint(0, 1024, 1)

--- a/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
@@ -34,7 +34,7 @@ class TestUpdateLossScalingOp(OpTest):
         self.place = paddle.NPUPlace(0)
 
         self.init()
-        found_inf = np.array([False], dtype=np.bool)
+        found_inf = np.array([False], dtype=np.bool_)
         x = np.random.random((1024, 1024)).astype(self.dtype)
 
         self.inputs = {
@@ -82,7 +82,7 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
         self.place = paddle.NPUPlace(0)
 
         self.init()
-        found_inf = np.array([True], dtype=np.bool)
+        found_inf = np.array([True], dtype=np.bool_)
         x = np.random.random((1024, 1024)).astype(self.dtype)
         i = np.random.randint(0, 1024, 1)
         j = np.random.randint(0, 1024, 1)

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -471,7 +471,7 @@ class OpTest(unittest.TestCase):
             np.dtype(np.int16),
             np.dtype(np.int8),
             np.dtype(np.uint8),
-            np.dtype(np.bool)
+            np.dtype(np.bool_)
         ]
         # check the dtype in dtype_list in order, select the first dtype that in dtype_set
         for dtype in dtype_list:

--- a/python/paddle/fluid/tests/unittests/test_assign_op.py
+++ b/python/paddle/fluid/tests/unittests/test_assign_op.py
@@ -145,7 +145,7 @@ class TestAssignOApi(unittest.TestCase):
 
     def test_assign_NumpyArray(self):
         with fluid.dygraph.guard():
-            array = np.random.random(size=(100, 10)).astype(np.bool)
+            array = np.random.random(size=(100, 10)).astype(np.bool_)
             result1 = paddle.zeros(shape=[3, 3], dtype='float32')
             paddle.assign(array, result1)
         self.assertTrue(np.allclose(result1.numpy(), array))

--- a/python/paddle/fluid/tests/unittests/test_bipartite_match_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bipartite_match_op.py
@@ -35,7 +35,7 @@ def bipartite_match(distance, match_indices, match_dist):
 
     match_sorted = sorted(match_pair, key=lambda tup: tup[2], reverse=True)
 
-    row_indices = -1 * np.ones((row, ), dtype=np.int)
+    row_indices = -1 * np.ones((row, ), dtype=np.int_)
 
     idx = 0
     for i, j, dist in match_sorted:
@@ -69,7 +69,7 @@ def batch_bipartite_match(distance, lod, match_type=None, dist_threshold=None):
     """
     n = len(lod)
     m = distance.shape[1]
-    match_indices = -1 * np.ones((n, m), dtype=np.int)
+    match_indices = -1 * np.ones((n, m), dtype=np.int_)
     match_dist = np.zeros((n, m), dtype=np.float32)
     cur_offset = 0
     for i in range(n):

--- a/python/paddle/fluid/tests/unittests/test_box_coder_op.py
+++ b/python/paddle/fluid/tests/unittests/test_box_coder_op.py
@@ -235,7 +235,7 @@ class TestBoxCoderOpWithVariance(OpTest):
         self.attrs = {
             'code_type': 'decode_center_size',
             'box_normalized': False,
-            'variance': prior_box_var.astype(np.float).flatten(),
+            'variance': prior_box_var.astype(np.float64).flatten(),
             'axis': axis
         }
         self.outputs = {'OutputBox': output_box}

--- a/python/paddle/fluid/tests/unittests/test_compare_op.py
+++ b/python/paddle/fluid/tests/unittests/test_compare_op.py
@@ -249,8 +249,8 @@ def create_paddle_case(op_type, callback):
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
                 exe = paddle.static.Executor(self.place)
-                input_x = np.array([True, False, True]).astype(np.bool)
-                input_y = np.array([True, True, False]).astype(np.bool)
+                input_x = np.array([True, False, True]).astype(np.bool_)
+                input_y = np.array([True, True, False]).astype(np.bool_)
                 real_result = callback(input_x, input_y)
                 res, = exe.run(feed={
                     "x": input_x,
@@ -267,8 +267,8 @@ def create_paddle_case(op_type, callback):
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
                 exe = paddle.static.Executor(self.place)
-                input_x = np.array([True, False, True]).astype(np.bool)
-                input_y = np.array([True]).astype(np.bool)
+                input_x = np.array([True, False, True]).astype(np.bool_)
+                input_y = np.array([True]).astype(np.bool_)
                 real_result = callback(input_x, input_y)
                 res, = exe.run(feed={
                     "x": input_x,

--- a/python/paddle/fluid/tests/unittests/test_density_prior_box_op.py
+++ b/python/paddle/fluid/tests/unittests/test_density_prior_box_op.py
@@ -70,7 +70,7 @@ class TestDensityPriorBoxOp(OpTest):
         self.batch_size = 10
 
         self.variances = [0.1, 0.1, 0.2, 0.2]
-        self.variances = np.array(self.variances, dtype=np.float).flatten()
+        self.variances = np.array(self.variances, dtype=np.float64).flatten()
 
         self.clip = True
         self.num_priors = 0

--- a/python/paddle/fluid/tests/unittests/test_fuse_gemm_epilogue_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_gemm_epilogue_pass.py
@@ -27,7 +27,7 @@ def compare(ref, res, atol, rtol):
     ref = np.array(ref).flatten()
     res = np.array(res).flatten()
 
-    tmp_ref = ref.astype(np.float)
+    tmp_ref = ref.astype(np.float64)
     tol = atol + rtol * abs(tmp_ref)
 
     diff = abs(res - ref)

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
@@ -164,7 +164,7 @@ class TestFusedMultiTransformerOp(OpTest):
                     self.attn_mask = (self.attn_mask - 1.0) * 1e4
                 else:
                     self.attn_mask = (np.tril(self.attn_mask) - 1.0) * 1e4
-            elif self.attn_mask_type == np.bool:
+            elif self.attn_mask_type == np.bool_:
                 if self.has_cache_kv and not self.gen_cache_kv:
                     self.attn_mask[:, :, :, -2] = 0
                 else:
@@ -395,7 +395,7 @@ class TestFusedMultiTransformerOp(OpTest):
         epsilon = 1e-05
         ln2_epsilon = 1e-05
 
-        if attn_mask is not None and self.attn_mask_type != np.bool:
+        if attn_mask is not None and self.attn_mask_type != np.bool_:
             attn_mask = _convert_attention_mask(attn_mask, x.dtype)
 
         qkv_weights, qkv_biases = [], []

--- a/python/paddle/fluid/tests/unittests/test_generate_mask_labels_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_mask_labels_op.py
@@ -79,8 +79,8 @@ def poly2mask(xy, k, h, w):
             u.extend([int(xs + s * t + .5) for t in ts])
 
     k = len(u)
-    x = np.zeros((k), np.int)
-    y = np.zeros((k), np.int)
+    x = np.zeros((k), np.int_)
+    y = np.zeros((k), np.int_)
     m = 0
     for j in six.moves.xrange(1, k):
         if u[j] != u[j - 1]:
@@ -116,7 +116,7 @@ def poly2mask(xy, k, h, w):
                 b[m - 1] += a[j]
                 j += 1
     mask = decode(b, m)
-    mask = np.array(mask, dtype=np.int).reshape((w, h))
+    mask = np.array(mask, dtype=np.int_).reshape((w, h))
     mask = mask.transpose((1, 0))
     return mask
 

--- a/python/paddle/fluid/tests/unittests/test_kron_op.py
+++ b/python/paddle/fluid/tests/unittests/test_kron_op.py
@@ -151,7 +151,7 @@ class TestComplexKronOp(OpTest):
         self.grad_y = self.get_grad_y_by_numpy()
 
     def get_grad_x_by_numpy(self):
-        grad_x = np.zeros(self.x_shape, np.complex)
+        grad_x = np.zeros(self.x_shape, np.complex128)
         for x_i in range(self.x_shape[0]):
             for x_j in range(self.x_shape[1]):
                 for i in range(self.y_shape[0]):
@@ -163,7 +163,7 @@ class TestComplexKronOp(OpTest):
         return grad_x
 
     def get_grad_y_by_numpy(self):
-        grad_y = np.zeros(self.y_shape, np.complex)
+        grad_y = np.zeros(self.y_shape, np.complex128)
         for y_i in range(self.y_shape[0]):
             for y_j in range(self.y_shape[1]):
                 for x_i in range(self.x_shape[0]):

--- a/python/paddle/fluid/tests/unittests/test_ones_like.py
+++ b/python/paddle/fluid/tests/unittests/test_ones_like.py
@@ -41,7 +41,7 @@ class TestOnesLikeAPI(unittest.TestCase):
 
             # 'bool', 'float32', 'float64', 'int32', 'int64'
             out1 = ones_like(x)
-            out2 = ones_like(x, np.bool)
+            out2 = ones_like(x, np.bool_)
             out3 = ones_like(x, 'float64')
             out4 = ones_like(x, 'int32')
             out5 = ones_like(x, 'int64')
@@ -54,7 +54,7 @@ class TestOnesLikeAPI(unittest.TestCase):
                        fetch_list=[out1, out2, out3, out4, out5])
 
         for i, dtype in enumerate(
-            [np.float32, np.bool, np.float64, np.int32, np.int64]):
+            [np.float32, np.bool_, np.float64, np.int32, np.int64]):
             self.assertEqual(outs[i].dtype, dtype)
             self.assertEqual((outs[i] == np.ones(shape, dtype)).all(), True)
 
@@ -67,7 +67,7 @@ class TestOnesLikeImpeartive(unittest.TestCase):
             0) if core.is_compiled_with_cuda() else fluid.CPUPlace()
         paddle.disable_static(place)
         x = paddle.to_tensor(np.ones(shape))
-        for dtype in [np.bool, np.float32, np.float64, np.int32, np.int64]:
+        for dtype in [np.bool_, np.float32, np.float64, np.int32, np.int64]:
             out = ones_like(x, dtype)
             self.assertEqual((out.numpy() == np.ones(shape, dtype)).all(), True)
 

--- a/python/paddle/fluid/tests/unittests/test_prior_box_op.py
+++ b/python/paddle/fluid/tests/unittests/test_prior_box_op.py
@@ -81,9 +81,9 @@ class TestPriorBoxOp(OpTest):
         self.set_min_max_aspect_ratios_order()
         self.real_aspect_ratios = [1, 2.0, 1.0 / 2.0, 3.0, 1.0 / 3.0]
         self.aspect_ratios = np.array(self.aspect_ratios,
-                                      dtype=np.float).flatten()
+                                      dtype=np.float64).flatten()
         self.variances = [0.1, 0.1, 0.2, 0.2]
-        self.variances = np.array(self.variances, dtype=np.float).flatten()
+        self.variances = np.array(self.variances, dtype=np.float64).flatten()
 
         self.clip = True
         self.num_priors = len(self.real_aspect_ratios) * len(self.min_sizes)

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -965,7 +965,7 @@ class TestAllAPI(unittest.TestCase):
         paddle.disable_static()
         for place in self.places:
             with fluid.dygraph.guard(place):
-                np_x = np.random.randint(0, 2, (12, 10)).astype(np.bool)
+                np_x = np.random.randint(0, 2, (12, 10)).astype(np.bool_)
                 x = fluid.layers.assign(np_x)
                 x = fluid.layers.cast(x, 'bool')
 
@@ -1021,7 +1021,7 @@ class TestAnyAPI(unittest.TestCase):
         paddle.disable_static()
         for place in self.places:
             with fluid.dygraph.guard(place):
-                np_x = np.random.randint(0, 2, (12, 10)).astype(np.bool)
+                np_x = np.random.randint(0, 2, (12, 10)).astype(np.bool_)
                 x = fluid.layers.assign(np_x)
                 x = fluid.layers.cast(x, 'bool')
 

--- a/python/paddle/fluid/tests/unittests/test_signal.py
+++ b/python/paddle/fluid/tests/unittests/test_signal.py
@@ -598,8 +598,8 @@ def rand_x(dims=1,
             np.random.randint(min_dim_len, max_dim_len) for i in range(dims)
         ]
     if complex:
-        return np.random.randn(*shape).astype(
-            dtype) + 1.j * np.random.randn(*shape).astype(dtype)
+        return np.random.randn(
+            *shape).astype(dtype) + 1.j * np.random.randn(*shape).astype(dtype)
     else:
         return np.random.randn(*shape).astype(dtype)
 

--- a/python/paddle/fluid/tests/unittests/test_signal.py
+++ b/python/paddle/fluid/tests/unittests/test_signal.py
@@ -81,7 +81,7 @@ def normalize(S, norm=np.inf, axis=0, threshold=None, fill=None):
         raise Exception("Input must be finite")
 
     # All norms only depend on magnitude, let's do that first
-    mag = np.abs(S).astype(np.float)
+    mag = np.abs(S).astype(np.float64)
 
     # For max/min norms, filling with 1 works
     fill_norm = 1

--- a/python/paddle/fluid/tests/unittests/test_update_loss_scaling_op.py
+++ b/python/paddle/fluid/tests/unittests/test_update_loss_scaling_op.py
@@ -24,7 +24,7 @@ class TestUpdateLossScalingOp(OpTest):
     def setUp(self):
         self.op_type = "update_loss_scaling"
         self.init()
-        found_inf = np.array([False], dtype=np.bool)
+        found_inf = np.array([False], dtype=np.bool_)
         x = np.random.random((1024, 1024)).astype(self.dtype)
 
         self.inputs = {
@@ -66,7 +66,7 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
     def setUp(self):
         self.op_type = "update_loss_scaling"
         self.init()
-        found_inf = np.array([True], dtype=np.bool)
+        found_inf = np.array([True], dtype=np.bool_)
         x = np.random.random((1024, 1024)).astype(self.dtype)
         i = np.random.randint(0, 1024, 1)
         j = np.random.randint(0, 1024, 1)

--- a/python/paddle/fluid/tests/unittests/test_zeros_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_zeros_like_op.py
@@ -43,7 +43,7 @@ class TestZerosLikeAPI(unittest.TestCase):
         with program_guard(train_program, startup_program):
             x = paddle.fluid.data('X', shape)
             out1 = zeros_like(x)
-            out2 = zeros_like(x, np.bool)
+            out2 = zeros_like(x, np.bool_)
             out3 = zeros_like(x, 'float64')
             out4 = zeros_like(x, 'int32')
             out5 = zeros_like(x, 'int64')
@@ -54,7 +54,7 @@ class TestZerosLikeAPI(unittest.TestCase):
                        feed={'X': np.ones(shape).astype('float32')},
                        fetch_list=[out1, out2, out3, out4, out5])
         for (i, dtype) in enumerate(
-            [np.float32, np.bool, np.float64, np.int32, np.int64]):
+            [np.float32, np.bool_, np.float64, np.int32, np.int64]):
             self.assertEqual(outs[i].dtype, dtype)
             self.assertEqual((outs[i] == np.zeros(shape, dtype)).all(), True)
 
@@ -71,7 +71,7 @@ class TestZerosLikeImpeartive(unittest.TestCase):
                  if core.is_compiled_with_cuda() else fluid.CPUPlace())
         paddle.disable_static(place)
         x = paddle.to_tensor(np.ones(shape))
-        for dtype in [np.bool, np.float32, np.float64, np.int32, np.int64]:
+        for dtype in [np.bool_, np.float32, np.float64, np.int32, np.int64]:
             out = zeros_like(x, dtype)
             self.assertEqual((out.numpy() == np.zeros(shape, dtype)).all(),
                              True)

--- a/python/paddle/fluid/tests/unittests/xpu/test_compare_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_compare_op_xpu.py
@@ -240,8 +240,8 @@ def create_paddle_case(op_type, callback):
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
                 exe = paddle.static.Executor(self.place)
-                input_x = np.array([True, False, True]).astype(np.bool)
-                input_y = np.array([True, True, False]).astype(np.bool)
+                input_x = np.array([True, False, True]).astype(np.bool_)
+                input_y = np.array([True, True, False]).astype(np.bool_)
                 real_result = callback(input_x, input_y)
                 res, = exe.run(feed={
                     "x": input_x,
@@ -258,8 +258,8 @@ def create_paddle_case(op_type, callback):
                 op = eval("paddle.%s" % (self.op_type))
                 out = op(x, y)
                 exe = paddle.static.Executor(self.place)
-                input_x = np.array([True, False, True]).astype(np.bool)
-                input_y = np.array([True]).astype(np.bool)
+                input_x = np.array([True, False, True]).astype(np.bool_)
+                input_y = np.array([True]).astype(np.bool_)
                 real_result = callback(input_x, input_y)
                 res, = exe.run(feed={
                     "x": input_x,

--- a/python/paddle/fluid/tests/unittests/xpu/test_prior_box_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_prior_box_op_xpu.py
@@ -98,9 +98,10 @@ class XPUTestPriorBoxOp(XPUOpTestWrapper):
             self.set_min_max_aspect_ratios_order()
             self.real_aspect_ratios = [1, 2.0, 1.0 / 2.0, 3.0, 1.0 / 3.0]
             self.aspect_ratios = np.array(self.aspect_ratios,
-                                          dtype=np.float).flatten()
+                                          dtype=np.float64).flatten()
             self.variances = [0.1, 0.1, 0.2, 0.2]
-            self.variances = np.array(self.variances, dtype=np.float).flatten()
+            self.variances = np.array(
+                self.variances, dtype=np.float64).flatten()
 
             self.clip = True
             self.num_priors = len(self.real_aspect_ratios) * len(self.min_sizes)

--- a/python/paddle/fluid/tests/unittests/xpu/test_prior_box_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_prior_box_op_xpu.py
@@ -100,8 +100,8 @@ class XPUTestPriorBoxOp(XPUOpTestWrapper):
             self.aspect_ratios = np.array(self.aspect_ratios,
                                           dtype=np.float64).flatten()
             self.variances = [0.1, 0.1, 0.2, 0.2]
-            self.variances = np.array(
-                self.variances, dtype=np.float64).flatten()
+            self.variances = np.array(self.variances,
+                                      dtype=np.float64).flatten()
 
             self.clip = True
             self.num_priors = len(self.real_aspect_ratios) * len(self.min_sizes)

--- a/python/paddle/fluid/tests/unittests/xpu/test_update_loss_scaling_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_update_loss_scaling_op_xpu.py
@@ -31,7 +31,7 @@ class TestUpdateLossScalingOp(XPUOpTest):
     def setUp(self):
         self.op_type = "update_loss_scaling"
         self.init()
-        found_inf = np.array([False], dtype=np.bool)
+        found_inf = np.array([False], dtype=np.bool_)
         x = np.random.random((1024, 1024)).astype(self.dtype)
 
         self.inputs = {
@@ -75,7 +75,7 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
     def setUp(self):
         self.op_type = "update_loss_scaling"
         self.init()
-        found_inf = np.array([True], dtype=np.bool)
+        found_inf = np.array([True], dtype=np.bool_)
         x = np.random.random((1024, 1024)).astype(self.dtype)
         i = np.random.randint(0, 1024, 1)
         j = np.random.randint(0, 1024, 1)

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -76,7 +76,7 @@ class _ConvNd(Layer):
                 format(valid_padding_modes, padding_mode))
 
         if padding_mode in {'reflect', 'replicate', 'circular'
-                            } and not isinstance(padding, np.int):
+                            } and not isinstance(padding, int):
             raise TypeError(
                 "when padding_mode in ['reflect', 'replicate', 'circular'], type of padding must be int"
             )

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -352,7 +352,7 @@ def to_tensor(data, dtype=None, place=None, stop_gradient=True):
             data = np.array([data])
         elif isinstance(data, (list, tuple)):
             data = np.array(data)
-            if data.dtype == np.object:
+            if data.dtype == np.object_:
                 raise ValueError(
                     "\n\tFaild to convert input data to a regular ndarray :\n\t - Usually "
                     "this means the input data contains nested lists with different lengths. "

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -430,7 +430,7 @@ def norm(x, p='fro', axis=None, keepdim=False, name=None):
         reduce_all = True if axis == None or axis == [] or asvector == True else False
         axis = axis if axis != None and axis != [] else [0]
 
-        reduce_type = 'reduce_max' if porder == np.float(
+        reduce_type = 'reduce_max' if porder == np.float64(
             'inf') else 'reduce_min'
         helper.append_op(type=reduce_type,
                          inputs={'X': out},

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -146,8 +146,8 @@ def logical_or(x, y, out=None, name=None):
             import paddle
             import numpy as np
 
-            x_data = np.array([True, False], dtype=np.bool).reshape(2, 1)
-            y_data = np.array([True, False, True, False], dtype=np.bool).reshape(2, 2)
+            x_data = np.array([True, False], dtype=np.bool_).reshape(2, 1)
+            y_data = np.array([True, False, True, False], dtype=np.bool_).reshape(2, 2)
             x = paddle.to_tensor(x_data)
             y = paddle.to_tensor(y_data)
             res = paddle.logical_or(x, y)
@@ -191,8 +191,8 @@ def logical_xor(x, y, out=None, name=None):
             import paddle
             import numpy as np
 
-            x_data = np.array([True, False], dtype=np.bool).reshape([2, 1])
-            y_data = np.array([True, False, True, False], dtype=np.bool).reshape([2, 2])
+            x_data = np.array([True, False], dtype=np.bool_).reshape([2, 1])
+            y_data = np.array([True, False, True, False], dtype=np.bool_).reshape([2, 2])
             x = paddle.to_tensor(x_data)
             y = paddle.to_tensor(y_data)
             res = paddle.logical_xor(x, y)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
`np.bool`, `np.int`, `np.float`, `np.complex`, `np.object`, `np.str`, `np.long`, `np.unicode` are deprecated. There are tons of warnings during Paddle runs, those warnings are very distracting. This PR makes following changes

* Replace `np.bool`/`np.bool8` with `np.bool_`
* Replace `np.object` with `np.object_`
* Replace `np.complex` with `np.complex128`
* Replace `np.float` with `np.float64`
* Replace `np.int` with `np.int_`

* See https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations for more details.
* Tensorflow alredy adopted the [change](https://github.com/tensorflow/tensorflow/pull/50527) last year
* Related issue: https://github.com/PaddlePaddle/Paddle/issues/41745
* Besides this PR, we should notify all developers that not to use the deprecated aliases