### PR TITLE
【PaddlePaddle Hackathon 3 No.51】为Paddle nearest_interp_v2算子实现float16数据类型支持

### DIFF
--- a/paddle/phi/kernels/funcs/interpolate_function.h
+++ b/paddle/phi/kernels/funcs/interpolate_function.h
@@ -28,12 +28,14 @@ namespace funcs {
 
 template <typename T>
 HOSTDEVICE inline T CubicConvolution1(T x, T A) {
-  return ((A + static_cast<T>(2)) * x - (A + static_cast<T>(3))) * x * x + static_cast<T>(1);
+  return ((A + static_cast<T>(2)) * x - (A + static_cast<T>(3))) * x * x +
+         static_cast<T>(1);
 }
 
 template <typename T>
 HOSTDEVICE inline T CubicConvolution2(T x, T A) {
-  return ((A * x - static_cast<T>(5) * A) * x + static_cast<T>(8) * A) * x - static_cast<T>(4) * A;
+  return ((A * x - static_cast<T>(5) * A) * x + static_cast<T>(8) * A) * x -
+         static_cast<T>(4) * A;
 }
 
 template <typename T>

--- a/paddle/phi/kernels/funcs/interpolate_function.h
+++ b/paddle/phi/kernels/funcs/interpolate_function.h
@@ -28,26 +28,26 @@ namespace funcs {
 
 template <typename T>
 HOSTDEVICE inline T CubicConvolution1(T x, T A) {
-  return ((A + 2) * x - (A + 3)) * x * x + 1;
+  return ((A + static_cast<T>(2)) * x - (A + static_cast<T>(3))) * x * x + static_cast<T>(1);
 }
 
 template <typename T>
 HOSTDEVICE inline T CubicConvolution2(T x, T A) {
-  return ((A * x - 5 * A) * x + 8 * A) * x - 4 * A;
+  return ((A * x - static_cast<T>(5) * A) * x + static_cast<T>(8) * A) * x - static_cast<T>(4) * A;
 }
 
 template <typename T>
 HOSTDEVICE inline void get_cubic_upsample_coefficients(T coeffs[4], T t) {
-  T A = -0.75;
+  T A = static_cast<T>(-0.75);
 
   T x1 = t;
-  coeffs[0] = CubicConvolution2<T>(x1 + 1.0, A);
+  coeffs[0] = CubicConvolution2<T>(x1 + static_cast<T>(1), A);
   coeffs[1] = CubicConvolution1<T>(x1, A);
 
   // opposite coefficients
-  T x2 = 1.0 - t;
+  T x2 = static_cast<T>(1) - t;
   coeffs[2] = CubicConvolution1<T>(x2, A);
-  coeffs[3] = CubicConvolution2<T>(x2 + 1.0, A);
+  coeffs[3] = CubicConvolution2<T>(x2 + static_cast<T>(1), A);
 }
 
 inline void ExtractNCDWH(const DDim& dims,

--- a/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
@@ -80,8 +80,8 @@ __global__ void KeLinearInterpBw(T* in,
 
     float src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
     src_w = (src_w > 0) ? src_w : 0;
-    T w1lambda =
-        static_cast<T>(align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
+    T w1lambda = static_cast<T>(
+        align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
     T w2lambda = static_cast<T>(1) - w1lambda;
 
     T* in_pos;
@@ -267,8 +267,12 @@ __global__ void KeBilinearInterpBwShareMemory(T* in,
 
     int in_img_idx, in_img_idy, w_id, h_id;
     T w1lambda, h1lambda, w2lambda, h2lambda;
-    T src_w = static_cast<T>(ratio_w) * (static_cast<T>(out_img_idx) + align_type_value) - align_type_value;
-    T src_h = static_cast<T>(ratio_h) * (static_cast<T>(out_img_idy) + align_type_value) - align_type_value;
+    T src_w = static_cast<T>(ratio_w) *
+                  (static_cast<T>(out_img_idx) + align_type_value) -
+              align_type_value;
+    T src_h = static_cast<T>(ratio_h) *
+                  (static_cast<T>(out_img_idy) + align_type_value) -
+              align_type_value;
 
     PreCalculatorForLinearInterpInputIndex(
         &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_w);
@@ -368,13 +372,17 @@ __global__ void KeBilinearInterpNCHWBw(T* in,
 
     int h1, y_id;
     T h1lambda, h0lambda;
-    T src_y = static_cast<T>(ratio_h) * (static_cast<T>(h2) + align_type_value) - align_type_value;
+    T src_y =
+        static_cast<T>(ratio_h) * (static_cast<T>(h2) + align_type_value) -
+        align_type_value;
 
     PreCalculatorForLinearInterpInputIndex(
         &h1, &y_id, &h1lambda, &h0lambda, src_y, in_h);
     int w1, x_id;
     T w1lambda, w0lambda;
-    T src_x = static_cast<T>(ratio_w) * (static_cast<T>(w2) + align_type_value) - align_type_value;
+    T src_x =
+        static_cast<T>(ratio_w) * (static_cast<T>(w2) + align_type_value) -
+        align_type_value;
     PreCalculatorForLinearInterpInputIndex(
         &w1, &x_id, &w1lambda, &w0lambda, src_x, in_w);
 
@@ -426,8 +434,12 @@ __global__ void KeBilinearInterpBw(T* in,
 
     int in_img_idx, in_img_idy, w_id, h_id;
     T w1lambda, h1lambda, w2lambda, h2lambda;
-    T src_w = static_cast<T>(ratio_w) * (static_cast<T>(out_img_idx) + align_type_value) - align_type_value;
-    T src_h = static_cast<T>(ratio_h) * (static_cast<T>(out_img_idy) + align_type_value) - align_type_value;
+    T src_w = static_cast<T>(ratio_w) *
+                  (static_cast<T>(out_img_idx) + align_type_value) -
+              align_type_value;
+    T src_h = static_cast<T>(ratio_h) *
+                  (static_cast<T>(out_img_idy) + align_type_value) -
+              align_type_value;
 
     PreCalculatorForLinearInterpInputIndex(
         &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_w);
@@ -580,8 +592,8 @@ __global__ void KeTrilinearInterpBw(T* in,
     int d_id = (in_img_idt < in_img_d - 1) ? 1 : 0;
     float src_d = ratio_d * (out_img_idt + 0.5) - 0.5;
     src_d = (src_d > 0) ? src_d : 0;
-    T d1lambda =
-        static_cast<T>(align_flag ? src_d - in_img_idt : ratio_d * out_img_idt - in_img_idt);
+    T d1lambda = static_cast<T>(
+        align_flag ? src_d - in_img_idt : ratio_d * out_img_idt - in_img_idt);
     T d2lambda = static_cast<T>(1) - d1lambda;
 
     int in_img_idy = align_flag
@@ -591,8 +603,8 @@ __global__ void KeTrilinearInterpBw(T* in,
     int h_id = (in_img_idy < in_img_h - 1) ? 1 : 0;
     float src_h = ratio_h * (out_img_idy + 0.5) - 0.5;
     src_h = (src_h > 0) ? src_h : 0;
-    T h1lambda =
-        static_cast<T>(align_flag ? src_h - in_img_idy : ratio_h * out_img_idy - in_img_idy);
+    T h1lambda = static_cast<T>(
+        align_flag ? src_h - in_img_idy : ratio_h * out_img_idy - in_img_idy);
     T h2lambda = static_cast<T>(1) - h1lambda;
 
     int in_img_idx = align_flag
@@ -602,8 +614,8 @@ __global__ void KeTrilinearInterpBw(T* in,
     int w_id = (in_img_idx < in_img_w - 1) ? 1 : 0;
     float src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
     src_w = (src_w > 0) ? src_w : 0;
-    T w1lambda =
-        static_cast<T>(align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
+    T w1lambda = static_cast<T>(
+        align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
     T w2lambda = static_cast<T>(1) - w1lambda;
 
     if (data_layout == DataLayout::kNCHW) {
@@ -1031,7 +1043,8 @@ static void Interpolate2DCUDABwd(
                                                          interp_divmods);
     }
   } else if ("bilinear" == interp_method) {
-    const T align_type_value = static_cast<T>((align_mode == 0 && !align_corners) ? 0.5f : 0);
+    const T align_type_value =
+        static_cast<T>((align_mode == 0 && !align_corners) ? 0.5f : 0);
     bool is_nchw = (data_layout == DataLayout::kNCHW) ? true : false;
     bool optimize_flag = false;
 #ifndef __HIPCC__
@@ -1583,7 +1596,7 @@ PD_REGISTER_KERNEL(nearest_interp_v2_grad,
                    ALL_LAYOUT,
                    phi::NearestInterpGradKernel,
                    phi::dtype::float16,
-				   float,
+                   float,
                    double) {
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);

--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -81,8 +81,8 @@ __global__ void KeLinearInterpFw(const T* in,
 
     float src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
     src_w = (src_w > 0) ? src_w : 0;
-    T w1lambda =
-        static_cast<T>(align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
+    T w1lambda = static_cast<T>(
+        align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
     T w2lambda = static_cast<T>(1) - w1lambda;
 
     if (data_layout == DataLayout::kNCHW) {
@@ -222,8 +222,12 @@ __global__ void KeBilinearInterpFw(const T* in,
 
     int in_img_idx, in_img_idy, h_id, w_id;
     T h1lambda, w1lambda, h2lambda, w2lambda;
-    T src_w = static_cast<T>(ratio_w) * (static_cast<T>(out_img_idx) + align_type_value) - align_type_value;
-    T src_h = static_cast<T>(ratio_h) * (static_cast<T>(out_img_idy) + align_type_value) - align_type_value;
+    T src_w = static_cast<T>(ratio_w) *
+                  (static_cast<T>(out_img_idx) + align_type_value) -
+              align_type_value;
+    T src_h = static_cast<T>(ratio_h) *
+                  (static_cast<T>(out_img_idy) + align_type_value) -
+              align_type_value;
 
     PreCalculatorForLinearInterpInputIndex(
         &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_img_w);
@@ -262,8 +266,12 @@ __global__ void KeBilinearInterpNCHWFw(const T* in,
 
   int in_img_idx, in_img_idy, h_id, w_id;
   T h1lambda, w1lambda, h2lambda, w2lambda;
-  T src_w = static_cast<T>(ratio_w) * (static_cast<T>(out_img_idx) + align_type_value) - align_type_value;
-  T src_h = static_cast<T>(ratio_h) * (static_cast<T>(out_img_idy) + align_type_value) - align_type_value;
+  T src_w = static_cast<T>(ratio_w) *
+                (static_cast<T>(out_img_idx) + align_type_value) -
+            align_type_value;
+  T src_h = static_cast<T>(ratio_h) *
+                (static_cast<T>(out_img_idy) + align_type_value) -
+            align_type_value;
 
   PreCalculatorForLinearInterpInputIndex(
       &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_img_w);
@@ -484,8 +492,8 @@ __global__ void KeTrilinearInterpFw(const T* in,
     int d_id = (in_img_idt < in_img_d - 1) ? 1 : 0;
     float src_d = ratio_d * (out_img_idt + 0.5) - 0.5;
     src_d = (src_d > 0) ? src_d : 0;
-    T d1lambda =
-        static_cast<T>(align_flag ? src_d - in_img_idt : ratio_d * out_img_idt - in_img_idt);
+    T d1lambda = static_cast<T>(
+        align_flag ? src_d - in_img_idt : ratio_d * out_img_idt - in_img_idt);
     T d2lambda = static_cast<T>(1) - d1lambda;
 
     int in_img_idy = align_flag
@@ -495,8 +503,8 @@ __global__ void KeTrilinearInterpFw(const T* in,
     int h_id = (in_img_idy < in_img_h - 1) ? 1 : 0;
     float src_h = ratio_h * (out_img_idy + 0.5) - 0.5;
     src_h = (src_h > 0) ? src_h : 0;
-    T h1lambda =
-        static_cast<T>(align_flag ? src_h - in_img_idy : ratio_h * out_img_idy - in_img_idy);
+    T h1lambda = static_cast<T>(
+        align_flag ? src_h - in_img_idy : ratio_h * out_img_idy - in_img_idy);
     T h2lambda = static_cast<T>(1) - h1lambda;
 
     int in_img_idx = align_flag
@@ -506,8 +514,8 @@ __global__ void KeTrilinearInterpFw(const T* in,
     int w_id = (in_img_idx < in_img_w - 1) ? 1 : 0;
     float src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
     src_w = (src_w > 0) ? src_w : 0;
-    T w1lambda =
-        static_cast<T>(align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
+    T w1lambda = static_cast<T>(
+        align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
     T w2lambda = static_cast<T>(1) - w1lambda;
 
     if (data_layout == DataLayout::kNCHW) {
@@ -926,7 +934,8 @@ static void Interpolate2DCUDAFwd(
       thread_num = 512;
     }
 #endif
-    const T align_type_value = static_cast<T>((align_mode == 0 && !align_corners) ? 0.5f : 0);
+    const T align_type_value =
+        static_cast<T>((align_mode == 0 && !align_corners) ? 0.5f : 0);
     if (data_layout == DataLayout::kNCHW) {
       // get launch 3D config
       int nc = n * c;
@@ -1455,7 +1464,7 @@ PD_REGISTER_KERNEL(nearest_interp_v2,
                    ALL_LAYOUT,
                    phi::NearestInterpKernel,
                    phi::dtype::float16,
-				   float,
+                   float,
                    double,
                    int,
                    int64_t) {

--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -34,11 +34,11 @@ __forceinline__ __device__ void PreCalculatorForLinearInterpInputIndex(
     T* lambda2,
     T src_x,
     const int in_img_x) {
-  src_x = (src_x > 0) ? src_x : 0.f;
+  src_x = (src_x > static_cast<T>(0)) ? src_x : static_cast<T>(0);
   *in_img_idx = static_cast<int>(src_x);
   *x_id = (*in_img_idx < in_img_x - 1) ? 1 : 0;
-  *lambda1 = src_x - *in_img_idx;
-  *lambda2 = 1.f - *lambda1;
+  *lambda1 = src_x - static_cast<T>(*in_img_idx);
+  *lambda2 = static_cast<T>(1) - *lambda1;
 }
 
 template <typename T>
@@ -79,11 +79,11 @@ __global__ void KeLinearInterpFw(const T* in,
     in_img_idx = (in_img_idx > 0) ? in_img_idx : 0;  // w
     int w_id = (in_img_idx < in_img_w - 1) ? 1 : 0;  // w_id
 
-    T src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
+    float src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
     src_w = (src_w > 0) ? src_w : 0;
     T w1lambda =
-        align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx;
-    T w2lambda = 1.f - w1lambda;
+        static_cast<T>(align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
+    T w2lambda = static_cast<T>(1) - w1lambda;
 
     if (data_layout == DataLayout::kNCHW) {
       const T* in_pos =
@@ -222,8 +222,8 @@ __global__ void KeBilinearInterpFw(const T* in,
 
     int in_img_idx, in_img_idy, h_id, w_id;
     T h1lambda, w1lambda, h2lambda, w2lambda;
-    T src_w = ratio_w * (out_img_idx + align_type_value) - align_type_value;
-    T src_h = ratio_h * (out_img_idy + align_type_value) - align_type_value;
+    T src_w = static_cast<T>(ratio_w) * (static_cast<T>(out_img_idx) + align_type_value) - align_type_value;
+    T src_h = static_cast<T>(ratio_h) * (static_cast<T>(out_img_idy) + align_type_value) - align_type_value;
 
     PreCalculatorForLinearInterpInputIndex(
         &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_img_w);
@@ -262,8 +262,8 @@ __global__ void KeBilinearInterpNCHWFw(const T* in,
 
   int in_img_idx, in_img_idy, h_id, w_id;
   T h1lambda, w1lambda, h2lambda, w2lambda;
-  T src_w = ratio_w * (out_img_idx + align_type_value) - align_type_value;
-  T src_h = ratio_h * (out_img_idy + align_type_value) - align_type_value;
+  T src_w = static_cast<T>(ratio_w) * (static_cast<T>(out_img_idx) + align_type_value) - align_type_value;
+  T src_h = static_cast<T>(ratio_h) * (static_cast<T>(out_img_idy) + align_type_value) - align_type_value;
 
   PreCalculatorForLinearInterpInputIndex(
       &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_img_w);
@@ -296,13 +296,13 @@ template <typename T>
 __device__ __forceinline__ static T Kecubic_interp(
     const T x0, const T x1, const T x2, const T x3, T t) {
   T coeffs[4];
-  T a = -0.75;
+  T a = static_cast<T>(-0.75);
   T x_1 = t;
-  T x_2 = 1.0 - t;
-  coeffs[0] = funcs::CubicConvolution2<T>(x_1 + 1.0, a);
+  T x_2 = static_cast<T>(1) - t;
+  coeffs[0] = funcs::CubicConvolution2<T>(x_1 + static_cast<T>(1), a);
   coeffs[1] = funcs::CubicConvolution1<T>(x_1, a);
   coeffs[2] = funcs::CubicConvolution1<T>(x_2, a);
-  coeffs[3] = funcs::CubicConvolution2<T>(x_2 + 1.0, a);
+  coeffs[3] = funcs::CubicConvolution2<T>(x_2 + static_cast<T>(1), a);
   return x0 * coeffs[0] + x1 * coeffs[1] + x2 * coeffs[2] + x3 * coeffs[3];
 }
 
@@ -348,13 +348,13 @@ __global__ void KeBicubicInterpFw(const T* in,
                        ? static_cast<T>(ratio_h * out_img_idy)
                        : static_cast<T>(ratio_h * (out_img_idy + 0.5) - 0.5);
     int input_y = floorf(in_img_idy);
-    const T y_t = in_img_idy - input_y;
+    const T y_t = in_img_idy - static_cast<T>(input_y);
 
     T in_img_idx = align_corners
                        ? static_cast<T>(ratio_w * out_img_idx)
                        : static_cast<T>(ratio_w * (out_img_idx + 0.5) - 0.5);
     int input_x = floorf(in_img_idx);
-    const T x_t = in_img_idx - input_x;
+    const T x_t = in_img_idx - static_cast<T>(input_x);
 
     T coefficients[4];
     const T* in_pos_0;
@@ -482,33 +482,33 @@ __global__ void KeTrilinearInterpFw(const T* in,
                          : static_cast<int>(ratio_d * out_img_idt);
     in_img_idt = (in_img_idt > 0) ? in_img_idt : 0;
     int d_id = (in_img_idt < in_img_d - 1) ? 1 : 0;
-    T src_d = ratio_d * (out_img_idt + 0.5) - 0.5;
+    float src_d = ratio_d * (out_img_idt + 0.5) - 0.5;
     src_d = (src_d > 0) ? src_d : 0;
     T d1lambda =
-        align_flag ? src_d - in_img_idt : ratio_d * out_img_idt - in_img_idt;
-    T d2lambda = 1.f - d1lambda;
+        static_cast<T>(align_flag ? src_d - in_img_idt : ratio_d * out_img_idt - in_img_idt);
+    T d2lambda = static_cast<T>(1) - d1lambda;
 
     int in_img_idy = align_flag
                          ? static_cast<int>(ratio_h * (out_img_idy + 0.5) - 0.5)
                          : static_cast<int>(ratio_h * out_img_idy);
     in_img_idy = (in_img_idy > 0) ? in_img_idy : 0;
     int h_id = (in_img_idy < in_img_h - 1) ? 1 : 0;
-    T src_h = ratio_h * (out_img_idy + 0.5) - 0.5;
+    float src_h = ratio_h * (out_img_idy + 0.5) - 0.5;
     src_h = (src_h > 0) ? src_h : 0;
     T h1lambda =
-        align_flag ? src_h - in_img_idy : ratio_h * out_img_idy - in_img_idy;
-    T h2lambda = 1.f - h1lambda;
+        static_cast<T>(align_flag ? src_h - in_img_idy : ratio_h * out_img_idy - in_img_idy);
+    T h2lambda = static_cast<T>(1) - h1lambda;
 
     int in_img_idx = align_flag
                          ? static_cast<int>(ratio_w * (out_img_idx + 0.5) - 0.5)
                          : static_cast<int>(ratio_w * out_img_idx);
     in_img_idx = (in_img_idx > 0) ? in_img_idx : 0;
     int w_id = (in_img_idx < in_img_w - 1) ? 1 : 0;
-    T src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
+    float src_w = ratio_w * (out_img_idx + 0.5) - 0.5;
     src_w = (src_w > 0) ? src_w : 0;
     T w1lambda =
-        align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx;
-    T w2lambda = 1.f - w1lambda;
+        static_cast<T>(align_flag ? src_w - in_img_idx : ratio_w * out_img_idx - in_img_idx);
+    T w2lambda = static_cast<T>(1) - w1lambda;
 
     if (data_layout == DataLayout::kNCHW) {
       int in_pos1_idx = out_id_h * input_w + channel_id * in_img_size +
@@ -926,7 +926,7 @@ static void Interpolate2DCUDAFwd(
       thread_num = 512;
     }
 #endif
-    const T align_type_value = (align_mode == 0 && !align_corners) ? 0.5f : 0;
+    const T align_type_value = static_cast<T>((align_mode == 0 && !align_corners) ? 0.5f : 0);
     if (data_layout == DataLayout::kNCHW) {
       // get launch 3D config
       int nc = n * c;
@@ -1454,7 +1454,8 @@ PD_REGISTER_KERNEL(nearest_interp_v2,
                    GPU,
                    ALL_LAYOUT,
                    phi::NearestInterpKernel,
-                   float,
+                   phi::dtype::float16,
+				   float,
                    double,
                    int,
                    int64_t) {

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
@@ -456,6 +456,88 @@ class TestNearestNeighborInterpCase2Uint8(TestNearestInterpOpUint8):
         self.align_corners = True
 
 
+
+class TestNearestInterpOpFloat16(OpTest):
+
+    def setUp(self):
+        self.out_size = None
+        self.actual_shape = None
+        self.init_test_case()
+        self.op_type = "nearest_interp_v2"
+        input_np = np.random.randint(low=0, high=256,
+                                     size=self.input_shape).astype("float16")
+
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    scale_h = scale_w = float(self.scale)
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                scale_w = scale_h = self.scale[0]
+            elif isinstance(self.scale, list) and len(self.scale) > 1:
+                scale_w = self.scale[1]
+                scale_h = self.scale[0]
+            out_h = int(self.input_shape[2] * scale_h)
+            out_w = int(self.input_shape[3] * scale_w)
+        else:
+            out_h = self.out_h
+            out_w = self.out_w
+
+        output_np = nearest_neighbor_interp_np(input_np, out_h, out_w, 0, 0,
+                                               self.out_size, self.actual_shape,
+                                               self.align_corners)
+        self.inputs = {'X': input_np}
+        if self.out_size is not None:
+            self.inputs['OutSize'] = self.out_size
+        self.attrs = {
+            'out_h': self.out_h,
+            'out_w': self.out_w,
+            'interp_method': self.interp_method,
+            'align_corners': self.align_corners
+        }
+        if self.scale:
+            if isinstance(self.scale, float) or isinstance(self.scale, int):
+                if self.scale > 0:
+                    self.scale = [self.scale]
+            if isinstance(self.scale, list) and len(self.scale) == 1:
+                self.scale = [self.scale[0], self.scale[0]]
+            self.attrs['scale'] = self.scale
+        self.outputs = {'Out': output_np}
+
+    def test_check_output(self):
+        self.check_output_with_place(place=core.CPUPlace(), atol=1)
+
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [1, 3, 9, 6]
+        self.out_h = 10
+        self.out_w = 9
+        self.scale = 0.
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpCase1Float16(TestNearestInterpOpFloat16):
+
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [2, 3, 32, 64]
+        self.out_h = 80
+        self.out_w = 40
+        self.scale = 0.
+        self.align_corners = True
+
+
+class TestNearestNeighborInterpCase2Float16(TestNearestInterpOpFloat16):
+
+    def init_test_case(self):
+        self.interp_method = 'nearest'
+        self.input_shape = [4, 1, 7, 8]
+        self.out_h = 5
+        self.out_w = 13
+        self.scale = 0.
+        self.out_size = np.array([6, 15]).astype("int32")
+        self.align_corners = True
+
+
 class TestNearestInterpWithoutCorners(TestNearestInterpOp):
 
     def set_align_corners(self):

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
@@ -456,7 +456,6 @@ class TestNearestNeighborInterpCase2Uint8(TestNearestInterpOpUint8):
         self.align_corners = True
 
 
-
 class TestNearestInterpOpFloat16(OpTest):
 
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
@@ -505,6 +505,9 @@ class TestNearestInterpOpFloat16(OpTest):
     def test_check_output(self):
         self.check_output_with_place(place=core.CPUPlace(), atol=1)
 
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out', in_place=True)
+
     def init_test_case(self):
         self.interp_method = 'nearest'
         self.input_shape = [1, 3, 9, 6]

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -312,7 +312,7 @@ def interpolate(x,
     https://en.wikipedia.org/wiki/Bicubic_interpolation
     
     Parameters:
-        x (Tensor): 3-D, 4-D or 5-D Tensor, its data type is float32, float64, or uint8,
+        x (Tensor): 3-D, 4-D or 5-D Tensor, its data type is float32, float64, float16, or uint8,
                           its data format is specified by :attr:`data_format`.
         size (list|tuple|Tensor|None): Output shape of image resize
              layer, the shape is (out_w, ) when input is a 3-D Tensor, the shape is (out_h, out_w) 


### PR DESCRIPTION
### PR types
Performance optimization 

### PR changes
OPs 

### Describe
-开发环境：
1、设备：RTX-3060 12G
2、环境：CUDA11.2 cuDNN 8

-优化方法：
1、在nearest interpolate方法中添加float16支持，使其支持混合精度训练；  
2、对比float16和float32运行性能，且对比2种方法的精度误差。  

-优化效果：
|No.|input_shape|scale|float16 perf(ms)|float32 perf(ms)|max abs error|
|:---:|:---:|:---:|:---:|:---:|:---:|
|1|[4,3,224,224]|2|0.25968|0.26539|0.000244140625|
|2|[4,3,2000,2000]|2|5.1141|5.1245|0.000244140625|
|3|[4,3,224,224]|4|1.2251|1.2282|0.000244140625|
|4|[4,3,2000,2000]|4|12.5724|12.4804|0.000244140625|
