### PR TITLE
modify graph_pattern to thread_local

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -28,10 +28,17 @@ using string::Style;
 
 size_t PDPattern::id_ = 0UL;
 
+#ifdef PADDLE_WITH_TENSORRT
+namespace patterns {
+thread_local std::unordered_map<std::string, size_t> KeyCounter::dic_;
+}
+#endif
+
 PDNode *PDPattern::NewNode(const std::string &name) {
   if (!name.empty()) {
     PADDLE_ENFORCE_EQ(
-        node_map_.count(name), 0UL,
+        node_map_.count(name),
+        0UL,
         platform::errors::PreconditionNotMet(
             "PDNode's name should be unique, get duplicate [%s]", name));
   }
@@ -45,7 +52,8 @@ PDNode *PDPattern::NewNode(const std::string &name) {
 PDNode *PDPattern::NewNode(PDNode::teller_t &&teller, const std::string &name) {
   if (!name.empty()) {
     PADDLE_ENFORCE_EQ(
-        node_map_.count(name), 0UL,
+        node_map_.count(name),
+        0UL,
         platform::errors::PreconditionNotMet(
             "PDNode's name should be unique, get duplicate [%s]", name));
   }
@@ -70,8 +78,10 @@ void PDPattern::AddEdge(PDNode *a, PDNode *b) {
       a, platform::errors::NotFound("PDNode %s is not found.", a->name()));
   PADDLE_ENFORCE_NOT_NULL(
       b, platform::errors::NotFound("PDNode %s is not found.", b->name()));
-  PADDLE_ENFORCE_NE(a, b, platform::errors::PermissionDenied(
-                              "Cannot connect the same node in the graph."));
+  PADDLE_ENFORCE_NE(a,
+                    b,
+                    platform::errors::PermissionDenied(
+                        "Cannot connect the same node in the graph."));
   edges_.emplace_back(a, b);
 }
 
@@ -128,7 +138,8 @@ void GraphPatternDetector::ValidateByNodeRole(
 
   subgraphs->erase(
       std::remove_if(
-          subgraphs->begin(), subgraphs->end(),
+          subgraphs->begin(),
+          subgraphs->end(),
           [](const GraphPatternDetector::subgraph_t &subgraph) -> bool {
             // Collect the inputs and outputs.
             std::set<Node *> ios;
@@ -310,7 +321,8 @@ void GraphPatternDetector::SortSubgraphs(
   }
 
   std::sort(
-      subgraphs->begin(), subgraphs->end(),
+      subgraphs->begin(),
+      subgraphs->end(),
       [](const GraphPatternDetector::subgraph_t &a,
          const GraphPatternDetector::subgraph_t &b) {
         for (auto &item : a) {
@@ -438,7 +450,8 @@ PDNode *PDNode::assert_is_persistable_var() {
 }
 
 PDNode *PDNode::assert_is_op_nth_input(const std::string &op_type,
-                                       const std::string &argument, int nth) {
+                                       const std::string &argument,
+                                       int nth) {
   assert_is_var();
   assert_is_op_input(op_type);
   asserts_.emplace_back([=](Node *x) {
@@ -453,7 +466,8 @@ PDNode *PDNode::assert_is_op_nth_input(const std::string &op_type,
 }
 
 PDNode *PDNode::assert_is_op_nth_output(const std::string &op_type,
-                                        const std::string &argument, int nth) {
+                                        const std::string &argument,
+                                        int nth) {
   assert_is_var();
   asserts_.emplace_back([=](Node *x) {
     for (auto *op : x->inputs) {
@@ -580,7 +594,8 @@ PDNode *PDNode::assert_is_ops(const std::unordered_set<std::string> &op_types) {
 
 PDNode *PDNode::assert_is_ops_nth_input(
     const std::unordered_set<std::string> &op_types,
-    const std::string &argument, int nth) {
+    const std::string &argument,
+    int nth) {
   assert_is_var();
   assert_is_ops_input(op_types);
   asserts_.emplace_back([=](Node *x) {
@@ -596,7 +611,8 @@ PDNode *PDNode::assert_is_ops_nth_input(
 
 PDNode *PDNode::assert_is_ops_nth_output(
     const std::unordered_set<std::string> &op_types,
-    const std::string &argument, int nth) {
+    const std::string &argument,
+    int nth) {
   assert_is_var();
   asserts_.emplace_back([=](Node *x) {
     for (auto *op : x->inputs) {
@@ -693,11 +709,13 @@ bool VarLinksToOp(Node *node, const std::string &op_type) {
 
 bool IsNthInput(Node *var, Node *op, const std::string &argument, size_t nth) {
   PADDLE_ENFORCE_EQ(
-      var->IsVar(), true,
+      var->IsVar(),
+      true,
       platform::errors::InvalidArgument(
           "First parameter of function IsNthInput must be Node::Var"));
   PADDLE_ENFORCE_EQ(
-      op->IsOp(), true,
+      op->IsOp(),
+      true,
       platform::errors::InvalidArgument(
           "Second parameter of function IsNthInput must be Node::Op"));
   if (!HasInput(op, argument) || op->Op()->Input(argument).size() <= nth)
@@ -707,7 +725,8 @@ bool IsNthInput(Node *var, Node *op, const std::string &argument, size_t nth) {
 
 bool HasInput(Node *op, const std::string &argument) {
   PADDLE_ENFORCE_EQ(
-      op->IsOp(), true,
+      op->IsOp(),
+      true,
       platform::errors::InvalidArgument(
           "First parameter of function HasInput must be Node::Op"));
   auto const &names = op->Op()->InputNames();
@@ -718,7 +737,8 @@ bool HasInput(Node *op, const std::string &argument) {
 
 bool HasOutput(Node *op, const std::string &argument) {
   PADDLE_ENFORCE_EQ(
-      op->IsOp(), true,
+      op->IsOp(),
+      true,
       platform::errors::InvalidArgument(
           "First parameter of function HasOuput must be Node::Op"));
   auto const &names = op->Op()->OutputNames();
@@ -729,11 +749,13 @@ bool HasOutput(Node *op, const std::string &argument) {
 
 bool IsNthOutput(Node *var, Node *op, const std::string &argument, size_t nth) {
   PADDLE_ENFORCE_EQ(
-      var->IsVar(), true,
+      var->IsVar(),
+      true,
       platform::errors::InvalidArgument(
           "First parameter of function IsNthOutput must be Node::Var"));
   PADDLE_ENFORCE_EQ(
-      op->IsOp(), true,
+      op->IsOp(),
+      true,
       platform::errors::InvalidArgument(
           "Second parameter of function IsNthOutput must be Node::Op"));
   if (!HasOutput(op, argument) || op->Op()->Output(argument).size() <= nth)
@@ -875,22 +897,35 @@ PDNode *patterns::ConvBN::operator()(paddle::framework::ir::PDNode *conv_input,
     eltwise_op->LinksFrom({conv_out_var, eltwise_y_in_var})
         .LinksTo({eltwise_out_var});
     batch_norm_op
-        ->LinksFrom({eltwise_out_var, bn_scale_var, bn_bias_var, bn_mean_var,
+        ->LinksFrom({eltwise_out_var,
+                     bn_scale_var,
+                     bn_bias_var,
+                     bn_mean_var,
                      bn_variance_var})
-        .LinksTo({bn_out_var, bn_mean_out_var, bn_variance_out_var,
-                  bn_saved_mean_var, bn_saved_variance_var});
+        .LinksTo({bn_out_var,
+                  bn_mean_out_var,
+                  bn_variance_out_var,
+                  bn_saved_mean_var,
+                  bn_saved_variance_var});
   } else {
     batch_norm_op
-        ->LinksFrom({conv_out_var, bn_scale_var, bn_bias_var, bn_mean_var,
+        ->LinksFrom({conv_out_var,
+                     bn_scale_var,
+                     bn_bias_var,
+                     bn_mean_var,
                      bn_variance_var})
-        .LinksTo({bn_out_var, bn_mean_out_var, bn_variance_out_var,
-                  bn_saved_mean_var, bn_saved_variance_var});
+        .LinksTo({bn_out_var,
+                  bn_mean_out_var,
+                  bn_variance_out_var,
+                  bn_saved_mean_var,
+                  bn_saved_variance_var});
   }
   return bn_out_var;
 }
 
 PDNode *patterns::ConvActivation::operator()(
-    paddle::framework::ir::PDNode *conv_input, std::string conv_type,
+    paddle::framework::ir::PDNode *conv_input,
+    std::string conv_type,
     std::string activation_type) {
   // Create Operators
   conv_input->assert_is_op_input(conv_type, "Input");
@@ -920,7 +955,8 @@ PDNode *patterns::ConvActivation::operator()(
 
 PDNode *patterns::ElementwiseActivation::operator()(
     paddle::framework::ir::PDNode *elementwise_a,
-    const std::string &elementwise_type, const std::string &activation_type) {
+    const std::string &elementwise_type,
+    const std::string &activation_type) {
   // Create Operators
   elementwise_a->assert_is_op_input(elementwise_type, "X");
   auto *elementwise_op =
@@ -995,7 +1031,8 @@ PDNode *patterns::SeqConvEltAddRelu::operator()(
 }
 
 PDNode *patterns::FC::operator()(paddle::framework::ir::PDNode *x,
-                                 bool with_bias, bool with_relu) {
+                                 bool with_bias,
+                                 bool with_relu) {
   // Create shared nodes.
   x->assert_is_op_input("mul", "X");
   auto *mul = pattern->NewNode(mul_repr())->assert_is_op("mul");
@@ -1261,8 +1298,12 @@ PDNode *patterns::BatchNormAct::operator()(
 
   bn->LinksFrom(
         {bn_x_var, bn_scale_var, bn_bias_var, bn_variance_var, bn_mean_var})
-      .LinksTo({bn_mean_out_var, bn_variance_out_var, bn_saved_variance_var,
-                bn_saved_mean_var, bn_reserve_space, bn_out_var});
+      .LinksTo({bn_mean_out_var,
+                bn_variance_out_var,
+                bn_saved_variance_var,
+                bn_saved_mean_var,
+                bn_reserve_space,
+                bn_out_var});
   act->LinksFrom({bn_out_var}).LinksTo({act_out_var});
 
   return act_out_var;
@@ -1319,8 +1360,13 @@ PDNode *patterns::BatchNormActGrad::operator()(
       .LinksTo({d_intermediate_var});
 
   bn_grad
-      ->LinksFrom({bn_x_var, d_intermediate_var, bn_scale_var, bn_bias_var,
-                   bn_saved_mean_var, bn_saved_variance_var, bn_reserve_space})
+      ->LinksFrom({bn_x_var,
+                   d_intermediate_var,
+                   bn_scale_var,
+                   bn_bias_var,
+                   bn_saved_mean_var,
+                   bn_saved_variance_var,
+                   bn_reserve_space})
       .LinksTo({d_bn_x_var, d_bn_scale_var, d_bn_bias_var});
 
   return bn_grad;
@@ -1404,8 +1450,12 @@ PDNode *patterns::BatchNormAddAct::operator()(
       pattern->NewNode(act_out_repr())->assert_is_ops_output(act_types, "Out");
 
   bn->LinksFrom({bn_x_var, bn_scale_var, bn_bias_var})
-      .LinksTo({bn_mean_out_var, bn_variance_out_var, bn_saved_variance_var,
-                bn_saved_mean_var, bn_reserve_space, bn_out_var});
+      .LinksTo({bn_mean_out_var,
+                bn_variance_out_var,
+                bn_saved_variance_var,
+                bn_saved_mean_var,
+                bn_reserve_space,
+                bn_out_var});
   elewise_add->LinksFrom({elewise_add_in_var, bn_out_var})
       .LinksTo({elewise_add_out_var});
   act->LinksFrom({elewise_add_out_var}).LinksTo({act_out_var});
@@ -1484,8 +1534,13 @@ PDNode *patterns::BatchNormAddActGrad::operator()(
       .LinksTo({d_elewise_add_in_var, d_bn_out_var});
 
   bn_grad
-      ->LinksFrom({bn_x_var, d_bn_out_var, bn_scale_var, bn_bias_var,
-                   bn_saved_mean_var, bn_saved_variance_var, bn_reserve_space})
+      ->LinksFrom({bn_x_var,
+                   d_bn_out_var,
+                   bn_scale_var,
+                   bn_bias_var,
+                   bn_saved_mean_var,
+                   bn_saved_variance_var,
+                   bn_reserve_space})
       .LinksTo({d_bn_x_var, d_bn_scale_var, d_bn_bias_var});
 
   return bn_grad;
@@ -1558,7 +1613,8 @@ PDNode *patterns::ElewiseAddAct::operator()(
 
 PDNode *patterns::LinearAct::operator()(
     paddle::framework::ir::PDNode *linear_x_var,
-    const std::unordered_set<std::string> &act_types, bool with_grad_link,
+    const std::unordered_set<std::string> &act_types,
+    bool with_grad_link,
     bool is_act_grad_x_from_act) {
   auto *matmul_w_var =
       pattern->NewNode(matmul_w_repr())->assert_is_op_input("matmul_v2", "Y");
@@ -1621,7 +1677,8 @@ PDNode *patterns::LinearAct::operator()(
 PDNode *patterns::ElewiseAddMatmulAct::operator()(
     paddle::framework::ir::PDNode *dout_var,
     const std::unordered_set<std::string> &act_grad_types,
-    bool without_x_gradient, bool is_act_grad_x_from_act) {
+    bool without_x_gradient,
+    bool is_act_grad_x_from_act) {
   auto *ele_grad_bias_var =
       pattern->NewNode(ele_grad_bias_repr())
           ->assert_is_op_input("elementwise_add_grad", "Y");
@@ -2052,7 +2109,8 @@ PDNode *patterns::Pool::operator()() {
   return output_var;
 }
 
-PDNode *patterns::Elementwise::operator()(PDNode *x_var, PDNode *y_var,
+PDNode *patterns::Elementwise::operator()(PDNode *x_var,
+                                          PDNode *y_var,
                                           const std::string elementwise_type) {
   auto elementwise_op =
       pattern->NewNode(elementwise_op_repr())->assert_is_op(elementwise_type);
@@ -2084,7 +2142,9 @@ PDNode *patterns::ElementwiseOp::operator()(
 }
 
 PDNode *patterns::ResidualElementwise::operator()(
-    PDNode *op_var, PDNode *residual_var, const std::string elementwise_type,
+    PDNode *op_var,
+    PDNode *residual_var,
+    const std::string elementwise_type,
     bool as_x) {
   auto elementwise_op =
       pattern->NewNode(elementwise_op_repr())->assert_is_op(elementwise_type);
@@ -3065,7 +3125,8 @@ void patterns::DeleteQuantDequantLinearOpPattern::operator()() {
 }
 
 PDNode *patterns::ReshapeTransposeMatmulPattern::operator()(
-    const std::string &op_name, bool with_reshape_xshape,
+    const std::string &op_name,
+    bool with_reshape_xshape,
     bool with_transpose_xshape) {
   auto reshape_op =
       pattern->NewNode(reshape_op_repr())->assert_is_op("reshape2");
@@ -3098,11 +3159,10 @@ PDNode *patterns::ReshapeTransposeMatmulPattern::operator()(
     transpose_out->assert_is_only_output_of_op("transpose2");
 
   auto transpose_xshape =
-      with_transpose_xshape
-          ? pattern->NewNode(transpose_xshape_repr())
-                ->AsIntermediate()
-                ->assert_is_op_output("transpose2", "XShape")
-          : nullptr;
+      with_transpose_xshape ? pattern->NewNode(transpose_xshape_repr())
+                                  ->AsIntermediate()
+                                  ->assert_is_op_output("transpose2", "XShape")
+                            : nullptr;
 
   auto matmul_out = pattern->NewNode(matmul_out_repr())
                         ->AsOutput()

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -122,10 +122,12 @@ struct PDNode {
   PDNode* assert_is_op_input(const std::string& op_type,
                              const std::string& argument);
   PDNode* assert_is_op_nth_input(const std::string& op_type,
-                                 const std::string& argument, int nth);
+                                 const std::string& argument,
+                                 int nth);
   PDNode* assert_is_not_op_input(const std::string& argument);
   PDNode* assert_is_op_nth_output(const std::string& op_type,
-                                  const std::string& argument, int nth);
+                                  const std::string& argument,
+                                  int nth);
   PDNode* assert_is_only_input_of_op(const std::string& op_type);
   PDNode* assert_is_only_output_of_op(const std::string& op_type);
   PDNode* assert_op_has_n_inputs(const std::string& op_type, size_t n);
@@ -138,13 +140,15 @@ struct PDNode {
                                const std::string& argument);
   PDNode* assert_is_ops_nth_input(
       const std::unordered_set<std::string>& op_types,
-      const std::string& argument, int nth);
+      const std::string& argument,
+      int nth);
   PDNode* assert_is_ops_input(const std::unordered_set<std::string>& op_types);
   PDNode* assert_is_ops_input(const std::unordered_set<std::string>& op_types,
                               const std::string& argument);
   PDNode* assert_is_ops_nth_output(
       const std::unordered_set<std::string>& op_types,
-      const std::string& argument, int nth);
+      const std::string& argument,
+      int nth);
 
   PDNode* assert_is_only_input_of_ops(
       const std::unordered_set<std::string>& op_types);
@@ -164,10 +168,13 @@ struct PDNode {
   }
 
  private:
-  PDNode(PDPattern* pattern, const std::string& name = "",
+  PDNode(PDPattern* pattern,
+         const std::string& name = "",
          Type type = Type::kVar)
       : pattern_(pattern), name_(name), type_(type) {}
-  PDNode(teller_t&& teller, PDPattern* pattern, const std::string& name = "",
+  PDNode(teller_t&& teller,
+         PDPattern* pattern,
+         const std::string& name = "",
          Type type = Type::kVar)
       : teller_(std::move(teller)),
         pattern_(pattern),
@@ -398,16 +405,25 @@ struct KeyCounter {
     return x;
   }
 
+#ifdef PADDLE_WITH_TENSORRT
+  static int IncCounter(const std::string& key) { return dic_[key]++; }
+  static void CleanCounter() { dic_.clear(); }
+
+ private:
+  static thread_local std::unordered_map<std::string, size_t> dic_;
+#else
   int IncCounter(const std::string& key) { return dic_[key]++; }
 
  private:
   std::unordered_map<std::string, size_t> dic_;
+#endif
 };
 
 // Generate a unique PDNode's name with name_scope and id.
 // The format is {name_scope}/{repr}/{id}/{name}
 static std::string PDNodeName(const std::string& name_scope,
-                              const std::string& repr, size_t id,
+                              const std::string& repr,
+                              size_t id,
                               const std::string& name) {
   return string::Sprintf("%s/%s/%d/%s", name_scope, repr, id, name);
 }
@@ -415,15 +431,15 @@ static std::string PDNodeName(const std::string& name_scope,
 // The format is {name_scope}/{repr}/{id}
 static std::string PDNodeName(const std::string& name_scope,
                               const std::string& repr) {
-  return string::Sprintf("%s/%s/%d", name_scope, repr,
-                         KeyCounter::Instance().IncCounter(repr));
+  return string::Sprintf(
+      "%s/%s/%d", name_scope, repr, KeyCounter::Instance().IncCounter(repr));
 }
 // Generate a unique key. It can be used for a universally unique temporary
 // name.
 // The format is {repr}/{id}
 static std::string UniqueKey(const std::string& repr) {
-  return string::Sprintf("%s/%d", repr,
-                         KeyCounter::Instance().IncCounter(repr));
+  return string::Sprintf(
+      "%s/%d", repr, KeyCounter::Instance().IncCounter(repr));
 }
 
 // Declare a PDNode in a pattern, will create two methods:
@@ -440,17 +456,19 @@ static std::string UniqueKey(const std::string& repr) {
 // arg: the argument declared by PATTERN_DECL_NODE in a pattern definition.
 // pat: the pattern object.
 #define GET_IR_NODE_FROM_SUBGRAPH(var, arg, pat)                               \
-  PADDLE_ENFORCE_NE(subgraph.count(pat.arg##_n()), 0UL,                        \
+  PADDLE_ENFORCE_NE(subgraph.count(pat.arg##_n()),                             \
+                    0UL,                                                       \
                     platform::errors::NotFound("Node not found for PDNode %s", \
                                                pat.arg##_repr()));             \
   Node* var = subgraph.at(pat.arg##_n());                                      \
-  PADDLE_ENFORCE_NOT_NULL(                                                     \
-      var, platform::errors::NotFound("node %s not exists in the sub-graph",   \
-                                      #arg));
+  PADDLE_ENFORCE_NOT_NULL(var,                                                 \
+                          platform::errors::NotFound(                          \
+                              "node %s not exists in the sub-graph", #arg));
 
 // The base class of all the patterns.
 struct PatternBase {
-  PatternBase(PDPattern* pattern, const std::string& name_scope,
+  PatternBase(PDPattern* pattern,
+              const std::string& name_scope,
               const std::string& repr)
       : pattern(pattern),
         name_scope_(name_scope),
@@ -476,7 +494,8 @@ struct ConvBN : public PatternBase {
   ConvBN(PDPattern* pattern, const std::string& name_scope)
       : PatternBase(pattern, name_scope, "conv_bn") {}
 
-  PDNode* operator()(PDNode* conv_input, const std::string& conv_type,
+  PDNode* operator()(PDNode* conv_input,
+                     const std::string& conv_type,
                      bool with_eltwise_add);
 
   // declare operator node's name
@@ -514,7 +533,8 @@ struct ConvActivation : public PatternBase {
   ConvActivation(PDPattern* pattern, const std::string& name_scope)
       : PatternBase(pattern, name_scope, "conv_activation") {}
 
-  PDNode* operator()(PDNode* conv_input, std::string conv_type = "conv2d",
+  PDNode* operator()(PDNode* conv_input,
+                     std::string conv_type = "conv2d",
                      std::string activation_type = "relu");
 
   // declare operator node's name
@@ -536,7 +556,8 @@ struct ElementwiseActivation : public PatternBase {
   ElementwiseActivation(PDPattern* pattern, const std::string& name_scope)
       : PatternBase(pattern, name_scope, "elementwise_add_activation") {}
 
-  PDNode* operator()(PDNode* elementwise_a, const std::string& elementwise_type,
+  PDNode* operator()(PDNode* elementwise_a,
+                     const std::string& elementwise_type,
                      const std::string& activation_type);
 
   // declare operator node's name
@@ -936,7 +957,8 @@ struct LinearAct : public PatternBase {
 
   PDNode* operator()(PDNode* x,
                      const std::unordered_set<std::string>& act_types,
-                     bool with_grad_link, bool is_act_grad_x_from_act);
+                     bool with_grad_link,
+                     bool is_act_grad_x_from_act);
 
   // declare operator node's name
   PATTERN_DECL_NODE(matmul);
@@ -965,7 +987,8 @@ struct ElewiseAddMatmulAct : public PatternBase {
 
   PDNode* operator()(PDNode* x,
                      const std::unordered_set<std::string>& act_grad_types,
-                     bool without_x_gradient, bool is_act_grad_x_from_act);
+                     bool without_x_gradient,
+                     bool is_act_grad_x_from_act);
 
   // declare operator node's name
   PATTERN_DECL_NODE(ele_add_grad);
@@ -1062,7 +1085,8 @@ struct Elementwise : public PatternBase {
   Elementwise(PDPattern* pattern, const std::string& name_scope)
       : PatternBase(pattern, name_scope, "elementwise") {}
 
-  PDNode* operator()(PDNode* x_var, PDNode* y_var,
+  PDNode* operator()(PDNode* x_var,
+                     PDNode* y_var,
                      const std::string elementwise_type);
 
   PATTERN_DECL_NODE(elementwise_op);
@@ -1088,11 +1112,14 @@ struct ElementwiseOp : public PatternBase {
 // This pattern allows operator output to be X or Y
 // and residual data Y or X, based on as_x flag
 struct ResidualElementwise : public PatternBase {
-  ResidualElementwise(PDPattern* pattern, const std::string& name_scope,
+  ResidualElementwise(PDPattern* pattern,
+                      const std::string& name_scope,
                       bool as_x)
       : PatternBase(pattern, name_scope, "residual_elementwise") {}
-  PDNode* operator()(PDNode* op_var, PDNode* residual_var,
-                     const std::string elementwise_type, bool as_x);
+  PDNode* operator()(PDNode* op_var,
+                     PDNode* residual_var,
+                     const std::string elementwise_type,
+                     bool as_x);
 
   PATTERN_DECL_NODE(operator_output);
   PATTERN_DECL_NODE(residual_data);
@@ -1467,8 +1494,8 @@ struct ConvElementwiseaddAct : public PatternBase {
 // Conv + ElementwiseAdd + ElementwiseAdd + Activation
 struct ConvElementwiseadd2Act : public PatternBase {
   ConvElementwiseadd2Act(PDPattern* pattern, const std::string& name_scope)
-      : PatternBase(pattern, name_scope,
-                    "conv_elementwiseadd2_elementwiseadd_act") {}
+      : PatternBase(
+            pattern, name_scope, "conv_elementwiseadd2_elementwiseadd_act") {}
 
   PDNode* operator()(PDNode* conv_in);
 
@@ -1702,7 +1729,8 @@ struct DequantOpFuse : public PatternBase {
   DequantOpFuse(PDPattern* pattern, const std::string& name_scope)
       : PatternBase(pattern, name_scope, "dequant_fuse") {}
 
-  void operator()(PDNode* quant_op_input, const std::string& quantized_op_type,
+  void operator()(PDNode* quant_op_input,
+                  const std::string& quantized_op_type,
                   const std::string& dequant_type,
                   const std::string& weight_name);
 
@@ -1758,8 +1786,8 @@ struct DeleteQuantDequantOpPattern : public PatternBase {
 struct DeleteQuantDequantFilterOpPattern : public PatternBase {
   DeleteQuantDequantFilterOpPattern(PDPattern* pattern,
                                     const std::string& name_scope)
-      : PatternBase(pattern, name_scope,
-                    "delete_quantdequant_filter_op_pattern") {}
+      : PatternBase(
+            pattern, name_scope, "delete_quantdequant_filter_op_pattern") {}
 
   void operator()();
 
@@ -1773,7 +1801,8 @@ struct DeleteQuantDequantFilterOpPattern : public PatternBase {
 struct DeleteWeightQuantDequantLinearOpPattern : public PatternBase {
   DeleteWeightQuantDequantLinearOpPattern(PDPattern* pattern,
                                           const std::string& name_scope)
-      : PatternBase(pattern, name_scope,
+      : PatternBase(pattern,
+                    name_scope,
                     "delete_weight_quant_dequant_linear_op_pattern") {}
 
   void operator()();
@@ -1788,8 +1817,8 @@ struct DeleteWeightQuantDequantLinearOpPattern : public PatternBase {
 struct DeleteQuantDequantLinearOpPattern : public PatternBase {
   DeleteQuantDequantLinearOpPattern(PDPattern* pattern,
                                     const std::string& name_scope)
-      : PatternBase(pattern, name_scope,
-                    "delete_quant_dequant_linear_op_pattern") {}
+      : PatternBase(
+            pattern, name_scope, "delete_quant_dequant_linear_op_pattern") {}
 
   void operator()();
 
@@ -1814,7 +1843,8 @@ struct ReshapeTransposeMatmulPattern : public PatternBase {
                                 const std::string& name_scope)
       : PatternBase(pattern, name_scope, "reshape_transpose_matmul") {}
 
-  PDNode* operator()(const std::string& op_name, bool with_reshape_xshape,
+  PDNode* operator()(const std::string& op_name,
+                     bool with_reshape_xshape,
                      bool with_transpose_xshape);
 
   PATTERN_DECL_NODE(reshape_in);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
由于 graph pattern 是进程共享的单例，导致同一个进程中的不同 predictor 的 pass 编号互相影响，同一模型初始化顺序不同，pass 创建的 var name 不同，trt 序列化的 key 不同，无法复用。

将进程共享的单例改为 thread local，但部分平台可能不支持，先支持 gpu 合入