### PR TITLE
set_state_dict not use state_dict hook

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1336,6 +1336,7 @@ class Layer(object):
             destination(dict, optional) : If provide, all the parameters and persistable buffers will be set to this dict . Default: None
             include_sublayers(bool, optional) : If true, also include the parameters and persistable buffers from sublayers. Default: True
             include_non_persistable_buffer(bool, optional): If true, include non persistable buffers of current layer and its sub-layers, it is used in pure fp16 and jit.save. Default: False
+            use_hook(bool, optional) : If true, the operations contained in _state_dict_hooks will be appended to the destination. Default: True
         """
 
         if destination is None:
@@ -1380,6 +1381,7 @@ class Layer(object):
         Parameters:
             destination(dict, optional) : If provide, all the parameters and persistable buffers will be set to this dict . Default: None
             include_sublayers(bool, optional) : If true, also include the parameters and persistable buffers from sublayers. Default: True
+            use_hook(bool, optional) : If true, the operations contained in _state_dict_hooks will be appended to the destination. Default: True
 
         Retruns:
             dict: a dict contains all the parameters and persistable buffers.
@@ -1413,6 +1415,7 @@ class Layer(object):
         Parameters:
             destination(dict, optional) : If provide, all the parameters and persistable buffers will be set to this dict . Default: None
             include_sublayers(bool, optional) : If true, also include the parameters and persistable buffers from sublayers. Default: True
+            use_hook(bool, optional) : If true, the operations contained in _state_dict_hooks will be appended to the destination. Default: True
 
         Retruns:
             dict: a dict contains all the parameters and persistable buffers.

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1400,7 +1400,7 @@ class Layer(object):
             include_sublayers=include_sublayers,
             structured_name_prefix=structured_name_prefix,
             include_non_persistable_buffer=True,
-            use_hook=True)
+            use_hook=use_hook)
 
     def state_dict(self,
                    destination=None,
@@ -1433,7 +1433,7 @@ class Layer(object):
             include_sublayers=include_sublayers,
             structured_name_prefix=structured_name_prefix,
             include_non_persistable_buffer=False,
-            use_hook=True)
+            use_hook=use_hook)
 
     @framework.deprecate_stat_dict
     def set_state_dict(self, state_dict, use_structured_name=True):

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1327,7 +1327,8 @@ class Layer(object):
                          destination=None,
                          include_sublayers=True,
                          structured_name_prefix="",
-                         include_non_persistable_buffer=False):
+                         include_non_persistable_buffer=False,
+                         use_hook=True):
         """
         Get all parameters and persistable buffers of current layer and its sub-layers. And set them into a dict
 
@@ -1358,19 +1359,21 @@ class Layer(object):
                         layer_item._state_dict_impl(
                             destination_temp, include_sublayers,
                             structured_name_prefix + layer_name + ".",
-                            include_non_persistable_buffer))
+                            include_non_persistable_buffer, use_hook))
                     destination = destination_temp
-        for state_dict_hook in self._state_dict_hooks.values():
-            hook_result = state_dict_hook(destination)
-            if hook_result is not None:
-                destination = hook_result
+        if use_hook:
+            for state_dict_hook in self._state_dict_hooks.values():
+                hook_result = state_dict_hook(destination)
+                if hook_result is not None:
+                    destination = hook_result
 
         return destination
 
     def to_static_state_dict(self,
                              destination=None,
                              include_sublayers=True,
-                             structured_name_prefix=""):
+                             structured_name_prefix="",
+                             use_hook=True):
         '''
         Get all parameters and buffers of current layer and its sub-layers. And set them into a dict
 
@@ -1396,12 +1399,14 @@ class Layer(object):
             destination=destination,
             include_sublayers=include_sublayers,
             structured_name_prefix=structured_name_prefix,
-            include_non_persistable_buffer=True)
+            include_non_persistable_buffer=True,
+            use_hook=True)
 
     def state_dict(self,
                    destination=None,
                    include_sublayers=True,
-                   structured_name_prefix=""):
+                   structured_name_prefix="",
+                   use_hook=True):
         '''
         Get all parameters and persistable buffers of current layer and its sub-layers. And set them into a dict
 
@@ -1427,7 +1432,8 @@ class Layer(object):
             destination=destination,
             include_sublayers=include_sublayers,
             structured_name_prefix=structured_name_prefix,
-            include_non_persistable_buffer=False)
+            include_non_persistable_buffer=False,
+            use_hook=True)
 
     @framework.deprecate_stat_dict
     def set_state_dict(self, state_dict, use_structured_name=True):
@@ -1478,7 +1484,7 @@ class Layer(object):
                 return param, state
 
         matched_param_state = []
-        for key, param in self.state_dict().items():
+        for key, param in self.state_dict(use_hook=False).items():
             key_name = key if use_structured_name else param.name
             try:
                 match_res = _check_match(key_name, param)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
**修复的问题：**
       在 amp-o2功能开发过程中，为了支持指定网络存储数据类型的功能，添加state_dict hook功能，但是在Layer的set_state_dict是通过state_dict获取网络参数并加载的，hook接口的存在导致 set_state_dict无法加载到原本网络参数。
       本pr通过增加hook控制开关，在set_state_dict中禁用hook解决该问题。

**具体改动：**
        为Layer 的 state_dict 接口增加一个bool参数：use_hook，默认为True，set_state_dict中有调用state_dict接口，use_hook为False
       用法上为用户提供了是否使用hook的控制接口，默认使用，用户无需显示声明。

api文档：[pr](https://github.com/PaddlePaddle/docs/pull/4923)