### PR TITLE
[cherry-pick]Modify quantization use tempfile to place the temporary files

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
@@ -20,6 +20,7 @@ import random
 import unittest
 import logging
 import warnings
+import tempfile
 
 import paddle
 import paddle.fluid as fluid
@@ -122,6 +123,16 @@ class ImperativeLenet(fluid.dygraph.Layer):
 
 
 class TestImperativeOutSclae(unittest.TestCase):
+    def setUp(self):
+        self.root_path = tempfile.TemporaryDirectory()
+        self.param_save_path = os.path.join(self.root_path.name,
+                                            "lenet.pdparams")
+        self.save_path = os.path.join(self.root_path.name,
+                                      "lenet_dynamic_outscale_infer_model")
+
+    def tearDown(self):
+        self.root_path.cleanup()
+
     def func_out_scale_acc(self):
         seed = 1000
         lr = 0.001
@@ -148,14 +159,30 @@ class TestImperativeOutSclae(unittest.TestCase):
             loss_list = train_lenet(lenet, reader, adam)
             lenet.eval()
 
-        param_save_path = "test_save_quantized_model/lenet.pdparams"
         save_dict = lenet.state_dict()
-        paddle.save(save_dict, param_save_path)
+        paddle.save(save_dict, self.param_save_path)
 
