### PR TITLE
upgrade pre-commit tools in docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,4 +80,3 @@ repos:
     hooks:
     -   id: cmakelint
         args: [--config=./tools/codestyle/.cmakelintrc]
-        # exclude files which need to be fixed

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -191,7 +191,7 @@ RUN pip3.6 --no-cache-dir install pytest astroid isort && \
     pip --no-cache-dir install pylint pytest astroid isort
 
 #For pre-commit
-RUN pip3.6 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+RUN pip3.6 --no-cache-dir install pre-commit==2.1.1 pylint==2.12.0 && \
     pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.8 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.9 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -22,7 +22,8 @@ RUN apt-get update --allow-unauthenticated && \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev
 
-RUN apt-get install -y --allow-downgrades --allow-change-held-packages \
+RUN apt-get update && \
+    apt-get install -y --allow-downgrades --allow-change-held-packages \
     patchelf git python-pip python-dev python-opencv openssh-server bison \
     wget unzip unrar tar xz-utils bzip2 gzip coreutils ntp \
     curl sed grep graphviz libjpeg-dev zlib1g-dev  \

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -172,23 +172,33 @@ RUN pip3.6 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
     pip --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
     pip --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark
 
-RUN pip3.6 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
+RUN pip3.6 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.6 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip3.7 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
+    pip3.7 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.7 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip3.8 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
+    pip3.8 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.8 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip3.9 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
+    pip3.9 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.9 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
     pip --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
     pip --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0'
 
 #For docstring checker
-RUN pip3.6 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.7 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.8 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.9 --no-cache-dir install pylint pytest astroid isort && \
+RUN pip3.6 --no-cache-dir install pytest astroid isort && \
+    pip3.7 --no-cache-dir install pytest astroid isort && \
+    pip3.8 --no-cache-dir install pytest astroid isort && \
+    pip3.9 --no-cache-dir install pytest astroid isort && \
     pip --no-cache-dir install pylint pytest astroid isort
+
+#For pre-commit
+RUN pip3.6 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.8 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.9 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.6 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+    pip3.7 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+    pip3.8 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+    pip3.9 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0
 
 RUN pip3.6 --no-cache-dir install coverage && \
     pip3.7 --no-cache-dir install coverage && \

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -191,7 +191,7 @@ RUN pip3.6 --no-cache-dir install pytest astroid isort && \
     pip --no-cache-dir install pylint pytest astroid isort
 
 #For pre-commit
-RUN pip3.6 --no-cache-dir install --upgrade pip && \
+RUN pip3.6 --no-cache-dir install --upgrade pip==20.3.3 && \
     pip3.7 --no-cache-dir install --upgrade pip && \
     pip3.8 --no-cache-dir install --upgrade pip && \
     pip3.9 --no-cache-dir install --upgrade pip
@@ -220,10 +220,6 @@ RUN pip3.6 --no-cache-dir install -r /root/requirements.txt && \
 # To fix https://github.com/PaddlePaddle/Paddle/issues/1954, we use
 # the solution in https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
 RUN apt-get install -y libssl-dev libffi-dev && apt-get clean -y && \
-    pip3.6 install --upgrade pip==20.3.3 && \ 
-    pip3.7 install --upgrade pip && \ 
-    pip3.8 install --upgrade pip && \ 
-    pip3.9 install --upgrade pip && \ 
     pip3.6 --no-cache-dir install certifi urllib3[secure] && \
     pip3.7 --no-cache-dir install certifi urllib3[secure] && \
     pip3.8 --no-cache-dir install certifi urllib3[secure] && \

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -28,7 +28,7 @@ RUN apt-get update && \
     wget unzip unrar tar xz-utils bzip2 gzip coreutils ntp \
     curl sed grep graphviz libjpeg-dev zlib1g-dev  \
     python-matplotlib \
-    automake locales clang-format swig  \
+    automake locales swig  \
     liblapack-dev liblapacke-dev \
     net-tools libtool module-init-tools && \
     apt-get clean -y
