### PR TITLE
Update fft.py

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -492,10 +492,11 @@ def fftn(x, s=None, axes=None, norm="backward", name=None):
             axes are used, or all axes if `s` is also not specified.      
         norm (str): Indicates which direction to scale the `forward` or `backward` transform
             pair and what normalization factor to use. The parameter value must be one 
-            of "forward" or "backward" or "ortho". Default is "backward", meaning no normalization on
-            the forward transforms and scaling by ``1/n`` on the `ifft`. "forward" instead applies 
-            the ``1/n`` factor on the forward tranform. For ``norm="ortho"``, both directions are 
-            scaled by ``1/sqrt(n)``.
+            of "forward" or "backward" or "ortho". 
+            Default is "backward", meaning no normalization on the forward transforms and scaling by ``1/n`` on the `ifft`. 
+            "forward" instead applies the ``1/n`` factor on the forward tranform. 
+            For ``norm="ortho"``, both directions are scaled by ``1/sqrt(n)``.
+            Where `n` is the continuous multiplication of each element in `s`.
         name (str, optional): The default value is None.  Normally there is no need for user to set 
             this property. For more information, please refer to :ref:`api_guide_Name`.
 


### PR DESCRIPTION
1）fftn()的英文版格式不如中文版好看--参数norm的三个可选值的解释在源代码中连为一行，而中文版则是分为了3个子条目，因此这里加了换行符，期待能改善。
2）fftn()源代码中参数norm的描述漏掉了中文版中的“其中 n 为 s 中每个元素连乘。” 因此在此补上

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
