### PR TITLE
fix squeeze2/unsqueeze2 unittest, *test=kunlun

### DIFF
--- a/python/paddle/fluid/tests/unittests/xpu/test_squeeze2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_squeeze2_op_xpu.py
@@ -38,6 +38,7 @@ class XPUTestSqueeze2Op(XPUOpTestWrapper):
 
         def setUp(self):
             self.op_type = "squeeze2"
+            self.__class__.op_type = "squeeze2"
             self.use_mkldnn = False
             self.init_dtype()
             self.init_test_case()

--- a/python/paddle/fluid/tests/unittests/xpu/test_unsqueeze2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_unsqueeze2_op_xpu.py
@@ -39,6 +39,7 @@ class XPUTestUnsqueeze2Op(XPUOpTestWrapper):
 
         def setUp(self):
             self.op_type = "unsqueeze2"
+            self.__class__.op_type = "unsqueeze2"
             self.use_mkldnn = False
             self.init_dtype()
             self.init_test_case()
@@ -117,6 +118,7 @@ class XPUTestUnsqueeze2Op(XPUOpTestWrapper):
 
         def setUp(self):
             self.op_type = "unsqueeze2"
+            self.__class__.op_type = "unsqueeze2"
             self.use_mkldnn = False
             self.init_dtype()
             self.init_test_case()
@@ -191,6 +193,7 @@ class XPUTestUnsqueeze2Op(XPUOpTestWrapper):
 
         def setUp(self):
             self.op_type = "unsqueeze2"
+            self.__class__.op_type = "unsqueeze2"
             self.use_mkldnn = False
             self.init_test_case()
             self.init_dtype()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
fix KL2 squeeze/unsqueeze unittest issue