@@ -191,6 +191,11 @@ RUN pip3.6 --no-cache-dir install pytest astroid isort && \
     pip --no-cache-dir install pylint pytest astroid isort
 
 #For pre-commit
+RUN pip3.6 --no-cache-dir install --upgrade pip && \
+    pip3.7 --no-cache-dir install --upgrade pip && \
+    pip3.8 --no-cache-dir install --upgrade pip && \
+    pip3.9 --no-cache-dir install --upgrade pip
+
 RUN pip3.6 --no-cache-dir install pre-commit==2.1.1 pylint==2.12.0 && \
     pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.8 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -22,8 +22,7 @@ RUN apt-get update --allow-unauthenticated && \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev
 
-RUN apt-get update && \
-    apt-get install -y --allow-downgrades --allow-change-held-packages \
+RUN apt-get install -y --allow-downgrades --allow-change-held-packages \
     patchelf git python-pip python-dev python-opencv openssh-server bison \
     wget unzip unrar tar xz-utils bzip2 gzip coreutils ntp \
     curl sed grep graphviz libjpeg-dev zlib1g-dev  \

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -107,23 +107,33 @@ RUN git config --global credential.helper store
 # Fix locales to en_US.UTF-8
 RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
-RUN pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+RUN pip3.6 --no-cache-dir install ipython==5.3.0 && \
     pip3.6 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.7 --no-cache-dir install ipython==5.3.0 && \
     pip3.7 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip3.8 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.8 --no-cache-dir install ipython==5.3.0 && \
     pip3.8 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip3.9 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.9 --no-cache-dir install ipython==5.3.0 && \
     pip3.9 --no-cache-dir install ipykernel==4.6.0 wheel && \
     pip2.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip2.7 --no-cache-dir install ipykernel==4.6.0 wheel 
 
 #For docstring checker
-RUN pip3.6 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.7 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.8 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.9 --no-cache-dir install pylint pytest astroid isort && \
-    pip2.7 --no-cache-dir install pylint pytest astroid isort
+RUN pip3.6 --no-cache-dir install pytest astroid isort && \
+    pip3.7 --no-cache-dir install pytest astroid isort && \
+    pip3.8 --no-cache-dir install pytest astroid isort && \
+    pip3.9 --no-cache-dir install pytest astroid isort && \
+    pip2.7 --no-cache-dir install pytest astroid isort
+
+#For pre-commit
+RUN pip3.6 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.8 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.9 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+    pip3.6 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+    pip3.7 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+    pip3.8 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0 && \
+    pip3.9 --no-cache-dir install cpplint==1.6.0 clang-format==13.0.0
 
 COPY ./python/requirements.txt /root/
 RUN pip3.6 --no-cache-dir install -r /root/requirements.txt && \

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -45,7 +45,7 @@ RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && ta
 ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 
-RUN apt-get install -y python2.7 python2.7-dev \
+RUN apt-get install -y --fix-missing python2.7 python2.7-dev \
   python3.6 python3.6-dev \
   python3.7 python3.7-dev \
   python3.8 python3.8-dev python3.8-distutils \

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -125,7 +125,7 @@ RUN pip3.6 --no-cache-dir install pytest astroid isort && \
     pip2.7 --no-cache-dir install pytest astroid isort
 
 #For pre-commit
-RUN pip3.6 --no-cache-dir install --upgrade pip && \
+RUN pip3.6 --no-cache-dir install --upgrade pip==20.3.3 && \
     pip3.7 --no-cache-dir install --upgrade pip && \
     pip3.8 --no-cache-dir install --upgrade pip && \
     pip3.9 --no-cache-dir install --upgrade pip

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -18,6 +18,11 @@ ENV HOME /root
 COPY paddle/scripts/docker/root/ /root/
 
 RUN chmod 777 /tmp
