### PR TITLE
force single thread when CINN is on

### DIFF
--- a/python/paddle/fluid/compiler.py
+++ b/python/paddle/fluid/compiler.py
@@ -16,6 +16,7 @@ import multiprocessing
 import os
 import six
 import sys
+import warnings
 from .. import compat as cpt
 from . import framework
 from .framework import _get_paddle_place, _get_paddle_place_list
@@ -372,6 +373,12 @@ class CompiledProgram(object):
                 self._exec_strategy.num_threads = 1
             else:
                 self._exec_strategy.num_threads = len(places) * 2
+
+        if core.globals(
+        )["FLAGS_use_cinn"] and self._exec_strategy.num_threads != 1:
+            warnings.warn("At present, when CINN is turned on, each process can " \
+                  "only contain one thread, so reset the number of threads to 1 here.")
+            self._exec_strategy.num_threads = 1
 
         if self._build_strategy.num_trainers > 1:
             assert self._is_data_parallel, \

--- a/python/paddle/fluid/compiler.py
+++ b/python/paddle/fluid/compiler.py
@@ -374,7 +374,7 @@ class CompiledProgram(object):
             else:
                 self._exec_strategy.num_threads = len(places) * 2
 
-        if core.globals(
+        if "FLAGS_use_cinn" in core.globals() and core.globals(
         )["FLAGS_use_cinn"] and self._exec_strategy.num_threads != 1:
             warnings.warn("At present, when CINN is turned on, each process can " \
                   "only contain one thread, so reset the number of threads to 1 here.")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
At present, when CINN is on, each process can only contain one thread, so reset the number of threads to 1.

![image](https://user-images.githubusercontent.com/39303645/177502772-3c5bd6ac-2606-46a4-9cd9-3642970b64b1.png)