### PR TITLE
Skip core ops api in static check

### DIFF
--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -292,6 +292,11 @@ def parse_args():
                         help="using get_all_api or from_modulelist")
     parser.add_argument('module', type=str, help='module',
                         default='paddle')  # not used
+    parser.add_argument('--skipped',
+                        dest='skipped',
+                        type=str,
+                        help='Skip Checking submodules',
+                        default='paddle.fluid.core_avx.eager.ops')
 
     if len(sys.argv) == 1:
         args = parser.parse_args(['paddle'])
@@ -320,6 +325,8 @@ if __name__ == '__main__':
             all_api_names_to_k[api_name] = k
         all_api_names_sorted = sorted(all_api_names_to_k.keys())
         for api_name in all_api_names_sorted:
+            if api_name.find(args.skipped) >= 0:
+                continue
             api_info = api_info_dict[all_api_names_to_k[api_name]]
             print("{0} ({2}, ('document', '{1}'))".format(
                 api_name, md5(api_info['docstring']), api_info['signature']

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -325,7 +325,7 @@ if __name__ == '__main__':
             all_api_names_to_k[api_name] = k
         all_api_names_sorted = sorted(all_api_names_to_k.keys())
         for api_name in all_api_names_sorted:
-            if api_name.find(args.skipped) >= 0:
+            if args.skipped != '' and api_name.find(args.skipped) >= 0:
                 continue
             api_info = api_info_dict[all_api_names_to_k[api_name]]
             print("{0} ({2}, ('document', '{1}'))".format(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->

Skip core ops api in static check

跳过生成core.eager.ops相关API签名，也尝试了在各个脚本检查过程中，hack过滤掉对core.eager.ops的检查，但是需要在多处加入生硬的记录、查找和跳过逻辑，不如直接从源头上不生成来得简洁