### PR TITLE
skip cast trt convert when input dtype is bool

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -2095,7 +2095,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
         VLOG(3) << "do not support input data type as bool now";
         return false;
       }
-      if (!((in_dtype == 5 || in_dtype == 4 || in_dtype == 2 ||) &&
+      if (!((in_dtype == 5 || in_dtype == 4 || in_dtype == 2) &&
             (out_dtype == 5 || out_dtype == 4 || out_dtype == 2))) {
         VLOG(3) << "only valid conversions are: "
                    "(kFLOAT | kHALF | kINT32) -> (kFLOAT | kHALF | kINT32)";

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -2091,12 +2091,14 @@ bool OpTeller::Tell(const framework::ir::Node* node,
         VLOG(3) << "unsupport data type conversion";
         return false;
       }
-      if (!((in_dtype == 5 || in_dtype == 4 || in_dtype == 2 ||
-             in_dtype == 0) &&
+      if (in_dtype == 0) {
+        VLOG(3) << "do not support input data type as bool now";
+        return false;
+      }
+      if (!((in_dtype == 5 || in_dtype == 4 || in_dtype == 2 ||) &&
             (out_dtype == 5 || out_dtype == 4 || out_dtype == 2))) {
-        VLOG(3)
-            << "only valid conversions are: "
-               "(kFLOAT | kHALF | kINT32 | kBOOL) -> (kFLOAT | kHALF | kINT32)";
+        VLOG(3) << "only valid conversions are: "
+                   "(kFLOAT | kHALF | kINT32) -> (kFLOAT | kHALF | kINT32)";
         return false;
       }
     }

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_cast.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_cast.py
@@ -27,10 +27,12 @@ class TrtConvertCastTest(TrtLayerAutoScanTest):
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
+        if attrs[0]['in_dtype'] == 0:
+            return False
         if attrs[0]['in_dtype'] in [4, 5] and attrs[0]['out_dtype'] == 4:
             return False
         if attrs[0]['in_dtype'] not in [
-                0, 2, 4, 5
+                2, 4, 5
         ] or attrs[0]['out_dtype'] not in [2, 4, 5]:
             return False
         return True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 

### Describe
<!-- Describe what this PR does -->
skip cast trt convert when input dtype is bool
