### PR TITLE
Fix bug of set_value

### DIFF
--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -78,6 +78,9 @@ inline void CheckAndUpdateSliceAttrs(const DDim in_dims,
         // dim_value-1
         // "end is -1" means contain the 0-th element of this axis.
         start = std::min(start, dim_value - 1);
+        if (end < -1) {
+          end += dim_value;
+        }
         end = std::max(end, static_cast<T>(-1));
         PADDLE_ENFORCE_GE(
             start,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
修复`set_value`处理切片step为负数时的Bug。
issue: [#43663](https://github.com/PaddlePaddle/Paddle/issues/43663)