### PR TITLE
[IPU] feat(): add identity_loss op to mark the loss variable on IPU.

### DIFF
--- a/paddle/fluid/operators/identity_loss_op.cc
+++ b/paddle/fluid/operators/identity_loss_op.cc
@@ -1,0 +1,104 @@
+/* Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <string>
+
+#include "paddle/fluid/framework/infershape_utils.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/phi/core/infermeta_utils.h"
+#include "paddle/phi/infermeta/unary.h"
+
+namespace paddle {
+namespace operators {
+
+class IdentityLossOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(
+        OperatorWithKernel::IndicateVarDataType(ctx, "X"),
+        platform::CPUPlace());
+  }
+};
+
+class IdentityLossOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor) The input of identity_loss op");
+    AddOutput("Out", "(Tensor) The output of identity_loss op");
+    AddAttr<int>("reduction", "(int, default 1). The reduction.")
+        .SetDefault(1)
+        .InEnum({0, 1, 2});
+    AddComment(R"DOC(
+IdentityLoss Operator mark the Loss var.
+
+)DOC");
+  }
+};
+
+class IdentityLossGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    ctx->SetOutputDim(framework::GradVarName("X"), ctx->GetInputDim("X"));
+    ctx->ShareLoD("X", framework::GradVarName("X"));
+  }
+
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    auto input_data_type = OperatorWithKernel::IndicateVarDataType(
+        ctx, framework::GradVarName("Out"));
+    return framework::OpKernelType(input_data_type, platform::CPUPlace());
+  }
+};
+
+template <typename T>
+class IdentityLossGradMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> grad_op) const override {
+    grad_op->SetType("identity_loss_grad");
+    grad_op->SetInput("X", this->Input("X"));
+    grad_op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    grad_op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    grad_op->SetAttrMap(this->Attrs());
+  }
+};
+
+DECLARE_INPLACE_OP_INFERER(IdentityLossInplaceInferer, {"X", "Out"});
+DECLARE_INPLACE_OP_INFERER(IdentityLossGradInplaceInferer,
+                           {framework::GradVarName("Out"),
+                            framework::GradVarName("X")});
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+DECLARE_INFER_SHAPE_FUNCTOR(identity_loss, IdentityLossInferShapeFunctor,
+                            PD_INFER_META(phi::IdentityLossInferMeta));
+
+REGISTER_OPERATOR(identity_loss, ops::IdentityLossOp, ops::IdentityLossOpMaker,
+                  ops::IdentityLossGradMaker<paddle::framework::OpDesc>,
+                  ops::IdentityLossGradMaker<paddle::imperative::OpBase>,
+                  ops::IdentityLossInplaceInferer,
+                  IdentityLossInferShapeFunctor);
+
+REGISTER_OPERATOR(identity_loss_grad, ops::IdentityLossGradOp,
+                  ops::IdentityLossGradInplaceInferer);

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3262,6 +3262,18 @@ void ChannelShuffleInferMeta(const MetaTensor& x,
   out->set_dims(output_dims);
 }
 
+void IdentityLossInferMeta(const MetaTensor& x,
+                           int reduction,
+                           MetaTensor* out) {
+  if (reduction == 2) {
+    out->set_dtype(x.dtype());
+    out->set_dims(x.dims());
+  } else {
+    out->set_dims(phi::make_ddim({1}));
+    out->set_dtype(x.dtype());
+  }
+}
+
 }  // namespace phi
 
 PD_REGISTER_INFER_META_FN(flatten, phi::FlattenInferMeta);

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -469,4 +469,6 @@ void ChannelShuffleInferMeta(const MetaTensor& x,
                              const std::string& data_format,
                              MetaTensor* out);
 
+void IdentityLossInferMeta(const MetaTensor& x, int reduction, MetaTensor* out);
+
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/identity_loss_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/identity_loss_grad_kernel.cc
@@ -1,0 +1,59 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/identity_loss_grad_kernel.h"
+
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/copy_kernel.h"
+#include "paddle/phi/kernels/mean_all_grad_kernel.h"
+#include "paddle/phi/kernels/reduce_sum_grad_kernel.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void IdentityLossGradKernel(const Context& dev_ctx,
+                            const DenseTensor& x,
+                            const DenseTensor& out_grad,
+                            const int reduction,
+                            DenseTensor* x_grad) {
+  switch (reduction) {
+    case 0:
+      // mean
+      phi::MeanAllGradKernel<T>(dev_ctx, x, out_grad, x_grad);
+      break;
+    case 1:
+      // sum
+      phi::ReduceSumGradKernel<T>(
+          dev_ctx, x, out_grad, std::vector<int64_t>{0}, false, true, x_grad);
+      break;
+    case 2:
+      // none
+      phi::Copy(dev_ctx, out_grad, dev_ctx.GetPlace(), false, x_grad);
+      break;
+    default:
+      // error
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "reduction should be 0, 1 and 2. But get %d", reduction));
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(identity_loss_grad,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::IdentityLossGradKernel,
+                   float,
+                   double) {}

--- a/paddle/phi/kernels/cpu/identity_loss_kernel.cc
+++ b/paddle/phi/kernels/cpu/identity_loss_kernel.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/identity_loss_kernel.h"
+
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/copy_kernel.h"
+#include "paddle/phi/kernels/mean_all_kernel.h"
+#include "paddle/phi/kernels/reduce_sum_kernel.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void IdentityLossKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        const int reduction,
+                        DenseTensor* out) {
+  switch (reduction) {
+    case 0:
+      // mean
+      phi::MeanAllKernel<T>(dev_ctx, x, out);
+      break;
+    case 1:
+      // sum
+      phi::SumRawKernel<T>(
+          dev_ctx, x, std::vector<int64_t>{0}, false, true, out->dtype(), out);
+      break;
+    case 2:
+      // none
+      phi::Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
+      break;
+    default:
+      // error
+      PADDLE_THROW(phi::errors::InvalidArgument(
+          "reduction should be 0, 1 and 2. But get %d", reduction));
+  }
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(
+    identity_loss, CPU, ALL_LAYOUT, phi::IdentityLossKernel, float, double) {}

--- a/paddle/phi/kernels/identity_loss_grad_kernel.h
+++ b/paddle/phi/kernels/identity_loss_grad_kernel.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void IdentityLossGradKernel(const Context& dev_ctx,
+                            const DenseTensor& x,
+                            const DenseTensor& out_grad,
+                            const int reduction,
+                            DenseTensor* x_grad);
+
+}  // namespace phi

--- a/paddle/phi/kernels/identity_loss_kernel.h
+++ b/paddle/phi/kernels/identity_loss_kernel.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void IdentityLossKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        const int reduction,
+                        DenseTensor* out);
+
+}  // namespace phi

--- a/paddle/phi/ops/compat/identity_loss_sig.cc
+++ b/paddle/phi/ops/compat/identity_loss_sig.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/compat/op_utils.h"
+
+namespace phi {
+
+KernelSignature IdentityLossOpArgumentMapping(
+    const ArgumentMappingContext& ctx) {
+  return KernelSignature("identity_loss", {"X"}, {"reduction"}, {"Out"});
+}
+
+KernelSignature IdentityLossGradOpArgumentMapping(
+    const ArgumentMappingContext& ctx) {
+  return KernelSignature(
+      "identity_loss_grad", {"X", "Out@GRAD"}, {"reduction"}, {"X@GRAD"});
+}
+
+}  // namespace phi
+
+PD_REGISTER_ARG_MAPPING_FN(identity_loss, phi::IdentityLossOpArgumentMapping);
+PD_REGISTER_ARG_MAPPING_FN(identity_loss_grad,
+                           phi::IdentityLossGradOpArgumentMapping);

--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -41,6 +41,7 @@ __all__ = [
     'hsigmoid',
     'sampled_softmax_with_cross_entropy',
     'softmax_with_cross_entropy',
+    'identity_loss',
     'rank_loss',
     'margin_rank_loss',
     'sigmoid_cross_entropy_with_logits',
@@ -1228,6 +1229,54 @@ def softmax_with_cross_entropy(logits,
     return paddle.nn.functional.loss.fluid_softmax_with_cross_entropy(
         logits, label, soft_label, ignore_index, numeric_stable_mode,
         return_softmax, axis)
+
+
+def identity_loss(x, reduction="none"):
+    r"""Marks a tensor as being part of the loss calculation for IPU.
+
+    This function should be called on the (final) loss of a model so that
+    it is used as the start of backpropagation. This is equivalent to calling
+    ``x.backward()`` on a tensor ``x`` when running on the CPU.
+
+    Parameters:
+        x (Variable): The calculated loss ``Tensor``.
+        reduction(str|int): Reduce the loss output. The default value is "none". Supported values are:
+
+            * ``"sum"``: Sum the losses.
+            * ``"mean"``: Take the mean of the losses.
+            * ``"none"``: Don't reduce the losses.
+
+    Returns:
+        Variable: The loss ``Tensor`` with the specified reduction applied.
+
+    Examples:
+
+        .. code-block:: python
+
+            import paddle.fluid as fluid
+            import paddle
+            paddle.enable_static()
+            loss = fluid.data(name="loss", shape=[-1, 1], dtype="float32")
+            out = fluid.layers.identity_loss(loss, reduction=1)
+    """
+    if isinstance(reduction, str):
+        reduction = {"mean": 0, "sum": 1, "none": 2}.get(reduction.lower())
+        if reduction is None:
+            raise Exception("Unsupported reduction type.")
+
+    if _non_static_mode():
+        return _C_ops.identity_loss(x, "reduction", reduction)
+
+    check_variable_and_dtype(x, 'x', ['float32', 'float64'], "identity_loss")
+    attrs = {'reduction': reduction}
+    helper = LayerHelper('identity_loss', **locals())
+    dtype = helper.input_dtype(input_param_name='x')
+    out = helper.create_variable_for_type_inference(dtype)
+    helper.append_op(type="identity_loss",
+                     inputs={"X": x},
+                     outputs={"Out": out},
+                     attrs=attrs)
+    return out
 
 
 def rank_loss(label, left, right, name=None):

--- a/python/paddle/fluid/tests/unittests/test_identity_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_identity_loss_op.py
@@ -1,0 +1,187 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
+from op_test import OpTest
+from paddle.fluid.framework import _test_eager_guard
+
+
+class TestIdentityLossOp(OpTest):
+
+    def setUp(self):
+        self.max_relative_error = 0.006
+        self.python_api = paddle.fluid.layers.identity_loss
+
+        self.inputs = {}
+        self.initTestCase()
+        self.dtype = np.float64
+
+        self.op_type = "identity_loss"
+        self.attrs = {}
+        self.attrs['reduction'] = self.reduction
+
+        input = np.random.random(self.shape).astype(self.dtype)
+
+        self.inputs['X'] = input
+        if self.reduction == 0:
+            output = input.mean()
+        elif self.reduction == 1:
+            output = input.sum()
+        else:
+            output = input
+        self.outputs = {'Out': output}
+
+    def test_check_output(self):
+        paddle.enable_static()
+        self.check_output(check_eager=True)
+        paddle.disable_static()
+
+    def test_check_grad_normal(self):
+        paddle.enable_static()
+        self.check_grad(['X'], 'Out', check_eager=True)
+        paddle.disable_static()
+
+    def initTestCase(self):
+        self.shape = (4, 10, 10)
+        self.reduction = 0
+
+
+class TestCase1(TestIdentityLossOp):
+
+    def initTestCase(self):
+        self.shape = (8, 16, 8)
+        self.reduction = 0
+
+
+class TestCase2(TestIdentityLossOp):
+
+    def initTestCase(self):
+        self.shape = (8, 16)
+        self.reduction = 1
+
+
+class TestCase3(TestIdentityLossOp):
+
+    def initTestCase(self):
+        self.shape = (4, 8, 16)
+        self.reduction = 2
+
+
+class TestIdentityLossFloat32(TestIdentityLossOp):
+
+    def set_attrs(self):
+        self.dtype = 'float32'
+
+
+class TestIdentityLossOpError(unittest.TestCase):
+
+    def test_errors(self):
+        paddle.enable_static()
+        with program_guard(Program(), Program()):
+            input_data = np.random.random((2, 4)).astype("float32")
+
+            def test_int():
+                fluid.layers.identity_loss(x=input_data, reduction=3)
+
+            self.assertRaises(Exception, test_int)
+
+            def test_string():
+                fluid.layers.identity_loss(x=input_data, reduction="wrongkey")
+
+            self.assertRaises(Exception, test_string)
+
+            def test_dtype():
+                x2 = fluid.layers.data(name='x2', shape=[1], dtype='int32')
+                fluid.layers.identity_loss(x=x2, reduction=1)
+
+            self.assertRaises(TypeError, test_dtype)
+        paddle.disable_static()
+
+
+class TestIdentityLossAPI(unittest.TestCase):
+
+    def setUp(self):
+        self.x_shape = [2, 3, 4, 5]
+        self.x = np.random.uniform(-1, 1, self.x_shape).astype(np.float32)
+        self.place = fluid.CPUPlace()
+
+    def identity_loss_ref(self, input, reduction):
+        if reduction == 0 or reduction == "mean":
+            return input.mean()
+        elif reduction == 1 or reduction == "sum":
+            return input.sum()
+        else:
+            return input
+
+    def test_api_static(self):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.fluid.data('X', self.x_shape)
+            out1 = paddle.fluid.layers.identity_loss(x)
+            out2 = paddle.fluid.layers.identity_loss(x, reduction=0)
+            out3 = paddle.fluid.layers.identity_loss(x, reduction=1)
+            out4 = paddle.fluid.layers.identity_loss(x, reduction=2)
+
+            exe = paddle.static.Executor(self.place)
+            res = exe.run(feed={'X': self.x},
+                          fetch_list=[out1, out2, out3, out4])
+        ref = [
+            self.identity_loss_ref(self.x, 2),
+            self.identity_loss_ref(self.x, 0),
+            self.identity_loss_ref(self.x, 1),
+            self.identity_loss_ref(self.x, 2)
+        ]
+        for out, out_ref in zip(res, ref):
+            self.assertEqual(np.allclose(out, out_ref, rtol=1e-04), True)
+
+    def test_api_dygraph(self):
+        paddle.disable_static(self.place)
+
+        def test_case(x, reduction):
+            x_tensor = paddle.to_tensor(x)
+            out = paddle.fluid.layers.identity_loss(x_tensor, reduction)
+            out_ref = self.identity_loss_ref(x, reduction)
+            self.assertEqual(np.allclose(out.numpy(), out_ref, rtol=1e-04),
+                             True)
+
+        test_case(self.x, 0)
+        test_case(self.x, 1)
+        test_case(self.x, 2)
+        test_case(self.x, "mean")
+        test_case(self.x, "sum")
+        test_case(self.x, "none")
+        paddle.enable_static()
+
+    def test_errors(self):
+        paddle.disable_static()
+        x = np.random.uniform(-1, 1, [10, 12]).astype('float32')
+        x = paddle.to_tensor(x)
+        self.assertRaises(Exception, paddle.fluid.layers.identity_loss, x, -1)
+        self.assertRaises(Exception, paddle.fluid.layers.identity_loss, x, 3)
+        self.assertRaises(Exception, paddle.fluid.layers.identity_loss, x,
+                          "wrongkey")
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.fluid.data('X', [10, 12], 'int32')
+            self.assertRaises(TypeError, paddle.fluid.layers.identity_loss, x)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### PR types
New features

### PR changes
Others

### Describe
https://github.com/PaddlePaddle/Paddle/pull/42952 改动过大，将IPU的动转静的功能分为两个PR来拆分：
1. IPU identity loss 算子的添加。
2. IPU 动转静功能支持。

该PR为identity loss算子添加。