### PR TITLE
【NOT MERGE】npu gil ensure in NpuOprunner

### DIFF
--- a/paddle/fluid/operators/cast_op_npu.cc
+++ b/paddle/fluid/operators/cast_op_npu.cc
@@ -89,7 +89,8 @@ class CastNPUKernel : public framework::OpKernel<T> {
 namespace ops = paddle::operators;
 
 REGISTER_OP_NPU_KERNEL(
-    cast, ops::CastNPUKernel<paddle::platform::NPUDeviceContext, int16_t>,
+    cast, ops::CastNPUKernel<paddle::platform::NPUDeviceContext, uint8_t>,
+    ops::CastNPUKernel<paddle::platform::NPUDeviceContext, int16_t>,
     ops::CastNPUKernel<paddle::platform::NPUDeviceContext, int32_t>,
     ops::CastNPUKernel<paddle::platform::NPUDeviceContext, int64_t>,
     ops::CastNPUKernel<paddle::platform::NPUDeviceContext, int>,

--- a/paddle/fluid/platform/device/npu/CMakeLists.txt
+++ b/paddle/fluid/platform/device/npu/CMakeLists.txt
@@ -30,4 +30,7 @@ if(WITH_ASCEND_CL)
     npu_op_runner
     SRCS npu_op_runner.cc
     DEPS operator npu_info)
+  find_package(PythonInterp ${PY_VERSION} REQUIRED)
+  find_package(PythonLibs ${PY_VERSION} REQUIRED)
+  target_link_libraries(npu_op_runner ${PYTHON_LIBRARIES})
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
In PaddleSeg deeplabv3, it hangs at Assign which can be solved by this PR and PaddleCustomDevice-npu:

<img width="610" alt="image" src="https://user-images.githubusercontent.com/5997715/180968359-bcdef8f8-d47b-4f7f-b7f9-96873d06e572.png">

Since paddle will not link libpython, when compiled with this PR, we have to copy libpython currently used to current path for  loading.