### PR TITLE
[BugFix]Fix dims mismatch when run rec_svtrnet model in eager mode

### DIFF
--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -57,7 +57,7 @@ class Controller {
   }
   bool HasGrad() const { return tracer_->HasGrad(); }
   void SetHasGrad(bool has_grad) { tracer_->SetHasGrad(has_grad); }
-  std::string GenerateUniqueName(std::string key = "eager_tmp") {
+  std::string GenerateUniqueName(std::string key = "eager_in_tmp") {
     return tracer_->GenerateUniqueName(key);
   }
   const std::shared_ptr<paddle::imperative::Tracer>& GetCurrentTracer() {

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -1776,7 +1776,7 @@ class TestEagerTensorGradNameValue(unittest.TestCase):
             b = a**2
             self.assertEqual(a._grad_value(), None)
             b.backward()
-            self.assertEqual('eager_tmp' in a._grad_name(), True)
+            self.assertEqual('eager_in_tmp' in a._grad_name(), True)
             self.assertNotEqual(a._grad_value(), None)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
在新动态图下执行PaddleOCR套件的rec_svtrnet 的导出模型的过程中，会报如下错误：
![image](https://user-images.githubusercontent.com/29249150/172820230-3136f221-ce0e-4b5e-8b53-17afe3c9cc9b.png)
经分析，该错误的原因是，新动态图最终态和中间态出现了Tensor重名，导致在save模型动转静过程中，模型的Tensor错误转换导致，该PR主要是来修复该问题。