### PR TITLE
fix dygraph bugs in broadcast_to api.

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -3000,8 +3000,10 @@ def broadcast_to(x, shape, name=None):
             print(out)
             # [[1, 2, 3], [1, 2, 3]]
     """
-    if paddle.in_dynamic_mode():
+    if in_dygraph_mode():
         return _C_ops.final_state_expand(x, shape)
+    if _in_legacy_dygraph():
+        return _C_ops.expand_v2(x, 'shape', shape)
 
     if isinstance(shape, Variable):
         assert len(shape.shape) == 1, ('shape must be an 1-D Tensor.')


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
For broadcast_to api, only new dygraph mode is supported, which will cause bug in old dygraph mode. In this PR, we fix it.
