### PR TITLE
generate_unify_header supports excludes

### DIFF
--- a/cmake/phi.cmake
+++ b/cmake/phi.cmake
@@ -15,7 +15,7 @@
 function(generate_unify_header DIR_NAME)
   set(options "")
   set(oneValueArgs HEADER_NAME SKIP_SUFFIX)
-  set(multiValueArgs "")
+  set(multiValueArgs EXCLUDES)
   cmake_parse_arguments(generate_unify_header "${options}" "${oneValueArgs}"
                         "${multiValueArgs}" ${ARGN})
 
@@ -33,6 +33,9 @@ function(generate_unify_header DIR_NAME)
     set(skip_suffix "${generate_unify_header_SKIP_SUFFIX}")
   endif()
 
+  # exclude files
+  list(LENGTH generate_unify_header_EXCLUDES generate_unify_header_EXCLUDES_len)
+
   # generate target header file
   set(header_file ${CMAKE_CURRENT_SOURCE_DIR}/include/${header_name}.h)
   file(
@@ -43,6 +46,13 @@ function(generate_unify_header DIR_NAME)
   # get all top-level headers and write into header file
   file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}\/${DIR_NAME}\/*.h")
   foreach(header ${HEADERS})
+    if(${generate_unify_header_EXCLUDES_len} GREATER 0)
+      get_filename_component(header_file_name ${header} NAME)
+      list(FIND generate_unify_header_EXCLUDES ${header_file_name} _index)
+      if(NOT ${_index} EQUAL -1)
+        continue()
+      endif()
+    endif()
     if("${skip_suffix}" STREQUAL "")
       string(REPLACE "${PADDLE_SOURCE_DIR}\/" "" header "${header}")
       file(APPEND ${header_file} "#include \"${header}\"\n")

--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -58,6 +58,6 @@ file(
 
 # generate inner headers include dir for users
 generate_unify_header(backends)
-generate_unify_header(core)
+generate_unify_header(core EXCLUDES cuda_stream.h)
 generate_unify_header(infermeta)
 generate_unify_header(kernels SKIP_SUFFIX grad_kernel)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
1.generate_unify_header supports excludes
2.excudes cuda_stream.h which depends on fluid header for CustomDevice compiling

related: https://xly.bce.baidu.com/paddlepaddle/paddle-custom-device/newipipe/detail/6236648/job/17112996
