### PR TITLE
Set FC input data format to ANY 

### DIFF
--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -236,7 +236,8 @@ class FCPrimitiveFactory {
     auto input_dims = phi::vectorize(input->dims());
     std::vector<int64_t> new_input_dims = {
         input_dims[0] * input_dims[1], input_dims[2], 1};
-    auto src_desc = CreateMemDescriptor<T_in>(new_input_dims, MKLDNNMemoryFormat::any);
+    auto src_desc =
+        CreateMemDescriptor<T_in>(new_input_dims, MKLDNNMemoryFormat::any);
 
     auto weight_dims = Get3DWeightDimsForDNNL(weights);
     auto weights_desc =

--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -209,7 +209,7 @@ class FCPrimitiveFactory {
       const Tensor* bias,
       LoDTensor* output,
       const ExecutionContext& ctx) {
-    auto src_desc = CreateMemDescriptor<T_in>(input, input->format());
+    auto src_desc = CreateMemDescriptor<T_in>(input, MKLDNNMemoryFormat::any);
     auto weight_dims = Get2DWeightDimsForDNNL(weights);
     auto weights_desc =
         CreateMemDescriptor<T_w>(weight_dims, MKLDNNMemoryFormat::any);
@@ -236,7 +236,7 @@ class FCPrimitiveFactory {
     auto input_dims = phi::vectorize(input->dims());
     std::vector<int64_t> new_input_dims = {
         input_dims[0] * input_dims[1], input_dims[2], 1};
-    auto src_desc = CreateMemDescriptor<T_in>(new_input_dims, input->format());
+    auto src_desc = CreateMemDescriptor<T_in>(new_input_dims, MKLDNNMemoryFormat::any);
 
     auto weight_dims = Get3DWeightDimsForDNNL(weights);
     auto weights_desc =
@@ -267,7 +267,7 @@ class FCPrimitiveFactory {
       const Tensor* bias,
       LoDTensor* output,
       const ExecutionContext& ctx) {
-    auto src_desc = CreateMemDescriptor<T_in>(input, input->format());
+    auto src_desc = CreateMemDescriptor<T_in>(input, MKLDNNMemoryFormat::any);
     // Since MKL-DNN doesn't support 4D column-major data formats in
     // inner_product primitive, transpose the weights to be in
     // row-major format


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
This PR sets the input data format to `any`, so the OneDNN library can choose the most optimized format. This corrects the problem of performance drop for larger batches.