### PR TITLE
fix record event for operator type in new dygraph

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/eager_generator.cc
+++ b/paddle/fluid/eager/auto_code_generator/eager_generator.cc
@@ -1386,7 +1386,7 @@ static std::string GenerateGradNodeCreationContent(
       "%s"
       "  {\n"
       "    paddle::platform::RecordEvent node_creation_record_event(\"%s\", "
-      "paddle::platform::TracerEventType::Operator, 1);\n"
+      "paddle::platform::TracerEventType::OperatorInner, 1);\n"
       "%s"
       "    if(require_any_grad) {\n"
       "      VLOG(6) << \" Construct Grad for %s \"; \n"

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
@@ -111,7 +111,7 @@ PARSE_PYTHON_C_ARGS_TEMPLATE = \
 
 
 RECORD_EVENT_TEMPLATE = \
-"paddle::platform::RecordEvent {}(\"{} {}\", paddle::platform::TracerEventType::Operator, 1);"
+"paddle::platform::RecordEvent {}(\"{} {}\", paddle::platform::TracerEventType::UserDefined, 1);"
 
 
 RETURN_INPLACE_PYOBJECT_TEMPLATE = \

--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -851,7 +851,7 @@ void Backward(
     bool retain_graph) {
   VLOG(3) << "Run in Backward";
   paddle::platform::RecordEvent backward_record_event(
-      "backward", paddle::platform::TracerEventType::Operator, 1);
+      "backward", paddle::platform::TracerEventType::UserDefined, 1);
   RunBackward(tensors, grad_tensors, retain_graph);
   phi::autotune::AutoTuneStatus::Instance().Update();
 }

--- a/paddle/fluid/platform/profiler/chrometracing_logger.cc
+++ b/paddle/fluid/platform/profiler/chrometracing_logger.cc
@@ -603,7 +603,7 @@ void ChromeTracingLogger::StartLog() {
         std::string(
             R"JSON(
     {
-       "id": %d, "name": "%s", "totalGlobalMem": %u,
+       "id": %d, "name": "%s", "totalGlobalMem": %llu,
       "computeMajor": %d, "computeMinor": %d,
       "maxThreadsPerBlock": %d, "maxThreadsPerMultiprocessor": %d,
       "regsPerBlock": %d, "regsPerMultiprocessor": %d, "warpSize": %d,
@@ -633,7 +633,7 @@ void ChromeTracingLogger::StartLog() {
         std::string(
             R"JSON(
     {
-       "id": %d, "name": "%s", "totalGlobalMem": %u,
+       "id": %d, "name": "%s", "totalGlobalMem": %llu,
       "computeMajor": %d, "computeMinor": %d,
       "maxThreadsPerBlock": %d, "maxThreadsPerMultiprocessor": %d,
       "regsPerBlock": %d, "regsPerMultiprocessor": %d, "warpSize": %d,

--- a/python/paddle/fluid/tests/unittests/test_profiler_statistic.py
+++ b/python/paddle/fluid/tests/unittests/test_profiler_statistic.py
@@ -82,9 +82,9 @@ class TestProfilerStatistic(unittest.TestCase):
                                       profiler.TracerEventType.Forward, 50, 110,
                                       1000, 1001)
 
-        userdefined_node = HostPythonNode('Communication Time',
-                                          profiler.TracerEventType.UserDefined,
-                                          100, 110, 1000, 1001)
+        userdefined_node = HostPythonNode(
+            'Communication Time', profiler.TracerEventType.PythonUserDefined,
+            100, 110, 1000, 1001)
 
         communication_node = HostPythonNode(
             'Communication', profiler.TracerEventType.Communication, 105, 110,
@@ -209,7 +209,7 @@ class TestProfilerStatistic(unittest.TestCase):
                 0, profiler.TracerEventType.Memcpy), 60)
         self.assertEqual(
             time_range_summary.get_cpu_range_sum(
-                profiler.TracerEventType.UserDefined), 25)
+                profiler.TracerEventType.UserDefined), 15)
         self.assertEqual(
             time_range_summary.get_cpu_range_sum(
                 profiler.TracerEventType.Communication), 5)
@@ -277,9 +277,9 @@ class TestProfilerStatistic(unittest.TestCase):
                                       profiler.TracerEventType.Forward, 50, 110,
                                       1000, 1001)
 
-        userdefined_node = HostPythonNode('Communication Time',
-                                          profiler.TracerEventType.UserDefined,
-                                          100, 110, 1000, 1001)
+        userdefined_node = HostPythonNode(
+            'Communication Time', profiler.TracerEventType.PythonUserDefined,
+            100, 110, 1000, 1001)
         allreduce_launchkernel0 = HostPythonNode(
             'cudalaunchkernel', profiler.TracerEventType.CudaRuntime, 102, 104,
             1000, 1001)
@@ -451,7 +451,7 @@ class TestProfilerStatistic(unittest.TestCase):
                 0, profiler.TracerEventType.Memcpy), 60)
         self.assertEqual(
             time_range_summary.get_cpu_range_sum(
-                profiler.TracerEventType.UserDefined), 25)
+                profiler.TracerEventType.UserDefined), 15)
         self.assertEqual(
             time_range_summary.get_cpu_range_sum(
                 profiler.TracerEventType.Communication), 5)
@@ -518,9 +518,9 @@ class TestProfilerStatistic(unittest.TestCase):
         optimization_node = HostPythonNode(
             'Optimization', profiler.TracerEventType.Optimization, 220, 300,
             1000, 1001)
