### PR TITLE
[Dy2St]Fix cond_block_grad error when handle no need grad vras

### DIFF
--- a/paddle/fluid/operators/controlflow/conditional_block_op.cc
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.cc
@@ -182,8 +182,8 @@ class ConditionalBlockGradOp : public ConditionalOp {
       framework::Variable *inside_var =
           cur_scope.FindLocalVar(inside_grad_name);
       if (inside_var == nullptr) {
-        assign_zero_outside_grads.push_back(outside_grad_name);
-        assign_zero_inputs.push_back(inputs[i]);
+        assign_zero_outside_grads.emplace_back(outside_grad_name);
+        assign_zero_inputs.emplace_back(inputs[i]);
         continue;
       }
       platform::DeviceContext *dev_ctx =
@@ -191,6 +191,8 @@ class ConditionalBlockGradOp : public ConditionalOp {
       framework::VisitVarType(*inside_var,
                               AssignFunctor(outside_var, *dev_ctx));
     }
+    // Assign zero to the grad_vars that are in outside_grads but not in
+    // inside_grads
     AssignZeroToParentScope(place, parent_scope, assign_zero_inputs,
                             assign_zero_outside_grads);
   }

--- a/paddle/fluid/operators/controlflow/conditional_block_op.cc
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.cc
@@ -153,7 +153,7 @@ class ConditionalBlockGradOp : public ConditionalOp {
                /* keep_kid_scopes */ false);
 
       AssignLocalGradientToParentScope(dev_place, cur_scope, scope,
-                                       inside_grads, outside_grads);
+                                       inside_grads, outside_grads, inputs);
       return;
     }
 
