### PR TITLE
[BugFix]Fix jit.save bugs when store program that don't need use tensor's value

### DIFF
--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -983,6 +983,21 @@ def save(layer, path, input_spec=None, **configs):
         #   - the input_spec's name should be in concrete_program.inputs
         input_var_names = _get_input_var_names(concrete_program.inputs,
                                                inner_input_spec)
+        # NOTE(YuanRisheng): [ Delete input variables name that is not used]
+        # There is a corner case that needs prune the inputs
+        # - The program need input's shape or other message and the program doesn't
+        #   need input itself. The input name should be pruned.
+        input_var_names_needed = []
+        for input_var_name in input_var_names:
+            is_use = False
+            for idx, op in enumerate(
+                    concrete_program.main_program.global_block().ops):
+                if input_var_name in op.input_arg_names:
+                    is_use = True
+                    break
+            if is_use:
+                input_var_names_needed.append(input_var_name)
+        input_var_names = input_var_names_needed
 
         # NOTE(chenweihang): [ Get output variables ]
         # the rule is like [ Get input variables name ]. For output var,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
当保存的Program未使用输入Tensor的具体数据，而只是使用了shape等信息的时候，jit.save会报错如下：
![image](https://user-images.githubusercontent.com/29249150/179485915-22c447c9-f3f5-4436-9476-52d03e1bd12d.png)
该问题原因是模型剪枝了这些输入Tensor，但是在调用save_inference_model的时候，feeded_var_names参数却传入了这些Tensor的name，导致报错