### PR TITLE
Fix bug of CUDAGraph kernel parameter comparation

### DIFF
--- a/paddle/fluid/platform/device/gpu/cuda/cuda_graph.h
+++ b/paddle/fluid/platform/device/gpu/cuda/cuda_graph.h
@@ -69,8 +69,7 @@ struct IsSameKernelHelper<Return (*)(FuncArgs...), kernel_fn> {
         return false;
       }
 
-      constexpr auto NewIsEnd =
-          (IDX + 1 == sizeof(std::tuple_size<TupleT>::value));
+      constexpr auto NewIsEnd = (IDX + 1 == std::tuple_size<TupleT>::value);
       return Impl<TupleT, IDX + 1, NewIsEnd>::Compare(params, args);
     }
   };

--- a/paddle/fluid/platform/device/gpu/cuda/cuda_graph.h
+++ b/paddle/fluid/platform/device/gpu/cuda/cuda_graph.h
@@ -60,10 +60,12 @@ template <typename Return, typename... FuncArgs,
           Return (*kernel_fn)(FuncArgs...)>
 struct IsSameKernelHelper<Return (*)(FuncArgs...), kernel_fn> {
  private:
+  using FuncArgsTuple = decltype(std::make_tuple(std::declval<FuncArgs>()...));
+
   template <typename TupleT, size_t IDX, bool IsEnd /*=false*/>
   struct Impl {
     static bool Compare(const CUDAKernelParams &params, const TupleT &args) {
-      using CompareT = typename std::tuple_element<IDX, TupleT>::type;
+      using CompareT = typename std::tuple_element<IDX, FuncArgsTuple>::type;
       if (!IsBitwiseEqual<CompareT>(params.As<CompareT>(IDX),
                                     std::get<IDX>(args))) {
         return false;
@@ -82,8 +84,6 @@ struct IsSameKernelHelper<Return (*)(FuncArgs...), kernel_fn> {
   };
 
  public:
-  using FuncArgsTuple = decltype(std::make_tuple(std::declval<FuncArgs>()...));
-
   template <typename... Args>
   static bool Compare(const CUDAKernelParams &params, Args... args) {
     constexpr auto kNumArgs = sizeof...(FuncArgs);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix the bug when comparing the kernel parameter in CUDAGraph nodes. It should use `std::tuple_size<TupleT>::value` instead of `sizeof(std::tuple_size<TupleT>::value)` . Related to https://github.com/PaddlePaddle/Paddle/pull/42786 .