### PR TITLE
update comments about fleet.init()

### DIFF
--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -178,8 +178,9 @@ class Fleet(object):
                 the rolemaker by yourself, it will be automatically initialized to PaddleRoleMaker.
                 The default value is None.
             is_collective (Boolean, optional): A ``Boolean`` variable determines whether the program 
-                runs on the CPU or GPU. False means set distributed training using CPU, and True means
-                GPU.The default value is False.The default value is False.
+                runs on Collective mode or ParameterServer mode. True means the program runs on
+                Collective mode, and False means running on ParameterServer mode. The default value 
+                is False.
             strategy (DistributedStrategy): Extra properties for distributed training. 
                 For details, please refer to paddle.distributed.fleet.DistributedStrategy. Default: None.
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
> update comments about fleet.init()

`fleet.init()`中对于参数`is_collective`的描述不太准确，与[文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/distributed/fleet/Fleet_cn.html#init-role-maker-none-is-collective-false-strategy-none)中的描述不一致，对用户来说具有一定迷惑性。  