### PR TITLE
transfer block_id to CreateVarNode in multi_devices_graph_pass

### DIFF
--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -579,12 +579,6 @@ void GraphToProgram(const Graph &graph,
 
     VLOG(3) << "Graph to program need convert " << graph.SubGraphsSize()
             << " sub graph";
-
-    std::unordered_set<std::string> vars_in_root_block;
-    for (const proto::VarDesc &var : block->vars()) {
-      vars_in_root_block.insert(var.name());
-    }
-
     for (size_t idx = 0; idx < graph.SubGraphsSize(); ++idx) {
       // avoid kRootBlockIndex not 0
       if (idx == kRootBlockIndex) continue;
@@ -592,14 +586,7 @@ void GraphToProgram(const Graph &graph,
       block = program_pb.add_blocks();
       block->set_idx(idx);
       block->set_parent_idx(kRootBlockIndex);
-
-      Graph *subgraph = graph.GetSubGraph(idx);
-      subgraph->SetNotOwned<std::unordered_set<std::string>>(
-          kGraphToProgramVarsToRemove, &vars_in_root_block);
-
-      GraphToBlock(*subgraph, block, sort_kind);
-
-      subgraph->Erase(kGraphToProgramVarsToRemove);
+      GraphToBlock(*graph.GetSubGraph(idx), block, sort_kind);
     }
   } else {
     GraphToBlock(graph, block, sort_kind);

--- a/paddle/fluid/framework/ir/multi_devices_graph_pass/multi_devices_graph_pass.cc
+++ b/paddle/fluid/framework/ir/multi_devices_graph_pass/multi_devices_graph_pass.cc
@@ -111,11 +111,12 @@ details::VarHandle *CreateOrGetLatestVarHandle(ir::Graph *graph,
   details::VarHandle *var = nullptr;
   if (var_holder.empty()) {
     if (node->Var()) {
-      var = new details::VarHandle(graph->CreateVarNode(node->Var()),
-                                   0,
-                                   place_offset,
-                                   node->Name(),
-                                   place);
+      var = new details::VarHandle(
+          graph->CreateVarNode(node->Var(), node->GetVarNodeBlockId()),
+          0,
+          place_offset,
+          node->Name(),
+          place);
     } else {
       var = new details::VarHandle(
           graph->CreateEmptyNode(node->Name(), ir::Node::Type::kVariable),
@@ -376,7 +377,8 @@ void MultiDevSSAGraphBuilderBase::CreateOpHandleIOs(ir::Graph *result,
   for (ir::Node *output : node->outputs) {
     ir::Node *new_node = nullptr;
     if (output->Var()) {
-      new_node = result->CreateVarNode(output->Var());
+      new_node =
+          result->CreateVarNode(output->Var(), output->GetVarNodeBlockId());
     } else {
       new_node =
           result->CreateEmptyNode(output->Name(), ir::Node::Type::kVariable);
@@ -696,7 +698,8 @@ void MultiDevSSAGraphBuilderBase::CreateScaleLossGradOp(
 
     CreateOpOutput(result,
                    op_handle,
-                   result->CreateVarNode(out_var_node->Var()),
+                   result->CreateVarNode(out_var_node->Var(),
+                                         out_var_node->GetVarNodeBlockId()),
                    places_[i],
                    i);
   }
@@ -1225,7 +1228,8 @@ int DistSSAGraphBuilder::CreateRPCOp(ir::Graph *result, ir::Node *node) const {
       p = places_[outvar_dev_id];
       ir::Node *new_node = nullptr;
       if (output->Var()) {
-        new_node = result->CreateVarNode(output->Var());
+        new_node =
+            result->CreateVarNode(output->Var(), output->GetVarNodeBlockId());
       } else {
         new_node =
             result->CreateEmptyNode(output->Name(), ir::Node::Type::kVariable);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
很多pass里CreateVarNode时没有传入block_id，导致创建var node时实际上使用的是graph_id。在有子block的情况时，本来应该通过var node的block_id与graph的graph_id比较，判断是否需要在子block里新建var。由于var node的block_id设置成了graph_id，导致这个判断没用了。
本PR在multi_devices_graph_pass中修复了这个问题，CreateVarNode时传入了block_id。