### PR TITLE
[BUG FIX]fix metric calculation error under multi instag scene

### DIFF
--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -59,7 +59,7 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
         local_prob(Variable): Local sum of predicted ctr
         local_q(Variable): Local sum of q value
 
-    Examples:
+    Examples 1:
         .. code-block:: python
 
             import paddle.fluid as fluid
@@ -67,9 +67,23 @@ def ctr_metric_bundle(input, label, ins_tag_weight=None):
             paddle.enable_static()
             data = fluid.layers.data(name="data", shape=[32, 32], dtype="float32")
             label = fluid.layers.data(name="label", shape=[-1, 1], dtype="int32")
-            ins_tag_weight = fluid.layers.data(name="ins_tag_weight", shape=[-1, 1], dtype="float32")
             predict = fluid.layers.sigmoid(fluid.layers.fc(input=data, size=1))
-            auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label, ins_tag_weight=ins_tag_weight)
+            auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label)
+    Examples 2:
+        .. code-block:: python
+
+            import paddle.fluid as fluid
+            import paddle
+            paddle.enable_static()
+            data = fluid.layers.data(name="data", shape=[32, 32], dtype="float32")
+            label = fluid.layers.data(name="label", shape=[-1, 1], dtype="int32")
+            filter_tag = layers.data(name='Filter_tag', shape=[-1,16], dtype='int64')
+            predict = fluid.layers.sigmoid(fluid.layers.fc(input=data, size=1))
+            ins_tag = layers.data(name='Ins_tag', shape=[-1,16], lod_level=0, dtype='int64')
+            label_after_filter, _ = fluid.layers.filter_by_instag(label, ins_tag, filter_tag, False)
+            predict_after_filter, ins_tag_weight = fluid.layers.filter_by_instag(predict, ins_tag, filter_tag, False)
+            auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict_after_filter, label=label_after_filter, ins_tag_weight=ins_tag_weight)
+
     """
     if ins_tag_weight is None:
         ins_tag_weight = tensor.fill_constant(shape=[1, 1],

--- a/python/paddle/fluid/contrib/layers/metric_op.py
+++ b/python/paddle/fluid/contrib/layers/metric_op.py
@@ -23,11 +23,12 @@ from paddle.fluid.initializer import Normal, Constant
 from paddle.fluid.framework import Variable
 from paddle.fluid.param_attr import ParamAttr
 from paddle.fluid.layers import nn
+from paddle.fluid.layers import tensor
 
 __all__ = ['ctr_metric_bundle']
 
 
-def ctr_metric_bundle(input, label):
+def ctr_metric_bundle(input, label, ins_tag_weight=None):
     """
     ctr related metric layer
 
@@ -48,6 +49,9 @@ def ctr_metric_bundle(input, label):
                          Variable indicates the probability of each label.
         label(Variable): A 2D int Variable indicating the label of the training
                          data. The height is batch size and width is always 1.
+        ins_tag_weight(Variable): A 2D int Variable indicating the ins_tag_weight of the training
+                         data. 1 means real data, 0 means fake data. 
+                         A LoDTensor or Tensor with type float32,float64.
 
     Returns:
         local_sqrerr(Variable): Local sum of squared error
@@ -59,11 +63,19 @@ def ctr_metric_bundle(input, label):
         .. code-block:: python
 
             import paddle.fluid as fluid
+            import paddle
+            paddle.enable_static()
             data = fluid.layers.data(name="data", shape=[32, 32], dtype="float32")
-            label = fluid.layers.data(name="label", shape=[1], dtype="int32")
+            label = fluid.layers.data(name="label", shape=[-1, 1], dtype="int32")
+            ins_tag_weight = fluid.layers.data(name="ins_tag_weight", shape=[-1, 1], dtype="float32")
             predict = fluid.layers.sigmoid(fluid.layers.fc(input=data, size=1))
-            auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label)
+            auc_out = fluid.contrib.layers.ctr_metric_bundle(input=predict, label=label, ins_tag_weight=ins_tag_weight)
     """
+    if ins_tag_weight is None:
+        ins_tag_weight = tensor.fill_constant(shape=[1, 1],
+                                              dtype="float32",
+                                              value=1.0)
+
     assert input.shape == label.shape
     helper = LayerHelper("ctr_metric_bundle", **locals())
 
@@ -164,12 +176,6 @@ def ctr_metric_bundle(input, label):
     helper.append_op(type="reduce_sum",
                      inputs={"X": [tmp_res_sigmoid]},
                      outputs={"Out": [batch_q]})
-    helper.append_op(type="elementwise_add",
-                     inputs={
-                         "X": [batch_q],
-                         "Y": [local_q]
-                     },
-                     outputs={"Out": [local_q]})
 
     helper.append_op(type="reduce_sum",
                      inputs={"X": [label]},
@@ -192,11 +198,45 @@ def ctr_metric_bundle(input, label):
     helper.append_op(type="reduce_sum",
                      inputs={"X": [tmp_ones]},
                      outputs={"Out": [batch_ins_num]})
+
+    #if data is fake, return 0
+    inputs_slice = {'Input': ins_tag_weight}
+    attrs = {'axes': [0]}
+    attrs['starts'] = [0]
+    attrs['ends'] = [1]
+    helper.append_op(type="slice",
+                     inputs=inputs_slice,
+                     attrs=attrs,
+                     outputs={"Out": ins_tag_weight})
+
+    axis = helper.kwargs.get('axis', 0)
+    helper.append_op(type="elementwise_mul",
+                     inputs={
+                         "X": [batch_ins_num],
+                         "Y": [ins_tag_weight]
+                     },
+                     outputs={"Out": [batch_ins_num]},
+                     attrs={'axis': axis})
+
     helper.append_op(type="elementwise_add",
                      inputs={
                          "X": [batch_ins_num],
                          "Y": [local_ins_num]
                      },
                      outputs={"Out": [local_ins_num]})
+
+    helper.append_op(type="elementwise_mul",
+                     inputs={
+                         "X": [batch_q],
+                         "Y": [ins_tag_weight]
+                     },
+                     outputs={"Out": [batch_q]},
+                     attrs={'axis': axis})
+    helper.append_op(type="elementwise_add",
+                     inputs={
+                         "X": [batch_q],
+                         "Y": [local_q]
+                     },
+                     outputs={"Out": [local_q]})
 
     return local_sqrerr, local_abserr, local_prob, local_q, local_pos_num, local_ins_num


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes 

### PR changes
APIs 

### Describe
背景介绍：如下图，当不存在tag2的数据时，目前的策略是填充‘0值假数据’，这导致了计算MSE, RMSE等指标时，包含了假数据，干扰真实指标。

![image](https://user-images.githubusercontent.com/41941775/159460402-4e52cbcf-d7b9-4db0-9f6f-74b2ad36981b.png)

解决方案：在ctr_metric_bundle里加入了ins_tag_weight属性，用来判别多任务中的真假数据，如果为真数据ins_tag_weight为全1值，然后分别做对应的处理。

