### PR TITLE
尝试修复了在新版本gcc上的编译报错

### DIFF
--- a/cmake/external/gloo.cmake
+++ b/cmake/external/gloo.cmake
@@ -33,6 +33,10 @@ set(GLOO_LIBRARIES
 
 include_directories(${GLOO_INCLUDE_DIR})
 
+if (UNIX)
+  set(GLOO_PATCH_COMMAND sh ${PADDLE_SOURCE_DIR}/patches/gloo/device_patch.sh ${GLOO_SOURCE_DIR})
+endif ()
+
 if(WITH_ASCEND OR WITH_ASCEND_CL)
   ExternalProject_Add(
     ${GLOO_PROJECT}
@@ -41,6 +45,7 @@ if(WITH_ASCEND OR WITH_ASCEND_CL)
     GIT_TAG ${GLOO_TAG}
     PREFIX "${GLOO_PREFIX_DIR}"
     UPDATE_COMMAND ""
+    PATCH_COMMAND ${GLOO_PATCH_COMMAND}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND
       mkdir -p ${GLOO_SOURCE_DIR}/build && cd ${GLOO_SOURCE_DIR}/build && cmake
@@ -59,6 +64,7 @@ else()
     GIT_TAG ${GLOO_TAG}
     PREFIX "${GLOO_PREFIX_DIR}"
     UPDATE_COMMAND ""
+    PATCH_COMMAND ${GLOO_PATCH_COMMAND}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND
       mkdir -p ${GLOO_SOURCE_DIR}/build && cd ${GLOO_SOURCE_DIR}/build && cmake

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -251,6 +251,11 @@ function(build_protobuf TARGET_NAME BUILD_FOR_HOST)
     set(PROTOBUF_REPOSITORY ${GIT_URL}/protocolbuffers/protobuf.git)
     set(PROTOBUF_TAG 9f75c5aa851cd877fb0d93ccc31b8567a6706546)
   endif()
+
+  if (UNIX)
+    set(PROTOBUF_PATCH_COMMAND sh ${PADDLE_SOURCE_DIR}/patches/protobuf/java_file_patch.sh ${PROTOBUF_SOURCE_DIR})
+  endif ()
+
   if(WITH_ARM_BRPC)
     set(ARM_PROTOBUF_URL
         "https://paddlerec.bj.bcebos.com/online_infer/arm_brpc_ubuntu18/arm_protobuf.tar.gz"
@@ -292,6 +297,7 @@ function(build_protobuf TARGET_NAME BUILD_FOR_HOST)
       PREFIX ${PROTOBUF_PREFIX_DIR}
       UPDATE_COMMAND ""
       DEPENDS zlib
+      PATCH_COMMAND   ${PROTOBUF_PATCH_COMMAND}
       CONFIGURE_COMMAND
         ${CMAKE_COMMAND} ${PROTOBUF_SOURCE_DIR}/cmake ${OPTIONAL_ARGS}
         -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_SKIP_RPATH=ON

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -157,6 +157,11 @@ if(NOT WIN32)
       -Wno-error=maybe-uninitialized # Warning in boost gcc 7.2
       ${fsanitize})
 
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.2)
+    set(COMMON_FLAGS ${COMMON_FLAGS}
+            -Wno-error)
+  endif ()
+
   if(WITH_IPU)
     set(COMMON_FLAGS ${COMMON_FLAGS} -Wno-sign-compare # Warnings in Popart
                      -Wno-non-virtual-dtor # Warnings in Popart

--- a/paddle/fluid/framework/data_feed.cc
+++ b/paddle/fluid/framework/data_feed.cc
@@ -1537,12 +1537,12 @@ void PrivateInstantDataFeed<T>::PutToFeedVec() {
     if (type[0] == 'f') {  // float
       const auto& feasign = ins_vec_[i].GetFloatData();
       float* tensor_ptr =
-          feed_vec_[i]->mutable_data<float>({total_instance, 1}, this->place_);
+          feed_vec_[i]->template mutable_data<float>({total_instance, 1}, this->place_);
       CopyToFeedTensor(tensor_ptr, &feasign[0], total_instance * sizeof(float));
     } else if (type[0] == 'u') {  // uint64
       // no uint64_t type in paddlepaddle
       const auto& feasign = ins_vec_[i].GetUint64Data();
-      int64_t* tensor_ptr = feed_vec_[i]->mutable_data<int64_t>(
+      int64_t* tensor_ptr = feed_vec_[i]->template mutable_data<int64_t>(
           {total_instance, 1}, this->place_);
       CopyToFeedTensor(
           tensor_ptr, &feasign[0], total_instance * sizeof(int64_t));

--- a/paddle/fluid/memory/detail/memory_block.h
+++ b/paddle/fluid/memory/detail/memory_block.h
@@ -14,6 +14,7 @@ limitations under the License. */
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include <unordered_map>
 
 namespace paddle {

--- a/patches/gloo/device_patch.sh
+++ b/patches/gloo/device_patch.sh
@@ -1,0 +1,2 @@
+sed -i ':a;N;$!ba;s/#include <string.h>\n\n/#include <string.h>\n#include <array>\n\n/' \
+"$1/gloo/transport/tcp/device.cc"

--- a/patches/protobuf/java_file_patch.sh
+++ b/patches/protobuf/java_file_patch.sh
@@ -1,0 +1,2 @@
+sed -i 's/bool operator ()(const FieldDescriptor\* f1, const FieldDescriptor\* f2) {/bool operator ()(const FieldDescriptor\* f1, const FieldDescriptor\* f2) const {/' \
+"$1/src/google/protobuf/compiler/java/java_file.cc"


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
#43422
在2.3.1版本tag上编译通过，目前看起来正常
编译环境: archlinux，gcc12.1
用了偷懒的办法 -Wno-error，总比编译不过去，然后用不了的好

提交中有protobuf和gloo的补丁，然后看到protobuf最后一次提交是2016年。额，这种低级的编译报错只要升一下版本就没了吧，然后也就没必要打补丁了。