### PR TITLE
Refine timeout for TCPStore, add friendly log.

### DIFF
--- a/paddle/fluid/distributed/store/tcp_store.h
+++ b/paddle/fluid/distributed/store/tcp_store.h
@@ -61,6 +61,7 @@ class MasterDaemon {
   void _do_get(SocketType socket);
   void _do_set(SocketType socket);
   void _do_stop(SocketType socket);
+  void _notify_waiting_sockets(const std::string&);
   SocketType _listen_socket;
   std::vector<SocketType> _sockets;
   std::unordered_map<std::string, std::vector<uint8_t>> _store;
@@ -70,6 +71,8 @@ class MasterDaemon {
   bool _stop = false;  // all workers stopped
   std::chrono::time_point<std::chrono::system_clock> _stop_time;
   bool _has_stop = false;  // at least one worker stopped
+  std::unordered_map<std::string, std::vector<SocketType>>
+      _waiting_sockets;  // key -> list of waiting sockets
 
   void InitControlFd();
   void CloseControlFd();
@@ -95,7 +98,8 @@ class TCPClient {
  public:
   explicit TCPClient(SocketType socket) : _socket{socket} {}
   static std::unique_ptr<TCPClient> connect(const std::string host,
-                                            uint16_t port);
+                                            uint16_t port,
+                                            int timeout);
   ~TCPClient() { tcputils::close_socket(_socket); }
   void send_command_for_key(Command type, const std::string& key);
 

--- a/paddle/fluid/distributed/store/test_tcp_store.cc
+++ b/paddle/fluid/distributed/store/test_tcp_store.cc
@@ -23,6 +23,28 @@
 namespace paddle {
 namespace distributed {
 
+int get_free_port() {
+  unsigned int seed = time(0);
+  int port = 10000 + rand_r(&seed) % 3000;
+  int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+  int opt = 1;
+  linger ling;
+  ling.l_onoff = 1;
+  ling.l_linger = 0;
+  setsockopt(server_fd, SOL_SOCKET, SO_LINGER, &ling, sizeof(ling));
+  setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  struct sockaddr_in address;
+  address.sin_family = AF_INET;
+  address.sin_addr.s_addr = INADDR_ANY;
+  address.sin_port = htons(port);
+  while (bind(server_fd, (struct sockaddr*)&address, sizeof(address)) == -1) {
+    port++;
+    address.sin_port = htons(port);
+  }
+  close(server_fd);
+  return port;
+}
+
 TEST(MasterDaemon, init) {
   int socket = tcputils::tcp_listen("", std::to_string(0), AF_INET);
   auto d = detail::MasterDaemon::start(socket, 1, 100);
@@ -35,6 +57,23 @@ TEST(MasterDaemon, init) {
   printf("end to reset\n");
 
   d.reset();
+}
+
+TEST(TCPStore, set_after_get) {
+  int rank = fork();
+  bool is_master = (rank == 0);
+  int port = get_free_port();
+  TCPStore store("127.0.0.1", port, is_master, 2, 10);
+  if (rank == 0) {
+#ifdef _WIN32
+    Sleep(2 * 1000);
+#else
+    usleep(2 * 1000 * 1000);
+#endif
+    store.set("bar", {3});
+  } else {
+    auto res = store.get("bar");
+  }
 }
 
 /* now for only c compile test


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Refine the timeout strategy of TCPStore:
- Set timeout for TCPStore wait. Once we cannot find the key in TCPStore during specific time, close the socket and print friendly log to notify user the reason.
- Use notify rather than polling to avoid unnecessary cost.
- Add set after get test case, modified the destructor to ensure TCPServer destroy after all the TCPClients.

完善TCPStore的超时机制：
- 之前TCPStore在找不到对应key时，会循环直到找到为止，本PR设置超时机制，超时后会关闭socket，并打印友好的提示
- 将wait中的主动轮询改成被动提示，避免不必要的开销
- 增加对应先get后set的测试用例，修改析构，保证TCPServer最后被销毁