### PR TITLE
Clean CI_SKIP_CPP_TEST

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -443,7 +443,7 @@ function(cc_binary TARGET_NAME)
 endfunction()
 
 function(cc_test_build TARGET_NAME)
-  if(WITH_TESTING AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+  if(WITH_TESTING)
     set(oneValueArgs "")
     set(multiValueArgs SRCS DEPS)
     cmake_parse_arguments(cc_test "${options}" "${oneValueArgs}"
@@ -484,7 +484,7 @@ function(cc_test_build TARGET_NAME)
 endfunction()
 
 function(cc_test_run TARGET_NAME)
-  if(WITH_TESTING AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+  if(WITH_TESTING)
     set(oneValueArgs "")
     set(multiValueArgs COMMAND ARGS)
     cmake_parse_arguments(cc_test "${options}" "${oneValueArgs}"
@@ -513,10 +513,7 @@ function(cc_test_run TARGET_NAME)
 endfunction()
 
 function(cc_test TARGET_NAME)
-  # The environment variable `CI_SKIP_CPP_TEST` is used to skip the compilation
-  # and execution of test in CI. `CI_SKIP_CPP_TEST` is set to ON when no files
-  # other than *.py are modified.
-  if(WITH_TESTING AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+  if(WITH_TESTING)
     set(oneValueArgs "")
     set(multiValueArgs SRCS DEPS ARGS)
     cmake_parse_arguments(cc_test "${options}" "${oneValueArgs}"
@@ -617,12 +614,7 @@ function(nv_binary TARGET_NAME)
 endfunction()
 
 function(nv_test TARGET_NAME)
-  # The environment variable `CI_SKIP_CPP_TEST` is used to skip the compilation
-  # and execution of test in CI. `CI_SKIP_CPP_TEST` is set to ON when no files
-  # other than *.py are modified.
-  if(WITH_GPU
-     AND WITH_TESTING
-     AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+  if(WITH_GPU AND WITH_TESTING)
     set(oneValueArgs "")
     set(multiValueArgs SRCS DEPS)
     cmake_parse_arguments(nv_test "${options}" "${oneValueArgs}"
@@ -736,12 +728,7 @@ function(hip_binary TARGET_NAME)
 endfunction()
 
 function(hip_test TARGET_NAME)
-  # The environment variable `CI_SKIP_CPP_TEST` is used to skip the compilation
-  # and execution of test in CI. `CI_SKIP_CPP_TEST` is set to ON when no files
-  # other than *.py are modified.
-  if(WITH_ROCM
-     AND WITH_TESTING
-     AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+  if(WITH_ROCM AND WITH_TESTING)
     set(oneValueArgs "")
     set(multiValueArgs SRCS DEPS)
     cmake_parse_arguments(hip_test "${options}" "${oneValueArgs}"
@@ -850,12 +837,7 @@ function(xpu_binary TARGET_NAME)
 endfunction()
 
 function(xpu_test TARGET_NAME)
-  # The environment variable `CI_SKIP_CPP_TEST` is used to skip the compilation
-  # and execution of test in CI. `CI_SKIP_CPP_TEST` is set to ON when no files
-  # other than *.py are modified.
-  if(WITH_XPU_KP
-     AND WITH_TESTING
-     AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+  if(WITH_XPU_KP AND WITH_TESTING)
     set(oneValueArgs "")
     set(multiValueArgs SRCS DEPS)
     cmake_parse_arguments(xpu_test "${options}" "${oneValueArgs}"

--- a/paddle/fluid/framework/new_executor/CMakeLists.txt
+++ b/paddle/fluid/framework/new_executor/CMakeLists.txt
@@ -62,8 +62,7 @@ cc_library(
 # skip win32 since wget is not installed by default on windows machine.
 if(WITH_GPU
    AND WITH_TESTING
-   AND NOT WIN32
-   AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+   AND NOT WIN32)
   add_custom_target(
     download_program
     COMMAND wget -nc https://paddle-ci.gz.bcebos.com/new_exec/lm_main_program

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -1,8 +1,3 @@
-# If CI_SKIP_CPP_TEST=ON, there is no need to build and run these test.
-if("$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
-  return()
-endif()
-
 # In Windows, c_api test link must link both 2 shared to avoid symbols redefinition,
 # in Linux, c_api test cant do like this or graph_to_program register more than once.
 # Both Windows and Linux can only use paddle_inference_c, but this will increase size
@@ -329,7 +324,7 @@ if(NOT APPLE AND WITH_MKLML)
   inference_analysis_api_test(
     test_analyzer_seq_pool1_profile ${SEQ_POOL1_INSTALL_DIR}
     analyzer_seq_pool1_profile_tester.cc)
-  if(NOT WIN32 AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+  if(NOT WIN32)
     set_tests_properties(test_analyzer_seq_pool1_compare_determine
                          PROPERTIES TIMEOUT 120)
     set_tests_properties(test_analyzer_seq_pool1 PROPERTIES TIMEOUT 120)

--- a/paddle/fluid/jit/CMakeLists.txt
+++ b/paddle/fluid/jit/CMakeLists.txt
@@ -29,9 +29,7 @@ cc_library(
   DEPS jit_serializer jit_function_utils jit_serializer_utils
        jit_compilation_unit jit_function_schema)
 
-if(WITH_TESTING
-   AND NOT WIN32
-   AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+if(WITH_TESTING AND NOT WIN32)
   add_custom_target(
     jit_download_program
     COMMAND wget -nc -q

--- a/paddle/fluid/memory/CMakeLists.txt
+++ b/paddle/fluid/memory/CMakeLists.txt
@@ -71,9 +71,7 @@ if(WITH_TESTING AND TEST cuda_managed_memory_test)
       TIMEOUT 50)
 endif()
 
-if(WITH_GPU
-   AND WITH_TESTING
-   AND NOT "$ENV{CI_SKIP_CPP_TEST}" STREQUAL "ON")
+if(WITH_GPU AND WITH_TESTING)
   nv_test(
     get_base_ptr_test
     SRCS get_base_ptr_test.cu

--- a/paddle/scripts/infrt_build.sh
+++ b/paddle/scripts/infrt_build.sh
@@ -62,17 +62,6 @@ function init() {
 
     # NOTE(chenweihang): For easy debugging, CI displays the C++ error stacktrace by default 
     export FLAGS_call_stack_level=2
-
-    # set CI_SKIP_CPP_TEST if only *.py changed
-    # In order to avoid using in some CI(such as daily performance), the current
-    # branch must not be `${BRANCH}` which is usually develop.
-    if [ ${CI_SKIP_CPP_TEST:-ON} == "OFF"  ];then
-        echo "CI_SKIP_CPP_TEST=OFF"
-    else
-        if [ "$(git branch | grep "^\*" | awk '{print $2}')" != "${BRANCH}" ]; then
-            git diff --name-only ${BRANCH} | grep -v "\.py$" || export CI_SKIP_CPP_TEST=ON
-        fi
-    fi
 }
 
 function infrt_gen_and_build() {

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -659,9 +659,6 @@ echo    ========================================
 echo    Step 4. Running unit tests ...
 echo    ========================================
 
-: set CI_SKIP_CPP_TEST if only *.py changed
-git diff --name-only %BRANCH% | findstr /V "\.py" || set CI_SKIP_CPP_TEST=ON
-
 pip install -r %work_dir%\python\unittest_py\requirements.txt
 if %ERRORLEVEL% NEQ 0 (
     echo pip install unittest requirements.txt failed!

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -60,17 +60,6 @@ function init() {
 
     # NOTE(chenweihang): For easy debugging, CI displays the C++ error stacktrace by default 
     export FLAGS_call_stack_level=2
-
-    # set CI_SKIP_CPP_TEST if only *.py changed
-    # In order to avoid using in some CI(such as daily performance), the current
-    # branch must not be `${BRANCH}` which is usually develop.
-    if [ ${CI_SKIP_CPP_TEST:-ON} == "OFF"  ];then
-        echo "CI_SKIP_CPP_TEST=OFF"
-    else
-        if [ "$(git branch | grep "^\*" | awk '{print $2}')" != "${BRANCH}" ]; then
-            git diff --name-only ${BRANCH} | grep -v "\.py$" || export CI_SKIP_CPP_TEST=ON
-        fi
-    fi
 }
 
 function cmake_base() {
@@ -3232,7 +3221,6 @@ function reuse_so_cache() {
     down_proto_so=`echo $?`
     set -e
     if [ "${down_proto_so}" -eq 0 ];then
-        export CI_SKIP_CPP_TEST=ON
         cd build && mv ../proto_so.tar.gz .
         tar --use-compress-program=pigz -xpf proto_so.tar.gz
         cmake_gen ${PYTHON_ABI:-""} ${parallel_number}

--- a/tools/check_added_ut.sh
+++ b/tools/check_added_ut.sh
@@ -21,7 +21,6 @@ if [ -z ${BRANCH} ]; then
     BRANCH="develop"
 fi
 
-export CI_SKIP_CPP_TEST=OFF
 if [[ "$SYSTEM" == "Linux" ]] || [[ "$SYSTEM" == "Darwin" ]];then
     PADDLE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../" && pwd )"
 elif [[ "$SYSTEM" == "Windows_NT" ]];then
@@ -75,4 +74,3 @@ git checkout -f $CURBRANCH
 echo $CURBRANCH
 git branch -D prec_added_ut
 cd $CURDIR
-export CI_SKIP_CPP_TEST=


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
CI_SKIP_CPP_TEST 经常会导致添加c++单测时，出现忘记设置变量从而编译失败问题，建议删除CI_SKIP_CPP_TEST变量