### PR TITLE
amp.decorate() save_dtype hook skip int dtype param

### DIFF
--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -395,9 +395,10 @@ class StateDictHook(object):
         for key in state_dict:
             param = state_dict[key]
             with paddle.fluid.dygraph.guard():
-                param_applied = paddle.cast(param, self._save_dtype)
-                param_applied.name = param.name
-                state_dict[key] = param_applied
+                if paddle.is_floating_point(param):
+                    param_applied = paddle.cast(param, self._save_dtype)
+                    param_applied.name = param.name
+                    state_dict[key] = param_applied
 
 
 @dygraph_only


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe

**问题背景**
`paddle.amp.decorate(model, save_dtype)`，用于将`model`的参数转换为float16类型，`save_dtype`参数用于指定模型通过`state_dict`进行参数存储时的参数数据类型。
amp-o2下，decorate仅针对float类型的数据转换成float16，int类型的参数不做转换，详见：[pr43760](https://github.com/PaddlePaddle/Paddle/pull/43760)。但是save_dtype的指定会对所有的参数都生效。

**pr内容**
本pr修复save_dtype的逻辑，同样仅对float类型参数生效，int类型参数保持数据类型不变。