### PR TITLE
Fix nan in fused_multi_transformer

### DIFF
--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -294,6 +294,52 @@ inline __device__ uint4 mul(uint4 a, uint4 b) {
   return c;
 }
 
+template <>
+inline __device__ uint32_t mul(uint32_t a, float b) {
+  float2 tmp = half2_to_float2(a);
+  float2 tmp_res;
+  tmp_res.x = tmp.x * b;
+  tmp_res.y = tmp.y * b;
+  uint32_t res = float2_to_half2(tmp_res);
+  return res;
+}
+
+template <>
+inline __device__ uint2 mul(uint2 a, float b) {
+  uint2 res;
+  res.x = mul<uint32_t, uint32_t, uint32_t>(a.x, b);
+  res.y = mul<uint32_t, uint32_t, uint32_t>(a.y, b);
+  return res;
+}
+
+template <>
+inline __device__ uint4 mul(uint4 a, float b) {
+  uint4 res;
+  res.x = mul<uint32_t, uint32_t, uint32_t>(a.x, b);
+  res.y = mul<uint32_t, uint32_t, uint32_t>(a.y, b);
+  res.z = mul<uint32_t, uint32_t, uint32_t>(a.z, b);
+  res.w = mul<uint32_t, uint32_t, uint32_t>(a.w, b);
+  return res;
+}
+
+template <>
+inline __device__ float2 mul(float2 a, float b) {
+  float2 res;
+  res.x = a.x * b;
+  res.y = a.y * b;
+  return res;
+}
+
+template <>
+inline __device__ float4 mul(float4 a, float b) {
+  float4 res;
+  res.x = a.x * b;
+  res.y = a.y * b;
+  res.z = a.z * b;
+  res.w = a.w * b;
+  return res;
+}
+
 inline __device__ float sum(float v) { return v; }
 inline __device__ float sum(float2 v) { return v.x + v.y; }
 inline __device__ float sum(float4 v) { return v.x + v.y + v.z + v.w; }
@@ -445,11 +491,15 @@ inline __device__ Float8_ cast_to_float(uint4 u) {
 }
 
 template <int THREADS_PER_KEY, typename K_vec, int N>
