### PR TITLE
[phi] add set_dtype for inverse_op

### DIFF
--- a/paddle/phi/infermeta/backward.cc
+++ b/paddle/phi/infermeta/backward.cc
@@ -419,6 +419,7 @@ void InverseGradInferMeta(const MetaTensor& out,
                           MetaTensor* dx) {
   if (dx) {
     dx->set_dims(dout.dims());
+    dx->set_dtype(out.dtype());
   }
 }
 

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -1059,6 +1059,7 @@ void InverseInferMeta(const MetaTensor& x, MetaTensor* out) {
   }
 
   out->set_dims(input_dims);
+  out->set_dtype(x.dtype());
   out->share_lod(x);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
Add set_dtype for inverse_op. Related:  #44471 