@@ -165,20 +165,25 @@ class ConditionalBlockGradOp : public ConditionalOp {
       const platform::Place &place, const framework::Scope &cur_scope,
       const framework::Scope &parent_scope,
       const std::vector<std::string> &inside_grads,
-      const std::vector<std::string> &outside_grads) const {
+      const std::vector<std::string> &outside_grads,
+      const std::vector<std::string> &inputs) const {
+    std::vector<std::string> assign_zero_outside_grads;
+    std::vector<std::string> assign_zero_inputs;
     for (size_t i = 0; i < outside_grads.size(); ++i) {
       const std::string &outside_grad_name = outside_grads[i];
       const std::string &inside_grad_name = inside_grads[i];
       VLOG(4) << "inside_grad_name = " << inside_grad_name
               << ", outside_grad_name = " << outside_grad_name;
-      framework::Variable *inside_var =
-          cur_scope.FindLocalVar(inside_grad_name);
-      if (inside_var == nullptr) {
-        continue;
-      }
       framework::Variable *outside_var =
           parent_scope.FindVar(outside_grad_name);
       if (outside_var == nullptr) {
+        continue;
+      }
+      framework::Variable *inside_var =
+          cur_scope.FindLocalVar(inside_grad_name);
+      if (inside_var == nullptr) {
+        assign_zero_outside_grads.push_back(outside_grad_name);
+        assign_zero_inputs.push_back(inputs[i]);
         continue;
       }
       platform::DeviceContext *dev_ctx =
@@ -186,6 +191,8 @@ class ConditionalBlockGradOp : public ConditionalOp {
       framework::VisitVarType(*inside_var,
                               AssignFunctor(outside_var, *dev_ctx));
     }
+    AssignZeroToParentScope(place, parent_scope, assign_zero_inputs,
+                            assign_zero_outside_grads);
   }
 
   void AssignZeroToParentScope(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
这个问题是在套件中ppyoloe模型中报出，排查后尝试使用demo进行了复现
#### 复现case：
```
import paddle

class Net(paddle.nn.Layer):
    def __init__(self):
        super(Net, self).__init__()
        self.param = self.create_parameter(
            shape=[3, 2],
            dtype='float32',
            is_bias=False)
    @paddle.jit.to_static
    def forward(self, a, b, c):
        a = paddle.matmul(a, self.param)
        cond = paddle.to_tensor([10])
        # import pdb; pdb.set_trace()
        a = paddle.reshape(a, (2, 4))
        if cond == 10:
            tmp = a.argmax(axis=-1)
            b = b + self.param
        else:
            print(c)
        return b

a = paddle.randn((4, 3), dtype='float32')
a.stop_gradient = False
b = paddle.to_tensor([10])
b.stop_gradient = False
c = paddle.to_tensor([2])
c.stop_gradient = False

net = Net()
net.train()
out = net(a, b, c)
out.backward()
print(out)
```

#### 报错分析
报错信息：
![image](https://user-images.githubusercontent.com/23097963/170647322-fef8791d-121a-45b8-8128-2013f5c2ed4f.png)
打印program，报错信息中未初始化var应该是`reshape2_0.tmp_0@GRAD`，后面reshape_grad时报出该var没有被初始化。这个var是的conditional_block_grad计算得到的对应的sublock是4号，但是block4中并没有做`reshape2_0.tmp_0@GRAD`的计算。
```
{Input@GRAD=['net_0.w_0@GRAD@RENAME@block0@0', 'reshape2_0.tmp_0@GRAD', 'generated_tensor_0@GRAD@RENAME@block0@1']} = conditional_block_grad(inputs={Cond=['tmp_1'], Input=['net_0.w_0', 'reshape2_0.tmp_0', 'generated_tensor_0'], Out=['_generated_var_0'], Out@GRAD=['_generated_var_0@GRAD'], Scope=['_generated_var_1']}, is_scalar_condition = True, op_device = , op_role = 1, sub_block = block[4])
```
![image](https://user-images.githubusercontent.com/23097963/170647511-6815eb53-da4b-44eb-9baa-0dc1a58ae0df.png)
为什么block0中有`reshape2_0.tmp_0@GRAD`这个var，但是反向的block4中没有计算这个var呢？在反向_append_backward_ops_的逻辑中会找到`sub_block_path`表示sub_block中需要求导op的路径，在block1中可以看到`reshape2_0.tmp_0`在arg_max之后其输出var `argmax_0.tmp_0`的stop_gradient属性是True，那么对于`argmax_0.tmp_0`和`reshape2_0.tmp_0`应该是不需要求导的，arg_max这个op应该不会在`sub_block_path`中，所以block4中也就不会对`reshape2_0.tmp_0`进行求导，即不会计算`reshape2_0.tmp_0@GRAD`。
那按理说在block0中也不不应该存在`reshape2_0.tmp_0@GRAD`这个var呀，为什么还是会有呢？`no_grad_dict`中对于不需要求导var的分析似乎有点问题？`reshape2_0.tmp_0`应该存在于这个dict中（把`reshape2_0.tmp_0`放到`no_grad_dict`似乎也不合理，因为在block0中`reshape2_0.tmp_0`的stop_gradient=False），然后调用`get_grad_op_desc`生成反向op_desc是将`reshape2_0.tmp_0@GRAD`对应位置的Input@GRAD用@EMPTY@代替。但是`reshape2_0.tmp_0`并不在`no_grad_dict`中，导致生成反向op的时候没有用@EMPTY@进行替换。
![image](https://user-images.githubusercontent.com/23097963/170647668-0a143da4-652e-4d0b-abd6-b7dabb9fe330.png)

#### 修复
尝试修改`_append_backward_ops_`中`sub_block_path`和`no_grad_dict`的处理逻辑，阅读相关代码后发现修改这部分的逻辑有些困难。于是转而修改cond_block_grad计算后返回的逻辑，cond_block_grad计算逻辑最后会调用`AssignLocalGradientToParentScope`将`sub_block`的grad_var拷贝到`parent_block`，我们只需要将在`AssignLocalGradientToParentScope`中找到`parent_block`需要计算反向的grad_var，但是在`sub_block`却没有计算，将这些grad_var赋值为0。

