### PR TITLE
[Sparse] support batch compute for SparseTensor matmul/masked_matmul/softmax

### DIFF
--- a/paddle/fluid/platform/dynload/cusparse.h
+++ b/paddle/fluid/platform/dynload/cusparse.h
@@ -31,24 +31,22 @@ namespace dynload {
 #if defined(PADDLE_WITH_CUDA)
 // APIs available after CUDA 11.0
 #if CUDA_VERSION >= 11000
-#define CUSPARSE_ROUTINE_EACH(__macro)   \
-  __macro(cusparseCreate);               \
-  __macro(cusparseSetStream);            \
-  __macro(cusparseCreateMatDescr);       \
-  __macro(cusparseDestroy);              \
-  __macro(cusparseSnnz);                 \
-  __macro(cusparseDnnz);                 \
-  __macro(cusparseSetMatType);           \
-  __macro(cusparseSetMatIndexBase);      \
-  __macro(cusparseCreateCsr);            \
-  __macro(cusparseCreateCoo);            \
-  __macro(cusparseCreateDnMat);          \
-  __macro(cusparseSpMM_bufferSize);      \
-  __macro(cusparseSpMM);                 \
-  __macro(cusparseDestroySpMat);         \
-  __macro(cusparseDestroyDnMat);         \
-  __macro(cusparseDnMatSetStridedBatch); \
-  __macro(cusparseCsrSetStridedBatch);
+#define CUSPARSE_ROUTINE_EACH(__macro) \
+  __macro(cusparseCreate);             \
+  __macro(cusparseSetStream);          \
+  __macro(cusparseCreateMatDescr);     \
+  __macro(cusparseDestroy);            \
+  __macro(cusparseSnnz);               \
+  __macro(cusparseDnnz);               \
+  __macro(cusparseSetMatType);         \
+  __macro(cusparseSetMatIndexBase);    \
+  __macro(cusparseCreateCsr);          \
+  __macro(cusparseCreateCoo);          \
+  __macro(cusparseCreateDnMat);        \
+  __macro(cusparseSpMM_bufferSize);    \
+  __macro(cusparseSpMM);               \
+  __macro(cusparseDestroySpMat);       \
+  __macro(cusparseDestroyDnMat);
 
 CUSPARSE_ROUTINE_EACH(PLATFORM_DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 #endif
@@ -62,7 +60,16 @@ CUSPARSE_ROUTINE_EACH(PLATFORM_DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 CUSPARSE_ROUTINE_EACH_R2(PLATFORM_DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 #endif
 
+#if CUDA_VERSION >= 11070
+#define CUSPARSE_ROUTINE_EACH_R3(__macro) \
+  __macro(cusparseDnMatSetStridedBatch);  \
+  __macro(cusparseCooSetStridedBatch);    \
+  __macro(cusparseCsrSetStridedBatch);
+
+CUSPARSE_ROUTINE_EACH_R3(PLATFORM_DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 #endif
+
+#endif  // PADDLE_WITH_CUDA
 
 #undef PLATFORM_DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP
 }  // namespace dynload

--- a/paddle/phi/backends/dynload/cusparse.h
+++ b/paddle/phi/backends/dynload/cusparse.h
@@ -43,24 +43,22 @@ extern void *cusparse_dso_handle;
 #if defined(PADDLE_WITH_CUDA)
 // APIs available after CUDA 11.0
 #if CUDA_VERSION >= 11000
-#define CUSPARSE_ROUTINE_EACH(__macro)   \
-  __macro(cusparseCreate);               \
-  __macro(cusparseSetStream);            \
-  __macro(cusparseCreateMatDescr);       \
-  __macro(cusparseDestroy);              \
-  __macro(cusparseSnnz);                 \
-  __macro(cusparseDnnz);                 \
-  __macro(cusparseSetMatType);           \
-  __macro(cusparseSetMatIndexBase);      \
-  __macro(cusparseCreateCsr);            \
-  __macro(cusparseCreateCoo);            \
-  __macro(cusparseCreateDnMat);          \
-  __macro(cusparseSpMM_bufferSize);      \
-  __macro(cusparseSpMM);                 \
-  __macro(cusparseDestroySpMat);         \
-  __macro(cusparseDestroyDnMat);         \
-  __macro(cusparseDnMatSetStridedBatch); \
-  __macro(cusparseCsrSetStridedBatch);
+#define CUSPARSE_ROUTINE_EACH(__macro) \
+  __macro(cusparseCreate);             \
+  __macro(cusparseSetStream);          \
+  __macro(cusparseCreateMatDescr);     \
+  __macro(cusparseDestroy);            \
+  __macro(cusparseSnnz);               \
+  __macro(cusparseDnnz);               \
+  __macro(cusparseSetMatType);         \
+  __macro(cusparseSetMatIndexBase);    \
+  __macro(cusparseCreateCsr);          \
+  __macro(cusparseCreateCoo);          \
+  __macro(cusparseCreateDnMat);        \
+  __macro(cusparseSpMM_bufferSize);    \
+  __macro(cusparseSpMM);               \
+  __macro(cusparseDestroySpMat);       \
+  __macro(cusparseDestroyDnMat);
 
 CUSPARSE_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 #endif
@@ -74,7 +72,16 @@ CUSPARSE_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 CUSPARSE_ROUTINE_EACH_R2(DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 #endif
 
+#if CUDA_VERSION >= 11070
+#define CUSPARSE_ROUTINE_EACH_R3(__macro) \
+  __macro(cusparseDnMatSetStridedBatch);  \
+  __macro(cusparseCooSetStridedBatch);    \
+  __macro(cusparseCsrSetStridedBatch);
+
+CUSPARSE_ROUTINE_EACH_R3(DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP)
 #endif
+
+#endif  // PADDLE_WITH_CUDA
 
 #undef DECLARE_DYNAMIC_LOAD_CUSPARSE_WRAP
 }  // namespace dynload

--- a/paddle/phi/kernels/funcs/sparse/sparse_blas.h
+++ b/paddle/phi/kernels/funcs/sparse/sparse_blas.h
@@ -28,33 +28,23 @@ class SparseBlas {
  public:
   explicit SparseBlas(const DeviceContext& dev_ctx) : dev_ctx_(dev_ctx) {}
 
-  // TODO(zhouwei25): implement "COO @ DENSE -> DENSE" of DSDMM
-  template <typename T>
-  void DSDMM(bool transa,
-             bool transb,
-             T alpha,
-             const phi::SparseCooTensor& mat_a,
-             const phi::DenseTensor& mat_b,
-             T beta,
-             phi::DenseTensor* mat_c) const;
+  template <typename T, typename TensorType>
+  void SPMM(bool transa,
+            bool transb,
+            T alpha,
+            const TensorType& mat_a,
+            const phi::DenseTensor& mat_b,
+            T beta,
+            phi::DenseTensor* mat_out) const;
 
-  template <typename T>
-  void DSDMM(bool transa,
-             bool transb,
-             T alpha,
-             const phi::SparseCsrTensor& mat_a,
-             const phi::DenseTensor& mat_b,
-             T beta,
-             phi::DenseTensor* mat_c) const;
-
-  template <typename T>
+  template <typename T, typename TensorType>
   void SDDMM(bool transa,
              bool transb,
              T alpha,
              const phi::DenseTensor& mat_a,
              const phi::DenseTensor& mat_b,
              T beta,
-             phi::SparseCsrTensor* mat_c) const;
+             TensorType* mat_out) const;
 
  private:
   const DeviceContext& dev_ctx_;
@@ -66,8 +56,8 @@ class SparseBlasT : private SparseBlas<DeviceContext> {
   using SparseBlas<DeviceContext>::SparseBlas;
 
   template <typename... ARGS>
-  void DSDMM(ARGS... args) const {
-    Base()->template DSDMM<T>(args...);
+  void SPMM(ARGS... args) const {
+    Base()->template SPMM<T>(args...);
   }
 
   template <typename... ARGS>

--- a/paddle/phi/kernels/sparse/cpu/softmax_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/softmax_kernel.cc
@@ -37,18 +37,23 @@ void SoftmaxCsrKernel(const Context& dev_ctx,
                         "SparseCsrTensor only support axis=-1 for softmax, "
                         "which is faster when reading data by row (axis=-1)"));
   EmptyLikeCsrKernel<T, Context>(dev_ctx, x, out);
-
   auto x_dim = x.dims();
+  auto x_rank = x_dim.size();
+
+  int batch_size = 1;
   int row_number = 1;
-  for (int i = 0; i < x_dim.size() - 1; ++i) {
-    row_number *= x_dim[i];
+  for (int i = 0; i < x_rank - 1; ++i) {
+    if (i < x_rank - 2) {
+      batch_size *= x_dim[i];
+    } else if (i == x_rank - 2) {
+      row_number = x_dim[i];
+    }
   }
 
   const DenseTensor& x_crows = x.non_zero_crows();
   const DenseTensor& x_values = x.non_zero_elements();
   DenseTensor* out_values = out->mutable_non_zero_elements();
 
-  int row_first = 0;
   int row_nnz = 0;
   T row_max_val = 0;
   const T* x_data = x_values.data<T>();
@@ -58,23 +63,26 @@ void SoftmaxCsrKernel(const Context& dev_ctx,
   PD_VISIT_INTEGRAL_TYPES(
       x.non_zero_crows().dtype(), "CsrSoftmaxKernel", ([&] {
         const data_t* x_crows_data = x_crows.data<data_t>();
-        for (int i = 0; i < row_number; ++i) {
-          row_first = static_cast<int>(x_crows_data[i]);
-          row_nnz = static_cast<int>(x_crows_data[i + 1] - x_crows_data[i]);
+        for (int i = 0; i < batch_size; ++i) {
+          for (int j = 0; j < row_number; ++j) {
+            int crow_idx = i * (row_number + 1) + j;
+            row_nnz = static_cast<int>(x_crows_data[crow_idx + 1] -
+                                       x_crows_data[crow_idx]);
 
-          x_data = x_data + row_first;
-          out_data = out_data + row_first;
+            row_max_val = *std::max_element(x_data, x_data + row_nnz);
+            phi::funcs::vec_add_bias<T, plt::avx>(
+                row_nnz, static_cast<T>(-1) * row_max_val, x_data, out_data);
 
-          row_max_val = *std::max_element(x_data, x_data + row_nnz);
-          phi::funcs::vec_add_bias<T, plt::avx>(
-              row_nnz, static_cast<T>(-1) * row_max_val, x_data, out_data);
+            phi::funcs::vec_exp<T>(row_nnz, out_data, out_data);
 
-          phi::funcs::vec_exp<T>(row_nnz, out_data, out_data);
+            T sum = 0;
+            phi::funcs::vec_sum<T, plt::avx>(row_nnz, out_data, &sum);
+            phi::funcs::vec_scal<T, plt::avx>(
+                row_nnz, static_cast<T>(1) / sum, out_data, out_data);
 
-          T sum = 0;
-          phi::funcs::vec_sum<T, plt::avx>(row_nnz, out_data, &sum);
-          phi::funcs::vec_scal<T, plt::avx>(
-              row_nnz, static_cast<T>(1) / sum, out_data, out_data);
+            x_data = x_data + row_nnz;
+            out_data = out_data + row_nnz;
+          }
         }
       }));
 }

--- a/paddle/phi/kernels/sparse/empty_kernel.cc
+++ b/paddle/phi/kernels/sparse/empty_kernel.cc
@@ -23,6 +23,25 @@ namespace phi {
 namespace sparse {
 
 template <typename T, typename Context>
+void EmptyLikeCooKernel(const Context& dev_ctx,
+                        const SparseCooTensor& x,
+                        SparseCooTensor* out) {
+  const DenseTensor& x_indices = x.non_zero_indices();
+  const DenseTensor& x_values = x.non_zero_elements();
+
+  DenseTensor* out_indices = out->mutable_non_zero_indices();
+  DenseTensor* out_values = out->mutable_non_zero_elements();
+
+  phi::Copy(dev_ctx, x_indices, dev_ctx.GetPlace(), false, out_indices);
+  phi::Copy(dev_ctx, x_values, dev_ctx.GetPlace(), false, out_values);
+
+  out_values->Resize(x_values.dims());
+  dev_ctx.template Alloc<T>(out_values);
+
+  out->set_dims(x.dims());
+}
+
+template <typename T, typename Context>
 void EmptyLikeCsrKernel(const Context& dev_ctx,
                         const SparseCsrTensor& x,
                         SparseCsrTensor* out) {
@@ -34,16 +53,32 @@ void EmptyLikeCsrKernel(const Context& dev_ctx,
   DenseTensor* out_cols = out->mutable_non_zero_cols();
   DenseTensor* out_values = out->mutable_non_zero_elements();
 
-  out->set_dims(x.dims());
   phi::Copy(dev_ctx, x_crows, dev_ctx.GetPlace(), false, out_crows);
   phi::Copy(dev_ctx, x_cols, dev_ctx.GetPlace(), false, out_cols);
 
   out_values->Resize(x_values.dims());
   dev_ctx.template Alloc<T>(out_values);
+
+  out->set_dims(x.dims());
 }
 
 }  // namespace sparse
 }  // namespace phi
+
+PD_REGISTER_KERNEL(empty_like_coo,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::sparse::EmptyLikeCooKernel,
+                   float,
+                   double,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool) {
+  kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
+}
 
 PD_REGISTER_KERNEL(empty_like_csr,
                    CPU,
@@ -61,6 +96,21 @@ PD_REGISTER_KERNEL(empty_like_csr,
 }
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+PD_REGISTER_KERNEL(empty_like_coo,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::sparse::EmptyLikeCooKernel,
+                   float,
+                   double,
+                   int8_t,
+                   uint8_t,
+                   int16_t,
+                   int,
+                   int64_t,
+                   bool) {
+  kernel->InputAt(0).SetDataLayout(phi::DataLayout::SPARSE_COO);
+}
+
 PD_REGISTER_KERNEL(empty_like_csr,
                    GPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/sparse/empty_kernel.h
+++ b/paddle/phi/kernels/sparse/empty_kernel.h
@@ -14,10 +14,16 @@ limitations under the License. */
 
 #pragma once
 
+#include "paddle/phi/core/sparse_coo_tensor.h"
 #include "paddle/phi/core/sparse_csr_tensor.h"
 
 namespace phi {
 namespace sparse {
+
+template <typename T, typename Context>
+void EmptyLikeCooKernel(const Context& dev_ctx,
+                        const SparseCooTensor& x,
+                        SparseCooTensor* out);
 
 template <typename T, typename Context>
 void EmptyLikeCsrKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/sparse/gpu/matmul_grad_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/matmul_grad_kernel.cu
@@ -21,6 +21,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/copy_kernel.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/funcs/sparse/sparse_blas.h"
+#include "paddle/phi/kernels/sparse/empty_kernel.h"
 #include "paddle/phi/kernels/transpose_kernel.h"
 
 namespace phi {
@@ -38,23 +39,8 @@ void CsrDenseMatmulGradKernel(const Context& dev_ctx,
 
   // dx{SparseCsr} = dout{Dense} * y'{Dense}
   if (dx) {
-    // InferMeta of SparseCsrTensor 'dx'
-    dx->set_dims(x.dims());
-
-    phi::Copy(dev_ctx,
-              x.non_zero_crows(),
-              dev_ctx.GetPlace(),
-              false,
-              dx->mutable_non_zero_crows());
-    phi::Copy(dev_ctx,
-              x.non_zero_cols(),
-              dev_ctx.GetPlace(),
-              false,
-              dx->mutable_non_zero_cols());
-
-    DenseTensor* values = dx->mutable_non_zero_elements();
-    values->Resize(x.non_zero_elements().dims());
-    dev_ctx.template Alloc<T>(values);
+    // InferMeta of SparseCsrTensor 'dx', CreateLikeInferMeta
+    EmptyLikeCsrKernel<T, Context>(dev_ctx, x, dx);
 
     sparse_blas.SDDMM(
         false, true, static_cast<T>(1), dout, y, static_cast<T>(0), dx);
@@ -69,13 +55,13 @@ void CsrDenseMatmulGradKernel(const Context& dev_ctx,
 
     dev_ctx.template Alloc<T>(dy);
 
-    sparse_blas.DSDMM(
+    sparse_blas.SPMM(
         true, false, static_cast<T>(1), x, dout, static_cast<T>(0), dy);
   }
 #else
   PADDLE_THROW(phi::errors::Unimplemented(
-      " backward of 'sparse.mm' use cusparseSDDMM, Only "
-      "support it from CUDA 11.3"));
+      "backward of 'sparse.matmul' use cusparseSDDMM, which is supported from "
+      "CUDA 11.3"));
 #endif
 }
 
@@ -97,7 +83,7 @@ void CsrMaskedMatmulGradKernel(const Context& dev_ctx,
     meta_dx.set_dtype(x.dtype());
 
     dev_ctx.template Alloc<T>(dx);
-    sparse_blas.DSDMM(
+    sparse_blas.SPMM(
         false, true, static_cast<T>(1), dout, y, static_cast<T>(0), dx);
   }
 
@@ -109,7 +95,7 @@ void CsrMaskedMatmulGradKernel(const Context& dev_ctx,
     std::swap(trans_dim_vec[rank - 1], trans_dim_vec[rank - 2]);
     DenseTensor trans_dy = phi::Empty<T, Context>(dev_ctx, trans_dim_vec);
 
-    sparse_blas.DSDMM(
+    sparse_blas.SPMM(
         true, false, static_cast<T>(1), dout, x, static_cast<T>(0), &trans_dy);
 
     // InferMeta of DenseTensor 'dy'

--- a/paddle/phi/kernels/sparse/gpu/matmul_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/matmul_kernel.cu
@@ -26,6 +26,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/copy_kernel.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/funcs/sparse/sparse_blas.h"
+#include "paddle/phi/kernels/sparse/empty_kernel.h"
 
 namespace phi {
 namespace sparse {
@@ -59,7 +60,7 @@ void CsrDenseMatmulKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_EQ(xdim_vec[i],
                       ydim_vec[i],
                       phi::errors::InvalidArgument(
-                          "x.dim[%d] and x.dim[%d] must match.", i, i));
+                          "x.dim[%d] and x.dim[%d] must be eaqul.", i, i));
   }
 
   PADDLE_ENFORCE_GE(
@@ -80,11 +81,11 @@ void CsrDenseMatmulKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
 
   auto sparse_blas = phi::funcs::sparse::GetSparseBlas<Context, T>(dev_ctx);
-  sparse_blas.DSDMM(
+  sparse_blas.SPMM(
       false, false, static_cast<T>(1), x, y, static_cast<T>(0), out);
 #else
   PADDLE_THROW(
-      phi::errors::Unimplemented(" forward of 'sparse.mm' use cusparseSpMM, "
+      phi::errors::Unimplemented("forward of 'sparse.matmul' use cusparseSpMM, "
                                  "which is supported from CUDA 11.0"));
 #endif
 }
@@ -159,32 +160,16 @@ void CsrMaskedMatmulKernel(const Context& dev_ctx,
           "The shape of Input(x) and Input(y) is not suitable for matmul "
           "opetation, mask_dim[-1] must be eaqual to y_dim[-1]."));
 
-  // InferMeta of SparseCsrTensor 'out'
-  out->set_dims(mask.dims());
-
-  phi::Copy(dev_ctx,
-            mask.non_zero_crows(),
-            dev_ctx.GetPlace(),
-            false,
-            out->mutable_non_zero_crows());
-  phi::Copy(dev_ctx,
-            mask.non_zero_cols(),
-            dev_ctx.GetPlace(),
-            false,
-            out->mutable_non_zero_cols());
-
-  DenseTensor* values = out->mutable_non_zero_elements();
-  values->Resize(mask.non_zero_elements().dims());
-  dev_ctx.template Alloc<T>(values);
+  // InferMeta of SparseCsrTensor 'out', CreateLikeInferMeta
+  EmptyLikeCsrKernel<T, Context>(dev_ctx, mask, out);
 
   auto sparse_blas = phi::funcs::sparse::GetSparseBlas<Context, T>(dev_ctx);
   sparse_blas.SDDMM(
       false, false, static_cast<T>(1), x, y, static_cast<T>(0), out);
 #else
-  PADDLE_THROW(
-      phi::errors::Unimplemented(" forward of 'sparse.masked_mm' use "
-                                 "cusparseSDDMM, which is supported from "
-                                 "CUDA 11.3"));
+  PADDLE_THROW(phi::errors::Unimplemented(
+      "forward of 'sparse.masked_matmul' use cusparseSDDMM, which is supported "
+      "from CUDA 11.3"));
 #endif
 }
 

--- a/python/paddle/fluid/tests/unittests/test_sparse_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sparse_softmax_op.py
@@ -28,10 +28,10 @@ np.random.seed(2022)
 
 class TestCsrSoftmax(unittest.TestCase):
 
-    def test_softmax(self):
+    def test_softmax2d(self):
         with _test_eager_guard():
-            mask = np.random.rand(1, 5) < 0.5
-            np_x = np.random.rand(1, 5) * mask
+            mask = np.random.rand(16, 128) < 0.5
+            np_x = np.random.rand(16, 128) * mask
             np_csr = sp.csr_matrix(np_x)
 
             row_number = np_csr.shape[0]
@@ -56,6 +56,7 @@ class TestCsrSoftmax(unittest.TestCase):
 
             # dx = (dout - sum(dout * out)) * out, dout=rand_x
             out.backward(csr.detach())
+            dx = np.array([])
             for i in range(row_number):
                 start = np_csr.indptr[i]
                 end = np_csr.indptr[i + 1]
@@ -64,12 +65,61 @@ class TestCsrSoftmax(unittest.TestCase):
                 out = np_out[start:end]
                 dout = np_csr.data[start:end]
                 sum = np.sum(dout * out, keepdims=True)
-                dx = (dout - sum) * out
+                dx = np.concatenate([dx, (dout - sum) * out])
 
             self.assertTrue(np.allclose(csr.grad.crows().numpy(),
                                         np_csr.indptr))
             self.assertTrue(np.allclose(csr.grad.cols().numpy(),
                                         np_csr.indices))
+            self.assertTrue(np.allclose(csr.grad.values().numpy(), dx))
+
+    def test_softmax3d(self):
+        with _test_eager_guard():
+            batchNum = 16
+            mask = np.random.rand(batchNum, 16, 128) < 0.5
+            np_x = np.random.rand(batchNum, 16, 128) * mask
+
+            np_out_list = []
+            np_out = np.array([])
+            for i in range(batchNum):
+                np_csr = sp.csr_matrix(np_x[i, :, :])
+                row_number = np_csr.shape[0]
+                for j in range(row_number, ):
+                    start = np_csr.indptr[j]
+                    end = np_csr.indptr[j + 1]
+                    if start == end:
+                        continue
+                    x = np_csr.data[start:end]
+                    x_max = np.max(x, keepdims=True)
+                    x_exp = np.exp(x - x_max)
+                    x_exp_sum = np.sum(x_exp, keepdims=True)
+                    np_out_list.append(x_exp / x_exp_sum)
+                    np_out = np.concatenate([np_out, x_exp / x_exp_sum])
+
+            csr = paddle.to_tensor(np_x, stop_gradient=False).to_sparse_csr()
+            m = paddle.incubate.sparse.nn.Softmax()
+            out = m(csr)
+            self.assertTrue(np.allclose(out.values().numpy(), np_out))
+
+            # dx = (dout - sum(dout * out)) * out, dout=rand_x
+            out.backward(csr.detach())
+            dx = np.array([])
+            batch_offset = 0
+            for i in range(batchNum):
+                np_csr = sp.csr_matrix(np_x[i, :, :])
+                row_number = np_csr.shape[0]
+                for j in range(row_number):
+                    start = np_csr.indptr[j]
+                    end = np_csr.indptr[j + 1]
+                    if start == end:
+                        continue
+                    dout = np_csr.data[start:end]
+                    out = np_out[batch_offset + start:batch_offset + end]
+                    sum = np.sum(dout * out, keepdims=True)
+                    dx = np.concatenate([dx, (dout - sum) * out])
+
+                batch_offset += np_csr.nnz
+
             self.assertTrue(np.allclose(csr.grad.values().numpy(), dx))
 
 

--- a/python/paddle/incubate/sparse/nn/functional/activation.py
+++ b/python/paddle/incubate/sparse/nn/functional/activation.py
@@ -55,7 +55,7 @@ def softmax(x, axis=-1, name=None):
     sparse softmax activation, x must be SparseCsrTensor or SparseCooTensor.
 
     Note:
-        Only supported axis=-1 for SparseCsrTensor, which is faster when read data 
+        Only support axis=-1 for SparseCsrTensor, which is faster when read data 
         by row (axis=-1).
 
     From the point of view of dense matrix, for each row :math:`i` and each column :math:`j` 

--- a/python/paddle/incubate/sparse/nn/layer/activation.py
+++ b/python/paddle/incubate/sparse/nn/layer/activation.py
@@ -66,7 +66,7 @@ class Softmax(Layer):
     sparse softmax activation, x must be SparseCsrTensor or SparseCooTensor.
 
     Note:
-        Only supported axis=-1 for SparseCsrTensor, which is faster when read data 
+        Only support axis=-1 for SparseCsrTensor, which is faster when read data 
         by row (axis=-1).
 
     From the point of view of dense matrix, for each row :math:`i` and each column :math:`j` 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->


**支持 matmul、masked_matmul、softmax三个SparseCsr算子的3D batch运算**：
- softmax为自定义实现的kernel函数

- masked_matmul和matmul使用CUDA11.7的新功能cusparseCsrSetStridedBatch、cusparseCooSetStridedBatch、cusparseDnMatSetStridedBatch