### PR TITLE
【code format check upgrade】 step3：revert modification to paddle_build.sh

### DIFF
--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -16,25 +16,29 @@ limitations under the License. */
 // https://github.com/NVIDIA/FasterTransformer/blob/v4.0/fastertransformer/cuda/masked_multihead_attention.cu
 // We add License in the head.
 
+// headers sort by clang-format may cause compiling error or test faiure,
+// see https://github.com/PaddlePaddle/Paddle/pull/42840/
+// clang-format off
 #include <cuda_fp16.h>
 #include <float.h>
-
 #include <cub/cub.cuh>
-
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/platform/device/gpu/gpu_device_function.h"
+#include "paddle/fluid/platform/device/gpu/gpu_dnn.h"
+
+#include "paddle/phi/kernels/funcs/math_function.h"
+
 #include "paddle/fluid/operators/fused/attention_layer_norm.h"
 #include "paddle/fluid/operators/fused/attn_gemm.h"
 #include "paddle/fluid/operators/fused/fmha_ref.h"
 #include "paddle/fluid/operators/fused/fused_dropout_helper.h"
-#include "paddle/fluid/platform/device/gpu/gpu_device_function.h"
-#include "paddle/fluid/platform/device/gpu/gpu_dnn.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
 #include "paddle/fluid/platform/collective_helper.h"
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"
 #endif
+// clang-format on
 
 namespace paddle {
 namespace operators {

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1130,8 +1130,7 @@ EOF
 function check_diff_file_for_coverage() {
     diff_h_file=$(git diff --name-status test develop | awk '$1 != "D" {print $2}' | grep '\.h$' | awk -F "/" '{printf "%s,",$NF}')
     diff_cc_file=$(git diff --name-status test develop | awk '$1 != "D" {print $2}' | grep -E '\.(cc|c)$' | awk -F "/" '{printf "%s,",$NF}')
-    #diff_py_file=$(git diff --name-status test develop | grep '\.py$' | awk '$1 != "D" {printf "%s,",$2}')
-    diff_py_file='tools/test_sampcd_processor.py,tools/timeline.py'
+    diff_py_file=$(git diff --name-status test develop | grep '\.py$' | awk '$1 != "D" {printf "%s,",$2}')
     export PADDLE_GIT_DIFF_H_FILE=${diff_h_file%*,}
     export PADDLE_GIT_DIFF_CC_FILE=${diff_cc_file%*,}
     export PADDLE_GIT_DIFF_PY_FILE=${diff_py_file%*,}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
revert modification for format PR passing CI; not sort headers for windows CI test failed.
- modification in paddle_build.sh, see PR #42944 
- window CI test failed: test_fused_multi_transformer_op
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/51314274/172033842-3b2c7c28-97c3-4207-8735-b18817518f20.png">
it may due to headers sort, while i'm not sure.
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/51314274/172033871-43fae18e-1273-4266-9c3c-bd2cc25fe1e2.png">
