### PR TITLE
[Codestyle-check] set defaul clang-format to avoid diff between local and CI

### DIFF
--- a/tools/codestyle/clang_format.hook
+++ b/tools/codestyle/clang_format.hook
@@ -15,6 +15,8 @@ if ! [[ $version == *"$VERSION"* ]]; then
     # low version of pip may not have the source of clang-format whl
     pip install --upgrade pip 
     pip install clang-format==13.0.0
+    bin_path=$(dirname $(which python))
+    ln -snf ${bin_path}/clang-format /usr/bin/clang-format
 fi
 
 clang-format $@


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
make soft link to installed clang-format to avoid diff between local and CI.