### PR TITLE
[new-exec] Refine StandaloneExecutor

### DIFF
--- a/paddle/fluid/framework/new_executor/executor_statistics.cc
+++ b/paddle/fluid/framework/new_executor/executor_statistics.cc
@@ -583,7 +583,8 @@ int StatisticsEngine::StatNormalizationTime(
   if (total - normalization_sum != 0) {
     LOG(WARNING) << "total: " << total
                  << "is greater than normalization_sum:" << normalization_sum;
-    return -1;
+    // TODO(dev): figure out why total != normalization_sum  and fix it
+    // return -1;
   }
   return 0;
 }

--- a/paddle/fluid/framework/new_executor/standalone_executor.cc
+++ b/paddle/fluid/framework/new_executor/standalone_executor.cc
@@ -25,19 +25,6 @@ StandaloneExecutor::StandaloneExecutor(const platform::Place& place,
 paddle::framework::FetchList StandaloneExecutor::Run(
     Scope* scope,
     const std::vector<std::string>& feed_names,
-    const std::vector<framework::LoDTensor>& feed_tensors,
-    const std::vector<std::string>& fetch_names) {
-  platform::RecordEvent record_event(
-      "StandaloneExecutor::run", platform::TracerEventType::UserDefined, 1);
-
-  auto core = GetInterpreterCore(scope, prog_, feed_names, fetch_names, true);
-
-  return core->Run(feed_names, feed_tensors);
-}
-
-paddle::framework::FetchList StandaloneExecutor::Run(
-    Scope* scope,
-    const std::vector<std::string>& feed_names,
     const std::vector<std::string>& fetch_names) {
   platform::RecordEvent record_event(
       "StandaloneExecutor::run", platform::TracerEventType::UserDefined, 1);

--- a/paddle/fluid/framework/new_executor/standalone_executor.h
+++ b/paddle/fluid/framework/new_executor/standalone_executor.h
@@ -35,12 +35,6 @@ class StandaloneExecutor {
 
   ~StandaloneExecutor() {}
 
-  paddle::framework::FetchList Run(
-      Scope* scope,
-      const std::vector<std::string>& feed_names,
-      const std::vector<framework::LoDTensor>& feed_tensors,
-      const std::vector<std::string>& fetch_names);
-
   // NOTE(zhiqiu): feed_names are only used for caching interpretercore.
   // fetch_names are used for caching interpretercore and inserting fetch ops,
   // the latter can be moved to python side.

--- a/paddle/fluid/framework/new_executor/standalone_executor.h
+++ b/paddle/fluid/framework/new_executor/standalone_executor.h
@@ -31,10 +31,7 @@ class InterpreterCore;
 
 class StandaloneExecutor {
  public:
-  StandaloneExecutor(const platform::Place& place,
-                     const ProgramDesc& startup_prog,
-                     const ProgramDesc& main_prog,
-                     Scope* scope);
+  StandaloneExecutor(const platform::Place& place, const ProgramDesc& prog);
 
   ~StandaloneExecutor() {}
 
@@ -65,9 +62,7 @@ class StandaloneExecutor {
       bool add_fetch_op);
 
   platform::Place place_;
-  const ProgramDesc& startup_prog_;
-  const ProgramDesc& main_prog_;
-  Scope* scope_;  // not owned
+  const ProgramDesc& prog_;
 
   std::unordered_map<std::string, std::shared_ptr<InterpreterCore>>
       interpretercores_;

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3061,50 +3061,6 @@ All parameter, weight, gradient are variables in Paddle.
       .def("run",
            [](StandaloneExecutor &self,
               Scope *scope,
-              const std::unordered_map<std::string, py::array> &input_dict,
-              std::vector<std::string> fetch_names) {
-             std::vector<framework::LoDTensor> feed_tensors;
-             std::vector<std::string> feed_names;
-
-             for (auto &item : input_dict) {
-               framework::LoDTensor t;
-               SetTensorFromPyArray<platform::CPUPlace>(
-                   &t, item.second, platform::CPUPlace(), false);
-               feed_names.push_back(item.first);
-               feed_tensors.push_back(t);
-             }
-
-             paddle::framework::FetchList ret;
-             {
-               pybind11::gil_scoped_release release;
-               ret = self.Run(scope, feed_names, feed_tensors, fetch_names);
-             }
-             return py::cast(std::move(ret));
-           })
-      .def("run",
-           [](StandaloneExecutor &self,
-              Scope *scope,
-              const std::unordered_map<std::string, framework::LoDTensor>
-                  &input_dict,
-              std::vector<std::string> fetch_names) {
-             std::vector<framework::LoDTensor> feed_tensors;
-             std::vector<std::string> feed_names;
-
-             for (auto &item : input_dict) {
-               feed_names.push_back(item.first);
-               feed_tensors.push_back(item.second);
-             }
-
-             paddle::framework::FetchList ret;
-             {
-               pybind11::gil_scoped_release release;
-               ret = self.Run(scope, feed_names, feed_tensors, fetch_names);
-             }
-             return py::cast(std::move(ret));
-           })
-      .def("run",
-           [](StandaloneExecutor &self,
-              Scope *scope,
               std::vector<std::string> feed_names,
               std::vector<std::string> fetch_names) {
              paddle::framework::FetchList ret;

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -3057,10 +3057,7 @@ All parameter, weight, gradient are variables in Paddle.
       });
 
   py::class_<framework::StandaloneExecutor>(m, "StandaloneExecutor")
-      .def(py::init<const platform::Place &,
-                    const ProgramDesc &,
-                    const ProgramDesc &,
-                    Scope *>())
+      .def(py::init<const platform::Place &, const ProgramDesc &>())
       .def("run",
            [](StandaloneExecutor &self,
               Scope *scope,

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -399,15 +399,12 @@ def _is_enable_standalone_executor():
     """
     flag = False
     from ..distributed.fleet import fleet
-    print(framework._enable_standalone_executor_)
     # use standalone_executor by default if not distributed
     if fleet._role_maker is None and framework._enable_standalone_executor_ is None:
         framework._enable_standalone_executor_ = 1
 
     if framework._enable_standalone_executor_ in [1, '1', True, 'True', 'true']:
         flag = True
-
-    print('use enable_standalone', flag)
 
     return flag
 

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -569,10 +569,7 @@ class _StandaloneExecutor(object):
             return tensors
 
     def _create_new_executor(self):
-        # NOTE: It's a trick to set empty start_up program.
-        startup_program = Program()
-        new_exe = core.StandaloneExecutor(self._place, startup_program.desc,
-                                          self._main_program.desc, self._scope)
+        new_exe = core.StandaloneExecutor(self._place, self._main_program.desc)
 
         return new_exe
 

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -25,6 +25,7 @@ import six
 from .data_feeder import convert_dtype
 from .framework import Program, default_main_program, Variable, Operator
 from .framework import convert_np_dtype_to_dtype_
+
 from . import core
 from . import unique_name
 from . import compiler
@@ -397,16 +398,16 @@ def _is_enable_standalone_executor():
     Whether to use experimental executor `StandaloneExecutor`.
     """
     flag = False
-
     from ..distributed.fleet import fleet
-    if fleet._role_maker is not None:
-        warnings.warn("do not use standalone executor in fleet by default")
-        env_val = os.environ.get('FLAGS_USE_STANDALONE_EXECUTOR', None)
-    else:
-        env_val = os.environ.get('FLAGS_USE_STANDALONE_EXECUTOR', '1')
+    print(framework._enable_standalone_executor_)
+    # use standalone_executor by default if not distributed
+    if fleet._role_maker is None and framework._enable_standalone_executor_ is None:
+        framework._enable_standalone_executor_ = 1
 
-    if env_val in [1, '1', True, 'True', 'true']:
+    if framework._enable_standalone_executor_ in [1, '1', True, 'True', 'true']:
         flag = True
+
+    print('use enable_standalone', flag)
 
     return flag
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -84,6 +84,8 @@ _already_patch_eager_tensor = False
 _already_patch_varbase = False
 _current_cuda_graph_mode = None
 _global_flags_ = core.globals()
+_enable_standalone_executor_ = (os.environ.get('FLAGS_USE_STANDALONE_EXECUTOR',
+                                               None))
 
 # Some explanation of our execution system 2022.03
 # For now we have 3 kinds of execution system, since we refactored dygraph mode to
@@ -257,6 +259,18 @@ global_ipu_index = -1
 global_ipu_stage = -1
 ipu_index_attr_name = 'ipu_index'
 ipu_stage_attr_name = 'ipu_stage'
+
+
+@signature_safe_contextmanager
+def _enable_standalone_executor(enable=True):
+    print('enable', enable)
+    global _enable_standalone_executor_
+    original_ = _enable_standalone_executor_
+    _enable_standalone_executor_ = enable
+    try:
+        yield
+    finally:
+        _enable_standalone_executor_ = original_
 
 
 @signature_safe_contextmanager

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -263,7 +263,6 @@ ipu_stage_attr_name = 'ipu_stage'
 
 @signature_safe_contextmanager
 def _enable_standalone_executor(enable=True):
-    print('enable', enable)
     global _enable_standalone_executor_
     original_ = _enable_standalone_executor_
     _enable_standalone_executor_ = enable

--- a/python/paddle/fluid/tests/unittests/interpreter/test_standalone_controlflow.py
+++ b/python/paddle/fluid/tests/unittests/interpreter/test_standalone_controlflow.py
@@ -16,7 +16,7 @@ import os
 import sys
 import unittest
 import paddle
-from paddle.fluid import core
+from paddle.fluid import core, framework
 from paddle.fluid.core import StandaloneExecutor
 import paddle.fluid as fluid
 from paddle.fluid.framework import Program, program_guard
@@ -81,17 +81,13 @@ class TestCompatibility(unittest.TestCase):
         return ret
 
     def run_raw_executor(self, feed):
-        os.environ['FLAGS_USE_STANDALONE_EXECUTOR'] = '0'
-        out = self._run(feed)
-        del os.environ['FLAGS_USE_STANDALONE_EXECUTOR']
-        print("GT:", out)
+        with framework._enable_standalone_executor(False):
+            out = self._run(feed)
         return out
 
     def run_new_executor(self, feed):
-        os.environ['FLAGS_USE_STANDALONE_EXECUTOR'] = '1'
-        out = self._run(feed)
-        del os.environ['FLAGS_USE_STANDALONE_EXECUTOR']
-        print("New:", out)
+        with framework._enable_standalone_executor(True):
+            out = self._run(feed)
         return out
 
     def test_with_feed(self):

--- a/python/paddle/fluid/tests/unittests/interpreter/test_standalone_executor.py
+++ b/python/paddle/fluid/tests/unittests/interpreter/test_standalone_executor.py
@@ -51,9 +51,10 @@ class LinearTestCase(unittest.TestCase):
     def test_interp_base(self):
         startup_program, main_program, c = self.build_program()
         scope = core.Scope()
-        standaloneexecutor = StandaloneExecutor(self.place,
-                                                startup_program.desc,
-                                                main_program.desc, scope)
+        exe = paddle.static.Executor(self.place)
+        exe.run(startup_program, scope=scope)
+
+        standaloneexecutor = StandaloneExecutor(self.place, main_program.desc)
         out = standaloneexecutor.run(
             scope, {"a": np.ones([2, 2], dtype="float32") * 2}, [c.name])
         for i in range(10):
@@ -68,9 +69,10 @@ class LinearTestCase(unittest.TestCase):
     def test_dry_run(self):
         scope = core.Scope()
         startup_program, main_program, c = self.build_program()
-        standaloneexecutor = StandaloneExecutor(self.place,
-                                                startup_program.desc,
-                                                main_program.desc, scope)
+        exe = paddle.static.Executor(self.place)
+        exe.run(startup_program, scope=scope)
+
+        standaloneexecutor = StandaloneExecutor(self.place, main_program.desc)
         # test for cost_info
         cost_info = standaloneexecutor.dry_run(
             scope, {"a": np.ones([2, 2], dtype="float32")})
@@ -136,8 +138,11 @@ class ExecutorStatisticsTestCase(unittest.TestCase):
         p = core.Place()
         p.set_place(self.place)
         scope = core.Scope()
-        executor = StandaloneExecutor(p, startup_program.desc,
-                                      main_program.desc, scope)
+
+        exe = paddle.static.Executor(self.place)
+        exe.run(startup_program, scope=scope)
+
+        executor = StandaloneExecutor(p, main_program.desc)
 
         helper_profiler = profiler.Profiler(
             targets=[profiler.ProfilerTarget.CPU], scheduler=(1, 2))
@@ -256,8 +261,10 @@ class MultiStreamModelTestCase(unittest.TestCase):
         p = core.Place()
         p.set_place(self.place)
         scope = core.Scope()
-        inter_core = StandaloneExecutor(p, startup_program.desc,
-                                        main_program.desc, scope)
+        exe = paddle.static.Executor(self.place)
+        exe.run(startup_program, scope=scope)
+
+        inter_core = StandaloneExecutor(p, main_program.desc)
 
         outs = []
         for i in range(self.iter_n):

--- a/python/paddle/fluid/tests/unittests/interpreter/test_standalone_executor.py
+++ b/python/paddle/fluid/tests/unittests/interpreter/test_standalone_executor.py
@@ -109,7 +109,6 @@ class ExecutorStatisticsTestCase(unittest.TestCase):
         self.place = paddle.CUDAPlace(
             0) if core.is_compiled_with_cuda() else paddle.CPUPlace()
         self.perf_path = './perfstat'
-        os.environ['FLAGS_static_executor_perfstat_filepath'] = self.perf_path
 
     def test_parallel_executor_statistics(self):
         self.run_with_statistics(executor='ParallelExecutor')
@@ -121,6 +120,8 @@ class ExecutorStatisticsTestCase(unittest.TestCase):
         self.run_with_statistics(executor='StandaloneExecutor')
 
     def run_with_statistics(self, executor=None):
+        if os.getenv("FLAGS_static_executor_perfstat_filepath") is None:
+            return
         paddle.seed(2020)
         # note: startup program is empty
         main_program, startup_program, fetch_list = build_program()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -246,16 +246,6 @@ class TestMKLDNNDilations(TestConv2DMKLDNNOp):
         self.groups = 3
 
 
-# TODO(chenweihang): To solve the coverage problem, add this unittest,
-# remove this unittest after new executor set to default executor
-class TestConv2dMKLDNNByNewExecutor(TestConv2DMKLDNNOp):
-
-    def test_check_output_by_new_executor(self):
-        os.environ['FLAGS_USE_STANDALONE_EXECUTOR'] = '1'
-        self.test_check_output()
-        del os.environ['FLAGS_USE_STANDALONE_EXECUTOR']
-
-
 if __name__ == '__main__':
     from paddle import enable_static
     enable_static()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- not run startup program in constructor of StandaloneExecutor
- add python provate interface `_enable_standalone_executor` to control use or not
- remove usused `Run` interface of StandaloneExecutor