### PR TITLE
[GPUPS]set sparse shard num from config_fleet.py

### DIFF
--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
@@ -254,6 +254,10 @@ class PSGPUWrapper {
                     float mf_initial_g2sum, float mf_initial_range,
                     float mf_min_bound, float mf_max_bound);
   void InitializeGPUServer(std::unordered_map<std::string, float> config) {
+    // set sparse shard num
+    int sparse_shard_num = (config.find("sparse_shard_num") == config.end()) ? 37: config["sparse_shard_num"];
+    thread_keys_shard_num_ = sparse_shard_num;
+    VLOG(0) << "GPUPS set sparse shard num: " << thread_keys_shard_num_;
     float nonclk_coeff = (config.find("nonclk_coeff") == config.end())
                              ? 1.0
                              : config["nonclk_coeff"];

--- a/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
+++ b/paddle/fluid/framework/fleet/ps_gpu_wrapper.h
@@ -254,6 +254,12 @@ class PSGPUWrapper {
                     float mf_initial_g2sum, float mf_initial_range,
                     float mf_min_bound, float mf_max_bound);
   void InitializeGPUServer(std::unordered_map<std::string, float> config) {
+    // set sparse shard num
+    int sparse_shard_num = (config.find("sparse_shard_num") == config.end())
+                               ? 37
+                               : config["sparse_shard_num"];
+    thread_keys_shard_num_ = sparse_shard_num;
+    VLOG(0) << "GPUPS set sparse shard num: " << thread_keys_shard_num_;
     float nonclk_coeff = (config.find("nonclk_coeff") == config.end())
                              ? 1.0
                              : config["nonclk_coeff"];

--- a/paddle/fluid/framework/ps_gpu_trainer.cc
+++ b/paddle/fluid/framework/ps_gpu_trainer.cc
@@ -238,6 +238,7 @@ void PSGPUTrainer::InitializeGPUServer(const TrainerDesc& trainer_desc) {
     add_sparse_optimizer(config, sparse_table_accessor.embedx_sgd_param(),
                          "mf_");
   }
+  config["sparse_shard_num"] = sparse_table.shard_num();
   auto ps_gpu_wrapper = paddle::framework::PSGPUWrapper::GetInstance();
   ps_gpu_wrapper->InitializeGPUServer(config);
 }

--- a/paddle/fluid/framework/ps_gpu_trainer.cc
+++ b/paddle/fluid/framework/ps_gpu_trainer.cc
@@ -238,6 +238,8 @@ void PSGPUTrainer::InitializeGPUServer(const TrainerDesc& trainer_desc) {
     add_sparse_optimizer(config, sparse_table_accessor.embedx_sgd_param(),
                          "mf_");
   }
+  
+  config["sparse_shard_num"] = sparse_table.shard_num();
   auto ps_gpu_wrapper = paddle::framework::PSGPUWrapper::GetInstance();
   ps_gpu_wrapper->InitializeGPUServer(config);
 }

--- a/paddle/fluid/framework/ps_gpu_trainer.cc
+++ b/paddle/fluid/framework/ps_gpu_trainer.cc
@@ -238,10 +238,6 @@ void PSGPUTrainer::InitializeGPUServer(const TrainerDesc& trainer_desc) {
     add_sparse_optimizer(config, sparse_table_accessor.embedx_sgd_param(),
                          "mf_");
   }
-<<<<<<< HEAD
-=======
-  
->>>>>>> 1483b4017ed2510656318f2584b7e6c27ce66dd9
   config["sparse_shard_num"] = sparse_table.shard_num();
   auto ps_gpu_wrapper = paddle::framework::PSGPUWrapper::GetInstance();
   ps_gpu_wrapper->InitializeGPUServer(config);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
gpups support setting sparse table's shard num from config_fleet.py