### PR TITLE
[Eager] Support EagerParamBase init by 'shape'(Tensor)

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -6619,6 +6619,9 @@ class EagerParamBase(_core_eager_eagertensor):
 
         name = kwargs.get('name', unique_name.generate('_eager_param_base'))
 
+        if isinstance(shape, core.eager.Tensor):
+            shape = shape.numpy()
+
         super(EagerParamBase, self).__init__(
             dtype if dtype else core.VarDesc.VarType.FP32,
             list(shape)

--- a/python/paddle/fluid/tests/unittests/test_egr_python_api.py
+++ b/python/paddle/fluid/tests/unittests/test_egr_python_api.py
@@ -279,6 +279,16 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
                 "The type of trainable MUST be bool, but the type is /*"):
             eager_param.trainable = "False"
 
+        eager_param_2 = EagerParamBase(
+            shape=paddle.shape(paddle.to_tensor([1, 2, 3, 4])), dtype="float32")
+        self.assertTrue(eager_param_2.trainable)
+        eager_param_2.trainable = False
+        self.assertFalse(eager_param_2.trainable)
+        with self.assertRaisesRegexp(
+                ValueError,
+                "The type of trainable MUST be bool, but the type is /*"):
+            eager_param_2.trainable = "False"
+
     def test_constructor(self):
         print("Test_constructor")
         paddle.set_device("cpu")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复 PaddleSeg 套件 ginet 系列模型传入 shape(Tensor) 调用 create_parameter() 在 EagerParamBase进行构造时报错的问题