### PR TITLE
[cherry pick]layer to 'NoneType' object has no attribute 'place' (#43597)

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1573,7 +1573,8 @@ class Layer(object):
                                             blocking)
 
         for key, buf in self._buffers.items():
-            self._buffers[key] = func(buf, device, dtype, blocking)
+            if buf is not None:
+                self._buffers[key] = func(buf, device, dtype, blocking)
 
         self._dtype = dtype
 

--- a/python/paddle/fluid/tests/unittests/test_base_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_base_layer.py
@@ -544,16 +544,25 @@ class TestLayerTo(unittest.TestCase):
             else:
                 self.assertTrue(isinstance(p, paddle.fluid.framework.ParamBase))
 
+    def func_test_to_api_none_buffer(self):
+        model = paddle.nn.Linear(2, 4)
+        buffer = None
+        model.register_buffer("buf_name", buffer, persistable=True)
+        model.to(dtype='float64')
+        self.assertEqual(model._buffers['buf_name'], None)
+
     def test_main(self):
         with _test_eager_guard():
             self.funcsetUp()
             self.func_test_to_api()
             self.func_test_to_api_paddle_dtype()
             self.func_test_to_api_numpy_dtype()
+            self.func_test_to_api_none_buffer()
         self.funcsetUp()
         self.func_test_to_api()
         self.func_test_to_api_paddle_dtype()
         self.func_test_to_api_numpy_dtype()
+        self.func_test_to_api_none_buffer()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
**bug：**
当class Layer的_buffers中有参数为None的时候，调用to()方法将会报`layer to 'NoneType' object has no attribute 'place'`的错误。
**修复方法：**
to()方法增加对_buffers中None类型参数的判断，如果为None，跳过该参数的处理。
