### PR TITLE
[PHI] Clean glog header in public header

### DIFF
--- a/paddle/phi/backends/device_manager.cc
+++ b/paddle/phi/backends/device_manager.cc
@@ -24,6 +24,8 @@
 #include <functional>
 #include <regex>
 
+#include "glog/logging.h"
+
 namespace phi {
 
 void Device::CreateStream(stream::Stream* stream,

--- a/paddle/phi/backends/dynload/port.cc
+++ b/paddle/phi/backends/dynload/port.cc
@@ -18,6 +18,9 @@
 #include <stdexcept>
 #include <string>
 
+#define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h
+#include "glog/logging.h"
+
 #if !defined(_WIN32)
 #include <dlfcn.h>  // dladdr
 #include <sys/stat.h>

--- a/paddle/phi/backends/dynload/port.cc
+++ b/paddle/phi/backends/dynload/port.cc
@@ -18,7 +18,6 @@
 #include <stdexcept>
 #include <string>
 
-#define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h
 #include "glog/logging.h"
 
 #if !defined(_WIN32)

--- a/paddle/phi/backends/dynload/port.h
+++ b/paddle/phi/backends/dynload/port.h
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h
+
 #if !defined(_WIN32)
 #include <dlfcn.h>  // dladdr
 #include <sys/time.h>

--- a/paddle/phi/backends/dynload/port.h
+++ b/paddle/phi/backends/dynload/port.h
@@ -16,9 +16,6 @@
 
 #include <string>
 
-#define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h
-#include "glog/logging.h"
-
 #if !defined(_WIN32)
 #include <dlfcn.h>  // dladdr
 #include <sys/time.h>

--- a/paddle/phi/backends/gpu/gpu_info.cc
+++ b/paddle/phi/backends/gpu/gpu_info.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/phi/backends/gpu/gpu_info.h"
 
+#include <sstream>
 #include <vector>
 
 #include "gflags/gflags.h"

--- a/paddle/phi/backends/gpu/gpu_launch_config.h
+++ b/paddle/phi/backends/gpu/gpu_launch_config.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <vector>
 
+#include "glog/logging.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/enforce.h"
 

--- a/paddle/phi/core/meta_tensor.cc
+++ b/paddle/phi/core/meta_tensor.cc
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #include "paddle/phi/core/meta_tensor.h"
 
+#include "glog/logging.h"
+
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/selected_rows.h"

--- a/paddle/phi/core/meta_tensor.h
+++ b/paddle/phi/core/meta_tensor.h
@@ -14,7 +14,6 @@ limitations under the License. */
 
 #pragma once
 
-#include "glog/logging.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/layout.h"
 #include "paddle/phi/core/ddim.h"

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -17,6 +17,8 @@ limitations under the License. */
 #include <algorithm>
 #include <vector>
 
+#include "glog/logging.h"
+
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/layout.h"
 #include "paddle/phi/core/ddim.h"

--- a/paddle/phi/infermeta/ternary.cc
+++ b/paddle/phi/infermeta/ternary.cc
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #include "paddle/phi/infermeta/ternary.h"
 
+#include "glog/logging.h"
+
 #include "paddle/phi/common/layout.h"
 #include "paddle/phi/core/ddim.h"
 #include "paddle/phi/kernels/funcs/common_shape.h"

--- a/paddle/phi/kernels/funcs/data_type_transform.h
+++ b/paddle/phi/kernels/funcs/data_type_transform.h
@@ -14,6 +14,8 @@ limitations under the License. */
 
 #pragma once
 
+#include "glog/logging.h"
+
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/cast_kernel.h"

--- a/paddle/phi/kernels/gpu/allclose_kernel.cu
+++ b/paddle/phi/kernels/gpu/allclose_kernel.cu
@@ -14,6 +14,8 @@
 
 #include "paddle/phi/kernels/allclose_kernel.h"
 
+#include "glog/logging.h"
+
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 

--- a/paddle/phi/kernels/impl/einsum_impl.h
+++ b/paddle/phi/kernels/impl/einsum_impl.h
@@ -15,6 +15,8 @@
 
 #include <set>
 
+#include "glog/logging.h"
+
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/matmul_kernel.h"
 #include "paddle/phi/kernels/reduce_sum_kernel.h"

--- a/paddle/phi/kernels/sparse/cpu/elementwise_grad_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/elementwise_grad_kernel.cc
@@ -12,6 +12,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include "glog/logging.h"
+
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[PHI] Clean glog header in public header

由于port.h中include了gloging.h，导致外部编译自定义算子的时候会出现头文件找不到的问题，glog和gflags并不会作为官方对外接口的依赖，相关头文件需要尽量放到cc中

![16e5432db4da9c9c233cd5ea2884392a](https://user-images.githubusercontent.com/22561442/178205430-45a40edc-93dd-4182-b96f-8541d4265035.png)

剩余增加gloging.h的头文件暂时不会作为公开头文件，后续也需要尽可能移到.cc