### PR TITLE
Modify quantization use tempfile to place the temporary files

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
@@ -119,6 +119,9 @@ class TestImperativeOutSclae(unittest.TestCase):
         self.save_path = os.path.join(self.root_path.name,
                                       "lenet_dynamic_outscale_infer_model")
 
+    def tearDown(self):
+        self.root_path.cleanup()
+
     def func_out_scale_acc(self):
         seed = 1000
         lr = 0.001
@@ -149,25 +152,9 @@ class TestImperativeOutSclae(unittest.TestCase):
         save_dict = lenet.state_dict()
         paddle.save(save_dict, self.param_save_path)
 
-        imperative_out_scale.save_quantized_model(
-            layer=lenet,
-            path=self.save_path,
-            input_spec=[
-                paddle.static.InputSpec(shape=[None, 1, 28, 28],
-                                        dtype='float32')
-            ])
-
         for i in range(len(loss_list) - 1):
             self.assertTrue(loss_list[i] > loss_list[i + 1],
                             msg='Failed to do the imperative qat.')
-
-    def func_save_quantized_model(self):
-        lr = 0.001
-        weight_quantize_type = 'abs_max'
-        activation_quantize_type = 'moving_average_abs_max'
-        imperative_out_scale = ImperativeQuantAware(
-            weight_quantize_type=weight_quantize_type,
-            activation_quantize_type=activation_quantize_type)
 
         with fluid.dygraph.guard():
             lenet = ImperativeLenet()
@@ -195,17 +182,10 @@ class TestImperativeOutSclae(unittest.TestCase):
             self.assertTrue(loss_list[i] > loss_list[i + 1],
                             msg='Failed to do the imperative qat.')
 
-        self.root_path.cleanup()
-
     def test_out_scale_acc(self):
         with _test_eager_guard():
             self.func_out_scale_acc()
         self.func_out_scale_acc()
-
-    def test_save_quantized_model(self):
-        with _test_eager_guard():
-            self.func_save_quantized_model()
-        self.func_save_quantized_model()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
@@ -20,6 +20,7 @@ import random
 import unittest
 import logging
 import warnings
+import tempfile
 
 import paddle
 import paddle.fluid as fluid
@@ -111,6 +112,13 @@ class ImperativeLenet(fluid.dygraph.Layer):
 
 class TestImperativeOutSclae(unittest.TestCase):
 
+    def setUp(self):
+        self.root_path = tempfile.TemporaryDirectory()
+        self.param_save_path = os.path.join(self.root_path.name,
+                                            "lenet.pdparams")
+        self.save_path = os.path.join(self.root_path.name,
+                                      "lenet_dynamic_outscale_infer_model")
+
     def func_out_scale_acc(self):
         seed = 1000
         lr = 0.001
@@ -138,14 +146,12 @@ class TestImperativeOutSclae(unittest.TestCase):
             loss_list = train_lenet(lenet, reader, adam)
             lenet.eval()
 
-        param_save_path = "test_save_quantized_model/lenet.pdparams"
         save_dict = lenet.state_dict()
-        paddle.save(save_dict, param_save_path)
+        paddle.save(save_dict, self.param_save_path)
 
