### PR TITLE
Update fft.py 修复paddle.fft.fftshift()的docstring问题

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -1293,14 +1293,14 @@ def fftshift(x, axes=None, name=None):
     Note that ``y[0]`` is the Nyquist component only if ``len(x)`` is even.
 
     Args:
-        n (int): Dimension inputed.
+        x (Tensor): The input data, data type is real or complex.
         axes (int|tuple, optional): The axis on which to move. The default is none, which moves all axes.
             Default is None.
         name (str, optional): The default value is None.  Normally there is no need for user to set 
             this property. For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        Tensor. The shifted tensor.
+        Tensor. The shifted tensor.The shape and data type are the same as the input tensor, and the output after moving along axes.
     
     Examples:
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
Issues: https://github.com/PaddlePaddle/docs/issues/5041

fftshift() 第一个参数名写错了; Returns部分也漏掉了中文版的后半句。