### PR TITLE
[inference]clone ort_predictor reuse Ort::Session

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -720,10 +720,6 @@ void Tensor::SetOrtBinding(const std::shared_ptr<Ort::IoBinding> binding) {
   binding_ = binding;
 }
 
-void Tensor::SetOrtBuffer(const std::shared_ptr<std::vector<int8_t>> buffer) {
-  buffer_ = buffer;
-}
-
 template <typename T>
 void Tensor::ORTCopyToCpu(T *data) const {
   auto binding = binding_.lock();

--- a/paddle/fluid/inference/api/paddle_tensor.h
+++ b/paddle/fluid/inference/api/paddle_tensor.h
@@ -191,15 +191,12 @@ class PD_INFER_DECL Tensor {
 #ifdef PADDLE_WITH_ONNXRUNTIME
   bool is_ort_tensor_{false};
   std::vector<int64_t> shape_;
-  std::weak_ptr<std::vector<int8_t>> buffer_;
   std::weak_ptr<Ort::IoBinding> binding_;
   int idx_{-1};
 
   void SetOrtMark(bool is_ort_tensor);
 
   void SetOrtBinding(const std::shared_ptr<Ort::IoBinding> binding);
-
-  void SetOrtBuffer(const std::shared_ptr<std::vector<int8_t>> buffer);
 
   template <typename T>
   void ORTCopyFromCpu(const T* data);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->Others

### Describe
<!-- Describe what this PR does -->clone ort_predictor reuse Ort::Session
Resolved memory growth due to Predictor->Clone().