-inline __device__ float qk_dot_(const K_vec (&q)[N], const K_vec (&k)[N]) {
-  K_vec qk_vec = mul<K_vec, K_vec, K_vec>(q[0], k[0]);
+inline __device__ float qk_dot_(const K_vec (&q)[N],
+                                const K_vec (&k)[N],
+                                float inv_sqrt_dh) {
+  K_vec inv_q = mul<K_vec, K_vec, float>(q[0], inv_sqrt_dh);
+  K_vec qk_vec = mul<K_vec, K_vec, K_vec>(inv_q, k[0]);
 #pragma unroll
   for (int ii = 1; ii < N; ++ii) {
-    qk_vec = fma(q[ii], k[ii], qk_vec);
+    inv_q = mul<K_vec, K_vec, float>(q[ii], inv_sqrt_dh);
+    qk_vec = fma(inv_q, k[ii], qk_vec);
   }
 
   float qk = sum(qk_vec);
@@ -463,8 +513,10 @@ inline __device__ float qk_dot_(const K_vec (&q)[N], const K_vec (&k)[N]) {
 template <typename T, int THREADS_PER_KEY>
 struct Qk_dot {
   template <typename K_vec, int N>
-  static inline __device__ float dot(const K_vec (&q)[N], const K_vec (&k)[N]) {
-    return qk_dot_<THREADS_PER_KEY>(q, k);
+  static inline __device__ float dot(const K_vec (&q)[N],
+                                     const K_vec (&k)[N],
+                                     float inv_sqrt_dh) {
+    return qk_dot_<THREADS_PER_KEY>(q, k, inv_sqrt_dh);
   }
 };
 
@@ -531,8 +583,12 @@ inline __device__ void zero(T &dst) {  // NOLINT
   dst = tmp.raw;
 }
 
-template <typename T, int Dh, int Dh_MAX, int THREADS_PER_KEY,
-          int THREADS_PER_VALUE, int THREADS_PER_BLOCK>
+template <typename T,
+          int Dh,
+          int Dh_MAX,
+          int THREADS_PER_KEY,
+          int THREADS_PER_VALUE,
+          int THREADS_PER_BLOCK>
 __global__ void masked_multihead_attention_kernel(
     Masked_multihead_attention_params<T> params) {
 #if CUDA_ARCH_FP16_SUPPORTED(__CUDA_ARCH__)
@@ -702,7 +758,9 @@ __global__ void masked_multihead_attention_kernel(
       }
     }
 
-    float qk = Qk_dot<T, THREADS_PER_KEY>::dot(q, k) * params.inv_sqrt_dh;
+    // NOTE(liyurui): We should multiple q with inv_sqrt_dh first, for dot(q, k)
+    // my overflow with FP16 in large model.
+    float qk = Qk_dot<T, THREADS_PER_KEY>::dot(q, k, params.inv_sqrt_dh);
 
     // bool is_mask = false;
     if (ti < params.timestep && tid % THREADS_PER_KEY == 0) {
@@ -875,8 +933,10 @@ __global__ void masked_multihead_attention_kernel(
 
 template <typename T>
 inline size_t smem_size_in_bytes(
-    const Masked_multihead_attention_params<T> &params, int dim_head,
-    int threads_per_value, int threads_per_block) {
+    const Masked_multihead_attention_params<T> &params,
+    int dim_head,
+    int threads_per_value,
+    int threads_per_block) {
   size_t qk_sz = div_up(params.timestep + 1, 4) * 16;
   size_t logits_sz = 0;
 
@@ -893,13 +953,17 @@ inline size_t smem_size_in_bytes(
   return max(softmax_sz, red_sz);
 }
 
-#define MMHA_LAUNCH_KERNEL(T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE,  \
-                           THDS_PER_BLOCK, stream)                       \
+#define MMHA_LAUNCH_KERNEL(                                              \
+    T, Dh, Dh_MAX, THDS_PER_KEY, THDS_PER_VALUE, THDS_PER_BLOCK, stream) \
   size_t smem_sz =                                                       \
       smem_size_in_bytes<T>(params, Dh, THDS_PER_VALUE, THDS_PER_BLOCK); \
   dim3 grid(params.num_head, params.batch_size);                         \
-  masked_multihead_attention_kernel<T, Dh, Dh_MAX, THDS_PER_KEY,         \
-                                    THDS_PER_VALUE, THDS_PER_BLOCK>      \
+  masked_multihead_attention_kernel<T,                                   \
+                                    Dh,                                  \
+                                    Dh_MAX,                              \
+                                    THDS_PER_KEY,                        \
+                                    THDS_PER_VALUE,                      \
+                                    THDS_PER_BLOCK>                      \
       <<<grid, THDS_PER_BLOCK, smem_sz, stream>>>(params)
 
 template <typename T, int Dh, int Dh_MAX>
@@ -916,10 +980,17 @@ void fmha_launch_kernel(const Masked_multihead_attention_params<T> &params,
 }
 
 template <typename T>
-void fmha(const platform::CUDADeviceContext &dev_ctx, const Tensor &qkv_tensor,
-          const Tensor &qkv_bias_tensor, const Tensor &src_mask_tensor,
-          Tensor *cache_kv_tensor, Tensor *out_tensor, int batch_size,
-          int max_seq_length, int num_head, int dim_head, int timestep,
+void fmha(const platform::CUDADeviceContext &dev_ctx,
+          const Tensor &qkv_tensor,
+          const Tensor &qkv_bias_tensor,
+          const Tensor &src_mask_tensor,
+          Tensor *cache_kv_tensor,
+          Tensor *out_tensor,
+          int batch_size,
+          int max_seq_length,
+          int num_head,
+          int dim_head,
+          int timestep,
           float inv_sqrt_dh) {
   Masked_multihead_attention_params<T> params;
   params.out = out_tensor->data<T>();
@@ -966,8 +1037,11 @@ void fmha(const platform::CUDADeviceContext &dev_ctx, const Tensor &qkv_tensor,
 constexpr int VEC_16B = 16;
 
 template <typename T>
-__global__ void write_cache_k_kernel(T *cache_k, const T *k, const int num_head,
-                                     const int dim_head, const int seq_len,
+__global__ void write_cache_k_kernel(T *cache_k,
+                                     const T *k,
+                                     const int num_head,
+                                     const int dim_head,
+                                     const int seq_len,
                                      const int max_seq_len) {
   const int bi = blockIdx.y;
   const int hi = blockIdx.z;
@@ -1001,8 +1075,11 @@ __global__ void write_cache_k_kernel(T *cache_k, const T *k, const int num_head,
 }
 
 template <typename T>
-__global__ void write_cache_v_kernel(T *cache_v, const T *v, const int num_head,
-                                     const int dim_head, const int seq_len,
+__global__ void write_cache_v_kernel(T *cache_v,
+                                     const T *v,
+                                     const int num_head,
+                                     const int dim_head,
+                                     const int seq_len,
                                      const int max_seq_len) {
   const int bi = blockIdx.y;
   const int hi = blockIdx.z;
@@ -1025,16 +1102,23 @@ __global__ void write_cache_v_kernel(T *cache_v, const T *v, const int num_head,
 }
 
 template <typename T>
-void write_cache_kv(const platform::CUDADeviceContext &dev_ctx, T *cache_k,
-                    T *cache_v, const T *k, const T *v, const int bsz,
-                    const int num_head, const int seq_len,
-                    const int max_seq_len, const int dim_head) {
+void write_cache_kv(const platform::CUDADeviceContext &dev_ctx,
+                    T *cache_k,
+                    T *cache_v,
+                    const T *k,
+                    const T *v,
+                    const int bsz,
+                    const int num_head,
+                    const int seq_len,
+                    const int max_seq_len,
+                    const int dim_head) {
   constexpr int block_sz = 128;
   constexpr int x = VEC_16B / sizeof(T);
 
   assert(dim_head % x == 0);
   PADDLE_ENFORCE_EQ(
-      dim_head % x, 0,
+      dim_head % x,
+      0,
       platform::errors::PreconditionNotMet(
           "dim_head=%d must be divisible by vec_size=%d", dim_head, x));
 
@@ -1098,15 +1182,15 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 
     bool compute_bias = qkv_biases.size() > 0 && time_step == nullptr;
     // (transA, transB, compute_bias) = (false, true, false)
-    auto qkv_compute = AttnMatMul<T>(dev_ctx, false, true, bsz_seq, output_size,
-                                     input_size, compute_bias);
+    auto qkv_compute = AttnMatMul<T>(
+        dev_ctx, false, true, bsz_seq, output_size, input_size, compute_bias);
     Tensor qkv_out;
     auto *qkv_out_data =
         qkv_out.mutable_data<T>({bsz, seq_len, 3, num_head, dim_head}, place);
 
     // 3. fmha
-    AttnDropoutParam attn_param(true, "upscale_in_train", 0.0, true, true, 0,
-                                nullptr);
+    AttnDropoutParam attn_param(
+        true, "upscale_in_train", 0.0, true, true, 0, nullptr);
     auto fmha_compute =
         FMHARef<T>(dev_ctx, bsz, seq_len, num_head, dim_head, attn_param);
     auto *src_mask = ctx.Input<Tensor>("SrcMask");
@@ -1116,17 +1200,20 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 
     auto out_seq_len = seq_len;
     if (time_step) {
-      PADDLE_ENFORCE_EQ(time_step->place(), platform::CPUPlace(),
+      PADDLE_ENFORCE_EQ(time_step->place(),
+                        platform::CPUPlace(),
                         platform::errors::PreconditionNotMet(
                             "The place of input(TimeStep) must be CPUPlace."));
       // cache_seq_len
       int time_step_value = time_step->data<int>()[0];
-      PADDLE_ENFORCE_GT(time_step_value, 0,
+      PADDLE_ENFORCE_GT(time_step_value,
+                        0,
                         platform::errors::PreconditionNotMet(
                             "The value of time_step must > 0, but now is %d",
                             time_step_value));
       PADDLE_ENFORCE_EQ(
-          seq_len, 1,
+          seq_len,
+          1,
           platform::errors::PreconditionNotMet(
               "In decode stage, the seq_len of input must be 1, but now is %d",
               seq_len));
@@ -1160,8 +1247,8 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     auto out_linear_biases = ctx.MultiInput<Tensor>("OutLinearBias");
     int ring_id = ctx.Attr<int>("ring_id");
     // (transA, transB, compute_bias) = (false, false, false)
-    auto out_linear_compute = AttnMatMul<T>(dev_ctx, false, false, bsz_seq,
-                                            dim_embed, hidden_size, false);
+    auto out_linear_compute = AttnMatMul<T>(
+        dev_ctx, false, false, bsz_seq, dim_embed, hidden_size, false);
 
     // 5. ln(residual + bias)
     DropoutParam dropout_param2(true, 0, true, true, 0.0, nullptr, 0);
@@ -1182,8 +1269,8 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     auto ffn1_weight_dim = ffn1_weights[0]->dims();
 
     int dim_ffn = ffn1_weight_dim[1];
-    auto ffn1_linear_compute = AttnMatMul<T>(dev_ctx, false, false, bsz_seq,
-                                             dim_ffn, dim_embed, false);
+    auto ffn1_linear_compute = AttnMatMul<T>(
+        dev_ctx, false, false, bsz_seq, dim_ffn, dim_embed, false);
     Tensor ffn1_out;
     auto *ffn1_out_data = ffn1_out.mutable_data<T>({bsz_seq, dim_ffn}, place);
 
@@ -1200,8 +1287,8 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     // 8. ffn2 matmul
     auto ffn2_weights = ctx.MultiInput<Tensor>("FFN2Weight");
     auto ffn2_biases = ctx.MultiInput<Tensor>("FFN2Bias");
-    auto ffn2_linear_compute = AttnMatMul<T>(dev_ctx, false, false, bsz_seq,
-                                             dim_embed, dim_ffn, false);
+    auto ffn2_linear_compute = AttnMatMul<T>(
+        dev_ctx, false, false, bsz_seq, dim_embed, dim_ffn, false);
 
     // 9. ffn2 residual bias
     DropoutParam ffn2_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
@@ -1240,8 +1327,12 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
         auto *ln_scale_data = ln_scales[i]->data<U>();
         auto *ln_bias_data = ln_biases[i]->data<U>();
         // TODO(wangxi): can remove mean var in inference
-        ln_compute.ComputeForward(x_data, ln_scale_data, ln_bias_data,
-                                  buf1->data<T>(), ln_mean_data, ln_var_data);
+        ln_compute.ComputeForward(x_data,
+                                  ln_scale_data,
+                                  ln_bias_data,
+                                  buf1->data<T>(),
+                                  ln_mean_data,
+                                  ln_var_data);
       } else if (!pre_layer_norm) {
         PADDLE_THROW(platform::errors::Unimplemented(
             "Unimplemented post_layer_norm for now."));
@@ -1254,8 +1345,8 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
       const Tensor *qkv_bias = qkv_biases.size() > 0 ? qkv_biases[i] : nullptr;
       // NOTE: in decoder stage, bias is fused in fmha
       const Tensor *bias = time_step ? nullptr : qkv_bias;
-      qkv_compute.ComputeForward(qkv_weights[i], buf1, bias, &qkv_out,
-                                 &qkv_out);
+      qkv_compute.ComputeForward(
+          qkv_weights[i], buf1, bias, &qkv_out, &qkv_out);
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step2";
 #endif
@@ -1267,15 +1358,32 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
       if (time_step) {  // generation decoder stage
         // [2, batch_size, num_head, max_seq_len, head_size]
         int max_seq_len = cache_kv->dims()[3];
-        fmha<T>(dev_ctx, qkv_out, *qkv_bias, *src_mask, cache_kv_out, &fmha_out,
-                bsz, max_seq_len, num_head, dim_head, time_step->data<int>()[0],
+        fmha<T>(dev_ctx,
+                qkv_out,
+                *qkv_bias,
+                *src_mask,
+                cache_kv_out,
+                &fmha_out,
+                bsz,
+                max_seq_len,
+                num_head,
+                dim_head,
+                time_step->data<int>()[0],
                 1. / sqrt(dim_head));
       } else if (cache_kv_out) {  // generation context stage
         // TODO(wangxi): can remove dropout in inference
-        fmha_compute.ComputeForward(qkv_out, nullptr, src_mask,
-                                    &transpose_out_2, nullptr, &qk_out, nullptr,
-                                    &softmax_out, &attn_dropout_mask_out,
-                                    &attn_dropout_out, &qktv_out, &fmha_out);
+        fmha_compute.ComputeForward(qkv_out,
+                                    nullptr,
+                                    src_mask,
+                                    &transpose_out_2,
+                                    nullptr,
+                                    &qk_out,
+                                    nullptr,
+                                    &softmax_out,
+                                    &attn_dropout_mask_out,
+                                    &attn_dropout_out,
+                                    &qktv_out,
+                                    &fmha_out);
         // [3, bsz, num_head, seq_len, head_dim]
         T *qkv_data = transpose_out_2_data;
         int64_t q_size = bsz * seq_len * num_head * dim_head;
@@ -1292,22 +1400,38 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
         T *cache_k_ptr = cache_kv_data;
         T *cache_v_ptr = cache_kv_data + cache_k_size;
 
-        write_cache_kv<T>(dev_ctx, cache_k_ptr, cache_v_ptr, k_ptr, v_ptr, bsz,
-                          num_head, seq_len, max_seq_len, dim_head);
+        write_cache_kv<T>(dev_ctx,
+                          cache_k_ptr,
+                          cache_v_ptr,
+                          k_ptr,
+                          v_ptr,
+                          bsz,
+                          num_head,
+                          seq_len,
+                          max_seq_len,
+                          dim_head);
       } else {  // not generation
         // TODO(wangxi): can remove dropout in inference
-        fmha_compute.ComputeForward(
-            qkv_out, cache_kv, src_mask, &transpose_out_2, cache_kv_out,
-            &qk_out, nullptr, &softmax_out, &attn_dropout_mask_out,
-            &attn_dropout_out, &qktv_out, &fmha_out);
+        fmha_compute.ComputeForward(qkv_out,
+                                    cache_kv,
+                                    src_mask,
+                                    &transpose_out_2,
+                                    cache_kv_out,
+                                    &qk_out,
+                                    nullptr,
+                                    &softmax_out,
+                                    &attn_dropout_mask_out,
+                                    &attn_dropout_out,
+                                    &qktv_out,
+                                    &fmha_out);
       }
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step3";
 #endif
 
       // step4. out_linear
-      out_linear_compute.ComputeForward(out_linear_weights[i], &fmha_out,
-                                        nullptr, buf1, nullptr);
+      out_linear_compute.ComputeForward(
+          out_linear_weights[i], &fmha_out, nullptr, buf1, nullptr);
       AllReduce<T>(*buf1, ring_id, dev_ctx);
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step4";
@@ -1321,9 +1445,17 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 
         // inplace
         fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
-            dev_ctx, buf1->data<T>(), x_data, out_linear_bias_data,
-            ln_scale_data, ln_bias_data, bias_dropout_residual_out_data,
-            dropout_mask_out_data, buf1->data<T>(), ln_mean_data, ln_var_data);
+            dev_ctx,
+            buf1->data<T>(),
+            x_data,
+            out_linear_bias_data,
+            ln_scale_data,
+            ln_bias_data,
+            bias_dropout_residual_out_data,
+            dropout_mask_out_data,
+            buf1->data<T>(),
+            ln_mean_data,
+            ln_var_data);
       } else {
       }
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
@@ -1331,24 +1463,27 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 #endif
 
       // step6. ffn matmul1
-      ffn1_linear_compute.ComputeForward(ffn1_weights[i], buf1, nullptr,
-                                         &ffn1_out, nullptr);
+      ffn1_linear_compute.ComputeForward(
+          ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step6";
 #endif
 
       // step7. act bias
       // TODO(wangxi): remove dropout mask in inference
-      fused_act_dropout_helper.DropoutActBias(
-          dev_ctx, ffn1_out_data, ffn1_biases[i]->data<T>(), "gelu",
-          ffn1_dropout_out_data, ffn1_dropout_mask_data);
+      fused_act_dropout_helper.DropoutActBias(dev_ctx,
+                                              ffn1_out_data,
+                                              ffn1_biases[i]->data<T>(),
+                                              "gelu",
+                                              ffn1_dropout_out_data,
+                                              ffn1_dropout_mask_data);
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step7";
 #endif
 
       // step8. ffn matmul2
-      ffn2_linear_compute.ComputeForward(ffn2_weights[i], &ffn1_dropout_out,
-                                         nullptr, buf1, nullptr);
+      ffn2_linear_compute.ComputeForward(
+          ffn2_weights[i], &ffn1_dropout_out, nullptr, buf1, nullptr);
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step8.0";
 #endif
@@ -1365,14 +1500,24 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
           auto *ln_scale_data = ln_scales[i + 1]->data<U>();
           auto *ln_bias_data = ln_biases[i + 1]->data<U>();
           ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
-              dev_ctx, buf1->data<T>(), bias_dropout_residual_out_data,
-              ffn2_biases[i]->data<T>(), ln_scale_data, ln_bias_data,
-              buf1->data<T>(), dropout_mask_out_data, buf0->data<T>(),
-              ln_mean_data, ln_var_data);
+              dev_ctx,
+              buf1->data<T>(),
+              bias_dropout_residual_out_data,
+              ffn2_biases[i]->data<T>(),
+              ln_scale_data,
+              ln_bias_data,
+              buf1->data<T>(),
+              dropout_mask_out_data,
+              buf0->data<T>(),
+              ln_mean_data,
+              ln_var_data);
         } else {
           ffn2_fused_dropout_helper.ResidualDropoutBias(
-              dev_ctx, buf1->data<T>(), bias_dropout_residual_out_data,
-              ffn2_biases[i]->data<T>(), buf1->data<T>(),
+              dev_ctx,
+              buf1->data<T>(),
+              bias_dropout_residual_out_data,
+              ffn2_biases[i]->data<T>(),
+              buf1->data<T>(),
               dropout_mask_out_data);
         }
       } else {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
- 现象：千亿模型在八卡A100上出nan，排查过程中发现，forward context计算没问题，在生成阶段，经过attention后，只有一张卡出nan，随后经过all_reduce，所有的卡一起挂掉，逐个打印中间结果后发现，masked_multihead_attention_kernel里qk相乘后出inf。
- 解决方法：和之前[fused_attention](https://github.com/PaddlePaddle/Paddle/pull/41933)一样，在qk相乘前，先让q乘根号维度。