-        save_path = "./dynamic_outscale_infer_model/lenet"
+        for i in range(len(loss_list) - 1):
+            self.assertTrue(
+                loss_list[i] > loss_list[i + 1],
+                msg='Failed to do the imperative qat.')
+
+        with fluid.dygraph.guard():
+            lenet = ImperativeLenet()
+            load_dict = paddle.load(self.param_save_path)
+            imperative_out_scale.quantize(lenet)
+            lenet.set_dict(load_dict)
+
+            reader = paddle.batch(
+                paddle.dataset.mnist.test(), batch_size=32, drop_last=True)
+            adam = AdamOptimizer(
+                learning_rate=lr, parameter_list=lenet.parameters())
+            loss_list = train_lenet(lenet, reader, adam)
+            lenet.eval()
+
         imperative_out_scale.save_quantized_model(
             layer=lenet,
-            path=save_path,
+            path=self.save_path,
             input_spec=[
                 paddle.static.InputSpec(
                     shape=[None, 1, 28, 28], dtype='float32')
@@ -170,51 +197,6 @@ class TestImperativeOutSclae(unittest.TestCase):
         with _test_eager_guard():
             self.func_out_scale_acc()
         self.func_out_scale_acc()
-
-
-class TestSaveQuanztizedModelFromCheckPoint(unittest.TestCase):
-    def func_save_quantized_model(self):
-        lr = 0.001
-
-        load_param_path = "test_save_quantized_model/lenet.pdparams"
-        save_path = "./dynamic_outscale_infer_model_from_checkpoint/lenet"
-
-        weight_quantize_type = 'abs_max'
-        activation_quantize_type = 'moving_average_abs_max'
-        imperative_out_scale = ImperativeQuantAware(
-            weight_quantize_type=weight_quantize_type,
-            activation_quantize_type=activation_quantize_type)
-
-        with fluid.dygraph.guard():
-            lenet = ImperativeLenet()
-            load_dict = paddle.load(load_param_path)
-            imperative_out_scale.quantize(lenet)
-            lenet.set_dict(load_dict)
-
-            reader = paddle.batch(
-                paddle.dataset.mnist.test(), batch_size=32, drop_last=True)
-            adam = AdamOptimizer(
-                learning_rate=lr, parameter_list=lenet.parameters())
-            loss_list = train_lenet(lenet, reader, adam)
-            lenet.eval()
-
-        imperative_out_scale.save_quantized_model(
-            layer=lenet,
-            path=save_path,
-            input_spec=[
-                paddle.static.InputSpec(
-                    shape=[None, 1, 28, 28], dtype='float32')
-            ])
-
-        for i in range(len(loss_list) - 1):
-            self.assertTrue(
-                loss_list[i] > loss_list[i + 1],
-                msg='Failed to do the imperative qat.')
-
-    def test_save_quantized_model(self):
-        with _test_eager_guard():
-            self.func_save_quantized_model()
-        self.func_save_quantized_model()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_amp.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_amp.py
@@ -21,6 +21,7 @@ import shutil
 import time
 import unittest
 import logging
+import tempfile
 
 import paddle
 import paddle.fluid as fluid
@@ -45,10 +46,9 @@ class TestImperativeQatAmp(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
-        cls.root_path = os.path.join(os.getcwd(),
-                                     "imperative_qat_amp_" + timestamp)
-        cls.save_path = os.path.join(cls.root_path, "model")
+        cls.root_path = tempfile.TemporaryDirectory(
+            prefix="imperative_qat_amp_")
+        cls.save_path = os.path.join(cls.root_path.name, "model")
 
         cls.download_path = 'dygraph_int8/download'
         cls.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
@@ -64,10 +64,7 @@ class TestImperativeQatAmp(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        try:
-            shutil.rmtree(cls.root_path)
-        except Exception as e:
-            print("Failed to delete {} due to {}".format(cls.root_path, str(e)))
+        cls.root_path.cleanup()
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):
@@ -106,8 +103,8 @@ class TestImperativeQatAmp(unittest.TestCase):
         for batch_id, data in enumerate(train_reader()):
             x_data = np.array([x[0].reshape(1, 28, 28)
                                for x in data]).astype('float32')
-            y_data = np.array(
-                [x[1] for x in data]).astype('int64').reshape(-1, 1)
+            y_data = np.array([x[1]
+                               for x in data]).astype('int64').reshape(-1, 1)
 
             img = paddle.to_tensor(x_data)
             label = paddle.to_tensor(y_data)
@@ -150,8 +147,8 @@ class TestImperativeQatAmp(unittest.TestCase):
         for batch_id, data in enumerate(test_reader()):
             x_data = np.array([x[0].reshape(1, 28, 28)
                                for x in data]).astype('float32')
-            y_data = np.array(
-                [x[1] for x in data]).astype('int64').reshape(-1, 1)
+            y_data = np.array([x[1]
+                               for x in data]).astype('int64').reshape(-1, 1)
 
             img = paddle.to_tensor(x_data)
             label = paddle.to_tensor(y_data)

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
@@ -20,6 +20,7 @@ import math
 import functools
 import contextlib
 import struct
+import tempfile
 import numpy as np
 import paddle
 import paddle.fluid as fluid
@@ -37,9 +38,9 @@ class TestPostTrainingQuantization(unittest.TestCase):
         self.download_path = 'int8/download'
         self.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
                                                self.download_path)
-        self.timestamp = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
-        self.int8_model_path = os.path.join(os.getcwd(),
-                                            "post_training_" + self.timestamp)
+        self.root_path = tempfile.TemporaryDirectory()
+        self.int8_model_path = os.path.join(self.root_path.name,
+                                            "post_training_quantization")
         try:
             os.system("mkdir -p " + self.int8_model_path)
         except Exception as e:
@@ -48,11 +49,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
             sys.exit(-1)
 
     def tearDown(self):
-        try:
-            os.system("rm -rf {}".format(self.int8_model_path))
-        except Exception as e:
-            print("Failed to delete {} due to {}".format(self.int8_model_path,
-                                                         str(e)))
+        self.root_path.cleanup()
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):

--- a/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
@@ -18,6 +18,7 @@ import json
 import random
 import numpy as np
 import six
+import tempfile
 import paddle.fluid as fluid
 import paddle
 from paddle.fluid.framework import IrGraph
@@ -108,18 +109,20 @@ class TestUserDefinedQuantization(unittest.TestCase):
         def get_optimizer():
             return fluid.optimizer.MomentumOptimizer(0.0001, 0.9)
 
-        def load_dict():
-            with open('mapping_table_for_saving_inference_model', 'r') as file:
+        def load_dict(mapping_table_path):
+            with open(mapping_table_path, 'r') as file:
                 data = file.read()
                 data = json.loads(data)
                 return data
 
-        def save_dict(Dict):
-            with open('mapping_table_for_saving_inference_model', 'w') as file:
+        def save_dict(Dict, mapping_table_path):
+            with open(mapping_table_path, 'w') as file:
                 file.write(json.dumps(Dict))
 
         random.seed(0)
         np.random.seed(0)
+        tempdir = tempfile.TemporaryDirectory()
+        mapping_table_path = os.path.join(tempdir.name, 'inference')
 
         main = fluid.Program()
         startup = fluid.Program()
@@ -160,7 +163,7 @@ class TestUserDefinedQuantization(unittest.TestCase):
             executor=exe)
 
         test_transform_pass.apply(test_graph)
