### PR TITLE
Fixed elt_act_mkldnn_fuse_pass glog

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/elt_act_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/elt_act_mkldnn_fuse_pass.cc
@@ -99,10 +99,11 @@ void ElementwiseActivationOneDNNPass::FuseElementwiseAct(
 
   gpd(graph, handler);
   AddStatis(found_elementwise_activation_count);
-  PrettyLogDetail("---    fused %d %s with %s activation",
-                  found_elementwise_activation_count,
-                  elt_type,
-                  act_type);
+  if (!Has("disable_logs") || !Get<bool>("disable_logs"))
+    PrettyLogDetail("---    fused %d %s with %s activation",
+                    found_elementwise_activation_count,
+                    elt_type,
+                    act_type);
 }
 
 }  // namespace ir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
修复ele_act_fuse pass 在mkldnn模式下，无法禁用此pass输出的日志问题 https://github.com/PaddlePaddle/Paddle/issues/44269