### PR TITLE
[mlu] add interploate_v2 kernel

### DIFF
--- a/paddle/fluid/operators/interpolate_op.h
+++ b/paddle/fluid/operators/interpolate_op.h
@@ -38,7 +38,8 @@ inline std::vector<int> get_new_shape(
                           "The shape of dimension tensor should be [1],"
                           "but received d%.",
                           tensor->dims()));
-    if (platform::is_gpu_place(tensor->place())) {
+    if (platform::is_gpu_place(tensor->place()) ||
+        platform::is_mlu_place(tensor->place())) {
       framework::Tensor temp;
       paddle::framework::TensorCopySync(*tensor, platform::CPUPlace(), &temp);
       vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
@@ -55,7 +56,8 @@ inline std::vector<T> get_new_data_from_tensor(const Tensor* new_data_tensor) {
   std::vector<T> vec_new_data;
   auto* new_data = new_data_tensor->data<T>();
   framework::Tensor cpu_starts_tensor;
-  if (platform::is_gpu_place(new_data_tensor->place())) {
+  if (platform::is_gpu_place(new_data_tensor->place()) ||
+      platform::is_mlu_place(new_data_tensor->place())) {
     paddle::framework::TensorCopySync(*new_data_tensor, platform::CPUPlace(),
                                       &cpu_starts_tensor);
     new_data = cpu_starts_tensor.data<T>();

--- a/paddle/fluid/operators/interpolate_v2_op_mlu.cc
+++ b/paddle/fluid/operators/interpolate_v2_op_mlu.cc
@@ -1,0 +1,469 @@
+/* Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/interpolate_op.h"
+#include "paddle/fluid/operators/mlu/mlu_baseop.h"
+#include "paddle/fluid/operators/utils.h"
+
+namespace paddle {
+namespace operators {
+
+using framework::Tensor;
+using DataLayout = framework::DataLayout;
+
+inline std::vector<int> get_new_shape_mlu(
+    const std::vector<const Tensor*>& list_new_shape_tensor) {
+  // get tensor from
+  std::vector<int> vec_new_shape;
+  for (size_t i = 0; i < list_new_shape_tensor.size(); ++i) {
+    auto tensor = list_new_shape_tensor[i];
+    PADDLE_ENFORCE_EQ(
+        tensor->dims(), phi::make_ddim({1}),
+        platform::errors::InvalidArgument("shape of dim tensor should be [1]"));
+    framework::Tensor temp;
+    paddle::framework::TensorCopySync(*tensor, platform::CPUPlace(), &temp);
+    vec_new_shape.push_back(static_cast<int32_t>(*temp.data<int32_t>()));
+  }
+
+  return vec_new_shape;
+}
+
+template <typename T>
+class InterpolateV2MLUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto& dev_ctx = ctx.template device_context<MLUDeviceContext>();
+    auto* input = ctx.Input<Tensor>("X");
+    auto* output = ctx.Output<Tensor>("Out");
+
+    auto input_dims = input->dims();
+    PADDLE_ENFORCE_GE(
+        input_dims.size(), 4,
+        platform::errors::External("MLU Interpolate kernel supports input "
+                                   "range greater or equal than 4."));
+    PADDLE_ENFORCE_LE(
+        input_dims.size(), 5,
+        platform::errors::External("MLU Interpolate kernel supports input "
+                                   "range less or equal than 5. "));
+
+    const std::string data_layout_str = ctx.Attr<std::string>("data_layout");
+    const DataLayout data_layout =
+        framework::StringToDataLayout(data_layout_str);
+    int n, c, in_d, in_h, in_w;
+    ExtractNCDWH(input_dims, data_layout, &n, &c, &in_d, &in_h, &in_w);
+
+    auto interp_method = ctx.Attr<std::string>("interp_method");
+    bool align_corners = ctx.Attr<bool>("align_corners");
+    int align_mode = ctx.Attr<int>("align_mode");
+    int align_center = align_corners ? 0 : (align_mode == 1 ? 0 : 1);
+
+    int out_d = ctx.Attr<int>("out_d");
+    int out_h = ctx.Attr<int>("out_h");
+    int out_w = ctx.Attr<int>("out_w");
+    float scale_d = -1;
+    float scale_h = -1;
+    float scale_w = -1;
+
+    auto list_new_size_tensor = ctx.MultiInput<framework::Tensor>("SizeTensor");
+    if (list_new_size_tensor.size() > 0) {
+      // have size tensor
+      auto new_size = get_new_shape_mlu(list_new_size_tensor);
+      if (new_size.size() <= 2) {
+        // default NCHW
+        out_h = new_size[0];
+        out_w = new_size[1];
+      } else {
+        // rank of input is 5, HCDHW
+        out_d = new_size[0];
+        out_h = new_size[1];
+        out_w = new_size[2];
+      }
+    } else {
+      auto scale_tensor = ctx.Input<Tensor>("Scale");
+      auto scale = ctx.Attr<std::vector<float>>("scale");
+      if (scale_tensor != nullptr) {
+        std::vector<float> scale_data;
+        scale_data = GetDataFromTensor<float>(scale_tensor);
+
+        if (scale_data.size() > 1 && scale_data.size() <= 2) {
+          scale_h = scale_data[0];
+          scale_w = scale_data[1];
+        } else if (scale_data.size() > 2) {
+          scale_d = scale_data[0];
+          scale_h = scale_data[1];
+          scale_w = scale_data[2];
+        } else {
+          scale_d = scale_data[0];
+          scale_h = scale_data[0];
+          scale_w = scale_data[0];
+        }
+        PADDLE_ENFORCE_EQ(
+            scale_w > 0 && scale_h > 0, true,
+            platform::errors::InvalidArgument("scale of Op(interpolate) "
+                                              "should be greater than 0."));
+      } else {
+        if (scale.size() > 1 && scale.size() <= 2) {
+          scale_h = scale[0];
+          scale_w = scale[1];
+
+          PADDLE_ENFORCE_EQ(
+              scale_w > 0 && scale_h > 0, true,
+              platform::errors::InvalidArgument("scale  of Op(interpolate) "
+                                                "should be greater than 0."));
+        } else if (scale.size() > 2) {
+          scale_d = scale[0];
+          scale_h = scale[1];
+          scale_w = scale[2];
+          PADDLE_ENFORCE_EQ(
+              scale_d > 0 && scale_w > 0 && scale_h > 0, true,
+              platform::errors::InvalidArgument("scale  of Op(interpolate) "
+                                                "should be greater than 0."));
+        }
+      }
+      if (scale_h > 0. && scale_w > 0.) {
+        out_h = static_cast<int>(in_h * scale_h);
+        out_w = static_cast<int>(in_w * scale_w);
+      }
+
+      if (scale_d > 0.) {
+        out_d = static_cast<int>(in_d * scale_d);
+      }
+      auto out_size = ctx.Input<Tensor>("OutSize");
+      if (out_size != nullptr) {
+        std::vector<int32_t> out_size_data;
+        out_size_data = GetDataFromTensor<int>(out_size);
+        if (out_size_data.size() <= 2) {
+          out_h = out_size_data[0];
+          out_w = out_size_data[1];
+        } else {
+          out_d = out_size_data[0];
+          out_h = out_size_data[1];
+          out_w = out_size_data[2];
+        }
+      }
+    }
+    PADDLE_ENFORCE_GT(
+        out_h, 0,
+        platform::errors::InvalidArgument("out_h in Attr(out_shape) of "
+                                          "Op(interpolate) "
+                                          "should be greater than 0."));
+    PADDLE_ENFORCE_GT(
+        out_w, 0,
+        platform::errors::InvalidArgument("out_w in Attr(out_shape) of "
+                                          "Op(interpolate) "
+                                          "should be greater than 0."));
+
+    // do transpose according to cnnl's constraints
+    // cnnlInterp_v2 only accepts NHWC when mode is CNNL_INTERP_BILINEAR and
+    // CNNL_INTERP_NEAREST,
+    framework::DDim dim_in, dim_in_trans, dim_out, dim_out_trans;
+    Tensor transformed_input, transformed_output;
+    bool need_transpose = input_dims.size() != 2;
+    if (input_dims.size() == 4) {
+      // need to do transpose if layout is kNCHW
+      need_transpose &= data_layout == DataLayout::kNCHW;
+      if (need_transpose) {
+        // if need_transpose, do the following
+        // 1. transpose input NCHW -> NHWC
+        // 2. interpolation in(NHWC) -> out(NHWC)
+        // 3. transpose output NHWC -> HCHW
+        // dim_in = {n, c, in_h, in_w};
+        dim_in_trans = {n, in_h, in_w, c};
+        dim_out = {n, c, out_h, out_w};
+        dim_out_trans = {n, out_h, out_w, c};
+        output->mutable_data<T>(dim_out, ctx.GetPlace());
+
+        if (in_h == out_h && in_w == out_w) {
+          framework::TensorCopy(*input, ctx.GetPlace(), output);
+          return;
+        }
+        // do transpose on input tensor, then do interpolation
+        MLUCnnlTensorDesc input_desc(*input, CNNL_LAYOUT_NCHW,
+                                     ToCnnlDataType(input->dtype()));
+
+        transformed_input =
+            ctx.AllocateTmpTensor<T, MLUDeviceContext>(dim_in_trans, dev_ctx);
+        transformed_output =
+            ctx.AllocateTmpTensor<T, MLUDeviceContext>(dim_out_trans, dev_ctx);
+
+        MLUCnnlTensorDesc input_reshaped_desc(
+            transformed_input, CNNL_LAYOUT_NHWC,
+            ToCnnlDataType(transformed_input.dtype()));
+        const std::vector<int> perm = {0, 2, 3, 1};
+        MLUCnnl::Transpose(ctx, perm, input_dims.size(), input_desc.get(),
+                           GetBasePtr(input), input_reshaped_desc.get(),
+                           GetBasePtr(&transformed_input));
+      } else {
+        // if no need_transpose, do the following
+        // 1. interpolation in(NHWC) -> out(NHWC)
+        // dim_in = {n, in_h, in_w, c};
+        dim_out = {n, out_h, out_w, c};
+        output->mutable_data<T>(dim_out, ctx.GetPlace());
+
+        if (in_h == out_h && in_w == out_w) {
+          framework::TensorCopy(*input, ctx.GetPlace(), output);
+          return;
+        }
+        transformed_input = *input;
+        transformed_output = *output;
+      }
+
+      MLUCnnlTensorDesc input_desc(transformed_input, CNNL_LAYOUT_NHWC,
+                                   ToCnnlDataType(transformed_input.dtype()));
+      MLUCnnlTensorDesc output_desc(transformed_output, CNNL_LAYOUT_NHWC,
+                                    ToCnnlDataType(transformed_output.dtype()));
+      MLUCnnl::Interp(ctx, GetMLUCnnlInterpMode(interp_method), align_corners,
+                      align_center, input_desc.get(),
+                      GetBasePtr(&transformed_input), output_desc.get(),
+                      GetBasePtr(&transformed_output));
+
+      if (need_transpose) {
+        // if need_transpose, reshape output back to NCHW
+        const std::vector<int> perm = {0, 3, 1, 2};
+        MLUCnnlTensorDesc output_reshape_desc(*output, CNNL_LAYOUT_NCHW,
+                                              ToCnnlDataType(output->dtype()));
+        MLUCnnl::Transpose(ctx, perm, dim_out_trans.size(), output_desc.get(),
+                           GetBasePtr(&transformed_output),
+                           output_reshape_desc.get(), GetBasePtr(output));
+      }
+    } else {
+      PADDLE_ENFORCE_EQ(
+          interp_method, "trilinear",
+          platform::errors::External("MLU Interpolate kernel only supports 5D "
+                                     "data in trilinear mode."));
+
+      // need to do transpose if layout is kNCDHW
+      need_transpose &= data_layout == DataLayout::kNCHW;
+      if (need_transpose) {
+        // if need_transpose, do the following
+        // 1. transpose input NCDHW -> NDHWC
+        // 2. interpolation in(NDHWC) -> out(NDHWC)
+        // 3. transpose output NDHWC -> HCDHW
+        // dim_in = {n, c, in_d, in_h, in_w};
+        dim_in_trans = {n, in_d, in_h, in_w, c};
+        dim_out = {n, c, out_d, out_h, out_w};
+        dim_out_trans = {n, out_d, out_h, out_w, c};
+        output->mutable_data<T>(dim_out, ctx.GetPlace());
+
+        if (in_h == out_h && in_w == out_w && in_d == out_d) {
+          framework::TensorCopy(*input, ctx.GetPlace(), output);
+          return;
+        }
+        // do transpose on input tensor (HCDHW -> NDHWC), then do interpolation
+        MLUCnnlTensorDesc input_desc(*input, CNNL_LAYOUT_NCDHW,
+                                     ToCnnlDataType(input->dtype()));
+
+        transformed_input =
+            ctx.AllocateTmpTensor<T, MLUDeviceContext>(dim_in_trans, dev_ctx);
+        transformed_output =
+            ctx.AllocateTmpTensor<T, MLUDeviceContext>(dim_out_trans, dev_ctx);
+
+        MLUCnnlTensorDesc input_reshaped_desc(
+            transformed_input, CNNL_LAYOUT_NDHWC,
+            ToCnnlDataType(transformed_input.dtype()));
+        const std::vector<int> perm = {0, 2, 3, 4, 1};
+        MLUCnnl::Transpose(ctx, perm, input_dims.size(), input_desc.get(),
+                           GetBasePtr(input), input_reshaped_desc.get(),
+                           GetBasePtr(&transformed_input));
+      } else {
+        // if no need_transpose, do the following
+        // 1. interpolation in(NDHWC) -> out(NDHWC)
+        // dim_in = {n, in_d, in_h, in_w, c};
+        dim_out = {n, out_d, out_h, out_w, c};
+        output->mutable_data<T>(dim_out, ctx.GetPlace());
+
+        if (in_h == out_h && in_w == out_w && in_d == out_d) {
+          framework::TensorCopy(*input, ctx.GetPlace(), output);
+          return;
+        }
+        transformed_input = *input;
+        transformed_output = *output;
+      }
+
+      MLUCnnlTensorDesc input_desc(transformed_input, CNNL_LAYOUT_NDHWC,
+                                   ToCnnlDataType(transformed_input.dtype()));
+      MLUCnnlTensorDesc output_desc(transformed_output, CNNL_LAYOUT_NDHWC,
+                                    ToCnnlDataType(transformed_output.dtype()));
+      // use trilinear mode in HCDHW layout
+      MLUCnnl::Interp(ctx, GetMLUCnnlInterpMode(interp_method), align_corners,
+                      align_center, input_desc.get(),
+                      GetBasePtr(&transformed_input), output_desc.get(),
+                      GetBasePtr(&transformed_output));
+
+      if (need_transpose) {
+        // if need_transpose, reshape output back (NDHWC -> NCDHW)
+        const std::vector<int> perm = {0, 4, 1, 2, 3};
+        MLUCnnlTensorDesc output_reshape_desc(*output, CNNL_LAYOUT_NCDHW,
+                                              ToCnnlDataType(output->dtype()));
+        MLUCnnl::Transpose(ctx, perm, dim_out_trans.size(), output_desc.get(),
+                           GetBasePtr(&transformed_output),
+                           output_reshape_desc.get(), GetBasePtr(output));
+      }
+    }
+  }
+};
+
+// template <typename DeviceContext, typename T>
+// class InterpolateV2NPUGradKernel : public framework::OpKernel<T> {
+//  public:
+//   void Compute(const framework::ExecutionContext& ctx) const override {
+//     auto* input = ctx.Input<Tensor>("X");
+//     auto* output_grad = ctx.Input<Tensor>(framework::GradVarName("Out"));
+//     auto* input_grad = ctx.Output<Tensor>(framework::GradVarName("X"));
+
+//     const std::string data_layout_str = ctx.Attr<std::string>("data_layout");
+//     const DataLayout data_layout =
+//         framework::StringToDataLayout(data_layout_str);
+//     int n, c, in_d, in_h, in_w;
+//     phi::funcs::ExtractNCDWH(input->dims(), data_layout, &n, &c, &in_d,
+//     &in_h,
+//                              &in_w);
+
+//     auto interp_method = ctx.Attr<std::string>("interp_method");
+//     bool align_corners = ctx.Attr<bool>("align_corners");
+
+//     // To-do(qili93): need to support align_corners = true case, try ReSizeD
+//     PADDLE_ENFORCE_EQ(
+//         align_corners, false,
+//         platform::errors::InvalidArgument(
+//             "NPU Interpolate Kernel has diff when align_corners is true."));
+
+//     int out_h = ctx.Attr<int>("out_h");
+//     int out_w = ctx.Attr<int>("out_w");
+//     float scale_h = -1;
+//     float scale_w = -1;
+
+//     // Priority: SizeTensor > OutSize > Scale > scale > out_h & out_w
+//     auto list_new_size_tensor =
+//     ctx.MultiInput<framework::Tensor>("SizeTensor");
+//     if (list_new_size_tensor.size() > 0) {
+//       std::vector<int32_t> output_h(1);
+//       std::vector<int32_t> output_w(1);
+//       auto dev_ctx =
+//           platform::DeviceContextPool::Instance().Get(ctx.GetPlace());
+//       framework::TensorToVector(*list_new_size_tensor[0], *dev_ctx,
+//       &output_h);
+//       framework::TensorToVector(*list_new_size_tensor[1], *dev_ctx,
+//       &output_w);
+//       out_h = output_h[0];
+//       out_w = output_w[0];
+//     } else if (ctx.HasInput("OutSize")) {
+//       auto out_size = ctx.Input<Tensor>("OutSize");
+//       auto out_size_data =
+//       phi::funcs::get_new_data_from_tensor<int>(out_size);
+//       out_h = out_size_data[0];
+//       out_w = out_size_data[1];
+//     } else {
+//       auto scale_tensor = ctx.Input<Tensor>("Scale");
+//       auto scale = ctx.Attr<std::vector<float>>("scale");
+//       if (scale_tensor != nullptr) {
+//         auto scale_data =
+//             phi::funcs::get_new_data_from_tensor<float>(scale_tensor);
+//         if (scale_data.size() > 1) {
+//           scale_h = scale_data[0];
+//           scale_w = scale_data[1];
+//         } else {
+//           scale_w = scale_data[0];
+//           scale_h = scale_data[0];
+//         }
+//         PADDLE_ENFORCE_EQ(
+//             scale_w > 0, true,
+//             platform::errors::InvalidArgument(
+//                 "The scale_w in input 'Scale' Tensor of Operator(interpolate)
+//                 "
+//                 "should be greater than 0, but received value is %d.",
+//                 scale_w));
+//         PADDLE_ENFORCE_EQ(
+//             scale_h > 0, true,
+//             platform::errors::InvalidArgument(
+//                 "The scale_h in input 'Scale' Tensor of Operator(interpolate)
+//                 "
+//                 "should be greater than 0, but received value is %d.",
+//                 scale_h));
+//       } else {
+//         if (scale.size() > 1) {
+//           scale_h = scale[0];
+//           scale_w = scale[1];
+//           PADDLE_ENFORCE_EQ(
+//               scale_w > 0, true,
+//               platform::errors::InvalidArgument(
+//                   "The scale_w in Attr(scale) of Operator(interpolate) "
+//                   "should be greater than 0, but received value is %d.",
+//                   scale_w));
+//           PADDLE_ENFORCE_EQ(
+//               scale_h > 0, true,
+//               platform::errors::InvalidArgument(
+//                   "The scale_h in Attr(scale) of Operator(interpolate) "
+//                   "should be greater than 0, but received value is %d.",
+//                   scale_h));
+//         }
+//       }
+//       if (scale_h > 0. && scale_w > 0.) {
+//         out_h = static_cast<int>(in_h * scale_h);
+//         out_w = static_cast<int>(in_w * scale_w);
+//       }
+//     }
+
+//     framework::DDim dim_grad;
+//     if (data_layout == DataLayout::kNCHW) {
+//       dim_grad = {n, c, in_h, in_w};
+//     } else {
+//       dim_grad = {n, in_h, in_w, c};
+//     }
+
+//     input_grad->mutable_data<T>(dim_grad, ctx.GetPlace());
+
+//     if (in_h == out_h && in_w == out_w) {
+//       framework::TensorCopy(*output_grad, ctx.GetPlace(), input_grad);
+//       return;
+//     }
+
+//     auto stream =
+//         ctx.template device_context<paddle::platform::NPUDeviceContext>()
+//             .stream();
+
+//     // To-do(qili93): need to support bilineare, try ResizeGradD
+//     if ("nearest" == interp_method) {
+//       NpuOpRunner runner;
+//       runner.SetType("ResizeNearestNeighborV2Grad")
+//           .AddInput(*output_grad)
+//           .AddInput(std::vector<int32_t>{in_h, in_w})
+//           .AddOutput(*input_grad)
+//           .AddAttr("align_corners", align_corners)
+//           .AddAttr("half_pixel_centers", false);
+//       runner.Run(stream);
+//     } else if ("bilinear" == interp_method) {
+//       int align_mode = ctx.Attr<int>("align_mode");
+//       BilinearBwdNpu<T>(ctx, output_grad, input_grad, scale_h, scale_w,
+//                         align_corners, align_mode, data_layout);
+//     }
+//   }
+// };
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_MLU_KERNEL(bilinear_interp_v2, ops::InterpolateV2MLUKernel<float>,
+                       ops::InterpolateV2MLUKernel<plat::float16>);
+REGISTER_OP_MLU_KERNEL(nearest_interp_v2, ops::InterpolateV2MLUKernel<float>,
+                       ops::InterpolateV2MLUKernel<plat::float16>);
+
+// REGISTER_OP_MLU_KERNEL(
+//     nearest_interp_v2_grad,
+//     ops::InterpolateV2NPUGradKernel<plat::NPUDeviceContext, float>,
+//     ops::InterpolateV2NPUGradKernel<plat::NPUDeviceContext, plat::float16>);

--- a/paddle/fluid/operators/mlu/mlu_baseop.cc
+++ b/paddle/fluid/operators/mlu/mlu_baseop.cc
@@ -1925,9 +1925,9 @@ MLUCnnlTrigonDesc::~MLUCnnlTrigonDesc() {
     const cnnlTensorDescriptor_t output_desc, void* output) {
   cnnlHandle_t handle = GetHandleFromCTX(ctx);
 
-  PADDLE_ENFORCE_MLU_SUCCESS(
-      cnnlInterpBackward(handle, align_corners, half_pixel_centers, mode,
-                         input_desc, input, output_desc, output));
+  PADDLE_ENFORCE_MLU_SUCCESS(cnnlInterpBackward_v2(
+      handle, align_corners, half_pixel_centers, mode, NULL, true, input_desc,
+      input, output_desc, output));
 }
 
 /* static */ void MLUCnnl::Cast(const ExecutionContext& ctx,

--- a/paddle/fluid/operators/mlu/mlu_baseop.h
+++ b/paddle/fluid/operators/mlu/mlu_baseop.h
@@ -41,6 +41,13 @@ const std::map<std::string, cnnlReduceOp_t> MLUReduceOpMap = {
     {"reduce_prod", CNNL_REDUCE_MUL},
 };
 
+const std::map<std::string, cnnlInterpMode_t> MLUInterpModeMap = {
+    {"bilinear", CNNL_INTERP_BILINEAR},
+    {"nearest", CNNL_INTERP_NEAREST},
+    {"linear", CNNL_INTERP_LINEAR},
+    {"trilinear", CNNL_INTERP_TRILINEAR},
+    {"bicubic", CNNL_INTERP_BICUBIC}};
+
 inline cnnlReduceOp_t GetMLUCnnlReduceOp(const std::string reduce_name) {
   auto iter = MLUReduceOpMap.find(reduce_name);
   if (iter != MLUReduceOpMap.end()) {
@@ -48,6 +55,15 @@ inline cnnlReduceOp_t GetMLUCnnlReduceOp(const std::string reduce_name) {
   }
   PADDLE_THROW(platform::errors::InvalidArgument(
       "Not support reduce op type of MLU Device: %s", reduce_name));
+}
+
+inline cnnlInterpMode_t GetMLUCnnlInterpMode(const std::string interp_mode) {
+  auto iter = MLUInterpModeMap.find(interp_mode);
+  if (iter != MLUInterpModeMap.end()) {
+    return iter->second;
+  }
+  PADDLE_THROW(platform::errors::InvalidArgument(
+      "Not support interp mode of MLU Device: %s", interp_mode));
 }
 
 inline const void* GetBasePtr(const Tensor* t) { return t->data(); }

--- a/paddle/fluid/operators/mlu/mlu_baseop.h
+++ b/paddle/fluid/operators/mlu/mlu_baseop.h
@@ -48,6 +48,13 @@ const std::map<std::string, cnnlInterpMode_t> MLUInterpModeMap = {
     {"trilinear", CNNL_INTERP_TRILINEAR},
     {"bicubic", CNNL_INTERP_BICUBIC}};
 
+const std::map<std::string, cnnlInterpBackwardMode_t> MLUInterpBackwardModeMap =
+    {{"bilinear", CNNL_INTERP_BACKWARD_BILINEAR},
+     {"nearest", CNNL_INTERP_BACKWARD_NEAREST},
+     {"linear", CNNL_INTERP_BACKWARD_LINEAR},
+     {"trilinear", CNNL_INTERP_BACKWARD_TRILINEAR},
+     {"bicubic", CNNL_INTERP_BACKWARD_BICUBIC}};
+
 inline cnnlReduceOp_t GetMLUCnnlReduceOp(const std::string reduce_name) {
   auto iter = MLUReduceOpMap.find(reduce_name);
   if (iter != MLUReduceOpMap.end()) {
@@ -60,6 +67,16 @@ inline cnnlReduceOp_t GetMLUCnnlReduceOp(const std::string reduce_name) {
 inline cnnlInterpMode_t GetMLUCnnlInterpMode(const std::string interp_mode) {
   auto iter = MLUInterpModeMap.find(interp_mode);
   if (iter != MLUInterpModeMap.end()) {
+    return iter->second;
+  }
+  PADDLE_THROW(platform::errors::InvalidArgument(
+      "Not support interp mode of MLU Device: %s", interp_mode));
+}
+
+inline cnnlInterpBackwardMode_t GetMLUCnnlInterpBackwardMode(
+    const std::string interp_mode) {
+  auto iter = MLUInterpBackwardModeMap.find(interp_mode);
+  if (iter != MLUInterpBackwardModeMap.end()) {
     return iter->second;
   }
   PADDLE_THROW(platform::errors::InvalidArgument(

--- a/python/paddle/fluid/tests/unittests/mlu/test_bilinear_interp_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_bilinear_interp_v2_op_mlu.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import sys
+
 sys.path.append('..')
 from op_test import OpTest
 import paddle.fluid.core as core
@@ -108,6 +109,7 @@ def bilinear_interp_np(input,
 
 
 class TestBilinearInterpOp(OpTest):
+
     def setUp(self):
         self.place = paddle.device.MLUPlace(0)
         self.__class__.use_mlu = True
@@ -142,9 +144,10 @@ class TestBilinearInterpOp(OpTest):
             out_h = self.out_h
             out_w = self.out_w
 
-        output_np = bilinear_interp_np(
-            input_np, out_h, out_w, 0, 0, self.out_size, self.actual_shape,
-            self.align_corners, self.align_mode, self.data_layout)
+        output_np = bilinear_interp_np(input_np, out_h, out_w, 0, 0,
+                                       self.out_size, self.actual_shape,
+                                       self.align_corners, self.align_mode,
+                                       self.data_layout)
         self.inputs = {'X': input_np}
         if self.out_size is not None:
             self.inputs['OutSize'] = self.out_size
@@ -159,7 +162,7 @@ class TestBilinearInterpOp(OpTest):
             'align_mode': self.align_mode,
             'data_layout': self.data_layout
         }
-        print(self.attrs)
+
         if self.scale:
             if isinstance(self.scale, float) or isinstance(self.scale, int):
                 if self.scale > 0.:
@@ -172,8 +175,8 @@ class TestBilinearInterpOp(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
-    # def test_check_grad(self):
-    #     self.check_grad(['X'], 'Out', in_place=True)
+    def test_check_grad(self):
+        self.check_grad_with_place(self.place, ['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         self.interp_method = 'bilinear'
@@ -187,6 +190,7 @@ class TestBilinearInterpOp(OpTest):
 
 
 class TestBilinearInterpCase1(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [4, 1, 7, 8]
@@ -198,6 +202,7 @@ class TestBilinearInterpCase1(TestBilinearInterpOp):
 
 
 class TestBilinearInterpCase2(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [3, 3, 9, 6]
@@ -209,6 +214,7 @@ class TestBilinearInterpCase2(TestBilinearInterpOp):
 
 
 class TestBilinearInterpCase3(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [1, 1, 32, 64]
@@ -219,10 +225,11 @@ class TestBilinearInterpCase3(TestBilinearInterpOp):
         self.align_mode = 1
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, atol=1e-7)
+        self.check_output_with_place(self.place, atol=1e-5)
 
 
 class TestBilinearInterpCase4(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [4, 1, 7, 8]
@@ -235,6 +242,7 @@ class TestBilinearInterpCase4(TestBilinearInterpOp):
 
 
 class TestBilinearInterpCase5(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [3, 3, 9, 6]
@@ -247,6 +255,7 @@ class TestBilinearInterpCase5(TestBilinearInterpOp):
 
 
 class TestBilinearInterpCase6(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [1, 1, 32, 64]
@@ -259,6 +268,7 @@ class TestBilinearInterpCase6(TestBilinearInterpOp):
 
 
 class TestBilinearInterpCase7(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [1, 1, 32, 64]
@@ -270,6 +280,7 @@ class TestBilinearInterpCase7(TestBilinearInterpOp):
 
 
 class TestBilinearInterpSame(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 3, 32, 64]
@@ -281,6 +292,7 @@ class TestBilinearInterpSame(TestBilinearInterpOp):
 
 
 class TestBilinearInterpActualShape(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [3, 2, 32, 16]
@@ -293,6 +305,7 @@ class TestBilinearInterpActualShape(TestBilinearInterpOp):
 
 
 class TestBilinearInterpDataLayout(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 5, 5, 3]
@@ -306,24 +319,28 @@ class TestBilinearInterpDataLayout(TestBilinearInterpOp):
 
 
 class TestBilinearInterpOtherMethod1(TestBilinearInterpOp):
+
     def set_align_mode(self):
         self.align_corners = False
         self.align_mode = 1
 
 
 class TestBilinearInterpWithMethod2(TestBilinearInterpOp):
+
     def set_align_mode(self):
         self.align_corners = False
         self.align_mode = 0
 
 
 class TestBilinearInterpWithMethod3(TestBilinearInterpOp):
+
     def set_align_mode(self):
         self.align_corners = True
         self.align_mode = 0
 
 
 class TestBilinearInterpScale1(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 3, 5, 7]
@@ -335,6 +352,7 @@ class TestBilinearInterpScale1(TestBilinearInterpOp):
 
 
 class TestBilinearInterpScale2(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 3, 5, 7]
@@ -346,6 +364,7 @@ class TestBilinearInterpScale2(TestBilinearInterpOp):
 
 
 class TestBilinearInterpScale3(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 3, 5, 7]
@@ -357,6 +376,7 @@ class TestBilinearInterpScale3(TestBilinearInterpOp):
 
 
 class TestBilinearInterpScale4(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 3, 5, 7]
@@ -368,6 +388,7 @@ class TestBilinearInterpScale4(TestBilinearInterpOp):
 
 
 class TestBilinearInterpZero(TestBilinearInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 3, 5, 7]
@@ -379,6 +400,7 @@ class TestBilinearInterpZero(TestBilinearInterpOp):
 
 
 class TestBilinearInterpOp_attr_tensor(OpTest):
+
     def setUp(self):
         self.place = paddle.device.MLUPlace(0)
         self.__class__.use_mlu = True
@@ -439,8 +461,8 @@ class TestBilinearInterpOp_attr_tensor(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
-    # def test_check_grad(self):
-    #     self.check_grad(['X'], 'Out', in_place=True)
+    def test_check_grad(self):
+        self.check_grad_with_place(self.place, ['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         self.interp_method = 'bilinear'
@@ -454,6 +476,7 @@ class TestBilinearInterpOp_attr_tensor(OpTest):
 
 # out_size is a 1-D tensor
 class TestBilinearInterp_attr_tensor_Case1(TestBilinearInterpOp_attr_tensor):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [3, 3, 9, 6]
@@ -466,6 +489,7 @@ class TestBilinearInterp_attr_tensor_Case1(TestBilinearInterpOp_attr_tensor):
 
 # scale is a 1-D tensor
 class TestBilinearInterp_attr_tensor_Case2(TestBilinearInterpOp_attr_tensor):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [3, 2, 32, 16]
@@ -479,6 +503,7 @@ class TestBilinearInterp_attr_tensor_Case2(TestBilinearInterpOp_attr_tensor):
 
 # scale is a 1-D tensor
 class TestBilinearInterp_attr_tensor_Case3(TestBilinearInterpOp_attr_tensor):
+
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [3, 2, 32, 16]
@@ -538,6 +563,7 @@ class TestBilinearInterp_attr_tensor_Case3(TestBilinearInterpOp_attr_tensor):
 
 
 class TestBilinearInterpOpAPI_dy(unittest.TestCase):
+
     def test_case(self):
         import paddle
         if core.is_compiled_with_mlu():
@@ -549,14 +575,19 @@ class TestBilinearInterpOpAPI_dy(unittest.TestCase):
             input_data = np.load('input.npy').astype("float32")
             # print(input_data)
             input_x = paddle.to_tensor(input_data)
-            expect_res = bilinear_interp_np(
-                input_data, out_h=12, out_w=12, align_corners=False)
-            out = interpolate(
-                x=input_x, size=[12, 12], mode="bilinear", align_corners=False)
+            expect_res = bilinear_interp_np(input_data,
+                                            out_h=12,
+                                            out_w=12,
+                                            align_corners=False)
+            out = interpolate(x=input_x,
+                              size=[12, 12],
+                              mode="bilinear",
+                              align_corners=False)
             self.assertTrue(np.allclose(out.numpy(), expect_res))
 
 
 class TestBilinearInterpOpAPI_dy2(unittest.TestCase):
+
     def test_case(self):
         import paddle
         if core.is_compiled_with_mlu():
@@ -568,14 +599,19 @@ class TestBilinearInterpOpAPI_dy2(unittest.TestCase):
             size_np = np.array([12, 12]).astype("int64")
             input_x = paddle.to_tensor(input_data)
             size = paddle.to_tensor(size_np)
-            expect_res = bilinear_interp_np(
-                input_data, out_h=12, out_w=12, align_corners=False)
-            out = interpolate(
-                x=input_x, size=size, mode="bilinear", align_corners=False)
+            expect_res = bilinear_interp_np(input_data,
+                                            out_h=12,
+                                            out_w=12,
+                                            align_corners=False)
+            out = interpolate(x=input_x,
+                              size=size,
+                              mode="bilinear",
+                              align_corners=False)
             self.assertTrue(np.allclose(out.numpy(), expect_res))
 
 
 class TestBilinearInterpOpAPI_dy3(unittest.TestCase):
+
     def test_case(self):
         import paddle
         if core.is_compiled_with_mlu():
@@ -587,17 +623,19 @@ class TestBilinearInterpOpAPI_dy3(unittest.TestCase):
             size_1 = np.array([12]).astype("int64")
             input_x = paddle.to_tensor(input_data)
             size = paddle.to_tensor(size_1)
-            expect_res = bilinear_interp_np(
-                input_data, out_h=12, out_w=12, align_corners=False)
-            out = interpolate(
-                x=input_x,
-                size=[size, size],
-                mode="bilinear",
-                align_corners=False)
+            expect_res = bilinear_interp_np(input_data,
+                                            out_h=12,
+                                            out_w=12,
+                                            align_corners=False)
+            out = interpolate(x=input_x,
+                              size=[size, size],
+                              mode="bilinear",
+                              align_corners=False)
             self.assertTrue(np.allclose(out.numpy(), expect_res))
 
 
 class TestBilinearInterpOpAPI_dy4(unittest.TestCase):
+
     def test_case(self):
         import paddle
         if core.is_compiled_with_mlu():
@@ -609,13 +647,14 @@ class TestBilinearInterpOpAPI_dy4(unittest.TestCase):
             scale_np = np.array([2, 2]).astype("int64")
             input_x = paddle.to_tensor(input_data)
             scale = paddle.to_tensor(scale_np)
-            expect_res = bilinear_interp_np(
-                input_data, out_h=12, out_w=12, align_corners=False)
-            out = interpolate(
-                x=input_x,
-                scale_factor=scale,
-                mode="bilinear",
-                align_corners=False)
+            expect_res = bilinear_interp_np(input_data,
+                                            out_h=12,
+                                            out_w=12,
+                                            align_corners=False)
+            out = interpolate(x=input_x,
+                              scale_factor=scale,
+                              mode="bilinear",
+                              align_corners=False)
 
             self.assertTrue(np.allclose(out.numpy(), expect_res))
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_bilinear_interp_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_bilinear_interp_v2_op_mlu.py
@@ -1,0 +1,624 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import sys
+sys.path.append('..')
+from op_test import OpTest
+import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.nn.functional import interpolate
+import paddle
+
+paddle.enable_static()
+
+
+def bilinear_interp_np(input,
+                       out_h,
+                       out_w,
+                       scale_w=0,
+                       scale_h=0,
+                       out_size=None,
+                       actual_shape=None,
+                       align_corners=True,
+                       align_mode=0,
+                       data_layout='NCHW'):
+    """bilinear interpolation implement in shape [N, C, H, W]"""
+    if data_layout == "NHWC":
+        input = np.transpose(input, (0, 3, 1, 2))  # NHWC => NCHW
+    if out_size is not None:
+        out_h = out_size[0]
+        out_w = out_size[1]
+    if actual_shape is not None:
+        out_h = actual_shape[0]
+        out_w = actual_shape[1]
+    batch_size, channel, in_h, in_w = input.shape
+
+    ratio_h = ratio_w = 0.0
+    if out_h > 1:
+        if (align_corners):
+            ratio_h = (in_h - 1.0) / (out_h - 1.0)
+        else:
+            if scale_h > 0:
+                ratio_h = 1.0 / scale_h
+            else:
+                ratio_h = 1.0 * in_h / out_h
+    if out_w > 1:
+        if (align_corners):
+            ratio_w = (in_w - 1.0) / (out_w - 1.0)
+        else:
+            if scale_w > 0:
+                ratio_w = 1.0 / scale_w
+            else:
+                ratio_w = 1.0 * in_w / out_w
+
+    out = np.zeros((batch_size, channel, out_h, out_w))
+
+    for i in range(out_h):
+        if (align_mode == 0 and not align_corners):
+            h = int(ratio_h * (i + 0.5) - 0.5)
+        else:
+            h = int(ratio_h * i)
+
+        h = max(0, h)
+        hid = 1 if h < in_h - 1 else 0
+        if (align_mode == 0 and not align_corners):
+            idx_src_h = max(ratio_h * (i + 0.5) - 0.5, 0)
+            h1lambda = idx_src_h - h
+        else:
+            h1lambda = ratio_h * i - h
+        h2lambda = 1.0 - h1lambda
+        for j in range(out_w):
+            if (align_mode == 0 and not align_corners):
+                w = int(ratio_w * (j + 0.5) - 0.5)
+            else:
+                w = int(ratio_w * j)
+            w = max(0, w)
+            wid = 1 if w < in_w - 1 else 0
+            if (align_mode == 0 and not align_corners):
+                idx_src_w = max(ratio_w * (j + 0.5) - 0.5, 0)
+                w1lambda = idx_src_w - w
+            else:
+                w1lambda = ratio_w * j - w
+            w2lambda = 1.0 - w1lambda
+
+            out[:, :, i, j] = h2lambda*(w2lambda*input[:, :, h, w] +
+                                        w1lambda*input[:, :, h, w+wid]) + \
+                h1lambda*(w2lambda*input[:, :, h+hid, w] +
+                          w1lambda*input[:, :, h+hid, w+wid])
+
+    if data_layout == "NHWC":
+        out = np.transpose(out, (0, 2, 3, 1))  # NCHW => NHWC
+
+    return out.astype(input.dtype)
+
+
+class TestBilinearInterpOp(OpTest):
+    def setUp(self):
+        self.place = paddle.device.MLUPlace(0)
+        self.__class__.use_mlu = True
+        self.out_size = None
+        self.actual_shape = None
+        self.data_layout = 'NCHW'
+        self.init_test_case()
+        self.dtype = "float32"
+        self.op_type = "bilinear_interp_v2"
+        input_np = np.random.random(self.input_shape).astype(self.dtype)
+
+        if self.data_layout == "NCHW":
+            in_h = self.input_shape[2]
+            in_w = self.input_shape[3]
+        else:
+            in_h = self.input_shape[1]
+            in_w = self.input_shape[2]
+        scale_h = 0
+        scale_w = 0
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0.:
+                    scale_h = scale_w = float(self.scale)
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                scale_w = scale_h = self.scale[0]
+            elif isinstance(self.scale, list) and len(self.scale) > 1:
+                scale_w = self.scale[1]
+                scale_h = self.scale[0]
+            out_h = int(in_h * scale_h)
+            out_w = int(in_w * scale_w)
+        else:
+            out_h = self.out_h
+            out_w = self.out_w
+
+        output_np = bilinear_interp_np(
+            input_np, out_h, out_w, 0, 0, self.out_size, self.actual_shape,
+            self.align_corners, self.align_mode, self.data_layout)
+        self.inputs = {'X': input_np}
+        if self.out_size is not None:
+            self.inputs['OutSize'] = self.out_size
+        if self.actual_shape is not None:
+            self.inputs['OutSize'] = self.actual_shape
+
+        self.attrs = {
+            'out_h': self.out_h,
+            'out_w': self.out_w,
+            'interp_method': self.interp_method,
+            'align_corners': self.align_corners,
+            'align_mode': self.align_mode,
+            'data_layout': self.data_layout
+        }
+        print(self.attrs)
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0.:
+                    self.scale = [self.scale]
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                self.scale = [self.scale[0], self.scale[0]]
+            self.attrs['scale'] = self.scale
+        self.outputs = {'Out': output_np}
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    # def test_check_grad(self):
+    #     self.check_grad(['X'], 'Out', in_place=True)
+
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 5]
+        self.out_h = 2
+        self.out_w = 2
+        self.scale = 0.
+        self.out_size = np.array([3, 3]).astype("int32")
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpCase1(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [4, 1, 7, 8]
+        self.out_h = 1
+        self.out_w = 1
+        self.scale = 0.
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpCase2(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [3, 3, 9, 6]
+        self.out_h = 12
+        self.out_w = 12
+        self.scale = 0.
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpCase3(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [1, 1, 32, 64]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.align_corners = True
+        self.align_mode = 1
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place, atol=1e-7)
+
+
+class TestBilinearInterpCase4(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [4, 1, 7, 8]
+        self.out_h = 1
+        self.out_w = 1
+        self.scale = 0.
+        self.out_size = np.array([2, 2]).astype("int32")
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpCase5(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [3, 3, 9, 6]
+        self.out_h = 12
+        self.out_w = 12
+        self.scale = 0.
+        self.out_size = np.array([11, 11]).astype("int32")
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpCase6(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [1, 1, 32, 64]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.out_size = np.array([65, 33]).astype("int32")
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpCase7(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [1, 1, 32, 64]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = [2.0, 0.5]
+        self.align_corners = False
+        self.align_mode = 1
+
+
+class TestBilinearInterpSame(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 32, 64]
+        self.out_h = 32
+        self.out_w = 64
+        self.scale = 0.
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpActualShape(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [3, 2, 32, 16]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.out_size = np.array([66, 40]).astype("int32")
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpDataLayout(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 5, 5, 3]
+        self.out_h = 2
+        self.out_w = 2
+        self.scale = 0.
+        self.out_size = np.array([3, 3]).astype("int32")
+        self.align_corners = True
+        self.align_mode = 1
+        self.data_layout = "NHWC"
+
+
+class TestBilinearInterpOtherMethod1(TestBilinearInterpOp):
+    def set_align_mode(self):
+        self.align_corners = False
+        self.align_mode = 1
+
+
+class TestBilinearInterpWithMethod2(TestBilinearInterpOp):
+    def set_align_mode(self):
+        self.align_corners = False
+        self.align_mode = 0
+
+
+class TestBilinearInterpWithMethod3(TestBilinearInterpOp):
+    def set_align_mode(self):
+        self.align_corners = True
+        self.align_mode = 0
+
+
+class TestBilinearInterpScale1(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 7]
+        self.out_h = 60
+        self.out_w = 25
+        self.scale = 2.
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpScale2(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 7]
+        self.out_h = 60
+        self.out_w = 25
+        self.scale = 1.
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpScale3(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 7]
+        self.out_h = 60
+        self.out_w = 25
+        self.scale = 1.5
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpScale4(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 7]
+        self.out_h = 60
+        self.out_w = 25
+        self.scale = [1.5, 0.5]
+        self.align_corners = True
+        self.align_mode = 1
+
+
+class TestBilinearInterpZero(TestBilinearInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 7]
+        self.out_h = 60
+        self.out_w = 25
+        self.scale = 0.2
+        self.align_corners = False
+        self.align_mode = 0
+
+
+class TestBilinearInterpOp_attr_tensor(OpTest):
+    def setUp(self):
+        self.place = paddle.device.MLUPlace(0)
+        self.__class__.use_mlu = True
+        self.out_size = None
+        self.actual_shape = None
+        self.init_test_case()
+        self.op_type = "bilinear_interp_v2"
+        self.shape_by_1Dtensor = False
+        self.scale_by_1Dtensor = False
+        self.attrs = {
+            'interp_method': self.interp_method,
+            'align_corners': self.align_corners,
+        }
+
+        input_np = np.random.random(self.input_shape).astype("float32")
+        self.inputs = {'X': input_np}
+
+        if self.scale_by_1Dtensor:
+            self.inputs['Scale'] = np.array([self.scale]).astype("float32")
+        elif self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    scale_h = scale_w = float(self.scale)
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                scale_w = scale_h = self.scale[0]
+            elif isinstance(self.scale, list) and len(self.scale) > 1:
+                scale_w = self.scale[1]
+                scale_h = self.scale[0]
+            out_h = int(self.input_shape[2] * scale_h)
+            out_w = int(self.input_shape[3] * scale_w)
+        else:
+            out_h = self.out_h
+            out_w = self.out_w
+
+        if self.shape_by_1Dtensor:
+            self.inputs['OutSize'] = self.out_size
+        elif self.out_size is not None:
+            size_tensor = []
+            for index, ele in enumerate(self.out_size):
+                size_tensor.append(("x" + str(index), np.ones(
+                    (1)).astype('int32') * ele))
+            self.inputs['SizeTensor'] = size_tensor
+
+        self.attrs['out_h'] = self.out_h
+        self.attrs['out_w'] = self.out_w
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    self.scale = [self.scale]
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                self.scale = [self.scale[0], self.scale[0]]
+            self.attrs['scale'] = self.scale
+        output_np = bilinear_interp_np(input_np, out_h, out_w, 0, 0,
+                                       self.out_size, self.actual_shape,
+                                       self.align_corners)
+        self.outputs = {'Out': output_np}
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    # def test_check_grad(self):
+    #     self.check_grad(['X'], 'Out', in_place=True)
+
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 5]
+        self.out_h = 3
+        self.out_w = 3
+        self.scale = 0.
+        self.out_size = [3, 3]
+        self.align_corners = True
+
+
+# out_size is a 1-D tensor
+class TestBilinearInterp_attr_tensor_Case1(TestBilinearInterpOp_attr_tensor):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [3, 3, 9, 6]
+        self.out_h = 12
+        self.out_w = 12
+        self.scale = 0.
+        self.out_size = [8, 12]
+        self.align_corners = True
+
+
+# scale is a 1-D tensor
+class TestBilinearInterp_attr_tensor_Case2(TestBilinearInterpOp_attr_tensor):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [3, 2, 32, 16]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.out_size = np.array([66, 40]).astype("int32")
+        self.align_corners = True
+        self.shape_by_1Dtensor = True
+
+
+# scale is a 1-D tensor
+class TestBilinearInterp_attr_tensor_Case3(TestBilinearInterpOp_attr_tensor):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [3, 2, 32, 16]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 2.0
+        self.out_size = None
+        self.align_corners = True
+        self.scale_by_1Dtensor = True
+
+
+#TODO: comment this test for now until bilinear_interp_op added.
+# class TestBilinearInterpOpAPI(unittest.TestCase):
+#     def test_case(self):
+#         x = fluid.data(name="x", shape=[2, 3, 6, 6], dtype="float32")
+
+#         dim = fluid.data(name="dim", shape=[1], dtype="int32")
+#         shape_tensor = fluid.data(name="shape_tensor", shape=[2], dtype="int32")
+#         actual_size = fluid.data(name="actual_size", shape=[2], dtype="int32")
+#         scale_tensor = fluid.data(
+#             name="scale_tensor", shape=[1], dtype="float32")
+
+#         out1 = fluid.layers.resize_bilinear(x, out_shape=[12, 12])
+#         out2 = fluid.layers.resize_bilinear(x, out_shape=[12, dim])
+#         out3 = fluid.layers.resize_bilinear(x, out_shape=shape_tensor)
+#         out4 = fluid.layers.resize_bilinear(
+#             x, out_shape=[4, 4], actual_shape=actual_size)
+#         out5 = fluid.layers.resize_bilinear(x, scale=scale_tensor)
+
+#         x_data = np.random.random((2, 3, 6, 6)).astype("float32")
+#         dim_data = np.array([12]).astype("int32")
+#         shape_data = np.array([12, 12]).astype("int32")
+#         actual_size_data = np.array([12, 12]).astype("int32")
+#         scale_data = np.array([2.0]).astype("float32")
+
+#         if core.is_compiled_with_mlu():
+#             place = paddle.device.MLUPlace(0)
+#         else:
+#             place = core.CPUPlace()
+#         exe = fluid.Executor(place)
+#         exe.run(fluid.default_startup_program())
+#         results = exe.run(fluid.default_main_program(),
+#                           feed={
+#                               "x": x_data,
+#                               "dim": dim_data,
+#                               "shape_tensor": shape_data,
+#                               "actual_size": actual_size_data,
+#                               "scale_tensor": scale_data
+#                           },
+#                           fetch_list=[out1, out2, out3, out4, out5],
+#                           return_numpy=True)
+
+#         expect_res = bilinear_interp_np(
+#             x_data, out_h=12, out_w=12, align_corners=True)
+#         for res in results:
+#             self.assertTrue(np.allclose(res, expect_res))
+
+
+class TestBilinearInterpOpAPI_dy(unittest.TestCase):
+    def test_case(self):
+        import paddle
+        if core.is_compiled_with_mlu():
+            place = paddle.device.MLUPlace(0)
+        else:
+            place = core.CPUPlace()
+        with fluid.dygraph.guard(place):
+            input_data = np.random.random((2, 3, 6, 6)).astype("float32")
+            input_data = np.load('input.npy').astype("float32")
+            # print(input_data)
+            input_x = paddle.to_tensor(input_data)
+            expect_res = bilinear_interp_np(
+                input_data, out_h=12, out_w=12, align_corners=False)
+            out = interpolate(
+                x=input_x, size=[12, 12], mode="bilinear", align_corners=False)
+            self.assertTrue(np.allclose(out.numpy(), expect_res))
+
+
+class TestBilinearInterpOpAPI_dy2(unittest.TestCase):
+    def test_case(self):
+        import paddle
+        if core.is_compiled_with_mlu():
+            place = paddle.device.MLUPlace(0)
+        else:
+            place = core.CPUPlace()
+        with fluid.dygraph.guard(place):
+            input_data = np.random.random((2, 3, 6, 6)).astype("float32")
+            size_np = np.array([12, 12]).astype("int64")
+            input_x = paddle.to_tensor(input_data)
+            size = paddle.to_tensor(size_np)
+            expect_res = bilinear_interp_np(
+                input_data, out_h=12, out_w=12, align_corners=False)
+            out = interpolate(
+                x=input_x, size=size, mode="bilinear", align_corners=False)
+            self.assertTrue(np.allclose(out.numpy(), expect_res))
+
+
+class TestBilinearInterpOpAPI_dy3(unittest.TestCase):
+    def test_case(self):
+        import paddle
+        if core.is_compiled_with_mlu():
+            place = paddle.device.MLUPlace(0)
+        else:
+            place = core.CPUPlace()
+        with fluid.dygraph.guard(place):
+            input_data = np.random.random((2, 3, 6, 6)).astype("float32")
+            size_1 = np.array([12]).astype("int64")
+            input_x = paddle.to_tensor(input_data)
+            size = paddle.to_tensor(size_1)
+            expect_res = bilinear_interp_np(
+                input_data, out_h=12, out_w=12, align_corners=False)
+            out = interpolate(
+                x=input_x,
+                size=[size, size],
+                mode="bilinear",
+                align_corners=False)
+            self.assertTrue(np.allclose(out.numpy(), expect_res))
+
+
+class TestBilinearInterpOpAPI_dy4(unittest.TestCase):
+    def test_case(self):
+        import paddle
+        if core.is_compiled_with_mlu():
+            place = paddle.device.MLUPlace(0)
+        else:
+            place = core.CPUPlace()
+        with fluid.dygraph.guard(place):
+            input_data = np.random.random((2, 3, 6, 6)).astype("float32")
+            scale_np = np.array([2, 2]).astype("int64")
+            input_x = paddle.to_tensor(input_data)
+            scale = paddle.to_tensor(scale_np)
+            expect_res = bilinear_interp_np(
+                input_data, out_h=12, out_w=12, align_corners=False)
+            out = interpolate(
+                x=input_x,
+                scale_factor=scale,
+                mode="bilinear",
+                align_corners=False)
+
+            self.assertTrue(np.allclose(out.numpy(), expect_res))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/mlu/test_nearest_interp_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_nearest_interp_v2_op_mlu.py
@@ -1,0 +1,617 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import sys
+sys.path.append('..')
+from op_test import OpTest
+import paddle.fluid.core as core
+import paddle.fluid as fluid
+import paddle.nn as nn
+import paddle
+from paddle.nn.functional import interpolate
+
+paddle.enable_static()
+
+
+def nearest_neighbor_interp_np(X,
+                               out_h,
+                               out_w,
+                               scale_h=0,
+                               scale_w=0,
+                               out_size=None,
+                               actual_shape=None,
+                               align_corners=True,
+                               data_layout='NCHW'):
+    """nearest neighbor interpolation implement in shape [N, C, H, W]"""
+    if data_layout == "NHWC":
+        X = np.transpose(X, (0, 3, 1, 2))  # NHWC => NCHW
+    if out_size is not None:
+        out_h = out_size[0]
+        out_w = out_size[1]
+    if actual_shape is not None:
+        out_h = actual_shape[0]
+        out_w = actual_shape[1]
+    n, c, in_h, in_w = X.shape
+
+    ratio_h = ratio_w = 0.0
+    if (out_h > 1):
+        if (align_corners):
+            ratio_h = (in_h - 1.0) / (out_h - 1.0)
+        else:
+            if scale_h > 0:
+                ratio_h = 1.0 / scale_h
+            else:
+                ratio_h = 1.0 * in_h / out_h
+    if (out_w > 1):
+        if (align_corners):
+            ratio_w = (in_w - 1.0) / (out_w - 1.0)
+        else:
+            if scale_w > 0:
+                ratio_w = 1.0 / scale_w
+            else:
+                ratio_w = 1.0 * in_w / out_w
+    out = np.zeros((n, c, out_h, out_w))
+
+    if align_corners:
+        for i in range(out_h):
+            in_i = int(ratio_h * i + 0.5)
+            for j in range(out_w):
+                in_j = int(ratio_w * j + 0.5)
+                out[:, :, i, j] = X[:, :, in_i, in_j]
+    else:
+        for i in range(out_h):
+            in_i = int(ratio_h * i)
+            for j in range(out_w):
+                in_j = int(ratio_w * j)
+                out[:, :, i, j] = X[:, :, in_i, in_j]
+
+    if data_layout == "NHWC":
+        out = np.transpose(out, (0, 2, 3, 1))  # NCHW => NHWC
+    # out = np.expand_dims(out, 2)
+    return out.astype(X.dtype)
+
+
+def nearest_neighbor_interp3d_np(X,
+                                 out_d,
+                                 out_h,
+                                 out_w,
+                                 scale_d=0,
+                                 scale_h=0,
+                                 scale_w=0,
+                                 out_size=None,
+                                 actual_shape=None,
+                                 align_corners=True,
+                                 data_layout='NCHW'):
+    """nearest neighbor interpolation implement in shape [N, C, H, W]"""
+    if data_layout == "NHWC":
+        X = np.transpose(X, (0, 4, 1, 2, 3))  # NDHWC => NCDHW
+    if out_size is not None:
+        out_d = out_size[0]
+        out_h = out_size[1]
+        out_w = out_size[2]
+    if actual_shape is not None:
+        out_d = actual_shape[0]
+        out_h = actual_shape[1]
+        out_w = actual_shape[2]
+    n, c, in_d, in_h, in_w = X.shape
+
+    ratio_d = ratio_h = ratio_w = 0.0
+    if (out_d > 1):
+        if (align_corners):
+            ratio_d = (in_d - 1.0) / (out_d - 1.0)
+        else:
+            if scale_d > 0:
+                ratio_d = 1.0 / scale_d
+            else:
+                ratio_d = 1.0 * in_d / out_d
+    if (out_h > 1):
+        if (align_corners):
+            ratio_h = (in_h - 1.0) / (out_h - 1.0)
+        else:
+            if scale_h > 0:
+                ratio_h = 1.0 / scale_h
+            else:
+                ratio_h = 1.0 * in_h / out_h
+    if (out_w > 1):
+        if (align_corners):
+            ratio_w = (in_w - 1.0) / (out_w - 1.0)
+        else:
+            if scale_w > 0:
+                ratio_w = 1.0 / scale_w
+            else:
+                ratio_w = 1.0 * in_w / out_w
+    out = np.zeros((n, c, out_d, out_h, out_w))
+
+    if align_corners:
+        for d in range(out_d):
+            in_d = int(ratio_d * d + 0.5)
+            for i in range(out_h):
+                in_i = int(ratio_h * i + 0.5)
+                for j in range(out_w):
+                    in_j = int(ratio_w * j + 0.5)
+                    out[:, :, d, i, j] = X[:, :, in_d, in_i, in_j]
+    else:
+        for d in range(out_d):
+            in_d = int(ratio_d * d)
+            for i in range(out_h):
+                in_i = int(ratio_h * i)
+                for j in range(out_w):
+                    in_j = int(ratio_w * j)
+                    out[:, :, d, i, j] = X[:, :, in_d, in_i, in_j]
+
+    if data_layout == "NDHWC":
+        out = np.transpose(out, (0, 2, 3, 4, 1))  # NCDHW => NDHWC
+    return out.astype(X.dtype)
+
+
+class TestNearestInterpOp(OpTest):
+    def setUp(self):
+        self.place = paddle.device.MLUPlace(0)
+        self.__class__.use_mlu = True
+        self.out_size = None
+        self.actual_shape = None
+        self.init_test_case()
+        self.data_layout = 'NCHW' if len(self.input_shape) == 4 else 'NCDHW'
+        self.op_type = "nearest_interp_v2"
+        input_np = np.random.random(self.input_shape).astype("float32")
+
+        if self.data_layout == "NCHW" and len(self.input_shape) == 4:
+            in_d = 1
+            in_h = self.input_shape[2]
+            in_w = self.input_shape[3]
+        else:
+            in_d = 1
+            in_h = self.input_shape[1]
+            in_w = self.input_shape[2]
+
+        if self.data_layout == "NCDHW" and len(self.input_shape) == 5:
+            in_d = self.input_shape[2]
+            in_h = self.input_shape[3]
+            in_w = self.input_shape[4]
+        else:
+            in_d = self.input_shape[1]
+            in_h = self.input_shape[2]
+            in_w = self.input_shape[3]
+        scale_d = 0
+        scale_h = 0
+        scale_w = 0
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    scale_d = scale_h = scale_w = float(self.scale)
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                scale_d = scale_w = scale_h = self.scale[0]
+            elif isinstance(self.scale, list) and len(self.scale) > 1:
+                if len(self.scale) == 5:
+                    scale_w = self.scale[2]
+                    scale_h = self.scale[1]
+                    scale_d = self.scale[0]
+                else:
+                    scale_w = self.scale[1]
+                    scale_h = self.scale[0]
+
+            out_h = int(in_h * scale_h)
+            out_w = int(in_w * scale_w)
+            out_d = int(in_d * scale_d)
+        else:
+            if len(self.input_shape) == 5:
+                out_d = self.out_d
+            out_h = self.out_h
+            out_w = self.out_w
+
+        if len(self.input_shape) == 4:
+            output_np = nearest_neighbor_interp_np(
+                input_np, out_h, out_w, scale_h, scale_w, self.out_size,
+                self.actual_shape, self.align_corners, self.data_layout)
+        elif len(self.input_shape) == 5:
+            output_np = nearest_neighbor_interp3d_np(
+                input_np, out_d, out_h, out_w, scale_d, scale_h, scale_w,
+                self.out_size, self.actual_shape, self.align_corners,
+                self.data_layout)
+        self.inputs = {'X': input_np}
+        if self.out_size is not None:
+            self.inputs['OutSize'] = self.out_size
+        if self.actual_shape is not None:
+            self.inputs['OutSize'] = self.actual_shape
+        if len(self.input_shape) == 5:
+            self.attrs = {
+                'out_d': self.out_d,
+                'out_h': self.out_h,
+                'out_w': self.out_w,
+                'interp_method': self.interp_method,
+                'align_corners': self.align_corners,
+                'data_layout': self.data_layout
+            }
+        else:
+            self.attrs = {
+                'out_h': self.out_h,
+                'out_w': self.out_w,
+                'interp_method': self.interp_method,
+                'align_corners': self.align_corners,
+                'data_layout': self.data_layout
+            }
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    self.scale = [self.scale]
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                self.scale = [self.scale[0], self.scale[0]]
+            self.attrs['scale'] = self.scale
+        self.outputs = {'Out': output_np}
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    # def test_check_grad(self):
+    #     self.check_grad(['X'], 'Out', in_place=True)
+
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [2, 3, 4, 5]
+        self.out_h = 2
+        self.out_w = 2
+        self.scale = 0.
+        self.out_size = np.array([3, 3]).astype("int32")
+        self.align_corners = True
+
+
+# class TestNearestNeighborInterpCase1(TestNearestInterpOp):
+#     def init_test_case(self):
+#         self.interp_method = 'nearest'
+#         self.input_shape = [4, 1, 1, 7, 8]
+#         self.out_d = 1
+#         self.out_h = 1
+#         self.out_w = 1
+#         self.scale = 0.
+#         self.align_corners = True
+
+
+class TestNearestNeighborInterpCase2(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 3, 9, 6]
+        self.out_h = 12
+        self.out_w = 12
+        self.scale = 0.
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpCase3(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [1, 1, 32, 64]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpCase4(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [4, 1, 7, 8]
+        self.out_h = 1
+        self.out_w = 1
+        self.scale = 0.
+        self.out_size = np.array([2, 2]).astype("int32")
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpCase5(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 3, 9, 6]
+        self.out_h = 12
+        self.out_w = 12
+        self.scale = 0.
+        self.out_size = np.array([11, 11]).astype("int32")
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpCase6(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [1, 1, 32, 64]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.out_size = np.array([65, 129]).astype("int32")
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpSame(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [2, 3, 32, 64]
+        self.out_h = 32
+        self.out_w = 64
+        self.scale = 0.
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpActualShape(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 2, 32, 16]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.out_size = np.array([66, 40]).astype("int32")
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpDataLayout(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [2, 4, 4, 5]
+        self.out_h = 2
+        self.out_w = 2
+        self.scale = 0.
+        self.out_size = np.array([3, 8]).astype("int32")
+        self.align_corners = True
+        self.data_layout = "NHWC"
+
+
+class TestNearestInterpWithoutCorners(TestNearestInterpOp):
+    def set_align_corners(self):
+        self.align_corners = False
+
+
+class TestNearestNeighborInterpScale1(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 2, 7, 5]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 2.
+        self.out_size = np.array([66, 40]).astype("int32")
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpScale2(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 2, 5, 7]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 1.5
+        self.out_size = np.array([66, 40]).astype("int32")
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpScale3(TestNearestInterpOp):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 2, 7, 5]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = [2.0, 3.0]
+        self.out_size = np.array([66, 40]).astype("int32")
+        self.align_corners = True
+
+
+# class TestNearestNeighbor3DInterp(TestNearestInterpOp):
+#     def init_test_case(self):
+#         self.interp_method = 'nearest'
+#         self.input_shape = [3, 2, 4, 7, 5]
+#         self.out_d = 8
+#         self.out_h = 64
+#         self.out_w = 32
+#         self.scale = [4.0, 2.0, 3.0]
+#         self.out_size = np.array([8, 66, 40]).astype("int32")
+#         self.align_corners = True
+
+
+class TestNearestInterpOp_attr_tensor(OpTest):
+    def setUp(self):
+        self.place = paddle.device.MLUPlace(0)
+        self.__class__.use_mlu = True
+        self.out_size = None
+        self.actual_shape = None
+        self.init_test_case()
+        self.op_type = "nearest_interp_v2"
+        self.shape_by_1Dtensor = False
+        self.scale_by_1Dtensor = False
+        self.attrs = {
+            'interp_method': self.interp_method,
+            'align_corners': self.align_corners,
+        }
+
+        input_np = np.random.random(self.input_shape).astype("float32")
+        self.inputs = {'X': input_np}
+
+        if self.scale_by_1Dtensor:
+            self.inputs['Scale'] = np.array([self.scale]).astype("float32")
+        elif self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    scale_h = scale_w = float(self.scale)
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                scale_w = scale_h = self.scale[0]
+            elif isinstance(self.scale, list) and len(self.scale) > 1:
+                scale_w = self.scale[1]
+                scale_h = self.scale[0]
+            out_h = int(self.input_shape[2] * scale_h)
+            out_w = int(self.input_shape[3] * scale_w)
+        else:
+            out_h = self.out_h
+            out_w = self.out_w
+
+        if self.shape_by_1Dtensor:
+            self.inputs['OutSize'] = self.out_size
+        elif self.out_size is not None:
+            size_tensor = []
+            for index, ele in enumerate(self.out_size):
+                size_tensor.append(("x" + str(index), np.ones(
+                    (1)).astype('int32') * ele))
+            self.inputs['SizeTensor'] = size_tensor
+
+        self.attrs['out_h'] = self.out_h
+        self.attrs['out_w'] = self.out_w
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    self.scale = [self.scale]
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                self.scale = [self.scale[0], self.scale[0]]
+            self.attrs['scale'] = self.scale
+        output_np = nearest_neighbor_interp_np(input_np, out_h, out_w, 0, 0,
+                                               self.out_size, self.actual_shape,
+                                               self.align_corners)
+        self.outputs = {'Out': output_np}
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place)
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out', in_place=True)
+
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [2, 5, 4, 4]
+        self.out_h = 3
+        self.out_w = 3
+        self.scale = 0.
+        self.out_size = [3, 3]
+        self.align_corners = True
+
+
+# out_size is a tensor list
+class TestNearestInterp_attr_tensor_Case1(TestNearestInterpOp_attr_tensor):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 3, 9, 6]
+        self.out_h = 12
+        self.out_w = 12
+        self.scale = 0.
+        self.out_size = [8, 12]
+        self.align_corners = True
+
+
+# out_size is a 1-D tensor
+class TestNearestInterp_attr_tensor_Case2(TestNearestInterpOp_attr_tensor):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 2, 32, 16]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 0.
+        self.out_size = np.array([66, 40]).astype("int32")
+        self.align_corners = True
+        self.shape_by_1Dtensor = True
+
+
+# scale is a 1-D tensor
+class TestNearestInterp_attr_tensor_Case3(TestNearestInterpOp_attr_tensor):
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [3, 2, 32, 16]
+        self.out_h = 64
+        self.out_w = 32
+        self.scale = 2.0
+        self.out_size = None
+        self.align_corners = True
+        self.scale_by_1Dtensor = True
+
+
+#TODO: comment this test for now until nearest_interp_op added.
+# class TestNearestAPI(unittest.TestCase):
+#     def test_case(self):
+#         x = fluid.data(name="x", shape=[2, 3, 6, 6], dtype="float32")
+#         y = fluid.data(name="y", shape=[2, 6, 6, 3], dtype="float32")
+
+#         dim = fluid.data(name="dim", shape=[1], dtype="int32")
+#         shape_tensor = fluid.data(name="shape_tensor", shape=[2], dtype="int32")
+#         actual_size = fluid.data(name="actual_size", shape=[2], dtype="int32")
+#         scale_tensor = fluid.data(
+#             name="scale_tensor", shape=[1], dtype="float32")
+
+#         out1 = fluid.layers.resize_nearest(
+#             y, out_shape=[12, 12], data_format='NHWC', align_corners=False)
+#         out2 = fluid.layers.resize_nearest(
+#             x, out_shape=[12, dim], align_corners=False)
+#         out3 = fluid.layers.resize_nearest(
+#             x, out_shape=shape_tensor, align_corners=False)
+#         out4 = fluid.layers.resize_nearest(
+#             x, out_shape=[4, 4], actual_shape=actual_size, align_corners=False)
+#         out5 = fluid.layers.resize_nearest(
+#             x, scale=scale_tensor, align_corners=False)
+
+#         x_data = np.random.random((2, 3, 6, 6)).astype("float32")
+#         dim_data = np.array([12]).astype("int32")
+#         shape_data = np.array([12, 12]).astype("int32")
+#         actual_size_data = np.array([12, 12]).astype("int32")
+#         scale_data = np.array([2.0]).astype("float32")
+
+#         place = paddle.MLUPlace(0)
+#         exe = fluid.Executor(place)
+#         exe.run(fluid.default_startup_program())
+#         results = exe.run(fluid.default_main_program(),
+#                           feed={
+#                               "x": x_data,
+#                               "y": np.transpose(x_data, (0, 2, 3, 1)),
+#                               "dim": dim_data,
+#                               "shape_tensor": shape_data,
+#                               "actual_size": actual_size_data,
+#                               "scale_tensor": scale_data
+#                           },
+#                           fetch_list=[out1, out2, out3, out4, out5],
+#                           return_numpy=True)
+
+#         expect_res = nearest_neighbor_interp_np(
+#             x_data, out_h=12, out_w=12, align_corners=False)
+#         self.assertTrue(
+#             np.allclose(results[0], np.transpose(expect_res, (0, 2, 3, 1))))
+#         for i in range(len(results) - 1):
+#             self.assertTrue(np.allclose(results[i + 1], expect_res))
+
+
+class TestNearestInterpException(unittest.TestCase):
+    def test_exception(self):
+        import paddle
+        input = fluid.data(name="input", shape=[1, 3, 6, 6], dtype="float32")
+
+        def attr_data_format():
+            # for 4-D input, data_format can only be NCHW or NHWC
+            out = fluid.layers.resize_nearest(
+                input, out_shape=[4, 8], data_format='NDHWC')
+
+        def attr_scale_type():
+            out = fluid.layers.resize_nearest(input, scale='scale')
+
+        def attr_scale_value():
+            out = fluid.layers.resize_nearest(input, scale=-0.3)
+
+        def input_shape_error():
+            x = paddle.randn([1, 3])
+            out = paddle.nn.functional.interpolate(x, scale_factor='scale')
+
+        def mode_error():
+            x = paddle.randn([1, 3])
+            out = paddle.nn.functional.interpolate(
+                x, scale_factor='scale', mode="BILINEAR")
+
+        self.assertRaises(ValueError, attr_data_format)
+        self.assertRaises(TypeError, attr_scale_type)
+        self.assertRaises(ValueError, attr_scale_value)
+        self.assertRaises(ValueError, input_shape_error)
+        self.assertRaises(ValueError, mode_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/mlu/test_nearest_interp_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_nearest_interp_v2_op_mlu.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import sys
+
 sys.path.append('..')
 from op_test import OpTest
 import paddle.fluid.core as core
@@ -160,6 +161,7 @@ def nearest_neighbor_interp3d_np(X,
 
 
 class TestNearestInterpOp(OpTest):
+
     def setUp(self):
         self.place = paddle.device.MLUPlace(0)
         self.__class__.use_mlu = True
@@ -219,10 +221,12 @@ class TestNearestInterpOp(OpTest):
                 input_np, out_h, out_w, scale_h, scale_w, self.out_size,
                 self.actual_shape, self.align_corners, self.data_layout)
         elif len(self.input_shape) == 5:
-            output_np = nearest_neighbor_interp3d_np(
-                input_np, out_d, out_h, out_w, scale_d, scale_h, scale_w,
-                self.out_size, self.actual_shape, self.align_corners,
-                self.data_layout)
+            output_np = nearest_neighbor_interp3d_np(input_np, out_d, out_h,
+                                                     out_w, scale_d, scale_h,
+                                                     scale_w, self.out_size,
+                                                     self.actual_shape,
+                                                     self.align_corners,
+                                                     self.data_layout)
         self.inputs = {'X': input_np}
         if self.out_size is not None:
             self.inputs['OutSize'] = self.out_size
@@ -257,8 +261,8 @@ class TestNearestInterpOp(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place)
 
-    # def test_check_grad(self):
-    #     self.check_grad(['X'], 'Out', in_place=True)
+    def test_check_grad(self):
+        self.check_grad_with_place(self.place, ['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         self.interp_method = 'nearest'
@@ -282,6 +286,7 @@ class TestNearestInterpOp(OpTest):
 
 
 class TestNearestNeighborInterpCase2(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 3, 9, 6]
@@ -292,6 +297,7 @@ class TestNearestNeighborInterpCase2(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpCase3(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [1, 1, 32, 64]
@@ -302,6 +308,7 @@ class TestNearestNeighborInterpCase3(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpCase4(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [4, 1, 7, 8]
@@ -313,6 +320,7 @@ class TestNearestNeighborInterpCase4(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpCase5(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 3, 9, 6]
@@ -324,6 +332,7 @@ class TestNearestNeighborInterpCase5(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpCase6(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [1, 1, 32, 64]
@@ -335,6 +344,7 @@ class TestNearestNeighborInterpCase6(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpSame(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [2, 3, 32, 64]
@@ -345,6 +355,7 @@ class TestNearestNeighborInterpSame(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpActualShape(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 2, 32, 16]
@@ -356,6 +367,7 @@ class TestNearestNeighborInterpActualShape(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpDataLayout(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [2, 4, 4, 5]
@@ -368,11 +380,13 @@ class TestNearestNeighborInterpDataLayout(TestNearestInterpOp):
 
 
 class TestNearestInterpWithoutCorners(TestNearestInterpOp):
+
     def set_align_corners(self):
         self.align_corners = False
 
 
 class TestNearestNeighborInterpScale1(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 2, 7, 5]
@@ -384,6 +398,7 @@ class TestNearestNeighborInterpScale1(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpScale2(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 2, 5, 7]
@@ -395,6 +410,7 @@ class TestNearestNeighborInterpScale2(TestNearestInterpOp):
 
 
 class TestNearestNeighborInterpScale3(TestNearestInterpOp):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 2, 7, 5]
@@ -405,19 +421,8 @@ class TestNearestNeighborInterpScale3(TestNearestInterpOp):
         self.align_corners = True
 
 
-# class TestNearestNeighbor3DInterp(TestNearestInterpOp):
-#     def init_test_case(self):
-#         self.interp_method = 'nearest'
-#         self.input_shape = [3, 2, 4, 7, 5]
-#         self.out_d = 8
-#         self.out_h = 64
-#         self.out_w = 32
-#         self.scale = [4.0, 2.0, 3.0]
-#         self.out_size = np.array([8, 66, 40]).astype("int32")
-#         self.align_corners = True
-
-
 class TestNearestInterpOp_attr_tensor(OpTest):
+
     def setUp(self):
         self.place = paddle.device.MLUPlace(0)
         self.__class__.use_mlu = True
@@ -479,7 +484,7 @@ class TestNearestInterpOp_attr_tensor(OpTest):
         self.check_output_with_place(self.place)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', in_place=True)
+        self.check_grad_with_place(self.place, ['X'], 'Out', in_place=True)
 
     def init_test_case(self):
         self.interp_method = 'nearest'
@@ -493,6 +498,7 @@ class TestNearestInterpOp_attr_tensor(OpTest):
 
 # out_size is a tensor list
 class TestNearestInterp_attr_tensor_Case1(TestNearestInterpOp_attr_tensor):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 3, 9, 6]
@@ -505,6 +511,7 @@ class TestNearestInterp_attr_tensor_Case1(TestNearestInterpOp_attr_tensor):
 
 # out_size is a 1-D tensor
 class TestNearestInterp_attr_tensor_Case2(TestNearestInterpOp_attr_tensor):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 2, 32, 16]
@@ -518,6 +525,7 @@ class TestNearestInterp_attr_tensor_Case2(TestNearestInterpOp_attr_tensor):
 
 # scale is a 1-D tensor
 class TestNearestInterp_attr_tensor_Case3(TestNearestInterpOp_attr_tensor):
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [3, 2, 32, 16]
@@ -582,14 +590,16 @@ class TestNearestInterp_attr_tensor_Case3(TestNearestInterpOp_attr_tensor):
 
 
 class TestNearestInterpException(unittest.TestCase):
+
     def test_exception(self):
         import paddle
         input = fluid.data(name="input", shape=[1, 3, 6, 6], dtype="float32")
 
         def attr_data_format():
             # for 4-D input, data_format can only be NCHW or NHWC
-            out = fluid.layers.resize_nearest(
-                input, out_shape=[4, 8], data_format='NDHWC')
+            out = fluid.layers.resize_nearest(input,
+                                              out_shape=[4, 8],
+                                              data_format='NDHWC')
 
         def attr_scale_type():
             out = fluid.layers.resize_nearest(input, scale='scale')
@@ -603,8 +613,9 @@ class TestNearestInterpException(unittest.TestCase):
 
         def mode_error():
             x = paddle.randn([1, 3])
-            out = paddle.nn.functional.interpolate(
-                x, scale_factor='scale', mode="BILINEAR")
+            out = paddle.nn.functional.interpolate(x,
+                                                   scale_factor='scale',
+                                                   mode="BILINEAR")
 
         self.assertRaises(ValueError, attr_data_format)
         self.assertRaises(TypeError, attr_scale_type)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
*add bilinear-and-nearest_interp_v2 kernel forward and backward*

nearest_interp_v2
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/21559339/172562028-a3e4940f-38e6-42c7-bc9d-f9dad64dbafa.png">

nearest_interp_v2_grad
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/21559339/172562115-c7662f6e-aa9c-4f2f-8a5f-ee6162b91930.png">

bilinear_interp_v2
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/21559339/172562314-74638970-2366-4d9e-99db-eba21a7479ea.png">

bilinear_interp_v2_grad
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/21559339/172562395-69b81c08-6b09-4f32-b1a3-c0965f8d748a.png">
