### PR TITLE
Remove boost::variant for FetchResultType

### DIFF
--- a/paddle/fluid/framework/details/async_ssa_graph_executor.cc
+++ b/paddle/fluid/framework/details/async_ssa_graph_executor.cc
@@ -174,7 +174,7 @@ FetchResultType AsyncSSAGraphExecutor::Run(
   HandleException();
 
   FetchList ret;
-  auto &val = boost::get<FetchList>(fetch_data);
+  auto &val = BOOST_GET(FetchList, fetch_data);
   for (size_t fetch_idx = 0; fetch_idx < fetch_tensors.size(); ++fetch_idx) {
     if (data_is_lod_tensor(val.at(fetch_idx))) {
       std::vector<const LoDTensor *> lodtensor_ptrs;

--- a/paddle/fluid/framework/details/fetch_async_op_handle.cc
+++ b/paddle/fluid/framework/details/fetch_async_op_handle.cc
@@ -228,7 +228,7 @@ void FetchAsyncOpHandle::RunImpl() {
   }
 
   if (return_merged_) {
-    auto &val = boost::get<FetchList>(*data_);
+    auto &val = BOOST_GET(FetchList, *data_);
     if (src_vars[0]->IsType<LoDTensor>()) {
       // to lodtensor type
       std::vector<const LoDTensor *> src_lodtensors;
@@ -263,7 +263,7 @@ void FetchAsyncOpHandle::RunImpl() {
       val.at(offset_) = std::move(dst_lodtensor_array);
     }
   } else {
-    auto &val = boost::get<FetchUnmergedList>(*data_);
+    auto &val = BOOST_GET(FetchUnmergedList, *data_);
     auto &dst_tensors = val.at(offset_);
     dst_tensors.reserve(src_vars.size());
 

--- a/paddle/fluid/framework/details/fetch_op_handle.cc
+++ b/paddle/fluid/framework/details/fetch_op_handle.cc
@@ -84,7 +84,7 @@ void FetchOpHandle::WaitAndMergeCPUFetchVars() const {
       for (auto &t : tensors_) {
         tensors_ptr.emplace_back(&BOOST_GET_CONST(LoDTensor, t));
       }
-      auto &val = boost::get<FetchList>(*data_);
+      auto &val = BOOST_GET(FetchList, *data_);
       LoDTensor var;
       MergeLoDTensor(&var, tensors_ptr, platform::CPUPlace());
       val.at(offset_) = std::move(var);
@@ -106,11 +106,11 @@ void FetchOpHandle::WaitAndMergeCPUFetchVars() const {
         tmp_array.emplace_back();
         MergeLoDTensor(&(tmp_array.back()), tensors_ptr, platform::CPUPlace());
       }
-      auto &val = boost::get<FetchList>(*data_);
+      auto &val = BOOST_GET(FetchList, *data_);
       val.at(offset_) = std::move(tmp_array);
     }
   } else {
-    auto &val = boost::get<FetchUnmergedList>(*data_);
+    auto &val = BOOST_GET(FetchUnmergedList, *data_);
     val.at(offset_) = std::move(tensors_);
   }
 }

--- a/paddle/fluid/framework/details/parallel_ssa_graph_executor.cc
+++ b/paddle/fluid/framework/details/parallel_ssa_graph_executor.cc
@@ -278,7 +278,8 @@ FetchResultType ParallelSSAGraphExecutor::Run(
         if (!is_valid[scope_idx]) {
           continue;
         }
-        const auto &fetch_list = boost::get<FetchList>(fetch_data[scope_idx]);
+        const auto &fetch_list =
+            BOOST_GET_CONST(FetchList, fetch_data[scope_idx]);
         if (data_is_lod_tensor(fetch_list[fetch_idx])) {
           lodtensor_ptrs.push_back(
               &(BOOST_GET_CONST(LoDTensor, fetch_list[fetch_idx])));
@@ -317,7 +318,7 @@ FetchResultType ParallelSSAGraphExecutor::Run(
           continue;
         }
         const auto &fetch_list =
-            boost::get<FetchUnmergedList>(fetch_data[scope_idx]);
+            BOOST_GET_CONST(FetchUnmergedList, fetch_data[scope_idx]);
         PADDLE_ENFORCE_EQ(
             fetch_list[fetch_idx].size(),
             1,

--- a/paddle/fluid/framework/feed_fetch_type.h
+++ b/paddle/fluid/framework/feed_fetch_type.h
@@ -30,7 +30,7 @@ using FetchType = paddle::variant<LoDTensor, LoDTensorArray, framework::Vocab>;
 using FetchList = std::vector<FetchType>;
 
 using FetchUnmergedList = std::vector<std::vector<FetchType>>;
-using FetchResultType = boost::variant<FetchList, FetchUnmergedList>;
+using FetchResultType = paddle::variant<FetchList, FetchUnmergedList>;
 
 inline bool data_is_lod_tensor(const FetchType &data) {
   if (data.type() == typeid(LoDTensor)) {

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -89,8 +89,8 @@ class ParallelExecutor {
   void FeedAndSplitTensorIntoLocalScopes(
       const std::unordered_map<std::string, LoDTensor> &tensors);
 
-  FetchResultType Run(const std::vector<std::string> &fetch_tensors,
-                      bool return_merged = true);
+  FetchUnmergedList Run(const std::vector<std::string> &fetch_tensors);
+  FetchList RunAndMerge(const std::vector<std::string> &fetch_tensors);
 
   void RunWithoutFetch(const std::vector<std::string> &skip_eager_vars);
 
@@ -125,6 +125,8 @@ class ParallelExecutor {
       const std::vector<Scope *> &local_scopes, bool create_new);
 
   std::vector<ir::Graph *> CloneGraphToMultiDevices(ir::Graph *graph);
+
+  void PreludeToRun(const std::vector<std::string> &fetch_tensors);
 
   void PrepareNCCLCommunicator(Scope *global_scope);
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -4606,16 +4606,18 @@ All parameter, weight, gradient are variables in Paddle.
               const std::vector<std::string> &fetch_tensors,
               bool return_merged) -> py::object {
              if (return_merged) {
-               pybind11::gil_scoped_release release;
-               paddle::framework::FetchList ret =
-                   self.RunAndMerge(fetch_tensors);
-
+               paddle::framework::FetchList ret;
+               /*gil_scoped_release*/ {
+                 pybind11::gil_scoped_release release;
+                 ret = self.RunAndMerge(fetch_tensors);
+               }
                return py::cast(std::move(ret));
              } else {
-               pybind11::gil_scoped_release release;
-               paddle::framework::FetchUnmergedList ret =
-                   self.Run(fetch_tensors);
-
+               paddle::framework::FetchUnmergedList ret;
+               /*gil_scoped_release*/ {
+                 pybind11::gil_scoped_release release;
+                 ret = self.Run(fetch_tensors);
+               }
                return py::cast(std::move(ret));
              }
            })


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
为绕开PR #43100 中遇到的将FetchResultType由boost::variant替换成paddle::variant后触发Windows平台installation_validate错误问题，将ParalleExecutor的run接口改造成不返回FetchResultType。
改造前：
```C++
using FetchResultType = boost::variant<FetchList, FetchUnmergedList>;
FetchResultType Run(const std::vector<std::string> &fetch_tensors,
                      bool return_merged = true);
```
改造后：
```C++
FetchUnmergedList Run(const std::vector<std::string> &fetch_tensors);
FetchList RunAndMerge(const std::vector<std::string> &fetch_tensors);
```

同时将FetchResultType由boost::variant替换成paddle::variant。