### PR TITLE
make Linux and windows both use external/cub 1.16.0

### DIFF
--- a/cmake/external/cub.cmake
+++ b/cmake/external/cub.cmake
@@ -24,7 +24,7 @@ set(CUB_PREFIX_DIR ${CUB_PATH})
 
 set(CUB_REPOSITORY ${GIT_URL}/NVlabs/cub.git)
 
-if(WIN32 AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6)
+if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6)
   # cuda_11.6.2_511.65‘s own cub is 1.15.0, which will cause compiling error in windows.
   set(CUB_TAG 1.16.0)
   # cub 1.16.0 is not compitable with current thrust version

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -327,8 +327,8 @@ if(WITH_ONNXRUNTIME)
 endif()
 
 if(WITH_GPU)
-  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0
-     OR (WIN32 AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6))
+  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0 OR ${CMAKE_CUDA_COMPILER_VERSION}
+                                                 GREATER_EQUAL 11.6)
     include(external/cub) # download cub
     list(APPEND third_party_deps extern_cub)
   endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -327,8 +327,8 @@ if(WITH_ONNXRUNTIME)
 endif()
 
 if(WITH_GPU)
-  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0 OR ${CMAKE_CUDA_COMPILER_VERSION}
-                                                 GREATER_EQUAL 11.6)
+  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0
+     OR (WIN32 AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6))
     include(external/cub) # download cub
     list(APPEND third_party_deps extern_cub)
   endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
make Linux and windows both use external/cub 1.16.0