+
+RUN apt-key del 7fa2af80
+RUN rm /etc/apt/sources.list.d/cuda.list && rm /etc/apt/sources.list.d/nvidia-ml.list
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.cn/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN apt-get update --allow-unauthenticated && \
   apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa && \
   apt-get update && \

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -45,8 +45,7 @@ RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && ta
 ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 
-RUN apt-get update && \
-  apt-get install -y python2.7 python2.7-dev \
+RUN apt-get install -y python2.7 python2.7-dev \
   python3.6 python3.6-dev \
   python3.7 python3.7-dev \
   python3.8 python3.8-dev python3.8-distutils \
@@ -126,6 +125,11 @@ RUN pip3.6 --no-cache-dir install pytest astroid isort && \
     pip2.7 --no-cache-dir install pytest astroid isort
 
 #For pre-commit
+RUN pip3.6 --no-cache-dir install --upgrade pip && \
+    pip3.7 --no-cache-dir install --upgrade pip && \
+    pip3.8 --no-cache-dir install --upgrade pip && \
+    pip3.9 --no-cache-dir install --upgrade pip
+
 RUN pip3.6 --no-cache-dir install pre-commit==2.1.1 pylint==2.12.0 && \
     pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.8 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
@@ -160,10 +164,5 @@ RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
     make -j8 && make install && \
     ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache && \
     cd ../ && rm -rf ccache-3.7.9 ccache-3.7.9.tar.gz
-
-# clang-form 3.8.0
-RUN wget https://paddle-ci.cdn.bcebos.com/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \ 
-    tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cd clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && \
-    cp -r * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
 
 EXPOSE 22

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -50,7 +50,8 @@ RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && ta
 ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 
-RUN apt-get install -y --fix-missing python2.7 python2.7-dev \
+RUN apt-get update && \
+  apt-get install -y python2.7 python2.7-dev \
   python3.6 python3.6-dev \
   python3.7 python3.7-dev \
   python3.8 python3.8-dev python3.8-distutils \

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -20,7 +20,6 @@ COPY paddle/scripts/docker/root/ /root/
 RUN chmod 777 /tmp
 RUN apt-get update --allow-unauthenticated && \
   apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa && \
-  apt-get update && \
   apt-get install -y curl wget vim git unzip unrar tar xz-utils libssl-dev bzip2 gzip \ 
     coreutils ntp language-pack-zh-hans python-qt4 libsm6 libxext6 libxrender-dev libgl1-mesa-glx \
     bison graphviz libjpeg-dev zlib1g-dev automake locales swig net-tools libtool module-init-tools

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -126,7 +126,7 @@ RUN pip3.6 --no-cache-dir install pytest astroid isort && \
     pip2.7 --no-cache-dir install pytest astroid isort
 
 #For pre-commit
-RUN pip3.6 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
+RUN pip3.6 --no-cache-dir install pre-commit==2.1.1 pylint==2.12.0 && \
     pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.8 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.9 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -20,6 +20,7 @@ COPY paddle/scripts/docker/root/ /root/
 RUN chmod 777 /tmp
 RUN apt-get update --allow-unauthenticated && \
   apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa && \
+  apt-get update && \
   apt-get install -y curl wget vim git unzip unrar tar xz-utils libssl-dev bzip2 gzip \ 
     coreutils ntp language-pack-zh-hans python-qt4 libsm6 libxext6 libxrender-dev libgl1-mesa-glx \
     bison graphviz libjpeg-dev zlib1g-dev automake locales swig net-tools libtool module-init-tools

