### PR TITLE
[cherry-pick]Update quantization round and clip calculation methods

### DIFF
--- a/paddle/fluid/framework/ir/delete_quant_dequant_filter_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_quant_dequant_filter_op_pass.cc
@@ -45,6 +45,10 @@ DeleteQuantDequantFilterOpPass::DeleteQuantDequantFilterOpPass() {
       .End()
       .AddAttr("bit_length")
       .IsIntIn({8, 16})
+      .End()
+      .AddAttr("round_type")
+      .IsOptional()
+      .IsIntIn({0, 1})
       .End();
   AddOpCompat(OpCompat("fake_channel_wise_quantize_dequantize_abs_max"))
       .AddInput("X")
@@ -60,6 +64,10 @@ DeleteQuantDequantFilterOpPass::DeleteQuantDequantFilterOpPass() {
       .IsIntIn({8, 16})
       .End()
       .AddAttr("quant_axis")
+      .IsIntIn({0, 1})
+      .End()
+      .AddAttr("round_type")
+      .IsOptional()
       .IsIntIn({0, 1})
       .End();
 }
@@ -96,15 +104,18 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
     auto var_map = any_op2_desc->Inputs();
     std::string arg_name = "";
     for (auto& name_m : var_map) {
-      if (std::find(name_m.second.begin(), name_m.second.end(),
+      if (std::find(name_m.second.begin(),
+                    name_m.second.end(),
                     quant_dequant_op_out_name) != name_m.second.end()) {
         arg_name = name_m.first;
         break;
       }
     }
-    PADDLE_ENFORCE_GT(arg_name.size(), 0, platform::errors::InvalidArgument(
-                                              "can not find the input %s.",
-                                              quant_dequant_op_out_name));
+    PADDLE_ENFORCE_GT(
+        arg_name.size(),
+        0,
+        platform::errors::InvalidArgument("can not find the input %s.",
+                                          quant_dequant_op_out_name));
     // any_op2_desc->SetAttr("enable_int8", true);
     any_op2_desc->SetAttr("bit_length", bit_length);
 
@@ -123,7 +134,8 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
     if (dequant_type == "fake_channel_wise_quantize_dequantize_abs_max") {
       int quant_axis =
           BOOST_GET_CONST(int, quant_dequant_op->Op()->GetAttr("quant_axis"));
-      PADDLE_ENFORCE_EQ(quant_axis == 0 || quant_axis == 1, true,
+      PADDLE_ENFORCE_EQ(quant_axis == 0 || quant_axis == 1,
+                        true,
                         platform::errors::InvalidArgument(
                             "'quant_axis' should be 0 or 1, but "
                             "the received is %d",
@@ -176,7 +188,8 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
         }
       }
       for (int i = 0; i < channel; i++) {
-        PADDLE_ENFORCE_NE(weight_scale[i], 0,
+        PADDLE_ENFORCE_NE(weight_scale[i],
+                          0,
                           platform::errors::InvalidArgument(
                               "Weight scale should be nonzero, but get zero."));
         weight_scale[i] = weight_scale[i] / range;
@@ -188,7 +201,8 @@ void DeleteQuantDequantFilterOpPass::ApplyImpl(ir::Graph* graph) const {
         abs_max_weight =
             std::max(abs_max_weight, std::abs(quantized_weight_data[j]));
       }
-      PADDLE_ENFORCE_NE(abs_max_weight, 0,
+      PADDLE_ENFORCE_NE(abs_max_weight,
+                        0,
                         platform::errors::InvalidArgument(
                             "Weight scale should be nonzero, but get zero"));
       weight_scale.push_back(abs_max_weight / range);

--- a/paddle/fluid/framework/ir/delete_quant_dequant_linear_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_quant_dequant_linear_op_pass.cc
@@ -54,6 +54,10 @@ DeleteQuantDequantLinearOpPass::DeleteQuantDequantLinearOpPass() {
       .End()
       .AddAttr("quant_axis")
       .IsType<int>()
+      .End()
+      .AddAttr("round_type")
+      .IsOptional()
+      .IsType<int>()
       .End();
   AddOpCompat(OpCompat("dequantize_linear"))
       .AddInput("X")
@@ -73,6 +77,10 @@ DeleteQuantDequantLinearOpPass::DeleteQuantDequantLinearOpPass() {
       .IsType<int>()
       .End()
       .AddAttr("quant_axis")
+      .IsType<int>()
+      .End()
+      .AddAttr("round_type")
+      .IsOptional()
       .IsType<int>()
       .End();
 }
@@ -112,7 +120,8 @@ void DeleteQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
     const LoDTensor& input_scale_tensor =
         scope->GetVar(quantize_linear_op_scale->Name())->Get<LoDTensor>();
     PADDLE_ENFORCE_EQ(
-        paddle::platform::is_cpu_place(input_scale_tensor.place()), true,
+        paddle::platform::is_cpu_place(input_scale_tensor.place()),
+        true,
         platform::errors::InvalidArgument(
             "Input scale tensor's place should be CPU."));
     const float* input_scale_data = input_scale_tensor.data<float>();

--- a/paddle/fluid/framework/ir/delete_weight_dequant_linear_op_pass.cc
+++ b/paddle/fluid/framework/ir/delete_weight_dequant_linear_op_pass.cc
@@ -52,6 +52,10 @@ DeleteWeightQuantDequantLinearOpPass::DeleteWeightQuantDequantLinearOpPass() {
       .End()
       .AddAttr("quant_axis")
       .IsType<int>()
+      .End()
+      .AddAttr("round_type")
+      .IsOptional()
+      .IsType<int>()
       .End();
   AddOpCompat(OpCompat("dequantize_linear"))
       .AddInput("X")
@@ -71,6 +75,10 @@ DeleteWeightQuantDequantLinearOpPass::DeleteWeightQuantDequantLinearOpPass() {
       .IsType<int>()
       .End()
       .AddAttr("quant_axis")
+      .IsType<int>()
+      .End()
+      .AddAttr("round_type")
+      .IsOptional()
       .IsType<int>()
       .End();
   AddOpCompat(OpCompat("conv2d"))
@@ -322,7 +330,8 @@ void DeleteWeightQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
     int quant_axis = BOOST_GET_CONST(
         int, weight_dequantize_linear_op->Op()->GetAttr("quant_axis"));
     if (quant_axis == -1) {  // per_layer quant_dequant: all OP
-      PADDLE_ENFORCE_EQ(weight_scale_nums, 1,
+      PADDLE_ENFORCE_EQ(weight_scale_nums,
+                        1,
                         platform::errors::InvalidArgument(
                             "When quant_axis == -1 means use per_layer "
                             "quant_dequant, weight_scale'number should be 1."));
@@ -335,11 +344,13 @@ void DeleteWeightQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
     } else if (quant_axis == 0) {  // per_channel quant_dequant: conv2d,
                                    // depthwise_conv2d, conv2d_fusion
       PADDLE_ENFORCE_EQ(
-          weight_scale_nums, w_dims[quant_axis],
+          weight_scale_nums,
+          w_dims[quant_axis],
           platform::errors::InvalidArgument(
               "When quant_axis == 0 means use per_channel quant_dequant, "
               "weight_scale'numbers should be equal channels."));
-      PADDLE_ENFORCE_EQ(w_dims.size(), 4,
+      PADDLE_ENFORCE_EQ(w_dims.size(),
+                        4,
                         platform::errors::InvalidArgument(
                             "When quant_axis == 0 means use per_channel "
                             "quant_dequant, (conv2d, depthwise_conv2d, "
@@ -352,7 +363,8 @@ void DeleteWeightQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
       }
     } else if (quant_axis == 1) {
       PADDLE_ENFORCE_EQ(
-          weight_scale_nums, w_dims[quant_axis],
+          weight_scale_nums,
+          w_dims[quant_axis],
           platform::errors::InvalidArgument(
               "When quant_axis == 1 means use per_channel quant_dequant, "
               "weight_scale'numbers should be equal channels."));
@@ -360,7 +372,8 @@ void DeleteWeightQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
       if (w_dims.size() == 4) {  // conv2d_transpose
         std::string quantized_op_type = any_op2->Op()->Type();
         PADDLE_ENFORCE_EQ(
-            quantized_op_type, "conv2d_transpose",
+            quantized_op_type,
+            "conv2d_transpose",
             platform::errors::InvalidArgument(
                 "When quant_axis == 1 means use per_channel quant_dequant, "
                 "only conv2d_transpose weight dims equal 4."));
@@ -388,7 +401,8 @@ void DeleteWeightQuantDequantLinearOpPass::ApplyImpl(ir::Graph* graph) const {
     weight_tensor->Resize(phi::make_ddim(phi::vectorize(w_dims)));
     float* new_quantized_weight_data =
         weight_tensor->mutable_data<float>(platform::CPUPlace());
-    memcpy(new_quantized_weight_data, weight_data_tmp.data(),
+    memcpy(new_quantized_weight_data,
+           weight_data_tmp.data(),
            weight_tensor->numel() * sizeof(float));
 
     nodes2rm.insert(weight_dequantize_linear_op_scale);

--- a/paddle/fluid/operators/quantize_linear_op.h
+++ b/paddle/fluid/operators/quantize_linear_op.h
@@ -29,9 +29,13 @@ namespace operators {
 
 template <typename DeviceContext, typename T>
 struct ChannelDequantizeFunctorV2 {
-  void operator()(const DeviceContext& dev_ctx, const framework::Tensor* in,
-                  const framework::Tensor** scales, const int scale_num,
-                  T max_range, const int quant_axis, framework::Tensor* out);
+  void operator()(const DeviceContext& dev_ctx,
+                  const framework::Tensor* in,
+                  const framework::Tensor** scales,
+                  const int scale_num,
+                  T max_range,
+                  const int quant_axis,
+                  framework::Tensor* out);
 };
 
 template <typename DeviceContext, typename T>
@@ -44,6 +48,7 @@ class QuantizeLinearKernel : public framework::OpKernel<T> {
     auto* out = context.Output<framework::Tensor>("Y");
     out->mutable_data<T>(context.GetPlace());
     int bit_length = context.Attr<int>("bit_length");
+    int round_type = context.Attr<int>("round_type");
     int bin_cnt = std::pow(2, bit_length - 1) - 1;
     int quant_axis = context.Attr<int>("quant_axis");
     bool is_test = context.Attr<bool>("is_test");
@@ -53,25 +58,25 @@ class QuantizeLinearKernel : public framework::OpKernel<T> {
       if (!is_test) {
         auto* out_scale = context.Output<framework::Tensor>("OutScale");
         T* out_s = out_scale->mutable_data<T>(context.GetPlace());
-        FindAbsMaxFunctor<DeviceContext, T>()(dev_ctx, in->data<T>(),
-                                              in->numel(), out_s);
-        ClipAndFakeQuantFunctor<DeviceContext, T>()(dev_ctx, *in, *out_scale,
-                                                    bin_cnt, out);
+        FindAbsMaxFunctor<DeviceContext, T>()(
+            dev_ctx, in->data<T>(), in->numel(), out_s);
+        ClipAndFakeQuantFunctor<DeviceContext, T>()(
+            dev_ctx, *in, *out_scale, bin_cnt, round_type, out);
       } else {
-        ClipAndFakeQuantFunctor<DeviceContext, T>()(dev_ctx, *in, *in_scale,
-                                                    bin_cnt, out);
+        ClipAndFakeQuantFunctor<DeviceContext, T>()(
+            dev_ctx, *in, *in_scale, bin_cnt, round_type, out);
       }
     } else {
       if (!is_test) {
         auto* out_scale = context.Output<framework::Tensor>("OutScale");
         T* out_scale_data = out_scale->mutable_data<T>(context.GetPlace());
-        FindChannelAbsMaxFunctor<DeviceContext, T>()(dev_ctx, *in, quant_axis,
-                                                     out_scale_data);
+        FindChannelAbsMaxFunctor<DeviceContext, T>()(
+            dev_ctx, *in, quant_axis, out_scale_data);
         ChannelClipAndFakeQuantFunctor<DeviceContext, T>()(
-            dev_ctx, *in, *out_scale, bin_cnt, quant_axis, out);
+            dev_ctx, *in, *out_scale, bin_cnt, round_type, quant_axis, out);
       } else {
         ChannelClipAndFakeQuantFunctor<DeviceContext, T>()(
-            dev_ctx, *in, *in_scale, bin_cnt, quant_axis, out);
+            dev_ctx, *in, *in_scale, bin_cnt, round_type, quant_axis, out);
       }
     }
   }
@@ -87,7 +92,8 @@ class DeQuantizeLinearKernel : public framework::OpKernel<T> {
     auto in_tmp = phi::Cast<T>(
         static_cast<const typename paddle::framework::ConvertToPhiContext<
             DeviceContext>::TYPE&>(dev_ctx),
-        *in, experimental::CppTypeToDataType<D>::Type());
+        *in,
+        experimental::CppTypeToDataType<D>::Type());
 
     auto* scale = context.Input<framework::Tensor>("Scale");
     auto* out = context.Output<framework::Tensor>("Y");
@@ -97,16 +103,18 @@ class DeQuantizeLinearKernel : public framework::OpKernel<T> {
 
     if (quant_axis < 0) {
       float max_range = (std::pow(2, bit_length - 1) - 1);
-      DequantizeFunctor<DeviceContext, D>()(dev_ctx, &in_tmp, scale,
-                                            static_cast<D>(max_range), out);
+      DequantizeFunctor<DeviceContext, D>()(
+          dev_ctx, &in_tmp, scale, static_cast<D>(max_range), out);
     } else {
       PADDLE_ENFORCE_EQ(
-          scale->numel(), in_tmp.dims()[quant_axis],
+          scale->numel(),
+          in_tmp.dims()[quant_axis],
           platform::errors::PreconditionNotMet(
               "The number of first scale values must be the same with "
               "quant_axis dimension value of Input(X) when the `scale` has "
               "only one element, but %ld != %ld here.",
-              scale->numel(), in_tmp.dims()[quant_axis]));
+              scale->numel(),
+              in_tmp.dims()[quant_axis]));
       int max_range = (std::pow(2, bit_length - 1) - 1);
 
       ChannelDequantizeFunctorV2<DeviceContext, D>()(

--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -657,7 +657,7 @@ class PostTrainingQuantization(object):
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
                 if self._onnx_format:
-                    quant_var = np.clip(distribution(var_tensor / scale * bins),
+                    quant_var = np.clip(np.round(var_tensor / scale * bins),
                                         -bins - 1, bins)
                     quant_dequant_var = quant_var / bins * scale
                 else:
@@ -701,7 +701,7 @@ class PostTrainingQuantization(object):
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
                 if self._onnx_format:
-                    quant_var = np.clip(distribution(var_tensor / scale * bins),
+                    quant_var = np.clip(np.round(var_tensor / scale * bins),
                                         -bins - 1, bins)
                     quant_dequant_var = quant_var / bins * scale
                 else:

--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -121,8 +121,7 @@ class PostTrainingQuantization(object):
                  algo="KL",
                  hist_percent=0.99999,
                  quantizable_op_type=["conv2d", "depthwise_conv2d", "mul"],
-                 weight_round_algo='round',
-                 round_type='TiesToEven',
+                 round_type='round',
                  learning_rate=0.001,
                  is_full_quantize=False,
                  bias_correction=False,
@@ -181,14 +180,10 @@ class PostTrainingQuantization(object):
             quantizable_op_type(list[str], optional): List the type of ops 
                 that will be quantized. Default is ["conv2d", "depthwise_conv2d", 
                 "mul"].
-            weight_round_algo(str, optional): The method of converting the quantized weights
+            round_type(str, optional): The method of converting the quantized weights
                 value float->int. Currently supports ['round', 'adaround'] methods.
                 Default is `round`, which is rounding nearest to the integer.
                 'adaround' is refer to https://arxiv.org/abs/2004.10568.
-            round_type(str, optional): The method of converting the tensor value float->int.
-                Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
-                Default is `TiesToEven`, which is rounding to nearest ties to even. 
-                'TiesAwayFromZero' is rounding to nearest ties away from zero.
             learning_rate(float, optional): The learning rate of adaround method.
             is_full_quantized(bool, optional): If set is_full_quantized as True, 
                 apply quantization to all supported quantizable op type. If set
@@ -269,10 +264,8 @@ class PostTrainingQuantization(object):
         self._support_algo_type = [
             'KL', 'hist', 'avg', 'mse', 'emd', 'abs_max', 'min_max'
         ]
-        assert round_type in ['TiesToEven', 'TiesAwayFromZero']
+        assert round_type in ['adaround', 'round']
         self._round_type = round_type
-        assert weight_round_algo in ['adaround', 'round']
-        self._weight_round_algo = weight_round_algo
         self._learning_rate = learning_rate
         self._dynamic_quantize_op_type = ['lstm']
         self._support_quantize_op_type = \
@@ -414,7 +407,7 @@ class PostTrainingQuantization(object):
         if self._algo in ["KL", "hist"]:
             self._calculate_kl_hist_threshold()
 
-        if self._weight_round_algo == 'adaround':
+        if self._round_type == 'adaround':
             self._adaround_apply()
 
         self._reset_activation_persistable()
@@ -651,7 +644,6 @@ class PostTrainingQuantization(object):
                                 float(np.max(np.abs(var_tensor[i]))))
                 self._quantized_threshold[var_name] = abs_max_value
         _logger.info("MSE searching stage ...")
-        distribution = np.round if self._round_type == 'TiesToEven' else utils.round_c
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
             var_tensor = var_tensor.flatten()
@@ -664,9 +656,14 @@ class PostTrainingQuantization(object):
                 scale = s * abs_max_value
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
-                quant_var = np.clip(distribution(var_tensor / scale * bins),
-                                    -bins - 1, bins)
-                quant_dequant_var = quant_var / bins * scale
+                if self._onnx_format:
+                    quant_var = np.clip(distribution(var_tensor / scale * bins),
+                                        -bins - 1, bins)
+                    quant_dequant_var = quant_var / bins * scale
+                else:
+                    quant_dequant_var = np.round(
+                        np.clip(var_tensor, 0.0, scale) / scale *
+                        bins) / bins * scale
                 mse_loss = ((var_tensor - quant_dequant_var)**2).mean()
                 if mse_loss <= self._best_calibration_loss[var_name]:
                     self._best_calibration_loss[var_name] = mse_loss
@@ -691,7 +688,6 @@ class PostTrainingQuantization(object):
                                 float(np.max(np.abs(var_tensor[i]))))
                 self._quantized_threshold[var_name] = abs_max_value
         _logger.info("EMD searching stage ...")
-        distribution = np.round if self._round_type == 'TiesToEven' else utils.round_c
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
             var_tensor = var_tensor.flatten()
@@ -704,9 +700,14 @@ class PostTrainingQuantization(object):
                 scale = s * abs_max_value
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
-                quant_var = np.clip(distribution(var_tensor / scale * bins),
-                                    -bins - 1, bins)
-                quant_dequant_var = quant_var / bins * scale
+                if self._onnx_format:
+                    quant_var = np.clip(distribution(var_tensor / scale * bins),
+                                        -bins - 1, bins)
+                    quant_dequant_var = quant_var / bins * scale
+                else:
+                    quant_dequant_var = np.round(
+                        np.clip(var_tensor, 0.0, scale) / scale *
+                        bins) / bins * scale
                 emd_loss = np.abs(
                     np.mean(var_tensor) - np.mean(quant_dequant_var)) + np.abs(
                         np.std(var_tensor) - np.std(quant_dequant_var))
@@ -918,8 +919,7 @@ class PostTrainingQuantization(object):
                 activation_bits=self._activation_bits,
                 activation_quantize_type=self._activation_quantize_type,
                 weight_quantize_type=self._weight_quantize_type,
-                quantizable_op_type=major_quantizable_op_types,
-                round_type=self._round_type)
+                quantizable_op_type=major_quantizable_op_types)
         else:
             transform_pass = QuantizationTransformPassV2(
                 scope=self._scope,
@@ -928,8 +928,7 @@ class PostTrainingQuantization(object):
                 activation_bits=self._activation_bits,
                 activation_quantize_type=self._activation_quantize_type,
                 weight_quantize_type=self._weight_quantize_type,
-                quantizable_op_type=major_quantizable_op_types,
-                round_type=self._round_type)
+                quantizable_op_type=major_quantizable_op_types)
 
         for sub_graph in graph.all_sub_graphs():
             # Insert fake_quant/fake_dequantize op must in test graph, so
@@ -946,15 +945,13 @@ class PostTrainingQuantization(object):
             add_quant_dequant_pass = AddQuantDequantPass(
                 scope=self._scope,
                 place=self._place,
-                quantizable_op_type=minor_quantizable_op_types,
-                round_type=self._round_type)
+                quantizable_op_type=minor_quantizable_op_types)
         else:
             add_quant_dequant_pass = AddQuantDequantPassV2(
                 scope=self._scope,
                 place=self._place,
                 quantizable_op_type=minor_quantizable_op_types,
-                is_full_quantized=self._is_full_quantize,
-                round_type=self._round_type)
+                is_full_quantized=self._is_full_quantize)
 
         for sub_graph in graph.all_sub_graphs():
             sub_graph._for_test = True
@@ -979,7 +976,6 @@ class PostTrainingQuantization(object):
                 place=self._place,
                 bias_correction=self._bias_correction,
                 weight_bits=self._weight_bits,
-                weight_round_algo=self._weight_round_algo,
                 round_type=self._round_type,
                 activation_bits=self._activation_bits,
                 weight_quantize_type=self._weight_quantize_type,

--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -36,8 +36,9 @@ from . import utils
 
 __all__ = ['PostTrainingQuantization', 'WeightQuantization']
 
-_logger = get_logger(
-    __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
+_logger = get_logger(__name__,
+                     logging.INFO,
+                     fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 
 def _all_persistable_var_names(program):
@@ -88,7 +89,8 @@ def _apply_pass(scope,
         cpp_graph.set_not_owned('__param_scope__', scope)
     if attrs:
         assert attr_values and len(attrs) == len(
-            attr_values), "Different number of pass attributes and their values."
+            attr_values
+        ), "Different number of pass attributes and their values."
         for attr, value in zip(attrs, attr_values):
             ir_pass.set(attr, value)
     ir_pass.apply(cpp_graph)
@@ -119,7 +121,8 @@ class PostTrainingQuantization(object):
                  algo="KL",
                  hist_percent=0.99999,
                  quantizable_op_type=["conv2d", "depthwise_conv2d", "mul"],
-                 round_type='round',
+                 weight_round_algo='round',
+                 round_type='TiesToEven',
                  learning_rate=0.001,
                  is_full_quantize=False,
                  bias_correction=False,
@@ -178,9 +181,14 @@ class PostTrainingQuantization(object):
             quantizable_op_type(list[str], optional): List the type of ops 
                 that will be quantized. Default is ["conv2d", "depthwise_conv2d", 
                 "mul"].
-            round_type(str, optional): The method of converting the quantized weights
+            weight_round_algo(str, optional): The method of converting the quantized weights
                 value float->int. Currently supports ['round', 'adaround'] methods.
-                Default is `round`, which is rounding nearest to the nearest whole number.
+                Default is `round`, which is rounding nearest to the integer.
+                'adaround' is refer to https://arxiv.org/abs/2004.10568.
+            round_type(str, optional): The method of converting the tensor value float->int.
+                Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
+                Default is `TiesToEven`, which is rounding to nearest ties to even. 
+                'TiesAwayFromZero' is rounding to nearest ties away from zero.
             learning_rate(float, optional): The learning rate of adaround method.
             is_full_quantized(bool, optional): If set is_full_quantized as True, 
                 apply quantization to all supported quantizable op type. If set
@@ -261,8 +269,10 @@ class PostTrainingQuantization(object):
         self._support_algo_type = [
             'KL', 'hist', 'avg', 'mse', 'emd', 'abs_max', 'min_max'
         ]
-        assert round_type in ['adaround', 'round']
+        assert round_type in ['TiesToEven', 'TiesAwayFromZero']
         self._round_type = round_type
+        assert weight_round_algo in ['adaround', 'round']
+        self._weight_round_algo = weight_round_algo
         self._learning_rate = learning_rate
         self._dynamic_quantize_op_type = ['lstm']
         self._support_quantize_op_type = \
@@ -364,7 +374,8 @@ class PostTrainingQuantization(object):
             batch_id = 0
             with tqdm(
                     total=self._batch_nums,
-                    bar_format='Preparation stage, Run batch:|{bar}| {n_fmt}/{total_fmt}',
+                    bar_format=
+                    'Preparation stage, Run batch:|{bar}| {n_fmt}/{total_fmt}',
                     ncols=80) as t:
                 for data in self._data_loader():
                     self._executor.run(program=self._program,
@@ -380,10 +391,10 @@ class PostTrainingQuantization(object):
             self._init_sampling_act_histogram()
 
         batch_id = 0
-        with tqdm(
-                total=self._batch_nums,
-                bar_format='Sampling stage, Run batch:|{bar}| {n_fmt}/{total_fmt}',
-                ncols=80) as t:
+        with tqdm(total=self._batch_nums,
+                  bar_format=
+                  'Sampling stage, Run batch:|{bar}| {n_fmt}/{total_fmt}',
+                  ncols=80) as t:
             for data in self._data_loader():
                 self._executor.run(program=self._program,
                                    feed=data,
@@ -403,7 +414,7 @@ class PostTrainingQuantization(object):
         if self._algo in ["KL", "hist"]:
             self._calculate_kl_hist_threshold()
 
-        if self._round_type == 'adaround':
+        if self._weight_round_algo == 'adaround':
             self._adaround_apply()
 
         self._reset_activation_persistable()
@@ -446,18 +457,18 @@ class PostTrainingQuantization(object):
             scale_dict = self._quantized_var_threshold
         else:
             scale_dict = self._quantized_threshold
-        run_adaround(
-            self._data_loader,
-            self._program,
-            self._fetch_list,
-            self._executor,
-            self._scope,
-            self._place,
-            self._quantized_op_pairs,
-            self._weight_op_pairs,
-            scale_dict,
-            num_iterations=self._batch_nums,
-            lr=self._learning_rate)
+        run_adaround(self._data_loader,
+                     self._program,
+                     self._fetch_list,
+                     self._executor,
+                     self._scope,
+                     self._place,
+                     self._quantized_op_pairs,
+                     self._weight_op_pairs,
+                     scale_dict,
+                     num_iterations=self._batch_nums,
+                     bias_correction=self._bias_correction,
+                     lr=self._learning_rate)
 
     def save_quantized_model(self,
                              save_model_path,
@@ -478,15 +489,14 @@ class PostTrainingQuantization(object):
             None
         '''
         clip_extra = True if self._onnx_format else False
-        io.save_inference_model(
-            dirname=save_model_path,
-            model_filename=model_filename,
-            params_filename=params_filename,
-            feeded_var_names=self._feed_list,
-            target_vars=self._fetch_list,
-            executor=self._executor,
-            main_program=self._program,
-            clip_extra=clip_extra)
+        io.save_inference_model(dirname=save_model_path,
+                                model_filename=model_filename,
+                                params_filename=params_filename,
+                                feeded_var_names=self._feed_list,
+                                target_vars=self._fetch_list,
+                                executor=self._executor,
+                                main_program=self._program,
+                                clip_extra=clip_extra)
         _logger.info("The quantized model is saved in " + save_model_path)
 
     def _load_model_data(self):
@@ -508,17 +518,18 @@ class PostTrainingQuantization(object):
 
         if self._data_loader is not None:
             return
-        self._data_loader = io.DataLoader.from_generator(
-            feed_list=feed_vars, capacity=3 * self._batch_size, iterable=True)
+        self._data_loader = io.DataLoader.from_generator(feed_list=feed_vars,
+                                                         capacity=3 *
+                                                         self._batch_size,
+                                                         iterable=True)
         if self._sample_generator is not None:
-            self._data_loader.set_sample_generator(
-                self._sample_generator,
-                batch_size=self._batch_size,
-                drop_last=True,
-                places=self._place)
+            self._data_loader.set_sample_generator(self._sample_generator,
+                                                   batch_size=self._batch_size,
+                                                   drop_last=True,
+                                                   places=self._place)
         elif self._batch_generator is not None:
-            self._data_loader.set_batch_generator(
-                self._batch_generator, places=self._place)
+            self._data_loader.set_batch_generator(self._batch_generator,
+                                                  places=self._place)
 
     def _optimize_fp32_model(self):
         '''
@@ -569,12 +580,10 @@ class PostTrainingQuantization(object):
                                     " is not supported for quantization.")
                 # For quantized ops, sample inputs and outputs
                 if op_type in self._quantizable_op_type:
-                    collect_var_name(
-                        utils._get_op_input_var_names(op),
-                        persistable_var_names, op_type)
-                    collect_var_name(
-                        utils._get_op_output_var_names(op),
-                        persistable_var_names, op_type)
+                    collect_var_name(utils._get_op_input_var_names(op),
+                                     persistable_var_names, op_type)
+                    collect_var_name(utils._get_op_output_var_names(op),
+                                     persistable_var_names, op_type)
                     # collect quanted op output var name
                     for out_var_name in utils._get_op_output_var_names(op):
                         for in_var_name in utils._get_op_input_var_names(op):
@@ -583,9 +592,8 @@ class PostTrainingQuantization(object):
                                     in_var_name] = out_var_name
                 # For other op, only sample output scale
                 elif op_type in self._out_scale_op_list:
-                    collect_var_name(
-                        utils._get_op_output_var_names(op),
-                        persistable_var_names, op_type)
+                    collect_var_name(utils._get_op_output_var_names(op),
+                                     persistable_var_names, op_type)
 
     def _set_activation_persistable(self):
         '''
@@ -643,6 +651,7 @@ class PostTrainingQuantization(object):
                                 float(np.max(np.abs(var_tensor[i]))))
                 self._quantized_threshold[var_name] = abs_max_value
         _logger.info("MSE searching stage ...")
+        distribution = np.round if self._round_type == 'TiesToEven' else utils.round_c
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
             var_tensor = var_tensor.flatten()
@@ -655,9 +664,9 @@ class PostTrainingQuantization(object):
                 scale = s * abs_max_value
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
-                quant_dequant_var = np.round(
-                    np.clip(var_tensor, 0.0, scale) / scale *
-                    bins) / bins * scale
+                quant_var = np.clip(distribution(var_tensor / scale * bins),
+                                    -bins - 1, bins)
+                quant_dequant_var = quant_var / bins * scale
                 mse_loss = ((var_tensor - quant_dequant_var)**2).mean()
                 if mse_loss <= self._best_calibration_loss[var_name]:
                     self._best_calibration_loss[var_name] = mse_loss
@@ -682,6 +691,7 @@ class PostTrainingQuantization(object):
                                 float(np.max(np.abs(var_tensor[i]))))
                 self._quantized_threshold[var_name] = abs_max_value
         _logger.info("EMD searching stage ...")
+        distribution = np.round if self._round_type == 'TiesToEven' else utils.round_c
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
             var_tensor = var_tensor.flatten()
@@ -694,9 +704,9 @@ class PostTrainingQuantization(object):
                 scale = s * abs_max_value
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
-                quant_dequant_var = np.round(
-                    np.clip(var_tensor, 0.0, scale) / scale *
-                    bins) / bins * scale
+                quant_var = np.clip(distribution(var_tensor / scale * bins),
+                                    -bins - 1, bins)
+                quant_dequant_var = quant_var / bins * scale
                 emd_loss = np.abs(
                     np.mean(var_tensor) - np.mean(quant_dequant_var)) + np.abs(
                         np.std(var_tensor) - np.std(quant_dequant_var))
@@ -846,8 +856,9 @@ class PostTrainingQuantization(object):
             if var_name not in self._sampling_act_histogram:
                 min_val = self._sampling_act_abs_min_max[var_name][0]
                 max_val = self._sampling_act_abs_min_max[var_name][1]
-                hist, hist_edeges = np.histogram(
-                    [], bins=self._histogram_bins, range=(min_val, max_val))
+                hist, hist_edeges = np.histogram([],
+                                                 bins=self._histogram_bins,
+                                                 range=(min_val, max_val))
                 self._sampling_act_histogram[var_name] = [hist, hist_edeges]
 
     def _calculate_kl_hist_threshold(self):
@@ -907,7 +918,8 @@ class PostTrainingQuantization(object):
                 activation_bits=self._activation_bits,
                 activation_quantize_type=self._activation_quantize_type,
                 weight_quantize_type=self._weight_quantize_type,
-                quantizable_op_type=major_quantizable_op_types)
+                quantizable_op_type=major_quantizable_op_types,
+                round_type=self._round_type)
         else:
             transform_pass = QuantizationTransformPassV2(
                 scope=self._scope,
@@ -916,7 +928,8 @@ class PostTrainingQuantization(object):
                 activation_bits=self._activation_bits,
                 activation_quantize_type=self._activation_quantize_type,
                 weight_quantize_type=self._weight_quantize_type,
-                quantizable_op_type=major_quantizable_op_types)
+                quantizable_op_type=major_quantizable_op_types,
+                round_type=self._round_type)
 
         for sub_graph in graph.all_sub_graphs():
             # Insert fake_quant/fake_dequantize op must in test graph, so
@@ -933,13 +946,15 @@ class PostTrainingQuantization(object):
             add_quant_dequant_pass = AddQuantDequantPass(
                 scope=self._scope,
                 place=self._place,
-                quantizable_op_type=minor_quantizable_op_types)
+                quantizable_op_type=minor_quantizable_op_types,
+                round_type=self._round_type)
         else:
             add_quant_dequant_pass = AddQuantDequantPassV2(
                 scope=self._scope,
                 place=self._place,
                 quantizable_op_type=minor_quantizable_op_types,
-                is_full_quantized=self._is_full_quantize)
+                is_full_quantized=self._is_full_quantize,
+                round_type=self._round_type)
 
         for sub_graph in graph.all_sub_graphs():
             sub_graph._for_test = True
@@ -951,18 +966,11 @@ class PostTrainingQuantization(object):
         else:
             scale_dict = self._quantized_threshold
         for key, val in scale_dict.items():
-            utils.set_variable_data(
-                self._scope,
-                self._place,
-                key + ".scale",
-                np.array(
-                    [val], dtype=np.float32))
-            utils.set_variable_data(
-                self._scope,
-                self._place,
-                key + ".quant_dequant.scale",
-                np.array(
-                    [val], dtype=np.float32))
+            utils.set_variable_data(self._scope, self._place, key + ".scale",
+                                    np.array([val], dtype=np.float32))
+            utils.set_variable_data(self._scope, self._place,
+                                    key + ".quant_dequant.scale",
+                                    np.array([val], dtype=np.float32))
 
         if not self._onnx_format:
             # apply QuantizationFreezePass, and obtain the final quant model
@@ -971,6 +979,7 @@ class PostTrainingQuantization(object):
                 place=self._place,
                 bias_correction=self._bias_correction,
                 weight_bits=self._weight_bits,
+                weight_round_algo=self._weight_round_algo,
                 round_type=self._round_type,
                 activation_bits=self._activation_bits,
                 weight_quantize_type=self._weight_quantize_type,
@@ -1038,8 +1047,8 @@ class PostTrainingQuantization(object):
 
         for block_id in range(len(self._program.blocks)):
             for op in self._program.blocks[block_id].ops:
-                if op.type in (
-                        self._quantizable_op_type + self._out_scale_op_list):
+                if op.type in (self._quantizable_op_type +
+                               self._out_scale_op_list):
                     out_var_names = utils._get_op_output_var_names(op)
                     for var_name in out_var_names:
                         analysis_and_save_info(op, var_name)
@@ -1175,10 +1184,11 @@ class WeightQuantization(object):
 
         if generate_test_model:
             test_model_dir = os.path.join(save_model_dir, "test_model")
-            self._quantize_weight_to_int(
-                test_model_dir, save_model_filename, save_params_filename,
-                quantizable_op_type, weight_bits, weight_quantize_type, True,
-                threshold_rate)
+            self._quantize_weight_to_int(test_model_dir, save_model_filename,
+                                         save_params_filename,
+                                         quantizable_op_type, weight_bits,
+                                         weight_quantize_type, True,
+                                         threshold_rate)
 
     def convert_weight_to_fp16(self, save_model_dir):
         """
@@ -1216,16 +1226,17 @@ class WeightQuantization(object):
             if self._params_filename is not None:
                 save_var_map[new_var.name] = new_var
             else:
-                save_file_path = os.path.join(
-                    os.path.normpath(save_model_dir), new_var.name)
-                save_block.append_op(
-                    type='save',
-                    inputs={'X': [new_var]},
-                    outputs={},
-                    attrs={
-                        'file_path': os.path.normpath(save_file_path),
-                        'save_as_fp16': True
-                    })
+                save_file_path = os.path.join(os.path.normpath(save_model_dir),
+                                              new_var.name)
+                save_block.append_op(type='save',
+                                     inputs={'X': [new_var]},
+                                     outputs={},
+                                     attrs={
+                                         'file_path':
+                                         os.path.normpath(save_file_path),
+                                         'save_as_fp16':
+                                         True
+                                     })
 
         if self._params_filename is not None:
             save_var_list = []
@@ -1237,14 +1248,15 @@ class WeightQuantization(object):
                 name=unique_name.generate("saved_params"))
             saved_params_var.desc.set_persistable(True)
 
-            save_path = os.path.join(
-                os.path.normpath(save_model_dir), self._params_filename)
-            save_block.append_op(
-                type='save_combine',
-                inputs={'X': save_var_list},
-                outputs={'Y': saved_params_var},
-                attrs={'file_path': save_path,
-                       'save_as_fp16': True})
+            save_path = os.path.join(os.path.normpath(save_model_dir),
+                                     self._params_filename)
+            save_block.append_op(type='save_combine',
+                                 inputs={'X': save_var_list},
+                                 outputs={'Y': saved_params_var},
+                                 attrs={
+                                     'file_path': save_path,
+                                     'save_as_fp16': True
+                                 })
 
         save_program._sync_with_cpp()
         exe.run(save_program)
@@ -1293,14 +1305,13 @@ class WeightQuantization(object):
                         self._weight_channel_wise_abs_max_quantization(
                             scope, place, weight_bits, op, var_name, for_test)
 
-        io.save_inference_model(
-            dirname=save_model_dir,
-            feeded_var_names=feed_list,
-            target_vars=fetch_list,
-            executor=exe,
-            main_program=program,
-            model_filename=save_model_filename,
-            params_filename=save_params_filename)
+        io.save_inference_model(dirname=save_model_dir,
+                                feeded_var_names=feed_list,
+                                target_vars=fetch_list,
+                                executor=exe,
+                                main_program=program,
+                                model_filename=save_model_filename,
+                                params_filename=save_params_filename)
 
     def _weight_abs_max_quantization(self, scope, place, weight_bits,
                                      threshold_rate, op, var_name, for_test):
@@ -1339,8 +1350,9 @@ class WeightQuantization(object):
         op._set_attr(var_name + "_quant_scale", [scale])  # Save as list
         op._set_attr("with_quant_attr", True)
 
-    def _weight_channel_wise_abs_max_quantization(
-            self, scope, place, weight_bits, op, var_name, for_test):
+    def _weight_channel_wise_abs_max_quantization(self, scope, place,
+                                                  weight_bits, op, var_name,
+                                                  for_test):
         ''' 
         Use channel_wise_abs_max method to quantize weight.
         '''
@@ -1390,8 +1402,8 @@ class WeightQuantization(object):
         and quantize the weights.
         '''
         scales = []
-        quantized_weight_data = np.zeros_like(
-            weight_data, dtype=save_weight_dtype)
+        quantized_weight_data = np.zeros_like(weight_data,
+                                              dtype=save_weight_dtype)
         channel_num = weight_data.shape[0]
         for i in range(channel_num):
             scale = np.max(np.abs(weight_data[i])) / quantize_range
@@ -1404,8 +1416,8 @@ class WeightQuantization(object):
         '''
         For conv2d and depthwise_conv2d, dequantize the weights to fp32.
         '''
-        dequantized_weight_data = np.zeros_like(
-            quantized_weight_data, dtype=np.float32)
+        dequantized_weight_data = np.zeros_like(quantized_weight_data,
+                                                dtype=np.float32)
         for i in range(len(scales)):
             dequantized_weight_data[i] = \
                 (quantized_weight_data[i] * scales[i]).astype(np.float32)
@@ -1418,8 +1430,8 @@ class WeightQuantization(object):
         and quantize the weights.
         '''
         scales = []
-        quantized_weight_data = np.zeros_like(
-            weight_data, dtype=save_weight_dtype)
+        quantized_weight_data = np.zeros_like(weight_data,
+                                              dtype=save_weight_dtype)
         channel_num = weight_data.shape[-1]
         for i in range(channel_num):
             scale = np.max(np.abs(weight_data[:, i])) / quantize_range
@@ -1432,8 +1444,8 @@ class WeightQuantization(object):
         '''
         For mul, dequantize the weights to fp32.
         '''
-        dequantized_weight_data = np.zeros_like(
-            quantized_weight_data, dtype=np.float32)
+        dequantized_weight_data = np.zeros_like(quantized_weight_data,
+                                                dtype=np.float32)
         for i in range(len(scales)):
             dequantized_weight_data[:, i] = \
                 (quantized_weight_data[:, i] * scales[i]).astype(np.float32)
@@ -1441,8 +1453,9 @@ class WeightQuantization(object):
 
     def _calculate_threshold(self, input, threshold_rate, histogram_bins=5000):
         input_abs = np.abs(input)
-        hist, hist_edeges = np.histogram(
-            input_abs, bins=histogram_bins, range=(0, np.max(input_abs)))
+        hist, hist_edeges = np.histogram(input_abs,
+                                         bins=histogram_bins,
+                                         range=(0, np.max(input_abs)))
         hist = hist / float(sum(hist))
         hist_sum = 0
         hist_index = 0

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -119,7 +119,6 @@ class QuantizationTransformPass(object):
                  moving_rate=0.9,
                  skip_pattern=['skip_quant'],
                  quantizable_op_type=['conv2d', 'depthwise_conv2d', 'mul'],
-                 round_type='TiesToEven',
                  weight_quantize_func=None,
                  act_quantize_func=None,
                  weight_preprocess_func=None,
@@ -157,10 +156,6 @@ class QuantizationTransformPass(object):
             quantizable_op_type(list[str]): List the type of ops that will be quantized. 
                 Default is ["conv2d", "depthwise_conv2d", "mul"]. The quantizable_op_type in
                 QuantizationFreezePass and ConvertToInt8Pass must be the same as this.
-            round_type(str, optional): The method of converting the tensor value float->int.
-                Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
-                Default is `TiesToEven`, which is rounding to nearest ties to even. 
-                'TiesAwayFromZero' is rounding to nearest ties away from zero.
             weight_quantize_func(function): Function that defines how to quantize weight.
                 Using this can quickly test if user's quantization method works or not.
                 In this function, user should both define quantization function and
@@ -211,7 +206,6 @@ class QuantizationTransformPass(object):
         self._weight_bits = weight_bits
         self._activation_bits = activation_bits
         self._skip_pattern = skip_pattern
-        self._round_type = round_type
         self._weight_quantize_func = weight_quantize_func
         self._act_quantize_func = act_quantize_func
         self._weight_preprocess_func = weight_preprocess_func
@@ -385,7 +379,7 @@ class QuantizationTransformPass(object):
         # The loop for transforming the forward graph:
         with tqdm(total=len(ops),
                   bar_format=
-                  'Adding quant op for weight:|{bar}| {n_fmt}/{total_fmt}',
+                  'Adding quant op with weight:|{bar}| {n_fmt}/{total_fmt}',
                   ncols=80) as t:
             for op in ops:
                 if op.name() in self._quantizable_ops:
@@ -465,12 +459,10 @@ class QuantizationTransformPass(object):
         _init_var_node(scale_var_node,
                        np.zeros(scale_var_node.shape(), dtype=data_type),
                        self._scope, self._place)
-        round_type = 0 if self._round_type == 'TiesToEven' else 1
         quant_op_node = graph.create_op_node(
             op_type='fake_quantize_abs_max',
             attrs={
                 'bit_length': quant_bits,
-                'round_type': round_type,
                 'op_role': core.op_proto_and_checker_maker.OpRole.Forward
             },
             inputs={'X': var_node},
@@ -525,11 +517,9 @@ class QuantizationTransformPass(object):
 
             inputs['Iter'] = self._global_step
             outputs['OutScales'] = scales_node
-        round_type = 0 if self._round_type == 'TiesToEven' else 1
         attrs = {
             'window_size': self._window_size,
             'bit_length': quant_bits,
-            'round_type': round_type,
             'is_test': self._is_test,
             'op_role': core.op_proto_and_checker_maker.OpRole.Forward
         }
@@ -600,10 +590,8 @@ class QuantizationTransformPass(object):
             outs['OutState'] = state_out_node
             outs['OutAccum'] = accum_out_node
 
-        round_type = 0 if self._round_type == 'TiesToEven' else 1
         attrs = {
             'bit_length': quant_bits,
-            'round_type': round_type,
             'moving_rate': self._moving_rate,
             'is_test': self._is_test,
             'op_role': core.op_proto_and_checker_maker.OpRole.Forward
@@ -650,12 +638,10 @@ class QuantizationTransformPass(object):
         _init_var_node(scale_var_node,
                        np.zeros(scale_var_node.shape(), dtype=data_type),
                        self._scope, self._place)
-        round_type = 0 if self._round_type == 'TiesToEven' else 1
         quant_op_node = graph.create_op_node(
             op_type='fake_channel_wise_quantize_abs_max',
             attrs={
                 'bit_length': quant_bits,
-                'round_type': round_type,
                 'quant_axis': quant_axis,
                 'is_test': self._is_test,
                 'op_role': core.op_proto_and_checker_maker.OpRole.Forward
@@ -949,8 +935,7 @@ class QuantizationFreezePass(object):
                  bias_correction=False,
                  weight_bits=8,
                  activation_bits=8,
-                 weight_round_algo='round',
-                 round_type='TiesToEven',
+                 round_type='round',
                  weight_quantize_type='abs_max',
                  quantizable_op_type=None):
         """
@@ -968,14 +953,10 @@ class QuantizationFreezePass(object):
                  https://arxiv.org/abs/1810.05723.
             weight_bits(int): quantization bit number for weights.
             activation_bits(int): quantization bit number for activation.
-            weight_round_algo(str, optional): The method of converting the quantized weights
+            round_type(str, optional): The method of converting the quantized weights
                 value float->int. Currently supports ['round', 'adaround'] methods.
                 Default is `round`, which is rounding nearest to the integer.
                 'adaround' is refer to https://arxiv.org/abs/2004.10568.
-            round_type(str, optional): The method of converting the tensor value float->int.
-                Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
-                Default is `TiesToEven`, which is rounding to nearest ties to even. 
-                'TiesAwayFromZero' is rounding to nearest ties away from zero.
             weight_quantize_type(str): quantization type for weights, support 'abs_max' and 
                 'channel_wise_abs_max'. The 'range_abs_max' usually is not used for weight, 
                 since weights are fixed once the model is well trained.
@@ -991,7 +972,6 @@ class QuantizationFreezePass(object):
         self._place = _get_paddle_place(place)
         self._weight_bits = weight_bits
         self._activation_bits = activation_bits
-        self._weight_round_algo = weight_round_algo
         self._round_type = round_type
         self._weight_quantize_type = weight_quantize_type
         self._fake_quant_op_names = _fake_quant_op_list
@@ -1039,7 +1019,7 @@ class QuantizationFreezePass(object):
                         scale_v = scale_v.tolist()
                     self._quant_var_scale_map[input_arg_name] = scale_v
                     # Quantize weight and restore
-                    if self._weight_round_algo == 'round':
+                    if self._round_type == 'round':
                         param_v = self._load_var(input_arg_name)
                         if any(
                                 _check_grandchild_op_node(op_node, op)
@@ -1049,7 +1029,8 @@ class QuantizationFreezePass(object):
                             quant_axis = 0
                         quantized_param_v = utils.quant_tensor(
                             param_v.copy(), scale_v, quant_axis,
-                            self._weight_bits, self._round_type)
+                            self._weight_bits)
+                        quantized_param_v = np.round(quantized_param_v)
                         # Weight bias correction
                         if self._bias_correction == True:
                             quantized_param_v = utils.bias_correction_w(
@@ -1058,6 +1039,7 @@ class QuantizationFreezePass(object):
                                 scale_v,
                                 quant_axis,
                                 weight_bits=self._weight_bits)
+                            quantized_param_v = np.round(quantized_param_v)
                         self._restore_var(input_arg_name, quantized_param_v)
                     self._remove_fake_quant_and_dequant_op(graph, op_node)
 
@@ -1600,8 +1582,7 @@ class AddQuantDequantPass(object):
                  quant_bits=8,
                  skip_pattern=["skip_quant"],
                  quantizable_op_type=["elementwise_add", "pool2d"],
-                 is_full_quantized=False,
-                 round_type='TiesToEven'):
+                 is_full_quantized=False):
         """
         Constructor.
 
@@ -1623,10 +1604,6 @@ class AddQuantDequantPass(object):
                 quantization to all supported quantizable op type. If set is_full_quantized
                 as False, only apply quantization to the op type according to the input 
                 quantizable_op_type.
-            round_type(str, optional): The method of converting the tensor value float->int.
-                Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
-                Default is `TiesToEven`, which is rounding to nearest ties to even. 
-                'TiesAwayFromZero' is rounding to nearest ties away from zero.
         """
         self._scope = scope
         self._place = _get_paddle_place(place)
@@ -1634,7 +1611,6 @@ class AddQuantDequantPass(object):
         self._quant_bits = quant_bits
         self._is_test = None
         self._skip_pattern = skip_pattern
-        self._round_type = round_type
 
         if is_full_quantized:
             self._quantizable_op_type = utils._act_supported_quantizable_op_type
@@ -1769,10 +1745,8 @@ class AddQuantDequantPass(object):
             outs['OutState'] = state_out_node
             outs['OutAccum'] = accum_out_node
 
-        round_type = 0 if self._round_type == 'TiesToEven' else 1
         attrs = {
             'bit_length': quant_bits,
-            'round_type': round_type,
             'moving_rate': self._moving_rate,
             'is_test': self._is_test,
             'op_role': core.op_proto_and_checker_maker.OpRole.Forward
@@ -1812,10 +1786,6 @@ class InsertQuantizeLinear(object):
             Default is -1.
         channel_wise(bool, optional): Whether quantization with per channel or not. Default is False.
         is_test(bool, optional): Whether quantization with training or not. Default is True.
-        round_type(str, optional): The method of converting the tensor value float->int.
-            Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
-            Default is `TiesToEven`, which is rounding to nearest ties to even. 
-            'TiesAwayFromZero' is rounding to nearest ties away from zero.
     """
 
     def __init__(self,
@@ -1824,15 +1794,13 @@ class InsertQuantizeLinear(object):
                  quant_bits=8,
                  quant_axis=-1,
                  channel_wise=False,
-                 is_test=True,
-                 round_type='TiesToEven'):
+                 is_test=True):
         self._place = place
         self._scope = scope
         self.quant_bits = quant_bits
         self.quant_axis = quant_axis
         self.channel_wise = channel_wise
         self._is_test = is_test
-        self._round_type = round_type
 
     def insert_quant_op(self, graph, var_node):
         assert var_node.is_var(), '{} is not a var'.format(var_node.name())
@@ -1875,12 +1843,7 @@ class InsertQuantizeLinear(object):
         if zero_point_node is not None:
             inputs["ZeroPoint"] = zero_point_node
 
-        round_type = 0 if self._round_type == 'TiesToEven' else 1
-        attrs = {
-            "quant_axis": self.quant_axis,
-            "bit_length": self.quant_bits,
-            "round_type": round_type
-        }
+        attrs = {"quant_axis": self.quant_axis, "bit_length": self.quant_bits}
         outputs = {"Y": quant_var_node}
         if not self._is_test:
             attrs["is_test"] = self._is_test
@@ -1985,7 +1948,6 @@ class QuantizationTransformPassV2(object):
                  moving_rate=0.9,
                  skip_pattern=['skip_quant'],
                  quantizable_op_type=['conv2d', 'depthwise_conv2d', 'mul'],
-                 round_type='TiesToEven',
                  weight_quantize_func=None,
                  act_quantize_func=None,
                  weight_preprocess_func=None,
@@ -2021,10 +1983,6 @@ class QuantizationTransformPassV2(object):
             quantizable_op_type(list[str]): List the type of ops that will be quantized. 
                 Default is ["conv2d", "depthwise_conv2d", "mul"]. The quantizable_op_type in
                 QuantizationFreezePass and ConvertToInt8Pass must be the same as this.
-            round_type(str, optional): The method of converting the tensor value float->int.
-                Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
-                Default is `TiesToEven`, which is rounding to nearest ties to even. 
-                'TiesAwayFromZero' is rounding to nearest ties away from zero.
             weight_quantize_func(function): Function that defines how to quantize weight.
                 Using this can quickly test if user's quantization method works or not.
                 In this function, user should both define quantization function and
@@ -2074,7 +2032,6 @@ class QuantizationTransformPassV2(object):
         self._weight_bits = weight_bits
         self._activation_bits = activation_bits
         self._skip_pattern = skip_pattern
-        self._round_type = round_type
         self._weight_quantize_func = weight_quantize_func
         self._act_quantize_func = act_quantize_func
         self._weight_preprocess_func = weight_preprocess_func
@@ -2198,8 +2155,7 @@ class QuantizationTransformPassV2(object):
                     quant_bits=quant_bits,
                     quant_axis=quant_axis,
                     channel_wise=channel_wise,
-                    is_test=self._is_test,
-                    round_type=self._round_type)
+                    is_test=self._is_test)
                 quant_var_node, scale_var_node = insert_quant_pass.insert_quant_op(
                     graph, var_node)
                 dequant_var_node = insert_quant_pass.insert_dequant_op(
@@ -2276,7 +2232,7 @@ class QuantizationTransformPassV2(object):
         # The loop for transforming the forward graph:
         with tqdm(total=len(ops),
                   bar_format=
-                  'Adding quant op for weight:|{bar}| {n_fmt}/{total_fmt}',
+                  'Adding quant op with weight:|{bar}| {n_fmt}/{total_fmt}',
                   ncols=80) as t:
             for op in ops:
                 if op.name() in self._quantizable_ops:
@@ -2307,8 +2263,7 @@ class AddQuantDequantPassV2(object):
                  quant_bits=8,
                  skip_pattern=["skip_quant"],
                  quantizable_op_type=["elementwise_add", "pool2d"],
-                 is_full_quantized=False,
-                 round_type='TiesToEven'):
+                 is_full_quantized=False):
         """
         Args:
             scope(paddle.Scope): The scope is used to initialize these new parameters.
@@ -2328,10 +2283,6 @@ class AddQuantDequantPassV2(object):
                 quantization to all supported quantizable op type. If set is_full_quantized
                 as False, only apply quantization to the op type according to the input 
                 quantizable_op_type.
-            round_type(str, optional): The method of converting the tensor value float->int.
-                Currently supports ['TiesToEven', 'TiesAwayFromZero'] methods.
-                Default is `TiesToEven`, which is rounding to nearest ties to even. 
-                'TiesAwayFromZero' is rounding to nearest ties away from zero.
         
         Examples:
         .. code-block:: python
@@ -2354,7 +2305,6 @@ class AddQuantDequantPassV2(object):
         self._quant_bits = quant_bits
         self._is_test = None
         self._skip_pattern = skip_pattern
-        self._round_type = round_type
 
         if is_full_quantized:
             self._quantizable_op_type = utils._act_supported_quantizable_op_type
@@ -2427,8 +2377,7 @@ class AddQuantDequantPassV2(object):
                                 quant_bits=self._quant_bits,
                                 quant_axis=-1,
                                 channel_wise=False,
-                                is_test=self._is_test,
-                                round_type=self._round_type)
+                                is_test=self._is_test)
                             quant_var_node, scale_var_node = insert_quant_pass.insert_quant_op(
                                 graph, in_node)
                             dequant_var_node = insert_quant_pass.insert_dequant_op(
@@ -2511,8 +2460,6 @@ class ReplaceFakeQuantDequantPass(object):
             "quant_axis") else -1
         bit_length = op.op().attr("bit_length") if op.op().has_attr(
             "bit_length") else 8
-        round_type = op.op().attr("round_type") if op.op().has_attr(
-            "round_type") else 0
 
         zero_point_node = None
         quanted_node = x_node
@@ -2534,8 +2481,7 @@ class ReplaceFakeQuantDequantPass(object):
         quant_op_node = graph.create_op_node(op_type="quantize_linear",
                                              attrs={
                                                  "quant_axis": quant_axis,
-                                                 "bit_length": bit_length,
-                                                 "round_type": round_type
+                                                 "bit_length": bit_length
                                              },
                                              inputs={
                                                  "X": x_node,
@@ -2654,11 +2600,11 @@ class QuantWeightPass(object):
                 param_v = self._load_var(x_node.name())
                 quant_axis = _op.op().attr("quant_axis")
                 bits_length = _op.op().attr("bit_length")
-                round_type = _op.op().attr("round_type") if _op.op().has_attr(
-                    "round_type") else 0
-                quantized_param_v = utils.quant_tensor(param_v.copy(), scale_v,
-                                                       quant_axis, bits_length,
-                                                       round_type)
+                quantized_param_v = utils.quant_tensor(param_v.copy(),
+                                                       scale_v,
+                                                       quant_axis,
+                                                       bits_length,
+                                                       onnx_format=True)
                 if self._bias_correction == True:
                     quantized_param_v = utils.bias_correction_w(
                         param_v,

--- a/python/paddle/fluid/contrib/slim/quantization/utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/utils.py
@@ -321,39 +321,41 @@ def set_variable_data(scope, place, var_name, np_value):
         tensor.set(np_value, place)
 
 
-def round_c_single_element(val):
-    dtype = type(val)
-    if val >= 0:
-        return dtype(np.floor(val + 0.5))
-    return dtype(np.ceil(val - 0.5))
+def quant_tensor(x, scale, quant_axis=0, weight_bits=8, onnx_format=False):
+    # symmetry quant
+    def _clip(x, scale):
+        x[x > scale] = scale
+        x[x < -scale] = -scale
+        return x
 
-
-# rounding to nearest ties away from zero
-round_c = np.vectorize(round_c_single_element)
-
-
-def quant_tensor(x,
-                 scale,
-                 quant_axis=0,
-                 weight_bits=8,
-                 round_type='TiesToEven'):
     assert quant_axis in [0, 1], 'quant_axis should be 0 or 1 for now.'
-    distribution = np.round if round_type == 'TiesToEven' else round_c
     bnt = (1 << (weight_bits - 1)) - 1
     if isinstance(scale, list):
         for i, s in enumerate(scale):
             if s == 0.0:
                 s = 1e-8
             if quant_axis == 0:
-                x[i] = distribution(x[i] / s * bnt)
-                x[i] = np.clip(x[i], -bnt - 1, bnt)
+                if onnx_format:
+                    x[i] = np.round(x[i] / s * bnt)
+                    x[i] = np.clip(x[i], -bnt - 1, bnt)
+                else:
+                    x[i] = _clip(x[i], s)
+                    x[i] = x[i] / s * bnt
             else:
-                x[:, i] = distribution(x[:, i] / s * bnt)
-                x[:, i] = np.clip(x[:, i], -bnt - 1, bnt)
+                if onnx_format:
+                    x[:, i] = np.round(x[:, i] / s * bnt)
+                    x[:, i] = np.clip(x[:, i], -bnt - 1, bnt)
+                else:
+                    x[:, i] = _clip(x[:, i], s)
+                    x[:, i] = x[:, i] / s * bnt
     else:
         scale = 1e-8 if scale == 0.0 else scale
-        x = distribution(x / scale * bnt)
-        x = np.clip(x, -bnt - 1, bnt)
+        if onnx_format:
+            x = np.round(x / scale * bnt)
+            x = np.clip(x, -bnt - 1, bnt)
+        else:
+            x = _clip(x, scale)
+            x = x / scale * bnt
     return x
 
 

--- a/python/paddle/fluid/contrib/slim/quantization/utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/utils.py
@@ -321,29 +321,39 @@ def set_variable_data(scope, place, var_name, np_value):
         tensor.set(np_value, place)
 
 
-def quant_tensor(x, scale, quant_axis=0, weight_bits=8):
-    # symmetry quant
-    def _clip(x, scale):
-        x[x > scale] = scale
-        x[x < -scale] = -scale
-        return x
+def round_c_single_element(val):
+    dtype = type(val)
+    if val >= 0:
+        return dtype(np.floor(val + 0.5))
+    return dtype(np.ceil(val - 0.5))
 
+
+# rounding to nearest ties away from zero
+round_c = np.vectorize(round_c_single_element)
+
+
+def quant_tensor(x,
+                 scale,
+                 quant_axis=0,
+                 weight_bits=8,
+                 round_type='TiesToEven'):
     assert quant_axis in [0, 1], 'quant_axis should be 0 or 1 for now.'
+    distribution = np.round if round_type == 'TiesToEven' else round_c
     bnt = (1 << (weight_bits - 1)) - 1
     if isinstance(scale, list):
         for i, s in enumerate(scale):
             if s == 0.0:
                 s = 1e-8
             if quant_axis == 0:
-                x[i] = _clip(x[i], s)
-                x[i] = x[i] / s * bnt
+                x[i] = distribution(x[i] / s * bnt)
+                x[i] = np.clip(x[i], -bnt - 1, bnt)
             else:
-                x[:, i] = _clip(x[:, i], s)
-                x[:, i] = x[:, i] / s * bnt
+                x[:, i] = distribution(x[:, i] / s * bnt)
+                x[:, i] = np.clip(x[:, i], -bnt - 1, bnt)
     else:
         scale = 1e-8 if scale == 0.0 else scale
-        x = _clip(x, scale)
-        x = x / scale * bnt
+        x = distribution(x / scale * bnt)
+        x = np.clip(x, -bnt - 1, bnt)
     return x
 
 
@@ -416,6 +426,7 @@ def calculate_quant_cos_error(orig_tensor, qdq_tensor):
 
 
 class tqdm(object):
+
     def __init__(self, total, bar_format='Loading|{bar}', ncols=80):
         self.total = total
         self.bar_format = bar_format

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -1,352 +1,523 @@
-file(GLOB TEST_OPS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "test_*.py")
+file(
+  GLOB TEST_OPS
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+  "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
-function(_inference_analysis_python_api_int8_test target model_dir data_path filename use_mkldnn)
-    py_test(${target} SRCS ${filename}
-        ENVS CPU_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
-             FLAGS_use_mkldnn=${use_mkldnn}
-        ARGS --infer_model ${model_dir}/model
-             --infer_data ${data_path}
-             --int8_model_save_path int8_models/${target}
-             --warmup_batch_size ${WARMUP_BATCH_SIZE}
-             --batch_size 50)
+function(_inference_analysis_python_api_int8_test target model_dir data_path
+         filename use_mkldnn)
+  py_test(
+    ${target}
+    SRCS ${filename}
+         ENVS
+         CPU_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+         FLAGS_use_mkldnn=${use_mkldnn}
+         ARGS
+         --infer_model
+         ${model_dir}/model
+         --infer_data
+         ${data_path}
+         --int8_model_save_path
+         int8_models/${target}
+         --warmup_batch_size
+         ${WARMUP_BATCH_SIZE}
+         --batch_size
+         50)
 endfunction()
 
-function(inference_analysis_python_api_int8_test target model_dir data_path filename)
-    _inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_path} ${filename} False)
+function(inference_analysis_python_api_int8_test target model_dir data_path
+         filename)
+  _inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_path}
+                                           ${filename} False)
 endfunction()
 
-function(inference_analysis_python_api_int8_test_custom_warmup_batch_size target model_dir data_dir filename warmup_batch_size)
-    set(WARMUP_BATCH_SIZE ${warmup_batch_size})
-    inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_dir} ${filename})
+function(inference_analysis_python_api_int8_test_custom_warmup_batch_size
+         target model_dir data_dir filename warmup_batch_size)
+  set(WARMUP_BATCH_SIZE ${warmup_batch_size})
+  inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_dir}
+                                          ${filename})
 endfunction()
 
-function(inference_analysis_python_api_int8_test_mkldnn target model_dir data_path filename)
-    _inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_path} ${filename} True)
+function(inference_analysis_python_api_int8_test_mkldnn target model_dir
+         data_path filename)
+  _inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_path}
+                                           ${filename} True)
 endfunction()
 
 function(download_data install_dir url data_file check_sum)
-    if (NOT EXISTS ${install_dir}/${data_file})
-	    inference_download_and_uncompress(${install_dir} ${url} ${data_file} ${check_sum})
-    endif()
+  if(NOT EXISTS ${install_dir}/${data_file})
+    inference_download_and_uncompress(${install_dir} ${url} ${data_file}
+                                      ${check_sum})
+  endif()
 endfunction()
 
 function(download_quant_data install_dir data_file check_sum)
-    if (NOT EXISTS ${install_dir}/${data_file})
-	    inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/int8 ${data_file} ${check_sum})
-    endif()
+  if(NOT EXISTS ${install_dir}/${data_file})
+    inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/int8
+                                      ${data_file} ${check_sum})
+  endif()
 endfunction()
 
 function(download_quant_model install_dir data_file check_sum)
-    if (NOT EXISTS ${install_dir}/${data_file})
-	    inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/int8/QAT_models ${data_file} ${check_sum})
-    endif()
+  if(NOT EXISTS ${install_dir}/${data_file})
+    inference_download_and_uncompress(
+      ${install_dir} ${INFERENCE_URL}/int8/QAT_models ${data_file} ${check_sum})
+  endif()
 endfunction()
 
 function(download_quant_fp32_model install_dir data_file check_sum)
-    if (NOT EXISTS ${install_dir}/${data_file})
-	    inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/int8/QAT_models/fp32 ${data_file} ${check_sum})
-    endif()
+  if(NOT EXISTS ${install_dir}/${data_file})
+    inference_download_and_uncompress(
+      ${install_dir} ${INFERENCE_URL}/int8/QAT_models/fp32 ${data_file}
+      ${check_sum})
+  endif()
 endfunction()
 
 function(download_lstm_model install_dir data_file check_sum)
-    if (NOT EXISTS ${install_dir}/${data_file})
-	    inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/lstm ${data_file} ${check_sum})
-    endif()
+  if(NOT EXISTS ${install_dir}/${data_file})
+    inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/lstm
+                                      ${data_file} ${check_sum})
+  endif()
 endfunction()
 
-function(inference_quant_int8_image_classification_test target quant_model_dir dataset_path)
-    py_test(${target} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant_int8_image_classification_comparison.py"
-            ENVS FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
-                 OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
-                 FLAGS_use_mkldnn=true
-            ARGS --quant_model ${quant_model_dir}
-                 --infer_data ${dataset_path}
-                 --batch_size 25
-                 --batch_num 2
-                 --acc_diff_threshold 0.1)
+function(inference_quant_int8_image_classification_test target quant_model_dir
+         dataset_path)
+  py_test(
+    ${target}
+    SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant_int8_image_classification_comparison.py"
+         ENVS
+         FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+         OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+         FLAGS_use_mkldnn=true
+         ARGS
+         --quant_model
+         ${quant_model_dir}
+         --infer_data
+         ${dataset_path}
+         --batch_size
+         25
+         --batch_num
+         2
+         --acc_diff_threshold
+         0.1)
 endfunction()
 
-
-# set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 25 
-function(inference_quant2_int8_image_classification_test target quant_model_dir fp32_model_dir dataset_path)
-    py_test(${target} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant2_int8_image_classification_comparison.py"
-            ENVS FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
-                 OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
-                 FLAGS_use_mkldnn=true
-            ARGS --quant_model ${quant_model_dir}
-                 --fp32_model ${fp32_model_dir}
-                 --infer_data ${dataset_path}
-                 --batch_size 50
-                 --batch_num 2
-                 --acc_diff_threshold 0.1)
+# set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 25
+function(inference_quant2_int8_image_classification_test target quant_model_dir
+         fp32_model_dir dataset_path)
+  py_test(
+    ${target}
+    SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant2_int8_image_classification_comparison.py"
+         ENVS
+         FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+         OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+         FLAGS_use_mkldnn=true
+         ARGS
+         --quant_model
+         ${quant_model_dir}
+         --fp32_model
+         ${fp32_model_dir}
+         --infer_data
+         ${dataset_path}
+         --batch_size
+         50
+         --batch_num
+         2
+         --acc_diff_threshold
+         0.1)
 endfunction()
 
-# set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 20 
-function(inference_quant2_int8_nlp_test target quant_model_dir fp32_model_dir dataset_path labels_path ops_to_quantize)
-    py_test(${target} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant2_int8_nlp_comparison.py"
-            ENVS FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
-                 OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
-                 FLAGS_use_mkldnn=true
-            ARGS --quant_model ${quant_model_dir}
-		 --fp32_model ${fp32_model_dir}
-                 --infer_data ${dataset_path}
-		 --labels ${labels_path}
-                 --batch_size 10
-                 --batch_num 2
-                 --acc_diff_threshold 0.1
-		 --ops_to_quantize ${ops_to_quantize})
+# set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 20
+function(
+  inference_quant2_int8_nlp_test
+  target
+  quant_model_dir
+  fp32_model_dir
+  dataset_path
+  labels_path
+  ops_to_quantize)
+  py_test(
+    ${target}
+    SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant2_int8_nlp_comparison.py"
+         ENVS
+         FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+         OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+         FLAGS_use_mkldnn=true
+         ARGS
+         --quant_model
+         ${quant_model_dir}
+         --fp32_model
+         ${fp32_model_dir}
+         --infer_data
+         ${dataset_path}
+         --labels
+         ${labels_path}
+         --batch_size
+         10
+         --batch_num
+         2
+         --acc_diff_threshold
+         0.1
+         --ops_to_quantize
+         ${ops_to_quantize})
 endfunction()
 
-function(inference_quant2_int8_lstm_model_test target fp32_model quant_model dataset_path)
-    py_test(${target} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant2_int8_lstm_model.py"
-            ARGS --fp32_model ${fp32_model}
-                 --quant_model ${quant_model}
-                 --infer_data ${dataset_path}
-                 --num_threads 1
-                 --mkldnn_cache_capacity 100
-                 --warmup_iter 100
-                 --acc_diff_threshold 0.11)
+function(inference_quant2_int8_lstm_model_test target fp32_model quant_model
+         dataset_path)
+  py_test(
+    ${target}
+    SRCS "${CMAKE_CURRENT_SOURCE_DIR}/quant2_int8_lstm_model.py"
+         ARGS
+         --fp32_model
+         ${fp32_model}
+         --quant_model
+         ${quant_model}
+         --infer_data
+         ${dataset_path}
+         --num_threads
+         1
+         --mkldnn_cache_capacity
+         100
+         --warmup_iter
+         100
+         --acc_diff_threshold
+         0.11)
 endfunction()
 
 function(download_quant_data install_dir data_file check_sum)
-    if (NOT EXISTS ${install_dir}/${data_file})
-           inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/int8 ${data_file} ${check_sum})
-    endif()
+  if(NOT EXISTS ${install_dir}/${data_file})
+    inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/int8
+                                      ${data_file} ${check_sum})
+  endif()
 endfunction()
 
 function(download_quant_model install_dir data_file check_sum)
-    if (NOT EXISTS ${install_dir}/${data_file})
-           inference_download_and_uncompress(${install_dir} ${INFERENCE_URL}/int8/QAT_models ${data_file} ${check_sum})
-    endif()
+  if(NOT EXISTS ${install_dir}/${data_file})
+    inference_download_and_uncompress(
+      ${install_dir} ${INFERENCE_URL}/int8/QAT_models ${data_file} ${check_sum})
+  endif()
 endfunction()
 
 function(save_quant_ic_model_test target quant_model_dir int8_model_save_path)
-    py_test(${target} SRCS ${CMAKE_CURRENT_SOURCE_DIR}/save_quant_model.py
-            ARGS --quant_model_path ${quant_model_dir}
-	         --int8_model_save_path ${int8_model_save_path}
-		 --debug)
+  py_test(
+    ${target}
+    SRCS ${CMAKE_CURRENT_SOURCE_DIR}/save_quant_model.py
+         ARGS
+         --quant_model_path
+         ${quant_model_dir}
+         --int8_model_save_path
+         ${int8_model_save_path}
+         --debug)
 endfunction()
 
-function(save_quant_nlp_model_test target quant_model_dir int8_model_save_path ops_to_quantize)
-    py_test(${target} SRCS ${CMAKE_CURRENT_SOURCE_DIR}/save_quant_model.py
-            ARGS --quant_model_path ${quant_model_dir}
-	         --int8_model_save_path ${int8_model_save_path}
-		 --ops_to_quantize ${ops_to_quantize})
+function(save_quant_nlp_model_test target quant_model_dir int8_model_save_path
+         ops_to_quantize)
+  py_test(
+    ${target}
+    SRCS ${CMAKE_CURRENT_SOURCE_DIR}/save_quant_model.py
+         ARGS
+         --quant_model_path
+         ${quant_model_dir}
+         --int8_model_save_path
+         ${int8_model_save_path}
+         --ops_to_quantize
+         ${ops_to_quantize})
 endfunction()
 
-function(convert_model2dot_test target model_path save_graph_dir save_graph_name)
-    py_test(${target} SRCS ${CMAKE_CURRENT_SOURCE_DIR}/convert_model2dot.py
-            ARGS --model_path ${model_path}
-	         --save_graph_dir ${save_graph_dir}
-	         --save_graph_name ${save_graph_name})
+function(convert_model2dot_test target model_path save_graph_dir
+         save_graph_name)
+  py_test(
+    ${target}
+    SRCS ${CMAKE_CURRENT_SOURCE_DIR}/convert_model2dot.py
+         ARGS
+         --model_path
+         ${model_path}
+         --save_graph_dir
+         ${save_graph_dir}
+         --save_graph_name
+         ${save_graph_name})
 endfunction()
 
 if(WIN32)
-	list(REMOVE_ITEM TEST_OPS test_light_nas)
-	list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mnist)
-	list(REMOVE_ITEM TEST_OPS test_post_training_quantization_while)
-	list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mobilenetv1)
-	list(REMOVE_ITEM TEST_OPS test_post_training_quantization_resnet50)
-	list(REMOVE_ITEM TEST_OPS test_post_training_quantization_lstm_model)
-	list(REMOVE_ITEM TEST_OPS test_imperative_ptq)
-	list(REMOVE_ITEM TEST_OPS test_weight_quantization_mobilenetv1)
-	list(REMOVE_ITEM TEST_OPS test_quantize_transpiler_v2)
-	list(REMOVE_ITEM TEST_OPS test_imperative_qat_amp)
+  list(REMOVE_ITEM TEST_OPS test_light_nas)
+  list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mnist)
+  list(REMOVE_ITEM TEST_OPS test_post_training_quantization_while)
+  list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mobilenetv1)
+  list(REMOVE_ITEM TEST_OPS test_post_training_quantization_resnet50)
+  list(REMOVE_ITEM TEST_OPS test_post_training_quantization_lstm_model)
+  list(REMOVE_ITEM TEST_OPS test_imperative_ptq)
+  list(REMOVE_ITEM TEST_OPS test_weight_quantization_mobilenetv1)
+  list(REMOVE_ITEM TEST_OPS test_quantize_transpiler_v2)
+  list(REMOVE_ITEM TEST_OPS test_imperative_qat_amp)
 endif()
 
 if(LINUX AND WITH_MKLDNN)
 
-	#### Image classification dataset: ImageNet (small)
-	# The dataset should already be downloaded for INT8v2 unit tests
-	set(IMAGENET_DATA_PATH "${INFERENCE_DEMO_INSTALL_DIR}/imagenet/data.bin")
+  #### Image classification dataset: ImageNet (small)
+  # The dataset should already be downloaded for INT8v2 unit tests
+  set(IMAGENET_DATA_PATH "${INFERENCE_DEMO_INSTALL_DIR}/imagenet/data.bin")
 
-	#### INT8 image classification python api test
-	# Models should be already downloaded for INT8v2 unit tests
+  #### INT8 image classification python api test
+  # Models should be already downloaded for INT8v2 unit tests
 
-	set(INT8_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/int8v2")
+  set(INT8_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/int8v2")
 
-	#### QUANT & INT8 comparison python api tests
+  #### QUANT & INT8 comparison python api tests
 
-	set(QUANT_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/quant")
+  set(QUANT_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/quant")
 
-	### Quant1 for image classification
+  ### Quant1 for image classification
 
-	# Quant ResNet50
-	set(QUANT_RESNET50_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet50_quant")
-	set(QUANT_RESNET50_MODEL_ARCHIVE "ResNet50_qat_model.tar.gz")
-	download_quant_model(${QUANT_RESNET50_MODEL_DIR} ${QUANT_RESNET50_MODEL_ARCHIVE} ff89b934ab961c3a4a844193ece2e8a7)
-	inference_quant_int8_image_classification_test(test_quant_int8_resnet50_mkldnn ${QUANT_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant ResNet50
+  set(QUANT_RESNET50_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet50_quant")
+  set(QUANT_RESNET50_MODEL_ARCHIVE "ResNet50_qat_model.tar.gz")
+  download_quant_model(
+    ${QUANT_RESNET50_MODEL_DIR} ${QUANT_RESNET50_MODEL_ARCHIVE}
+    ff89b934ab961c3a4a844193ece2e8a7)
+  inference_quant_int8_image_classification_test(
+    test_quant_int8_resnet50_mkldnn ${QUANT_RESNET50_MODEL_DIR}/model
+    ${IMAGENET_DATA_PATH})
 
-	# Quant ResNet101
-	set(QUANT_RESNET101_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet101_quant")
-	set(QUANT_RESNET101_MODEL_ARCHIVE "ResNet101_qat_model.tar.gz")
-	download_quant_model(${QUANT_RESNET101_MODEL_DIR} ${QUANT_RESNET101_MODEL_ARCHIVE} 95c6d01e3aeba31c13efb2ba8057d558)
-	# inference_quant_int8_image_classification_test(test_quant_int8_resnet101_mkldnn ${QUANT_RESNET101_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant ResNet101
+  set(QUANT_RESNET101_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet101_quant")
+  set(QUANT_RESNET101_MODEL_ARCHIVE "ResNet101_qat_model.tar.gz")
+  download_quant_model(
+    ${QUANT_RESNET101_MODEL_DIR} ${QUANT_RESNET101_MODEL_ARCHIVE}
+    95c6d01e3aeba31c13efb2ba8057d558)
+  # inference_quant_int8_image_classification_test(test_quant_int8_resnet101_mkldnn ${QUANT_RESNET101_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
 
-	# Quant GoogleNet
-	set(QUANT_GOOGLENET_MODEL_DIR "${QUANT_INSTALL_DIR}/GoogleNet_quant")
-	set(QUANT_GOOGLENET_MODEL_ARCHIVE "GoogleNet_qat_model.tar.gz")
-	download_quant_model(${QUANT_GOOGLENET_MODEL_DIR} ${QUANT_GOOGLENET_MODEL_ARCHIVE} 1d4a7383baa63e7d1c423e8db2b791d5)
-	inference_quant_int8_image_classification_test(test_quant_int8_googlenet_mkldnn ${QUANT_GOOGLENET_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant GoogleNet
+  set(QUANT_GOOGLENET_MODEL_DIR "${QUANT_INSTALL_DIR}/GoogleNet_quant")
+  set(QUANT_GOOGLENET_MODEL_ARCHIVE "GoogleNet_qat_model.tar.gz")
+  download_quant_model(
+    ${QUANT_GOOGLENET_MODEL_DIR} ${QUANT_GOOGLENET_MODEL_ARCHIVE}
+    1d4a7383baa63e7d1c423e8db2b791d5)
+  inference_quant_int8_image_classification_test(
+    test_quant_int8_googlenet_mkldnn ${QUANT_GOOGLENET_MODEL_DIR}/model
+    ${IMAGENET_DATA_PATH})
 
-	# Quant MobileNetV1
-	set(QUANT_MOBILENETV1_MODEL_DIR "${QUANT_INSTALL_DIR}/MobileNetV1_quant")
-	set(QUANT_MOBILENETV1_MODEL_ARCHIVE "MobileNetV1_qat_model.tar.gz")
-	download_quant_model(${QUANT_MOBILENETV1_MODEL_DIR} ${QUANT_MOBILENETV1_MODEL_ARCHIVE} 3b774d94a9fcbb604d09bdb731fc1162)
-	inference_quant_int8_image_classification_test(test_quant_int8_mobilenetv1_mkldnn ${QUANT_MOBILENETV1_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant MobileNetV1
+  set(QUANT_MOBILENETV1_MODEL_DIR "${QUANT_INSTALL_DIR}/MobileNetV1_quant")
+  set(QUANT_MOBILENETV1_MODEL_ARCHIVE "MobileNetV1_qat_model.tar.gz")
+  download_quant_model(
+    ${QUANT_MOBILENETV1_MODEL_DIR} ${QUANT_MOBILENETV1_MODEL_ARCHIVE}
+    3b774d94a9fcbb604d09bdb731fc1162)
+  inference_quant_int8_image_classification_test(
+    test_quant_int8_mobilenetv1_mkldnn ${QUANT_MOBILENETV1_MODEL_DIR}/model
+    ${IMAGENET_DATA_PATH})
 
-	# Quant MobileNetV2
-	set(QUANT_MOBILENETV2_MODEL_DIR "${QUANT_INSTALL_DIR}/MobileNetV2_quant")
-	set(QUANT_MOBILENETV2_MODEL_ARCHIVE "MobileNetV2_qat_model.tar.gz")
-	download_quant_model(${QUANT_MOBILENETV2_MODEL_DIR} ${QUANT_MOBILENETV2_MODEL_ARCHIVE} 758a99d9225d8b73e1a8765883f96cdd)
-	inference_quant_int8_image_classification_test(test_quant_int8_mobilenetv2_mkldnn ${QUANT_MOBILENETV2_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant MobileNetV2
+  set(QUANT_MOBILENETV2_MODEL_DIR "${QUANT_INSTALL_DIR}/MobileNetV2_quant")
+  set(QUANT_MOBILENETV2_MODEL_ARCHIVE "MobileNetV2_qat_model.tar.gz")
+  download_quant_model(
+    ${QUANT_MOBILENETV2_MODEL_DIR} ${QUANT_MOBILENETV2_MODEL_ARCHIVE}
+    758a99d9225d8b73e1a8765883f96cdd)
+  inference_quant_int8_image_classification_test(
+    test_quant_int8_mobilenetv2_mkldnn ${QUANT_MOBILENETV2_MODEL_DIR}/model
+    ${IMAGENET_DATA_PATH})
 
-	# Quant VGG16
-	set(QUANT_VGG16_MODEL_DIR "${QUANT_INSTALL_DIR}/VGG16_quant")
-	set(QUANT_VGG16_MODEL_ARCHIVE "VGG16_qat_model.tar.gz")
-	download_quant_model(${QUANT_VGG16_MODEL_DIR} ${QUANT_VGG16_MODEL_ARCHIVE} c37e63ca82a102f47be266f8068b0b55)
-	# inference_quant_int8_image_classification_test(test_quant_int8_vgg16_mkldnn ${QUANT_VGG16_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant VGG16
+  set(QUANT_VGG16_MODEL_DIR "${QUANT_INSTALL_DIR}/VGG16_quant")
+  set(QUANT_VGG16_MODEL_ARCHIVE "VGG16_qat_model.tar.gz")
+  download_quant_model(${QUANT_VGG16_MODEL_DIR} ${QUANT_VGG16_MODEL_ARCHIVE}
+                       c37e63ca82a102f47be266f8068b0b55)
+  # inference_quant_int8_image_classification_test(test_quant_int8_vgg16_mkldnn ${QUANT_VGG16_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
 
-	# Quant VGG19
-	set(QUANT_VGG19_MODEL_DIR "${QUANT_INSTALL_DIR}/VGG19_quant")
-	set(QUANT_VGG19_MODEL_ARCHIVE "VGG19_qat_model.tar.gz")
-	download_quant_model(${QUANT_VGG19_MODEL_DIR} ${QUANT_VGG19_MODEL_ARCHIVE} 62bcd4b6c3ca2af67e8251d1c96ea18f)
-	# inference_quant_int8_image_classification_test(test_quant_int8_vgg19_mkldnn ${QUANT_VGG19_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant VGG19
+  set(QUANT_VGG19_MODEL_DIR "${QUANT_INSTALL_DIR}/VGG19_quant")
+  set(QUANT_VGG19_MODEL_ARCHIVE "VGG19_qat_model.tar.gz")
+  download_quant_model(${QUANT_VGG19_MODEL_DIR} ${QUANT_VGG19_MODEL_ARCHIVE}
+                       62bcd4b6c3ca2af67e8251d1c96ea18f)
+  # inference_quant_int8_image_classification_test(test_quant_int8_vgg19_mkldnn ${QUANT_VGG19_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
 
-	### Quant2 for image classification
+  ### Quant2 for image classification
 
-	# Quant2 ResNet50 with input/output scales in `fake_quantize_moving_average_abs_max` operators,
-	# with weight scales in `fake_dequantize_max_abs` operators
-        set(QUANT2_RESNET50_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet50_quant2")
-	set(QUANT2_RESNET50_MODEL_ARCHIVE "ResNet50_qat_perf.tar.gz")
-	download_quant_model(${QUANT2_RESNET50_MODEL_DIR} ${QUANT2_RESNET50_MODEL_ARCHIVE} e87309457e8c462a579340607f064d66)
-	set(FP32_RESNET50_MODEL_DIR "${INT8_INSTALL_DIR}/resnet50")
-	inference_quant2_int8_image_classification_test(test_quant2_int8_resnet50_mkldnn ${QUANT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant2 ResNet50 with input/output scales in `fake_quantize_moving_average_abs_max` operators,
+  # with weight scales in `fake_dequantize_max_abs` operators
+  set(QUANT2_RESNET50_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet50_quant2")
+  set(QUANT2_RESNET50_MODEL_ARCHIVE "ResNet50_qat_perf.tar.gz")
+  download_quant_model(
+    ${QUANT2_RESNET50_MODEL_DIR} ${QUANT2_RESNET50_MODEL_ARCHIVE}
+    e87309457e8c462a579340607f064d66)
+  set(FP32_RESNET50_MODEL_DIR "${INT8_INSTALL_DIR}/resnet50")
+  inference_quant2_int8_image_classification_test(
+    test_quant2_int8_resnet50_mkldnn
+    ${QUANT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float
+    ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
 
-	# Quant2 ResNet50 with input/output scales in `fake_quantize_range_abs_max` operators and the `out_threshold` attributes,
-	# with weight scales in `fake_dequantize_max_abs` operators
-	set(QUANT2_RESNET50_RANGE_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet50_quant2_range")
-	set(QUANT2_RESNET50_RANGE_MODEL_ARCHIVE "ResNet50_qat_range.tar.gz")
-	download_quant_model(${QUANT2_RESNET50_RANGE_MODEL_DIR} ${QUANT2_RESNET50_RANGE_MODEL_ARCHIVE} 2fdc8a139f041c0d270abec826b2d304)
-	inference_quant2_int8_image_classification_test(test_quant2_int8_resnet50_range_mkldnn ${QUANT2_RESNET50_RANGE_MODEL_DIR}/ResNet50_qat_range ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant2 ResNet50 with input/output scales in `fake_quantize_range_abs_max` operators and the `out_threshold` attributes,
+  # with weight scales in `fake_dequantize_max_abs` operators
+  set(QUANT2_RESNET50_RANGE_MODEL_DIR
+      "${QUANT_INSTALL_DIR}/ResNet50_quant2_range")
+  set(QUANT2_RESNET50_RANGE_MODEL_ARCHIVE "ResNet50_qat_range.tar.gz")
+  download_quant_model(
+    ${QUANT2_RESNET50_RANGE_MODEL_DIR} ${QUANT2_RESNET50_RANGE_MODEL_ARCHIVE}
+    2fdc8a139f041c0d270abec826b2d304)
+  inference_quant2_int8_image_classification_test(
+    test_quant2_int8_resnet50_range_mkldnn
+    ${QUANT2_RESNET50_RANGE_MODEL_DIR}/ResNet50_qat_range
+    ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
 
-	# Quant2 ResNet50 with input/output scales in `fake_quantize_range_abs_max` operators and the `out_threshold` attributes,
-	# with weight scales in `fake_channel_wise_dequantize_max_abs` operators
-	set(QUANT2_RESNET50_CHANNELWISE_MODEL_DIR "${QUANT_INSTALL_DIR}/ResNet50_quant2_channelwise")
-	set(QUANT2_RESNET50_CHANNELWISE_MODEL_ARCHIVE "ResNet50_qat_channelwise.tar.gz")
-	download_quant_model(${QUANT2_RESNET50_CHANNELWISE_MODEL_DIR} ${QUANT2_RESNET50_CHANNELWISE_MODEL_ARCHIVE} 887a1b1b0e9a4efd10f263a43764db26)
-	inference_quant2_int8_image_classification_test(test_quant2_int8_resnet50_channelwise_mkldnn ${QUANT2_RESNET50_CHANNELWISE_MODEL_DIR}/ResNet50_qat_channelwise ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
+  # Quant2 ResNet50 with input/output scales in `fake_quantize_range_abs_max` operators and the `out_threshold` attributes,
+  # with weight scales in `fake_channel_wise_dequantize_max_abs` operators
+  set(QUANT2_RESNET50_CHANNELWISE_MODEL_DIR
+      "${QUANT_INSTALL_DIR}/ResNet50_quant2_channelwise")
+  set(QUANT2_RESNET50_CHANNELWISE_MODEL_ARCHIVE
+      "ResNet50_qat_channelwise.tar.gz")
+  download_quant_model(
+    ${QUANT2_RESNET50_CHANNELWISE_MODEL_DIR}
+    ${QUANT2_RESNET50_CHANNELWISE_MODEL_ARCHIVE}
+    887a1b1b0e9a4efd10f263a43764db26)
+  inference_quant2_int8_image_classification_test(
+    test_quant2_int8_resnet50_channelwise_mkldnn
+    ${QUANT2_RESNET50_CHANNELWISE_MODEL_DIR}/ResNet50_qat_channelwise
+    ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
 
-	# Quant2 MobileNetV1
-        set(QUANT2_MOBILENETV1_MODEL_DIR "${QUANT_INSTALL_DIR}/MobileNetV1_quant2")
-	set(QUANT2_MOBILENETV1_MODEL_ARCHIVE "MobileNet_qat_perf.tar.gz")
-	download_quant_model(${QUANT2_MOBILENETV1_MODEL_DIR} ${QUANT2_MOBILENETV1_MODEL_ARCHIVE} 7f626e453db2d56fed6c2538621ffacf)
-	set(FP32_MOBILENETV1_MODEL_DIR "${INT8_INSTALL_DIR}/mobilenetv1")
-	inference_quant2_int8_image_classification_test(test_quant2_int8_mobilenetv1_mkldnn ${QUANT2_MOBILENETV1_MODEL_DIR}/MobileNet_qat_perf/float ${FP32_MOBILENETV1_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
-	
-	### Quant2 for NLP
+  # Quant2 MobileNetV1
+  set(QUANT2_MOBILENETV1_MODEL_DIR "${QUANT_INSTALL_DIR}/MobileNetV1_quant2")
+  set(QUANT2_MOBILENETV1_MODEL_ARCHIVE "MobileNet_qat_perf.tar.gz")
+  download_quant_model(
+    ${QUANT2_MOBILENETV1_MODEL_DIR} ${QUANT2_MOBILENETV1_MODEL_ARCHIVE}
+    7f626e453db2d56fed6c2538621ffacf)
+  set(FP32_MOBILENETV1_MODEL_DIR "${INT8_INSTALL_DIR}/mobilenetv1")
+  inference_quant2_int8_image_classification_test(
+    test_quant2_int8_mobilenetv1_mkldnn
+    ${QUANT2_MOBILENETV1_MODEL_DIR}/MobileNet_qat_perf/float
+    ${FP32_MOBILENETV1_MODEL_DIR}/model ${IMAGENET_DATA_PATH})
 
-	set(NLP_DATA_ARCHIVE "Ernie_dataset.tar.gz")
-	set(NLP_DATA_DIR "${INFERENCE_DEMO_INSTALL_DIR}/Ernie_dataset")
-	set(NLP_DATA_PATH "${NLP_DATA_DIR}/Ernie_dataset/1.8w.bs1")
-	set(NLP_LABLES_PATH "${NLP_DATA_DIR}/Ernie_dataset/label.xnli.dev")
-	download_quant_data(${NLP_DATA_DIR} ${NLP_DATA_ARCHIVE} e650ce0cbc1fadbed5cc2c01d4e734dc)
+  ### Quant2 for NLP
 
-	# Quant2 Ernie
-	set(QUANT2_ERNIE_MODEL_ARCHIVE "ernie_qat.tar.gz")
-	set(QUANT2_ERNIE_MODEL_DIR "${QUANT_INSTALL_DIR}/Ernie_quant2")
-	download_quant_model(${QUANT2_ERNIE_MODEL_DIR} ${QUANT2_ERNIE_MODEL_ARCHIVE} f7cdf4720755ecf66efbc8044e9922d9)
-	set(FP32_ERNIE_MODEL_ARCHIVE "ernie_fp32_model.tar.gz")
-	set(FP32_ERNIE_MODEL_DIR "${QUANT_INSTALL_DIR}/Ernie_float")
-	download_quant_fp32_model(${FP32_ERNIE_MODEL_DIR} ${FP32_ERNIE_MODEL_ARCHIVE} 114f38804a3ef8c45e7259e68bbd838b)
-	set(QUANT2_ERNIE_OPS_TO_QUANTIZE "fc,reshape2,transpose2,matmul,elementwise_add,slice")
-	inference_quant2_int8_nlp_test(test_quant2_int8_ernie_mkldnn ${QUANT2_ERNIE_MODEL_DIR}/Ernie_qat/float ${FP32_ERNIE_MODEL_DIR}/ernie_fp32_model ${NLP_DATA_PATH} ${NLP_LABLES_PATH} ${QUANT2_ERNIE_OPS_TO_QUANTIZE})
+  set(NLP_DATA_ARCHIVE "Ernie_dataset.tar.gz")
+  set(NLP_DATA_DIR "${INFERENCE_DEMO_INSTALL_DIR}/Ernie_dataset")
+  set(NLP_DATA_PATH "${NLP_DATA_DIR}/Ernie_dataset/1.8w.bs1")
+  set(NLP_LABLES_PATH "${NLP_DATA_DIR}/Ernie_dataset/label.xnli.dev")
+  download_quant_data(${NLP_DATA_DIR} ${NLP_DATA_ARCHIVE}
+                      e650ce0cbc1fadbed5cc2c01d4e734dc)
 
-	# Quant2 GRU
-	set(QUANT2_GRU_MODEL_ARCHIVE "GRU_quant_acc.tar.gz")
-	set(QUANT2_GRU_MODEL_DIR "${QUANT_INSTALL_DIR}/GRU_quant2")
-	download_quant_model(${QUANT2_GRU_MODEL_DIR} ${QUANT2_GRU_MODEL_ARCHIVE} cf207f8076dcfb8b74d8b6bdddf9090c)
-	set(QUANT2_GRU_OPS_TO_QUANTIZE "multi_gru")
+  # Quant2 Ernie
+  set(QUANT2_ERNIE_MODEL_ARCHIVE "ernie_qat.tar.gz")
+  set(QUANT2_ERNIE_MODEL_DIR "${QUANT_INSTALL_DIR}/Ernie_quant2")
+  download_quant_model(${QUANT2_ERNIE_MODEL_DIR} ${QUANT2_ERNIE_MODEL_ARCHIVE}
+                       f7cdf4720755ecf66efbc8044e9922d9)
+  set(FP32_ERNIE_MODEL_ARCHIVE "ernie_fp32_model.tar.gz")
+  set(FP32_ERNIE_MODEL_DIR "${QUANT_INSTALL_DIR}/Ernie_float")
+  download_quant_fp32_model(${FP32_ERNIE_MODEL_DIR} ${FP32_ERNIE_MODEL_ARCHIVE}
+                            114f38804a3ef8c45e7259e68bbd838b)
+  set(QUANT2_ERNIE_OPS_TO_QUANTIZE
+      "fc,reshape2,transpose2,matmul,elementwise_add,slice")
+  inference_quant2_int8_nlp_test(
+    test_quant2_int8_ernie_mkldnn ${QUANT2_ERNIE_MODEL_DIR}/Ernie_qat/float
+    ${FP32_ERNIE_MODEL_DIR}/ernie_fp32_model ${NLP_DATA_PATH}
+    ${NLP_LABLES_PATH} ${QUANT2_ERNIE_OPS_TO_QUANTIZE})
 
-	# Quant2 LSTM
-	set(QUANT2_LSTM_MODEL_ARCHIVE "lstm_quant.tar.gz")
-	set(QUANT2_LSTM_MODEL_DIR "${QUANT_INSTALL_DIR}/lstm_quant_test")
-	download_quant_model(${QUANT2_LSTM_MODEL_DIR} ${QUANT2_LSTM_MODEL_ARCHIVE} 40a693803b12ee9e251258f32559abcb)
-	set(QUANT2_LSTM_OPS_TO_QUANTIZE "fusion_lstm")
+  # Quant2 GRU
+  set(QUANT2_GRU_MODEL_ARCHIVE "GRU_quant_acc.tar.gz")
+  set(QUANT2_GRU_MODEL_DIR "${QUANT_INSTALL_DIR}/GRU_quant2")
+  download_quant_model(${QUANT2_GRU_MODEL_DIR} ${QUANT2_GRU_MODEL_ARCHIVE}
+                       cf207f8076dcfb8b74d8b6bdddf9090c)
+  set(QUANT2_GRU_OPS_TO_QUANTIZE "multi_gru")
 
-	### Save FP32 model or INT8 model from Quant model
-        
-	set(QUANT2_INT8_RESNET50_SAVE_PATH "${QUANT_INSTALL_DIR}/ResNet50_quant2_int8")
-	save_quant_ic_model_test(save_quant2_model_resnet50 ${QUANT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float ${QUANT2_INT8_RESNET50_SAVE_PATH})
+  # Quant2 LSTM
+  set(QUANT2_LSTM_MODEL_ARCHIVE "lstm_quant.tar.gz")
+  set(QUANT2_LSTM_MODEL_DIR "${QUANT_INSTALL_DIR}/lstm_quant_test")
+  download_quant_model(${QUANT2_LSTM_MODEL_DIR} ${QUANT2_LSTM_MODEL_ARCHIVE}
+                       40a693803b12ee9e251258f32559abcb)
+  set(QUANT2_LSTM_OPS_TO_QUANTIZE "fusion_lstm")
 
-	set(QUANT2_INT8_ERNIE_SAVE_PATH "${QUANT_INSTALL_DIR}/Ernie_quant2_int8")
-	save_quant_nlp_model_test(save_quant2_model_ernie ${QUANT2_ERNIE_MODEL_DIR}/Ernie_qat/float ${QUANT2_INT8_ERNIE_SAVE_PATH} ${QUANT2_ERNIE_OPS_TO_QUANTIZE})
+  ### Save FP32 model or INT8 model from Quant model
 
-	set(QUANT2_INT8_GRU_SAVE_PATH "${QUANT_INSTALL_DIR}/GRU_quant2_int8")
-	save_quant_nlp_model_test(save_quant2_model_gru ${QUANT2_GRU_MODEL_DIR}/GRU_quant_acc ${QUANT2_INT8_GRU_SAVE_PATH} ${QUANT2_GRU_OPS_TO_QUANTIZE})
+  set(QUANT2_INT8_RESNET50_SAVE_PATH
+      "${QUANT_INSTALL_DIR}/ResNet50_quant2_int8")
+  save_quant_ic_model_test(
+    save_quant2_model_resnet50
+    ${QUANT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float
+    ${QUANT2_INT8_RESNET50_SAVE_PATH})
 
-	set(QUANT2_INT8_LSTM_SAVE_PATH "${QUANT_INSTALL_DIR}/lstm_quant2_int8")
-	save_quant_nlp_model_test(save_quant2_model_lstm ${QUANT2_LSTM_MODEL_DIR}/lstm_quant ${QUANT2_INT8_LSTM_SAVE_PATH} ${QUANT2_LSTM_OPS_TO_QUANTIZE})
+  set(QUANT2_INT8_ERNIE_SAVE_PATH "${QUANT_INSTALL_DIR}/Ernie_quant2_int8")
+  save_quant_nlp_model_test(
+    save_quant2_model_ernie ${QUANT2_ERNIE_MODEL_DIR}/Ernie_qat/float
+    ${QUANT2_INT8_ERNIE_SAVE_PATH} ${QUANT2_ERNIE_OPS_TO_QUANTIZE})
 
-	# Convert Quant2 model to dot and pdf files 
-	set(QUANT2_INT8_ERNIE_DOT_SAVE_PATH "${QUANT_INSTALL_DIR}/Ernie_quant2_int8_dot_file")
-	convert_model2dot_test(convert_model2dot_ernie ${QUANT2_ERNIE_MODEL_DIR}/Ernie_qat/float ${QUANT2_INT8_ERNIE_DOT_SAVE_PATH} "Ernie_quant2_int8")
+  set(QUANT2_INT8_GRU_SAVE_PATH "${QUANT_INSTALL_DIR}/GRU_quant2_int8")
+  save_quant_nlp_model_test(
+    save_quant2_model_gru ${QUANT2_GRU_MODEL_DIR}/GRU_quant_acc
+    ${QUANT2_INT8_GRU_SAVE_PATH} ${QUANT2_GRU_OPS_TO_QUANTIZE})
 
-	### PTQ INT8
+  set(QUANT2_INT8_LSTM_SAVE_PATH "${QUANT_INSTALL_DIR}/lstm_quant2_int8")
+  save_quant_nlp_model_test(
+    save_quant2_model_lstm ${QUANT2_LSTM_MODEL_DIR}/lstm_quant
+    ${QUANT2_INT8_LSTM_SAVE_PATH} ${QUANT2_LSTM_OPS_TO_QUANTIZE})
 
-	# PTQ int8 lstm model
-	set(LSTM_DATA_FILE "quant_lstm_input_data.tar.gz")
-	set(LSTM_URL "${INFERENCE_URL}/int8/unittest_model_data")
-	download_data(${QUANT2_INT8_LSTM_SAVE_PATH} ${LSTM_URL} ${LSTM_DATA_FILE} add84c754e9b792fea1fbd728d134ab7)
-	set(QUANT2_FP32_LSTM_MODEL_ARCHIVE "lstm_fp32_model.tar.gz")
-	download_lstm_model(${QUANT2_INT8_LSTM_SAVE_PATH} ${QUANT2_FP32_LSTM_MODEL_ARCHIVE} eecd9f44d69a84acc1cf2235c4b8b743)
-	inference_quant2_int8_lstm_model_test(test_quant2_int8_lstm_mkldnn ${QUANT2_INT8_LSTM_SAVE_PATH}/lstm_fp32_model ${QUANT2_LSTM_MODEL_DIR}/lstm_quant ${QUANT2_INT8_LSTM_SAVE_PATH}/quant_lstm_input_data)
+  # Convert Quant2 model to dot and pdf files
+  set(QUANT2_INT8_ERNIE_DOT_SAVE_PATH
+      "${QUANT_INSTALL_DIR}/Ernie_quant2_int8_dot_file")
+  convert_model2dot_test(
+    convert_model2dot_ernie ${QUANT2_ERNIE_MODEL_DIR}/Ernie_qat/float
+    ${QUANT2_INT8_ERNIE_DOT_SAVE_PATH} "Ernie_quant2_int8")
+
+  ### PTQ INT8
+
+  # PTQ int8 lstm model
+  set(LSTM_DATA_FILE "quant_lstm_input_data.tar.gz")
+  set(LSTM_URL "${INFERENCE_URL}/int8/unittest_model_data")
+  download_data(${QUANT2_INT8_LSTM_SAVE_PATH} ${LSTM_URL} ${LSTM_DATA_FILE}
+                add84c754e9b792fea1fbd728d134ab7)
+  set(QUANT2_FP32_LSTM_MODEL_ARCHIVE "lstm_fp32_model.tar.gz")
+  download_lstm_model(
+    ${QUANT2_INT8_LSTM_SAVE_PATH} ${QUANT2_FP32_LSTM_MODEL_ARCHIVE}
+    eecd9f44d69a84acc1cf2235c4b8b743)
+  inference_quant2_int8_lstm_model_test(
+    test_quant2_int8_lstm_mkldnn ${QUANT2_INT8_LSTM_SAVE_PATH}/lstm_fp32_model
+    ${QUANT2_LSTM_MODEL_DIR}/lstm_quant
+    ${QUANT2_INT8_LSTM_SAVE_PATH}/quant_lstm_input_data)
 
 endif()
 
-# Since the tests for Quant & INT8 comparison support only testing on Linux 
+# Since the tests for Quant & INT8 comparison support only testing on Linux
 # with MKL-DNN, we remove it here to not test it on other systems.
-list(REMOVE_ITEM TEST_OPS
-	test_mkldnn_int8_quantization_strategy
-	quant_int8_image_classification_comparison
-	quant_int8_nlp_comparison)
+list(REMOVE_ITEM TEST_OPS test_mkldnn_int8_quantization_strategy
+     quant_int8_image_classification_comparison quant_int8_nlp_comparison)
 
 #TODO(wanghaoshuang): Fix this unitest failed on GCC8.
-LIST(REMOVE_ITEM TEST_OPS test_auto_pruning)
-LIST(REMOVE_ITEM TEST_OPS test_filter_pruning)
-	
+list(REMOVE_ITEM TEST_OPS test_auto_pruning)
+list(REMOVE_ITEM TEST_OPS test_filter_pruning)
+
 # fix
 if(WIN32)
-    SET(SINGLE_CARD_TEST_OPS
-        test_user_defined_quantization
-        test_quantization_scale_pass
-        test_quantization_pass
-        test_moving_average_abs_max_scale_op
-        test_imperative_qat_channelwise
-        test_imperative_qat
-        test_imperative_out_scale
-        test_graph)
-    LIST(REMOVE_ITEM TEST_OPS ${SINGLE_CARD_TEST_OPS})
-    foreach(src ${SINGLE_CARD_TEST_OPS})
-        py_test(${src} SRCS ${src}.py ENVS CUDA_VISIBLE_DEVICES=0)
-    endforeach()
+  set(SINGLE_CARD_TEST_OPS
+      test_user_defined_quantization
+      test_quantization_scale_pass
+      test_quantization_pass
+      test_moving_average_abs_max_scale_op
+      test_imperative_qat_channelwise
+      test_imperative_qat
+      test_imperative_out_scale
+      test_graph)
+  list(REMOVE_ITEM TEST_OPS ${SINGLE_CARD_TEST_OPS})
+  foreach(src ${SINGLE_CARD_TEST_OPS})
+    py_test(${src} SRCS ${src}.py ENVS CUDA_VISIBLE_DEVICES=0)
+  endforeach()
 endif()
 
-
 foreach(src ${TEST_OPS})
-    py_test(${src} SRCS ${src}.py)
+  py_test(${src} SRCS ${src}.py)
 endforeach()
 
 # setting timeout value for old unittests
 if(NOT WIN32)
-    set_tests_properties(test_post_training_quantization_lstm_model PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_post_training_quantization_mobilenetv1 PROPERTIES TIMEOUT 600 LABELS "RUN_TYPE=NIGHTLY")
-    set_tests_properties(test_post_training_quantization_resnet50 PROPERTIES TIMEOUT 600 LABELS "RUN_TYPE=NIGHTLY")
-    set_tests_properties(test_post_training_quantization_mnist PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_post_training_quantization_while PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_imperative_ptq PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_weight_quantization_mobilenetv1 PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_post_training_quantization_lstm_model
+                       PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_post_training_quantization_mobilenetv1
+                       PROPERTIES TIMEOUT 600 LABELS "RUN_TYPE=NIGHTLY")
+  set_tests_properties(test_post_training_quantization_resnet50
+                       PROPERTIES TIMEOUT 600 LABELS "RUN_TYPE=NIGHTLY")
+  set_tests_properties(test_post_training_quantization_mnist PROPERTIES TIMEOUT
+                                                                        120)
+  set_tests_properties(test_post_training_quantization_while PROPERTIES TIMEOUT
+                                                                        120)
+  set_tests_properties(test_imperative_ptq PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_weight_quantization_mobilenetv1 PROPERTIES TIMEOUT
+                                                                       120)
 endif()
 
 set_tests_properties(test_graph PROPERTIES TIMEOUT 120)
@@ -359,23 +530,30 @@ set_tests_properties(test_imperative_out_scale PROPERTIES TIMEOUT 200)
 set_tests_properties(test_imperative_qat_user_defined PROPERTIES TIMEOUT 200)
 
 if(LINUX AND WITH_MKLDNN)
-    set_tests_properties(test_quant2_int8_mobilenetv1_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(convert_model2dot_ernie PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant2_int8_resnet50_channelwise_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant_int8_mobilenetv2_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant2_int8_resnet50_range_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(save_quant2_model_resnet50 PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant_int8_resnet50_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant_int8_mobilenetv1_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant2_int8_ernie_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant_int8_googlenet_mkldnn PROPERTIES TIMEOUT 120)
-    set_tests_properties(test_quant2_int8_resnet50_mkldnn PROPERTIES TIMEOUT 120)
-	set_tests_properties(test_quant2_int8_lstm_mkldnn PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant2_int8_mobilenetv1_mkldnn PROPERTIES TIMEOUT
+                                                                      120)
+  set_tests_properties(convert_model2dot_ernie PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant2_int8_resnet50_channelwise_mkldnn
+                       PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant_int8_mobilenetv2_mkldnn PROPERTIES TIMEOUT
+                                                                     120)
+  set_tests_properties(test_quant2_int8_resnet50_range_mkldnn PROPERTIES TIMEOUT
+                                                                         120)
+  set_tests_properties(save_quant2_model_resnet50 PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant_int8_resnet50_mkldnn PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant_int8_mobilenetv1_mkldnn PROPERTIES TIMEOUT
+                                                                     120)
+  set_tests_properties(test_quant2_int8_ernie_mkldnn PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant_int8_googlenet_mkldnn PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant2_int8_resnet50_mkldnn PROPERTIES TIMEOUT 120)
+  set_tests_properties(test_quant2_int8_lstm_mkldnn PROPERTIES TIMEOUT 120)
 endif()
 
 if(APPLE)
-    set_tests_properties(test_post_training_quantization_mnist PROPERTIES TIMEOUT 300)
-    set_tests_properties(test_post_training_quantization_while PROPERTIES TIMEOUT 300)
-	set_tests_properties(test_imperative_ptq PROPERTIES TIMEOUT 300)
-    set_tests_properties(test_imperative_skip_op PROPERTIES TIMEOUT 300)
+  set_tests_properties(test_post_training_quantization_mnist PROPERTIES TIMEOUT
+                                                                        300)
+  set_tests_properties(test_post_training_quantization_while PROPERTIES TIMEOUT
+                                                                        300)
+  set_tests_properties(test_imperative_ptq PROPERTIES TIMEOUT 300)
+  set_tests_properties(test_imperative_skip_op PROPERTIES TIMEOUT 300)
 endif()

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_ptq.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_ptq.py
@@ -35,8 +35,9 @@ from paddle.fluid.framework import _test_eager_guard
 from imperative_test_utils import fix_model_dict, ImperativeLenet, ImperativeLinearBn
 from imperative_test_utils import ImperativeLinearBn_hook
 
-_logger = get_logger(
-    __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
+_logger = get_logger(__name__,
+                     logging.INFO,
+                     fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 
 class TestFuseLinearBn(unittest.TestCase):
@@ -55,15 +56,15 @@ class TestFuseLinearBn(unittest.TestCase):
         quant_h = ptq.quantize(model_h, fuse=True, fuse_list=f_l)
         for name, layer in quant_model.named_sublayers():
             if name in f_l:
-                assert not (isinstance(layer, nn.BatchNorm1D) or
-                            isinstance(layer, nn.BatchNorm2D))
+                assert not (isinstance(layer, nn.BatchNorm1D)
+                            or isinstance(layer, nn.BatchNorm2D))
         out = model(inputs)
         out_h = model_h(inputs)
         out_quant = quant_model(inputs)
         out_quant_h = quant_h(inputs)
         cos_sim_func = nn.CosineSimilarity(axis=0)
-        print('fuse linear+bn',
-              cos_sim_func(out.flatten(), out_quant.flatten()))
+        print('fuse linear+bn', cos_sim_func(out.flatten(),
+                                             out_quant.flatten()))
         print(cos_sim_func(out_h.flatten(), out_quant_h.flatten()))
 
 
@@ -87,8 +88,8 @@ class TestImperativePTQ(unittest.TestCase):
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):
-            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(target_folder,
-                                                          zip_path)
+            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(
+                target_folder, zip_path)
             os.system(cmd)
 
     def download_model(self, data_url, data_md5, folder_name):
@@ -123,8 +124,8 @@ class TestImperativePTQ(unittest.TestCase):
     def model_test(self, model, batch_num=-1, batch_size=8):
         model.eval()
 
-        test_reader = paddle.batch(
-            paddle.dataset.mnist.test(), batch_size=batch_size)
+        test_reader = paddle.batch(paddle.dataset.mnist.test(),
+                                   batch_size=batch_size)
 
         eval_acc_top1_list = []
         for batch_id, data in enumerate(test_reader()):
@@ -157,8 +158,8 @@ class TestImperativePTQ(unittest.TestCase):
         [inference_program, feed_target_names, fetch_targets
          ] = (paddle.static.load_inference_model(program_path, exe))
 
-        test_reader = paddle.batch(
-            paddle.dataset.mnist.test(), batch_size=batch_size)
+        test_reader = paddle.batch(paddle.dataset.mnist.test(),
+                                   batch_size=batch_size)
 
         top1_correct_num = 0.
         total_num = 0.
@@ -203,13 +204,13 @@ class TestImperativePTQ(unittest.TestCase):
                                           self.batch_size)
 
         input_spec = [
-            paddle.static.InputSpec(
-                shape=[None, 1, 28, 28], dtype='float32')
+            paddle.static.InputSpec(shape=[None, 1, 28, 28], dtype='float32')
         ]
         with tempfile.TemporaryDirectory(prefix="imperative_ptq_") as tmpdir:
             save_path = os.path.join(tmpdir, "model")
-            self.ptq.save_quantized_model(
-                model=quant_model, path=save_path, input_spec=input_spec)
+            self.ptq.save_quantized_model(model=quant_model,
+                                          path=save_path,
+                                          input_spec=input_spec)
             print('Quantized model saved in {%s}' % save_path)
 
             after_acc_top1 = self.model_test(quant_model, self.batch_num,
@@ -225,13 +226,11 @@ class TestImperativePTQ(unittest.TestCase):
             print('After converted acc_top1: %s' % after_acc_top1)
             print('Infer acc_top1: %s' % infer_acc_top1)
 
-            self.assertTrue(
-                after_acc_top1 >= self.eval_acc_top1,
-                msg="The test acc {%f} is less than {%f}." %
-                (after_acc_top1, self.eval_acc_top1))
-            self.assertTrue(
-                infer_acc_top1 >= after_acc_top1,
-                msg='The acc is lower after converting model.')
+            self.assertTrue(after_acc_top1 >= self.eval_acc_top1,
+                            msg="The test acc {%f} is less than {%f}." %
+                            (after_acc_top1, self.eval_acc_top1))
+            self.assertTrue(infer_acc_top1 >= after_acc_top1,
+                            msg='The acc is lower after converting model.')
 
             end_time = time.time()
             print("total time: %ss \n" % (end_time - start_time))
@@ -243,6 +242,7 @@ class TestImperativePTQ(unittest.TestCase):
 
 
 class TestImperativePTQfuse(TestImperativePTQ):
+
     def func_ptq(self):
         start_time = time.time()
 
@@ -261,19 +261,19 @@ class TestImperativePTQfuse(TestImperativePTQ):
         quant_model = self.ptq.quantize(model, fuse=True, fuse_list=f_l)
         for name, layer in quant_model.named_sublayers():
             if name in f_l:
-                assert not (isinstance(layer, nn.BatchNorm1D) or
-                            isinstance(layer, nn.BatchNorm2D))
+                assert not (isinstance(layer, nn.BatchNorm1D)
+                            or isinstance(layer, nn.BatchNorm2D))
         before_acc_top1 = self.model_test(quant_model, self.batch_num,
                                           self.batch_size)
 
         input_spec = [
-            paddle.static.InputSpec(
-                shape=[None, 1, 28, 28], dtype='float32')
+            paddle.static.InputSpec(shape=[None, 1, 28, 28], dtype='float32')
         ]
         with tempfile.TemporaryDirectory(prefix="imperative_ptq_") as tmpdir:
             save_path = os.path.join(tmpdir, "model")
-            self.ptq.save_quantized_model(
-                model=quant_model, path=save_path, input_spec=input_spec)
+            self.ptq.save_quantized_model(model=quant_model,
+                                          path=save_path,
+                                          input_spec=input_spec)
             print('Quantized model saved in {%s}' % save_path)
 
             after_acc_top1 = self.model_test(quant_model, self.batch_num,
@@ -291,15 +291,13 @@ class TestImperativePTQfuse(TestImperativePTQ):
 
             #Check whether the quant_model is correct after converting.
             #The acc of quantized model should be higher than 0.95.
-            self.assertTrue(
-                after_acc_top1 >= self.eval_acc_top1,
-                msg="The test acc {%f} is less than {%f}." %
-                (after_acc_top1, self.eval_acc_top1))
+            self.assertTrue(after_acc_top1 >= self.eval_acc_top1,
+                            msg="The test acc {%f} is less than {%f}." %
+                            (after_acc_top1, self.eval_acc_top1))
             #Check the saved infer_model.The acc of infer model
             #should not be lower than the one of dygraph model.
-            self.assertTrue(
-                infer_acc_top1 >= after_acc_top1,
-                msg='The acc is lower after converting model.')
+            self.assertTrue(infer_acc_top1 >= after_acc_top1,
+                            msg='The acc is lower after converting model.')
 
             end_time = time.time()
             print("total time: %ss \n" % (end_time - start_time))
@@ -311,6 +309,7 @@ class TestImperativePTQfuse(TestImperativePTQ):
 
 
 class TestImperativePTQHist(TestImperativePTQ):
+
     def set_vars(self):
         config = PTQConfig(HistQuantizer(), AbsmaxQuantizer())
         self.ptq = ImperativePTQ(config)
@@ -332,13 +331,14 @@ class TestImperativePTQHist(TestImperativePTQ):
 
 
 class TestImperativePTQKL(TestImperativePTQ):
+
     def set_vars(self):
         config = PTQConfig(KLQuantizer(), PerChannelAbsmaxQuantizer())
         self.ptq = ImperativePTQ(config)
 
         self.batch_num = 10
         self.batch_size = 10
-        self.eval_acc_top1 = 1.0
+        self.eval_acc_top1 = 0.98
 
         conv2d_1_wt_thresholds = [
             0.18116560578346252, 0.17079241573810577, 0.1702047884464264,

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
@@ -165,7 +165,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                  model_path,
                                  data_path,
                                  algo="KL",
-                                 weight_round_algo="round",
+                                 round_type="round",
                                  quantizable_op_type=["conv2d"],
                                  is_full_quantize=False,
                                  is_use_cache_file=False,
@@ -185,7 +185,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                        batch_nums=batch_nums,
                                        algo=algo,
                                        quantizable_op_type=quantizable_op_type,
-                                       weight_round_algo=weight_round_algo,
+                                       round_type=round_type,
                                        is_full_quantize=is_full_quantize,
                                        optimize_model=is_optimize_model,
                                        onnx_format=onnx_format,
@@ -201,7 +201,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                  data_url,
                  data_md5,
                  algo,
-                 weight_round_algo,
+                 round_type,
                  quantizable_op_type,
                  is_full_quantize,
                  is_use_cache_file,
@@ -224,7 +224,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
         print("Start post training quantization for {0} on {1} samples ...".
               format(model_name, quant_iterations))
         self.generate_quantized_model(fp32_model_path, data_path, algo,
-                                      weight_round_algo, quantizable_op_type,
+                                      round_type, quantizable_op_type,
                                       is_full_quantize, is_use_cache_file,
                                       is_optimize_model, quant_iterations,
                                       onnx_format)
@@ -255,7 +255,7 @@ class TestPostTrainingAvgForLSTM(TestPostTrainingQuantization):
         data_url = "https://paddle-inference-dist.cdn.bcebos.com/int8/unittest_model_data/quant_lstm_input_data.tar.gz"
         data_md5 = "add84c754e9b792fea1fbd728d134ab7"
         algo = "avg"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["mul", "lstm"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -264,7 +264,7 @@ class TestPostTrainingAvgForLSTM(TestPostTrainingQuantization):
         infer_iterations = 100
         quant_iterations = 10
         self.run_test(model_name, model_url, model_md5, data_name, data_url,
-                      data_md5, algo, weight_round_algo, quantizable_op_type,
+                      data_md5, algo, round_type, quantizable_op_type,
                       is_full_quantize, is_use_cache_file, is_optimize_model,
                       diff_threshold, infer_iterations, quant_iterations)
 
@@ -279,7 +279,7 @@ class TestPostTrainingAvgForLSTMONNXFormat(TestPostTrainingQuantization):
         data_url = "https://paddle-inference-dist.cdn.bcebos.com/int8/unittest_model_data/quant_lstm_input_data.tar.gz"
         data_md5 = "add84c754e9b792fea1fbd728d134ab7"
         algo = "avg"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["mul", "lstm"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -295,7 +295,7 @@ class TestPostTrainingAvgForLSTMONNXFormat(TestPostTrainingQuantization):
                       data_url,
                       data_md5,
                       algo,
-                      weight_round_algo,
+                      round_type,
                       quantizable_op_type,
                       is_full_quantize,
                       is_use_cache_file,

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_lstm_model.py
@@ -34,6 +34,7 @@ np.random.seed(0)
 
 
 class TestPostTrainingQuantization(unittest.TestCase):
+
     def setUp(self):
         self.download_path = 'int8/download'
         self.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
@@ -44,8 +45,8 @@ class TestPostTrainingQuantization(unittest.TestCase):
         try:
             os.system("mkdir -p " + self.int8_model_path)
         except Exception as e:
-            print("Failed to create {} due to {}".format(self.int8_model_path,
-                                                         str(e)))
+            print("Failed to create {} due to {}".format(
+                self.int8_model_path, str(e)))
             sys.exit(-1)
 
     def tearDown(self):
@@ -53,8 +54,8 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):
-            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(target_folder,
-                                                          zip_path)
+            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(
+                target_folder, zip_path)
             os.system(cmd)
 
     def download_model(self, data_url, data_md5, folder_name):
@@ -68,6 +69,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
         return data_cache_folder
 
     def get_batch_reader(self, data_path, place):
+
         def reader():
             with open(data_path, 'rb') as in_file:
                 while True:
@@ -80,15 +82,14 @@ class TestPostTrainingQuantization(unittest.TestCase):
                     seq_len = (alllen >> 16) & 0xFFFF
 
                     label = in_file.read(4 * label_len)
-                    label = np.frombuffer(
-                        label, dtype=np.int32).reshape([len(label) // 4])
+                    label = np.frombuffer(label, dtype=np.int32).reshape(
+                        [len(label) // 4])
                     if label.shape[0] != 1 or label[0] > 6350:
                         continue
 
                     feat = in_file.read(4 * seq_len * 8)
-                    feat = np.frombuffer(
-                        feat,
-                        dtype=np.float32).reshape([len(feat) // 4 // 8, 8])
+                    feat = np.frombuffer(feat, dtype=np.float32).reshape(
+                        [len(feat) // 4 // 8, 8])
                     lod_feat = [feat.shape[0]]
 
                     minputs = fluid.create_lod_tensor(feat, [lod_feat], place)
@@ -97,6 +98,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
         return reader
 
     def get_simple_reader(self, data_path, place):
+
         def reader():
             with open(data_path, 'rb') as in_file:
                 while True:
@@ -109,15 +111,14 @@ class TestPostTrainingQuantization(unittest.TestCase):
                     seq_len = (alllen >> 16) & 0xFFFF
 
                     label = in_file.read(4 * label_len)
-                    label = np.frombuffer(
-                        label, dtype=np.int32).reshape([len(label) // 4])
+                    label = np.frombuffer(label, dtype=np.int32).reshape(
+                        [len(label) // 4])
                     if label.shape[0] != 1 or label[0] > 6350:
                         continue
 
                     feat = in_file.read(4 * seq_len * 8)
-                    feat = np.frombuffer(
-                        feat,
-                        dtype=np.float32).reshape([len(feat) // 4 // 8, 8])
+                    feat = np.frombuffer(feat, dtype=np.float32).reshape(
+                        [len(feat) // 4 // 8, 8])
                     lod_feat = [feat.shape[0]]
 
                     minputs = fluid.create_lod_tensor(feat, [lod_feat], place)
@@ -164,7 +165,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                  model_path,
                                  data_path,
                                  algo="KL",
-                                 round_type="round",
+                                 weight_round_algo="round",
                                  quantizable_op_type=["conv2d"],
                                  is_full_quantize=False,
                                  is_use_cache_file=False,
@@ -178,18 +179,17 @@ class TestPostTrainingQuantization(unittest.TestCase):
         scope = fluid.global_scope()
         batch_generator = self.get_batch_reader(data_path, place)
 
-        ptq = PostTrainingQuantization(
-            executor=exe,
-            model_dir=model_path,
-            batch_generator=batch_generator,
-            batch_nums=batch_nums,
-            algo=algo,
-            quantizable_op_type=quantizable_op_type,
-            round_type=round_type,
-            is_full_quantize=is_full_quantize,
-            optimize_model=is_optimize_model,
-            onnx_format=onnx_format,
-            is_use_cache_file=is_use_cache_file)
+        ptq = PostTrainingQuantization(executor=exe,
+                                       model_dir=model_path,
+                                       batch_generator=batch_generator,
+                                       batch_nums=batch_nums,
+                                       algo=algo,
+                                       quantizable_op_type=quantizable_op_type,
+                                       weight_round_algo=weight_round_algo,
+                                       is_full_quantize=is_full_quantize,
+                                       optimize_model=is_optimize_model,
+                                       onnx_format=onnx_format,
+                                       is_use_cache_file=is_use_cache_file)
         ptq.quantize()
         ptq.save_quantized_model(self.int8_model_path)
 
@@ -201,7 +201,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                  data_url,
                  data_md5,
                  algo,
-                 round_type,
+                 weight_round_algo,
                  quantizable_op_type,
                  is_full_quantize,
                  is_use_cache_file,
@@ -223,10 +223,11 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
         print("Start post training quantization for {0} on {1} samples ...".
               format(model_name, quant_iterations))
-        self.generate_quantized_model(
-            fp32_model_path, data_path, algo, round_type, quantizable_op_type,
-            is_full_quantize, is_use_cache_file, is_optimize_model,
-            quant_iterations, onnx_format)
+        self.generate_quantized_model(fp32_model_path, data_path, algo,
+                                      weight_round_algo, quantizable_op_type,
+                                      is_full_quantize, is_use_cache_file,
+                                      is_optimize_model, quant_iterations,
+                                      onnx_format)
 
         print("Start INT8 inference for {0} on {1} samples ...".format(
             model_name, infer_iterations))
@@ -245,6 +246,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
 
 class TestPostTrainingAvgForLSTM(TestPostTrainingQuantization):
+
     def test_post_training_avg(self):
         model_name = "nlp_lstm_fp32_model"
         model_url = "https://paddle-inference-dist.cdn.bcebos.com/int8/unittest_model_data/nlp_lstm_fp32_model.tar.gz"
@@ -253,7 +255,7 @@ class TestPostTrainingAvgForLSTM(TestPostTrainingQuantization):
         data_url = "https://paddle-inference-dist.cdn.bcebos.com/int8/unittest_model_data/quant_lstm_input_data.tar.gz"
         data_md5 = "add84c754e9b792fea1fbd728d134ab7"
         algo = "avg"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["mul", "lstm"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -262,12 +264,13 @@ class TestPostTrainingAvgForLSTM(TestPostTrainingQuantization):
         infer_iterations = 100
         quant_iterations = 10
         self.run_test(model_name, model_url, model_md5, data_name, data_url,
-                      data_md5, algo, round_type, quantizable_op_type,
+                      data_md5, algo, weight_round_algo, quantizable_op_type,
                       is_full_quantize, is_use_cache_file, is_optimize_model,
                       diff_threshold, infer_iterations, quant_iterations)
 
 
 class TestPostTrainingAvgForLSTMONNXFormat(TestPostTrainingQuantization):
+
     def test_post_training_avg_onnx_format(self):
         model_name = "nlp_lstm_fp32_model"
         model_url = "https://paddle-inference-dist.cdn.bcebos.com/int8/unittest_model_data/nlp_lstm_fp32_model.tar.gz"
@@ -276,7 +279,7 @@ class TestPostTrainingAvgForLSTMONNXFormat(TestPostTrainingQuantization):
         data_url = "https://paddle-inference-dist.cdn.bcebos.com/int8/unittest_model_data/quant_lstm_input_data.tar.gz"
         data_md5 = "add84c754e9b792fea1fbd728d134ab7"
         algo = "avg"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["mul", "lstm"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -285,23 +288,22 @@ class TestPostTrainingAvgForLSTMONNXFormat(TestPostTrainingQuantization):
         infer_iterations = 100
         quant_iterations = 10
         onnx_format = True
-        self.run_test(
-            model_name,
-            model_url,
-            model_md5,
-            data_name,
-            data_url,
-            data_md5,
-            algo,
-            round_type,
-            quantizable_op_type,
-            is_full_quantize,
-            is_use_cache_file,
-            is_optimize_model,
-            diff_threshold,
-            infer_iterations,
-            quant_iterations,
-            onnx_format=onnx_format)
+        self.run_test(model_name,
+                      model_url,
+                      model_md5,
+                      data_name,
+                      data_url,
+                      data_md5,
+                      algo,
+                      weight_round_algo,
+                      quantizable_op_type,
+                      is_full_quantize,
+                      is_use_cache_file,
+                      is_optimize_model,
+                      diff_threshold,
+                      infer_iterations,
+                      quant_iterations,
+                      onnx_format=onnx_format)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
@@ -108,7 +108,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
     def generate_quantized_model(self,
                                  model_path,
                                  algo="KL",
-                                 weight_round_algo="round",
+                                 round_type="round",
                                  quantizable_op_type=["conv2d"],
                                  is_full_quantize=False,
                                  is_use_cache_file=False,
@@ -130,7 +130,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                        batch_nums=batch_nums,
                                        algo=algo,
                                        quantizable_op_type=quantizable_op_type,
-                                       weight_round_algo=weight_round_algo,
+                                       round_type=round_type,
                                        is_full_quantize=is_full_quantize,
                                        optimize_model=is_optimize_model,
                                        bias_correction=bias_correction,
@@ -145,7 +145,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                  data_url,
                  data_md5,
                  algo,
-                 weight_round_algo,
+                 round_type,
                  quantizable_op_type,
                  is_full_quantize,
                  is_use_cache_file,
@@ -169,11 +169,10 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
         print("Start INT8 post training quantization for {0} on {1} images ...".
               format(model_name, quant_iterations * batch_size))
-        self.generate_quantized_model(origin_model_path, algo,
-                                      weight_round_algo, quantizable_op_type,
-                                      is_full_quantize, is_use_cache_file,
-                                      is_optimize_model, batch_size,
-                                      quant_iterations, onnx_format,
+        self.generate_quantized_model(origin_model_path, algo, round_type,
+                                      quantizable_op_type, is_full_quantize,
+                                      is_use_cache_file, is_optimize_model,
+                                      batch_size, quant_iterations, onnx_format,
                                       skip_tensor_list, bias_correction)
 
         print("Start INT8 inference for {0} on {1} images ...".format(
@@ -204,7 +203,7 @@ class TestPostTrainingKLForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "KL"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -213,7 +212,7 @@ class TestPostTrainingKLForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
+        self.run_test(model_name, data_url, data_md5, algo, round_type,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
@@ -226,7 +225,7 @@ class TestPostTraininghistForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "hist"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -235,7 +234,7 @@ class TestPostTraininghistForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
+        self.run_test(model_name, data_url, data_md5, algo, round_type,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
@@ -248,7 +247,7 @@ class TestPostTrainingmseForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -257,7 +256,7 @@ class TestPostTrainingmseForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
+        self.run_test(model_name, data_url, data_md5, algo, round_type,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
@@ -270,7 +269,7 @@ class TestPostTrainingemdForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "emd"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -279,7 +278,7 @@ class TestPostTrainingemdForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
+        self.run_test(model_name, data_url, data_md5, algo, round_type,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
@@ -292,7 +291,7 @@ class TestPostTrainingavgForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "avg"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -301,7 +300,7 @@ class TestPostTrainingavgForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
+        self.run_test(model_name, data_url, data_md5, algo, round_type,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
@@ -314,7 +313,7 @@ class TestPostTrainingAbsMaxForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "abs_max"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "mul"]
         is_full_quantize = True
         is_use_cache_file = False
@@ -323,7 +322,7 @@ class TestPostTrainingAbsMaxForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 10
-        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
+        self.run_test(model_name, data_url, data_md5, algo, round_type,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
@@ -336,7 +335,7 @@ class TestPostTrainingmseAdaroundForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        weight_round_algo = "adaround"
+        round_type = "adaround"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -350,7 +349,7 @@ class TestPostTrainingmseAdaroundForMnist(TestPostTrainingQuantization):
                       data_url,
                       data_md5,
                       algo,
-                      weight_round_algo,
+                      round_type,
                       quantizable_op_type,
                       is_full_quantize,
                       is_use_cache_file,
@@ -369,7 +368,7 @@ class TestPostTrainingKLAdaroundForMnist(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "KL"
-        weight_round_algo = "adaround"
+        round_type = "adaround"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -378,7 +377,7 @@ class TestPostTrainingKLAdaroundForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
+        self.run_test(model_name, data_url, data_md5, algo, round_type,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
@@ -391,7 +390,7 @@ class TestPostTrainingmseForMnistONNXFormat(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -405,7 +404,7 @@ class TestPostTrainingmseForMnistONNXFormat(TestPostTrainingQuantization):
                       data_url,
                       data_md5,
                       algo,
-                      weight_round_algo,
+                      round_type,
                       quantizable_op_type,
                       is_full_quantize,
                       is_use_cache_file,
@@ -425,7 +424,7 @@ class TestPostTrainingmseForMnistONNXFormatFullQuant(
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = True
         is_use_cache_file = False
@@ -439,7 +438,7 @@ class TestPostTrainingmseForMnistONNXFormatFullQuant(
                       data_url,
                       data_md5,
                       algo,
-                      weight_round_algo,
+                      round_type,
                       quantizable_op_type,
                       is_full_quantize,
                       is_use_cache_file,
@@ -458,7 +457,7 @@ class TestPostTrainingavgForMnistSkipOP(TestPostTrainingQuantization):
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "avg"
-        weight_round_algo = "round"
+        round_type = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -472,7 +471,7 @@ class TestPostTrainingavgForMnistSkipOP(TestPostTrainingQuantization):
                       data_url,
                       data_md5,
                       algo,
-                      weight_round_algo,
+                      round_type,
                       quantizable_op_type,
                       is_full_quantize,
                       is_use_cache_file,

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
@@ -33,6 +33,7 @@ np.random.seed(0)
 
 
 class TestPostTrainingQuantization(unittest.TestCase):
+
     def setUp(self):
         self.root_path = tempfile.TemporaryDirectory()
         self.int8_model_path = os.path.join(self.root_path.name,
@@ -43,8 +44,8 @@ class TestPostTrainingQuantization(unittest.TestCase):
         try:
             os.system("mkdir -p " + self.int8_model_path)
         except Exception as e:
-            print("Failed to create {} due to {}".format(self.int8_model_path,
-                                                         str(e)))
+            print("Failed to create {} due to {}".format(
+                self.int8_model_path, str(e)))
             sys.exit(-1)
 
     def tearDown(self):
@@ -52,8 +53,8 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):
-            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(target_folder,
-                                                          zip_path)
+            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(
+                target_folder, zip_path)
             os.system(cmd)
 
     def download_model(self, data_url, data_md5, folder_name):
@@ -107,7 +108,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
     def generate_quantized_model(self,
                                  model_path,
                                  algo="KL",
-                                 round_type="round",
+                                 weight_round_algo="round",
                                  quantizable_op_type=["conv2d"],
                                  is_full_quantize=False,
                                  is_use_cache_file=False,
@@ -115,26 +116,27 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                  batch_size=10,
                                  batch_nums=10,
                                  onnx_format=False,
-                                 skip_tensor_list=None):
+                                 skip_tensor_list=None,
+                                 bias_correction=False):
 
         place = fluid.CPUPlace()
         exe = fluid.Executor(place)
         val_reader = paddle.dataset.mnist.train()
 
-        ptq = PostTrainingQuantization(
-            executor=exe,
-            model_dir=model_path,
-            sample_generator=val_reader,
-            batch_size=batch_size,
-            batch_nums=batch_nums,
-            algo=algo,
-            quantizable_op_type=quantizable_op_type,
-            round_type=round_type,
-            is_full_quantize=is_full_quantize,
-            optimize_model=is_optimize_model,
-            onnx_format=onnx_format,
-            skip_tensor_list=skip_tensor_list,
-            is_use_cache_file=is_use_cache_file)
+        ptq = PostTrainingQuantization(executor=exe,
+                                       model_dir=model_path,
+                                       sample_generator=val_reader,
+                                       batch_size=batch_size,
+                                       batch_nums=batch_nums,
+                                       algo=algo,
+                                       quantizable_op_type=quantizable_op_type,
+                                       weight_round_algo=weight_round_algo,
+                                       is_full_quantize=is_full_quantize,
+                                       optimize_model=is_optimize_model,
+                                       bias_correction=bias_correction,
+                                       onnx_format=onnx_format,
+                                       skip_tensor_list=skip_tensor_list,
+                                       is_use_cache_file=is_use_cache_file)
         ptq.quantize()
         ptq.save_quantized_model(self.int8_model_path)
 
@@ -143,7 +145,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                  data_url,
                  data_md5,
                  algo,
-                 round_type,
+                 weight_round_algo,
                  quantizable_op_type,
                  is_full_quantize,
                  is_use_cache_file,
@@ -152,6 +154,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                  batch_size=10,
                  infer_iterations=10,
                  quant_iterations=5,
+                 bias_correction=False,
                  onnx_format=False,
                  skip_tensor_list=None):
 
@@ -160,20 +163,24 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
         print("Start FP32 inference for {0} on {1} images ...".format(
             model_name, infer_iterations * batch_size))
-        (fp32_throughput, fp32_latency, fp32_acc1) = self.run_program(
-            origin_model_path, batch_size, infer_iterations)
+        (fp32_throughput, fp32_latency,
+         fp32_acc1) = self.run_program(origin_model_path, batch_size,
+                                       infer_iterations)
 
         print("Start INT8 post training quantization for {0} on {1} images ...".
               format(model_name, quant_iterations * batch_size))
-        self.generate_quantized_model(
-            origin_model_path, algo, round_type, quantizable_op_type,
-            is_full_quantize, is_use_cache_file, is_optimize_model, batch_size,
-            quant_iterations, onnx_format, skip_tensor_list)
+        self.generate_quantized_model(origin_model_path, algo,
+                                      weight_round_algo, quantizable_op_type,
+                                      is_full_quantize, is_use_cache_file,
+                                      is_optimize_model, batch_size,
+                                      quant_iterations, onnx_format,
+                                      skip_tensor_list, bias_correction)
 
         print("Start INT8 inference for {0} on {1} images ...".format(
             model_name, infer_iterations * batch_size))
-        (int8_throughput, int8_latency, int8_acc1) = self.run_program(
-            self.int8_model_path, batch_size, infer_iterations)
+        (int8_throughput, int8_latency,
+         int8_acc1) = self.run_program(self.int8_model_path, batch_size,
+                                       infer_iterations)
 
         print("---Post training quantization of {} method---".format(algo))
         print(
@@ -191,12 +198,13 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
 
 class TestPostTrainingKLForMnist(TestPostTrainingQuantization):
+
     def test_post_training_kl(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "KL"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -205,19 +213,20 @@ class TestPostTrainingKLForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
+        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
 
 
 class TestPostTraininghistForMnist(TestPostTrainingQuantization):
+
     def test_post_training_hist(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "hist"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -226,19 +235,20 @@ class TestPostTraininghistForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
+        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
 
 
 class TestPostTrainingmseForMnist(TestPostTrainingQuantization):
+
     def test_post_training_mse(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -247,19 +257,20 @@ class TestPostTrainingmseForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
+        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
 
 
 class TestPostTrainingemdForMnist(TestPostTrainingQuantization):
+
     def test_post_training_mse(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "emd"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -268,19 +279,20 @@ class TestPostTrainingemdForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
+        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
 
 
 class TestPostTrainingavgForMnist(TestPostTrainingQuantization):
+
     def test_post_training_avg(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "avg"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -289,19 +301,20 @@ class TestPostTrainingavgForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
+        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
 
 
 class TestPostTrainingAbsMaxForMnist(TestPostTrainingQuantization):
+
     def test_post_training_abs_max(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "abs_max"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "mul"]
         is_full_quantize = True
         is_use_cache_file = False
@@ -310,19 +323,20 @@ class TestPostTrainingAbsMaxForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 10
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
+        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
 
 
 class TestPostTrainingmseAdaroundForMnist(TestPostTrainingQuantization):
+
     def test_post_training_mse(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        round_type = "adaround"
+        weight_round_algo = "adaround"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -331,19 +345,31 @@ class TestPostTrainingmseAdaroundForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
-                      quantizable_op_type, is_full_quantize, is_use_cache_file,
-                      is_optimize_model, diff_threshold, batch_size,
-                      infer_iterations, quant_iterations)
+        bias_correction = True
+        self.run_test(model_name,
+                      data_url,
+                      data_md5,
+                      algo,
+                      weight_round_algo,
+                      quantizable_op_type,
+                      is_full_quantize,
+                      is_use_cache_file,
+                      is_optimize_model,
+                      diff_threshold,
+                      batch_size,
+                      infer_iterations,
+                      quant_iterations,
+                      bias_correction=bias_correction)
 
 
 class TestPostTrainingKLAdaroundForMnist(TestPostTrainingQuantization):
+
     def test_post_training_kl(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "KL"
-        round_type = "adaround"
+        weight_round_algo = "adaround"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -352,19 +378,20 @@ class TestPostTrainingKLAdaroundForMnist(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(model_name, data_url, data_md5, algo, round_type,
+        self.run_test(model_name, data_url, data_md5, algo, weight_round_algo,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold, batch_size,
                       infer_iterations, quant_iterations)
 
 
 class TestPostTrainingmseForMnistONNXFormat(TestPostTrainingQuantization):
+
     def test_post_training_mse_onnx_format(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -374,31 +401,31 @@ class TestPostTrainingmseForMnistONNXFormat(TestPostTrainingQuantization):
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(
-            model_name,
-            data_url,
-            data_md5,
-            algo,
-            round_type,
-            quantizable_op_type,
-            is_full_quantize,
-            is_use_cache_file,
-            is_optimize_model,
-            diff_threshold,
-            batch_size,
-            infer_iterations,
-            quant_iterations,
-            onnx_format=onnx_format)
+        self.run_test(model_name,
+                      data_url,
+                      data_md5,
+                      algo,
+                      weight_round_algo,
+                      quantizable_op_type,
+                      is_full_quantize,
+                      is_use_cache_file,
+                      is_optimize_model,
+                      diff_threshold,
+                      batch_size,
+                      infer_iterations,
+                      quant_iterations,
+                      onnx_format=onnx_format)
 
 
 class TestPostTrainingmseForMnistONNXFormatFullQuant(
         TestPostTrainingQuantization):
+
     def test_post_training_mse_onnx_format_full_quant(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "mse"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = True
         is_use_cache_file = False
@@ -408,30 +435,30 @@ class TestPostTrainingmseForMnistONNXFormatFullQuant(
         batch_size = 10
         infer_iterations = 50
         quant_iterations = 5
-        self.run_test(
-            model_name,
-            data_url,
-            data_md5,
-            algo,
-            round_type,
-            quantizable_op_type,
-            is_full_quantize,
-            is_use_cache_file,
-            is_optimize_model,
-            diff_threshold,
-            batch_size,
-            infer_iterations,
-            quant_iterations,
-            onnx_format=onnx_format)
+        self.run_test(model_name,
+                      data_url,
+                      data_md5,
+                      algo,
+                      weight_round_algo,
+                      quantizable_op_type,
+                      is_full_quantize,
+                      is_use_cache_file,
+                      is_optimize_model,
+                      diff_threshold,
+                      batch_size,
+                      infer_iterations,
+                      quant_iterations,
+                      onnx_format=onnx_format)
 
 
 class TestPostTrainingavgForMnistSkipOP(TestPostTrainingQuantization):
+
     def test_post_training_avg_skip_op(self):
         model_name = "mnist_model"
         data_url = "http://paddle-inference-dist.bj.bcebos.com/int8/mnist_model.tar.gz"
         data_md5 = "be71d3997ec35ac2a65ae8a145e2887c"
         algo = "avg"
-        round_type = "round"
+        weight_round_algo = "round"
         quantizable_op_type = ["conv2d", "depthwise_conv2d", "mul"]
         is_full_quantize = False
         is_use_cache_file = False
@@ -441,21 +468,20 @@ class TestPostTrainingavgForMnistSkipOP(TestPostTrainingQuantization):
         infer_iterations = 50
         quant_iterations = 5
         skip_tensor_list = ["fc_0.w_0"]
-        self.run_test(
-            model_name,
-            data_url,
-            data_md5,
-            algo,
-            round_type,
-            quantizable_op_type,
-            is_full_quantize,
-            is_use_cache_file,
-            is_optimize_model,
-            diff_threshold,
-            batch_size,
-            infer_iterations,
-            quant_iterations,
-            skip_tensor_list=skip_tensor_list)
+        self.run_test(model_name,
+                      data_url,
+                      data_md5,
+                      algo,
+                      weight_round_algo,
+                      quantizable_op_type,
+                      is_full_quantize,
+                      is_use_cache_file,
+                      is_optimize_model,
+                      diff_threshold,
+                      batch_size,
+                      infer_iterations,
+                      quant_iterations,
+                      skip_tensor_list=skip_tensor_list)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -425,7 +425,7 @@ class TestPostTrainingAvgONNXFormatForMobilenetv1(TestPostTrainingQuantization):
 
     def test_post_training_onnx_format_mobilenetv1(self):
         model = "MobileNet-V1"
-        algo = "avg"
+        algo = "emd"
         round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -242,12 +242,11 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                  model_path,
                                  quantizable_op_type,
                                  algo="KL",
-                                 weight_round_algo="round",
+                                 round_type="round",
                                  is_full_quantize=False,
                                  is_use_cache_file=False,
                                  is_optimize_model=False,
-                                 onnx_format=False,
-                                 skip_tensor_list=None):
+                                 onnx_format=False):
         try:
             os.system("mkdir " + self.int8_model)
         except Exception as e:
@@ -265,7 +264,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                        model_dir=model_path,
                                        algo=algo,
                                        quantizable_op_type=quantizable_op_type,
-                                       weight_round_algo=weight_round_algo,
+                                       round_type=round_type,
                                        is_full_quantize=is_full_quantize,
                                        optimize_model=is_optimize_model,
                                        onnx_format=onnx_format,
@@ -276,7 +275,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
     def run_test(self,
                  model,
                  algo,
-                 weight_round_algo,
+                 round_type,
                  data_urls,
                  data_md5s,
                  quantizable_op_type,
@@ -284,8 +283,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                  is_use_cache_file,
                  is_optimize_model,
                  diff_threshold,
-                 onnx_format=False,
-                 skip_tensor_list=None):
+                 onnx_format=False):
         infer_iterations = self.infer_iterations
         batch_size = self.batch_size
         sample_iterations = self.sample_iterations
@@ -301,10 +299,9 @@ class TestPostTrainingQuantization(unittest.TestCase):
         print("Start INT8 post training quantization for {0} on {1} images ...".
               format(model, sample_iterations * batch_size))
         self.generate_quantized_model(model_cache_folder + "/model",
-                                      quantizable_op_type, algo,
-                                      weight_round_algo, is_full_quantize,
-                                      is_use_cache_file, is_optimize_model,
-                                      onnx_format)
+                                      quantizable_op_type, algo, round_type,
+                                      is_full_quantize, is_use_cache_file,
+                                      is_optimize_model, onnx_format)
 
         print("Start INT8 inference for {0} on {1} images ...".format(
             model, infer_iterations * batch_size))
@@ -332,7 +329,7 @@ class TestPostTrainingKLForMobilenetv1(TestPostTrainingQuantization):
     def test_post_training_kl_mobilenetv1(self):
         model = "MobileNet-V1"
         algo = "KL"
-        weight_round_algo = "round"
+        round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
         ]
@@ -347,7 +344,7 @@ class TestPostTrainingKLForMobilenetv1(TestPostTrainingQuantization):
         is_use_cache_file = False
         is_optimize_model = True
         diff_threshold = 0.025
-        self.run_test(model, algo, weight_round_algo, data_urls, data_md5s,
+        self.run_test(model, algo, round_type, data_urls, data_md5s,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold)
 
@@ -357,7 +354,7 @@ class TestPostTrainingavgForMobilenetv1(TestPostTrainingQuantization):
     def test_post_training_avg_mobilenetv1(self):
         model = "MobileNet-V1"
         algo = "avg"
-        weight_round_algo = "round"
+        round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
         ]
@@ -371,7 +368,7 @@ class TestPostTrainingavgForMobilenetv1(TestPostTrainingQuantization):
         is_use_cache_file = False
         is_optimize_model = True
         diff_threshold = 0.025
-        self.run_test(model, algo, weight_round_algo, data_urls, data_md5s,
+        self.run_test(model, algo, round_type, data_urls, data_md5s,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold)
 
@@ -381,7 +378,7 @@ class TestPostTraininghistForMobilenetv1(TestPostTrainingQuantization):
     def test_post_training_hist_mobilenetv1(self):
         model = "MobileNet-V1"
         algo = "hist"
-        weight_round_algo = "round"
+        round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
         ]
@@ -395,7 +392,7 @@ class TestPostTraininghistForMobilenetv1(TestPostTrainingQuantization):
         is_use_cache_file = False
         is_optimize_model = True
         diff_threshold = 0.03
-        self.run_test(model, algo, weight_round_algo, data_urls, data_md5s,
+        self.run_test(model, algo, round_type, data_urls, data_md5s,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold)
 
@@ -405,7 +402,7 @@ class TestPostTrainingAbsMaxForMobilenetv1(TestPostTrainingQuantization):
     def test_post_training_abs_max_mobilenetv1(self):
         model = "MobileNet-V1"
         algo = "abs_max"
-        weight_round_algo = "round"
+        round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
         ]
@@ -419,7 +416,7 @@ class TestPostTrainingAbsMaxForMobilenetv1(TestPostTrainingQuantization):
         is_optimize_model = False
         # The accuracy diff of post-training quantization (abs_max) maybe bigger
         diff_threshold = 0.05
-        self.run_test(model, algo, weight_round_algo, data_urls, data_md5s,
+        self.run_test(model, algo, round_type, data_urls, data_md5s,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold)
 
@@ -429,7 +426,7 @@ class TestPostTrainingAvgONNXFormatForMobilenetv1(TestPostTrainingQuantization):
     def test_post_training_onnx_format_mobilenetv1(self):
         model = "MobileNet-V1"
         algo = "avg"
-        weight_round_algo = "round"
+        round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
         ]
@@ -446,7 +443,7 @@ class TestPostTrainingAvgONNXFormatForMobilenetv1(TestPostTrainingQuantization):
         diff_threshold = 0.05
         self.run_test(model,
                       algo,
-                      weight_round_algo,
+                      round_type,
                       data_urls,
                       data_md5s,
                       quantizable_op_type,

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
@@ -25,7 +25,7 @@ class TestPostTrainingForResnet50(TestPostTrainingQuantization):
     def test_post_training_resnet50(self):
         model = "ResNet-50"
         algo = "min_max"
-        weight_round_algo = "round"
+        round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/resnet50_int8_model.tar.gz'
         ]
@@ -35,7 +35,7 @@ class TestPostTrainingForResnet50(TestPostTrainingQuantization):
         is_use_cache_file = False
         is_optimize_model = False
         diff_threshold = 0.025
-        self.run_test(model, algo, weight_round_algo, data_urls, data_md5s,
+        self.run_test(model, algo, round_type, data_urls, data_md5s,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold)
 
@@ -45,7 +45,7 @@ class TestPostTrainingForResnet50ONNXFormat(TestPostTrainingQuantization):
     def test_post_training_resnet50(self):
         model = "ResNet-50"
         algo = "min_max"
-        weight_round_algo = "round"
+        round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/resnet50_int8_model.tar.gz'
         ]
@@ -58,7 +58,7 @@ class TestPostTrainingForResnet50ONNXFormat(TestPostTrainingQuantization):
         onnx_format = True
         self.run_test(model,
                       algo,
-                      weight_round_algo,
+                      round_type,
                       data_urls,
                       data_md5s,
                       quantizable_op_type,

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
@@ -21,10 +21,11 @@ paddle.enable_static()
 
 
 class TestPostTrainingForResnet50(TestPostTrainingQuantization):
+
     def test_post_training_resnet50(self):
         model = "ResNet-50"
         algo = "min_max"
-        round_type = "round"
+        weight_round_algo = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/resnet50_int8_model.tar.gz'
         ]
@@ -34,16 +35,17 @@ class TestPostTrainingForResnet50(TestPostTrainingQuantization):
         is_use_cache_file = False
         is_optimize_model = False
         diff_threshold = 0.025
-        self.run_test(model, algo, round_type, data_urls, data_md5s,
+        self.run_test(model, algo, weight_round_algo, data_urls, data_md5s,
                       quantizable_op_type, is_full_quantize, is_use_cache_file,
                       is_optimize_model, diff_threshold)
 
 
 class TestPostTrainingForResnet50ONNXFormat(TestPostTrainingQuantization):
+
     def test_post_training_resnet50(self):
         model = "ResNet-50"
         algo = "min_max"
-        round_type = "round"
+        weight_round_algo = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/resnet50_int8_model.tar.gz'
         ]
@@ -54,18 +56,17 @@ class TestPostTrainingForResnet50ONNXFormat(TestPostTrainingQuantization):
         is_optimize_model = False
         diff_threshold = 0.025
         onnx_format = True
-        self.run_test(
-            model,
-            algo,
-            round_type,
-            data_urls,
-            data_md5s,
-            quantizable_op_type,
-            is_full_quantize,
-            is_use_cache_file,
-            is_optimize_model,
-            diff_threshold,
-            onnx_format=onnx_format)
+        self.run_test(model,
+                      algo,
+                      weight_round_algo,
+                      data_urls,
+                      data_md5s,
+                      quantizable_op_type,
+                      is_full_quantize,
+                      is_use_cache_file,
+                      is_optimize_model,
+                      diff_threshold,
+                      onnx_format=onnx_format)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_fake_quantize_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fake_quantize_op.py
@@ -21,8 +21,6 @@ import math
 from op_test import OpTest
 
 
-# numpy.round has different behavior in comparision to c++ round function
-# so we use round_c instead of numpy.round to align the output data
 def round_c_single_element(val):
     dtype = type(val)
     if val >= 0:
@@ -30,6 +28,7 @@ def round_c_single_element(val):
     return dtype(np.ceil(val - 0.5))
 
 
+# rounding to nearest ties away from zero
 round_c = np.vectorize(round_c_single_element)
 
 
@@ -41,17 +40,30 @@ def get_compute_type(dtype):
 
 
 class TestFakeQuantizeAbsMaxOp(OpTest):
+
     def setUp(self):
         self.op_type = 'fake_quantize_abs_max'
         self.attrs = {'bit_length': 8}
 
-    def _fake_quantize_abs_max(self, dtype, input_shape, distribution):
+    def _fake_quantize_abs_max(self,
+                               dtype,
+                               input_shape,
+                               distribution,
+                               round_type='TiesToEven'):
         input_data = distribution(input_shape).astype(dtype)
         compute_type = get_compute_type(dtype)
         scale = np.max(np.abs(input_data))
         bnt = (1 << (self.attrs['bit_length'] - 1)) - 1
         inv_scale = 1.0 / (scale + 1e-6) if scale < 1e-30 else 1.0 / scale
-        output_data = round_c(input_data.astype(compute_type) * inv_scale * bnt)
+        if round_type == 'TiesToEven':
+            round_out = np.round(
+                input_data.astype(compute_type) * inv_scale * bnt)
+            self.attrs['round_type'] = 0
+        else:
+            round_out = round_c(
+                input_data.astype(compute_type) * inv_scale * bnt)
+            self.attrs['round_type'] = 1
+        output_data = np.clip(round_out, -bnt - 1, bnt)
         self.inputs = {'X': input_data}
         self.outputs = {'Out': output_data, 'OutScale': scale}
         self.dtype = dtype
@@ -59,6 +71,11 @@ class TestFakeQuantizeAbsMaxOp(OpTest):
 
     def test_fake_quantize_abs_max(self):
         self._fake_quantize_abs_max(np.float32, (124, 240), np.random.random)
+
+    def test_fake_quantize_abs_max_round1(self):
+        self._fake_quantize_abs_max(np.float32, (124, 240),
+                                    np.random.random,
+                                    round_type='TiesAwayFromZero')
 
     def test_fake_quantize_abs_max_float16(self):
         self._fake_quantize_abs_max(np.float16, (124, 240), np.random.random)
@@ -72,21 +89,33 @@ class TestFakeQuantizeAbsMaxOp(OpTest):
 
 
 class TestFakeChannelWiseQuantizeAbsMaxOp(OpTest):
+
     def setUp(self):
         self.op_type = 'fake_channel_wise_quantize_abs_max'
         self.attrs = {'bit_length': 8}
 
-    def _fake_channel_wise_quantize_abs_max(self, dtype, input_shape,
-                                            quant_axis, distribution):
+    def _fake_channel_wise_quantize_abs_max(self,
+                                            dtype,
+                                            input_shape,
+                                            quant_axis,
+                                            distribution,
+                                            round_type='TiesToEven'):
         assert quant_axis in [0, 1], 'quant_axis should be 0 or 1.'
         input_data = distribution(input_shape).astype(dtype)
         compute_type = get_compute_type(dtype)
         bnt = (1 << (self.attrs['bit_length'] - 1)) - 1
-        compute_axis = tuple(
-            i for i in range(len(input_shape)) if i != quant_axis)
+        compute_axis = tuple(i for i in range(len(input_shape))
+                             if i != quant_axis)
         scale_broadcast = np.amax(input_data, axis=compute_axis, keepdims=True)
-        output_data = round_c(bnt * input_data.astype(compute_type) /
-                              scale_broadcast)
+        if round_type == 'TiesToEven':
+            round_out = np.round(
+                input_data.astype(compute_type) / scale_broadcast * bnt)
+            self.attrs['round_type'] = 0
+        else:
+            round_out = round_c(
+                input_data.astype(compute_type) / scale_broadcast * bnt)
+            self.attrs['round_type'] = 1
+        output_data = np.clip(round_out, -bnt - 1, bnt)
         if quant_axis == 1:
             scale_broadcast = np.transpose(scale_broadcast,
                                            (1, ) + compute_axis)
@@ -100,19 +129,24 @@ class TestFakeChannelWiseQuantizeAbsMaxOp(OpTest):
     def test_fake_channel_wise_quantize_abs_max(self):
         dtype_options = [np.float32, np.float16]
         input_shape_quant_axis_options = [[(20, 15, 6, 6), 0],
-                                          [(15, 20, 5, 5), 1], [(30, 15), 0],
-                                          [(30, 15), 1]]
-        for dtype, input_shape_quant_axis in itertools.product(
-                dtype_options, input_shape_quant_axis_options):
+                                          [(20, 15, 6, 6), 1], [(30, 30), 0],
+                                          [(30, 30), 1]]
+        round_type_options = ['TiesToEven', 'TiesAwayFromZero']
+        for dtype, input_shape_quant_axis, round_type in itertools.product(
+                dtype_options, input_shape_quant_axis_options,
+                round_type_options):
             input_shape, quant_axis = input_shape_quant_axis
-            with self.subTest(
-                    dtype=dtype, input_shape=input_shape,
-                    quant_axis=quant_axis):
+            with self.subTest(dtype=dtype,
+                              input_shape=input_shape,
+                              quant_axis=quant_axis,
+                              round_type=round_type):
                 self._fake_channel_wise_quantize_abs_max(
-                    dtype, input_shape, quant_axis, np.random.random)
+                    dtype, input_shape, quant_axis, np.random.random,
+                    round_type)
 
 
 class TestFakeQuantizeRangeAbsMaxOp(OpTest):
+
     def setUp(self):
         self.op_type = 'fake_quantize_range_abs_max'
         self.attrs = {'bit_length': 5, 'window_size': 1}
@@ -121,7 +155,8 @@ class TestFakeQuantizeRangeAbsMaxOp(OpTest):
                                      dtype,
                                      input_shape,
                                      distribution,
-                                     is_test=False):
+                                     is_test=False,
+                                     round_type='TiesToEven'):
         input_data = distribution(input_shape).astype(dtype)
         compute_type = get_compute_type(dtype)
         bnt = (1 << (self.attrs['bit_length'] - 1)) - 1
@@ -130,11 +165,15 @@ class TestFakeQuantizeRangeAbsMaxOp(OpTest):
         out_scale[0] = np.max(np.abs(input_data))
         if is_test:
             out_scale[0] = in_scale[0] = out_scale[0] - 1.0
-            clip_data = np.clip(input_data, -in_scale, in_scale)
+        if round_type == 'TiesToEven':
+            round_out = np.round(
+                input_data.astype(compute_type) / out_scale[0] * bnt)
+            self.attrs['round_type'] = 0
         else:
-            clip_data = input_data
-        output_data = round_c(
-            clip_data.astype(compute_type) / out_scale[0] * bnt)
+            round_out = round_c(
+                input_data.astype(compute_type) / out_scale[0] * bnt)
+            self.attrs['round_type'] = 1
+        output_data = np.clip(round_out, -bnt - 1, bnt)
         self.inputs = {
             'X': input_data,
             'Iter': np.zeros(1).astype(np.int64),
@@ -150,18 +189,24 @@ class TestFakeQuantizeRangeAbsMaxOp(OpTest):
         self.check_output()
 
     def test_fake_quantize_range_abs_max(self):
-        dtype_options = [np.float32, np.float16]
+        dtype_options = [np.float16, np.float32]
         is_test_options = [False, True]
-        for dtype, is_test in itertools.product(dtype_options, is_test_options):
+        round_type_options = ['TiesToEven', 'TiesAwayFromZero']
+        for dtype, is_test, round_type in itertools.product(
+                dtype_options, is_test_options, round_type_options):
             self.attrs['bit_length'] = 8 if is_test else 5
-            with self.subTest(dtype=dtype, is_test=is_test):
+            with self.subTest(dtype=dtype,
+                              is_test=is_test,
+                              round_type=round_type):
                 self._fake_quantize_range_abs_max(
-                    dtype, (8, 16, 7, 7),
-                    lambda shape: (np.random.random(shape) - 0.5) * 10,
-                    is_test=is_test)
+                    dtype, (8, 16, 6, 6),
+                    lambda shape: (np.random.random(shape) - 0.4) * 10,
+                    is_test=is_test,
+                    round_type=round_type)
 
 
 class TestMovingAverageAbsMaxScaleOp(OpTest):
+
     def setUp(self):
         self.op_type = 'moving_average_abs_max_scale'
         self.attrs = {'moving_rate': float(0.9), 'is_test': False}
@@ -194,6 +239,7 @@ class TestMovingAverageAbsMaxScaleOp(OpTest):
 
 
 class TestFakeQuantizeMovingAverageAbsMaxOp(OpTest):
+
     def setUp(self):
         self.op_type = 'fake_quantize_moving_average_abs_max'
         self.attrs = {'bit_length': 5, 'moving_rate': 0.9, 'is_test': False}
@@ -203,7 +249,8 @@ class TestFakeQuantizeMovingAverageAbsMaxOp(OpTest):
                                               input_shape,
                                               distribution,
                                               dequantize=False,
-                                              with_gradient=False):
+                                              with_gradient=False,
+                                              round_type='TiesToEven'):
         input_data = distribution(input_shape).astype(dtype)
         compute_type = get_compute_type(dtype)
         bnt = (1 << (self.attrs['bit_length'] - 1)) - 1
@@ -217,12 +264,20 @@ class TestFakeQuantizeMovingAverageAbsMaxOp(OpTest):
             np.abs(input_data))
         out_state[0] = self.attrs['moving_rate'] * in_state[0] + 1.0
         out_scale = out_accum / out_state
-        round_data = round_c(input_data.astype(compute_type) / out_scale * bnt)
+        if round_type == 'TiesToEven':
+            round_out = np.round(
+                input_data.astype(compute_type) / out_scale * bnt)
+            self.attrs['round_type'] = 0
+        else:
+            round_out = round_c(
+                input_data.astype(compute_type) / out_scale * bnt)
+            self.attrs['round_type'] = 1
+        quant_data = np.clip(round_out, -bnt - 1, bnt)
         if dequantize:
-            output_data = (round_data * out_scale / bnt).astype(dtype)
+            output_data = (quant_data * out_scale / bnt).astype(dtype)
             self.op_type = 'fake_quantize_dequantize_moving_average_abs_max'
         else:
-            output_data = round_data.astype(dtype)
+            output_data = quant_data.astype(dtype)
         self.inputs = {
             'X': input_data,
             'InScale': in_scale,
@@ -251,25 +306,40 @@ class TestFakeQuantizeMovingAverageAbsMaxOp(OpTest):
         self._fake_quantize_moving_average_abs_max(np.float16, (8, 16, 7, 7),
                                                    np.random.random)
 
-    def test_fake_quantize_dequantize_moving_average_abs_max(self):
+    def test_fake_quantize_moving_average_abs_max_round1(self):
         self._fake_quantize_moving_average_abs_max(
             np.float32, (8, 16, 7, 7),
             np.random.random,
-            dequantize=True,
-            with_gradient=True)
+            round_type='TiesAwayFromZero')
+
+    def test_fake_quantize_dequantize_moving_average_abs_max(self):
+        self._fake_quantize_moving_average_abs_max(np.float32, (8, 16, 7, 7),
+                                                   np.random.random,
+                                                   dequantize=True,
+                                                   with_gradient=True)
 
 
 class TestFakeQuantizeDequantizeAbsMaxOp(OpTest):
+
     def setUp(self):
         self.op_type = 'fake_quantize_dequantize_abs_max'
         self.attrs = {'bit_length': 8}
 
-    def _fake_quantize_dequantize_abs_max(self, dtype, input_shape,
-                                          distribution):
+    def _fake_quantize_dequantize_abs_max(self,
+                                          dtype,
+                                          input_shape,
+                                          distribution,
+                                          round_type='TiesToEven'):
         input_data = distribution(input_shape).astype(dtype)
         scale = np.max(np.abs(input_data)).astype(dtype)
         bnt = (1 << (self.attrs['bit_length'] - 1)) - 1
-        output_data = round_c(input_data / scale * bnt) * scale / bnt
+        if round_type == 'TiesToEven':
+            round_out = np.round(input_data / scale * bnt)
+            self.attrs['round_type'] = 0
+        else:
+            round_out = round_c(input_data / scale * bnt)
+            self.attrs['round_type'] = 1
+        output_data = np.clip(round_out, -bnt - 1, bnt) * scale / bnt
         self.inputs = {'X': input_data}
         self.outputs = {
             'Out': output_data,
@@ -284,24 +354,39 @@ class TestFakeQuantizeDequantizeAbsMaxOp(OpTest):
         self._fake_quantize_dequantize_abs_max(np.float32, (124, 240),
                                                np.random.random)
 
+    def test_fake_quantize_dequantize_abs_max_round1(self):
+        self._fake_quantize_dequantize_abs_max(np.float32, (124, 240),
+                                               np.random.random,
+                                               round_type='TiesAwayFromZero')
+
 
 class TestChannelWiseFakeQuantizeDequantizeAbsMaxOp(OpTest):
+
     def setUp(self):
         self.op_type = 'fake_channel_wise_quantize_dequantize_abs_max'
         self.attrs = {'bit_length': 8}
 
-    def _fake_channel_wise_quantize_dequantize_abs_max(
-            self, dtype, input_shape, quant_axis, distribution):
+    def _fake_channel_wise_quantize_dequantize_abs_max(self,
+                                                       dtype,
+                                                       input_shape,
+                                                       quant_axis,
+                                                       distribution,
+                                                       round_type='TiesToEven'):
         assert quant_axis in [0, 1], 'quant_axis should be 0 or 1.'
         input_data = distribution(input_shape).astype(dtype)
         compute_type = get_compute_type(dtype)
         bnt = (1 << (self.attrs['bit_length'] - 1)) - 1
         output_data = input_data.copy().astype(compute_type)
-        compute_axis = tuple(
-            i for i in range(len(input_shape)) if i != quant_axis)
+        compute_axis = tuple(i for i in range(len(input_shape))
+                             if i != quant_axis)
         scale_broadcast = np.amax(input_data, axis=compute_axis, keepdims=True)
-        output_data = round_c(bnt * output_data /
-                              scale_broadcast) * scale_broadcast / bnt
+        if round_type == 'TiesToEven':
+            round_out = np.round(bnt * output_data / scale_broadcast)
+            self.attrs['round_type'] = 0
+        else:
+            round_out = round_c(bnt * output_data / scale_broadcast)
+            self.attrs['round_type'] = 1
+        output_data = np.clip(round_out, -bnt - 1, bnt) * scale_broadcast / bnt
         if quant_axis == 1:
             scale_broadcast = np.transpose(scale_broadcast,
                                            (1, ) + compute_axis)
@@ -318,10 +403,19 @@ class TestChannelWiseFakeQuantizeDequantizeAbsMaxOp(OpTest):
         input_shape_quant_axis_options = [[(3, 4, 64, 64), 0],
                                           [(15, 20, 5, 5), 1], [(30, 15), 0],
                                           [(30, 15), 1]]
-        for input_shape, quant_axis in input_shape_quant_axis_options:
-            with self.subTest(input_shape=input_shape, quant_axis=quant_axis):
+        round_type_options = ['TiesToEven', 'TiesAwayFromZero']
+        for input_shape_quant_axis, round_type in itertools.product(
+                input_shape_quant_axis_options, round_type_options):
+            input_shape, quant_axis = input_shape_quant_axis
+            with self.subTest(input_shape=input_shape,
+                              quant_axis=quant_axis,
+                              round_type=round_type):
                 self._fake_channel_wise_quantize_dequantize_abs_max(
-                    np.float32, input_shape, quant_axis, np.random.random)
+                    np.float32,
+                    input_shape,
+                    quant_axis,
+                    np.random.random,
+                    round_type=round_type)
 
 
 def quantize_max_abs(x, max_range):
@@ -349,6 +443,7 @@ def channel_wise_quantize_max_abs(x, quant_bit=8, quant_axis=0):
 
 
 class TestChannelWiseQuantizeOp(OpTest):
+
     def set_args(self):
         self.bit_length = 8
         self.data_type = "float32"
@@ -375,6 +470,7 @@ class TestChannelWiseQuantizeOp(OpTest):
 
 
 class TestChannelWiseQuantizeOp1(TestChannelWiseQuantizeOp):
+
     def set_args(self):
         self.bit_length = 8
         self.data_type = "float32"
@@ -382,6 +478,7 @@ class TestChannelWiseQuantizeOp1(TestChannelWiseQuantizeOp):
 
 
 class TestChannelWiseQuantizeOpTrain(OpTest):
+
     def set_args(self):
         self.bit_length = 8
         self.data_type = "float32"
@@ -410,6 +507,7 @@ class TestChannelWiseQuantizeOpTrain(OpTest):
 
 
 class TestquantizeOp(OpTest):
+
     def set_args(self):
         self.bit_length = 8
         self.quant_axis = -1
@@ -436,6 +534,7 @@ class TestquantizeOp(OpTest):
 
 
 class TestquantizeOpTrain(TestquantizeOp):
+
     def set_args(self):
         self.bit_length = 8
         self.quant_axis = -1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
更新模型量化接口，包括如下内容： (cherry pick #42695 #43764 )
- 在量化fp32->int时，新增支持`rounding to nearest ties to even`的四舍五入方式。
- 修正量化取值范围，比如INT8量化时，数值范围从原先[-127, 127]的取值范围改变至[-128, 127]。
- 量化旧格式保持原本计算不变的前提下新增round_type属性，可修改round和clip方式，默认模式不影响现有模型量化；量化新格式默认支持全新的round和clip方式，对齐onnx和trt，同时也新增round_type属性，可修改round和clip方式。