### PR TITLE
[Phi] Polish assign kernel copy impl

### DIFF
--- a/paddle/phi/kernels/assign_kernel.cc
+++ b/paddle/phi/kernels/assign_kernel.cc
@@ -26,7 +26,7 @@ template <typename Context>
 void AssignKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   DenseTensor* out) {
-  paddle::framework::TensorCopy(x, x.place(), dev_ctx, out);
+  paddle::framework::TensorCopy(x, x.place(), out);
 }
 
 template <typename Context>

--- a/paddle/phi/kernels/assign_kernel.cc
+++ b/paddle/phi/kernels/assign_kernel.cc
@@ -26,7 +26,7 @@ template <typename Context>
 void AssignKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   DenseTensor* out) {
-  Copy<Context>(dev_ctx, x, x.place(), false, out);
+  paddle::framework::TensorCopy(x, x.place(), dev_ctx, out);
 }
 
 template <typename Context>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

[Phi] Polish assign kernel copy impl

assign kernel在复用Copy时，在异构设备下的一些情况会出现错误，例如，x是xpu tensor时，加入assign找不到xpu kernel，会fallback到CPU kernel，但assign会跳过x的place转换，直接交给kernel负责，所以，xpu的x输入会传入到cpu kernel中，此时，context参数是CPUContext，因此会分发到CPU Copy kernel，而CPU copy kernel无法处理xpu tensor的输入，因此这里还是需要调用原先的TensorCopy方法，临时修复此问题

后续phi下面的copy kernel会改为公共组件形式，copy kernel按需封装为更具体的kernel