### PR TITLE
[cherry pick] cherry pick code format check upgrade to release/2.3

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,4 +24,6 @@ Standard:  Cpp11
 AllowAllParametersOfDeclarationOnNextLine: true
 BinPackParameters: false
 BinPackArguments: false
+IncludeBlocks: Preserve
+IncludeIsMainSourceRegex: (\.cu)$
 ...

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):
+
+    # How wide to allow formatted cmake files
+    line_width = 80
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section("markup"):
+    # enable comment markup parsing and reflow
+    enable_markup = False
+
+    # If comment markup is enabled, don't reflow the first comment block in each
+    # listfile. Use this to preserve formatting of your copyright/license
+    # statements.
+    first_comment_is_literal = True
+
+# ----------------------------------
+# Options affecting listfile parsing
+# ----------------------------------
+with section("parse"):
+    # Additional FLAGS and KWARGS for custom commands
+    additional_commands = {
+        "cc_library": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "nv_library": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "hip_library": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "xpu_library": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "hip_library": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "hip_library": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "go_library": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "copy": {
+            "kwargs": {
+                "SRCS": '*',
+                "DSTS": '*',
+            }
+        },
+        "cc_test": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "nv_test": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "hip_test": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "xpu_test": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "go_test": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        },
+        "py_test": {
+            "kwargs": {
+                "SRCS": '*',
+                "DEPS": '*',
+            }
+        }
+    }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,16 @@ repos:
     hooks:
     -   id: remove-crlf
         files: (?!.*third_party)^.*$ | (?!.*book)^.*$
--   repo: https://github.com/PaddlePaddle/mirrors-yapf.git
-    sha: 0d79c0c469bab64f7229c9aca2b1186ef47f0e37
+-   repo: https://github.com/google/yapf
+    rev: v0.32.0
     hooks:
     -   id: yapf
         files: (.*\.(py|bzl)|BUILD|.*\.BUILD|WORKSPACE)$
+        exclude: |
+            (?x)^(
+                python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py|
+                python/paddle/fluid/tests/unittests/dygraph_to_static/test_origin_info.py
+            )$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
@@ -22,12 +27,16 @@ repos:
         files: (api|backward)\.yaml$
 -   repo: local
     hooks:
-    -   id: clang-format-with-version-check
+    -   id: clang-format
         name: clang-format
         description: Format files with ClangFormat.
         entry: bash ./tools/codestyle/clang_format.hook -i
         language: system
-        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|proto|xpu|kps)$
+        files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|xpu|kps)$
+        exclude: |
+            (?x)^(
+                paddle/fluid/distributed/ps/thirdparty/round_robin.h
+            )$
 -   repo: local
     hooks:
     -   id: cpplint-cpp-source
@@ -54,4 +63,14 @@ repos:
         exclude: |
             (?x)^(
                 paddle/utils/.*
+            )$
+-   repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.13
+    hooks:
+    -   id: cmake-format
+        # exclude paddle/fluid/operators/CMakeLists.txt, see the comment
+        # https://github.com/PaddlePaddle/Paddle/pull/43057
+        exclude: |
+            (?x)^(
+                paddle/fluid/operators/CMakeLists.txt
             )$

--- a/paddle/fluid/.clang-format
+++ b/paddle/fluid/.clang-format
@@ -1,5 +1,0 @@
----
-Language:        Cpp
-BasedOnStyle:  Google
-Standard:  Cpp11 
-...

--- a/tools/codestyle/clang_format.hook
+++ b/tools/codestyle/clang_format.hook
@@ -1,15 +1,19 @@
 #!/bin/bash
 set -e
 
-readonly VERSION="3.8"
-
+readonly VERSION="13.0.0"
 version=$(clang-format -version)
 
+if ! [[ $(python -V 2>&1 | awk '{print $2}' | awk -F '.' '{print $1$2}') -ge 36 ]]; then
+    echo "clang-format installation by pip need python version great equal 3.6, 
+          please change the default python to higher version."
+    exit 1
+fi
+
 if ! [[ $version == *"$VERSION"* ]]; then
-    echo "clang-format version check failed."
-    echo "a version contains '$VERSION' is needed, but get '$version'"
-    echo "you can install the right version, and make an soft-link to '\$PATH' env"
-    exit -1
+    # low version of pip may not have the source of clang-format whl
+    pip install --upgrade pip 
+    pip install clang-format==13.0.0
 fi
 
 clang-format $@

--- a/tools/codestyle/pre_commit.sh
+++ b/tools/codestyle/pre_commit.sh
@@ -1,0 +1,54 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set +x
+
+# use pre-commit 2.17
+if ! [[ $(pre-commit --version) == *"2.17.0"* ]]; then
+    pip install pre-commit==2.17.0 1>nul
+fi
+
+# Install clang-format before git commit to avoid repeat installation due to
+# pre-commit multi-thread running.
+readonly VERSION="13.0.0"
+version=$(clang-format -version)
+if ! [[ $(python -V 2>&1 | awk '{print $2}' | awk -F '.' '{print $1$2}') -ge 36 ]]; then
+    echo "clang-format installation by pip need python version great equal 3.6, 
+          please change the default python to higher version."
+    exit 1
+fi
+
+diff_files=$(git diff --numstat ${BRANCH} | awk '{print $NF}')
+echo -e "diff files between pr and ${BRANCH}:\n${diff_files}"
+
+echo "Checking code style by pre-commit ..."
+pre-commit run --files ${diff_files};check_error=$?
+
+if test ! -z "$(git diff)"; then
+    echo -e '\n************************************************************************************'
+    echo -e "These files have been formated by code format hook. You should use pre-commit to \
+format them before git push."
+    echo -e '************************************************************************************\n'
+    git diff 2>&1
+fi
+
+echo -e '\n***********************************'
+if [ ${check_error} != 0 ];then
+    echo "Your PR code style check failed."
+else
+    echo "Your PR code style check passed."
+fi
+echo -e '***********************************\n'
+
+exit ${check_error}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- Only cherry pick format tool(clang-format, yapf, cmake-format) upgrade to release/2.3, lint tool such as cpplint will not move, because we are not going to fix cpplint error in release/2.3
- pre_commit.sh also is moved to release/2.3 so that both PR-CI-pre-commit and PR-CI-pre-commit-23 can works.
- pre install clang-format to avoid repeat installation due to pre-commit's multi-thread running.