### PR TITLE
Fix the bug of ModuleNotFound when compiling,test=document_fix

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -200,6 +200,7 @@ function cmake_base() {
     if [ "$CMD" != "assert_file_approvals" ];then
       which python
       python -V
+      python -m pip install distro
       python ${PADDLE_ROOT}/tools/summary_env.py
       bash ${PADDLE_ROOT}/tools/get_cpu_info.sh
     fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
编译脚本中删除`python -m pip install distro`安装命令后会导致编译脚本不可用，报错如下：
![image](https://user-images.githubusercontent.com/32428676/179946615-afb47050-4de7-4a96-a0ae-ebd780674fac.png)
将安装命令加回至编译脚本