### PR TITLE
fix ut new_group_api

### DIFF
--- a/python/paddle/fluid/tests/unittests/collective_allreduce_new_group_api.py
+++ b/python/paddle/fluid/tests/unittests/collective_allreduce_new_group_api.py
@@ -51,7 +51,7 @@ class TestCollectiveAllreduceNewGroupAPI(TestCollectiveAPIRunnerBase):
             gp = paddle.distributed.new_group([0, 1])
             paddle.distributed.all_reduce(tindata,
                                           group=gp,
-                                          use_calc_stream=False)
+                                          use_calc_stream=True)
             return [tindata]
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
The meaning of *use_calc_stream* is changed, user should *sync/wait* manually if using *use_calc_stream=False*.

