### PR TITLE
Fix update_loss_scaling op StopUpdate input

### DIFF
--- a/paddle/fluid/operators/amp/update_loss_scaling_op.cc
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op.cc
@@ -107,9 +107,9 @@ class UpdateLossScalingOpMaker : public framework::OpProtoAndCheckerMaker {
     AddOutput("LossScaling", "(Tensor) 1-dim tensor, updated loss scaling.");
     AddOutput("OutGoodSteps", "(Tensor) 1-dim tensor, pdated good steps.");
     AddOutput("OutBadSteps", "(Tensor) 1-dim tensor, updated bad steps.");
-    AddOutput("StopUpdate",
-              "(Tensor) 1-dim tensor. Stop updating loss scaling, and just "
-              "zero inputs. It has higher priority than Attr(stop_update).")
+    AddInput("StopUpdate",
+             "(Tensor) 1-dim tensor. Stop updating loss scaling, and just "
+             "zero inputs. It has higher priority than Attr(stop_update).")
         .AsDispensable();
     AddAttr<int>("incr_every_n_steps",
                  "A value represents increasing loss scaling every n "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Ops

### Describe
Change the output `StopUpdate` of `update_loss_scaling` to be input. This is a bug. `StopUpdate` should be input. 

Related to https://github.com/PaddlePaddle/Paddle/pull/40177/files#diff-802ebd3faae0d407ba5521ae8c51852004e92b7d4895ac716bb62036590d342eR135 .