### PR TITLE
[Bug Fix] set device_id=current_id when calling Tensor.cuda() without device_id

### DIFF
--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1538,9 +1538,7 @@ void BindImperative(py::module *m_ptr) {
              int device_count = platform::GetGPUDeviceCount();
              int device_id = 0;
              if (handle == py::none()) {
-               if (platform::is_gpu_place(self->Place())) {
-                 return self;
-               }
+               device_id = platform::GetCurrentDeviceId();
              } else {
                PyObject *py_obj = handle.ptr();
                PADDLE_ENFORCE_EQ(
@@ -1588,16 +1586,17 @@ void BindImperative(py::module *m_ptr) {
               # required: gpu
               import paddle
               x = paddle.to_tensor(1.0, place=paddle.CPUPlace())
-              print(x.place)        # CPUPlace
+              print(x.place)        # Place(cpu)
 
               y = x.cuda()
-              print(y.place)        # CUDAPlace(0)
+              print(y.place)        # Place(gpu:0)
             
               y = x.cuda(None)
-              print(y.place)        # CUDAPlace(0)
+              print(y.place)        # Place(gpu:0)
 
-              y = x.cuda(1)
-              print(y.place)        # CUDAPlace(1)
+              paddle.device.set_device("gpu:1")
+              y = x.cuda(None)
+              print(y.place)        # Place(gpu:1)
        )DOC")
       .def(
           "_share_memory",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix issue #41819. When device_id not given, it should be set by current device id instead of 0.

- Note: use plat::form::GetCurrentDeviceId can not get the real current device_id, it has a latency, the device id will be set only when `x = paddle.to_tensor(1.0)` called.
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/51314274/173813906-bf2a9027-f72f-4038-9f46-dd8f2e8a018b.png">

Before:
<img width="302" alt="image" src="https://user-images.githubusercontent.com/51314274/173542462-9a845fbd-602d-405c-af2d-e2b2792d6df9.png">
After:
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/51314274/173822869-a6c12206-909b-4e0a-8a5f-e8d312e294f0.png">
