### PR TITLE
set parallel_job according to CUDA memory in Windows CI unittest

### DIFF
--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -336,7 +336,13 @@ function run_unittest_gpu() {
     if [ "$2" == "" ]; then
         parallel_job=$parallel_level_base
     else
-        parallel_job=`expr $2 \* $parallel_level_base`
+        # set parallel_job according to CUDA memory and suggested parallel num,
+        # the latter is derived in linux server with 16G CUDA memory.
+        cuda_memory=$(nvidia-smi --query-gpu=memory.total --format=csv | tail -1 | awk -F ' ' '{print $1}')
+        parallel_job=$(($2 * $cuda_memory / 16000))
+        if [$parallel_job -lt 1]; then
+            parallel_job=1
+        fi
     fi
     echo "************************************************************************"
     echo "********These unittests run $parallel_job job each time with 1 GPU**********"

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -340,7 +340,7 @@ function run_unittest_gpu() {
         # the latter is derived in linux server with 16G CUDA memory.
         cuda_memory=$(nvidia-smi --query-gpu=memory.total --format=csv | tail -1 | awk -F ' ' '{print $1}')
         parallel_job=$(($2 * $cuda_memory / 16000))
-        if [$parallel_job -lt 1]; then
+        if [ $parallel_job -lt 1 ]; then
             parallel_job=1
         fi
     fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
背景：
单测并行策略调整后（PR #44334），win-inference1 2单测大面积失败率增加。
win-inference 1   26号（调整后）共13个任务，9个失败，5个是大面积挂。25号（调整前）共9个任务，1个失败，无大面积挂。
win-inference-2   26号（调整后）共7个任务，4个失败，3个是大面积挂。25号（调整前）8个任务，0个失败，4个取消。
![image](https://user-images.githubusercontent.com/51314274/182100535-56723b7b-4a4a-4d8a-a145-c8aa3a6163ad.png)
![image](https://user-images.githubusercontent.com/51314274/182100771-96c37375-b1b1-4dbb-a381-d576a7b7aaff.png)

结论：单测并行策略基于Linux 16G显存设计，原策略统计有误，多统计了600M显存，相比新策略并行度更低。新策略合入后，更高的并行度导致在Windows部分显存少于16G的机器（8G 11G）跑CI时单测大面积挂的概率增加很多。

优化策略：
在Windows执行单测前获取本机显存，根据实际显存和16G（Linux显存基准）的比值调整单测并行数量。

效果：
- 解决因显存不足导致的单测大面积挂：PR在上述出现问题的机器上，运行了9次任务，均成功。
- 并发数减小带来的需要rerun的单测数量减少（未严格统计）
- 时间方面
  - PR-CI-Windows流水线（3次均值，运行机器 win 7 10 11）：更新前单测耗时2697s、更新后2812s
  - PR-CI-Windows-inference流水线：更新后9次均值 3491s，更新前5次均值3786s。