### PR TITLE
add option padding to DistributedBatchSampler

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_batch_sampler.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_sampler.py
@@ -291,5 +291,31 @@ class TestWeightedRandomSampler(unittest.TestCase):
             self.assertTrue(True)
 
 
+class TestDistributedBatchSampler(unittest.TestCase):
+
+    def test_main(self):
+        dataset = RandomDataset(100, 10)
+        sampler1 = DistributedBatchSampler(dataset, 8, 3, 0, padding=False)
+        sampler2 = DistributedBatchSampler(dataset, 8, 3, 1, padding=False)
+        sampler3 = DistributedBatchSampler(dataset, 8, 3, 2, padding=False)
+
+        act_index = []
+        for data1 in sampler1:
+            act_index += data1
+
+        for data2 in sampler2:
+            act_index += data2
+
+        for data3 in sampler3:
+            act_index += data3
+
+        assert data1 == [96, 97]
+        assert data2 == [98, 99]
+        assert data3 == [88, 89, 90, 91, 92, 93, 94, 95]
+        act_index = sorted(act_index)
+        assert act_index[0] == 0
+        assert act_index[99] == 99
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
多卡训练时，DistributedSampler会默认对不能被卡数整除的数据集做padding，使得每个step每张卡都有数据。预测时其实是没有必要的，因此添加一个参数来控制该行为。
