### PR TITLE
allow multiple input in paddle.summary

### DIFF
--- a/python/paddle/hapi/model_summary.py
+++ b/python/paddle/hapi/model_summary.py
@@ -234,7 +234,7 @@ def summary(net, input_size=None, dtypes=None, input=None):
 @paddle.no_grad()
 def summary_string(model, input_size=None, dtypes=None, input=None):
 
-    def _all_is_numper(items):
+    def _all_is_number(items):
         for item in items:
             if not isinstance(item, numbers.Number):
                 return False
@@ -244,7 +244,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
         if dtype is None:
             dtype = 'float32'
 
-        if isinstance(input_size, (list, tuple)) and _all_is_numper(input_size):
+        if isinstance(input_size, (list, tuple)) and _all_is_number(input_size):
             return [dtype]
         else:
             return [_build_dtypes(i, dtype) for i in input_size]
@@ -336,7 +336,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
         input_size = [input_size]
 
     def build_input(input_size, dtypes):
-        if isinstance(input_size, (list, tuple)) and _all_is_numper(input_size):
+        if isinstance(input_size, (list, tuple)) and _all_is_number(input_size):
             if isinstance(dtypes, (list, tuple)):
                 dtype = dtypes[0]
             else:
@@ -439,7 +439,7 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
         summary_str += line_new + "\n"
 
     def _get_input_size(input_size, size):
-        if isinstance(input_size, (list, tuple)) and _all_is_numper(input_size):
+        if isinstance(input_size, (list, tuple)) and _all_is_number(input_size):
             size = abs(np.prod(input_size) * 4. / (1024**2.))
         else:
             size = sum([_get_input_size(i, size) for i in input_size])

--- a/python/paddle/hapi/model_summary.py
+++ b/python/paddle/hapi/model_summary.py
@@ -37,7 +37,9 @@ def summary(net, input_size=None, dtypes=None, input=None):
                     batch_size can be None or -1. Default: None. Note that 
                     input_size and input cannot be None at the same time.
         dtypes (str, optional): if dtypes is None, 'float32' will be used, Default: None.
-        input: the input tensor. if input is given, input_size and dtype will be ignored, Default: None.
+        input (Tensor|list[Tensor]): the input tensor. if input is given, input_size and dtype will be ignored.
+                    if model only have one input, input can be Tensor. if model have multiple input, 
+                    input must be a list which contain every input. Default: None.
 
     Returns:
         Dict: a summary of the network including total params and total trainable params.
@@ -352,11 +354,13 @@ def summary_string(model, input_size=None, dtypes=None, input=None):
     model.apply(register_hook)
     if input is not None:
         x = input
-        model(x)
+        if not isinstance(input, (list, tuple)):
+            x = [x]
     else:
         x = build_input(input_size, dtypes)
-        # make a forward pass
-        model(*x)
+
+    # make a forward pass
+    model(*x)
 
     # remove these hooks
     for h in hooks:

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -444,6 +444,19 @@ class MyModel(paddle.nn.Layer):
         return y
 
 
+class MyModelMultipleInputs(paddle.nn.Layer):
+
+    def __init__(self):
+        super(MyModelMultipleInputs, self).__init__()
+        self._fc1 = Linear(20, 10)
+        self._fc2 = Linear(10, 10)
+
+    def forward(self, x1, x2):
+        y1 = self._fc1(x1)
+        y2 = self._fc2(x2)
+        return y1 + y2
+
+
 class MyDataset(Dataset):
 
     def __getitem__(self, idx):
@@ -722,6 +735,16 @@ class TestModelFunction(unittest.TestCase):
         input_shape = (3, 1)
         net = paddle.nn.Embedding(10, 3, sparse=True)
         paddle.summary(net, input_shape, dtypes='int64')
+
+    def test_summary_multiple_inputs(self):
+        input_shape_1 = (3, 30)
+        input_shape_2 = (3, 10)
+        mymodel = MyModelMultipleInputs()
+        paddle.summary(mymodel, input_size=[input_shape_1, input_shape_2])
+
+        input_data_1 = paddle.rand(input_shape_1)
+        input_data_2 = paddle.rand(input_shape_2)
+        paddle.summary(mymodel, input=[input_data_1, input_data_2])
 
     def test_summary_error(self):
         with self.assertRaises(TypeError):

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -448,7 +448,7 @@ class MyModelMultipleInputs(paddle.nn.Layer):
 
     def __init__(self):
         super(MyModelMultipleInputs, self).__init__()
-        self._fc1 = Linear(20, 10)
+        self._fc1 = Linear(30, 10)
         self._fc2 = Linear(10, 10)
 
     def forward(self, x1, x2):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

APIs

### Describe
<!-- Describe what this PR does -->

closes #43499

详情见 #43499，简单来说就是允许 paddle.summary 的参数 input 传入多个输入，使其与 input_size 行为一致