### PR TITLE
[code format] remove .clang-format in paddle/fluid to use the same config file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,4 +24,6 @@ Standard:  Cpp11
 AllowAllParametersOfDeclarationOnNextLine: true
 BinPackParameters: false
 BinPackArguments: false
+IncludeBlocks: Preserve
+IncludeIsMainSourceRegex: (\.cu)$
 ...

--- a/paddle/fluid/.clang-format
+++ b/paddle/fluid/.clang-format
@@ -1,5 +1,0 @@
----
-Language:        Cpp
-BasedOnStyle:  Google
-Standard:  Cpp11 
-...

--- a/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.cc
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-// clang-format off
 #include "paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.h"
 
 #include <algorithm>
@@ -31,7 +30,6 @@ limitations under the License. */
 #include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/errors.h"
-// clang-format on
 
 namespace paddle {
 namespace framework {
@@ -79,7 +77,8 @@ FeedInfoMap CinnGraphSymbolization::GetFeedInfoMapFromInput() const {
   for (auto& feed_pair : input_tensors_) {
     const auto& feed_name = feed_pair.first;
     const auto* tensor = feed_pair.second;
-    PADDLE_ENFORCE_NE(tensor, nullptr,
+    PADDLE_ENFORCE_NE(tensor,
+                      nullptr,
                       platform::errors::PreconditionNotMet(
                           "The input variable %s's tensor cannot be NULL,"
                           "we need the variable's dtype and shape from tensor.",
@@ -96,7 +95,8 @@ FeedInfoMap CinnGraphSymbolization::GetFeedInfoMapFromInput() const {
     }
 
     PADDLE_ENFORCE_NE(
-        feed_map[feed_name].shape.size(), 0UL,
+        feed_map[feed_name].shape.size(),
+        0UL,
         platform::errors::PreconditionNotMet(
             "The input variable %s's tensor shape cannot be empty,"
             "we need the variable's dtype and shape from tensor.",
@@ -136,7 +136,8 @@ CinnGraphSymbolization::CreateCinnScope(const FeedInfoMap& feed_map) {
 
   for (const auto& param_name : parameter_names) {
     PADDLE_ENFORCE_GT(
-        feed_map.count(param_name), 0UL,
+        feed_map.count(param_name),
+        0UL,
         platform::errors::NotFound("Cannot find parameter %s from input list,"
                                    "please add the tensor into input.",
                                    param_name.c_str()));
@@ -162,12 +163,12 @@ CinnGraphSymbolization::CreateCinnScope(const FeedInfoMap& feed_map) {
 
 std::vector<Node*> CinnGraphSymbolization::TopologicalSort() const {
   std::unordered_set<Node*> op_nodes;
-  std::for_each(graph_.Nodes().begin(), graph_.Nodes().end(),
-                [&op_nodes](Node* n) {
-                  if (n->IsOp()) {
-                    op_nodes.emplace(n);
-                  }
-                });
+  std::for_each(
+      graph_.Nodes().begin(), graph_.Nodes().end(), [&op_nodes](Node* n) {
+        if (n->IsOp()) {
+          op_nodes.emplace(n);
+        }
+      });
 
   std::unordered_map<Node*, std::unordered_map<Node*, size_t>> adj_list;
   std::unordered_map<Node*, size_t> in_degrees;
@@ -210,7 +211,8 @@ std::vector<Node*> CinnGraphSymbolization::TopologicalSort() const {
     }
   }
 
-  PADDLE_ENFORCE_EQ(sorted_ops.size(), op_nodes.size(),
+  PADDLE_ENFORCE_EQ(sorted_ops.size(),
+                    op_nodes.size(),
                     platform::errors::PreconditionNotMet(
                         "The sorting graph contains cycles."));
   return sorted_ops;
@@ -234,7 +236,8 @@ void CinnGraphSymbolization::RunOp(const CinnOpDesc& op_desc,
                                    const OpMapperContext& ctx) const {
   const auto& op_type = op_desc.Type();
   auto* kernel = ::cinn::frontend::OpMapperRegistry::Global()->Find(op_type);
-  PADDLE_ENFORCE_NE(kernel, nullptr,
+  PADDLE_ENFORCE_NE(kernel,
+                    nullptr,
                     platform::errors::NotFound(
                         "Op %s is Not Supported by CINN, please register"
                         " this op in the CINN repo.",
@@ -256,10 +259,12 @@ std::unordered_set<std::string> CinnGraphSymbolization::GetFetchIds() const {
   std::unordered_set<std::string> fetch_names;
   fetch_names.reserve(fetch_var_names_.size());
   std::for_each(
-      fetch_var_names_.begin(), fetch_var_names_.end(),
+      fetch_var_names_.begin(),
+      fetch_var_names_.end(),
       [this, &fetch_names](const std::string& name) {
         PADDLE_ENFORCE_EQ(
-            var_model_to_program_map_.count(name), 1,
+            var_model_to_program_map_.count(name),
+            1,
             platform::errors::PreconditionNotMet(
                 "Cannot find %s in var_model_to_program_map_", name.c_str()));
         fetch_names.insert(var_model_to_program_map_.at(name));
@@ -276,8 +281,12 @@ std::unordered_set<std::string> CinnGraphSymbolization::GetFetchIds() const {
   auto feed_map = GetFeedInfoMapFromInput();
   auto cinn_scope = CreateCinnScope(feed_map);
 
-  OpMapperContext ctx(*cinn_scope, target_, &builder, &var_map_,
-                      &var_model_to_program_map_, &fetch_var_names_);
+  OpMapperContext ctx(*cinn_scope,
+                      target_,
+                      &builder,
+                      &var_map_,
+                      &var_model_to_program_map_,
+                      &fetch_var_names_);
   // add all tensor's feed info into context
   for (auto& feed_pair : feed_map) {
     ctx.AddFeedInfo(feed_pair.first, feed_pair.second);

--- a/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.h
+++ b/paddle/fluid/framework/paddle2cinn/cinn_graph_symbolization.h
@@ -14,7 +14,6 @@ limitations under the License. */
 
 #pragma once
 
-// clang-format off
 #include <map>
 #include <string>
 #include <unordered_map>
@@ -27,7 +26,6 @@ limitations under the License. */
 
 #include "cinn/frontend/net_builder.h"
 #include "cinn/frontend/op_mapper_registry.h"
-// clang-format on
 
 namespace paddle {
 namespace framework {
@@ -65,7 +63,8 @@ namespace paddle2cinn {
 class CinnGraphSymbolization {
  public:
   CinnGraphSymbolization(
-      int64_t graph_id, const ir::Graph& graph,
+      int64_t graph_id,
+      const ir::Graph& graph,
       const ::cinn::common::Target& target,
       const std::map<std::string, const LoDTensor*>& input_tensors)
       : graph_id_(graph_id),

--- a/paddle/fluid/framework/paddle2cinn/transform_desc.h
+++ b/paddle/fluid/framework/paddle2cinn/transform_desc.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-// The headers cant be sorted by clang-format or compilint error occurs.
-// clang-format off
 #include "paddle/fluid/framework/block_desc.h"
 #include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/program_desc.h"
@@ -26,7 +24,6 @@
 #include "cinn/frontend/paddle/cpp/op_desc.h"
 #include "cinn/frontend/paddle/cpp/program_desc.h"
 #include "cinn/frontend/paddle/cpp/var_desc.h"
-// clang-format on
 
 namespace paddle {
 namespace framework {

--- a/paddle/infrt/dialect/infrt/ir/infrt_dialect.cc
+++ b/paddle/infrt/dialect/infrt/ir/infrt_dialect.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clang-format off
 #include "paddle/infrt/dialect/infrt/ir/infrt_dialect.h"
 
 #include <llvm/ADT/TypeSwitch.h>
@@ -61,7 +60,6 @@ void InfrtDialect::initialize() {
 #include "paddle/infrt/dialect/infrt/ir/test_kernels.cpp.inc"
       >();
 }
-// clang-format on
 
 /// Parse a type registered to this dialect.
 mlir::Type InfrtDialect::parseType(::mlir::DialectAsmParser &parser) const {

--- a/paddle/infrt/tests/models/test_abs.cc
+++ b/paddle/infrt/tests/models/test_abs.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clang-format off
 #include <gtest/gtest.h>
 #include <llvm/Support/CommandLine.h>
 #include <mlir/Pass/PassManager.h>
@@ -50,7 +49,6 @@
 #include "paddle/infrt/dialect/phi/ir/infrt_phi_tensor.h"
 #include "paddle/infrt/dialect/phi/ir/phi_base.h"
 #include "paddle/infrt/dialect/phi/ir/phi_kernels.h"
-// clang-format on
 
 static llvm::cl::list<std::string> cl_shared_libs(  // NOLINT
     "shared_libs",

--- a/paddle/phi/kernels/gpu/gelu_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/gelu_grad_kernel.cu
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// clang-format off
 #include "paddle/phi/kernels/gelu_kernel.h"
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
@@ -21,7 +20,6 @@
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/broadcast_function.h"
 #include "paddle/phi/kernels/gpu/gelu_funcs.h"
-// clang-format on
 
 DECLARE_bool(use_fast_math);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

-  remove .clang-format in paddle/fluid to use the same config file. 
- remove "// clang-format off" in some files, their headers will not be sort after set IncludeBlocks as Preserve in clang-format config file, this option tells clang-format not merge include blocks which are seperate by blank line