### PR TITLE
[Auto Parallel] Fix local sizes bug in auto search

### DIFF
--- a/python/paddle/distributed/auto_parallel/dist_tensor.py
+++ b/python/paddle/distributed/auto_parallel/dist_tensor.py
@@ -163,7 +163,6 @@ class DistributedTensor:
         self._batch_dim = 0
         # Reuse the dist_attr setter to initialize _dist_attr
         self.dist_attr = dist_attr
-        self._local_sizes_map = {}
         self._local_offsets_map = {}
         self._local_shard_map = {}
         self._local_tensor_map = {}
@@ -223,20 +222,16 @@ class DistributedTensor:
         return True
 
     def local_sizes(self, rank=None):
+        """Get local sizes of the given rank."""
         rank = paddle.distributed.get_rank() if rank is None else rank
-        local_sizes = None
-        if rank in self._local_sizes_map.keys():
-            local_sizes = self._local_sizes_map[rank]
-        else:
-            global_sizes = self.serial_tensor.shape
-            dims_mapping = self.dist_attr.dims_mapping
-            shard_sizes = self.dist_attr.shard_sizes
-            processes = self.dist_attr.process_mesh.processes
-            topology = self.dist_attr.process_mesh.topology
-            local_sizes = DistributedTensor.get_local_sizes(
-                global_sizes, dims_mapping, topology, processes, rank,
-                shard_sizes)
-            self._local_sizes_map[rank] = local_sizes
+        global_sizes = self.serial_tensor.shape
+        dims_mapping = self.dist_attr.dims_mapping
+        shard_sizes = self.dist_attr.shard_sizes
+        processes = self.dist_attr.process_mesh.processes
+        topology = self.dist_attr.process_mesh.topology
+        local_sizes = DistributedTensor.get_local_sizes(
+            global_sizes, dims_mapping, topology, processes, rank,
+            shard_sizes)
 
         return local_sizes
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR fixes the bug that the dist attr of dist tensor  will be changed in auto parallel scene, so the local sizes should not be cached .