### PR TITLE
Turn OFF WITH_PSORE when compiling with ROCM due to rocksdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,18 +475,14 @@ if(WITH_DISTRIBUTE)
         OFF
         CACHE BOOL "Disable WITH_PSCORE when compiling with NPU" FORCE)
   endif()
-  if(WITH_ROCM AND HIP_VERSION LESS_EQUAL 40020496)
-    # TODO(qili93): third-party rocksdb throw Illegal instruction with HIP version 40020496
+  if(WITH_ROCM)
+    # TODO(qili93): third-party rocksdb throw Illegal instruction with HIP
     message(
       WARNING
-        "Disable WITH_PSCORE when HIP_VERSION is less than or equal 40020496. Force WITH_PSCORE=OFF."
-    )
+        "Disable WITH_PSCORE when compiling with ROCm. Force WITH_PSCORE=OFF.")
     set(WITH_PSCORE
         OFF
-        CACHE
-          BOOL
-          "Disable WITH_PSCORE when HIP_VERSION is less than or equal 40020496"
-          FORCE)
+        CACHE BOOL "Disable WITH_PSCORE when compiling with ROCm" FORCE)
   endif()
 endif()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

ROCm will result in core dump with rocksdb core stack as following:

```bash
Core was generated by `python -c import paddle'.
Program terminated with signal SIGILL, Illegal instruction.
#0  0x00007f8e09df883b in rocksdb::AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions() () from /opt/conda/lib/python3.7/site-packages/paddle/fluid/core_avx.so
[Current thread is 1 (Thread 0x7f8ec4265740 (LWP 32783))]
Missing separate debuginfos, use: debuginfo-install glibc-2.17-326.el7_9.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 krb5-libs-1.15.1-51.el7_9.x86_64 libcom_err-1.42.9-19.el7.x86_64 libgomp-4.8.5-44.el7.x86_64 libselinux-2.5-15.el7.x86_64 numactl-libs-2.0.12-5.el7.x86_64 openssl-libs-1.0.2k-25.el7_9.x86_64 pcre-8.32-17.el7.x86_64
(gdb) bt
#0  0x00007f8e09df883b in rocksdb::AdvancedColumnFamilyOptions::AdvancedColumnFamilyOptions() () from /opt/conda/lib/python3.7/site-packages/paddle/fluid/core_avx.so
#1  0x00007f8e09df907e in rocksdb::ColumnFamilyOptions::ColumnFamilyOptions() () from /opt/conda/lib/python3.7/site-packages/paddle/fluid/core_avx.so
#2  0x00007f8e09deaf67 in ?? () from /opt/conda/lib/python3.7/site-packages/paddle/fluid/core_avx.so
#3  0x00007f8e09ded5a7 in ?? () from /opt/conda/lib/python3.7/site-packages/paddle/fluid/core_avx.so
#4  0x00007f8ec40619c3 in _dl_init_internal () from /lib64/ld-linux-x86-64.so.2
#5  0x00007f8ec406659e in dl_open_worker () from /lib64/ld-linux-x86-64.so.2
#6  0x00007f8ec40617d4 in _dl_catch_error () from /lib64/ld-linux-x86-64.so.2
#7  0x00007f8ec4065b8b in _dl_open () from /lib64/ld-linux-x86-64.so.2
#8  0x00007f8ec3e4efab in dlopen_doit () from /lib64/libdl.so.2
#9  0x00007f8ec40617d4 in _dl_catch_error () from /lib64/ld-linux-x86-64.so.2
#10 0x00007f8ec3e4f5ad in _dlerror_run () from /lib64/libdl.so.2
#11 0x00007f8ec3e4f041 in dlopen@@GLIBC_2.2.5 () from /lib64/libdl.so.2
#12 0x00005605123187bc in _PyImport_FindSharedFuncptr () at /tmp/build/80754af9/python_1627392990942/work/Python/dynload_shlib.c:96
#13 0x0000560512337c28 in _PyImport_LoadDynamicModuleWithSpec () at /tmp/build/80754af9/python_1627392990942/work/Python/importdl.c:129
#14 0x0000560512337e73 in _imp_create_dynamic_impl.isra.15 (file=0x0, spec=0x7f8eba3f8990) at /tmp/build/80754af9/python_1627392990942/work/Python/import.c:2174
#15 _imp_create_dynamic () at /tmp/build/80754af9/python_1627392990942/work/Python/clinic/import.c.h:289
#16 0x0000560512256772 in _PyMethodDef_RawFastCallDict () at /tmp/build/80754af9/python_1627392990942/work/Objects/call.c:530
#17 0x00005605122d530b in _PyCFunction_FastCallDict (kwargs=0x7f8eba3f7b90, nargs=<optimized out>, args=0x7f8eba3f87e8, func=0x7f8ec334f7d0) at /tmp/build/80754af9/python_1627392990942/work/Objects/call.c:585
#18 PyCFunction_Call (kwargs=0x7f8eba3f7b90, args=0x7f8eba3f87d0, func=0x7f8ec334f7d0) at /tmp/build/80754af9/python_1627392990942/work/Objects/call.c:789
```
