### PR TITLE
pr file count is greater than 30 need to run all cases

### DIFF
--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -125,12 +125,16 @@ class PRChecker(object):
         """ Get files in pull request. """
         page = 0
         file_dict = {}
+        file_count = 0
         while True:
             files = self.pr.get_files().get_page(page)
             if not files:
                 break
             for f in files:
                 file_dict[PADDLE_ROOT + f.filename] = f.status
+                file_count += 1
+            if file_count == 30:  #if pr file count = 31, nend to run all case
+                break
             page += 1
         print("pr modify files: %s" % file_dict)
         return file_dict
@@ -282,6 +286,8 @@ class PRChecker(object):
         filterFiles = []
         file_list = []
         file_dict = self.get_pr_files()
+        if len(file_dict) == 30:  #if pr file count = 31, nend to run all case
+            return ''
         for filename in file_dict:
             if filename.startswith(PADDLE_ROOT + 'python/'):
                 file_list.append(filename)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
当PR修改的文件个数大于30个，无需继续做精准测试的检查，需要跑全量case。
原因是当修改文件个数很多时，需要访问GitHub API来判断哪些文件是修改，而这个过程是漫长的：
![image](https://user-images.githubusercontent.com/22937122/176125167-319d707b-2908-4251-908d-10a532f82ac9.png)
[PR 43776](https://github.com/PaddlePaddle/Paddle/pull/43776) 修改了2786个文件，耗时5个小时。