### PR TITLE
Revert md-in-tensor refactoring in Softmax Mkldnn Op 

### DIFF
--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -47,8 +47,12 @@ class SoftmaxMKLDNNHandler
         platform::errors::InvalidArgument(
             "The shape of input and output tensor must be identical."));
 
-    this->AcquireForwardPrimitiveDescriptor(prop_kind::forward_scoring,
-                                            input->mem_desc(), axis);
+    auto softmax_tz = phi::vectorize(input->dims());
+    auto md = memory::desc(softmax_tz, platform::MKLDNNGetDataType<T>(),
+                           input->format());
+
+    this->AcquireForwardPrimitiveDescriptor(prop_kind::forward_scoring, md,
+                                            axis);
   }
 
   SoftmaxMKLDNNHandler(const framework::ExecutionContext& ctx,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

Changes from PR https://github.com/PaddlePaddle/Paddle/pull/41997 in Softmax mkldnn op caused error described in this issue https://github.com/PaddlePaddle/Paddle/issues/42972.  This PR reverts defective part of the code. 

