### PR TITLE
Update math.py  paddle.outer() Returns部分 补上"shape=[x.size, y.size]"

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1796,7 +1796,7 @@ def outer(x, y, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        Tensor: The outer-product Tensor.
+        Tensor: The outer-product Tensor. shape=[x.size, y.size].
 
     Examples:
         .. code-block:: python


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
Issues： https://github.com/PaddlePaddle/docs/issues/4983

outer()的中文版"返回"里有“Tensor shape为 [x.size, y.size]”，因此在源代码docstring对应位置补上"shape=[x.size, y.size]"

中文版无需修改。