--- a/tools/dockerfile/ci_dockerfile.sh
+++ b/tools/dockerfile/ci_dockerfile.sh
@@ -66,7 +66,7 @@ function make_cinn_dockerfile(){
   sed -i 's#<install_cpu_package>##g' ${dockerfile_name}
   sed -i "7i ENV TZ=Asia/Beijing" ${dockerfile_name}
   sed -i "8i RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone" ${dockerfile_name}
-  sed -i "9i RUN apt-get update && apt-get install -y liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev" ${dockerfile_name}
+  sed -i "9i RUN apt-get install -y liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev" ${dockerfile_name}
   dockerfile_line=$(wc -l ${dockerfile_name}|awk '{print $1}')
   sed -i "${dockerfile_line}i RUN wget --no-check-certificate -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz \&\& \
      tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/" ${dockerfile_name}

--- a/tools/dockerfile/ci_dockerfile.sh
+++ b/tools/dockerfile/ci_dockerfile.sh
@@ -64,10 +64,10 @@ function make_cinn_dockerfile(){
   sed "s#<baseimg>#nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04#g" ./Dockerfile.ubuntu18 >${dockerfile_name}
   sed -i "s#<setcuda>#ENV LD_LIBRARY_PATH=/usr/local/cuda-11.2/targets/x86_64-linux/lib:\$LD_LIBRARY_PATH #g" ${dockerfile_name}
   sed -i 's#<install_cpu_package>##g' ${dockerfile_name}
-  sed -i "7i ENV TZ=Asia/Beijing" ${dockerfile_name}
-  sed -i "8i RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone" ${dockerfile_name}
-  sed -i "9i RUN apt-get install -y liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev" ${dockerfile_name}
   dockerfile_line=$(wc -l ${dockerfile_name}|awk '{print $1}')
+  sed -i "${dockerfile_line}i ENV TZ=Asia/Beijing" ${dockerfile_name}
+  sed -i "${dockerfile_line}i RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone" ${dockerfile_name}
+  sed -i "${dockerfile_line}i RUN apt-get install -y liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev" ${dockerfile_name}
   sed -i "${dockerfile_line}i RUN wget --no-check-certificate -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz \&\& \
      tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/" ${dockerfile_name}
   sed -i "${dockerfile_line}i RUN apt remove git -y \&\& apt install -y libcurl4-openssl-dev gettext \&\& wget -q https://paddle-ci.gz.bcebos.com/git-2.17.1.tar.gz \&\& \

--- a/tools/dockerfile/ci_dockerfile.sh
+++ b/tools/dockerfile/ci_dockerfile.sh
@@ -64,10 +64,10 @@ function make_cinn_dockerfile(){
   sed "s#<baseimg>#nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04#g" ./Dockerfile.ubuntu18 >${dockerfile_name}
   sed -i "s#<setcuda>#ENV LD_LIBRARY_PATH=/usr/local/cuda-11.2/targets/x86_64-linux/lib:\$LD_LIBRARY_PATH #g" ${dockerfile_name}
   sed -i 's#<install_cpu_package>##g' ${dockerfile_name}
+  sed -i "7i ENV TZ=Asia/Beijing" ${dockerfile_name}
+  sed -i "8i RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone" ${dockerfile_name}
+  sed -i "9i RUN apt-get update && apt-get install -y liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev" ${dockerfile_name}
   dockerfile_line=$(wc -l ${dockerfile_name}|awk '{print $1}')
-  sed -i "${dockerfile_line}i ENV TZ=Asia/Beijing" ${dockerfile_name}
-  sed -i "${dockerfile_line}i RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone" ${dockerfile_name}
-  sed -i "${dockerfile_line}i RUN apt-get install -y liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev" ${dockerfile_name}
   sed -i "${dockerfile_line}i RUN wget --no-check-certificate -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz \&\& \
      tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/" ${dockerfile_name}
   sed -i "${dockerfile_line}i RUN apt remove git -y \&\& apt install -y libcurl4-openssl-dev gettext \&\& wget -q https://paddle-ci.gz.bcebos.com/git-2.17.1.tar.gz \&\& \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- python36 support pre-commit<=2.1.1 
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/51314274/173775080-cda6c195-c9f6-41dd-8de4-271eda5ac671.png">

- update cuda11.2 source image public key to avoid GPG problem, see [here](https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/)
![image](https://user-images.githubusercontent.com/51314274/175015230-a62d0f59-337e-4430-a6b8-9871bdac995a.png)
