### PR TITLE
[CustomDevice]fix phi kernel header

### DIFF
--- a/paddle/phi/kernels/inverse_kernel.h
+++ b/paddle/phi/kernels/inverse_kernel.h
@@ -14,9 +14,7 @@
 
 #pragma once
 
-#include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
-#include "paddle/phi/kernels/funcs/matrix_inverse.h"
 
 namespace phi {
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Fix header of inverse_kernel.h which causes compiling failure of CustomDevice 
