### PR TITLE
fix conv/fc with bias miss out_threshold problem in QAT

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/fuse_utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/fuse_utils.py
@@ -44,7 +44,7 @@ def fuse_conv_bn(model):
         if tmp_pair[0] and tmp_pair[1] and len(tmp_pair) == 2:
             fuse_list.append(tmp_pair)
             tmp_pair = [None, None]
-    model = fuse_layers(model, fuse_list)
+    model = fuse_layers(model, fuse_list, inplace=True)
     if is_train:
         model.train()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix conv/fc with bias miss out_threshold problem in QAT.