### PR TITLE
Fix for ernie3.0 int8

### DIFF
--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -170,11 +170,11 @@ class FCPrimitiveFactory {
     // In case of 2 dims, we set the only possible format, nc
     if (dim_num == 2) {
       out->set_format(MKLDNNMemoryFormat::nc);
-      // In case of 3 dims, we generate a format that is based on number
-      // of output dims and the layout of input format (nchw or nhwc).
       out->set_mem_desc({phi::vectorize(out->dims()),
                          platform::MKLDNNGetDataType<T_out>(),
                          out->format()});
+      // In case of 3 dims, we generate a format that is based on number
+      // of output dims and the layout of input format (nchw or nhwc).
     } else if (dim_num == 3) {
       if (in_format == MKLDNNMemoryFormat::nwc ||
           in_format == MKLDNNMemoryFormat::nhwc) {

--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -172,6 +172,9 @@ class FCPrimitiveFactory {
       out->set_format(MKLDNNMemoryFormat::nc);
       // In case of 3 dims, we generate a format that is based on number
       // of output dims and the layout of input format (nchw or nhwc).
+      out->set_mem_desc({phi::vectorize(out->dims()),
+                         platform::MKLDNNGetDataType<T_out>(),
+                         out->format()});
     } else if (dim_num == 3) {
       if (in_format == MKLDNNMemoryFormat::nwc ||
           in_format == MKLDNNMemoryFormat::nhwc) {
@@ -185,9 +188,6 @@ class FCPrimitiveFactory {
     } else {
       out->set_format(in_format);
     }
-    out->set_mem_desc({phi::vectorize(out->dims()),
-                       platform::MKLDNNGetDataType<T_out>(),
-                       out->format()});
   }
 
   void UpdateDataPointers(const ExecutionContext& ctx,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR fixes a bug in the ernie3.0 int8 model caused by #43567. The oneDNN memory descriptor is now only explicitly set for 2-dimensional output.