### PR TITLE
[Eager] eager variable back sync

### DIFF
--- a/paddle/fluid/eager/eager_tensor.h
+++ b/paddle/fluid/eager/eager_tensor.h
@@ -234,7 +234,9 @@ class EagerVariable final {
     if (src_tensor_) {
       auto* framework_tensor = var_.GetMutable<phi::DenseTensor>();
       auto tensor_dense = static_cast<phi::DenseTensor*>(src_tensor_.get());
-      tensor_dense->ShareDataWith(*framework_tensor);
+      if (framework_tensor->memory_size() > 0) {
+        tensor_dense->ShareDataWith(*framework_tensor);
+      }
     }
   }
 

--- a/paddle/fluid/eager/eager_tensor.h
+++ b/paddle/fluid/eager/eager_tensor.h
@@ -235,8 +235,9 @@ class EagerVariable final {
       auto* framework_tensor = var_.GetMutable<phi::DenseTensor>();
       auto tensor_dense = static_cast<phi::DenseTensor*>(src_tensor_.get());
       if (framework_tensor->memory_size() > 0 &&
-          !paddle::platform::is_same_place(framework_tensor->place(),
-                                           tensor_dense->place())) {
+          (!paddle::platform::is_same_place(framework_tensor->place(),
+                                            tensor_dense->place()) ||
+           framework_tensor->dtype() != tensor_dense->dtype())) {
         tensor_dense->ShareBufferWith(*framework_tensor);
       }
     }

--- a/paddle/fluid/eager/eager_tensor.h
+++ b/paddle/fluid/eager/eager_tensor.h
@@ -234,8 +234,10 @@ class EagerVariable final {
     if (src_tensor_) {
       auto* framework_tensor = var_.GetMutable<phi::DenseTensor>();
       auto tensor_dense = static_cast<phi::DenseTensor*>(src_tensor_.get());
-      if (framework_tensor->memory_size() > 0) {
-        tensor_dense->ShareDataWith(*framework_tensor);
+      if (framework_tensor->memory_size() > 0 &&
+          !paddle::platform::is_same_place(framework_tensor->place(),
+                                           tensor_dense->place())) {
+        tensor_dense->ShareBufferWith(*framework_tensor);
       }
     }
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
中间态，在创建EagerVariable时，会var_.GetMutable，然后把原始tensor中的数据复制过去一份。
但在训练中，会存在TransFormData的情况。老动态图是直接TransForm原始Tensor的。而中间态TransForm了EagerVariable中的临时Tensor。导致原始Tensor没有改变。

Bert中存在一种场景：1个DataLoader的Tensor会被使用多次。在老动态图中只需要TransForm1次，但在新动态图中需要TransForm多次，导致性能下降。

本PR在EagerVariable析构时，将被TransForm的临时Tensor，回写到原始Tensor中。