### PR TITLE
revert -Wno-error=maybe-uninitialized

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -154,6 +154,7 @@ if(NOT WIN32)
       -Wno-error=terminate # Warning in PADDLE_ENFORCE
       -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2
       -Wimplicit-fallthrough=0 # Warning in tinyformat.h
+      -Wno-error=maybe-uninitialized # Warning in boost gcc 7.2
       ${fsanitize})
 
   if(WITH_IPU)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
PR #42902 removes `-Wno-error=maybe-uninitialized` and fixes some warnings, but there are other warnings not reported in the CI building enviroment (see issue #43156), and may result in compilation error in some enviroments.

So, this PR reverts `-Wno-error=maybe-uninitialized`