### PR TITLE
hide prim2orig in executor

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1454,7 +1454,7 @@ class Executor(object):
                                                      for_test=True)
                         inner_program = ir_graph.to_program()
                     else:
-                        from ..incubate.autograd import prim_enabled, prim2orig
+                        from paddle.incubate.autograd import prim_enabled, prim2orig
                         if prim_enabled() and program == default_main_program():
                             prim2orig()
 

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1453,6 +1453,11 @@ class Executor(object):
                         ir_graph = framework.IrGraph(compiled_graph,
                                                      for_test=True)
                         inner_program = ir_graph.to_program()
+                    else:
+                        from ..incubate.autograd import prim_enabled, prim2orig
+                        if prim_enabled() and program == default_main_program():
+                            prim2orig()
+
                     program = self._add_feed_fetch_ops(
                         program=inner_program,
                         feed=feed,

--- a/python/paddle/fluid/tests/unittests/autograd/test_primapi.py
+++ b/python/paddle/fluid/tests/unittests/autograd/test_primapi.py
@@ -48,7 +48,7 @@ class TestWithoutProgramGuard(unittest.TestCase):
 
     def test_forward_grad_without_program_guard(self):
 
-        def with_param_guard():
+        def with_program_guard():
             paddle.incubate.autograd.enable_prim()
             sp = paddle.static.Program()
             mp = paddle.static.Program()
@@ -66,7 +66,7 @@ class TestWithoutProgramGuard(unittest.TestCase):
             paddle.incubate.autograd.disable_prim()
             return out
 
-        def without_param_guard():
+        def without_program_guard():
             paddle.incubate.autograd.enable_prim()
             feed, static_xs, static_v = utils.gen_static_data_and_feed(
                 self.xs, self.v, stop_gradient=False)
@@ -82,8 +82,8 @@ class TestWithoutProgramGuard(unittest.TestCase):
             paddle.incubate.autograd.disable_prim()
             return out
 
-        expected = with_param_guard()
-        actual = without_param_guard()
+        expected = with_program_guard()
+        actual = without_program_guard()
         self.assertEqual(type(actual), type(expected))
         np.testing.assert_allclose(np.concatenate(actual),
                                    np.concatenate(expected),
@@ -92,7 +92,7 @@ class TestWithoutProgramGuard(unittest.TestCase):
 
     def test_grad_without_program_guard(self):
 
-        def with_param_guard():
+        def with_program_guard():
             paddle.incubate.autograd.enable_prim()
             sp = paddle.static.Program()
             mp = paddle.static.Program()
@@ -109,7 +109,7 @@ class TestWithoutProgramGuard(unittest.TestCase):
             paddle.incubate.autograd.disable_prim()
             return out
 
-        def without_param_guard():
+        def without_program_guard():
             paddle.incubate.autograd.enable_prim()
             feed, static_xs, static_v = utils.gen_static_data_and_feed(
                 self.xs, self.v, stop_gradient=False)
@@ -124,8 +124,8 @@ class TestWithoutProgramGuard(unittest.TestCase):
             paddle.incubate.autograd.disable_prim()
             return out
 
-        expected = with_param_guard()
-        actual = without_param_guard()
+        expected = with_program_guard()
+        actual = without_program_guard()
         for i, j in zip(actual, expected):
             self.assertEqual(type(i), type(j))
             np.testing.assert_allclose(np.concatenate(i),

--- a/python/paddle/fluid/tests/unittests/autograd/test_primapi.py
+++ b/python/paddle/fluid/tests/unittests/autograd/test_primapi.py
@@ -27,6 +27,117 @@ import utils
 @utils.parameterize(
     (utils.TEST_CASE_NAME, 'fun', 'xs', 'v', 'dtype'),
     (('matmul', paddle.matmul,
+      (np.random.rand(2, 3), np.random.rand(3, 2)), None, 'float32'), ))
+class TestWithoutProgramGuard(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.xs = tuple(x.astype(cls.dtype) for x in cls.xs)
+        cls._rtol = config.TOLERANCE.get(str(
+            cls.dtype)).get("first_order_grad").get("rtol")
+        cls._atol = config.TOLERANCE.get(str(
+            cls.dtype)).get("first_order_grad").get("atol")
+
+    def setUp(self):
+        paddle.enable_static()
+        paddle.incubate.autograd.enable_prim()
+
+    def tearDown(self):
+        paddle.incubate.autograd.disable_prim()
+        paddle.disable_static()
+
+    def test_forward_grad_without_program_guard(self):
+
+        def with_param_guard():
+            paddle.incubate.autograd.enable_prim()
+            sp = paddle.static.Program()
+            mp = paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                feed, static_xs, static_v = utils.gen_static_data_and_feed(
+                    self.xs, self.v, stop_gradient=False)
+                ys = self.fun(*static_xs) if isinstance(
+                    static_xs, typing.Sequence) else self.fun(static_xs)
+                ys_grad = paddle.incubate.autograd.forward_grad(
+                    ys, static_xs, static_v)
+                paddle.incubate.autograd.prim2orig(mp.block(0))
+            exe = paddle.static.Executor()
+            exe.run(sp)
+            out = exe.run(mp, feed=feed, fetch_list=ys_grad)
+            paddle.incubate.autograd.disable_prim()
+            return out
+
+        def without_param_guard():
+            paddle.incubate.autograd.enable_prim()
+            feed, static_xs, static_v = utils.gen_static_data_and_feed(
+                self.xs, self.v, stop_gradient=False)
+            ys = self.fun(*static_xs) if isinstance(
+                static_xs, typing.Sequence) else self.fun(static_xs)
+            ys_grad = paddle.incubate.autograd.forward_grad(
+                ys, static_xs, static_v)
+            sp = paddle.fluid.framework.default_startup_program()
+            mp = paddle.fluid.framework.default_main_program()
+            exe = paddle.static.Executor()
+            exe.run(sp)
+            out = exe.run(mp, feed=feed, fetch_list=ys_grad)
+            paddle.incubate.autograd.disable_prim()
+            return out
+
+        expected = with_param_guard()
+        actual = without_param_guard()
+        self.assertEqual(type(actual), type(expected))
+        np.testing.assert_allclose(np.concatenate(actual),
+                                   np.concatenate(expected),
+                                   rtol=self._rtol,
+                                   atol=self._atol)
+
+    def test_grad_without_program_guard(self):
+
+        def with_param_guard():
+            paddle.incubate.autograd.enable_prim()
+            sp = paddle.static.Program()
+            mp = paddle.static.Program()
+            with paddle.static.program_guard(mp, sp):
+                feed, static_xs, static_v = utils.gen_static_data_and_feed(
+                    self.xs, self.v, stop_gradient=False)
+                ys = self.fun(*static_xs) if isinstance(
+                    static_xs, typing.Sequence) else self.fun(static_xs)
+                xs_grad = paddle.incubate.autograd.grad(ys, static_xs, static_v)
+                paddle.incubate.autograd.prim2orig(mp.block(0))
+            exe = paddle.static.Executor()
+            exe.run(sp)
+            out = exe.run(mp, feed=feed, fetch_list=xs_grad)
+            paddle.incubate.autograd.disable_prim()
+            return out
+
+        def without_param_guard():
+            paddle.incubate.autograd.enable_prim()
+            feed, static_xs, static_v = utils.gen_static_data_and_feed(
+                self.xs, self.v, stop_gradient=False)
+            ys = self.fun(*static_xs) if isinstance(
+                static_xs, typing.Sequence) else self.fun(static_xs)
+            xs_grad = paddle.incubate.autograd.grad(ys, static_xs, static_v)
+            sp = paddle.fluid.framework.default_startup_program()
+            mp = paddle.fluid.framework.default_main_program()
+            exe = paddle.static.Executor()
+            exe.run(sp)
+            out = exe.run(mp, feed=feed, fetch_list=xs_grad)
+            paddle.incubate.autograd.disable_prim()
+            return out
+
+        expected = with_param_guard()
+        actual = without_param_guard()
+        for i, j in zip(actual, expected):
+            self.assertEqual(type(i), type(j))
+            np.testing.assert_allclose(np.concatenate(i),
+                                       np.concatenate(j),
+                                       rtol=self._rtol,
+                                       atol=self._atol)
+
+
+@utils.place(config.DEVICES)
+@utils.parameterize(
+    (utils.TEST_CASE_NAME, 'fun', 'xs', 'v', 'dtype'),
+    (('matmul', paddle.matmul,
       (np.random.rand(2, 3), np.random.rand(3, 2)), None, 'float32'),
      ('multiply', paddle.multiply,
       (np.random.rand(2, 3), np.random.rand(2, 3)), None, 'float64'),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
The conversion function from automatic differential basic operator to native operator is integrated into the executor
