### PR TITLE
[CINN] Enable test_resnet50_with_cinn

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -1667,8 +1667,14 @@ if(WITH_CINN AND WITH_TESTING)
       LABELS
       "RUN_TYPE=CINN"
       ENVIRONMENT
-      "FLAGS_allow_cinn_ops=batch_norm;batch_norm_grad;conv2d;conv2d_grad;elementwise_add;elementwise_add_grad;relu;relu_grad;sum"
+      FLAGS_allow_cinn_ops="conv2d;conv2d_grad;elementwise_add;elementwise_add_grad;relu;relu_grad;sum"
   )
-  set_tests_properties(test_parallel_executor_run_cinn
-                       PROPERTIES LABELS "RUN_TYPE=CINN")
+  set_tests_properties(
+    test_parallel_executor_run_cinn
+    PROPERTIES
+      LABELS
+      "RUN_TYPE=CINN"
+      ENVIRONMENT
+      FLAGS_allow_cinn_ops="conv2d;conv2d_grad;elementwise_add;elementwise_add_grad;relu;relu_grad;sum"
+  )
 endif()

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -1659,3 +1659,16 @@ if($ENV{USE_STANDALONE_EXECUTOR})
   set_tests_properties(test_imperative_mnist_sorted_gradient
                        PROPERTIES ENVIRONMENT FLAGS_USE_STANDALONE_EXECUTOR=0)
 endif()
+
+if(WITH_CINN AND WITH_TESTING)
+  set_tests_properties(
+    test_resnet50_with_cinn
+    PROPERTIES
+      LABELS
+      "RUN_TYPE=CINN"
+      ENVIRONMENT
+      "FLAGS_allow_cinn_ops=batch_norm;batch_norm_grad;conv2d;conv2d_grad;elementwise_add;elementwise_add_grad;relu;relu_grad;sum"
+  )
+  set_tests_properties(test_parallel_executor_run_cinn
+                       PROPERTIES LABELS "RUN_TYPE=CINN")
+endif()

--- a/python/paddle/fluid/tests/unittests/test_resnet50_with_cinn.py
+++ b/python/paddle/fluid/tests/unittests/test_resnet50_with_cinn.py
@@ -108,6 +108,10 @@ class TestResnet50Accuracy(unittest.TestCase):
 
         loss_c = self.train(place, loop_num, feed, use_cinn=True)
         loss_p = self.train(place, loop_num, feed, use_cinn=False)
+        print("Losses of CINN:")
+        print(loss_c)
+        print("Losses of Paddle")
+        print(loss_p)
         self.assertTrue(np.allclose(loss_c, loss_p, atol=1e-5))
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add `test_resnet50_with_cinn` test case to paddle-cinn
Note: currently, if we add `batch_norm` and `batch_norm_grad` op, the loss will be large in this test case (like 10.xx vs 13.xx at 10-th iteration)
