### PR TITLE
Update random.py  paddle.poisson()  对标中文版API添加了API功能描述部分遗漏的部分

### DIFF
--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -87,7 +87,7 @@ def bernoulli(x, name=None):
 
 def poisson(x, name=None):
     r"""
-    Returns a tensor filled with random number from a Poisson Distribution.
+    Returns a tensor filled with random number from a Poisson Distribution. The shape and dtype of the output Tensor are the same as those of the input Tensor.
 
     .. math::
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
Issues: https://github.com/PaddlePaddle/docs/issues/4984

poisson()的中文版api功能描述部分有“输出Tensor的shape和dtype与输入Tensor相同。”，而英文版没有对应描述，因此添加了“The shape and dtype of the output Tensor are the same as those of the input Tensor.”并申请PR