### PR TITLE
[Dy2Stat]Enhance nonlocal mechanism while nonlocal vars is empty

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -524,7 +524,8 @@ def transform_if_else(node, root):
     if ARGS_NAME in nonlocal_names:
         nonlocal_names.remove(ARGS_NAME)
 
-    nonlocal_stmt_node = [create_nonlocal_stmt_node(nonlocal_names)]
+    nonlocal_stmt_node = [create_nonlocal_stmt_node(nonlocal_names)
+                          ] if nonlocal_names else []
 
     empty_arg_node = gast.arguments(args=[],
                                     posonlyargs=[],
@@ -557,8 +558,20 @@ def create_get_args_node(names):
 
         def get_args_0():
             nonlocal x, y
+            return x, y
     """
+
+    def empty_node():
+        func_def = """
+        def {func_name}():
+            return
+        """.format(func_name=unique_name.generate(GET_ARGS_FUNC_PREFIX))
+        return gast.parse(textwrap.dedent(func_def)).body[0]
+
     assert isinstance(names, (list, tuple))
+    if not names:
+        return empty_node()
+
     template = """
     def {func_name}():
         nonlocal {vars}
@@ -578,7 +591,19 @@ def create_set_args_node(names):
             nonlocal x, y
             x, y = __args
     """
+
+    def empty_node():
+        func_def = """
+        def {func_name}({args}):
+            pass
+        """.format(func_name=unique_name.generate(SET_ARGS_FUNC_PREFIX),
+                   args=ARGS_NAME)
+        return gast.parse(textwrap.dedent(func_def)).body[0]
+
     assert isinstance(names, (list, tuple))
+    if not names:
+        return empty_node()
+
     template = """
     def {func_name}({args}):
         nonlocal {vars}

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -28,6 +28,18 @@ def loss_fn(x, lable):
     return loss
 
 
+def dyfunc_empty_nonlocal(x):
+    flag = True
+    if flag:
+        print("It's a test for empty nonlocal stmt")
+
+    if paddle.mean(x) < 0:
+        x + 1
+
+    out = x * 2
+    return out
+
+
 def dyfunc_with_if_else(x_v, label=None):
     if fluid.layers.mean(x_v).numpy()[0] > 5:
         x_v = x_v - 1

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -73,6 +73,13 @@ class TestDygraphIfElse3(TestDygraphIfElse):
         self.dyfunc = dyfunc_with_if_else3
 
 
+class TestDygraphIfElse4(TestDygraphIfElse):
+
+    def setUp(self):
+        self.x = np.random.random([10, 16]).astype('float32')
+        self.dyfunc = dyfunc_empty_nonlocal
+
+
 class TestDygraphIfElseWithListGenerator(TestDygraphIfElse):
 
     def setUp(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[Dy2Stat] Enhance nonlocal machanism while nonlocal vars is empty.

修复了当if-else的body函数中nonlocal names为空时，AST语法解析错误的问题，原始报错信息如下：
```bash
  File "/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py", line 60, in transform
    self.visit(self.root)
  File "/usr/lib/python3.7/ast.py", line 271, in visit
    return visitor(node)
  File "/usr/lib/python3.7/ast.py", line 326, in generic_visit
    value = self.visit(value)
  File "/usr/lib/python3.7/ast.py", line 271, in visit
    return visitor(node)
  File "/usr/lib/python3.7/ast.py", line 326, in generic_visit
    value = self.visit(value)
  File "/usr/lib/python3.7/ast.py", line 271, in visit
    return visitor(node)
  File "/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py", line 65, in visit_If
    node, self.root)
  File "/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py", line 527, in transform_if_else
    import pdb;pdb.set_trace()
  File "/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py", line 85, in create_nonlocal_stmt_node
    return gast.parse(func_code).body[0]
  File "/workspace/env3.7/lib/python3.7/site-packages/paddle/utils/gast/gast.py", line 613, in parse
    return ast_to_gast(_ast.parse(*args, **kwargs))
  File "/usr/lib/python3.7/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)
  File "<unknown>", line 1
    nonlocal
            ^
SyntaxError: invalid syntax
```