### PR TITLE
remove include of all.h in resnet_basic_block_op_xpu.cc, test=kunlun

### DIFF
--- a/paddle/fluid/operators/fused/resnet_basic_block_op_xpu.cc
+++ b/paddle/fluid/operators/fused/resnet_basic_block_op_xpu.cc
@@ -17,7 +17,6 @@
 #include "paddle/fluid/operators/conv_op.h"
 #include "paddle/fluid/platform/device/device_wrapper.h"
 #include "paddle/fluid/platform/device/xpu/xpu_header.h"
-#include "paddle/phi/api/all.h"
 
 namespace paddle {
 namespace operators {


### PR DESCRIPTION

### PR types
Bug fixes

### PR changes
OPs

### Describe
remove include of all.h in resnet_basic_block_op_xpu.cc
