### PR TITLE
make inference_c test linking only paddle_inference_c

### DIFF
--- a/paddle/fluid/inference/capi/CMakeLists.txt
+++ b/paddle/fluid/inference/capi/CMakeLists.txt
@@ -20,6 +20,10 @@ cc_library(
   SRCS ${C_API_SRCS}
   DEPS paddle_inference)
 
+if(NOT ON_INFER)
+  return()
+endif()
+
 # Create inference capi shared library
 cc_library(
   paddle_inference_c_shared SHARED

--- a/paddle/fluid/inference/capi_exp/CMakeLists.txt
+++ b/paddle/fluid/inference/capi_exp/CMakeLists.txt
@@ -20,6 +20,10 @@ cc_library(
   SRCS ${C_API_SRCS}
   DEPS paddle_inference)
 
+if(NOT ON_INFER)
+  return()
+endif()
+
 # Create inference capi shared library
 cc_library(
   paddle_inference_c_shared SHARED

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -943,28 +943,17 @@ if(WITH_GPU AND TENSORRT_FOUND)
     SRCS
     analyzer_capi_exp_gpu_tester.cc
     EXTRA_DEPS
-    ${INFERENCE_EXTRA_DEPS}
+    paddle_inference_c
     ARGS
     --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
-  if(WIN32)
-    target_link_libraries(test_analyzer_capi_exp_gpu paddle_inference_c_shared)
-  else()
-    target_link_libraries(test_analyzer_capi_exp_gpu paddle_inference_c)
-  endif()
   inference_analysis_test(
     test_analyzer_capi_exp_xpu
     SRCS
     analyzer_capi_exp_xpu_tester.cc
     EXTRA_DEPS
-    ${INFERENCE_EXTRA_DEPS}
+    paddle_inference_c
     ARGS
     --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
-  if(WIN32)
-    target_link_libraries(test_analyzer_capi_exp_xpu paddle_inference_c_shared)
-  else()
-    target_link_libraries(test_analyzer_capi_exp_xpu paddle_inference_c)
-  endif()
-
   set(TRT_MODEL_QUANT_RESNET_DIR
       "${INFERENCE_DEMO_INSTALL_DIR}/small_quant_model")
   if(NOT EXISTS ${INFERENCE_DEMO_INSTALL_DIR}/small_quant_model.tgz)
@@ -1110,44 +1099,27 @@ inference_analysis_test(
   SRCS
   analyzer_capi_exp_tester.cc
   EXTRA_DEPS
-  ${INFERENCE_EXTRA_DEPS}
+  paddle_inference_c
   ARGS
   --infer_model=${RESNET50_MODEL_DIR}/model)
-if(WIN32)
-  target_link_libraries(test_analyzer_capi_exp paddle_inference_c_shared)
-else()
-  target_link_libraries(test_analyzer_capi_exp paddle_inference_c)
-endif()
 
 inference_analysis_test(
   test_analyzer_capi_exp_pd_config
   SRCS
   analyzer_capi_exp_pd_config_tester.cc
   EXTRA_DEPS
-  ${INFERENCE_EXTRA_DEPS}
+  paddle_inference_c
   ARGS
   --infer_model=${MOBILENET_INSTALL_DIR}/model)
-if(WIN32)
-  target_link_libraries(test_analyzer_capi_exp_pd_config
-                        paddle_inference_c_shared)
-else()
-  target_link_libraries(test_analyzer_capi_exp_pd_config paddle_inference_c)
-endif()
 
 inference_analysis_test(
   test_analyzer_capi_exp_pd_tensor
   SRCS
   analyzer_capi_exp_pd_tensor_tester.cc
   EXTRA_DEPS
-  ${INFERENCE_EXTRA_DEPS}
+  paddle_inference_c
   ARGS
   --infer_model=${MOBILENET_INSTALL_DIR}/model)
-if(WIN32)
-  target_link_libraries(test_analyzer_capi_exp_pd_tensor
-                        paddle_inference_c_shared)
-else()
-  target_link_libraries(test_analyzer_capi_exp_pd_tensor paddle_inference_c)
-endif()
 
 if(NOT APPLE AND NOT WIN32)
   inference_analysis_test(
@@ -1155,15 +1127,9 @@ if(NOT APPLE AND NOT WIN32)
     SRCS
     analyzer_capi_exp_pd_threads_tester.cc
     EXTRA_DEPS
-    ${INFERENCE_EXTRA_DEPS}
+    paddle_inference_c
     ARGS
     --infer_model=${MOBILENET_INSTALL_DIR}/model)
-  if(WIN32)
-    target_link_libraries(test_analyzer_capi_exp_pd_threads
-                          paddle_inference_c_shared)
-  else()
-    target_link_libraries(test_analyzer_capi_exp_pd_threads paddle_inference_c)
-  endif()
 endif()
 
 inference_analysis_test(
@@ -1205,14 +1171,9 @@ if(WITH_MKLDNN)
     SRCS
     analyzer_capi_exp_int_tester.cc
     EXTRA_DEPS
-    ${INFERENCE_EXTRA_DEPS}
+    paddle_inference_c
     ARGS
     --infer_model=${INT8_DATA_DIR}/resnet50/model)
-  if(WIN32)
-    target_link_libraries(test_analyzer_capi_exp_int paddle_inference_c_shared)
-  else()
-    target_link_libraries(test_analyzer_capi_exp_int paddle_inference_c)
-  endif()
 endif()
 
 inference_analysis_test(
@@ -1220,14 +1181,9 @@ inference_analysis_test(
   SRCS
   analyzer_capi_exp_ner_tester.cc
   EXTRA_DEPS
-  ${INFERENCE_EXTRA_DEPS}
+  paddle_inference_c
   ARGS
   --infer_model=${CHINESE_NER_INSTALL_DIR}/model)
-if(WIN32)
-  target_link_libraries(test_analyzer_capi_exp_ner paddle_inference_c_shared)
-else()
-  target_link_libraries(test_analyzer_capi_exp_ner paddle_inference_c)
-endif()
 
 if(WITH_GPU)
   inference_analysis_test(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
See the original PR #41944 #43936, after these 2 PR merged, the code becomes complicated and paddle_inference_c_shared build but not used in linux. So make inference_c test linking only paddle_inference_c.
- the paddle_inference_shared is not needed since paddle_inference_c already depend paddle_inference
- make 8 c_api test still compile with static library so that we needn's compile paddle_inference_c_shared when ON_INFER=OFF 
- Since only 8 test compiling method were restored, the optimization effect described in PR #41944 has not been influenced almost, the linking time of C++ test in paddle\fluid\inference\tests\api is still 10 second around.