### PR TITLE
add FLAGS_enable_api_kernel_fallback

### DIFF
--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -184,6 +184,19 @@ PADDLE_DEFINE_EXPORTED_string(
     "please refer to the documents");
 #endif
 
+/*
+ * Kernel related FLAG
+ * Name: FLAGS_enable_api_kernel_fallback
+ * Since Version: 2.4
+ * Value Range: bool, default=true
+ * Example: FLAGS_enable_api_kernel_fallback=true would allow kernel of current
+ * backend fallback to CPU one when not found
+ */
+PADDLE_DEFINE_EXPORTED_bool(
+    enable_api_kernel_fallback,
+    true,
+    "Whether enable api kernel fallback to CPU one when not found");
+
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 /**
  * CUDNN related FLAG

--- a/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_plugin.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_plugin.py
@@ -40,6 +40,7 @@ class TestCustomCPUPlugin(unittest.TestCase):
             self._test_custom_device_mnist()
             self._test_eager_backward_api()
             self._test_eager_copy_to()
+            self._test_fallback_kernel()
         self._test_custom_device_dataloader()
         self._test_custom_device_mnist()
 
@@ -159,6 +160,15 @@ class TestCustomCPUPlugin(unittest.TestCase):
             paddle.CustomPlace('custom_cpu', 0), True)
         self.assertTrue(np.array_equal(another_custom_cpu_tensor, x))
         self.assertTrue(another_custom_cpu_tensor.place.is_custom_place())
+
+    def _test_fallback_kernel(self):
+        # using (custom_cpu, add, int16) which is not registered
+        import paddle
+        r = np.array([6, 6, 6], 'int16')
+        x = paddle.to_tensor([5, 4, 3], 'int16')
+        y = paddle.to_tensor([1, 2, 3], 'int16')
+        z = paddle.add(x, y)
+        self.assertTrue(np.array_equal(z, r))
 
     def tearDown(self):
         del os.environ['CUSTOM_DEVICE_ROOT']


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe

add FLAGS_enable_api_kernel_fallback for users to choose whether to fallback kernel in api call.
related: https://github.com/PaddlePaddle/Paddle/pull/44681  https://github.com/PaddlePaddle/Paddle/pull/44639  https://github.com/PaddlePaddle/Paddle/pull/44699

1. 没查到 且 CPU => 抛异常[提示没有]
2. 没查到 且 非CPU 且 允许fallback => fallback CPU 查到 return {kernel true} 否则 抛异常[提示fallback失败]
3. 没查到 且 非CPU 且 不允许fallback => 抛异常[提示可fallback]
4. 查到 且 非CPU return {kernel false}
5. 查到 且 CPU return {kernel false}

```
# test code with custom-npu:ascend
import paddle

paddle.set_device('ascend')
x = paddle.to_tensor([1], 'float32')
y = paddle.to_tensor([1], 'float32')
z = paddle.add(x, y)  # custom-npu does not have add kernel
a = paddle.max(z)     # custom-npu has max kernel
print(a)

# 1. normal use
$ python ./test.py
Tensor(shape=[1], dtype=float32, place=Place(ascend:0), stop_gradient=True,
       [2.])

# 2. flag is set false
$ FLAGS_enable_api_kernel_fallback=0 python ./test.py
Traceback (most recent call last):
  File "./test.py", line 7, in <module>
    z = paddle.add(x, y)
  File "/opt/conda/lib/python3.7/site-packages/paddle/tensor/math.py", line 510, in add
    return _C_ops.final_state_add( x, y)
RuntimeError: (NotFound) The kernel with key (ascend, NCHW, float32) of kernel `add` is not registered and the current value of FLAGS_enable_api_kernel_fallback(bool, default true) is false. If you want to fallback this kernel to CPU one, please set the flag true before run again.
  [Hint: Expected kernel_iter != iter->second.end(), but received kernel_iter == iter->second.end().] (at /workspace/tmp/Paddle/paddle/phi/core/kernel_factory.cc:155)

# 3. with GLOG_v=4 to print fallbacked kernel
$ GLOG_v=4 python ./test.py
... ...
I0728 17:56:08.829829 13956 kernel_factory.cc:141] missing ascend kernel: add, expected_kernel_key:(ascend, NCHW, float32), fallbacking to CPU one!
... ...
Tensor(shape=[1], dtype=float32, place=Place(ascend:0), stop_gradient=True,
       [2.])
```
