### PR TITLE
[Dy2Stat]Polish break/continue statement transformer logic

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/break_continue_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/break_continue_transformer.py
@@ -20,7 +20,7 @@ from paddle.fluid import unique_name
 from paddle.fluid.dygraph.dygraph_to_static.utils import index_in_list
 from paddle.fluid.dygraph.dygraph_to_static.utils import ForNodeVisitor
 from paddle.fluid.dygraph.dygraph_to_static.utils import BaseNodeVisitor
-from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import create_fill_constant_node
+from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import create_bool_node
 
 __all__ = ['BreakContinueTransformer']
 
@@ -140,7 +140,7 @@ class BreakContinueTransformer(BaseNodeVisitor):
         self._replace_if_stmt(loop_node_index, first_block_index, variable_name)
 
         # 4. For 'break' add break into condition of the loop.
-        assign_false_node = create_fill_constant_node(variable_name, False)
+        assign_false_node = create_bool_node(variable_name, False)
         self._add_stmt_before_cur_node(loop_node_index, assign_false_node)
 
         cond_var_node = gast.UnaryOp(op=gast.Not(),
@@ -177,7 +177,7 @@ class BreakContinueTransformer(BaseNodeVisitor):
         self._replace_if_stmt(loop_node_index, first_block_index, variable_name)
 
         # 4. For 'continue', set continue to False at the beginning of each loop
-        assign_false_node = create_fill_constant_node(variable_name, False)
+        assign_false_node = create_bool_node(variable_name, False)
         loop_node.body.insert(0, assign_false_node)
 
     def _remove_stmts_after_break_continue(self, break_continue_node,
@@ -221,7 +221,7 @@ class BreakContinueTransformer(BaseNodeVisitor):
         i = index_in_list(stmt_list, break_continue_node)
         if i == -1:
             return False
-        assign_true_node = create_fill_constant_node(break_continue_name, True)
+        assign_true_node = create_bool_node(break_continue_name, True)
         stmt_list[i:] = [assign_true_node]
         return True
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
@@ -78,3 +78,12 @@ def create_bool_as_type(x, value=True):
         return paddle.full(shape=[1], fill_value=value, dtype="bool")
     else:
         return value
+
+
+def create_bool_node(name, value):
+    '''
+    Create a assign stmt for name = value .
+    '''
+    assert isinstance(value, bool)
+    node = "{} = {}".format(name, value)
+    return gast.parse(node).body[0]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
@@ -101,7 +101,11 @@ def test_break_continue_in_for(x):
         x += 10086
 
     a = fluid.layers.fill_constant(shape=[1], dtype='int32', value=0)
-    for i in range(1, 10, 1):
+    b = fluid.layers.fill_constant(shape=[1], dtype='int32', value=3)
+    # b = 10
+    # TODO: add Raise Error and suggestion for usage:
+    #   Py for contains break/continue depends on control-flow.
+    for i in range(b):
         if a <= 4:
             x += 1
             a += 1
@@ -202,6 +206,7 @@ class TestContinueInFor(unittest.TestCase):
 
     def run_static_mode(self):
         with fluid.dygraph.guard():
+            print(declarative(self.dygraph_func).code)
             res = declarative(self.dygraph_func)(self.input)
             return res.numpy()
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
@@ -206,7 +206,6 @@ class TestContinueInFor(unittest.TestCase):
 
     def run_static_mode(self):
         with fluid.dygraph.guard():
-            print(declarative(self.dygraph_func).code)
             res = declarative(self.dygraph_func)(self.input)
             return res.numpy()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[Dy2Stat]Polish break/continue statement transformer logic.

样例代码：
```python
def for_break_single_return(max_len):
    x = 0
    __break_0 = False
    i = 0

    def while_condition_0(x, __break_0, i):
        return _jst.convert_logical_and(lambda : i < 3, lambda : _jst.
            convert_logical_not(__break_0))

    def while_body_0(x, __break_0, i):

        def true_fn_0(__break_0):
            __break_0 = True
            return __break_0

        def false_fn_0(__break_0):
            return __break_0
        __break_0 = _jst.convert_ifelse(i == 2, true_fn_0, false_fn_0, (
            __break_0,), (__break_0,))

        def true_fn_1(x):
            x += 1
            return x

        def false_fn_1(x):
            return x
        x = _jst.convert_ifelse(_jst.convert_logical_not(__break_0),
            true_fn_1, false_fn_1, (x,), (x,))
        i += 1
        return x, __break_0, i
    [x, __break_0, i] = _jst.convert_while_loop(while_condition_0,
        while_body_0, [x, __break_0, i])
    return x

```
