### PR TITLE
Export symbols of phi operator library

### DIFF
--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -3,7 +3,7 @@
 		*paddle*;
 		*Pass*;
 		*profile*;
+		*phi*;
 	local:
 		*;
 };
-


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
用户自定义Op时，无法使用 phi 算子库的相关API，如遇到编译报错未定义的函数等。 通过 `nm` 指令查看 paddle_inferen.so 相关函数符号发现， phi 算子库中的相关函数符号是 local 属性, 也即预测动态库将这些符号隐藏起来了。
<img width="648" alt="image" src="https://user-images.githubusercontent.com/63448337/174214799-bd710b68-8282-412a-b7eb-dce433ef5e18.png">
将 phi 算子库的相关函数符号属性设为 global 即可。