### PR TITLE
[Eager] Polish append op using for model perf

### DIFF
--- a/paddle/fluid/pybind/op_function_generator.h
+++ b/paddle/fluid/pybind/op_function_generator.h
@@ -119,6 +119,11 @@ std::map<std::string, std::set<std::string>> op_ins_map = {
      {"X", "Scale", "Bias", "Mean", "Variance", "MomentumTensor"}},
     {"inplace_abn",
      {"X", "Scale", "Bias", "Mean", "Variance", "MomentumTensor"}},
+    {"linear_interp", {"X", "OutSize"}},
+    {"bilinear_interp", {"X", "OutSize"}},
+    {"trilinear_interp", {"X", "OutSize"}},
+    {"nearest_interp", {"X", "OutSize"}},
+    {"bicubic_interp", {"X", "OutSize"}},
 };
 
 // NOTE(zhiqiu): Like op_ins_map.
@@ -259,6 +264,7 @@ std::map<std::string, std::set<std::string>> op_passing_outs_map = {
     {"split", {"Out"}},
     {"concat", {"Out"}},
     {"fused_multi_transformer", {"CacheKVOut"}},
+    {"group_norm", {"Mean", "Variance"}},
 };
 
 // NOTE(pangyoki): Tensor View Strategy.

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -3016,9 +3016,15 @@ class GroupNorm(layers.Layer):
             is_bias=True)
 
     def forward(self, input):
-        if in_dygraph_mode():
+        mean_out = self._helper.create_variable_for_type_inference(
+            dtype=self._dtype, stop_gradient=True)
+        variance_out = self._helper.create_variable_for_type_inference(
+            dtype=self._dtype, stop_gradient=True)
+
+        if _non_static_mode():
             attrs = ('epsilon', self._epsilon, 'groups', self._groups)
-            out, _, _ = _C_ops.group_norm(input, self.weight, self.bias, *attrs)
+            out, _, _ = _C_ops.group_norm(input, self.weight, self.bias,
+                                          mean_out, variance_out, *attrs)
 
             return dygraph_utils._append_activation_in_dygraph(out, self._act)
         else:
@@ -3029,10 +3035,6 @@ class GroupNorm(layers.Layer):
                 inputs['Scale'] = self.weight
 
             # create output
-            mean_out = self._helper.create_variable_for_type_inference(
-                dtype=self._dtype, stop_gradient=True)
-            variance_out = self._helper.create_variable_for_type_inference(
-                dtype=self._dtype, stop_gradient=True)
             group_norm_out = self._helper.create_variable_for_type_inference(
                 dtype=self._dtype)
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3600,6 +3600,10 @@ class Block(object):
             attrs = kwargs.get("attrs", {})
             inplace_map = kwargs.get("inplace_map", None)
             type = kwargs.get("type", None)
