### PR TITLE
delete id 0

### DIFF
--- a/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
@@ -103,12 +103,12 @@ __global__ void dy_mf_search_kernel(Table* table,
       cur->cpu_ptr = input.cpu_ptr;
       cur->delta_score = input.delta_score;
       cur->lr_g2sum = input.lr_g2sum;
-      for(int j = 0; j < cur->mf_dim + 1; ++j) {
-         cur->mf[j] = input.mf[j];
+      for (int j = 0; j < cur->mf_dim + 1; ++j) {
+        cur->mf[j] = input.mf[j];
       }
     } else {
       if (keys[i] != 0) {
-        printf("yxf::pull miss key: %d",keys[i]);
+        printf("yxf::pull miss key: %d", keys[i]);
       }
       FeatureValue* cur = (FeatureValue*)(vals + i * pull_feature_value_size);
       cur->delta_score = 0;

--- a/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
@@ -108,7 +108,7 @@ __global__ void dy_mf_search_kernel(Table* table,
       }
     } else {
       if (keys[i] != 0) {
-        printf("yxf::pull miss key: %d", keys[i]);
+        printf("warning::pull miss key: %d", keys[i]);
       }
       FeatureValue* cur = (FeatureValue*)(vals + i * pull_feature_value_size);
       cur->delta_score = 0;
@@ -156,7 +156,7 @@ __global__ void dy_mf_update_kernel(Table* table,
       sgd.dy_mf_update_value(optimizer_config, (it.getter())->second, *cur);
     } else {
       if (keys[i] != 0) {
-        printf("yxf::push miss key: %d", keys[i]);
+        printf("warning::push miss key: %d", keys[i]);
       }
     }
   }

--- a/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
+++ b/paddle/fluid/framework/fleet/heter_ps/hashtable_kernel.cu
@@ -103,8 +103,25 @@ __global__ void dy_mf_search_kernel(Table* table,
       cur->cpu_ptr = input.cpu_ptr;
       cur->delta_score = input.delta_score;
       cur->lr_g2sum = input.lr_g2sum;
-      for (int j = 0; j < cur->mf_dim + 1; ++j) {
-        cur->mf[j] = input.mf[j];
+      for(int j = 0; j < cur->mf_dim + 1; ++j) {
+         cur->mf[j] = input.mf[j];
+      }
+    } else {
+      if (keys[i] != 0) {
+        printf("yxf::pull miss key: %d",keys[i]);
+      }
+      FeatureValue* cur = (FeatureValue*)(vals + i * pull_feature_value_size);
+      cur->delta_score = 0;
+      cur->show = 0;
+      cur->clk = 0;
+      cur->slot = -1;
+      cur->lr = 0;
+      cur->lr_g2sum = 0;
+      cur->mf_size = 0;
+      cur->mf_dim = 8;
+      cur->cpu_ptr;
+      for (int j = 0; j < cur->mf_dim + 1; j++) {
+        cur->mf[j] = 0;
       }
     }
   }
@@ -138,7 +155,9 @@ __global__ void dy_mf_update_kernel(Table* table,
       FeaturePushValue* cur = (FeaturePushValue*)(grads + i * grad_value_size);
       sgd.dy_mf_update_value(optimizer_config, (it.getter())->second, *cur);
     } else {
-      printf("warning: push miss key: %d", keys[i]);
+      if (keys[i] != 0) {
+        printf("yxf::push miss key: %d", keys[i]);
+      }
     }
   }
 }

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
@@ -234,13 +234,8 @@ void PSGPUWrapper::PreBuildTask(std::shared_ptr<HeterContext> gpu_task) {
   VLOG(0) << "GpuPs task unique cost " << timeline.ElapsedSec() << " seconds.";
   for (int i = 0; i < thread_keys_shard_num_; i++) {
     for (int j = 0; j < multi_mf_dim_; j++) {
-      if (i == 0 && j == multi_mf_dim_ - 1) {
-        gpu_task->feature_dim_keys_[i][j].push_back(0);
-      }
       VLOG(0) << "GpuPs shard: " << i << "mf dim: " << index_dim_vec_[j]
               << " key len: " << gpu_task->feature_dim_keys_[i][j].size();
-      gpu_task->value_dim_ptr_[i][j].resize(
-          gpu_task->feature_dim_keys_[i][j].size());
     }
   }
 }

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.cc
@@ -236,6 +236,8 @@ void PSGPUWrapper::PreBuildTask(std::shared_ptr<HeterContext> gpu_task) {
     for (int j = 0; j < multi_mf_dim_; j++) {
       VLOG(0) << "GpuPs shard: " << i << "mf dim: " << index_dim_vec_[j]
               << " key len: " << gpu_task->feature_dim_keys_[i][j].size();
+      gpu_task->value_dim_ptr_[i][j].resize(
+          gpu_task->feature_dim_keys_[i][j].size());
     }
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
delete id 0 in gpups, we set id 0's embedding to default value while pull sparse in gpups instead of keep a kv pair of id 0