### PR TITLE
Update fft.py ihfft2() 对参数x的描述补上中文版“数据类型为实数”的描述

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -1144,7 +1144,7 @@ def ihfft2(x, s=None, axes=(-2, -1), norm="backward", name=None):
     For more details see `ihfftn`.
 
     Args:
-        x(Tensor): Input tensor
+        x(Tensor): Input tensor. The data type is real.
         s(Sequence[int], optional): Shape of the real input to the inverse FFT.
         axes(Sequance[int], optional): The axes over which to compute the 
             inverse fft. Default is the last two axes.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
ihfft2() 中文版 参数x的描述里有“数据类型为实数”， 源代码里缺少对应的描述，因此补上