### PR TITLE
Update manipulation.py 补上了paddle.repeat_interleave()API描述部分漏掉了2句描述(对标中文版)

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3934,7 +3934,8 @@ def repeat_interleave(x, repeats, axis=None, name=None):
     """
 
     Returns a new tensor which repeats the ``x`` tensor along dimension ``axis`` using
-    the entries in ``repeats`` which is a int or a Tensor.
+    the entries in ``repeats`` which is a int or a Tensor. When repeats is 1-D Tensor, the repeats length must match the specified axis dimension, and the value of the corresponding position of repeats indicates the number of times the x corresponding position element needs to be copied. When repeats is int, x copies repeats times along all elements on the specified axis axis.
+
 
     Args:
         x (Tensor): The input Tensor to be operated. The data of ``x`` can be one of float32, float64, int32, int64.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
Issues: https://github.com/PaddlePaddle/docs/issues/4992

paddle.repeat_interleave()英文版的API描述部分漏掉了中文版中的2句描述，补上了