### PR TITLE
[CINN] Emergency Fix for Paddle-CINN CI Problem

### DIFF
--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -171,4 +171,9 @@ RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
     ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache && \
     cd ../ && rm -rf ccache-3.7.9 ccache-3.7.9.tar.gz
 
+# clang+llvm 3.8.0
+RUN wget https://paddle-ci.cdn.bcebos.com/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \ 
+    tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cd clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && \
+    cp -r * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
+
 EXPOSE 22

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -174,6 +174,6 @@ RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
 # clang+llvm 3.8.0
 RUN wget https://paddle-ci.cdn.bcebos.com/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \ 
     tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cd clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && \
-    cp -r * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
+    cp -rn * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
 
 EXPOSE 22


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The paddle-cinn failed recently and block all PRs from merging. We found the key error reason from the log:

![b207bbfd3ebfabb2141a88b85241420b](https://user-images.githubusercontent.com/7913861/175882664-4dd14059-b716-44c4-a975-528de17ace46.png)

The CI environment didn't contain llvm.

We then debug and found https://github.com/PaddlePaddle/Paddle/pull/43534 deleted the llvm due to clang-format upgrade:
![f9d07b8e3c2b2cba7a790716961d98cf](https://user-images.githubusercontent.com/7913861/175883020-1a29c538-e511-4ada-a899-9b3ced3c0ae2.png)

So this PR added the llvm back. However, `clang-llvm-3.8.0` contains `clang-format-3.8`, so we modified the old command `cp -r` to `cp -rn`, which could ignore the installed `clang-format-13`