-        save_dict(test_graph.out_node_mapping_table)
+        save_dict(test_graph.out_node_mapping_table, mapping_table_path)
 
         add_quant_dequant_pass = AddQuantDequantPass(scope=scope, place=place)
         add_quant_dequant_pass.apply(main_graph)
@@ -202,10 +205,11 @@ class TestUserDefinedQuantization(unittest.TestCase):
             activation_bits=8,
             weight_quantize_type=weight_quant_type)
 
-        mapping_table = load_dict()
+        mapping_table = load_dict(mapping_table_path)
         test_graph.out_node_mapping_table = mapping_table
         if act_quantize_func == None and weight_quantize_func == None:
             freeze_pass.apply(test_graph)
+        tempdir.cleanup()
 
     def test_act_preprocess_cuda(self):
         if fluid.core.is_compiled_with_cuda():

--- a/python/paddle/fluid/tests/unittests/test_save_inference_model_conditional_op.py
+++ b/python/paddle/fluid/tests/unittests/test_save_inference_model_conditional_op.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import os
 import unittest
 import numpy as np
+import tempfile
 
 import paddle
 import paddle.fluid as fluid
@@ -31,7 +32,6 @@ def getModelOp(model_path):
 
     result = set()
     for i in range(0, size):
-        #print(main_block.op(i).type())    
         result.add(main_block.op(i).type())
 
     return result
@@ -90,18 +90,20 @@ class TestConditionalOp(unittest.TestCase):
                 paddle.static.InputSpec(
                     shape=[1, 3, 8, 8], dtype='float32')
             ])
-        paddle.jit.save(net, './while_net')
+        root_path = tempfile.TemporaryDirectory()
+        model_file = os.path.join(root_path.name, "while_net")
+        paddle.jit.save(net, model_file)
 
         right_pdmodel = set([
             "uniform_random", "shape", "slice", "not_equal", "while",
             "elementwise_add"
         ])
         paddle.enable_static()
-        pdmodel = getModelOp("while_net.pdmodel")
-        #print(len(right_pdmodel.difference(pdmodel)))
+        pdmodel = getModelOp(model_file + ".pdmodel")
         self.assertTrue(
             len(right_pdmodel.difference(pdmodel)) == 0,
             "The while op is pruned by mistake.")
+        root_path.cleanup()
 
     def test_for_op(self):
         paddle.disable_static()
@@ -110,18 +112,20 @@ class TestConditionalOp(unittest.TestCase):
             net,
             input_spec=[paddle.static.InputSpec(
                 shape=[1], dtype='int32')])
-        paddle.jit.save(net, './for_net')
+        root_path = tempfile.TemporaryDirectory()
+        model_file = os.path.join(root_path.name, "for_net")
+        paddle.jit.save(net, model_file)
 
         right_pdmodel = set([
             "randint", "fill_constant", "cast", "less_than", "while",
             "elementwise_add"
         ])
         paddle.enable_static()
-        pdmodel = getModelOp("for_net.pdmodel")
-        #print(len(right_pdmodel.difference(pdmodel)))
+        pdmodel = getModelOp(model_file + ".pdmodel")
         self.assertTrue(
             len(right_pdmodel.difference(pdmodel)) == 0,
             "The for op is pruned by mistake.")
+        root_path.cleanup()
 
     def test_if_op(self):
         paddle.disable_static()
@@ -130,18 +134,20 @@ class TestConditionalOp(unittest.TestCase):
             net,
             input_spec=[paddle.static.InputSpec(
                 shape=[1], dtype='int32')])
-        paddle.jit.save(net, './if_net')
+        root_path = tempfile.TemporaryDirectory()
+        model_file = os.path.join(root_path.name, "if_net")
+        paddle.jit.save(net, model_file)
 
         right_pdmodel = set([
             "assign_value", "greater_than", "cast", "conditional_block",
             "logical_not", "select_input"
         ])
         paddle.enable_static()
-        pdmodel = getModelOp("if_net.pdmodel")
-        #print(len(right_pdmodel.difference(pdmodel)))
+        pdmodel = getModelOp(model_file + ".pdmodel")
         self.assertTrue(
             len(right_pdmodel.difference(pdmodel)) == 0,
             "The if op is pruned by mistake.")
+        root_path.cleanup()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry-pick #43267  模型量化及save_inference_model相关单测中包含一些模型导出和save的逻辑，为了更好的管理导出文件，此处用tempfile来管理此类文件，保证单测执行完之后所有的临时文件都会被正常的删除掉，避免占用磁盘文件。

此PR仅涉及单测修改，不涉及新功能。