### PR TITLE
SandaloneExecutor not support parallel graph

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1398,18 +1398,24 @@ class Executor(object):
                 if program._program is None:
                     return False
 
-                # Unsupported case 2 : disabled by FLAGS_CONVERT_GRAPH_TO_PROGRAM
-                if os.environ.get('FLAGS_CONVERT_GRAPH_TO_PROGRAM',
-                                  None) not in [1, '1', True, 'True', 'true']:
-                    return False
-
-                # Unsupported case 3: data parallel
+                # Unsupported case 2: data parallel
                 if program._is_data_parallel and len(
                         program._get_places(place, program._places)) != 1:
                     return False
 
+                # Unsupported case 3 : parallel graph
+                if core.globals()['FLAGS_enable_parallel_graph'] in [
+                        1, '1', True, 'True', 'true'
+                ]:
+                    return False
+
                 # Unsupported case 4: inference
                 if program._is_inference:
+                    return False
+
+                # Unsupported case 5 : disabled by FLAGS_CONVERT_GRAPH_TO_PROGRAM
+                if os.environ.get('FLAGS_CONVERT_GRAPH_TO_PROGRAM',
+                                  None) not in [1, '1', True, 'True', 'true']:
                     return False
 
                 return True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

`FLAGS_enable_parallel_graph`开关打开后会使用parallel graph方式执行PE，将graph拆分成多个graph生成final_graph再执行，graph回转program方案中不会使用final_graph引发报错。
parallel graph主要应用在分布式场景中，新执行器中暂不支持，跳过这种case。
