### PR TITLE
【code format check upgrade】 step3：optimize installation and instruction of clang-format

### DIFF
--- a/tools/codestyle/clang_format.hook
+++ b/tools/codestyle/clang_format.hook
@@ -5,7 +5,15 @@ readonly VERSION="13.0.0"
 
 version=$(clang-format -version)
 
+if ! [[ $(python -V 2>&1 | awk '{print $2}' | awk -F '.' '{print $1$2}') -ge 36 ]]; then
+    echo "clang-format installation by pip need python version great equal 3.6, 
+          please change the default python to higher version."
+    exit 1
+fi
+
 if ! [[ $version == *"$VERSION"* ]]; then
+    # low version of pip may not have the source of clang-format whl
+    pip install --upgrade pip 
     pip install clang-format==13.0.0
 fi
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Local installation of clang-format is not easy, optimize installation and instruction of it.

- add default python version limit
![image](https://user-images.githubusercontent.com/51314274/172164834-18467ea0-07f8-4999-9969-cf801bcf7fde.png)
- upgrade pip before pip install since low version pip does not have the source of clang-format whl.
![image](https://user-images.githubusercontent.com/51314274/172165372-4d1e83cc-6e56-4d5a-b38b-c659db34acc0.png)
after upgrade:
![image](https://user-images.githubusercontent.com/51314274/172165343-39b21afb-c345-4ab6-8570-1e7ce6f8fce0.png)