### PR TITLE
Update math.py paddle.rad2deg()等API的Returns部分有多余的out()，因此删除

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -3640,7 +3640,7 @@ def conj(x, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): The conjugate of input. The shape and data type is the same with input. If the elements of tensor is real type such as float32, float64, int32 or int64, the out is the same with input.
+        Tensor: The conjugate of input. The shape and data type is the same with input. If the elements of tensor is real type such as float32, float64, int32 or int64, the out is the same with input.
 
     Examples:
         .. code-block:: python
@@ -3720,7 +3720,7 @@ def neg(x, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): The negative of input Tensor. The shape and data type are the same with input Tensor.
+        Tensor: The negative of input Tensor. The shape and data type are the same with input Tensor.
 
     Examples:
         .. code-block:: python
@@ -3757,7 +3757,7 @@ def atan2(x, y, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float64 when the input data type is int).
+        Tensor: An N-D Tensor, the shape and data type is the same with input (The output data type is float64 when the input data type is int).
 
     Examples:
         .. code-block:: python
@@ -3867,7 +3867,7 @@ def lerp(x, y, weight, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): An N-D Tensor, the shape and data type is the same with input.
+        Tensor: An N-D Tensor, the shape and data type is the same with input.
 
     Example:
         .. code-block:: python
@@ -3935,7 +3935,7 @@ def erfinv(x, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): An N-D Tensor, the shape and data type is the same with input.
+        Tensor: An N-D Tensor, the shape and data type is the same with input.
 
     Example:
         .. code-block:: python
@@ -3983,7 +3983,7 @@ def rad2deg(x, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float32 when the input data type is int).
+        Tensor: An N-D Tensor, the shape and data type is the same with input (The output data type is float32 when the input data type is int).
 
     Examples:
         .. code-block:: python
@@ -4046,7 +4046,7 @@ def deg2rad(x, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float32 when the input data type is int).
+        Tensor: An N-D Tensor, the shape and data type is the same with input (The output data type is float32 when the input data type is int).
 
     Examples:
         .. code-block:: python
@@ -4105,7 +4105,7 @@ def gcd(x, y, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): An N-D Tensor, the data type is the same with input.
+        Tensor: An N-D Tensor, the data type is the same with input.
 
     Examples:
         .. code-block:: python
@@ -4183,7 +4183,7 @@ def lcm(x, y, name=None):
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        out (Tensor): An N-D Tensor, the data type is the same with input.
+        Tensor: An N-D Tensor, the data type is the same with input.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4052,7 +4052,6 @@ def deg2rad(x, name=None):
         .. code-block:: python
 
             import paddle
-            import numpy as np
             
             x1 = paddle.to_tensor([180.0, -180.0, 360.0, -360.0, 90.0, -90.0])
             result1 = paddle.deg2rad(x1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
Issues: https://github.com/PaddlePaddle/docs/issues/4988

rad2deg()等API的Returns部分有多余的out()，因此删除