### PR TITLE
add necessary dependency for fwd_func 

### DIFF
--- a/paddle/fluid/eager/api/manual/fluid_manual/forwards/CMakeLists.txt
+++ b/paddle/fluid/eager/api/manual/fluid_manual/forwards/CMakeLists.txt
@@ -3,21 +3,24 @@ cc_library(
   SRCS fused_gate_attention_fwd_func.cc
   DEPS ${eager_deps} ${fluid_deps} ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS})
 
-add_dependencies(fused_gate_attention_fwd_func eager_codegen)
+add_dependencies(fused_gate_attention_fwd_func eager_codegen
+                 copy_dygraph_forward_functions)
 
 cc_library(
   fused_feedforward_fwd_func
   SRCS fused_feedforward_fwd_func.cc
   DEPS ${eager_deps} ${fluid_deps} ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS})
 
-add_dependencies(fused_feedforward_fwd_func eager_codegen)
+add_dependencies(fused_feedforward_fwd_func eager_codegen
+                 copy_dygraph_forward_functions)
 
 cc_library(
   fused_attention_fwd_func
   SRCS fused_attention_fwd_func.cc
   DEPS ${eager_deps} ${fluid_deps} ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS})
 
-add_dependencies(fused_attention_fwd_func eager_codegen)
+add_dependencies(fused_attention_fwd_func eager_codegen
+                 copy_dygraph_forward_functions)
 
 set(fluid_manual_functions
     fused_gate_attention_fwd_func fused_feedforward_fwd_func


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add necessary dependency for fwd_func to avoid compiling error of random parallel compiling.
![Pasted Graphic 1](https://user-images.githubusercontent.com/51314274/178636794-1a3e66f8-9755-40c3-a785-fc8fb6bc13e6.png)

- fused_attention_fwd_func.cc's header amp_auto_cast.h depend cast_dygraph_function identifier, which is declared in dygraph_forward_api.h. 
- dygraph_forward_api.h will be generated actually only after copy_dygraph_forward_functions target built.
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/51314274/178496214-10f8a117-0ed6-48fe-9faa-21cd8a71e6d0.png">

- So fused_attention_fwd_func should depend on copy_dygraph_forward_functions.