### PR TITLE
[Dy2Static] Fix backward error when multi-forward in a dy2static model

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -152,7 +152,6 @@ class PartialProgramLayer:
         assert isinstance(self._build_strategy, BuildStrategy)
 
         self._origin_main_program = self._verify_program(main_program)
-        self._tmp_scope_vec = self._create_scope_vec()
         self._cuda_graph_vec = self._create_cuda_graph_vec()
         self._cuda_graph_capture_mode = ""
         self._cuda_graph_pool_id = 0
@@ -363,9 +362,8 @@ class PartialProgramLayer:
 
         _C_ops.run_program(self._valid_vars(in_vars),
                            self._valid_vars(self._params),
-                           self._valid_vars(out_vars), self._tmp_scope_vec,
+                           self._valid_vars(out_vars), self._create_scope_vec(),
                            self._double_grads, self._cuda_graph_vec, *attrs)
-        self.drop_scope_if_no_grad()
         restored_nest_out = self._restore_out(out_vars)
         return self._remove_no_value(restored_nest_out)
 
@@ -378,13 +376,6 @@ class PartialProgramLayer:
                         == paddle.float16):
                     in_vars[i] = var.astype('float16')
                     in_vars[i].name = name
-
-    def drop_scope_if_no_grad(self):
-        tracer = framework._dygraph_tracer()
-        scope = self._tmp_scope_vec.value().get_scope() if isinstance(
-            self._tmp_scope_vec, (core.VarBase)) else self._tmp_scope_vec[0]
-        if self.training and not tracer._has_grad:
-            scope.drop_kids()
 
     @property
     def program(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复了动转静多次前向一次反向的错误：
之前的实现是使用一个 vector scope，并且每次前向都是共用同一个 vec scope，如果前向和反向的顺序错误，那么就会出现梯度不对的问题，一个case如下： 
```
import paddle
class MyLayer(paddle.nn.Layer):
    def __init__(self):
        super().__init__()
        self.linear = paddle.nn.Linear(1, 1)

    @paddle.jit.to_static(input_spec=[
        paddle.static.InputSpec(
            shape=[None, None], dtype=paddle.float32
        )
    ])
    def forward(self, x):
        return self.linear(x)

model = MyLayer()
model.clear_gradients()
inp = paddle.ones([1, 1])
out1 = model(inp * 1)
out2 = model(inp * 2)
# loss = out1 * 1 + out2 * 2  # right gradients
loss = out2 * 2 + out1 * 1    # wrong gradients
loss.backward()
print(model.linear.weight.grad)
```

因此将N次前向共用一个 vec scope 换为了N次前向分别使用自己的一个vecscope，解决了上述的问题。


TODO：添加单测，cherrypick-2.3.1