### PR TITLE
delete the log printing in layout autotune

### DIFF
--- a/paddle/fluid/imperative/layout_autotune.cc
+++ b/paddle/fluid/imperative/layout_autotune.cc
@@ -25,7 +25,6 @@ namespace imperative {
 bool LayoutAutoTune::UseLayoutAutoTune() const {
 #if defined(PADDLE_WITH_CUDA)
   if (!phi::backends::gpu::TensorCoreAvailable()) {
-    LOG(INFO) << "Layout AutoTuning is not available.";
     return false;
   } else {
     return use_layout_autotune_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
删除  layout autotune 中的多余打印
背景 ：layout autotune log会导致模型打印信息增多