### PR TITLE
[cherry-pick] Fix bug of strided_slice and slice (#43388, #43443)

### DIFF
--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -101,7 +101,11 @@ class SliceOp : public framework::OperatorWithKernel {
           platform::errors::InvalidArgument(
               "The size of ends must be equal to the size of axes."));
     }
-
+    for (auto &axis : axes) {
+      if (axis < 0) {
+        axis = std::max(0, axis + in_dims.size());
+      }
+    }
     phi::funcs::CheckAndUpdateSliceAttrs<int>(in_dims, axes, &starts, &ends,
                                               nullptr, &infer_flags);
 

--- a/paddle/phi/kernels/funcs/strided_slice.h
+++ b/paddle/phi/kernels/funcs/strided_slice.h
@@ -74,10 +74,14 @@ static void StridedSliceOutDims(const std::vector<int64_t>& starts,
 
     if (start_index < 0) {
       start_index = start_index + axis_size;
+      start_index = std::max<int64_t>(start_index, 0);
     }
     if (end_index < 0) {
       if (!(end_index == -1 && stride_index < 0)) {  // skip None stop condition
         end_index = end_index + axis_size;
+        if (end_index < 0) {
+          end_index = 0;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

- 修复`strided_slice`处理参数为负数时的Bug。issue: [#43375](https://github.com/PaddlePaddle/Paddle/issues/43375)
- 修复静态图下`slice`在axes为负数时infershape结果异常的问题。[PR43443](https://github.com/PaddlePaddle/Paddle/pull/43443)
