### PR TITLE
Update fft.py 修复paddle.fft.fftfreq()等API的docstring问题

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -1204,7 +1204,8 @@ def fftfreq(n, d=1.0, dtype=None, name=None):
 
     Args:
         n (int): Dimension inputed.
-        d (scalar, optional): Sample spacing (inverse of the sampling rate). Defaults is 1.
+        d (scalar, optional): Sample spacing (inverse of the sampling rate). Default is 1.
+        dtype (str, optional): Data type of Tensor. Default is the return data type of paddle.get_default_dtype().
         name (str, optional): The default value is None.  Normally there is no need for user to set 
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
@@ -1253,7 +1254,8 @@ def rfftfreq(n, d=1.0, dtype=None, name=None):
 
     Args:
         n (int): Dimension inputed.
-        d (scalar, optional): Sample spacing (inverse of the sampling rate). Defaults is 1.
+        d (scalar, optional): Sample spacing (inverse of the sampling rate). Default is 1.
+        dtype (str, optional): Data type of Tensor. Default is the return data type of paddle.get_default_dtype().
         name (str, optional): The default value is None.  Normally there is no need for user to set 
             this property. For more information, please refer to :ref:`api_guide_Name`.
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
Issues: https://github.com/PaddlePaddle/docs/issues/5037

paddle.fft.fftfreq()里的参数描述漏掉了参数dtype，对原文的 Defaults is 1 认为不应该使用复数形式，修改为单数形式的Default。
将同样问题的rfftfreq也顺手改掉了