### PR TITLE
[BugFix]Fix randint_like bugs when save program that don't need use tensor's value

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_randint_like.py
+++ b/python/paddle/fluid/tests/unittests/test_randint_like.py
@@ -132,10 +132,10 @@ class TestRandintLikeAPI(unittest.TestCase):
 
     def test_dygraph_api(self):
         paddle.disable_static(self.place)
-        # x dtype ["bool", "int32", "int64", "float16", "float32", "float64"]
+        # x dtype ["bool", "int32", "int64", "float32", "float64"]
         for x in [
-                self.x_bool, self.x_int32, self.x_int64, self.x_float16,
-                self.x_float32, self.x_float64
+                self.x_bool, self.x_int32, self.x_int64, self.x_float32,
+                self.x_float64
         ]:
             x_inputs = paddle.to_tensor(x)
             # self.dtype ["bool", "int32", "int64", "float16", "float32", "float64"]
@@ -147,7 +147,18 @@ class TestRandintLikeAPI(unittest.TestCase):
                 self.assertTrue(out.numpy().dtype, np.dtype(dtype))
                 self.assertTrue(
                     ((out.numpy() >= -100) & (out.numpy() <= 100)).all(), True)
-
+        # x dtype ["float16"]
+        if paddle.is_compiled_with_cuda():
+            x_inputs = paddle.to_tensor(self.x_float16)
+            # self.dtype ["bool", "int32", "int64", "float16", "float32", "float64"]
+            for dtype in self.dtype:
+                out = paddle.randint_like(x_inputs,
+                                          low=-100,
+                                          high=100,
+                                          dtype=dtype)
+                self.assertTrue(out.numpy().dtype, np.dtype(dtype))
+                self.assertTrue(
+                    ((out.numpy() >= -100) & (out.numpy() <= 100)).all(), True)
         paddle.enable_static()
 
     def test_errors(self):
@@ -210,21 +221,22 @@ class TestRandintLikeAPI(unittest.TestCase):
 
             # x dtype is float16
             # low is 5 and high is 5, low must less then high
-            self.assertRaises(ValueError,
-                              paddle.randint_like,
-                              x_float16,
-                              low=5,
-                              high=5)
-            # low(default value) is 0 and high is -5, low must less then high
-            self.assertRaises(ValueError,
-                              paddle.randint_like,
-                              x_float16,
-                              high=-5)
-            # if high is None, low must be greater than 0
-            self.assertRaises(ValueError,
-                              paddle.randint_like,
-                              x_float16,
-                              low=-5)
+            if paddle.is_compiled_with_cuda():
+                self.assertRaises(ValueError,
+                                  paddle.randint_like,
+                                  x_float16,
+                                  low=5,
+                                  high=5)
+                # low(default value) is 0 and high is -5, low must less then high
+                self.assertRaises(ValueError,
+                                  paddle.randint_like,
+                                  x_float16,
+                                  high=-5)
+                # if high is None, low must be greater than 0
+                self.assertRaises(ValueError,
+                                  paddle.randint_like,
+                                  x_float16,
+                                  low=-5)
 
             # x dtype is float32
             # low is 5 and high is 5, low must less then high

--- a/python/paddle/fluid/tests/unittests/test_randint_like.py
+++ b/python/paddle/fluid/tests/unittests/test_randint_like.py
@@ -81,22 +81,22 @@ class TestRandintLikeAPI(unittest.TestCase):
             for out, dtype in zip(outs3, self.dtype):
                 self.assertTrue(out.dtype, np.dtype(dtype))
                 self.assertTrue(((out >= -100) & (out <= 100)).all(), True)
