### PR TITLE
Add use_master_acc_grad for DistributedFusedLamb

### DIFF
--- a/paddle/fluid/operators/optimizers/distributed_fused_lamb_op.cc
+++ b/paddle/fluid/operators/optimizers/distributed_fused_lamb_op.cc
@@ -141,6 +141,9 @@ class DistributedFusedLambOpMaker : public framework::OpProtoAndCheckerMaker {
         "NCCL communication data. If it is false, it would be less accurate "
         "and be less NCCL communication data.")
         .SetDefault(true);
+    AddAttr<bool>("use_master_acc_grad",
+                  "Whether to use master gradient when acc_steps > 1.")
+        .SetDefault(true);
     AddAttr<bool>("is_grad_scaled_by_nranks",
                   "Whether the input gradient has been scaled by nranks.")
         .SetDefault(true);

--- a/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
@@ -162,6 +162,7 @@ def run_model(use_distributed_lamb, use_fp16, use_master_param_norm, **kwargs):
                 kwargs = dict(kwargs)
                 kwargs.pop('clip_after_allreduce', None)
                 kwargs.pop('alignment', None)
+                kwargs.pop('use_master_acc_grad', None)
                 base_clip = grad_clip if grad_clip is not None else IdentityGradClip(
                 )
                 kwargs['grad_clip'] = GradClipDecorator(base_clip,
@@ -271,6 +272,7 @@ class TestDistributedFusedLamb(unittest.TestCase):
             distutils.util.strtobool(os.getenv('CLIP_AFTER_ALLREDUCE', 'True')))
         max_global_norm = float(os.getenv('MAX_GLOBAL_NORM', -1.0))
         gm_steps = int(os.getenv('GRADIENT_MERGE_STEPS', 1))
+        use_master_acc_grad = bool(int(os.getenv('USE_MASTER_ACC_GRAD', '1')))
         print('clip_after_allreduce = {}, max_global_norm = {}'.format(
             clip_after_allreduce, max_global_norm))
         return {
@@ -281,9 +283,14 @@ class TestDistributedFusedLamb(unittest.TestCase):
             'grad_clip':
             paddle.nn.ClipGradByGlobalNorm(max_global_norm)
             if max_global_norm > 0 else None,
+            'use_master_acc_grad':
+            use_master_acc_grad,
         }
 
-    def run_main(self, use_fp16, use_master_param_norm=True):
+    def run_main(self,
+                 use_fp16,
+                 use_master_param_norm=True,
+                 use_master_acc_grad=True):
         if not paddle.is_compiled_with_cuda():
             return
 

--- a/python/paddle/fluid/tests/unittests/test_distributed_fused_lamb_op_with_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_distributed_fused_lamb_op_with_clip.py
@@ -36,7 +36,8 @@ def remove_file_if_exists(file_name):
 
 def run_test(clip_after_allreduce=True,
              max_global_norm=-1.0,
-             gradient_merge_steps=1):
+             gradient_merge_steps=1,
+             use_master_acc_grad=True):
     if not paddle.is_compiled_with_cuda():
         return
     if os.name == 'nt':
@@ -58,6 +59,7 @@ def run_test(clip_after_allreduce=True,
     os.environ['CLIP_AFTER_ALLREDUCE'] = str(clip_after_allreduce)
     os.environ['MAX_GLOBAL_NORM'] = str(max_global_norm)
     os.environ['GRADIENT_MERGE_STEPS'] = str(gradient_merge_steps)
+    os.environ['USE_MASTER_ACC_GRAD'] = str(1 if use_master_acc_grad else 0)
 
     touch_file_env = 'SUCCESS_TOUCH_FILE'
     touch_file_name = 'distributed_fused_lamb_touch_file_{}'.format(os.getpid())

--- a/python/paddle/fluid/tests/unittests/test_distributed_fused_lamb_op_with_gradient_merge.py
+++ b/python/paddle/fluid/tests/unittests/test_distributed_fused_lamb_op_with_gradient_merge.py
@@ -23,6 +23,12 @@ class TestDistributedFusedLambGradientMerge(unittest.TestCase):
                  max_global_norm=-1.0,
                  gradient_merge_steps=2)
 
+    def test_gm_with_fp16_acc_grad(self):
+        run_test(clip_after_allreduce=True,
+                 max_global_norm=-1.0,
+                 gradient_merge_steps=2,
+                 use_master_acc_grad=False)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/incubate/optimizer/distributed_fused_lamb.py
+++ b/python/paddle/incubate/optimizer/distributed_fused_lamb.py
@@ -40,6 +40,7 @@ class DistributedFusedLamb(Optimizer):
                  alignment=128,
                  use_master_param_norm=True,
                  gradient_accumulation_steps=1,
+                 use_master_acc_grad=True,
                  name=None):
         assert not framework._non_static_mode(
         ), "DistributedFusedLamb does not support dygraph mode"
@@ -67,6 +68,7 @@ class DistributedFusedLamb(Optimizer):
         self._ring_id = 0
         self._use_master_param_norm = use_master_param_norm
         self._gradient_accumulation_steps = gradient_accumulation_steps
+        self._use_master_acc_grad = use_master_acc_grad
         assert self._gradient_accumulation_steps >= 1
 
         self.helper = LayerHelper('distributed_fused_lamb')
@@ -353,5 +355,6 @@ class DistributedFusedLamb(Optimizer):
                 'use_master_param_norm': self._use_master_param_norm,
                 'is_grad_scaled_by_nranks': self._is_grad_scaled_by_nranks,
                 'acc_steps': self._gradient_accumulation_steps,
+                'use_master_acc_grad': self._use_master_acc_grad,
             })
         return [lamb_op]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe
Add `use_master_acc_grad` argument for `DistributedFusedLamb`.  This argument is only valid when `gradient_accumulation_steps > 1`.

- If `use_master_acc_grad=True`, the gradient accumulation would use FP32 master gradient for accumulating FP16 gradient.
- If `use_master_acc_grad=False`, the gradient accumulation would use FP16 gradient for accumulating FP16 gradient.

This change would save about 600M GPU memory for MLPerf BERT Large model. After this PR, the MLPerf BERT Large model can run on 8 40G A100 GPUs when local batch size is 48 and gradient accumulation step is 8.