### PR TITLE
[MLU] fix mlu ctest for bilinear, relu6 and squared_l2_norm

### DIFF
--- a/python/paddle/fluid/tests/unittests/mlu/test_bilinear_interp_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_bilinear_interp_v2_op_mlu.py
@@ -576,8 +576,6 @@ class TestBilinearInterpOpAPI_dy(unittest.TestCase):
             place = core.CPUPlace()
         with fluid.dygraph.guard(place):
             input_data = np.random.random((2, 3, 6, 6)).astype("float32")
-            input_data = np.load('input.npy').astype("float32")
-            # print(input_data)
             input_x = paddle.to_tensor(input_data)
             expect_res = bilinear_interp_np(input_data,
                                             out_h=12,

--- a/python/paddle/fluid/tests/unittests/mlu/test_relu6_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_relu6_op_mlu.py
@@ -15,13 +15,13 @@
 from __future__ import print_function
 import paddle.fluid as fluid
 import paddle
+import sys
+
+sys.path.append("..")
 from op_test import OpTest
 
 import numpy as np
 import unittest
-import sys
-
-sys.path.append("..")
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/mlu/test_squared_l2_norm_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_squared_l2_norm_op_mlu.py
@@ -24,6 +24,8 @@ from op_test import OpTest
 import paddle
 from paddle import _C_ops
 
+paddle.enable_static()
+
 
 class TestL2LossOp(OpTest):
     """Test squared_l2_norm
@@ -66,5 +68,4 @@ class TestL2LossDeterministic(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
fix mlu ctest for bilinear, relu6 and squared_l2_norm