### PR TITLE
fix Standalone Executor bug that intermediate_out in fused_elemwise_add_activation op is not in scope

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -366,7 +366,8 @@ void build_op_func_list(const platform::Place& place,
         op->Type() == "rnn_memory_helper_grad" ||
         op->Type() == "conditional_block" ||
         op->Type() == "conditional_block_grad" || op->Type() == "while" ||
-        op->Type() == "while_grad") {
+        op->Type() == "while_grad" ||
+        op->Type() == "fused_elemwise_add_activation") {
       enforce_exist = false;
     }
     std::tie(ins_map, ins_name2id) =


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

在`fuse_elwise_add_act_pass`中，会使用`RemoveIntermediateOut`方法将中间变量`IntermediateOut`节点删掉，所以scope中找不到该变量。
新执行器会对每个变量是否存在做检查，导致报错。
这个PR允许`fused_elemwise_add_activation` op跳过这个检查。