### PR TITLE
[Paddle-TRT] fix_ernie

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
@@ -30,10 +30,11 @@ class SkipLayerNormOpConverter : public OpConverter {
     framework::OpDesc op_desc(op, nullptr);
     // Declare inputs
     auto* input1 = engine_->GetITensor(op_desc.Input("X")[0]);
-    // We should expand input1 to 4 dimensions
-    if (input1->getDimensions().nbDims < 4) {
+    auto* input2 = engine_->GetITensor(op_desc.Input("Y")[0]);
+    // We should expand input1 to input2's nbDims
+    if (input1->getDimensions().nbDims < input2->getDimensions().nbDims) {
       nvinfer1::Dims reshape_input1_dim;
-      reshape_input1_dim.nbDims = 4;
+      reshape_input1_dim.nbDims = input2->getDimensions().nbDims;
       for (int i = 0; i < reshape_input1_dim.nbDims; i++) {
         if (i < input1->getDimensions().nbDims) {
           reshape_input1_dim.d[i] = 0;
@@ -46,7 +47,7 @@ class SkipLayerNormOpConverter : public OpConverter {
       reshape_input1_layer->setReshapeDimensions(reshape_input1_dim);
       input1 = reshape_input1_layer->getOutput(0);
     }
-    auto* input2 = engine_->GetITensor(op_desc.Input("Y")[0]);
+    
     std::vector<nvinfer1::ITensor*> inputs;
     inputs.push_back(input1);
     inputs.push_back(input2);

--- a/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
@@ -26,11 +26,24 @@ class SkipLayerNormOpConverter : public OpConverter {
   void operator()(const framework::proto::OpDesc& op,
                   const framework::Scope& scope,
                   bool test_mode) override {
-#if IS_TRT_VERSION_GE(6000)
     VLOG(4) << "convert fused skip layernorm op to tensorrt layer";
     framework::OpDesc op_desc(op, nullptr);
     // Declare inputs
     auto* input1 = engine_->GetITensor(op_desc.Input("X")[0]);
+    nvinfer1::Dims reshape_input1_dim;
+    reshape_input1_dim.nbDims = 4;
+    for (int i = 0; i < reshape_input1_dim.nbDims; i++) {
+      if (i < input1->getDimensions().nbDims) {
+        reshape_input1_dim.d[i] = 0;
+      } else {
+        reshape_input1_dim.d[i] = 1;
+      }
+    }
+    auto* reshape_input1_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *input1);
+    reshape_input1_layer->setReshapeDimensions(reshape_input1_dim);
+    input1 = reshape_input1_layer->getOutput(0);
+
     auto* input2 = engine_->GetITensor(op_desc.Input("Y")[0]);
     std::vector<nvinfer1::ITensor*> inputs;
     inputs.push_back(input1);
@@ -74,10 +87,10 @@ class SkipLayerNormOpConverter : public OpConverter {
              bias_weight.values,
              GetPluginFieldType(bias_weight.type),
              static_cast<int32_t>(bias_weight.count)},
-            { "gamma",
-              scale_weight.values,
-              GetPluginFieldType(scale_weight.type),
-              static_cast<int32_t>(scale_weight.count) }};
+            {"gamma",
+             scale_weight.values,
+             GetPluginFieldType(scale_weight.type),
+             static_cast<int32_t>(scale_weight.count)}};
         nvinfer1::PluginFieldCollection* pluginPtr =
             static_cast<nvinfer1::PluginFieldCollection*>(
                 malloc(sizeof(*pluginPtr) +
@@ -178,11 +191,6 @@ class SkipLayerNormOpConverter : public OpConverter {
 
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "skip_layernorm", {output_name}, test_mode);
-#else
-    PADDLE_THROW(platform::errors::Fatal(
-        "You are running the TRT Dynamic Shape mode, need to confirm that "
-        "your TRT version is no less than 6.0"));
-#endif
   }
 };
 

--- a/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
@@ -31,6 +31,7 @@ class SkipLayerNormOpConverter : public OpConverter {
     // Declare inputs
     auto* input1 = engine_->GetITensor(op_desc.Input("X")[0]);
     auto* input2 = engine_->GetITensor(op_desc.Input("Y")[0]);
+
     // We should expand input1 to input2's nbDims
     if (input1->getDimensions().nbDims < input2->getDimensions().nbDims) {
       nvinfer1::Dims reshape_input1_dim;
@@ -47,7 +48,7 @@ class SkipLayerNormOpConverter : public OpConverter {
       reshape_input1_layer->setReshapeDimensions(reshape_input1_dim);
       input1 = reshape_input1_layer->getOutput(0);
     }
-    
+
     std::vector<nvinfer1::ITensor*> inputs;
     inputs.push_back(input1);
     inputs.push_back(input2);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[pr1](https://github.com/PaddlePaddle/Paddle/pull/44382)提交后，，导致ernie模型出错。
- check后发现是pr1之前的fc的trt转换存在bug
  - 在pr1之前：4维的输入，in_num_col_dims为1，paddle应输出2维，但fc的trt转换逻辑迫使他输出4维，skip_layernorm默认自己得到4维
  - pr1删掉了【但fc的trt转换逻辑迫使他输出4维】这部分代码。
  - pr1提交后，skip_layernorm仍认为自己得到4维，实际只能得到2维。
  - 因此pr1提交后，因修正skip_layernorm的输入维度，即此pr之用。
