### PR TITLE
[ Phi Kernel ] Transfer as_real to phi.

### DIFF
--- a/paddle/fluid/operators/complex_view_op.cc
+++ b/paddle/fluid/operators/complex_view_op.cc
@@ -20,7 +20,9 @@
 #include <vector>
 
 #include "paddle/fluid/framework/data_type.h"
+#include "paddle/fluid/framework/infershape_utils.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/infermeta/unary.h"
 
 namespace paddle {
 namespace operators {
@@ -94,17 +96,6 @@ class AsRealOp : public framework::OperatorWithKernel {
  public:
   using framework::OperatorWithKernel::OperatorWithKernel;
 
-  void InferShape(framework::InferShapeContext *ctx) const override {
-    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "as_real");
-    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "as_real");
-
-    auto out_dims_v = phi::vectorize(ctx->GetInputDim("X"));
-    out_dims_v.push_back(2);
-    const framework::DDim out_dims = phi::make_ddim(out_dims_v);
-    ctx->SetOutputDim("Out", out_dims);
-    ctx->ShareLoD("X", /*->*/ "Out");
-  }
-
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
@@ -148,6 +139,9 @@ class AsRealGradMaker : public framework::SingleGradOpMaker<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
+DECLARE_INFER_SHAPE_FUNCTOR(as_real,
+                            AsRealInferShapeFunctor,
+                            PD_INFER_META(phi::AsRealInferMeta));
 
 REGISTER_OPERATOR(as_complex,
                   ops::AsComplexOp,
@@ -158,13 +152,10 @@ REGISTER_OPERATOR(as_complex,
 REGISTER_OPERATOR(as_real,
                   ops::AsRealOp,
                   ops::AsRealOpMaker,
+                  AsRealInferShapeFunctor,
                   ops::AsRealGradMaker<paddle::framework::OpDesc>,
                   ops::AsRealGradMaker<paddle::imperative::OpBase>);
 
 REGISTER_OP_CPU_KERNEL(as_complex,
                        ops::AsComplexKernel<phi::CPUContext, float>,
                        ops::AsComplexKernel<phi::CPUContext, double>);
-
-REGISTER_OP_CPU_KERNEL(as_real,
-                       ops::AsRealKernel<phi::CPUContext, float>,
-                       ops::AsRealKernel<phi::CPUContext, double>);

--- a/paddle/fluid/operators/complex_view_op.h
+++ b/paddle/fluid/operators/complex_view_op.h
@@ -41,20 +41,5 @@ class AsComplexKernel : public framework::OpKernel<T> {
   }
 };
 
-template <typename DeviceContext, typename T>
-class AsRealKernel : public framework::OpKernel<T> {
- public:
-  void Compute(const framework::ExecutionContext& context) const override {
-    const auto* x = context.Input<framework::LoDTensor>("X");
-    auto* out = context.Output<framework::LoDTensor>("Out");
-
-    out->mutable_data<T>(context.GetPlace());
-    const framework::DDim out_dims_original = out->dims();
-    framework::TensorCopy(*x, context.GetPlace(), out);
-    out->Resize(out_dims_original);            // restored the shape
-    out->mutable_data<T>(context.GetPlace());  // restore the dtype
-  }
-};
-
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/phi/api/yaml/api.yaml
+++ b/paddle/phi/api/yaml/api.yaml
@@ -1,12 +1,3 @@
-- api : as_real
-  args : (Tensor x)
-  output : Tensor
-  infer_meta :
-    func : AsRealInferMeta
-  kernel :
-    func : as_real
-#  backward : as_complex
-
 - api : atan2
   args : (Tensor x, Tensor y)
   output : Tensor

--- a/paddle/phi/api/yaml/api.yaml
+++ b/paddle/phi/api/yaml/api.yaml
@@ -1,3 +1,12 @@
+- api : as_real
+  args : (Tensor x)
+  output : Tensor
+  infer_meta :
+    func : AsRealInferMeta
+  kernel :
+    func : as_real
+#  backward : as_complex
+
 - api : atan2
   args : (Tensor x, Tensor y)
   output : Tensor

--- a/paddle/phi/api/yaml/legacy_api.yaml
+++ b/paddle/phi/api/yaml/legacy_api.yaml
@@ -167,6 +167,15 @@
     func : argsort
   backward : argsort_grad
 
+- api : as_real
+  args : (Tensor x)
+  output : Tensor
+  infer_meta :
+    func : AsRealInferMeta
+  kernel :
+    func : as_real
+#  backward : as_complex
+
 # asin
 - api : asin
   args : (Tensor x)

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -148,6 +148,14 @@ void ArgsortInferMeta(const MetaTensor& input,
   indices->share_lod(input);
 }
 
+void AsRealInferMeta(const MetaTensor& input, MetaTensor* output) {
+  auto out_dims_v = phi::vectorize(input.dims());
+  out_dims_v.push_back(2);
+  auto out_dims = phi::make_ddim(out_dims_v);
+  output->set_dims(out_dims);
+  output->share_lod(input);
+}
+
 void BatchSizeLikeInferMeta(const MetaTensor& x,
                             const std::vector<int>& shape,
                             int x_batch_size_dim,

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -48,6 +48,8 @@ void ArgsortInferMeta(const MetaTensor& input,
                       MetaTensor* output,
                       MetaTensor* indices);
 
+void AsRealInferMeta(const MetaTensor& input, MetaTensor* output);
+
 void BatchSizeLikeInferMeta(const MetaTensor& x,
                             const std::vector<int>& shape,
                             int x_batch_size_dim,

--- a/paddle/phi/kernels/as_real_kernel.h
+++ b/paddle/phi/kernels/as_real_kernel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/fluid/operators/complex_view_op.h"
-#include "paddle/fluid/framework/data_type.h"
-#include "paddle/fluid/platform/enforce.h"
+#pragma once
 
-namespace ops = paddle::operators;
+#include "paddle/phi/core/dense_tensor.h"
 
-REGISTER_OP_CUDA_KERNEL(
-    as_complex,
-    ops::AsComplexKernel<paddle::platform::CUDADeviceContext, float>,
-    ops::AsComplexKernel<paddle::platform::CUDADeviceContext, double>);
+namespace phi {
+
+template <typename T, typename Context>
+void AsRealKernel(const Context& dev_ctx,
+                  const DenseTensor& x,
+                  DenseTensor* out);
+
+}  // namespace phi

--- a/paddle/phi/kernels/cpu/as_real_kernel.cc
+++ b/paddle/phi/kernels/cpu/as_real_kernel.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/fluid/operators/complex_view_op.h"
-#include "paddle/fluid/framework/data_type.h"
-#include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/kernels/as_real_kernel.h"
 
-namespace ops = paddle::operators;
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/impl/as_real_impl.h"
 
-REGISTER_OP_CUDA_KERNEL(
-    as_complex,
-    ops::AsComplexKernel<paddle::platform::CUDADeviceContext, float>,
-    ops::AsComplexKernel<paddle::platform::CUDADeviceContext, double>);
+PD_REGISTER_KERNEL(as_real, CPU, ALL_LAYOUT, phi::AsRealKernel, float, double) {
+}

--- a/paddle/phi/kernels/gpu/as_real_kernel.cu
+++ b/paddle/phi/kernels/gpu/as_real_kernel.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/fluid/operators/complex_view_op.h"
-#include "paddle/fluid/framework/data_type.h"
-#include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/kernels/as_real_kernel.h"
 
-namespace ops = paddle::operators;
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/impl/as_real_impl.h"
 
-REGISTER_OP_CUDA_KERNEL(
-    as_complex,
-    ops::AsComplexKernel<paddle::platform::CUDADeviceContext, float>,
-    ops::AsComplexKernel<paddle::platform::CUDADeviceContext, double>);
+PD_REGISTER_KERNEL(as_real, GPU, ALL_LAYOUT, phi::AsRealKernel, float, double) {
+}

--- a/paddle/phi/kernels/impl/as_real_impl.h
+++ b/paddle/phi/kernels/impl/as_real_impl.h
@@ -25,7 +25,7 @@ template <typename T, typename Context>
 void AsRealKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   ctx.template Alloc<T>(out);
   auto out_dims_original = out->dims();
-  Copy(ctx, x, ctx.GetPlace(), true, out);
+  Copy(ctx, x, ctx.GetPlace(), false, out);
   out->Resize(out_dims_original);  // restored the shape.
   out->set_type(
       paddle::experimental::CppTypeToDataType<T>::Type());  // restored the

--- a/paddle/phi/kernels/impl/as_real_impl.h
+++ b/paddle/phi/kernels/impl/as_real_impl.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/kernels/as_real_kernel.h"
+
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/tensor_utils.h"
+#include "paddle/phi/kernels/funcs/for_range.h"
+
+namespace phi {
+template <typename T, typename Context>
+void AsRealKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
+  ctx.template Alloc<T>(out);
+  auto out_dims_original = out->dims();
+  Copy(ctx, x, ctx.GetPlace(), true, out);
+  out->Resize(out_dims_original);  // restored the shape.
+  out->set_type(
+      paddle::experimental::CppTypeToDataType<T>::Type());  // restored the
+                                                            // dtype.
+}
+
+}  // namespace phi

--- a/python/paddle/fluid/tests/unittests/test_complex_view_op.py
+++ b/python/paddle/fluid/tests/unittests/test_complex_view_op.py
@@ -67,6 +67,7 @@ class TestViewAsRealOp(OpTest):
         out_ref = ref_view_as_real(x)
         self.inputs = {'X': x}
         self.outputs = {'Out': out_ref}
+        self.python_api = paddle.as_real
         self.out_grad = np.ones([10, 10, 2], dtype="float64")
 
     def test_check_output(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Transfer as_real to phi.
backward of as_real is as_complex which will be transfered by feiyu.