-        save_path = "./dynamic_outscale_infer_model/lenet"
         imperative_out_scale.save_quantized_model(
             layer=lenet,
-            path=save_path,
+            path=self.save_path,
             input_spec=[
                 paddle.static.InputSpec(shape=[None, 1, 28, 28],
                                         dtype='float32')
@@ -155,20 +161,8 @@ class TestImperativeOutSclae(unittest.TestCase):
             self.assertTrue(loss_list[i] > loss_list[i + 1],
                             msg='Failed to do the imperative qat.')
 
-    def test_out_scale_acc(self):
-        with _test_eager_guard():
-            self.func_out_scale_acc()
-        self.func_out_scale_acc()
-
-
-class TestSaveQuanztizedModelFromCheckPoint(unittest.TestCase):
-
     def func_save_quantized_model(self):
         lr = 0.001
-
-        load_param_path = "test_save_quantized_model/lenet.pdparams"
-        save_path = "./dynamic_outscale_infer_model_from_checkpoint/lenet"
-
         weight_quantize_type = 'abs_max'
         activation_quantize_type = 'moving_average_abs_max'
         imperative_out_scale = ImperativeQuantAware(
@@ -177,7 +171,7 @@ class TestSaveQuanztizedModelFromCheckPoint(unittest.TestCase):
 
         with fluid.dygraph.guard():
             lenet = ImperativeLenet()
-            load_dict = paddle.load(load_param_path)
+            load_dict = paddle.load(self.param_save_path)
             imperative_out_scale.quantize(lenet)
             lenet.set_dict(load_dict)
 
@@ -191,7 +185,7 @@ class TestSaveQuanztizedModelFromCheckPoint(unittest.TestCase):
 
         imperative_out_scale.save_quantized_model(
             layer=lenet,
-            path=save_path,
+            path=self.save_path,
             input_spec=[
                 paddle.static.InputSpec(shape=[None, 1, 28, 28],
                                         dtype='float32')
@@ -200,6 +194,13 @@ class TestSaveQuanztizedModelFromCheckPoint(unittest.TestCase):
         for i in range(len(loss_list) - 1):
             self.assertTrue(loss_list[i] > loss_list[i + 1],
                             msg='Failed to do the imperative qat.')
+
+        self.root_path.cleanup()
+
+    def test_out_scale_acc(self):
+        with _test_eager_guard():
+            self.func_out_scale_acc()
+        self.func_out_scale_acc()
 
     def test_save_quantized_model(self):
         with _test_eager_guard():

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_ptq.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_ptq.py
@@ -22,6 +22,7 @@ import time
 import unittest
 import copy
 import logging
+import tempfile
 
 import paddle.nn as nn
 import paddle
@@ -73,10 +74,6 @@ class TestImperativePTQ(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
-        cls.root_path = os.path.join(os.getcwd(), "imperative_ptq_" + timestamp)
-        cls.save_path = os.path.join(cls.root_path, "model")
-
         cls.download_path = 'dygraph_int8/download'
         cls.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
                                               cls.download_path)
@@ -88,14 +85,6 @@ class TestImperativePTQ(unittest.TestCase):
         np.random.seed(seed)
         paddle.static.default_main_program().random_seed = seed
         paddle.static.default_startup_program().random_seed = seed
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            pass
-            # shutil.rmtree(cls.root_path)
-        except Exception as e:
-            print("Failed to delete {} due to {}".format(cls.root_path, str(e)))
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):
@@ -217,32 +206,34 @@ class TestImperativePTQ(unittest.TestCase):
         input_spec = [
             paddle.static.InputSpec(shape=[None, 1, 28, 28], dtype='float32')
         ]
-        self.ptq.save_quantized_model(model=quant_model,
-                                      path=self.save_path,
-                                      input_spec=input_spec)
-        print('Quantized model saved in {%s}' % self.save_path)
+        with tempfile.TemporaryDirectory(prefix="imperative_ptq_") as tmpdir:
+            save_path = os.path.join(tmpdir, "model")
+            self.ptq.save_quantized_model(model=quant_model,
+                                          path=save_path,
+                                          input_spec=input_spec)
+            print('Quantized model saved in {%s}' % save_path)
 
-        after_acc_top1 = self.model_test(quant_model, self.batch_num,
-                                         self.batch_size)
+            after_acc_top1 = self.model_test(quant_model, self.batch_num,
+                                             self.batch_size)
 
-        paddle.enable_static()
-        infer_acc_top1 = self.program_test(self.save_path, self.batch_num,
-                                           self.batch_size)
-        paddle.disable_static()
+            paddle.enable_static()
+            infer_acc_top1 = self.program_test(save_path, self.batch_num,
+                                               self.batch_size)
+            paddle.disable_static()
 
-        # Check
-        print('Before converted acc_top1: %s' % before_acc_top1)
-        print('After converted acc_top1: %s' % after_acc_top1)
-        print('Infer acc_top1: %s' % infer_acc_top1)
+            # Check
+            print('Before converted acc_top1: %s' % before_acc_top1)
+            print('After converted acc_top1: %s' % after_acc_top1)
+            print('Infer acc_top1: %s' % infer_acc_top1)
 
-        self.assertTrue(after_acc_top1 >= self.eval_acc_top1,
-                        msg="The test acc {%f} is less than {%f}." %
-                        (after_acc_top1, self.eval_acc_top1))
-        self.assertTrue(infer_acc_top1 >= after_acc_top1,
-                        msg='The acc is lower after converting model.')
+            self.assertTrue(after_acc_top1 >= self.eval_acc_top1,
+                            msg="The test acc {%f} is less than {%f}." %
+                            (after_acc_top1, self.eval_acc_top1))
+            self.assertTrue(infer_acc_top1 >= after_acc_top1,
+                            msg='The acc is lower after converting model.')
 
-        end_time = time.time()
-        print("total time: %ss \n" % (end_time - start_time))
+            end_time = time.time()
+            print("total time: %ss \n" % (end_time - start_time))
 
     def test_ptq(self):
         with _test_eager_guard():
@@ -278,36 +269,38 @@ class TestImperativePTQfuse(TestImperativePTQ):
         input_spec = [
             paddle.static.InputSpec(shape=[None, 1, 28, 28], dtype='float32')
         ]
-        self.ptq.save_quantized_model(model=quant_model,
-                                      path=self.save_path,
-                                      input_spec=input_spec)
-        print('Quantized model saved in {%s}' % self.save_path)
+        with tempfile.TemporaryDirectory(prefix="imperative_ptq_") as tmpdir:
+            save_path = os.path.join(tmpdir, "model")
+            self.ptq.save_quantized_model(model=quant_model,
+                                          path=save_path,
+                                          input_spec=input_spec)
+            print('Quantized model saved in {%s}' % save_path)
 
-        after_acc_top1 = self.model_test(quant_model, self.batch_num,
-                                         self.batch_size)
+            after_acc_top1 = self.model_test(quant_model, self.batch_num,
+                                             self.batch_size)
 
-        paddle.enable_static()
-        infer_acc_top1 = self.program_test(self.save_path, self.batch_num,
-                                           self.batch_size)
-        paddle.disable_static()
+            paddle.enable_static()
+            infer_acc_top1 = self.program_test(save_path, self.batch_num,
+                                               self.batch_size)
+            paddle.disable_static()
 
-        # Check
-        print('Before converted acc_top1: %s' % before_acc_top1)
-        print('After converted acc_top1: %s' % after_acc_top1)
-        print('Infer acc_top1: %s' % infer_acc_top1)
+            # Check
+            print('Before converted acc_top1: %s' % before_acc_top1)
+            print('After converted acc_top1: %s' % after_acc_top1)
+            print('Infer acc_top1: %s' % infer_acc_top1)
 
-        #Check whether the quant_model is correct after converting.
-        #The acc of quantized model should be higher than 0.95.
-        self.assertTrue(after_acc_top1 >= self.eval_acc_top1,
-                        msg="The test acc {%f} is less than {%f}." %
-                        (after_acc_top1, self.eval_acc_top1))
-        #Check the saved infer_model.The acc of infer model
-        #should not be lower than the one of dygraph model.
-        self.assertTrue(infer_acc_top1 >= after_acc_top1,
-                        msg='The acc is lower after converting model.')
+            #Check whether the quant_model is correct after converting.
+            #The acc of quantized model should be higher than 0.95.
+            self.assertTrue(after_acc_top1 >= self.eval_acc_top1,
+                            msg="The test acc {%f} is less than {%f}." %
+                            (after_acc_top1, self.eval_acc_top1))
+            #Check the saved infer_model.The acc of infer model
+            #should not be lower than the one of dygraph model.
+            self.assertTrue(infer_acc_top1 >= after_acc_top1,
+                            msg='The acc is lower after converting model.')
 
-        end_time = time.time()
-        print("total time: %ss \n" % (end_time - start_time))
+            end_time = time.time()
+            print("total time: %ss \n" % (end_time - start_time))
 
     def test_ptq(self):
         with _test_eager_guard():

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_amp.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_amp.py
@@ -21,6 +21,7 @@ import shutil
 import time
 import unittest
 import logging
+import tempfile
 
 import paddle
 import paddle.fluid as fluid
@@ -46,10 +47,9 @@ class TestImperativeQatAmp(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
-        cls.root_path = os.path.join(os.getcwd(),
-                                     "imperative_qat_amp_" + timestamp)
-        cls.save_path = os.path.join(cls.root_path, "model")
+        cls.root_path = tempfile.TemporaryDirectory(
+            prefix="imperative_qat_amp_")
+        cls.save_path = os.path.join(cls.root_path.name, "model")
 
         cls.download_path = 'dygraph_int8/download'
         cls.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
@@ -65,10 +65,7 @@ class TestImperativeQatAmp(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        try:
-            shutil.rmtree(cls.root_path)
-        except Exception as e:
-            print("Failed to delete {} due to {}".format(cls.root_path, str(e)))
+        cls.root_path.cleanup()
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
@@ -20,6 +20,7 @@ import math
 import functools
 import contextlib
 import struct
+import tempfile
 import numpy as np
 import paddle
 import paddle.fluid as fluid
@@ -38,9 +39,9 @@ class TestPostTrainingQuantization(unittest.TestCase):
         self.download_path = 'int8/download'
         self.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
                                                self.download_path)
-        self.timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
-        self.int8_model_path = os.path.join(os.getcwd(),
-                                            "post_training_" + self.timestamp)
+        self.root_path = tempfile.TemporaryDirectory()
+        self.int8_model_path = os.path.join(self.root_path.name,
+                                            "post_training_quantization")
         try:
             os.system("mkdir -p " + self.int8_model_path)
         except Exception as e:
@@ -49,11 +50,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
             sys.exit(-1)
 
     def tearDown(self):
-        try:
-            os.system("rm -rf {}".format(self.int8_model_path))
-        except Exception as e:
-            print("Failed to delete {} due to {}".format(
-                self.int8_model_path, str(e)))
+        self.root_path.cleanup()
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
@@ -18,6 +18,7 @@ import sys
 import random
 import math
 import functools
+import tempfile
 import contextlib
 import numpy as np
 import paddle
@@ -34,12 +35,12 @@ np.random.seed(0)
 class TestPostTrainingQuantization(unittest.TestCase):
 
     def setUp(self):
+        self.root_path = tempfile.TemporaryDirectory()
+        self.int8_model_path = os.path.join(self.root_path.name,
+                                            "post_training_quantization")
         self.download_path = 'int8/download'
         self.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
                                                self.download_path)
-        self.timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
-        self.int8_model_path = os.path.join(os.getcwd(),
-                                            "post_training_" + self.timestamp)
         try:
             os.system("mkdir -p " + self.int8_model_path)
         except Exception as e:
@@ -48,11 +49,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
             sys.exit(-1)
 
     def tearDown(self):
-        try:
-            os.system("rm -rf {}".format(self.int8_model_path))
-        except Exception as e:
-            print("Failed to delete {} due to {}".format(
-                self.int8_model_path, str(e)))
+        self.root_path.cleanup()
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):
@@ -123,7 +120,6 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
         place = fluid.CPUPlace()
         exe = fluid.Executor(place)
-        scope = fluid.global_scope()
         val_reader = paddle.dataset.mnist.train()
 
         ptq = PostTrainingQuantization(executor=exe,

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -19,6 +19,7 @@ import random
 import math
 import functools
 import contextlib
+import tempfile
 import numpy as np
 from PIL import Image, ImageEnhance
 import paddle
@@ -150,16 +151,12 @@ class TestPostTrainingQuantization(unittest.TestCase):
         self.infer_iterations = 50000 if os.environ.get(
             'DATASET') == 'full' else 2
 
-        self.timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
-        self.int8_model = os.path.join(os.getcwd(),
-                                       "post_training_" + self.timestamp)
+        self.root_path = tempfile.TemporaryDirectory()
+        self.int8_model = os.path.join(self.root_path.name,
+                                       "post_training_quantization")
 
     def tearDown(self):
-        try:
-            os.system("rm -rf {}".format(self.int8_model))
-        except Exception as e:
-            print("Failed to delete {} due to {}".format(
-                self.int8_model, str(e)))
+        self.root_path.cleanup()
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):

--- a/python/paddle/fluid/contrib/slim/tests/test_quantization_scale_pass.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quantization_scale_pass.py
@@ -17,6 +17,7 @@ import unittest
 import random
 import numpy as np
 import six
+import tempfile
 import paddle.fluid as fluid
 import paddle
 from paddle.fluid.framework import IrGraph
@@ -166,15 +167,19 @@ class TestQuantizationScalePass(unittest.TestCase):
                     marked_nodes.add(op)
             test_graph.draw('.', 'quant_scale' + dev_name, marked_nodes)
 
-        with open('quant_scale_model' + dev_name + '.txt', 'w') as f:
+        tempdir = tempfile.TemporaryDirectory()
+        mapping_table_path = os.path.join(
+            tempdir.name, 'quant_scale_model' + dev_name + '.txt')
+        save_path = os.path.join(tempdir.name, 'quant_scale_model' + dev_name)
+        with open(mapping_table_path, 'w') as f:
             f.write(str(server_program))
 
         with fluid.scope_guard(scope):
-            fluid.io.save_inference_model('quant_scale_model' + dev_name,
-                                          ['image', 'label'], [loss],
+            fluid.io.save_inference_model(save_path, ['image', 'label'], [loss],
                                           exe,
                                           server_program,
                                           clip_extra=True)
+        tempdir.cleanup()
 
     def test_quant_scale_cuda(self):
         if fluid.core.is_compiled_with_cuda():

--- a/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
@@ -18,6 +18,7 @@ import json
 import random
 import numpy as np
 import six
+import tempfile
 import paddle.fluid as fluid
 import paddle
 from paddle.fluid.framework import IrGraph
@@ -110,18 +111,20 @@ class TestUserDefinedQuantization(unittest.TestCase):
         def get_optimizer():
             return fluid.optimizer.MomentumOptimizer(0.0001, 0.9)
 
-        def load_dict():
-            with open('mapping_table_for_saving_inference_model', 'r') as file:
+        def load_dict(mapping_table_path):
+            with open(mapping_table_path, 'r') as file:
                 data = file.read()
                 data = json.loads(data)
                 return data
 
-        def save_dict(Dict):
-            with open('mapping_table_for_saving_inference_model', 'w') as file:
+        def save_dict(Dict, mapping_table_path):
+            with open(mapping_table_path, 'w') as file:
                 file.write(json.dumps(Dict))
 
         random.seed(0)
         np.random.seed(0)
+        tempdir = tempfile.TemporaryDirectory()
+        mapping_table_path = os.path.join(tempdir.name, 'inference')
 
         main = fluid.Program()
         startup = fluid.Program()
@@ -162,7 +165,7 @@ class TestUserDefinedQuantization(unittest.TestCase):
             executor=exe)
 
         test_transform_pass.apply(test_graph)
-        save_dict(test_graph.out_node_mapping_table)
+        save_dict(test_graph.out_node_mapping_table, mapping_table_path)
 
         add_quant_dequant_pass = AddQuantDequantPass(scope=scope, place=place)
         add_quant_dequant_pass.apply(main_graph)
@@ -203,10 +206,11 @@ class TestUserDefinedQuantization(unittest.TestCase):
             activation_bits=8,
             weight_quantize_type=weight_quant_type)
 
-        mapping_table = load_dict()
+        mapping_table = load_dict(mapping_table_path)
         test_graph.out_node_mapping_table = mapping_table
         if act_quantize_func == None and weight_quantize_func == None:
             freeze_pass.apply(test_graph)
+        tempdir.cleanup()
 
     def test_act_preprocess_cuda(self):
         if fluid.core.is_compiled_with_cuda():

--- a/python/paddle/fluid/tests/unittests/test_inference_model_io.py
+++ b/python/paddle/fluid/tests/unittests/test_inference_model_io.py
@@ -18,6 +18,7 @@ import unittest
 
 import os
 import six
+import tempfile
 import numpy as np
 import paddle.fluid.core as core
 import paddle.fluid as fluid
@@ -46,8 +47,9 @@ class InferModel(object):
 class TestBook(unittest.TestCase):
 
     def test_fit_line_inference_model(self):
-        MODEL_DIR = "./tmp/inference_model"
-        UNI_MODEL_DIR = "./tmp/inference_model1"
+        root_path = tempfile.TemporaryDirectory()
+        MODEL_DIR = os.path.join(root_path.name, "inference_model")
+        UNI_MODEL_DIR = os.path.join(root_path.name, "inference_model1")
 
         init_program = Program()
         program = Program()
@@ -118,6 +120,8 @@ class TestBook(unittest.TestCase):
             print("fetch %s" % str(model.fetch_vars[0]))
             self.assertEqual(expected, actual)
 
+        root_path.cleanup()
+
         self.assertRaises(ValueError, fluid.io.load_inference_model, None, exe,
                           model_str, None)
 
@@ -125,7 +129,8 @@ class TestBook(unittest.TestCase):
 class TestSaveInferenceModel(unittest.TestCase):
 
     def test_save_inference_model(self):
-        MODEL_DIR = "./tmp/inference_model2"
+        root_path = tempfile.TemporaryDirectory()
+        MODEL_DIR = os.path.join(root_path.name, "inference_model2")
         init_program = Program()
         program = Program()
 
@@ -144,9 +149,11 @@ class TestSaveInferenceModel(unittest.TestCase):
         exe.run(init_program, feed={}, fetch_list=[])
 
         save_inference_model(MODEL_DIR, ["x", "y"], [avg_cost], exe, program)
+        root_path.cleanup()
 
     def test_save_inference_model_with_auc(self):
-        MODEL_DIR = "./tmp/inference_model4"
+        root_path = tempfile.TemporaryDirectory()
+        MODEL_DIR = os.path.join(root_path.name, "inference_model4")
         init_program = Program()
         program = Program()
 
@@ -168,6 +175,7 @@ class TestSaveInferenceModel(unittest.TestCase):
             warnings.simplefilter("always")
             save_inference_model(MODEL_DIR, ["x", "y"], [avg_cost], exe,
                                  program)
+            root_path.cleanup()
             expected_warn = "please ensure that you have set the auc states to zeros before saving inference model"
             self.assertTrue(len(w) > 0)
             self.assertTrue(expected_warn == str(w[0].message))
@@ -176,7 +184,8 @@ class TestSaveInferenceModel(unittest.TestCase):
 class TestInstance(unittest.TestCase):
 
     def test_save_inference_model(self):
-        MODEL_DIR = "./tmp/inference_model3"
+        root_path = tempfile.TemporaryDirectory()
+        MODEL_DIR = os.path.join(root_path.name, "inference_model3")
         init_program = Program()
         program = Program()
 
@@ -202,12 +211,14 @@ class TestInstance(unittest.TestCase):
         save_inference_model(MODEL_DIR, ["x", "y"], [avg_cost], exe, cp_prog)
         self.assertRaises(TypeError, save_inference_model,
                           [MODEL_DIR, ["x", "y"], [avg_cost], [], cp_prog])
+        root_path.cleanup()
 
 
 class TestSaveInferenceModelNew(unittest.TestCase):
 
     def test_save_and_load_inference_model(self):
-        MODEL_DIR = "./tmp/inference_model5"
+        root_path = tempfile.TemporaryDirectory()
+        MODEL_DIR = os.path.join(root_path.name, "inference_model5")
         init_program = fluid.default_startup_program()
         program = fluid.default_main_program()
 
@@ -368,6 +379,7 @@ class TestSaveInferenceModelNew(unittest.TestCase):
         self.assertEqual(res, None)
         self.assertRaises(TypeError, paddle.static.io.deserialize_persistables,
                           None, None, None)
+        root_path.cleanup()
 
     def test_normalize_program(self):
         init_program = fluid.default_startup_program()

--- a/python/paddle/fluid/tests/unittests/test_inference_model_io.py
+++ b/python/paddle/fluid/tests/unittests/test_inference_model_io.py
@@ -314,6 +314,7 @@ class TestSaveInferenceModelNew(unittest.TestCase):
 
         model = InferModel(paddle.static.io.load_inference_model(
             MODEL_DIR, exe))
+        root_path.cleanup()
 
         outs = exe.run(model.program,
                        feed={
@@ -379,7 +380,6 @@ class TestSaveInferenceModelNew(unittest.TestCase):
         self.assertEqual(res, None)
         self.assertRaises(TypeError, paddle.static.io.deserialize_persistables,
                           None, None, None)
-        root_path.cleanup()
 
     def test_normalize_program(self):
         init_program = fluid.default_startup_program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
模型量化及save_inference_model相关单测中包含一些模型导出和save的逻辑，为了更好的管理导出文件，此处用tempfile来管理此类文件，保证单测执行完之后所有的临时文件都会被正常的删除掉，避免占用磁盘文件。

此PR仅涉及单测修改，不涉及新功能。