### PR TITLE
[bug-fix] make only win32 and 11.6 use external/cub

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -257,8 +257,8 @@ if(WITH_ONNXRUNTIME)
 endif()
 
 if(WITH_GPU)
-    if (${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0 OR ${CMAKE_CUDA_COMPILER_VERSION}
-                                                    GREATER_EQUAL 11.6)
+    if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0
+        OR (WIN32 AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6))
         include(external/cub)       # download cub
         list(APPEND third_party_deps extern_cub)
     endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
make only win32 and 11.6 use external/cub.