-        userdefined_node = HostPythonNode('Communication Time',
-                                          profiler.TracerEventType.UserDefined,
-                                          60, 70, 1000, 1001)
+        userdefined_node = HostPythonNode(
+            'Communication Time', profiler.TracerEventType.PythonUserDefined,
+            60, 70, 1000, 1001)
 
         conv2d_node = HostPythonNode('conv2d',
                                      profiler.TracerEventType.Operator, 25, 25,

--- a/python/paddle/profiler/profiler_statistic.py
+++ b/python/paddle/profiler/profiler_statistic.py
@@ -514,7 +514,8 @@ class EventSummary:
                         or 'memset' in host_statistic_node.name.lower():
                         self.add_memory_manipulation_item(host_statistic_node)
                     else:
-                        self.add_userdefined_item(host_statistic_node)
+                        if host_statistic_node.type == TracerEventType.PythonUserDefined:
+                            self.add_userdefined_item(host_statistic_node)
             self.add_kernel_item(host_statistic_nodes[0])
 
         for threadid, root_statistic_node in node_statistic_trees.items():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. 新动态图里记录Operator性能数据的打点外围也包裹了很多打点，这些外围的打点都被标记成了Operator类型，导致打印出来的算子表单严重冗余，并且会因为干扰没有办法获取真实的最大耗时op。现在通过将如下外围打点给标记为UserDefined类型进行修复。
<img width="875" alt="image" src="https://user-images.githubusercontent.com/22424850/180723328-b012a909-3ee4-44bf-a4f7-2441b55c668f.png">
通过跑PaddleDetection的yolov3_mobilenet_v1_roadsign.yml任务测试输出的算子表单如下：

```text
----------------------------------------------------------------Operator Summary----------------------------------------------------------------
Time unit: ms
----------------------------------------------------  ------  ----------------------------------------  ----------------------------------------  
Name                                                  Calls   CPU Total / Avg / Max / Min / Ratio(%)    GPU Total / Avg / Max / Min / Ratio(%)    
----------------------------------------------------  ------  ----------------------------------------  ----------------------------------------  
-----------------------------------------------------------Thread: All threads merged-----------------------------------------------------------
Conv2dGradNodeFinal                                   296     195.39 / 0.66 / 1.17 / 0.18 / 13.89       622.99 / 2.10 / 4.79 / 0.24 / 23.94       
  MEMSET                                              344     - / - / - / - / -                         1.12 / 0.00 / 0.02 / 0.00 / 0.18          
  void wgrad_alg0_engine<float, 128, 5, 5, 3, 3, ...  32      - / - / - / - / -                         22.94 / 0.72 / 1.61 / 0.14 / 3.68         
  void cask_cudnn::computeOffsetsKernel<true, fal...  200     - / - / - / - / -                         0.74 / 0.00 / 0.01 / 0.00 / 0.12          
  cask_cudnn::computeBOffsetsKernel(cask_cudnn::C...  200     - / - / - / - / -                         0.73 / 0.00 / 0.00 / 0.00 / 0.12          
  maxwell_scudnn_128x64_stridedB_small_nn_v0          120     - / - / - / - / -                         79.47 / 0.66 / 1.32 / 0.09 / 12.76        
  void wgrad_alg0_engine<float, 128, 6, 7, 3, 3, ...  48      - / - / - / - / -                         56.80 / 1.18 / 3.46 / 0.17 / 9.12         
  void wgrad_alg0_engine<float, 128, 6, 8, 3, 3, ...  24      - / - / - / - / -                         32.42 / 1.35 / 2.46 / 0.50 / 5.20         
  cask_cudnn::computeWgradSplitKOffsetsKernel(cas...  120     - / - / - / - / -                         0.46 / 0.00 / 0.00 / 0.00 / 0.07          
  cask_cudnn::computeWgradBOffsetsKernel(cask_cud...  120     - / - / - / - / -                         0.46 / 0.00 / 0.00 / 0.00 / 0.07          
  maxwell_scudnn_128x128_stridedB_splitK_medium_n...  120     - / - / - / - / -                         102.69 / 0.86 / 1.27 / 0.29 / 16.48       
  void cudnn::ops::scalePackedTensor_kernel<float...  16      - / - / - / - / -                         1.08 / 0.07 / 0.07 / 0.07 / 0.17          
  void cudnn::detail::dgrad_engine<float, 512, 6,...  16      - / - / - / - / -                         6.51 / 0.41 / 0.55 / 0.26 / 1.05          
  maxwell_scudnn_128x128_stridedB_small_nn_v0         80      - / - / - / - / -                         49.89 / 0.62 / 0.79 / 0.40 / 8.01         
  void cudnn::winograd::generateWinogradTilesKern...  48      - / - / - / - / -                         6.80 / 0.14 / 0.23 / 0.06 / 1.09          
  maxwell_scudnn_winograd_128x128_ldg1_ldg4_relu_...  48      - / - / - / - / -                         87.96 / 1.83 / 1.97 / 1.72 / 14.12        
  void cudnn::winograd_nonfused::winogradWgradDat...  72      - / - / - / - / -                         15.53 / 0.22 / 0.36 / 0.09 / 2.49         
  void cudnn::winograd_nonfused::winogradWgradDel...  72      - / - / - / - / -                         31.56 / 0.44 / 0.75 / 0.19 / 5.07         
  maxwell_sgemm_32x128_nt                             48      - / - / - / - / -                         48.79 / 1.02 / 1.06 / 0.93 / 7.83         
  void cudnn::winograd_nonfused::winogradWgradOut...  72      - / - / - / - / -                         14.22 / 0.20 / 0.43 / 0.04 / 2.28         
  void axpy_kernel_val<float, float>(cublasAxpyPa...  16      - / - / - / - / -                         1.64 / 0.10 / 0.14 / 0.07 / 0.26          
  maxwell_sgemm_64x64_nt                              24      - / - / - / - / -                         19.12 / 0.80 / 0.81 / 0.79 / 3.07         
  void cudnn::winograd::generateWinogradTilesKern...  24      - / - / - / - / -                         0.41 / 0.02 / 0.02 / 0.02 / 0.07          
  maxwell_scudnn_winograd_128x128_ldg1_ldg4_relu_...  24      - / - / - / - / -                         41.65 / 1.74 / 1.76 / 1.72 / 6.69         
sync_batch_norm dygraph                               376     32.75 / 0.09 / 0.49 / 0.07 / 2.33         521.43 / 1.39 / 7.58 / 0.13 / 20.04       
  sync_batch_norm compute                             376     21.44 / 0.06 / 0.09 / 0.05 / 65.47        521.43 / 1.39 / 7.58 / 0.13 / 100.00      
    void phi::KeLocalStats<float, 256, (paddle::e...  376     - / - / - / - / -                         62.65 / 0.17 / 0.86 / 0.01 / 12.02        
    void phi::KeSyncAndMovingStats<float>(paddle:...  376     - / - / - / - / -                         2.15 / 0.01 / 0.01 / 0.00 / 0.41          
    void phi::KeNormAffine<float, (paddle::experi...  376     - / - / - / - / -                         456.63 / 1.21 / 6.71 / 0.11 / 87.57       
  sync_batch_norm node_creation                       376     4.58 / 0.01 / 0.02 / 0.01 / 13.98         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
SyncBatchNormGradNodeFinal                            376     28.69 / 0.08 / 0.13 / 0.06 / 2.04         421.23 / 1.12 / 6.17 / 0.12 / 16.18       
  sync_batch_norm_grad compute                        376     15.70 / 0.04 / 0.09 / 0.03 / 54.73        421.23 / 1.12 / 6.17 / 0.12 / 100.00      
    void phi::KeBackwardLocalStats<float, 256, (p...  376     - / - / - / - / -                         128.51 / 0.34 / 1.83 / 0.04 / 30.51       
    void phi::KeBNBackwardScaleBias<float, 256, (...  376     - / - / - / - / -                         125.86 / 0.33 / 1.82 / 0.03 / 29.88       
    void phi::KeBNBackwardData<float, (paddle::ex...  376     - / - / - / - / -                         166.86 / 0.44 / 2.53 / 0.04 / 39.61       
conv2d dygraph                                        296     115.38 / 0.39 / 0.65 / 0.24 / 8.20        341.94 / 1.16 / 5.38 / 0.09 / 13.14       
  conv2d node_creation                                296     2.14 / 0.01 / 0.02 / 0.01 / 1.85          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  void cask_cudnn::computeOffsetsKernel<false, fa...  176     - / - / - / - / -                         0.63 / 0.00 / 0.01 / 0.00 / 0.18          
  maxwell_scudnn_128x32_relu_medium_nn_v1             8       - / - / - / - / -                         1.99 / 0.25 / 0.25 / 0.25 / 0.58          
  maxwell_sgemm_64x64_nn                              40      - / - / - / - / -                         19.94 / 0.50 / 1.20 / 0.13 / 5.83         
  maxwell_sgemm_128x32_nn                             8       - / - / - / - / -                         0.79 / 0.10 / 0.10 / 0.09 / 0.23          
  void cudnn::winograd::generateWinogradTilesKern...  48      - / - / - / - / -                         6.27 / 0.13 / 0.25 / 0.02 / 1.83          
  maxwell_scudnn_winograd_128x128_ldg1_ldg4_mobil...  48      - / - / - / - / -                         153.01 / 3.19 / 5.13 / 1.96 / 44.75       
  maxwell_scudnn_128x64_relu_interior_nn_v1           104     - / - / - / - / -                         61.09 / 0.59 / 1.25 / 0.12 / 17.86        
  void cudnn::winograd::generateWinogradTilesKern...  24      - / - / - / - / -                         1.55 / 0.06 / 0.07 / 0.06 / 0.45          
  maxwell_scudnn_winograd_128x128_ldg1_ldg4_relu_...  24      - / - / - / - / -                         48.56 / 2.02 / 2.07 / 1.99 / 14.20        
  maxwell_scudnn_128x64_relu_small_nn_v1              48      - / - / - / - / -                         38.06 / 0.79 / 0.89 / 0.48 / 11.13        
  maxwell_scudnn_128x128_relu_medium_nn_v1            8       - / - / - / - / -                         5.28 / 0.66 / 0.67 / 0.65 / 1.54          
  maxwell_scudnn_128x32_relu_small_nn_v1              8       - / - / - / - / -                         4.78 / 0.60 / 0.61 / 0.59 / 1.40          
DepthwiseConv2dGradNodeFinal                          104     6.58 / 0.06 / 0.09 / 0.06 / 0.47          239.45 / 2.30 / 4.10 / 1.16 / 9.20        
  depthwise_conv2d_grad compute                       104     4.80 / 0.05 / 0.05 / 0.04 / 72.87         232.81 / 2.24 / 4.10 / 1.16 / 97.23       
    void Eigen::internal::EigenMetaKernel<Eigen::...  208     - / - / - / - / -                         23.15 / 0.11 / 0.75 / 0.00 / 9.94         
    void paddle::operators::math::KernelDepthwise...  72      - / - / - / - / -                         38.00 / 0.53 / 1.16 / 0.23 / 16.32        
    void paddle::operators::math::KernelDepthwise...  72      - / - / - / - / -                         113.23 / 1.57 / 2.02 / 1.35 / 48.64       
    void paddle::operators::math::KernelDepthwise...  32      - / - / - / - / -                         27.12 / 0.85 / 1.85 / 0.28 / 11.65        
    void paddle::operators::math::KernelDepthwise...  32      - / - / - / - / -                         31.30 / 0.98 / 1.50 / 0.78 / 13.45        
  void axpy_kernel_val<float, float>(cublasAxpyPa...  16      - / - / - / - / -                         6.64 / 0.42 / 0.56 / 0.27 / 2.77          
ReluGradNodeFinal                                     216     6.60 / 0.03 / 0.05 / 0.02 / 0.47          115.71 / 0.54 / 2.31 / 0.07 / 4.45        
  relu_grad compute                                   216     3.21 / 0.01 / 0.03 / 0.01 / 48.61         115.71 / 0.54 / 2.31 / 0.07 / 100.00      
    void phi::funcs::VectorizedElementwiseKernel<...  216     - / - / - / - / -                         115.71 / 0.54 / 2.31 / 0.07 / 100.00      
relu dygraph                                          216     6.23 / 0.03 / 0.06 / 0.02 / 0.44          77.51 / 0.36 / 1.54 / 0.05 / 2.98         
  relu compute                                        216     3.98 / 0.02 / 0.04 / 0.02 / 63.86         77.51 / 0.36 / 1.54 / 0.05 / 100.00       
    void phi::funcs::VectorizedElementwiseKernel<...  216     - / - / - / - / -                         77.51 / 0.36 / 1.54 / 0.05 / 100.00       
  relu node_creation                                  216     0.68 / 0.00 / 0.01 / 0.00 / 10.88         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
depthwise_conv2d dygraph                              104     4.17 / 0.04 / 0.06 / 0.04 / 0.30          55.37 / 0.53 / 1.16 / 0.18 / 2.13         
  depthwise_conv2d compute                            104     2.41 / 0.02 / 0.04 / 0.02 / 57.67         55.37 / 0.53 / 1.16 / 0.18 / 100.00       
    void paddle::operators::math::KernelDepthwise...  72      - / - / - / - / -                         37.94 / 0.53 / 1.16 / 0.23 / 68.52        
    void paddle::operators::math::KernelDepthwise...  32      - / - / - / - / -                         17.43 / 0.54 / 1.13 / 0.18 / 31.48        
  depthwise_conv2d node_creation                      104     0.63 / 0.01 / 0.01 / 0.00 / 15.03         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
LeakyReluGradNodeFinal                                160     5.35 / 0.03 / 0.04 / 0.02 / 0.38          37.42 / 0.23 / 0.58 / 0.03 / 1.44         
  leaky_relu_grad compute                             160     2.60 / 0.02 / 0.03 / 0.01 / 48.53         37.42 / 0.23 / 0.58 / 0.03 / 100.00       
    void phi::funcs::VectorizedElementwiseKernel<...  160     - / - / - / - / -                         37.42 / 0.23 / 0.58 / 0.03 / 100.00       
slice dygraph                                         608     42.74 / 0.07 / 3.37 / 0.02 / 3.04         29.04 / 0.05 / 3.06 / 0.00 / 1.12         
  slice compute                                       600     10.80 / 0.02 / 0.03 / 0.01 / 25.26        4.60 / 0.01 / 0.04 / 0.00 / 15.84         
    void Eigen::internal::EigenMetaKernel<Eigen::...  96      - / - / - / - / -                         0.47 / 0.00 / 0.01 / 0.00 / 10.22         
    void Eigen::internal::EigenMetaKernel<Eigen::...  96      - / - / - / - / -                         0.26 / 0.00 / 0.00 / 0.00 / 5.69          
    void Eigen::internal::EigenMetaKernel<Eigen::...  408     - / - / - / - / -                         3.87 / 0.01 / 0.04 / 0.00 / 84.09         
  slice node_creation                                 200     1.04 / 0.01 / 0.02 / 0.00 / 2.44          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  GpuMemcpySync:CUDAPinned->GPU                       8       0.26 / 0.03 / 0.03 / 0.03 / 0.61          0.01 / 0.00 / 0.00 / 0.00 / 0.04          
    MEMCPY_HtoD                                       8       - / - / - / - / -                         0.01 / 0.00 / 0.00 / 0.00 / 100.00        
leaky_relu dygraph                                    160     4.57 / 0.03 / 0.04 / 0.03 / 0.32          24.93 / 0.16 / 0.39 / 0.02 / 0.96         
  leaky_relu compute                                  160     3.02 / 0.02 / 0.03 / 0.02 / 66.09         24.93 / 0.16 / 0.39 / 0.02 / 100.00       
    void phi::funcs::VectorizedElementwiseKernel<...  160     - / - / - / - / -                         24.93 / 0.16 / 0.39 / 0.02 / 100.00       
  leaky_relu node_creation                            160     0.50 / 0.00 / 0.00 / 0.00 / 10.90         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
slice                                                 8       26.23 / 3.28 / 3.33 / 3.20 / 1.86         24.42 / 3.05 / 3.06 / 3.05 / 0.94         
  GpuMemcpySync:CUDAPinned->GPU                       8       24.78 / 3.10 / 3.12 / 3.08 / 94.46        24.40 / 3.05 / 3.06 / 3.04 / 99.88        
    MEMCPY_HtoD                                       8       - / - / - / - / -                         24.40 / 3.05 / 3.06 / 3.04 / 100.00       
  infer_shape                                         8       0.08 / 0.01 / 0.01 / 0.01 / 0.30          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  compute                                             8       0.57 / 0.07 / 0.10 / 0.05 / 2.17          0.03 / 0.00 / 0.00 / 0.00 / 0.12          
    void Eigen::internal::EigenMetaKernel<Eigen::...  8       - / - / - / - / -                         0.03 / 0.00 / 0.00 / 0.00 / 100.00        
  grad_node_creation                                  8       0.00 / 0.00 / 0.00 / 0.00 / 0.01          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
subtract dygraph                                      216     7.00 / 0.03 / 0.06 / 0.02 / 0.50          11.58 / 0.05 / 0.68 / 0.00 / 0.44         
  subtract compute                                    216     4.80 / 0.02 / 0.04 / 0.02 / 68.46         11.58 / 0.05 / 0.68 / 0.00 / 100.00       
    void phi::funcs::VectorizedBroadcastKernel<fl...  216     - / - / - / - / -                         11.58 / 0.05 / 0.68 / 0.00 / 100.00       
  subtract node_creation                              168     0.97 / 0.01 / 0.01 / 0.00 / 13.80         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
concat dygraph                                        64      3.34 / 0.05 / 0.11 / 0.03 / 0.24          8.86 / 0.14 / 0.65 / 0.01 / 0.34          
  concat compute                                      64      2.29 / 0.04 / 0.09 / 0.02 / 68.71         8.86 / 0.14 / 0.65 / 0.01 / 100.00        
    void phi::funcs::ConcatKernel_<float>(float c...  24      - / - / - / - / -                         0.20 / 0.01 / 0.01 / 0.01 / 2.20          
    void phi::funcs::ConcatKernel_<float>(float c...  24      - / - / - / - / -                         0.92 / 0.04 / 0.07 / 0.02 / 10.34         
    void phi::funcs::ConcatKernel_<float>(float c...  16      - / - / - / - / -                         7.71 / 0.48 / 0.65 / 0.32 / 87.07         
  concat node_creation                                40      0.28 / 0.01 / 0.01 / 0.01 / 8.33          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
ConcatGradNodeFinal                                   16      1.43 / 0.09 / 0.10 / 0.08 / 0.10          7.65 / 0.48 / 0.64 / 0.31 / 0.29          
  concat_grad compute                                 16      0.99 / 0.06 / 0.07 / 0.06 / 69.06         7.65 / 0.48 / 0.64 / 0.31 / 100.00        
    void phi::funcs::SplitKernel_<float>(float co...  16      - / - / - / - / -                         7.62 / 0.48 / 0.64 / 0.31 / 99.56         
transpose dygraph                                     48      814.82 / 16.98 / 103.17 / 0.03 / 57.90    6.29 / 0.13 / 0.53 / 0.01 / 0.24          
  GpuMemcpySync:CUDAPinned->GPU                       24      812.45 / 33.85 / 103.12 / 0.15 / 99.71    5.04 / 0.21 / 0.48 / 0.03 / 80.10         
    MEMCPY_HtoD                                       24      - / - / - / - / -                         5.04 / 0.21 / 0.48 / 0.03 / 100.00        
  transpose compute                                   48      1.41 / 0.03 / 0.07 / 0.02 / 0.17          1.25 / 0.03 / 0.06 / 0.01 / 19.90         
    void paddle::operators::TilingSwapDim1And2<un...  16      - / - / - / - / -                         0.88 / 0.06 / 0.06 / 0.05 / 70.55         
    void paddle::operators::TilingSwapDim1And2<un...  16      - / - / - / - / -                         0.17 / 0.01 / 0.01 / 0.01 / 13.43         
    void paddle::operators::TilingSwapDim1And2<un...  16      - / - / - / - / -                         0.20 / 0.01 / 0.02 / 0.01 / 16.02         
  transpose node_creation                             24      0.07 / 0.00 / 0.01 / 0.00 / 0.01          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
reduce_prod dygraph                                   72      2.84 / 0.04 / 0.06 / 0.03 / 0.20          5.04 / 0.07 / 0.45 / 0.00 / 0.19          
  prod_raw compute                                    72      2.09 / 0.03 / 0.05 / 0.02 / 73.66         5.04 / 0.07 / 0.45 / 0.00 / 100.00        
    void phi::funcs::ReduceAnyKernel<float, float...  72      - / - / - / - / -                         5.04 / 0.07 / 0.45 / 0.00 / 100.00        
  reduce_prod node_creation                           48      0.22 / 0.00 / 0.01 / 0.00 / 7.90          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
SliceGradNodeFinal                                    144     4.73 / 0.03 / 0.05 / 0.02 / 0.34          4.96 / 0.03 / 0.09 / 0.00 / 0.19          
  slice_grad compute                                  144     1.95 / 0.01 / 0.02 / 0.01 / 41.14         1.92 / 0.01 / 0.04 / 0.00 / 38.73         
    void Eigen::internal::EigenMetaKernel<Eigen::...  144     - / - / - / - / -                         1.92 / 0.01 / 0.04 / 0.00 / 100.00        
  void axpy_kernel_val<float, float>(cublasAxpyPa...  120     - / - / - / - / -                         3.04 / 0.03 / 0.06 / 0.00 / 61.27         
clip dygraph                                          72      2.04 / 0.03 / 0.05 / 0.02 / 0.15          4.91 / 0.07 / 0.45 / 0.00 / 0.19          
  clip compute                                        72      1.46 / 0.02 / 0.04 / 0.02 / 71.51         4.91 / 0.07 / 0.45 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  72      - / - / - / - / -                         4.91 / 0.07 / 0.45 / 0.00 / 100.00        
  clip node_creation                                  48      0.13 / 0.00 / 0.00 / 0.00 / 6.57          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
maximum dygraph                                       24      1.03 / 0.04 / 0.07 / 0.04 / 0.07          4.13 / 0.17 / 0.38 / 0.04 / 0.16          
  maximum compute                                     24      0.69 / 0.03 / 0.05 / 0.02 / 66.89         4.13 / 0.17 / 0.38 / 0.04 / 100.00        
    void phi::funcs::VectorizedBroadcastKernel<fl...  24      - / - / - / - / -                         4.13 / 0.17 / 0.38 / 0.04 / 100.00        
  maximum node_creation                               24      0.14 / 0.01 / 0.01 / 0.00 / 13.62         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
minimum dygraph                                       24      0.91 / 0.04 / 0.04 / 0.03 / 0.06          4.11 / 0.17 / 0.37 / 0.04 / 0.16          
  minimum compute                                     24      0.62 / 0.03 / 0.03 / 0.02 / 68.28         4.11 / 0.17 / 0.37 / 0.04 / 100.00        
    void phi::funcs::VectorizedBroadcastKernel<fl...  24      - / - / - / - / -                         4.11 / 0.17 / 0.37 / 0.04 / 100.00        
  minimum node_creation                               24      0.10 / 0.00 / 0.00 / 0.00 / 10.66         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
add dygraph                                           352     10.91 / 0.03 / 0.05 / 0.02 / 0.78         3.74 / 0.01 / 0.16 / 0.00 / 0.14          
  add compute                                         352     7.22 / 0.02 / 0.04 / 0.02 / 66.16         3.74 / 0.01 / 0.16 / 0.00 / 100.00        
    void phi::funcs::VectorizedBroadcastKernel<fl...  352     - / - / - / - / -                         3.74 / 0.01 / 0.16 / 0.00 / 100.00        
  add node_creation                                   304     1.71 / 0.01 / 0.02 / 0.00 / 15.72         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
scale dygraph                                         440     10.26 / 0.02 / 0.06 / 0.02 / 0.73         3.73 / 0.01 / 0.23 / 0.00 / 0.14          
  scale compute                                       440     7.25 / 0.02 / 0.05 / 0.01 / 70.66         3.73 / 0.01 / 0.23 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  440     - / - / - / - / -                         3.73 / 0.01 / 0.23 / 0.00 / 100.00        
  scale node_creation                                 320     0.71 / 0.00 / 0.02 / 0.00 / 6.91          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
divide dygraph                                        24      0.81 / 0.03 / 0.04 / 0.03 / 0.06          3.68 / 0.15 / 0.35 / 0.02 / 0.14          
  divide compute                                      24      0.52 / 0.02 / 0.03 / 0.02 / 64.04         3.68 / 0.15 / 0.35 / 0.02 / 100.00        
    void phi::funcs::VectorizedBroadcastKernel<fl...  24      - / - / - / - / -                         3.68 / 0.15 / 0.35 / 0.02 / 100.00        
  divide node_creation                                24      0.15 / 0.01 / 0.02 / 0.00 / 18.50         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
nearest_interp_v2GradNodeCompat                       16      1.79 / 0.11 / 0.16 / 0.09 / 0.13          3.29 / 0.21 / 0.28 / 0.14 / 0.13          
nearest_interp_v2_grad                                16      1.35 / 0.08 / 0.12 / 0.06 / 0.10          3.29 / 0.21 / 0.28 / 0.14 / 0.13          
  infer_shape                                         16      0.04 / 0.00 / 0.00 / 0.00 / 3.31          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  compute                                             16      0.77 / 0.05 / 0.08 / 0.04 / 56.86         3.29 / 0.21 / 0.28 / 0.14 / 100.00        
    void Eigen::internal::EigenMetaKernel<Eigen::...  16      - / - / - / - / -                         0.31 / 0.02 / 0.03 / 0.01 / 9.45          
    void phi::KeNearestNeighborInterpNCHWBw<float...  16      - / - / - / - / -                         2.98 / 0.19 / 0.25 / 0.12 / 90.55         
  grad_node_creation                                  16      0.00 / 0.00 / 0.00 / 0.00 / 0.31          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
max dygraph                                           24      0.90 / 0.04 / 0.05 / 0.03 / 0.06          2.02 / 0.08 / 0.19 / 0.02 / 0.08          
  max compute                                         24      0.73 / 0.03 / 0.04 / 0.03 / 81.28         2.02 / 0.08 / 0.19 / 0.02 / 100.00        
    void phi::funcs::ReduceAnyKernel<float, float...  24      - / - / - / - / -                         2.02 / 0.08 / 0.19 / 0.02 / 100.00        
nearest_interp_v2 dygraph                             16      1.90 / 0.12 / 0.16 / 0.09 / 0.13          1.57 / 0.10 / 0.13 / 0.07 / 0.06          
  nearest_interp_v2 node_creation                     16      0.09 / 0.01 / 0.01 / 0.01 / 4.98          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
nearest_interp_v2                                     16      1.48 / 0.09 / 0.13 / 0.07 / 0.11          1.57 / 0.10 / 0.13 / 0.07 / 0.06          
  infer_shape                                         16      0.25 / 0.02 / 0.03 / 0.01 / 17.17         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  compute                                             16      0.59 / 0.04 / 0.06 / 0.03 / 39.82         1.57 / 0.10 / 0.13 / 0.07 / 100.00        
    void phi::KeNearestNeighborInterpNCHWFw<float...  16      - / - / - / - / -                         1.57 / 0.10 / 0.13 / 0.07 / 100.00        
  grad_node_creation                                  16      0.00 / 0.00 / 0.00 / 0.00 / 0.27          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
multiply dygraph                                      216     6.71 / 0.03 / 0.06 / 0.02 / 0.48          1.30 / 0.01 / 0.03 / 0.00 / 0.05          
  multiply compute                                    216     4.59 / 0.02 / 0.05 / 0.02 / 68.41         1.30 / 0.01 / 0.03 / 0.00 / 100.00        
    void phi::funcs::VectorizedBroadcastKernel<fl...  216     - / - / - / - / -                         1.30 / 0.01 / 0.03 / 0.00 / 100.00        
  multiply node_creation                              192     0.82 / 0.00 / 0.01 / 0.00 / 12.15         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
MultiplyGradNodeFinal                                 144     5.16 / 0.04 / 0.45 / 0.02 / 0.37          1.12 / 0.01 / 0.03 / 0.00 / 0.04          
  multiply_grad compute                               144     2.40 / 0.02 / 0.04 / 0.01 / 46.61         1.01 / 0.01 / 0.03 / 0.00 / 90.33         
    void phi::funcs::VectorizedBroadcastKernel<fl...  144     - / - / - / - / -                         1.01 / 0.01 / 0.03 / 0.00 / 100.00        
  void axpy_kernel_val<float, float>(cublasAxpyPa...  24      - / - / - / - / -                         0.11 / 0.00 / 0.01 / 0.00 / 9.67          
AddGradNodeFinal                                      184     6.49 / 0.04 / 0.07 / 0.02 / 0.46          1.03 / 0.01 / 0.04 / 0.00 / 0.04          
  add_grad compute                                    184     4.40 / 0.02 / 0.05 / 0.02 / 67.84         1.03 / 0.01 / 0.04 / 0.00 / 100.00        
    void phi::funcs::ReduceAnyKernel<float, float...  24      - / - / - / - / -                         0.42 / 0.02 / 0.04 / 0.01 / 40.56         
    void phi::funcs::ReduceHigherDimKernel<float,...  24      - / - / - / - / -                         0.11 / 0.00 / 0.01 / 0.00 / 10.89         
SigmoidCrossEntropyWithLogitsGradNodeFinal            48      1.36 / 0.03 / 0.04 / 0.02 / 0.10          0.85 / 0.02 / 0.05 / 0.00 / 0.03          
  sigmoid_cross_entropy_with_logits_grad compute      48      0.83 / 0.02 / 0.03 / 0.01 / 61.00         0.85 / 0.02 / 0.05 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.85 / 0.02 / 0.05 / 0.00 / 100.00        
sum dygraph                                           96      5.20 / 0.05 / 0.07 / 0.04 / 0.37          0.84 / 0.01 / 0.02 / 0.00 / 0.03          
  sum compute                                         96      4.04 / 0.04 / 0.05 / 0.03 / 77.72         0.84 / 0.01 / 0.02 / 0.00 / 100.00        
    void phi::funcs::ReduceAnyKernel<float, float...  96      - / - / - / - / -                         0.48 / 0.00 / 0.01 / 0.00 / 56.94         
    void phi::funcs::ReduceHigherDimKernel<float,...  72      - / - / - / - / -                         0.36 / 0.01 / 0.01 / 0.00 / 43.06         
  sum node_creation                                   96      0.35 / 0.00 / 0.01 / 0.00 / 6.82          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
sigmoid_cross_entropy_with_logits dygraph             48      1.62 / 0.03 / 0.06 / 0.03 / 0.12          0.70 / 0.01 / 0.04 / 0.01 / 0.03          
  sigmoid_cross_entropy_with_logits compute           48      1.07 / 0.02 / 0.05 / 0.02 / 66.24         0.70 / 0.01 / 0.04 / 0.01 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.70 / 0.01 / 0.04 / 0.01 / 100.00        
  sigmoid_cross_entropy_with_logits node_creation     48      0.25 / 0.01 / 0.01 / 0.00 / 15.38         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
TransposeGradNodeFinal                                24      0.61 / 0.03 / 0.04 / 0.02 / 0.04          0.54 / 0.02 / 0.05 / 0.01 / 0.02          
  transpose_grad compute                              24      0.39 / 0.02 / 0.02 / 0.01 / 64.36         0.54 / 0.02 / 0.05 / 0.01 / 100.00        
    void paddle::operators::TilingSwapDim1And2<un...  16      - / - / - / - / -                         0.18 / 0.01 / 0.01 / 0.01 / 33.21         
    void paddle::operators::TilingSwapDim1And2<un...  8       - / - / - / - / -                         0.36 / 0.05 / 0.05 / 0.04 / 66.79         
cast dygraph                                          144     3.35 / 0.02 / 0.04 / 0.02 / 0.24          0.50 / 0.00 / 0.01 / 0.00 / 0.02          
  cast compute                                        144     2.60 / 0.02 / 0.03 / 0.01 / 77.64         0.50 / 0.00 / 0.01 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  96      - / - / - / - / -                         0.37 / 0.00 / 0.01 / 0.00 / 73.94         
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.13 / 0.00 / 0.00 / 0.00 / 26.06         
SumGradNodeFinal                                      96      2.57 / 0.03 / 0.07 / 0.02 / 0.18          0.45 / 0.00 / 0.02 / 0.00 / 0.02          
  sum_grad compute                                    96      1.67 / 0.02 / 0.06 / 0.01 / 65.21         0.45 / 0.00 / 0.02 / 0.00 / 100.00        
    void phi::funcs::VectorizedBroadcastKernel<fl...  96      - / - / - / - / -                         0.45 / 0.00 / 0.02 / 0.00 / 100.00        
ScaleGradNodeFinal                                    104     2.14 / 0.02 / 0.03 / 0.02 / 0.15          0.42 / 0.00 / 0.01 / 0.00 / 0.02          
  scale compute                                       104     1.23 / 0.01 / 0.02 / 0.01 / 57.42         0.42 / 0.00 / 0.01 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  104     - / - / - / - / -                         0.42 / 0.00 / 0.01 / 0.00 / 100.00        
BceLossGradNodeFinal                                  48      1.21 / 0.03 / 0.05 / 0.02 / 0.09          0.39 / 0.01 / 0.02 / 0.00 / 0.01          
  bce_loss_grad compute                               48      0.58 / 0.01 / 0.04 / 0.01 / 48.33         0.39 / 0.01 / 0.02 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.39 / 0.01 / 0.02 / 0.00 / 100.00        
meshgrid dygraph                                      24      2.65 / 0.11 / 0.15 / 0.10 / 0.19          0.34 / 0.01 / 0.01 / 0.01 / 0.01          
  meshgrid compute                                    24      2.29 / 0.10 / 0.14 / 0.08 / 86.57         0.34 / 0.01 / 0.01 / 0.01 / 100.00        
    void Eigen::internal::EigenMetaKernel<Eigen::...  48      - / - / - / - / -                         0.22 / 0.00 / 0.01 / 0.00 / 65.70         
mean dygraph                                          96      5.32 / 0.06 / 0.60 / 0.04 / 0.38          0.33 / 0.00 / 0.00 / 0.00 / 0.01          
  mean compute                                        96      4.27 / 0.04 / 0.59 / 0.04 / 80.21         0.33 / 0.00 / 0.00 / 0.00 / 100.00        
    void cub::DeviceReduceSingleTileKernel<cub::D...  96      - / - / - / - / -                         0.33 / 0.00 / 0.00 / 0.00 / 100.00        
  mean node_creation                                  96      0.42 / 0.00 / 0.01 / 0.00 / 7.98          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
bce_loss dygraph                                      48      1.16 / 0.02 / 0.05 / 0.02 / 0.08          0.31 / 0.01 / 0.01 / 0.00 / 0.01          
  bce_loss compute                                    48      0.77 / 0.02 / 0.04 / 0.01 / 65.98         0.31 / 0.01 / 0.01 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.31 / 0.01 / 0.01 / 0.00 / 100.00        
  bce_loss node_creation                              48      0.14 / 0.00 / 0.01 / 0.00 / 12.24         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
AbsGradNodeFinal                                      48      1.21 / 0.03 / 0.05 / 0.02 / 0.09          0.30 / 0.01 / 0.01 / 0.00 / 0.01          
  abs_grad compute                                    48      0.66 / 0.01 / 0.04 / 0.01 / 55.01         0.30 / 0.01 / 0.01 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.30 / 0.01 / 0.01 / 0.00 / 100.00        
MeanGradNodeFinal                                     96      2.58 / 0.03 / 0.06 / 0.02 / 0.18          0.27 / 0.00 / 0.00 / 0.00 / 0.01          
  mean_grad compute                                   96      1.67 / 0.02 / 0.05 / 0.01 / 64.80         0.27 / 0.00 / 0.00 / 0.00 / 100.00        
    void phi::funcs::VectorizedBroadcastKernel<fl...  96      - / - / - / - / -                         0.27 / 0.00 / 0.00 / 0.00 / 100.00        
SigmoidGradNodeFinal                                  48      1.03 / 0.02 / 0.04 / 0.02 / 0.07          0.26 / 0.01 / 0.01 / 0.00 / 0.01          
  sigmoid_grad compute                                48      0.55 / 0.01 / 0.03 / 0.01 / 53.57         0.26 / 0.01 / 0.01 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.26 / 0.01 / 0.01 / 0.00 / 100.00        
sigmoid dygraph                                       48      1.19 / 0.02 / 0.04 / 0.02 / 0.08          0.24 / 0.01 / 0.01 / 0.00 / 0.01          
  sigmoid compute                                     48      0.77 / 0.02 / 0.03 / 0.01 / 65.16         0.24 / 0.01 / 0.01 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.24 / 0.01 / 0.01 / 0.00 / 100.00        
  sigmoid node_creation                               48      0.17 / 0.00 / 0.01 / 0.00 / 14.09         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
exp dygraph                                           48      1.24 / 0.03 / 0.04 / 0.02 / 0.09          0.21 / 0.00 / 0.01 / 0.00 / 0.01          
  exp compute                                         48      0.85 / 0.02 / 0.03 / 0.01 / 68.41         0.21 / 0.00 / 0.01 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.21 / 0.00 / 0.01 / 0.00 / 100.00        
  exp node_creation                                   48      0.15 / 0.00 / 0.00 / 0.00 / 12.12         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
abs dygraph                                           48      1.19 / 0.02 / 0.03 / 0.02 / 0.08          0.15 / 0.00 / 0.00 / 0.00 / 0.01          
  abs compute                                         48      0.79 / 0.02 / 0.02 / 0.01 / 66.53         0.15 / 0.00 / 0.00 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  48      - / - / - / - / -                         0.15 / 0.00 / 0.00 / 0.00 / 100.00        
  abs node_creation                                   48      0.13 / 0.00 / 0.00 / 0.00 / 11.04         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
stack dygraph                                         24      1.22 / 0.05 / 0.09 / 0.04 / 0.09          0.11 / 0.00 / 0.00 / 0.00 / 0.00          
  stack compute                                       24      0.96 / 0.04 / 0.07 / 0.03 / 78.73         0.11 / 0.00 / 0.00 / 0.00 / 100.00        
    void phi::StackCUDAKernel<long, int>(long**, ...  24      - / - / - / - / -                         0.08 / 0.00 / 0.00 / 0.00 / 75.61         
fill_constant dygraph                                 8       0.74 / 0.09 / 0.10 / 0.09 / 0.05          0.02 / 0.00 / 0.00 / 0.00 / 0.00          
fill_constant                                         8       0.63 / 0.08 / 0.08 / 0.07 / 0.04          0.02 / 0.00 / 0.00 / 0.00 / 0.00          
  infer_shape                                         8       0.02 / 0.00 / 0.00 / 0.00 / 3.54          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  compute                                             8       0.27 / 0.03 / 0.04 / 0.03 / 43.38         0.02 / 0.00 / 0.00 / 0.00 / 100.00        
    void phi::funcs::VectorizedElementwiseKernel<...  8       - / - / - / - / -                         0.02 / 0.00 / 0.00 / 0.00 / 100.00        
  grad_node_creation                                  8       0.00 / 0.00 / 0.00 / 0.00 / 0.32          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
GradNodeAccumulation                                  1176    4.78 / 0.00 / 0.01 / 0.00 / 0.34          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
ReshapeGradNodeFinal                                  72      0.78 / 0.01 / 0.02 / 0.00 / 0.06          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  reshape_grad compute                                72      0.11 / 0.00 / 0.00 / 0.00 / 14.40         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
SubtractGradNodeFinal                                 48      0.36 / 0.01 / 0.01 / 0.01 / 0.03          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  subtract_grad compute                               48      0.03 / 0.00 / 0.00 / 0.00 / 8.48          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
reshape dygraph                                       168     1.99 / 0.01 / 0.02 / 0.01 / 0.14          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  reshape_with_xshape compute                         168     0.25 / 0.00 / 0.01 / 0.00 / 12.36         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  reshape node_creation                               96      0.31 / 0.00 / 0.00 / 0.00 / 15.59         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
unsqueeze dygraph                                     48      0.54 / 0.01 / 0.02 / 0.01 / 0.04          0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  unsqueeze_with_xshape compute                       48      0.09 / 0.00 / 0.00 / 0.00 / 17.58         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
  unsqueeze node_creation                             24      0.10 / 0.00 / 0.00 / 0.00 / 18.80         0.00 / 0.00 / 0.00 / 0.00 / 0.00          
----------------------------------------------------  ------  ----------------------------------------  ----------------------------------------  
```
2. 修复导出的chrome tracing中显卡内存数据格式化字符串设置错误的bug。
3. 用户自定义表单只统计python层用户自定义的打点。