### PR TITLE
fix the bug that _DataLoaderIterMultiProcess use time to generate the seed

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -374,7 +374,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         # see _try_put_indices
         self._thread_lock = threading.Lock()
 
-        self._base_seed = paddle.randint(low=0, high=2**31-1, shape=[1]).item()
+        self._base_seed = np.random.randint(low=0, high=sys.maxsize)
 
         # init workers and indices queues and put 2 indices in each indices queue
         self._init_workers()
@@ -408,7 +408,8 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                       self._data_queue, self._workers_done_event,
                       self._auto_collate_batch, self._collate_fn,
                       self._drop_last, self._worker_init_fn, i,
-                      self._num_workers, self._use_shared_memory, self._base_seed))
+                      self._num_workers, self._use_shared_memory,
+                      self._base_seed))
             worker.daemon = True
             worker.start()
             self._workers.append(worker)

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -374,6 +374,8 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         # see _try_put_indices
         self._thread_lock = threading.Lock()
 
+        self._base_seed = paddle.randint(low=0, high=2**31-1, shape=[1]).item()
+
         # init workers and indices queues and put 2 indices in each indices queue
         self._init_workers()
         for _ in range(self._outstanding_capacity):
@@ -406,7 +408,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                       self._data_queue, self._workers_done_event,
                       self._auto_collate_batch, self._collate_fn,
                       self._drop_last, self._worker_init_fn, i,
-                      self._num_workers, self._use_shared_memory))
+                      self._num_workers, self._use_shared_memory, self._base_seed))
             worker.daemon = True
             worker.start()
             self._workers.append(worker)

--- a/python/paddle/fluid/dataloader/worker.py
+++ b/python/paddle/fluid/dataloader/worker.py
@@ -257,7 +257,7 @@ def _generate_states(base_seed=0, worker_id=0):
 
 def _worker_loop(dataset, dataset_kind, indices_queue, out_queue, done_event,
                  auto_collate_batch, collate_fn, drop_last, init_fn, worker_id,
-                 num_workers, use_shared_memory):
+                 num_workers, use_shared_memory, base_seed):
     try:
         # NOTE: [ mmap files clear ] When the child process exits unexpectedly,
         # some shared memory objects may have been applied for but have not yet
@@ -272,15 +272,20 @@ def _worker_loop(dataset, dataset_kind, indices_queue, out_queue, done_event,
         try:
             import numpy as np
             import time
+            import random
         except ImportError:
             pass
         else:
-            np.random.seed(_generate_states(int(time.time()), worker_id))
+            seed = base_seed + worker_id
+            random.seed(seed)
+            paddle.seed(seed)
+            np.random.seed(_generate_states(base_seed, worker_id))
 
         global _worker_info
         _worker_info = WorkerInfo(id=worker_id,
                                   num_workers=num_workers,
-                                  dataset=dataset)
+                                  dataset=dataset,
+                                  seed=base_seed)
 
         init_exception = None
         try:

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
@@ -181,10 +181,11 @@ class TestDataLoaderWorkerLoop(unittest.TestCase):
                 for i in range(10):
                     indices_queue.put([i, i + 10])
                 indices_queue.put(None)
+                base_seed = 1234
                 _worker_loop(loader._dataset, 0, indices_queue,
                              loader._data_queue, loader._workers_done_event,
                              True, _collate_fn, True, _init_fn, 0, 1,
-                             loader._use_shared_memory)
+                             loader._use_shared_memory, base_seed)
                 self.assertTrue(False)
         except AssertionError:
             pass
@@ -223,10 +224,11 @@ class TestDataLoaderWorkerLoop(unittest.TestCase):
                     indices_queue.put([i, i + 10])
                 indices_queue.put(None)
                 loader._workers_done_event.set()
+                base_seed = 1234
                 _worker_loop(loader._dataset, 0, indices_queue,
                              loader._data_queue, loader._workers_done_event,
                              True, _collate_fn, True, _init_fn, 0, 1,
-                             loader._use_shared_memory)
+                             loader._use_shared_memory, base_seed)
                 self.assertTrue(True)
         except AssertionError:
             pass


### PR DESCRIPTION


<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> APIs

### Describe
<!-- Describe what this PR does --> fix the bug that DataLoaderIterMultiProcess use the time to generate seed

#### 背景
在 #33310 中dataloader在多进程数据读取的场景下，会使用系统时间去生成随机种子。该PR是为了避免每个进程，以及每个epoch产生相同的随机数。

但使用系统时间生成随机种子，并且重置了numpy的随机种子，会导致在模型中即使固定numpy、random和paddle的随机种子后，训练结果依然无法复现。因为每一次启动训练，系统时间都不一样，原始的随机种子已经被dataloader重置。

#### PR效果

本PR在多进程数据读取中使用randint生成base_seed，替代使用系统时间生成base_seed的方式，可以解决 #33310 中提到的问题，并且在固定种子后多次运行，相同数据在经过dataloader和预处理（随机裁切、翻转等具有随机性的操作）后，可以得到稳定复现的输出。

- 验证1:
    - 以下demo固定随机种子，固定原始数据，但在Dataset的getitem中引入一些随机性，模拟数据预处理的过程
    - DataLoader使用多进程数据读取（num_workers>0），shuffle=True
```
import numpy as np
import paddle
from paddle.io import Dataset, IterableDataset, BatchSampler, DataLoader
import random


seed = 300
paddle.seed(seed)
np.random.seed(seed)
random.seed(seed)

all_data = np.random.random((8, 3))
all_label = np.random.randint(0, 100, (8,))


class RandomDataset(Dataset):
    def __getitem__(self, index):
        data = all_data[index]
        label = all_label[index] * np.random.randint(0, 100, 1)
        return data, label

    def __len__(self):
        return 8

dataset = RandomDataset()
dataloader = DataLoader(dataset, batch_size=2, num_workers=2, shuffle=True)
epoch = 2
for i in range(epoch):
    print('epoch: ', i)
    for batch in dataloader:
        print(batch)
```

##### 修复后输出
- 第一次运行：
<img width="1344" alt="image" src="https://user-images.githubusercontent.com/26615455/172561818-b504afaa-8d62-4c19-95b7-84c5b03cb96a.png">

- 第二次运行（可以看到尽管label预处理引入了随机性，但第二次运行和第一次的label是稳定复现的）
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/26615455/172561949-6d2e8afc-964d-4e97-b715-ef7baeaae658.png">

##### 修复前的输出
- 第一次运行：
<img width="1133" alt="image" src="https://user-images.githubusercontent.com/26615455/172562813-448a0a23-e6fb-4316-aec0-ed2aa3c03af9.png">

- 第二次运行：可以看到由于label的预处理引入的随机性，导致第二次运行和第一次的label已经不一样
<img width="1106" alt="image" src="https://user-images.githubusercontent.com/26615455/172562986-f366ca26-98d0-49a2-a7a4-e04a541d189c.png">


