### PR TITLE
[Plugin] Fix Custom device in eager mode, test=develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,12 @@ endif()
 if(LINUX
    AND NOT WITH_CUSTOM_DEVICE
    AND NOT ON_INFER)
-  set(WITH_CUSTOM_DEVICE ON)
+  set(WITH_CUSTOM_DEVICE
+      ON
+      CACHE BOOL "Enable Custom Device when compiling for Linux" FORCE)
+  message(
+    "Enable Custom Device when compiling for Linux. Force WITH_CUSTOM_DEVICE=ON."
+  )
 endif()
 
 if(WIN32)

--- a/paddle/phi/core/tensor_utils.cc
+++ b/paddle/phi/core/tensor_utils.cc
@@ -54,6 +54,10 @@ void Copy(const Context& dev_ctx,
   } else if (paddle::platform::is_xpu_place(dst_place)) {
     dst_ptr = dev_ctx.Alloc(dst, src.dtype());
 #endif
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+  } else if (paddle::platform::is_custom_place(dst_place)) {
+    dst_ptr = dev_ctx.Alloc(dst, src.dtype());
+#endif
   }
 
   auto size = src.numel() * paddle::experimental::SizeOf(src.dtype());

--- a/python/paddle/fluid/tests/custom_kernel/CMakeLists.txt
+++ b/python/paddle/fluid/tests/custom_kernel/CMakeLists.txt
@@ -1,2 +1,15 @@
-py_test(test_custom_kernel_dot SRCS test_custom_kernel_dot.py)
-py_test(test_custom_kernel_load SRCS test_custom_kernel_load.py)
+file(
+  GLOB TEST_OPS
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+  "test_*.py")
+string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
+
+set(CUSTOM_ENVS
+    PADDLE_SOURCE_DIR=${PADDLE_SOURCE_DIR}
+    PADDLE_BINARY_DIR=${PADDLE_BINARY_DIR}
+    CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle/fluid/tests/custom_kernel
+)
+
+foreach(TEST_OP ${TEST_OPS})
+  py_test(${TEST_OP} SRCS ${TEST_OP}.py ENVS ${CUSTOM_ENVS})
+endforeach()

--- a/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_c_setup.py
+++ b/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_c_setup.py
@@ -48,8 +48,8 @@ paddle_custom_kernel_include = [
     os.path.join(site_packages_path, 'paddle', 'include'),
 ]
 # include path third_party
-compile_third_party_path = os.path.join(os.environ['PADDLE_ROOT'],
-                                        'build/third_party')
+compile_third_party_path = os.path.join(os.environ['PADDLE_BINARY_DIR'],
+                                        'third_party')
 paddle_custom_kernel_include += [
     os.path.join(compile_third_party_path, 'install/gflags/include'),  # gflags
     os.path.join(compile_third_party_path, 'install/glog/include'),  # glog

--- a/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_setup.py
+++ b/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_setup.py
@@ -50,8 +50,8 @@ paddle_custom_kernel_include = list(
         site_packages_path))
 
 # include path third_party
-compile_third_party_path = os.path.join(os.environ['PADDLE_ROOT'],
-                                        'build/third_party')
+compile_third_party_path = os.path.join(os.environ['PADDLE_BINARY_DIR'],
+                                        'third_party')
 paddle_custom_kernel_include += [
     os.path.join(compile_third_party_path, 'install/gflags/include'),  # gflags
     os.path.join(compile_third_party_path, 'install/glog/include'),  # glog

--- a/python/paddle/fluid/tests/custom_kernel/test_custom_kernel_dot.py
+++ b/python/paddle/fluid/tests/custom_kernel/test_custom_kernel_dot.py
@@ -31,10 +31,6 @@ class TestCustomKernelDot(unittest.TestCase):
             cur_dir, sys.executable)
         os.system(cmd)
 
-        # set environment for loading and registering compiled custom kernels
-        # only valid in current process
-        os.environ['CUSTOM_DEVICE_ROOT'] = cur_dir
-
     def test_custom_kernel_dot_run(self):
         # test dot run
         x_data = np.random.uniform(1, 5, [2, 10]).astype(np.int8)
@@ -51,9 +47,6 @@ class TestCustomKernelDot(unittest.TestCase):
             np.array_equal(out.numpy(), result),
             "custom kernel dot out: {},\n numpy dot out: {}".format(
                 out.numpy(), result))
-
-    def tearDown(self):
-        del os.environ['CUSTOM_DEVICE_ROOT']
 
 
 class TestCustomKernelDotC(unittest.TestCase):
@@ -67,10 +60,6 @@ class TestCustomKernelDotC(unittest.TestCase):
             cur_dir, sys.executable)
         os.system(cmd)
 
-        # set environment for loading and registering compiled custom kernels
-        # only valid in current process
-        os.environ['CUSTOM_DEVICE_ROOT'] = cur_dir
-
     def test_custom_kernel_dot_run(self):
         # test dot run
         x_data = np.random.uniform(1, 5, [2, 10]).astype(np.int8)
