### PR TITLE
Adjust exclude file order of cmakelint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,54 +84,26 @@ repos:
         exclude: |
             (?x)^(
                 cmake/generic.cmake|
-                CMakeLists.txt|
                 paddle/fluid/pybind/CMakeLists.txt|
-                python/paddle/fluid/tests/unittests/CMakeLists.txt|
                 paddle/fluid/eager/auto_code_generator/CMakeLists.txt|
                 paddle/fluid/framework/CMakeLists.txt|
                 paddle/fluid/eager/auto_code_generator/final_state_generator/CMakeLists.txt|
                 cmake/third_party.cmake|
-                paddle/fluid/inference/tests/infer_ut/CMakeLists.txt|
-                cmake/configure.cmake|
-                paddle/fluid/inference/api/demo_ci/CMakeLists.txt|
-                cmake/flags.cmake|
-                cmake/inference_lib.cmake|
-                cmake/external/protobuf.cmake|
                 cmake/system.cmake|
                 cmake/cudnn.cmake|
                 cmake/external/mkldnn.cmake|
                 cmake/unity_build.cmake|
-                paddle/fluid/framework/fleet/CMakeLists.txt|
-                paddle/fluid/inference/CMakeLists.txt|
-                paddle/fluid/inference/tests/api/CMakeLists.txt|
-                paddle/fluid/operators/CMakeLists.txt|
                 paddle/phi/api/lib/CMakeLists.txt|
                 cmake/external/gflags.cmake|
-                cmake/external/lite.cmake|
-                cmake/external/poplar.cmake|
-                cmake/python_module.cmake|
-                python/paddle/fluid/tests/unittests/asp/CMakeLists.txt|
-                cmake/cuda.cmake|
-                cmake/FindNumPy.cmake|
                 cmake/phi.cmake|
                 paddle/fluid/framework/ir/CMakeLists.txt|
                 paddle/fluid/platform/CMakeLists.txt|
                 python/paddle/fluid/tests/unittests/mlu/CMakeLists.txt|
                 python/paddle/tests/CMakeLists.txt|
                 cmake/ccache.cmake|
-                cmake/coveralls.cmake|
-                cmake/external/glog.cmake|
-                cmake/external/onnxruntime.cmake|
-                cmake/external/openblas.cmake|
-                cmake/external/xpu.cmake|
-                cmake/hip.cmake|
                 paddle/fluid/distributed/CMakeLists.txt|
                 paddle/fluid/framework/details/CMakeLists.txt|
                 paddle/fluid/imperative/CMakeLists.txt|
-                paddle/fluid/inference/analysis/ir_passes/CMakeLists.txt|
-                paddle/fluid/inference/api/CMakeLists.txt|
-                paddle/fluid/operators/controlflow/CMakeLists.txt|
-                python/paddle/fluid/tests/unittests/distributed_passes/CMakeLists.txt|
                 cmake/cblas.cmake|
                 cmake/coverallsGcovJsons.cmake|
                 cmake/external/brpc.cmake|
@@ -142,6 +114,50 @@ repos:
                 cmake/external/warpctc.cmake|
                 cmake/external/zlib.cmake|
                 cmake/FindGperftools.cmake|
+                paddle/fluid/distributed/fleet_executor/CMakeLists.txt|
+                paddle/fluid/eager/api/generated/fluid_generated/forwards/CMakeLists.txt|
+                paddle/fluid/framework/io/CMakeLists.txt|
+                paddle/fluid/imperative/tests/CMakeLists.txt|
+                paddle/fluid/operators/collective/CMakeLists.txt|
+                paddle/fluid/operators/ipu/CMakeLists.txt|
+                paddle/fluid/operators/jit/CMakeLists.txt|
+                paddle/fluid/operators/pscore/CMakeLists.txt|
+                paddle/fluid/platform/device/ipu/CMakeLists.txt|
+                paddle/fluid/platform/dynload/CMakeLists.txt|
+                paddle/phi/backends/dynload/CMakeLists.txt|
+                paddle/phi/CMakeLists.txt|
+                paddle/phi/kernels/CMakeLists.txt|
+                paddle/phi/tests/core/CMakeLists.txt|
+                python/CMakeLists.txt|
+
+                CMakeLists.txt|
+                python/paddle/fluid/tests/unittests/CMakeLists.txt|
+                paddle/fluid/inference/tests/infer_ut/CMakeLists.txt|
+                cmake/configure.cmake|
+                paddle/fluid/inference/api/demo_ci/CMakeLists.txt|
+                cmake/flags.cmake|
+                cmake/inference_lib.cmake|
+                cmake/external/protobuf.cmake|
+                paddle/fluid/framework/fleet/CMakeLists.txt|
+                paddle/fluid/inference/CMakeLists.txt|
+                paddle/fluid/inference/tests/api/CMakeLists.txt|
+                paddle/fluid/operators/CMakeLists.txt|
+                cmake/external/lite.cmake|
+                cmake/external/poplar.cmake|
+                cmake/python_module.cmake|
+                python/paddle/fluid/tests/unittests/asp/CMakeLists.txt|
+                cmake/cuda.cmake|
+                cmake/FindNumPy.cmake|
+                cmake/coveralls.cmake|
+                cmake/external/glog.cmake|
+                cmake/external/onnxruntime.cmake|
+                cmake/external/openblas.cmake|
+                cmake/external/xpu.cmake|
+                cmake/hip.cmake|
+                paddle/fluid/inference/analysis/ir_passes/CMakeLists.txt|
+                paddle/fluid/inference/api/CMakeLists.txt|
+                paddle/fluid/operators/controlflow/CMakeLists.txt|
+                python/paddle/fluid/tests/unittests/distributed_passes/CMakeLists.txt|
                 cmake/operators.cmake|
                 cmake/tensorrt.cmake|
                 paddle/fluid/inference/api/details/CMakeLists.txt|
@@ -154,28 +170,13 @@ repos:
                 cmake/miopen.cmake|
                 cmake/nccl.cmake|
                 cmake/simd.cmake|
-                paddle/fluid/distributed/fleet_executor/CMakeLists.txt|
-                paddle/fluid/eager/api/generated/fluid_generated/forwards/CMakeLists.txt|
-                paddle/fluid/framework/io/CMakeLists.txt|
-                paddle/fluid/imperative/tests/CMakeLists.txt|
                 paddle/fluid/inference/analysis/CMakeLists.txt|
                 paddle/fluid/inference/tests/infer_ut/external-cmake/gtest-cpp.cmake|
                 paddle/fluid/memory/allocation/CMakeLists.txt|
                 paddle/fluid/memory/CMakeLists.txt|
                 paddle/fluid/operators/cinn/CMakeLists.txt|
-                paddle/fluid/operators/collective/CMakeLists.txt|
-                paddle/fluid/operators/ipu/CMakeLists.txt|
-                paddle/fluid/operators/jit/CMakeLists.txt|
-                paddle/fluid/operators/pscore/CMakeLists.txt|
-                paddle/fluid/platform/device/ipu/CMakeLists.txt|
-                paddle/fluid/platform/dynload/CMakeLists.txt|
                 paddle/infrt/external_kernels/CMakeLists.txt|
                 paddle/infrt/kernel/phi/CMakeLists.txt|
-                paddle/phi/backends/dynload/CMakeLists.txt|
-                paddle/phi/CMakeLists.txt|
-                paddle/phi/kernels/CMakeLists.txt|
-                paddle/phi/tests/core/CMakeLists.txt|
-                python/CMakeLists.txt|
                 python/paddle/fluid/contrib/slim/tests/CMakeLists.txt|
                 python/paddle/fluid/tests/unittests/autograd/CMakeLists.txt|
                 python/paddle/fluid/tests/unittests/distribution/CMakeLists.txt|


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
pre-commit-config.yaml中对cmakelint临时设置了跳过检查的exclude-file清单，该清单后续将由@From00 和@jiweibo 集中进行逐一修复，在相关文件修复并通过cmakelint检查后，同步将清单中对应的文件名移除。
为避免集中修复过程中两人提交的PR相互冲突，将此清单中的文件名按分工进行排序，相同同学修复的文件集中排在一起。