### PR TITLE
Fix format for doc

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -264,16 +264,16 @@ def ipu_shard_guard(index=None, stage=None):
     Used to shard the graph on IPUs. Set each Op run on which IPU in the sharding and which stage in the pipelining.
 
     Args:
-        index(int, optional): Specify which ipu the Tensor is computed on, (such as ‘0, 1, 2, 3’).
+        index(int, optional): Specify which ipu the Tensor is computed on, (such as '0, 1, 2, 3').
             The default value is None, which means the Op only run on IPU 0.
-        stage(int, optional): Specify the computation order of the sharded model(such as ‘0, 1, 2, 3’).
+        stage(int, optional): Specify the computation order of the sharded model(such as '0, 1, 2, 3').
             The sharded model will be computed from small to large. The default value is None, 
             which means no pipelining computation order and run Ops in terms of graph.
     
     **Note**:
-    Only if the enable_manual_shard=True, the ‘index’ is able to be set not None. Please refer 
+    Only if the enable_manual_shard=True, the 'index' is able to be set not None. Please refer 
     to :code:`paddle.static.IpuStrategy` . 
-    Only if the enable_pipelining=True, the ‘stage’ is able to be set not None. Please refer 
+    Only if the enable_pipelining=True, the 'stage' is able to be set not None. Please refer 
     to :code:`paddle.static.IpuStrategy` .
     A index is allowed to match none stage or a stage. A stage is only allowed to match a new or 
     duplicated index.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix format for doc,
This PR will solve the error when run: ctest -R test_parallel_dygraph_pipeline_parallel -V

> t_parallel_dygraph_pipeline_parallel_run.log
> 1636:      1    Traceback (most recent call last):
> 1636:      2      File "test_parallel_dygraph_pipeline_parallel.py", line 18, in <module>
> 1636:      3        import paddle.fluid as fluid
> 1636:      4      File "/home/Paddle/build/python/paddle/__init__.py", line 25, in <module>
> 1636:      5        from .framework import monkey_patch_variable
> 1636:      6      File "/home/Paddle/build/python/paddle/framework/__init__.py", line 17, in <module>
> 1636:      7        from . import random  # noqa: F401
> 1636:      8      File "/home/Paddle/build/python/paddle/framework/random.py", line 16, in <module>
> 1636:      9        import paddle.fluid as fluid
> 1636:     10      File "/home/Paddle/build/python/paddle/fluid/__init__.py", line 36, in <module>
> 1636:     11        from . import framework
> 1636:     12      File "/home/Paddle/build/python/paddle/fluid/framework.py", line 268
> 1636:     13    SyntaxError: Non-ASCII character '\xe2' in file /home/Paddle/build/python/paddle/fluid/framework.py on line 269, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
> 1636: /usr/bin/nvidia-smi
