### PR TITLE
modify graph_pattern to thread_local

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -29,6 +29,12 @@ using string::Style;
 
 size_t PDPattern::id_ = 0UL;
 
+#ifdef PADDLE_WITH_CUDA
+namespace patterns {
+thread_local std::unordered_map<std::string, size_t> KeyCounter::dic_;
+}
+#endif
+
 PDNode *PDPattern::NewNode(const std::string &name) {
   if (!name.empty()) {
     PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -29,7 +29,7 @@ using string::Style;
 
 size_t PDPattern::id_ = 0UL;
 
-#ifdef PADDLE_WITH_CUDA
+#ifdef PADDLE_WITH_TENSORRT
 namespace patterns {
 thread_local std::unordered_map<std::string, size_t> KeyCounter::dic_;
 }

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -406,7 +406,7 @@ struct KeyCounter {
     return x;
   }
 
-#ifdef PADDLE_WITH_CUDA
+#ifdef PADDLE_WITH_TENSORRT
   static int IncCounter(const std::string& key) { return dic_[key]++; }
   static void CleanCounter() { dic_.clear(); }
 

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -406,10 +406,18 @@ struct KeyCounter {
     return x;
   }
 
+#ifdef PADDLE_WITH_CUDA
+  static int IncCounter(const std::string& key) { return dic_[key]++; }
+  static void CleanCounter() { dic_.clear(); }
+
+ private:
+  static thread_local std::unordered_map<std::string, size_t> dic_;
+#else
   int IncCounter(const std::string& key) { return dic_[key]++; }
 
  private:
   std::unordered_map<std::string, size_t> dic_;
+#endif
 };
 
 // Generate a unique PDNode's name with name_scope and id.

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1360,7 +1360,7 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
   config.SetInValid();
   auto predictor_p = dynamic_cast<AnalysisPredictor *>(predictor.get());
 
-#ifdef PADDLE_WITH_CUDA
+#ifdef PADDLE_WITH_TENSORRT
   paddle::framework::ir::patterns::KeyCounter::Instance().CleanCounter();
 #endif
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1360,6 +1360,10 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
   config.SetInValid();
   auto predictor_p = dynamic_cast<AnalysisPredictor *>(predictor.get());
 
+#ifdef PADDLE_WITH_CUDA
+  paddle::framework::ir::patterns::KeyCounter::Instance().CleanCounter();
+#endif
+
   if (!predictor_p->Init(nullptr)) {
     return nullptr;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
由于 graph pattern 是进程共享的单例，导致同一个进程中的不同 predictor 的 pass 编号互相影响，同一模型初始化顺序不同，pass 创建的 var name 不同，trt 序列化的 key 不同，无法复用。

将进程共享的单例改为 thread local，但部分平台可能不支持，先支持 gpu 合入