### PR TITLE
【code format check upgrade】 step3：enable clang-format sort these cinn files's headers

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/cinn_cache_key_test.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_cache_key_test.cc
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clang-format off
+#include "paddle/fluid/framework/paddle2cinn/cinn_cache_key.h"
+
 #include <map>
 #include <unordered_set>
 
 #include "gtest/gtest.h"
 #include "paddle/fluid/framework/ir/graph.h"
 #include "paddle/fluid/framework/lod_tensor.h"
-#include "paddle/fluid/framework/paddle2cinn/cinn_cache_key.h"
 #include "paddle/fluid/framework/program_desc.h"
 #include "paddle/phi/core/ddim.h"
-// clang-format on
 
 namespace paddle {
 namespace framework {

--- a/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization_test.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization_test.cc
@@ -12,12 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-// clang-format off
-#include "gtest/gtest.h"
-
-#include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.h"
-// clang-format on
+
+#include "gtest/gtest.h"
+#include "paddle/fluid/framework/convert_utils.h"
 
 namespace paddle {
 namespace framework {

--- a/paddle/fluid/framework/paddle2cinn/transform_desc_test.cc
+++ b/paddle/fluid/framework/paddle2cinn/transform_desc_test.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clang-format off
+#include "paddle/fluid/framework/paddle2cinn/transform_desc.h"
+
 #include <unordered_map>
 
 #include "gtest/gtest.h"
-#include "paddle/fluid/framework/paddle2cinn/transform_desc.h"
-// clang-format on
 
 namespace paddle {
 namespace framework {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
These files's headers can be sorted by clang-format.