### PR TITLE
Revert "Revert md-in-tensor refactoring in Softmax Mkldnn Op "

### DIFF
--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -47,12 +47,8 @@ class SoftmaxMKLDNNHandler
         platform::errors::InvalidArgument(
             "The shape of input and output tensor must be identical."));
 
-    auto softmax_tz = phi::vectorize(input->dims());
-    auto md = memory::desc(softmax_tz, platform::MKLDNNGetDataType<T>(),
-                           input->format());
-
-    this->AcquireForwardPrimitiveDescriptor(prop_kind::forward_scoring, md,
-                                            axis);
+    this->AcquireForwardPrimitiveDescriptor(prop_kind::forward_scoring,
+                                            input->mem_desc(), axis);
   }
 
   SoftmaxMKLDNNHandler(const framework::ExecutionContext& ctx,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
#43564 is said to fix https://github.com/PaddlePaddle/Paddle/issues/42972, but it is not the root cause, https://github.com/PaddlePaddle/Paddle/pull/43567 is the final fix for 42972. Given the final fix #43567 has been merged, here I revert the temp fix #43564