### PR TITLE
Correct skip_quant condition

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/compute_propagate_scales_mkldnn_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/compute_propagate_scales_mkldnn_pass.cc
@@ -347,9 +347,9 @@ std::unordered_set<std::string> ComputePropagateScalesMkldnnPass::UpdateScales(
         waiting_for_scale.insert(input_name);
         waiting_for_scale.insert(output_name);
       } else if (in_iter != var_quant_scales->end()) {
-        out_iter->second = in_iter->second;
+        (*var_quant_scales)[output_name] = in_iter->second;
       } else if (out_iter != var_quant_scales->end()) {
-        in_iter->second = out_iter->second;
+        (*var_quant_scales)[input_name] = out_iter->second;
       }
     } else if (op_name == "scale") {
       const std::string output_name = op_node->Op()->Output("Out")[0];

--- a/paddle/fluid/framework/ir/mkldnn/quant_dequant_mkldnn_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/quant_dequant_mkldnn_pass.cc
@@ -36,7 +36,7 @@ void QuantDequantMkldnnPass::MarkSkipQuantizedOps(
         for (auto* node_input : op_node->inputs) {
           for (auto* node_input_input : node_input->inputs) {
             if (!node_input_input->IsOp()) continue;
-            if (node_input_input->Name().find("quantize_dequantize") ==
+            if (node_input_input->Name().find("quantize") ==
                 std::string::npos) {
               is_quantized_op = false;
               break;

--- a/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
@@ -158,7 +158,7 @@ class Quant2Int8MkldnnPass(object):
                 is_quantized_op = True
                 for var_node in op_node.inputs:
                     for front_op_node in var_node.inputs:
-                        if "quantize_dequantize" not in front_op_node.name():
+                        if "quantize" not in front_op_node.name():
                             is_quantized_op = False
                 if not is_quantized_op:
                     op_node.op()._set_attr("skip_quant", True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
In quant-aware quantization when there is no quantization_type there is condition to check if before operator is `quantize-dequantize` op, if not op is not quantize. Some old QAT models have no quantization_type but has `fake_quantize` op before operator (picture below)  and this should be quantized. This PR changes this condition to work for all models. 
![image](https://user-images.githubusercontent.com/33838455/171639630-4d68f8dc-cf82-4bd7-8b6b-035c53dee94c.png)
