### PR TITLE
Update fft.py ihfftn() 对参数x的描述补上中文版“数据类型为实数”的描述

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -807,7 +807,7 @@ def ihfftn(x, s=None, axes=None, norm="backward", name=None):
     efficient algorithm called the Fast Fourier Transform (FFT).
 
     Args:
-        x(Tensor): Input tensor.
+        x(Tensor): Input tensor. The data type is real.
         s(Sequence[int], optional) : Shape (length along each transformed axis) 
             to use from the input. (``s[0]`` refers to axis 0, ``s[1]`` to axis 
             1, etc.). Along any axis, if the given shape is smaller than that 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs

### Describe
<!-- Describe what this PR does -->
ihfftn() 中文版 参数x的描述里有“数据类型为实数”， 源代码里缺少对应的描述，因此补上