### PR TITLE
[Eager] enable legacy 2 fused op test and add retain_grad flag under eager

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_fused_bias_dropout_residual_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_bias_dropout_residual_layer_norm_op.py
@@ -26,7 +26,9 @@ from paddle import tensor
 from paddle.fluid import layers
 import unittest
 from op_test import OpTest
-from paddle.fluid.framework import default_main_program
+from paddle.fluid.framework import default_main_program, _enable_legacy_dygraph
+
+_enable_legacy_dygraph()
 
 default_main_program().random_seed = 42
 

--- a/python/paddle/fluid/tests/unittests/test_fused_gate_attention_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_gate_attention_op.py
@@ -21,8 +21,10 @@ import unittest
 from op_test import OpTest, convert_float_to_uint16
 from test_sparse_attention_op import get_cuda_version
 from paddle import _C_ops
-from paddle.fluid.framework import default_main_program
+from paddle.fluid.framework import default_main_program, _enable_legacy_dygraph
 from paddle.fluid import core
+
+_enable_legacy_dygraph()
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),

--- a/python/paddle/fluid/tests/unittests/test_tensor_fill_diagonal_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_fill_diagonal_tensor.py
@@ -30,10 +30,10 @@ class TensorFillDiagTensor_Test(unittest.TestCase):
 
     def test_dim2(self):
         fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
-        expected_np = np.array(
-            [[1, 2, 2], [2, 1, 2], [2, 2, 1], [2, 2, 2]]).astype('float32')
-        expected_grad = np.array(
-            [[0, 1, 1], [1, 0, 1], [1, 1, 0], [1, 1, 1]]).astype('float32')
+        expected_np = np.array([[1, 2, 2], [2, 1, 2], [2, 2, 1],
+                                [2, 2, 2]]).astype('float32')
+        expected_grad = np.array([[0, 1, 1], [1, 0, 1], [1, 1, 0],
+                                  [1, 1, 1]]).astype('float32')
 
         for idx, p in enumerate(self.places):
             if idx == 0:
@@ -59,10 +59,10 @@ class TensorFillDiagTensor_Test(unittest.TestCase):
 
     def test_dim2_offset_1(self):
         fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
-        expected_np = np.array(
-            [[2, 2, 2], [1, 2, 2], [2, 1, 2], [2, 2, 1]]).astype('float32')
-        expected_grad = np.array(
-            [[1, 1, 1], [0, 1, 1], [1, 0, 1], [1, 1, 0]]).astype('float32')
+        expected_np = np.array([[2, 2, 2], [1, 2, 2], [2, 1, 2],
+                                [2, 2, 1]]).astype('float32')
+        expected_grad = np.array([[1, 1, 1], [0, 1, 1], [1, 0, 1],
+                                  [1, 1, 0]]).astype('float32')
 
         for idx, p in enumerate(self.places):
             if idx == 0:
@@ -88,10 +88,10 @@ class TensorFillDiagTensor_Test(unittest.TestCase):
 
     def test_dim2_offset1(self):
         fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
-        expected_np = np.array(
-            [[2, 1, 2], [2, 2, 1], [2, 2, 2], [2, 2, 2]]).astype('float32')
-        expected_grad = np.array(
-            [[1, 0, 1], [1, 1, 0], [1, 1, 1], [1, 1, 1]]).astype('float32')
+        expected_np = np.array([[2, 1, 2], [2, 2, 1], [2, 2, 2],
+                                [2, 2, 2]]).astype('float32')
+        expected_grad = np.array([[1, 0, 1], [1, 1, 0], [1, 1, 1],
+                                  [1, 1, 1]]).astype('float32')
 
         for idx, p in enumerate(self.places):
             if idx == 0:
@@ -117,18 +117,22 @@ class TensorFillDiagTensor_Test(unittest.TestCase):
 
     def test_dim4(self):
         fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
-        expected_np = np.array(
-            [[[[0, 3], [2, 2], [2, 2]], [[2, 2], [1, 4], [2, 2]],
-              [[2, 2], [2, 2], [2, 5]], [[2, 2], [2, 2], [2, 2]]],
-             [[[6, 9], [2, 2], [2, 2]], [[2, 2], [7, 10], [2, 2]],
-              [[2, 2], [2, 2], [8, 11]],
-              [[2, 2], [2, 2], [2, 2]]]]).astype('float32')
-        expected_grad = np.array(
-            [[[[0, 0], [1, 1], [1, 1]], [[1, 1], [0, 0], [1, 1]],
-              [[1, 1], [1, 1], [0, 0]], [[1, 1], [1, 1], [1, 1]]],
-             [[[0, 0], [1, 1], [1, 1]], [[1, 1], [0, 0], [1, 1]],
-              [[1, 1], [1, 1], [0, 0]],
-              [[1, 1], [1, 1], [1, 1]]]]).astype('float32')
+        expected_np = np.array([[[[0, 3], [2, 2], [2, 2]],
+                                 [[2, 2], [1, 4], [2, 2]],
+                                 [[2, 2], [2, 2], [2, 5]],
+                                 [[2, 2], [2, 2], [2, 2]]],
+                                [[[6, 9], [2, 2], [2, 2]],
+                                 [[2, 2], [7, 10], [2, 2]],
+                                 [[2, 2], [2, 2], [8, 11]],
+                                 [[2, 2], [2, 2], [2, 2]]]]).astype('float32')
+        expected_grad = np.array([[[[0, 0], [1, 1], [1, 1]],
+                                   [[1, 1], [0, 0], [1, 1]],
+                                   [[1, 1], [1, 1], [0, 0]],
+                                   [[1, 1], [1, 1], [1, 1]]],
+                                  [[[0, 0], [1, 1], [1, 1]],
+                                   [[1, 1], [0, 0], [1, 1]],
+                                   [[1, 1], [1, 1], [0, 0]],
+                                   [[1, 1], [1, 1], [1, 1]]]]).astype('float32')
 
         for idx, p in enumerate(self.places):
             if idx == 0:
@@ -154,6 +158,7 @@ class TensorFillDiagTensor_Test(unittest.TestCase):
         fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
     def test_largedim(self):
+        fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": True})
         if len(self.places) > 1:
             bsdim = 1024
             fsdim = 128
@@ -175,6 +180,7 @@ class TensorFillDiagTensor_Test(unittest.TestCase):
 
                 self.assertEqual((ny == expected_pred).all(), True)
                 self.assertEqual((y.grad == expected_grad).all(), True)
+        fluid.set_flags({"FLAGS_retain_grad_for_all_tensor": False})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. _enable_leagcy for to fused related op test
2. Add FLAGS_retain_grad_for_all_tensor for test_tensor_fill_diagonal_tensor.py