### PR TITLE
[NPU] fix reduce_max_grad

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_max_op_npu.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_max_op_npu.cc
@@ -141,6 +141,9 @@ class ReduceMaxGradNPUKernel : public framework::OpKernel<T> {
     Tensor tmp_out, tmp_out_grad;
     auto tmp_out_dims_vec = x_dims_vec;
     for (auto d : reduce_dims) {
+      if (d < 0) {
+        d += x_dims_vec.size();
+      }
       tmp_out_dims_vec[d] = 1;
     }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
OPs

### Describe
In reduce_max_grad, reduce_dims can be {-1} when called by paddle.maximum():
<img width="736" alt="5622d6c5f317f1dea7804c3862caf148" src="https://user-images.githubusercontent.com/5997715/172121841-3be13b65-8d66-4791-b06d-ed15dcb53c66.png">
