### PR TITLE
[JitLayer]Support predictor function in JitLayer

### DIFF
--- a/paddle/fluid/jit/CMakeLists.txt
+++ b/paddle/fluid/jit/CMakeLists.txt
@@ -1,7 +1,7 @@
 cc_library(
   jit_serializer
   SRCS serializer.cc
-  DEPS lod_tensor device_context)
+  DEPS lod_tensor device_context paddle_inference_api analysis_predictor)
 
 cc_library(
   jit_function_utils

--- a/paddle/fluid/jit/executor_function.h
+++ b/paddle/fluid/jit/executor_function.h
@@ -49,7 +49,9 @@ class ExecutorFunction : public BaseFunction {
 
   std::vector<DenseTensor> operator()(const std::vector<DenseTensor> &inputs) {
     utils::ShareIntoScope(info_->InputArgNames(), inputs, &scope_);
-    inner_exe_.Run(info_->ProgramDesc(),
+    framework::ProgramDesc desc(info_->ProgramDesc());
+    utils::RemoveFeedFetch(&desc);
+    inner_exe_.Run(desc,
                    &scope_,
                    /*blockID=*/0,
                    false,

--- a/paddle/fluid/jit/function_schema.cc
+++ b/paddle/fluid/jit/function_schema.cc
@@ -62,8 +62,6 @@ FunctionInfo::FunctionInfo(const std::string& func_name,
   for (auto& out_name : program_desc_.GetFetchTargetNames()) {
     schema_.AddOutputArg(out_name);
   }
-  // remove feed fetch op
-  utils::RemoveFeedFetch(&program_desc_);
 }
 
 const std::string& FunctionInfo::FunctionName() const { return func_name_; }

--- a/paddle/fluid/jit/pe_function.h
+++ b/paddle/fluid/jit/pe_function.h
@@ -51,14 +51,14 @@ class PEFunction : public BaseFunction {
   std::vector<DenseTensor> operator()(const std::vector<DenseTensor> &inputs) {
     std::string prog_string;
     std::hash<std::string> string_hash;
-    auto &program_desc = info_->ProgramDesc();
-    // TODO(dev): Serialize is very slow.
-    const_cast<framework::ProgramDesc *>(&program_desc)
-        ->Proto()
-        ->SerializePartialToString(&prog_string);
 
+    framework::ProgramDesc desc(info_->ProgramDesc());
+    utils::RemoveFeedFetch(&desc);
+    // TODO(dev): Serialize is very slow.
+    desc.Proto()->SerializePartialToString(&prog_string);
     int64_t program_id = static_cast<int64_t>(string_hash(prog_string));
-    const framework::BlockDesc &global_block = program_desc.Block(0);
+
+    const framework::BlockDesc &global_block = desc.Block(0);
     int64_t start_op_index = 0;
     int64_t end_op_index = static_cast<int64_t>(global_block.OpSize());
 
@@ -67,7 +67,7 @@ class PEFunction : public BaseFunction {
     std::vector<std::string> output_var_names = info_->OutputArgNames();
 
     if (end_op_index > start_op_index) {
-      auto cache_info = framework::GetExecutorInfoFromCache(program_desc,
+      auto cache_info = framework::GetExecutorInfoFromCache(desc,
                                                             place_,
                                                             start_op_index,
                                                             end_op_index,
@@ -85,10 +85,7 @@ class PEFunction : public BaseFunction {
                                       output_var_names.end());
 
         framework::details::ParseSafeEagerDeletionSkipVars(
-            program_desc,
-            end_op_index,
-            output_var_names,
-            &skip_eager_delete_vars);
+            desc, end_op_index, output_var_names, &skip_eager_delete_vars);
       }
       parallel_executor->RunWithoutFetch(skip_eager_delete_vars);
     }

--- a/paddle/fluid/jit/pe_function.h
+++ b/paddle/fluid/jit/pe_function.h
@@ -94,6 +94,8 @@ class PEFunction : public BaseFunction {
     return res;
   }
 
+  const std::shared_ptr<FunctionInfo> &Info() const { return info_; }
+
  private:
   std::shared_ptr<FunctionInfo> info_;
   framework::Scope scope_;

--- a/paddle/fluid/jit/predictor_function.h
+++ b/paddle/fluid/jit/predictor_function.h
@@ -1,0 +1,190 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/inference/api/analysis_predictor.h"
+#include "paddle/fluid/inference/api/paddle_api.h"
+
+#include "paddle/fluid/jit/base_function.h"
+#include "paddle/fluid/jit/function_schema.h"
+#include "paddle/fluid/jit/function_utils.h"
+
+namespace paddle {
+namespace jit {
+
+PaddleTensor DenseTensorToPaddleTensor(DenseTensor *t) {
+  PaddleTensor pt;
+
+  if (framework::TransToProtoVarType(t->dtype()) ==
+      framework::proto::VarType::INT32) {
+    pt.data.Reset(t->data(), t->numel() * sizeof(int32_t));
+    pt.dtype = PaddleDType::INT32;
+  } else if (framework::TransToProtoVarType(t->dtype()) ==
+             framework::proto::VarType::INT64) {
+    pt.data.Reset(t->data(), t->numel() * sizeof(int64_t));
+    pt.dtype = PaddleDType::INT64;
+  } else if (framework::TransToProtoVarType(t->dtype()) ==
+             framework::proto::VarType::FP32) {
+    pt.data.Reset(t->data(), t->numel() * sizeof(float));
+    pt.dtype = PaddleDType::FLOAT32;
+  } else {
+    PADDLE_THROW(platform::errors::Unimplemented(
+        "Unsupported tensor date type. Now only supports INT64, FP32, INT32."));
+  }
+  pt.shape = phi::vectorize<int>(t->dims());
+  return pt;
+}
+
+bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
+                               DenseTensor *t,
+                               const platform::Place &place) {
+  framework::DDim ddim = phi::make_ddim(pt.shape);
+  void *input_ptr;
+  if (pt.dtype == PaddleDType::INT64) {
+    input_ptr = t->mutable_data<int64_t>(ddim, place);
+  } else if (pt.dtype == PaddleDType::FLOAT32) {
+    input_ptr = t->mutable_data<float>(ddim, place);
+  } else if (pt.dtype == PaddleDType::INT32) {
+    input_ptr = t->mutable_data<int32_t>(ddim, place);
+  } else if (pt.dtype == PaddleDType::FLOAT16) {
+    input_ptr = t->mutable_data<float16>(ddim, place);
+  } else {
+    LOG(ERROR) << "unsupported feed type " << pt.dtype;
+    return false;
+  }
+
+  PADDLE_ENFORCE_NOT_NULL(
+      input_ptr,
+      paddle::platform::errors::Fatal(
+          "Cannot convert to LoDTensor because LoDTensor creation failed."));
+  PADDLE_ENFORCE_NOT_NULL(
+      pt.data.data(),
+      paddle::platform::errors::InvalidArgument(
+          "The data contained in the input PaddleTensor is illegal."));
+
+  if (platform::is_cpu_place(place)) {
+    // TODO(panyx0718): Init LoDTensor from existing memcpy to save a copy.
+    std::memcpy(
+        static_cast<void *>(input_ptr), pt.data.data(), pt.data.length());
+  } else if (platform::is_ipu_place(place)) {
+#ifdef PADDLE_WITH_IPU
+    std::memcpy(
+        static_cast<void *>(input_ptr), pt.data.data(), pt.data.length());
+#else
+    PADDLE_THROW(paddle::platform::errors::Fatal(
+        "Not compile with WITH_IPU, should not reach here."));
+#endif
+  } else if (platform::is_gpu_place(place)) {
+    PADDLE_ENFORCE_EQ(platform::is_xpu_place(place),
+                      false,
+                      platform::errors::InvalidArgument(
+                          "Only one choice can be made between CPU and XPU."));
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    auto *dev_ctx =
+        static_cast<const platform::CUDADeviceContext *>(pool.Get(place));
+    auto dst_gpu_place = place;
+    memory::Copy(dst_gpu_place,
+                 static_cast<void *>(input_ptr),
+                 platform::CPUPlace(),
+                 pt.data.data(),
+                 pt.data.length(),
+                 dev_ctx->stream());
+#else
+    PADDLE_THROW(paddle::platform::errors::Fatal(
+        "Not compile with CUDA, should not reach here."));
+#endif
+  } else if (platform::is_xpu_place(place)) {
+#ifdef PADDLE_WITH_XPU
+    auto dst_xpu_place = place;
+    memory::Copy(dst_xpu_place,
+                 static_cast<void *>(input_ptr),
+                 platform::CPUPlace(),
+                 pt.data.data(),
+                 pt.data.length());
+#else
+    PADDLE_THROW(paddle::platform::errors::Fatal(
+        "Not compile with XPU, should not reach here."));
+#endif
+  } else {
+    PADDLE_THROW(paddle::platform::errors::InvalidArgument(
+        "The analysis predictor supports CPU, GPU and XPU now."));
+  }
+  // TODO(Superjomn) Low performance, need optimization for heavy LoD copy.
+  framework::LoD lod;
+  for (auto &level : pt.lod) {
+    lod.emplace_back(level);
+  }
+  t->set_lod(lod);
+  return true;
+}
+
+class PredictorFunction : public BaseFunction {
+ public:
+  PredictorFunction(const std::shared_ptr<FunctionInfo> &info,
+                    const Name2VariableMap &params_dict,
+                    const phi::Place &place)
+      : info_(info), scope_(new framework::Scope()), place_(place) {
+    utils::ShareParamsIntoScope(info_->ParamNames(), params_dict, scope_.get());
+    VLOG(6) << framework::GenScopeTreeDebugInfo(scope_.get());
+
+    AnalysisConfig config;
+    if (platform::is_gpu_place(place_)) {
+      config.EnableUseGpu(100, place_.GetDeviceId());
+    } else if (platform::is_cpu_place(place_)) {
+      config.DisableGpu();
+    }
+    predictor_.reset(new AnalysisPredictor(config));
+
+    predictor_->Init(
+        scope_, std::make_shared<framework::ProgramDesc>(info_->ProgramDesc()));
+  }
+
+  ~PredictorFunction() noexcept {}
+
+  std::vector<Tensor> operator()(const std::vector<Tensor> &inputs) {
+    auto dense_tensors = utils::ToDenseTensors(inputs);
+    return utils::ToTensors(this->operator()(dense_tensors));
+  }
+
+  std::vector<DenseTensor> operator()(const std::vector<DenseTensor> &inputs) {
+    std::vector<PaddleTensor> pt_inputs;
+    std::vector<PaddleTensor> pt_outputs;
+    for (auto &t : inputs) {
+      auto non_const_t = const_cast<DenseTensor *>(&t);
+      pt_inputs.emplace_back(DenseTensorToPaddleTensor(non_const_t));
+    }
+
+    predictor_->Run(pt_inputs, &pt_outputs);
+
+    std::vector<DenseTensor> outputs;
+    for (auto &pt : pt_outputs) {
+      DenseTensor t;
+      PaddleTensorToDenseTensor(pt, &t, place_);
+      outputs.emplace_back(t);
+    }
+
+    return outputs;
+  }
+
+ private:
+  std::shared_ptr<FunctionInfo> info_;
+  std::shared_ptr<framework::Scope> scope_;
+  phi::Place place_;
+  std::shared_ptr<AnalysisPredictor> predictor_;
+};
+
+}  // namespace jit
+}  // namespace paddle

--- a/paddle/fluid/jit/serializer.cc
+++ b/paddle/fluid/jit/serializer.cc
@@ -104,7 +104,7 @@ void Deserializer::ReadAttributeData(const std::string& file_path,
                                      Name2VariableMap* attrs_dict) const {}
 
 framework::ProgramDesc Deserializer::LoadProgram(const std::string& file_name) {
-  VLOG(3) << "LoadProgram " << file_name;
+  VLOG(3) << "LoadProgram from: " << file_name;
   std::ifstream fin(file_name, std::ios::in | std::ios::binary);
   fin.seekg(0, std::ios::end);
   std::string buffer(fin.tellg(), ' ');

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -922,7 +922,7 @@ PADDLE_DEFINE_EXPORTED_bool(
  * Name: FLAGS_function_type
  * Since Version: 2.3.0
  * Value Range: string, {Executor, PE, Predictor},
- * default=Executor
+ * default=PE
  * Example:
  * Note:
  * FLAGS_function_type == Executor, using ExecutorFunction by default
@@ -930,5 +930,5 @@ PADDLE_DEFINE_EXPORTED_bool(
  * FLAGS_function_type == Predictor, using PredictorFunction by default
  */
 PADDLE_DEFINE_EXPORTED_string(function_type,
-                              "Executor",
+                              "PE",
                               "Choose default funciton type in JitLayer.");

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -916,3 +916,19 @@ PADDLE_DEFINE_EXPORTED_bool(
     einsum_opt,
     false,
     "EinsumOp backward will be speedup at the expense of more gpu memory.");
+
+/**
+ * JitLayer related FLAG
+ * Name: FLAGS_function_type
+ * Since Version: 2.3.0
+ * Value Range: string, {Executor, PE, Predictor},
+ * default=Executor
+ * Example:
+ * Note:
+ * FLAGS_function_type == Executor, using ExecutorFunction by default
+ * FLAGS_function_type == PE, using PEFunction by default
+ * FLAGS_function_type == Predictor, using PredictorFunction by default
+ */
+PADDLE_DEFINE_EXPORTED_string(function_type,
+                              "Executor",
+                              "Choose default funciton type in JitLayer.");

--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -21,6 +21,8 @@ limitations under the License. */
 #include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/fluid/framework/scope.h"
 #include "paddle/fluid/framework/scope_guard.h"
+#include "paddle/fluid/jit/executor_function.h"
+#include "paddle/fluid/jit/pe_function.h"
 #include "paddle/fluid/memory/allocation/allocator.h"
 #include "paddle/fluid/operators/py_func_op.h"
 #include "paddle/fluid/operators/utils.h"
@@ -52,6 +54,7 @@ extern PyTypeObject* g_framework_tensor_pytype;
 extern PyTypeObject* g_framework_lodtensorarray_pytype;
 extern PyTypeObject* g_custom_op_kernel_ctx_pytype;
 extern PyTypeObject* g_executor_function_pytype;
+extern PyTypeObject* g_pe_function_pytype;
 
 int TensorDtype2NumpyDtype(phi::DataType dtype) {
   switch (dtype) {
@@ -234,6 +237,9 @@ std::shared_ptr<jit::BaseFunction> CastPyArg2BaseFunction(PyObject* obj,
           obj, reinterpret_cast<PyObject*>(g_executor_function_pytype))) {
     return ::pybind11::handle(obj)
         .cast<std::shared_ptr<jit::ExecutorFunction>>();
+  } else if (PyObject_IsInstance(
+                 obj, reinterpret_cast<PyObject*>(g_pe_function_pytype))) {
+    return ::pybind11::handle(obj).cast<std::shared_ptr<jit::PEFunction>>();
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "argument (position %d) must be "

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -19,7 +19,7 @@ typedef SSIZE_T ssize_t;
 
 #include "paddle/fluid/framework/lod_tensor.h"
 #include "paddle/fluid/framework/tensor.h"
-#include "paddle/fluid/jit/executor_function.h"
+#include "paddle/fluid/jit/base_function.h"
 #include "paddle/fluid/platform/place.h"
 #include "paddle/phi/common/backend.h"
 #include "paddle/phi/common/data_type.h"

--- a/paddle/fluid/pybind/jit.cc
+++ b/paddle/fluid/pybind/jit.cc
@@ -21,6 +21,7 @@ limitations under the License. */
 #include "paddle/fluid/jit/executor_function.h"
 #include "paddle/fluid/jit/function_schema.h"
 #include "paddle/fluid/jit/layer.h"
+#include "paddle/fluid/jit/pe_function.h"
 #include "paddle/fluid/jit/serializer.h"
 
 namespace py = pybind11;
@@ -29,6 +30,7 @@ namespace paddle {
 namespace pybind {
 
 PyTypeObject *g_executor_function_pytype = nullptr;
+PyTypeObject *g_pe_function_pytype = nullptr;
 using Variable = paddle::framework::Variable;
 
 void BindJit(pybind11::module *m) {
@@ -43,6 +45,11 @@ void BindJit(pybind11::module *m) {
   g_executor_function_pytype =
       reinterpret_cast<PyTypeObject *>(executor_function.ptr());
   executor_function.def("info", &jit::ExecutorFunction::Info);
+
+  py::class_<jit::PEFunction, std::shared_ptr<jit::PEFunction>> pe_function(
+      *m, "PEFunction", R"DOC(PEFunction Class.)DOC");
+  g_pe_function_pytype = reinterpret_cast<PyTypeObject *>(pe_function.ptr());
+  pe_function.def("info", &jit::PEFunction::Info);
 
   py::class_<jit::FunctionInfo, std::shared_ptr<jit::FunctionInfo>>(
       *m, "FunctionInfo", R"DOC(FunctionInfo Class.)DOC")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[JitLayer]Support predictor function in JitLayer
1. JitLayer支持使用Predictor执行program
2. 将PEFuntion暴露到python
3. 使用flag切换默认执行器类型，默认使用PE