### PR TITLE
Fix index calculation error in ElementwiseKernel.

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_base.h
+++ b/paddle/phi/kernels/funcs/elementwise_base.h
@@ -768,7 +768,7 @@ __global__ void VectorizedElementwiseKernel(
         ins, outs, data_offset, read_lens * BLOCK_NUM_X, read_lens, func);
   }
 
-  int remain = numel - data_offset;
+  kps::IndexType remain = numel - data_offset;
   if (remain > 0) {
     VectorizedElementwiseKernelImpl<OutT,
                                     Functor,
@@ -776,7 +776,7 @@ __global__ void VectorizedElementwiseKernel(
                                     NumOuts,
                                     VecSize,
                                     true>(
-        ins, outs, data_offset, remain, read_lens, func);
+        ins, outs, data_offset, static_cast<int>(remain), read_lens, func);
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPS

### Describe
<!-- Describe what this PR does -->
```python
x_shape = [1, 4392, 4392, 128]
x = paddle.randn(x_shape).astype(paddle.bfloat16)
```

以上测试代码，develop会出现如下错误：
<img width="1332" alt="image" src="https://user-images.githubusercontent.com/12538138/174092360-ffb69fb9-6580-452e-9d63-833dbf3d7028.png">

<img width="286" alt="image" src="https://user-images.githubusercontent.com/12538138/174092562-4e211f5b-f3b9-4ef0-b4a0-cc2cb74fe4a6.png">

`numel`和`data_offset`都是`int64_t`类型。追查发现，`numel`和`data_offset`都是一个超出了int32表示范围的正数，且`numel < data_offset`，`remain`理应是一个负数，实际上却得到一个很大的正数。
