### PR TITLE
[MLU] rollback cntoolkit vetsion to 2.8.5

### DIFF
--- a/paddle/fluid/platform/device/mlu/mlu_info.h
+++ b/paddle/fluid/platform/device/mlu/mlu_info.h
@@ -16,9 +16,9 @@ limitations under the License. */
 
 #ifdef PADDLE_WITH_MLU
 #include <cn_api.h>
+#include <cndrv_id.h>
 #include <cnnl.h>
 #include <cnpapi.h>
-#include <cnpapi_cndrv_id.h>
 #include <cnrt.h>
 #ifdef PADDLE_WITH_CNCL
 #include <cncl.h>

--- a/python/paddle/fluid/tests/unittests/mlu/test_grid_sampler_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_grid_sampler_op_mlu.py
@@ -186,15 +186,16 @@ class TestGridSamplerOp(OpTest):
         self.mode = "bilinear"
 
 
-class Case1(TestGridSamplerOp):
-
-    def initTestCase(self):
-        self.x_shape = (2, 3, 5, 6)
-        self.grid_shape = (2, 8, 9, 2)
-        self.theta_shape = (2, 2, 3)
-        self.align_corners = True
-        self.padding_mode = "zeros"
-        self.mode = "bilinear"
+# TODO(fwg): Test this case when cnnl support align_corners = True.
+# class Case1(TestGridSamplerOp):
+#
+#     def initTestCase(self):
+#         self.x_shape = (2, 3, 5, 6)
+#         self.grid_shape = (2, 8, 9, 2)
+#         self.theta_shape = (2, 2, 3)
+#         self.align_corners = True
+#         self.padding_mode = "zeros"
+#         self.mode = "bilinear"
 
 
 class LargeInputCase(TestGridSamplerOp):
@@ -208,16 +209,16 @@ class LargeInputCase(TestGridSamplerOp):
         self.mode = "bilinear"
 
 
-class Case2(LargeInputCase):
-
-    def initTestCase(self):
-        self.x_shape = (2, 3, 128, 128)
-        self.grid_shape = (2, 130, 130, 2)
-        self.theta_shape = (2, 2, 3)
-        self.align_corners = True
-        self.padding_mode = "zeros"
-        self.mode = "bilinear"
-
+# TODO(fwg): Test this case when cnnl support align_corners = True.
+# class Case2(LargeInputCase):
+#
+#     def initTestCase(self):
+#         self.x_shape = (2, 3, 128, 128)
+#         self.grid_shape = (2, 130, 130, 2)
+#         self.theta_shape = (2, 2, 3)
+#         self.align_corners = True
+#         self.padding_mode = "zeros"
+#         self.mode = "bilinear"
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/dockerfile/Dockerfile.mlu
+++ b/tools/dockerfile/Dockerfile.mlu
@@ -2,14 +2,14 @@
 # Update CNTOOLKIT_VERSION, CNNL_VERSION and CNCL_VERSION if using other versions
 #
 # Build:
-# - CNTOOLKIT_VERSION 3.0.0-1
-# - CNNL_VERSION 1.11.0-1
-# - CNCL_VERSION 1.2.0-1
+# - CNTOOLKIT_VERSION 2.8.5
+# - CNNL_VERSION 1.10.5
+# - CNCL_VERSION 1.1.2
 #
 # Download three packages from FTP (need to connect cambricon AE to get FTP url)
-# - cntoolkit_3.0.0-1.ubuntu18.04_amd64.deb
-# - cnnl_1.11.0-1.ubuntu18.04_amd64.deb
-# - cncl_1.2.0-1.ubuntu18.04_amd64.deb
+# - cntoolkit_2.8.5.ubuntu18.04_amd64.deb
+# - cnnl_1.10.5.ubuntu18.04_amd64.deb
+# - cncl_1.1.2.ubuntu18.04_amd64.deb
 # copy them to current directory first, then run build commands
 #
 # For example:
@@ -21,9 +21,9 @@
 # (get cncl pkg)
 #
 # docker build -f Dockerfile.mlu  \
-# --build-arg CNTOOLKIT_VERSION=3.0.0-1 \
-# --build-arg CNNL_VERSION=1.11.0-1 \
-# --build-arg CNCL_VERSION=1.2.0-1 \
+# --build-arg CNTOOLKIT_VERSION=2.8.5 \
+# --build-arg CNNL_VERSION=1.10.5 \
+# --build-arg CNCL_VERSION=1.1.2 \
 # -t paddlepaddle/paddle:latest-dev-mlu .
 #
 # without mlu device:
@@ -40,9 +40,9 @@ MAINTAINER PaddlePaddle Authors <paddle-dev@baidu.com>
 
 ENV WITH_GPU=OFF
 
-ARG CNTOOLKIT_VERSION=3.0.0-1
-ARG CNNL_VERSION=1.11.0-1
-ARG CNCL_VERSION=1.2.0-1
+ARG CNTOOLKIT_VERSION=2.8.5
+ARG CNNL_VERSION=1.10.5
+ARG CNCL_VERSION=1.1.2
 ARG CNTOOLKIT_PKG=cntoolkit_$CNTOOLKIT_VERSION.ubuntu18.04_amd64.deb
 ARG CNNL_PKG=cnnl_$CNNL_VERSION.ubuntu18.04_amd64.deb
 ARG CNCL_PKG=cncl_$CNCL_VERSION.ubuntu18.04_amd64.deb


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
rollback cntoolkit vetsion to 2.8.5， rollback cnnl version to 1.10.5