### PR TITLE
Fix bug of infer shape for slice

### DIFF
--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -104,7 +104,11 @@ class SliceOp : public framework::OperatorWithKernel {
           platform::errors::InvalidArgument(
               "The size of ends must be equal to the size of axes."));
     }
-
+    for (auto &axis : axes) {
+      if (axis < 0) {
+        axis = std::max(0, axis + in_dims.size());
+      }
+    }
     phi::funcs::CheckAndUpdateSliceAttrs<int>(in_dims, axes, &starts, &ends,
                                               nullptr, &infer_flags);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复静态图下`slice`在`axes`为负数时infershape结果异常的问题。

问题示例：
```
x = paddle.static.data(shape=[-1, 460, 12], name='x')
y = paddle.slice(input=x, axes=[-1], starts=[1], ends=[2])
print(y.shape)

# 修复前结果：(-1, 460, 12)
# 预期结果：(-1, 460, 1)
```
