### PR TITLE
Update fft.py ihfft() 对参数x的描述补上中文版“数据类型为实数”的描述

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -436,7 +436,7 @@ def ihfft(x, n=None, axis=-1, norm="backward", name=None):
     ``n//2 + 1``.
 
     Args:
-        x(Tensor): Input tensor.
+        x(Tensor): Input tensor. The data type is real.
         n(int, optional): The number of points along transformation axis in the 
             input to use.  If `n` is smaller than the length of the input, the 
             input is cropped.  If it is larger, the input is padded with zeros. 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
Issues: https://github.com/PaddlePaddle/docs/issues/5064
ihfft() 中文版 参数x的描述里有“数据类型为实数”， 源代码里缺少对应的描述，因此补上