### PR TITLE
[DCU] fix compiling error on DTK22.04, test=develop

### DIFF
--- a/paddle/fluid/operators/class_center_sample_op.cu
+++ b/paddle/fluid/operators/class_center_sample_op.cu
@@ -221,6 +221,12 @@ class NotEqualToPreviousAdjacentIterator {
   }
 
   template <typename Distance>
+  __host__ __device__ __forceinline__ self_type operator-(Distance n) const {
+    self_type ret(arr_, offset_ - n);
+    return ret;
+  }
+
+  template <typename Distance>
   __host__ __device__ __forceinline__ reference operator[](Distance n) const {
     return *(*this + n);
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->


### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

When compiling with DTK 22.04, will throw compiling error as following, reload operator - to fix rocPRIM compiling error.

![image](https://user-images.githubusercontent.com/16605440/176823415-e56e7a35-3620-4e4b-8aab-b20c461f399a.png)