-
-        with program_guard(Program(), Program()):
-            x_float16 = paddle.fluid.data(name="x_float16",
-                                          shape=[10, 12],
-                                          dtype="float16")
-            exe = paddle.static.Executor(self.place)
-            # x dtype is float16 output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
-            outlist4 = [
-                paddle.randint_like(x_float16, low=-3, high=25, dtype=dtype)
-                for dtype in self.dtype
-            ]
-            outs4 = exe.run(feed={'x_float16': self.x_float16},
-                            fetch_list=outlist4)
-            for out, dtype in zip(outs4, self.dtype):
-                self.assertTrue(out.dtype, np.dtype(dtype))
-                self.assertTrue(((out >= -3) & (out <= 25)).all(), True)
+        if paddle.is_compiled_with_cuda():
+            with program_guard(Program(), Program()):
+                x_float16 = paddle.fluid.data(name="x_float16",
+                                              shape=[10, 12],
+                                              dtype="float16")
+                exe = paddle.static.Executor(self.place)
+                # x dtype is float16 output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
+                outlist4 = [
+                    paddle.randint_like(x_float16, low=-3, high=25, dtype=dtype)
+                    for dtype in self.dtype
+                ]
+                outs4 = exe.run(feed={'x_float16': self.x_float16},
+                                fetch_list=outlist4)
+                for out, dtype in zip(outs4, self.dtype):
+                    self.assertTrue(out.dtype, np.dtype(dtype))
+                    self.assertTrue(((out >= -3) & (out <= 25)).all(), True)
 
         with program_guard(Program(), Program()):
             x_float32 = paddle.fluid.data(name="x_float32",

--- a/python/paddle/fluid/tests/unittests/test_randint_like.py
+++ b/python/paddle/fluid/tests/unittests/test_randint_like.py
@@ -42,24 +42,7 @@ class TestRandintLikeAPI(unittest.TestCase):
             x_bool = paddle.fluid.data(name="x_bool",
                                        shape=[10, 12],
                                        dtype="bool")
-            x_int32 = paddle.fluid.data(name="x_int32",
-                                        shape=[10, 12],
-                                        dtype="int32")
-            x_int64 = paddle.fluid.data(name="x_int64",
-                                        shape=[10, 12],
-                                        dtype="int64")
-            x_float16 = paddle.fluid.data(name="x_float16",
-                                          shape=[10, 12],
-                                          dtype="float16")
-            x_float32 = paddle.fluid.data(name="x_float32",
-                                          shape=[10, 12],
-                                          dtype="float32")
-            x_float64 = paddle.fluid.data(name="x_float64",
-                                          shape=[10, 12],
-                                          dtype="float64")
-
             exe = paddle.static.Executor(self.place)
-
             # x dtype is bool output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
             outlist1 = [
                 paddle.randint_like(x_bool, low=-10, high=10, dtype=dtype)
@@ -69,7 +52,11 @@ class TestRandintLikeAPI(unittest.TestCase):
             for out, dtype in zip(outs1, self.dtype):
                 self.assertTrue(out.dtype, np.dtype(dtype))
                 self.assertTrue(((out >= -10) & (out <= 10)).all(), True)
-
+        with program_guard(Program(), Program()):
+            x_int32 = paddle.fluid.data(name="x_int32",
+                                        shape=[10, 12],
+                                        dtype="int32")
+            exe = paddle.static.Executor(self.place)
             # x dtype is int32 output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
             outlist2 = [
                 paddle.randint_like(x_int32, low=-5, high=10, dtype=dtype)
@@ -80,6 +67,11 @@ class TestRandintLikeAPI(unittest.TestCase):
                 self.assertTrue(out.dtype, np.dtype(dtype))
                 self.assertTrue(((out >= -5) & (out <= 10)).all(), True)
 
+        with program_guard(Program(), Program()):
+            x_int64 = paddle.fluid.data(name="x_int64",
+                                        shape=[10, 12],
+                                        dtype="int64")
+            exe = paddle.static.Executor(self.place)
             # x dtype is int64 output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
             outlist3 = [
                 paddle.randint_like(x_int64, low=-100, high=100, dtype=dtype)
@@ -90,6 +82,11 @@ class TestRandintLikeAPI(unittest.TestCase):
                 self.assertTrue(out.dtype, np.dtype(dtype))
                 self.assertTrue(((out >= -100) & (out <= 100)).all(), True)
 
+        with program_guard(Program(), Program()):
+            x_float16 = paddle.fluid.data(name="x_float16",
+                                          shape=[10, 12],
+                                          dtype="float16")
+            exe = paddle.static.Executor(self.place)
             # x dtype is float16 output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
             outlist4 = [
                 paddle.randint_like(x_float16, low=-3, high=25, dtype=dtype)
@@ -101,6 +98,11 @@ class TestRandintLikeAPI(unittest.TestCase):
                 self.assertTrue(out.dtype, np.dtype(dtype))
                 self.assertTrue(((out >= -3) & (out <= 25)).all(), True)
 
+        with program_guard(Program(), Program()):
+            x_float32 = paddle.fluid.data(name="x_float32",
+                                          shape=[10, 12],
+                                          dtype="float32")
+            exe = paddle.static.Executor(self.place)
             # x dtype is float32 output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
             outlist5 = [
                 paddle.randint_like(x_float32, low=-25, high=25, dtype=dtype)
@@ -112,6 +114,11 @@ class TestRandintLikeAPI(unittest.TestCase):
                 self.assertTrue(out.dtype, np.dtype(dtype))
                 self.assertTrue(((out >= -25) & (out <= 25)).all(), True)
 
+        with program_guard(Program(), Program()):
+            x_float64 = paddle.fluid.data(name="x_float64",
+                                          shape=[10, 12],
+                                          dtype="float64")
+            exe = paddle.static.Executor(self.place)
             # x dtype is float64 output dtype in ["bool", "int32", "int64", "float16", "float32", "float64"]
             outlist6 = [
                 paddle.randint_like(x_float64, low=-16, high=16, dtype=dtype)

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -869,7 +869,7 @@ def randint_like(x, low=0, high=None, dtype=None, name=None):
         dtype = x.dtype
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
-    shape = x.shape
+    shape = paddle.shape(x)
 
     if low >= high:
         raise ValueError(
@@ -888,17 +888,13 @@ def randint_like(x, low=0, high=None, dtype=None, name=None):
                 ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'],
                 'randint_like')
 
-    inputs = dict()
+    inputs = {"ShapeTensor": shape}
     attrs = {
         'low': low,
         'high': high,
         'seed': 0,
         'dtype': core.VarDesc.VarType.INT64
     }
-    utils.get_shape_tensor_inputs(inputs=inputs,
-                                  attrs=attrs,
-                                  shape=shape,
-                                  op_type='randint_like')
 
     helper = LayerHelper("randint", **locals())
     out = helper.create_variable_for_type_inference(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
当使用randint_like接受输入并进行动转静保存时，会出现如下bug：
![](https://user-images.githubusercontent.com/29249150/179485915-22c447c9-f3f5-4436-9476-52d03e1bd12d.png)
该bug原因是randint_like在内部使用输入tensor的时候将其脱离开了program中的op，导致保存模型裁剪的时候将输入剪掉了，该pr修复这个问题.