### PR TITLE
fix post_training_quantization typo

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -657,7 +657,7 @@ class PostTrainingQuantization(object):
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
                 if self._onnx_format:
-                    quant_var = np.clip(distribution(var_tensor / scale * bins),
+                    quant_var = np.clip(np.round(var_tensor / scale * bins),
                                         -bins - 1, bins)
                     quant_dequant_var = quant_var / bins * scale
                 else:
@@ -701,7 +701,7 @@ class PostTrainingQuantization(object):
                 s += 0.02
                 bins = 2**(self._activation_bits - 1) - 1
                 if self._onnx_format:
-                    quant_var = np.clip(distribution(var_tensor / scale * bins),
+                    quant_var = np.clip(np.round(var_tensor / scale * bins),
                                         -bins - 1, bins)
                     quant_dequant_var = quant_var / bins * scale
                 else:

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -425,7 +425,7 @@ class TestPostTrainingAvgONNXFormatForMobilenetv1(TestPostTrainingQuantization):
 
     def test_post_training_onnx_format_mobilenetv1(self):
         model = "MobileNet-V1"
-        algo = "avg"
+        algo = "emd"
         round_type = "round"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix PostTrainingQuantization api `sample_mes` and `sample_emd` typo.