### PR TITLE
Support reusing forward api for grad api in yaml

### DIFF
--- a/python/paddle/utils/code_gen/legacy_backward.yaml
+++ b/python/paddle/utils/code_gen/legacy_backward.yaml
@@ -1687,26 +1687,12 @@
   backward : rsqrt_double_grad
   inplace : (out_grad -> x_grad)
 
-- backward_api : scale_double_grad
-  forward : scale_grad (Tensor grad_out, Scalar scale, float bias, bool bias_after_scale) -> Tensor(grad_x)
-  args : (Tensor grad_x_grad, Scalar scale=1.0, float bias=0.0, bool bias_after_scale=true)
-  output : Tensor(grad_out_grad)
-  invoke : scale(grad_x_grad, scale, 0.0, bias_after_scale)
-  backward : scale_triple_grad
-
 - backward_api : scale_grad
   forward : scale (Tensor x, Scalar scale, float bias, bool bias_after_scale) -> Tensor(out)
   args : (Tensor out_grad, Scalar scale=1.0, float bias=0.0, bool bias_after_scale=true)
   output : Tensor(x_grad)
   invoke : scale(out_grad, scale, 0.0, bias_after_scale)
-  backward : scale_double_grad
   inplace : (out_grad -> x_grad)
-
-- backward_api : scale_triple_grad
-  forward : scale_double_grad (Tensor grad_grad_x, Scalar scale, float bias, bool bias_after_scale) -> Tensor(grad_grad_out)
-  args : (Tensor grad_grad_out_grad, Scalar scale=1.0, float bias=0.0, bool bias_after_scale=true)
-  output : Tensor(grad_grad_x_grad)
-  invoke : scale(grad_grad_out_grad, scale, 0.0, bias_after_scale)
 
 - backward_api : scatter_grad
   forward : scatter (Tensor x, Tensor index, Tensor updates, bool overwrite) -> Tensor(out)
@@ -1921,7 +1907,7 @@
 - backward_api : squeeze_double_grad
   forward : squeeze_grad(Tensor xshape, Tensor grad_out, int[] axes) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, int[] axes)
-  output : Tensor(grad_out_grad)
+  output : Tensor(grad_out_grad), Tensor(xshape)
   invoke: squeeze(grad_x_grad, axes)
 
 - backward_api : squeeze_grad
@@ -2187,7 +2173,7 @@
 - backward_api : unsqueeze_double_grad
   forward : unsqueeze_grad(Tensor xshape, Tensor grad_out, IntArray axes) -> Tensor(grad_x)
   args : (Tensor grad_x_grad, IntArray axes)
-  output : Tensor(grad_out_grad)
+  output : Tensor(grad_out_grad), Tensor(xshape)
   invoke : unsqueeze(grad_x_grad, axes)
 
 - backward_api : unsqueeze_grad


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
基于Yaml的代码自动生成支持反向复用简单前向API，并能够自动支持更高阶反向的计算。