### PR TITLE
[pre-commit]remove proto check of clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         description: Format files with ClangFormat.
         entry: bash ./tools/codestyle/clang_format.hook -i
         language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto|xpu|kps)$
+        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|xpu|kps)$
         exclude: |
             (?x)^(
                 paddle/fluid/distributed/ps/thirdparty/round_robin.h


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
remove proto check of clang-format. PR #43405 modified proto file and trigered this error.
![enrageretten faleda) Be(en Bet Hgeere PPBn NorgBRESHLBASHLPEL EIM-N81 vrasgscePesd lel cLangefenser](https://user-images.githubusercontent.com/51314274/173304739-da84eeb1-bab7-400a-ac1c-97d2e2521fd3.png)
