### PR TITLE
[WIP] Remove gpu_cpu_reshape2_matmul_fuse_pass in EnableMkldnn

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -286,7 +286,11 @@ void CpuPassStrategy::EnableMKLDNN() {
 #ifdef PADDLE_WITH_MKLDNN
   if (!use_mkldnn_) {
     passes_.insert(passes_.begin(), "mkldnn_placement_pass");
-
+    int id = GetPassIndex("gpu_cpu_reshape2_matmul_fuse_pass");
+    // this pass slows down FC mkldnn int8 operator
+    if (id != -1) {
+      passes_.erase(passes_.begin() + id);
+    }
     for (auto &pass : std::vector<std::string>({
              "depthwise_conv_mkldnn_pass",    //
              "conv_bn_fuse_pass",             // Execute BN passes again to
@@ -381,7 +385,8 @@ void CpuPassStrategy::EnableMkldnnInt8() {
     passes_.push_back("multi_gru_seq_fuse_pass");
     passes_.push_back("seq_concat_fc_fuse_pass");
     passes_.push_back("gpu_cpu_squeeze2_matmul_fuse_pass");
-    passes_.push_back("gpu_cpu_reshape2_matmul_fuse_pass");
+    // this pass slows down FC mkldnn int8 operator
+    // passes_.push_back("gpu_cpu_reshape2_matmul_fuse_pass");
     passes_.push_back("gpu_cpu_flatten2_matmul_fuse_pass");
     passes_.push_back("matmul_v2_scale_fuse_pass");
     passes_.push_back("squared_mat_sub_fuse_pass");

--- a/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
@@ -409,7 +409,8 @@ class Quant2Int8MkldnnPass(object):
         graph = self._apply_pass(graph, 'multi_gru_seq_fuse_pass')
         graph = self._apply_pass(graph, 'seq_concat_fc_fuse_pass')
         graph = self._apply_pass(graph, 'gpu_cpu_squeeze2_matmul_fuse_pass')
-        graph = self._apply_pass(graph, 'gpu_cpu_reshape2_matmul_fuse_pass')
+        # this pass slows down FC mkldnn int8 operator
+        # graph = self._apply_pass(graph, 'gpu_cpu_reshape2_matmul_fuse_pass')
         graph = self._apply_pass(graph, 'gpu_cpu_flatten2_matmul_fuse_pass')
         graph = self._apply_pass(graph, 'matmul_v2_scale_fuse_pass')
         graph = self._apply_pass(graph, 'squared_mat_sub_fuse_pass')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
This PR removes gpu_cpu_reshape2_matmul_fuse_pass from EnableMkldnn, EnableMkldnnInt8 and save_quant_model.py. When reshape2 is fused with matmul and then matmul and elementwise is fused to FC, Mkldnn FC for a batch size bigger than 1 slows down. This corrected Resnet50 performance, but I am still waiting for results for other models. 