### PR TITLE
[phi] add get_compile_flags get_link_flags for phi

### DIFF
--- a/python/paddle/sysconfig.py
+++ b/python/paddle/sysconfig.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import os
+import paddle
+from pathlib import Path
 
-__all__ = ['get_include', 'get_lib']
+__all__ = ['get_include', 'get_lib', 'get_compile_flags', 'get_link_flags']
 
 
 def get_include():
@@ -49,3 +51,44 @@ def get_lib():
     """
     import paddle
     return os.path.join(os.path.dirname(paddle.__file__), 'libs')
+
+
+def get_compile_flags():
+    """Get the compilation flags for custom operators.
+    Returns:
+      The compilation flags.
+      
+    Examples:
+      .. code-block:: python
+
+          import paddle
+          compiler_flags = paddle.sysconfig.get_compile_flags()
+    """
+    flags = []
+    flags.append(f"-I{get_include()}")
+    return flags
+
+
+def get_link_flags():
+    """Get the link flags for custom operators.
+    
+    Returns:
+      The link flags.
+      
+      
+    Examples:
+      .. code-block:: python
+
+          import paddle
+          link_flags = paddle.sysconfig.get_link_flags()
+    """
+    flags = []
+    flags.append("-L%s" % get_lib())
+    core_so_path = Path(paddle.__file__).parent / 'fluid'
+    flags.append("-L%s" % core_so_path)
+
+    if paddle.fluid.core.has_avx_core:
+        flags.append("-l:core_avx.so")
+    else:
+        flags.append("-l:core_noavx.so")
+    return flags


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
add get_compile_flags get_link_flags  in paddle.sysconfig

![image](https://user-images.githubusercontent.com/3038472/176834853-36af67b9-1973-40f8-b9a1-f80579405471.png)


```
cmake_minimum_required(VERSION 3.14)
project(tensortest LANGUAGES CXX)

find_package(Threads REQUIRED)

find_package (PythonLibs REQUIRED)
find_package (Python3 REQUIRED)
find_package(pybind11 CONFIG)

message(STATUS "PYTHON_LIBRARIES = ${PYTHON_LIBRARIES}")
message(STATUS "Python3_EXECUTABLE = ${Python3_EXECUTABLE}")
message(STATUS "Pybind11_INCLUDES = ${pybind11_INCLUDE_DIRS}, pybind11_LIBRARIES=${pybind11_LIBRARIES}, pybind11_DEFINITIONS=${pybind11_DEFINITIONS}")

set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
set(CMAKE_POSITION_INDEPENDENT_CODE ON)
set(CMAKE_VERBOSE_MAKEFILE ON)

execute_process(COMMAND python -c "import paddle ; print(' '.join(paddle.sysconfig.get_link_flags()), end='')"
                OUTPUT_VARIABLE PADDLE_LINK_FLAGS
                RESULT_VARIABLE SUCESS)

message(STATUS PADDLE_LINK_FLAGS= ${PADDLE_LINK_FLAGS})
string(STRIP ${PADDLE_LINK_FLAGS} PADDLE_LINK_FLAGS)


execute_process(COMMAND python -c "import paddle ; print(' '.join(paddle.sysconfig.get_compile_flags()), end='')"
                OUTPUT_VARIABLE PADDLE_COMPILE_FLAGS)
message(STATUS PADDLE_COMPILE_FLAGS= ${PADDLE_COMPILE_FLAGS})
string(STRIP ${PADDLE_COMPILE_FLAGS} PADDLE_COMPILE_FLAGS)


set(name main)
add_executable(${name} main.cc)
target_compile_options(${name} PUBLIC ${PADDLE_COMPILE_FLAGS})
target_include_directories(${name} PUBLIC ${pybind11_INCLUDE_DIRS})
target_link_libraries(${name} ${PYTHON_LIBRARIES} ${PADDLE_LINK_FLAGS})
```

```
#include "paddle/extension.h"
#include "paddle/phi/api/all.h"

int main (){
    std::cout << "Run Start" << std::endl;

    auto d = paddle::Tensor("test");

    auto a = paddle::full({3, 4}, 2.0);
    auto b = paddle::full({4, 5}, 3.0);
    auto out = paddle::matmul(a, b);

    std::cout << "Run End" << std::endl;
}
```