### PR TITLE
Use all sitepackages path as the library/include path

### DIFF
--- a/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_setup.py
+++ b/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import site
 from paddle.fluid import core
 from distutils.sysconfig import get_python_lib
 from distutils.core import setup, Extension
@@ -42,10 +43,11 @@ if core.is_compiled_with_npu():
     paddle_extra_compile_args += ['-D_GLIBCXX_USE_CXX11_ABI=0']
 
 # include path
-site_packages_path = get_python_lib()
-paddle_custom_kernel_include = [
-    os.path.join(site_packages_path, 'paddle', 'include'),
-]
+site_packages_path = site.getsitepackages()
+paddle_custom_kernel_include = list(
+    map(lambda path: os.path.join(path, 'paddle', 'include'),
+        site_packages_path))
+
 # include path third_party
 compile_third_party_path = os.path.join(os.environ['PADDLE_ROOT'],
                                         'build/third_party')
@@ -56,9 +58,8 @@ paddle_custom_kernel_include += [
 ]
 
 # libs path
-paddle_custom_kernel_library_dir = [
-    os.path.join(site_packages_path, 'paddle', 'fluid'),
-]
+paddle_custom_kernel_library_dir = list(
+    map(lambda path: os.path.join(path, 'paddle', 'fluid'), site_packages_path))
 
 # libs
 libs = [':core_avx.so']


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Original `custom_kernel_dot_setup.py` uses `distutils.sysconfig.get_python_lib` to get the paddle library/include path. But this is not Ubuntu compatible, see this [discussion](https://stackoverflow.com/a/4611382).

We met the similar issue on our container, `distutils.sysconfig.get_python_lib` didn't output the correct path. But `site.getsitepackages` can, and [test_custom_relu_op_setup.py](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/tests/custom_op/test_custom_relu_op_setup.py#L178)  uses `site.getsitepackages`  too.

Following is the difference between `distutils.sysconfig.get_python_lib` and `site.getsitepackages`. On Ubuntu, paddle is installed on `/usr/local/lib/python3.8`, but `get_python_lib()` returns `/usr/lib/python3/dist-packages`.
```bash
Python 3.8.10 (default, Mar 15 2022, 12:22:08)
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from distutils.sysconfig import get_python_lib
>>> import site
>>> get_python_lib()
'/usr/lib/python3/dist-packages'
>>> site.getsitepackages()
['/usr/local/lib/python3.8/dist-packages', '/usr/lib/python3/dist-packages', '/usr/lib/python3.8/dist-packages']
>>> import paddle
>>> paddle.__path__
['/usr/local/lib/python3.8/dist-packages/paddle']
```