### PR TITLE
[Phi] Fix tensor copy

### DIFF
--- a/paddle/phi/api/lib/tensor_copy.cc
+++ b/paddle/phi/api/lib/tensor_copy.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/phi/api/lib/tensor_copy.h"
 
+#include "paddle/phi/api/include/context_pool.h"
 #include "paddle/phi/api/lib/api_gen_utils.h"
 #include "paddle/phi/api/lib/kernel_dispatch.h"
 #include "paddle/phi/core/compat/convert_utils.h"
@@ -24,18 +25,21 @@ limitations under the License. */
 namespace paddle {
 namespace experimental {
 
-void copy(const Tensor& src, Place place, bool blocking, Tensor* dst) {
+void copy(const Tensor& src, const Place& place, bool blocking, Tensor* dst) {
   auto kernel_key_set = ParseKernelKeyByInputArgs(src);
   kernel_key_set.backend_set =
       kernel_key_set.backend_set | BackendSet(phi::TransToPhiBackend(place));
   auto kernel_key = kernel_key_set.GetHighestPriorityKernelKey();
-  auto kernel = phi::KernelFactory::Instance().SelectKernelOrThrowError(
-      "copy", kernel_key);
 
   VLOG(6) << "copy API kernel key: " << kernel_key;
+  auto kernel = phi::KernelFactory::Instance().SelectKernelOrThrowError(
+      "copy", kernel_key);
   VLOG(6) << "copy API kernel: " << kernel;
 
-  auto* dev_ctx = GetDeviceContextByBackend(kernel_key.backend());
+  auto target_place = phi::TransToPhiPlace(kernel_key.backend());
+  auto& pool = paddle::experimental::DeviceContextPool::Instance();
+  auto* dev_ctx = pool.GetMutable(
+      target_place.GetType() == place.GetType() ? place : target_place);
 
   auto dense_x = TensorToDenseTensor(src);
 

--- a/paddle/phi/api/lib/tensor_copy.h
+++ b/paddle/phi/api/lib/tensor_copy.h
@@ -19,7 +19,7 @@ limitations under the License. */
 namespace paddle {
 namespace experimental {
 
-void copy(const Tensor& src, Place place, bool blocking, Tensor* dst);
+void copy(const Tensor& src, const Place& place, bool blocking, Tensor* dst);
 
 }  // namespace experimental
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复C++ copy接口在多卡设备拷贝时的bug，即在执行如下代码时：
```
y = paddle::copy(x /*on gpu:0*/, place /*gpu:1*/)
```
返回结果`y`的预期place应为`gpu:1`，但目前y的place为`gpu:0`
