### PR TITLE
[Dy2Stat]Enhance Python if-else by pruning usless no_return variable

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_return.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_return.py
@@ -201,6 +201,28 @@ def test_return_without_paddle_cond(x):
     return y
 
 
+def two_value(x):
+    return x * 2, x + 1
+
+
+def diff_return_hepler(x):
+    if False:
+        y = x + 1
+        z = x - 1
+        return y, z
+    else:
+        return two_value(x)
+
+
+@to_static
+def test_diff_return(x):
+    x = paddle.to_tensor(x)
+    y, z = diff_return_hepler(x)
+    if y.shape[0] > 1:
+        y = y + 1
+    return y, z
+
+
 class TestReturnBase(unittest.TestCase):
 
     def setUp(self):
@@ -253,6 +275,12 @@ class TestReturnIf(TestReturnBase):
 
     def init_dygraph_func(self):
         self.dygraph_func = test_return_if
+
+
+class TestReturnIfDiff(TestReturnBase):
+
+    def init_dygraph_func(self):
+        self.dygraph_func = test_diff_return
 
 
 class TestReturnIfElse(TestReturnBase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

### What's New?
优化了在执行 Python if-else后未正确移除框架中的 NO_RETURN_VAR 的逻辑。

### 后续优化

 长期来看，我们不应该支持变长的提前return。虽然Python是支持控制流中可以分别返回不同长度的变量，但是在深度学习框架中，是要求每个true_branch 和 false_branch 返回相同的structure。

从普适性和鲁棒性上来看，在代码转写时不需要对变长的return语句做padding处理的。在执行期间，如果是不依赖控制流的非控制流IF，只需要保持和Python一致的执行即可。如果是依赖控制流的控制流IF，则执行期间需要添加强检查，并抛出详尽的报错信息。