### PR TITLE
Add type() interface for paddle::variant

### DIFF
--- a/paddle/utils/CMakeLists.txt
+++ b/paddle/utils/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_subdirectory(string)
-cc_test(small_vector_test SRCS small_vector_test.cc DEPS gtest gflags)
+
 cc_test(array_ref_test SRCS array_ref_test.cc DEPS gtest gflags)
+cc_test(small_vector_test SRCS small_vector_test.cc DEPS gtest gflags)
+cc_test(variant_test SRCS variant_test.cc DEPS gtest)

--- a/paddle/utils/variant_test.cc
+++ b/paddle/utils/variant_test.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/utils/variant.h"
+
+#include <string>
+#include <vector>
+#include "gtest/gtest.h"
+#include "paddle/phi/core/enforce.h"
+
+TEST(interface_test, type) {
+  using phi::enforce::demangle;
+
+  paddle::variant<bool, int, float, std::string, std::vector<int>> var;
+
+  var = true;
+  EXPECT_EQ(demangle(var.type().name()), "bool");
+
+  var = 0;
+  EXPECT_EQ(demangle(var.type().name()), "int");
+
+  var = 0.f;
+  EXPECT_EQ(demangle(var.type().name()), "float");
+
+  var = std::string();
+  EXPECT_EQ(demangle(var.type().name()),
+            "std::__cxx11::basic_string<char, std::char_traits<char>, "
+            "std::allocator<char> >");
+
+  var = std::vector<int>();
+  EXPECT_EQ(demangle(var.type().name()),
+            "std::vector<int, std::allocator<int> >");
+}

--- a/paddle/utils/variant_test.cc
+++ b/paddle/utils/variant_test.cc
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 #include "paddle/utils/variant.h"
-
-#include <string>
-#include <vector>
 #include "gtest/gtest.h"
 #include "paddle/phi/core/enforce.h"
 
 TEST(interface_test, type) {
   using phi::enforce::demangle;
 
-  paddle::variant<bool, int, float, std::string, std::vector<int>> var;
+  paddle::variant<bool, int, float> var;
 
   var = true;
   EXPECT_EQ(demangle(var.type().name()), "bool");
@@ -32,13 +29,4 @@ TEST(interface_test, type) {
 
   var = 0.f;
   EXPECT_EQ(demangle(var.type().name()), "float");
-
-  var = std::string();
-  EXPECT_EQ(demangle(var.type().name()),
-            "std::__cxx11::basic_string<char, std::char_traits<char>, "
-            "std::allocator<char> >");
-
-  var = std::vector<int>();
-  EXPECT_EQ(demangle(var.type().name()),
-            "std::vector<int, std::allocator<int> >");
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
Add type() interface for paddle::variant, example:
```C++
#include <iostream>
#include "paddle/phi/core/enforce.h"
#include "paddle/utils/variant.h"

int main() {
  using phi::enforce::demangle;

  paddle::variant<bool, int, float> var;

  var = true;
  std::cout << demangle(var.type().name()) << std::endl; // print "bool"

  var = 0;
  std::cout << demangle(var.type().name()) << std::endl; // print "int"

  var = 0.f;
  std::cout << demangle(var.type().name()) << std::endl; // print "float"

  return 0;
}
```
