### PR TITLE
Fix core so name mismatch error

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -583,7 +583,6 @@ if '${CMAKE_BUILD_TYPE}' == 'Release':
         # The sw_64 not suppot patchelf, so we just disable that.
         if platform.machine() != 'sw_64' and platform.machine() != 'mips64':
             for command in commands:
-                print(command)
                 if os.system(command) != 0:
                     raise Exception("patch ${FLUID_CORE_NAME}.%s failed, command: %s" % (ext_name, command))
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -578,10 +578,12 @@ if '${CMAKE_BUILD_TYPE}' == 'Release':
             commands = ["install_name_tool -id '@loader_path/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/fluid/${FLUID_CORE_NAME}" + '.so']
             commands.append("install_name_tool -add_rpath '@loader_path/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/fluid/${FLUID_CORE_NAME}" + '.so')
         else:
-            commands = ["patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/fluid/${FLUID_CORE_NAME}" + '.so']
+            commands = ["patchelf --set-soname '${FLUID_CORE_NAME}.so' ${PADDLE_BINARY_DIR}/python/paddle/fluid/${FLUID_CORE_NAME}" + '.so']
+            commands.append("patchelf --set-rpath '$ORIGIN/../libs/' ${PADDLE_BINARY_DIR}/python/paddle/fluid/${FLUID_CORE_NAME}" + '.so')
         # The sw_64 not suppot patchelf, so we just disable that.
         if platform.machine() != 'sw_64' and platform.machine() != 'mips64':
             for command in commands:
+                print(command)
                 if os.system(command) != 0:
                     raise Exception("patch ${FLUID_CORE_NAME}.%s failed, command: %s" % (ext_name, command))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix core so name mismatch error

paddle编译完成后，将libpaddle_pybind.so copy为core_(no)avx.so，但是并没有更新其soname，其soname仍然是libpaddle_pybind.so，这导致外部链接的时候会找不到的libpaddle_pybind.so，示例如下

- core_avx.so信息
![image](https://user-images.githubusercontent.com/22561442/176664812-bce38d9a-072e-404e-8c00-13c5178f16ff.png)
- 编译完自定义算子so的链接信息
![image](https://user-images.githubusercontent.com/22561442/176664907-1685b7e2-2a9c-4f3c-8fa0-2a958e766c89.png)

因此本PR修复该问题，修复之后，core_avx.so信息如下：
![image](https://user-images.githubusercontent.com/22561442/176665182-27c938b4-6879-483b-91bc-10546db53a4c.png)

该问题修复后，可以基于安装后的paddle phi c++ API在外部编译可执行文件，示例如下：

- CMakeLists.txt
```
cmake_minimum_required(VERSION 3.14)
project(tensortest LANGUAGES CXX)

find_package(Threads REQUIRED)

find_package (PythonLibs REQUIRED PATH /work/dev3/paddle/build_venv/bin/python/lib)
message(STATUS "PYTHON_LIBRARIES = ${PYTHON_LIBRARIES}")

find_package(pybind11 CONFIG)
message(STATUS "Pybind11_INCLUDES = ${pybind11_INCLUDE_DIRS}, pybind11_LIBRARIES=${pybind11_LIBRARIES}, pybind11_DEFINITIONS=${pybind11_DEFINITIONS}")

set(link_libraries
/usr/local/python3.7.0/lib/libpython3.7m.so.1.0
-l:core_avx.so)

set(include_dirs
${pybind11_INCLUDE_DIRS}
/work/dev3/paddle/build_venv/lib/python3.7/site-packages/paddle/include/)

set(link_libraries_path
${CMAKE_SOURCE_DIR}
/work/dev3/paddle/build_venv/lib/python3.7/site-packages/paddle/libs/
/work/dev3/paddle/build_venv/lib/python3.7/site-packages/paddle/fluid/)

include_directories(${include_dirs})
link_directories(${link_libraries_path})

set(name main)
set(source main.cc)
add_executable(${name} ${source})
target_link_libraries(${name} ${link_libraries})
```

- main.cc
```
#include "paddle/extension.h"

int main (){
    std::cout << "Run Start" << std::endl;

    auto a = paddle::full({3, 4}, 2.0);
    auto b = paddle::full({4, 5}, 3.0);
    auto out = paddle::matmul(a, b);

    std::cout << "Run End" << std::endl;
}
```

- 执行结果：
```
Run Start
Run End
```

### patchelf 命令
patchelf 是一个用来修改elf格式的动态库和可执行程序的小工具，可以修改动态链接库的库名字，以及链接库的RPATH。
``` bash
打印出动态库的soname

patchelf --print-soname xxx.so

修改动态库的soname

patchelf --set-soname oldxxx.so newxxx.so

查看并修改第三方依赖库

patchelf --print-needed xxx.so

patchelf --replace-needed oldxxx.so newxxx.so this.so

修改rpath

patchelf --set-rpath '$ORIGIN/' main
```