### PR TITLE
fix compiling error in cuda 11.6 windows

### DIFF
--- a/cmake/external/cub.cmake
+++ b/cmake/external/cub.cmake
@@ -23,7 +23,15 @@ set(CUB_PATH
 set(CUB_PREFIX_DIR ${CUB_PATH})
 
 set(CUB_REPOSITORY ${GIT_URL}/NVlabs/cub.git)
-set(CUB_TAG 1.8.0)
+
+if(WIN32 AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6)
+  # cuda_11.6.2_511.65‘s own cub is 1.15.0, which will cause compiling error in windows.
+  set(CUB_TAG 1.16.0)
+  # cub 1.16.0 is not compitable with current thrust version
+  add_definitions(-DTHRUST_IGNORE_CUB_VERSION_CHECK)
+else()
+  set(CUB_TAG 1.8.0)
+endif()
 
 set(CUB_INCLUDE_DIR ${CUB_PREFIX_DIR}/src/extern_cub)
 message("CUB_INCLUDE_DIR is ${CUB_INCLUDE_DIR}")

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -327,7 +327,8 @@ if(WITH_ONNXRUNTIME)
 endif()
 
 if(WITH_GPU)
-  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0)
+  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0 OR ${CMAKE_CUDA_COMPILER_VERSION}
+                                                 GREATER_EQUAL 11.6)
     include(external/cub) # download cub
     list(APPEND third_party_deps extern_cub)
   endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The original cub in cuda11.6 is cub 1.15.0, which has bug as follows:
![image](https://user-images.githubusercontent.com/51314274/176370118-f118f9be-bf5e-4e2a-9229-7d183c7d9689.png)

This problem can be found in NVIDIA [forum](https://forums.developer.nvidia.com/t/c-and-cuda/5521), and has been fixed in PR #[423](https://github.com/NVIDIA/cub/pull/423) (which landed in CUB 1.16.0).  So use cub 1.16.0 when cuda version greater_equal 11.6. 

Another problem happened after this set because of thrust and cub version not compitable, so add definition just as the cuda error says.
<img width="972" alt="image" src="https://user-images.githubusercontent.com/51314274/176381976-c44c3587-a3be-4b4c-9bc8-aeca5e697e64.png">
