### PR TITLE
Export symbols of phi operator library

### DIFF
--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -3,6 +3,7 @@
 		*paddle*;
 		*Pass*;
 		*profile*;
+		*phi*;
 	local:
 		*;
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
自定义op中需要用到phi算子库的api， 因此 paddle_inference 动态库中需要导出这些符号。