### PR TITLE
limit windows minimum protobuf version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,7 @@
 requests>=2.20.0
 numpy>=1.13
-protobuf>=3.1.0, <=3.20.0
+protobuf>=3.1.0, <=3.20.0 ; platform_system != "Windows"
+protobuf>=3.17.0, <=3.20.0 ; platform_system == "Windows"
 Pillow
 six
 decorator


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

PR https://github.com/PaddlePaddle/Paddle/pull/41201 导致windows系统上，protobuf版本低于3.17时，会报字符集的bug。对windows系统的protobuf版本做了限制。
