### PR TITLE
Fix all_gather_object to support various length object

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_collective_api_base.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_api_base.py
@@ -63,6 +63,8 @@ def create_complex_test_data(shape=None, dtype=None, seed=None):
 def create_pylist_test_data(shape=None, seed=None):
     if seed:
         np.random.seed(seed)
+    # Generate random shape test case for xxx_object api
+    shape = np.random.randint(0, high=100, size=(2)).tolist()
     data = np.random.random(shape).tolist()
     return data
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Fix all_gather_object for we don't consider the length of object may not equal, this will cause hang while doing all_gather. So make the ranks get all the object length first, find the max one, resize the tensor and do real all_gather communication.

支持all_gather_object时没有考虑不同进程间序列化后的object长度不一致的问题，因为通信原语要求每个进程发送缓冲区大小一致，否则会hang住，所以在实际进程all_gather之前，先同步序列化后object的长度，并对发送的tensor进行扩充。