### PR TITLE
Fix for FC for quant model

### DIFF
--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -178,6 +178,8 @@ class FCPrimitiveFactory {
     } else {
       out->set_format(in_format);
     }
+    out->set_mem_desc({phi::vectorize(out->dims()),
+                       platform::MKLDNNGetDataType<T_out>(), out->format()});
   }
 
   void UpdateDataPointers(const ExecutionContext& ctx, Tensor* out,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix for FC for quant model. The error was associated with FC kernel not using infer shape and instead of that inferring output dims inside its kernel without updating oneDNN's memory descriptor, which caused softmax kernel to use previous batch size.
