### PR TITLE
create cusparse handle when cusparse api called for the first time

### DIFF
--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -230,7 +230,6 @@ struct GPUContext::Impl {
     phi::InitBlasLtHandle(&blaslt_handle_);
     phi::InitDnnHandle(&dnn_handle_, stream_, place_);
     phi::InitSolverHandle(&solver_handle_, stream_);
-    // phi::InitSparseHandle(&sparse_handle_, stream_);
     InitDnnWorkspace();
   }
 
@@ -262,7 +261,6 @@ struct GPUContext::Impl {
     phi::InitBlasLtHandle(&blaslt_handle_);
     phi::InitDnnHandle(&dnn_handle_, stream_, place_);
     phi::InitSolverHandle(&solver_handle_, stream_);
-    // phi::InitSparseHandle(&sparse_handle_, stream_);
   }
 
   void PartialInitWithAllocator() {

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -230,7 +230,7 @@ struct GPUContext::Impl {
     phi::InitBlasLtHandle(&blaslt_handle_);
     phi::InitDnnHandle(&dnn_handle_, stream_, place_);
     phi::InitSolverHandle(&solver_handle_, stream_);
-    phi::InitSparseHandle(&sparse_handle_, stream_);
+    // phi::InitSparseHandle(&sparse_handle_, stream_);
     InitDnnWorkspace();
   }
 
@@ -262,7 +262,7 @@ struct GPUContext::Impl {
     phi::InitBlasLtHandle(&blaslt_handle_);
     phi::InitDnnHandle(&dnn_handle_, stream_, place_);
     phi::InitSolverHandle(&solver_handle_, stream_);
-    phi::InitSparseHandle(&sparse_handle_, stream_);
+    // phi::InitSparseHandle(&sparse_handle_, stream_);
   }
 
   void PartialInitWithAllocator() {
@@ -407,6 +407,10 @@ struct GPUContext::Impl {
   void SetSolverHandle(solverHandle_t handle) { solver_handle_ = handle; }
 
   sparseHandle_t GetSparseHandle() const {
+    if (sparse_handle_ == nullptr) {
+      phi::InitSparseHandle(const_cast<cusparseContext**>(&sparse_handle_),
+                            stream_);
+    }
     PD_CHECK(sparse_handle_ != nullptr, "the gpu sparse handle is nullptr.");
     return sparse_handle_;
   }
@@ -486,6 +490,10 @@ struct GPUContext::Impl {
   inline void CusparseCall(
       const std::function<void(sparseHandle_t)>& callback) const {
     std::lock_guard<std::mutex> guard(sparse_mtx_);
+    if (sparse_handle_ == nullptr) {
+      phi::InitSparseHandle(const_cast<cusparseContext**>(&sparse_handle_),
+                            stream_);
+    }
     callback(sparse_handle_);
   }
 

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -406,7 +406,7 @@ struct GPUContext::Impl {
 
   sparseHandle_t GetSparseHandle() const {
     if (sparse_handle_ == nullptr) {
-      phi::InitSparseHandle(const_cast<cusparseContext**>(&sparse_handle_),
+      phi::InitSparseHandle(const_cast<sparseHandle_t*>(&sparse_handle_),
                             stream_);
     }
     PD_CHECK(sparse_handle_ != nullptr, "the gpu sparse handle is nullptr.");
@@ -489,7 +489,7 @@ struct GPUContext::Impl {
       const std::function<void(sparseHandle_t)>& callback) const {
     std::lock_guard<std::mutex> guard(sparse_mtx_);
     if (sparse_handle_ == nullptr) {
-      phi::InitSparseHandle(const_cast<cusparseContext**>(&sparse_handle_),
+      phi::InitSparseHandle(const_cast<sparseHandle_t*>(&sparse_handle_),
                             stream_);
     }
     callback(sparse_handle_);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
优化cusparse handle的创建时间点：修改前在context初始化的时候创建，修改后，在调用cusparse api的时候创建。
测试代码
```
a = paddle.randn((1,))
```
v100上显存占用从1322MiB 降到 1106MiB