+            warnings.warn(
+                "Op `%s` is executed through `append_op` under the dynamic mode, "
+                "the corresponding API implementation needs to be upgraded to "
+                "using `_C_ops` method." % type, DeprecationWarning)
             op = Operator(
                 block=self,
                 desc=None,

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7902,15 +7902,15 @@ def image_resize(input,
         dy_attr = tuple(attr_list)
 
         if resample_type == "linear":
-            out = _C_ops.linear_interp(x, actual_shape, *dy_attr)
+            out = _C_ops.linear_interp(input, actual_shape, *dy_attr)
         elif resample_type == "bilinear":
-            out = _C_ops.bilinear_interp(x, actual_shape, *dy_attr)
+            out = _C_ops.bilinear_interp(input, actual_shape, *dy_attr)
         elif resample_type == "trilinear":
-            out = _C_ops.trilinear_interp(x, actual_shape, *dy_attr)
+            out = _C_ops.trilinear_interp(input, actual_shape, *dy_attr)
         elif resample_type == "nearest":
-            out = _C_ops.nearest_interp(x, actual_shape, *dy_attr)
+            out = _C_ops.nearest_interp(input, actual_shape, *dy_attr)
         elif resample_type == "bicubic":
-            out = _C_ops.bicubic_interp(x, actual_shape, *dy_attr)
+            out = _C_ops.bicubic_interp(input, actual_shape, *dy_attr)
         return out
 
     out = helper.create_variable_for_type_inference(dtype)

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7793,10 +7793,18 @@ def image_resize(input,
     }
 
     if out_shape is not None:
-        if isinstance(out_shape, Variable):
+        if isinstance(out_shape, Variable) and not _non_static_mode():
             out_shape.stop_gradient = True
             inputs['OutSize'] = out_shape
         else:
+            if _non_static_mode():
+                if isinstance(out_shape, Variable):
+                    out_shape = list(out_shape.numpy())
+                else:
+                    out_shape = list(out_shape)
+                for i, dim in enumerate(out_shape):
+                    if isinstance(dim, Variable):
+                        out_shape[i] = dim.numpy()[0]
             if not (_is_list_or_turple_(out_shape)):
                 raise TypeError(
                     "out_shape should be a list or tuple or Variable.")
@@ -7863,7 +7871,9 @@ def image_resize(input,
                     attrs['out_w'] = out_shape[2]
 
     else:
-        if isinstance(scale, Variable):
+        if _non_static_mode() and isinstance(scale, Variable):
+            scale = scale.numpy()
+        elif isinstance(scale, Variable):
             scale.stop_gradient = True
             inputs["Scale"] = scale
         elif isinstance(scale, float) or isinstance(scale, int):
@@ -7883,6 +7893,26 @@ def image_resize(input,
         inputs["OutSize"] = actual_shape
     elif actual_shape is not None:
         raise TypeError("actual_shape should either be Variable or None.")
+
+    if _non_static_mode():
+        attr_list = []
+        for k, v in attrs.items():
+            attr_list.append(k)
+            attr_list.append(v)
+        dy_attr = tuple(attr_list)
+
+        if resample_type == "linear":
+            out = _C_ops.linear_interp(x, actual_shape, *dy_attr)
+        elif resample_type == "bilinear":
+            out = _C_ops.bilinear_interp(x, actual_shape, *dy_attr)
+        elif resample_type == "trilinear":
+            out = _C_ops.trilinear_interp(x, actual_shape, *dy_attr)
+        elif resample_type == "nearest":
+            out = _C_ops.nearest_interp(x, actual_shape, *dy_attr)
+        elif resample_type == "bicubic":
+            out = _C_ops.bicubic_interp(x, actual_shape, *dy_attr)
+        return out
+
     out = helper.create_variable_for_type_inference(dtype)
     helper.append_op(
         type='{}_interp'.format(resample_type),

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -681,14 +681,19 @@ def assign(input, output=None):
                              "saving it to file and 'load_op' to load it")
         if output is None:
             output = helper.create_variable_for_type_inference(dtype=dtype)
-        helper.append_op(
-            type='assign_value',
-            outputs={'Out': [output]},
-            attrs={
-                'dtype': dtype,
-                'shape': list(input.shape),
-                value_name: values
-            })
+        if _non_static_mode():
+            _C_ops.assign_value(output, 'shape',
+                                list(input.shape), 'dtype', dtype, value_name,
+                                values)
+        else:
+            helper.append_op(
+                type='assign_value',
+                outputs={'Out': [output]},
+                attrs={
+                    'dtype': dtype,
+                    'shape': list(input.shape),
+                    value_name: values
+                })
 
     if is_inplace and _non_static_mode():
         output._bump_inplace_version()

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1568,14 +1568,19 @@ def assign(x, output=None):
         if output is None:
             output = helper.create_variable_for_type_inference(
                 dtype=input.dtype)
-        helper.append_op(
-            type='assign_value',
-            outputs={'Out': [output]},
-            attrs={
-                'dtype': dtype,
-                'shape': list(input.shape),
-                value_name: values
-            })
+        if _non_static_mode():
+            _C_ops.assign_value(output, 'shape',
+                                list(input.shape), 'dtype', dtype, value_name,
+                                values)
+        else:
+            helper.append_op(
+                type='assign_value',
+                outputs={'Out': [output]},
+                attrs={
+                    'dtype': dtype,
+                    'shape': list(input.shape),
+                    value_name: values
+                })
 
     if is_inplace and _in_legacy_dygraph():
         output._bump_inplace_version()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

[Eager] Polish append op using for model perf

新动态图兼容适配老动态图的append_op行为时，采用了在运行时生成代码并执行的方式，因此耗时较长，事实上部分模型套件中使用append op路径的接口导致新动态图性能相比老动态图出现了明显下降

![image](https://user-images.githubusercontent.com/22561442/171082454-4e188fb2-cd14-441e-ae14-0f53bae49560.png)
![image](https://user-images.githubusercontent.com/22561442/171087897-2ce93226-f88d-472f-899c-31771b2ab3f6.png)


经过排查，发现以下几个使用了append op的算子，本PR将其升级改为使用core.ops

* fcos/solov2/gfl：group_norm
* fomm：nearest_interp/assign_value

其中nearest_interp是fluid的废弃接口，本不需要升级，但GAN模型使用了该fluid接口，暂时不能直接修改模型代码，因此仍然对它进行了升级

升级后以上4个模型新动态图性能均能追平或超越老动态图

此外，为append op在动态图下的使用添加了warning，便于之后分析时发现此类问题