### PR TITLE
cancel transforming seed data in dropout op

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2173,17 +2173,11 @@ Scope* OperatorWithKernel::PrepareData(
 
       // Do transfer
       Tensor out;
-      if ((new_expected_kernel_key
-               ? *new_expected_kernel_key
-               : expected_kernel_key) == kernel_type_for_var) {
-        out.ShareDataWith(*tensor_in);
-      } else {
-        TransformData(new_expected_kernel_key ? *new_expected_kernel_key
-                                              : expected_kernel_key,
-                      kernel_type_for_var,
-                      *tensor_in,
-                      &out);
-      }
+      TransformData(new_expected_kernel_key ? *new_expected_kernel_key
+                                            : expected_kernel_key,
+                    kernel_type_for_var,
+                    *tensor_in,
+                    &out);
       SetTensorToVariable(*var, out, trans_var);
     }
   };

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2173,11 +2173,17 @@ Scope* OperatorWithKernel::PrepareData(
 
       // Do transfer
       Tensor out;
-      TransformData(new_expected_kernel_key ? *new_expected_kernel_key
-                                            : expected_kernel_key,
-                    kernel_type_for_var,
-                    *tensor_in,
-                    &out);
+      if ((new_expected_kernel_key
+               ? *new_expected_kernel_key
+               : expected_kernel_key) == kernel_type_for_var) {
+        out.ShareDataWith(*tensor_in);
+      } else {
+        TransformData(new_expected_kernel_key ? *new_expected_kernel_key
+                                              : expected_kernel_key,
+                      kernel_type_for_var,
+                      *tensor_in,
+                      &out);
+      }
       SetTensorToVariable(*var, out, trans_var);
     }
   };

--- a/paddle/phi/kernels/gpu/dropout_kernel.cu
+++ b/paddle/phi/kernels/gpu/dropout_kernel.cu
@@ -84,7 +84,9 @@ PD_REGISTER_KERNEL(dropout,
                    float,
                    double,
                    phi::dtype::bfloat16,
-                   phi::dtype::float16) {}
+                   phi::dtype::float16) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
+}
 
 PD_REGISTER_KERNEL(dropout_nd,
                    GPU,
@@ -93,4 +95,6 @@ PD_REGISTER_KERNEL(dropout_nd,
                    float,
                    double,
                    phi::dtype::bfloat16,
-                   phi::dtype::float16) {}
+                   phi::dtype::float16) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
+}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
seed parameter in dropout op needn't be transformed