@@ -87,9 +76,6 @@ class TestCustomKernelDotC(unittest.TestCase):
             np.array_equal(out.numpy(), result),
             "custom kernel dot out: {},\n numpy dot out: {}".format(
                 out.numpy(), result))
-
-    def tearDown(self):
-        del os.environ['CUSTOM_DEVICE_ROOT']
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/custom_runtime/CMakeLists.txt
+++ b/python/paddle/fluid/tests/custom_runtime/CMakeLists.txt
@@ -5,13 +5,7 @@ if(WITH_CUSTOM_DEVICE)
     "test_*.py")
   string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
-  set(CUSTOM_ENVS
-      PADDLE_SOURCE_DIR=${PADDLE_SOURCE_DIR}
-      PADDLE_BINARY_DIR=${PADDLE_BINARY_DIR}
-      CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle/fluid/tests/custom_runtime
-  )
-
   foreach(TEST_OP ${TEST_OPS})
-    py_test(${TEST_OP} SRCS ${TEST_OP}.py ENVS ${CUSTOM_ENVS})
+    py_test(${TEST_OP} SRCS ${TEST_OP}.py)
   endforeach()
 endif()

--- a/python/paddle/fluid/tests/custom_runtime/CMakeLists.txt
+++ b/python/paddle/fluid/tests/custom_runtime/CMakeLists.txt
@@ -1,4 +1,17 @@
 if(WITH_CUSTOM_DEVICE)
-  py_test(test_custom_cpu_plugin SRCS test_custom_cpu_plugin.py)
-  set_tests_properties(test_custom_cpu_plugin PROPERTIES TIMEOUT 120)
+  file(
+    GLOB TEST_OPS
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "test_*.py")
+  string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
+
+  set(CUSTOM_ENVS
+      PADDLE_SOURCE_DIR=${PADDLE_SOURCE_DIR}
+      PADDLE_BINARY_DIR=${PADDLE_BINARY_DIR}
+      CUSTOM_DEVICE_ROOT=${CMAKE_BINARY_DIR}/python/paddle/fluid/tests/custom_runtime
+  )
+
+  foreach(TEST_OP ${TEST_OPS})
+    py_test(${TEST_OP} SRCS ${TEST_OP}.py ENVS ${CUSTOM_ENVS})
+  endforeach()
 endif()

--- a/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_plugin.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_plugin.py
@@ -120,6 +120,22 @@ class TestCustomCPUPlugin(unittest.TestCase):
 
         self.assertTrue(pred.place.is_custom_place())
 
+    def test_eager_backward_api(self):
+        x = np.random.random([2, 2]).astype("float32")
+        y = np.random.random([2, 2]).astype("float32")
+        grad = np.ones([2, 2]).astype("float32")
+
+        import paddle
+        paddle.set_device('custom_cpu')
+        x_tensor = paddle.to_tensor(x, stop_gradient=False)
+        y_tensor = paddle.to_tensor(y)
+        z_tensor = paddle.add(x_tensor, y_tensor)
+
+        grad_tensor = paddle.to_tensor(grad)
+        paddle.autograd.backward([z_tensor], [grad_tensor], False)
+
+        self.assertTrue(np.allclose(grad, x_tensor.grad.numpy()))
+
     def tearDown(self):
         del os.environ['CUSTOM_DEVICE_ROOT']
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

1. 修复 Eager mode 下 tensor not initialized 错误。

```python
import paddle

# export FLAGS_enable_eager_mode=1
paddle.fluid.framework._disable_legacy_dygraph()

#paddle.set_device('cpu')
paddle.set_device('custom_cpu')

x = paddle.to_tensor([[1, 2], [3, 4]], dtype='float32', stop_gradient=False)
y = paddle.to_tensor([[3, 2], [3, 4]], dtype='float32')

grad_tensor = paddle.to_tensor([[1,2], [2, 3]], dtype='float32')
z = paddle.add(x, y)

print(f"x = {x}")
print(f"y = {y}")
print(f"z = {z}")
print(f"grad_tensor = {grad_tensor}")

paddle.autograd.backward([z], [grad_tensor], False)
print(f"x.grad={x.grad.numpy()}")
```


错误截图如下：

![587ffe272f9591c0c90c2b05d34ac326](https://user-images.githubusercontent.com/16605440/176409052-a96a35ef-6b5b-457b-95e7-d513a0a8be35.png)

2. 修改 CMAKE 支持目录下直接执行 ctest

之前的单测代码与 CMAKE 只能在 paddle_build.sh 下成功运行，依赖脚本中的 PADDLE_ROOT 等环境变量，修改为 CMAKE 传入环境变量的方式，支持手动编译之后在对应目录下直接执行 ctest，无需手动设置 PADDLE_ROOT 等环境变量


