### PR TITLE
Fix random seed for test_distribution_* UTs

### DIFF
--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta_static.py
@@ -23,6 +23,7 @@ import parameterize as param
 from config import ATOL, RTOL
 from parameterize import xrand
 
+np.random.seed(2022)
 paddle.enable_static()
 
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_categorical.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_categorical.py
@@ -23,6 +23,7 @@ from paddle.fluid import layers
 
 from test_distribution import DistributionNumpy
 
+np.random.seed(2022)
 
 class CategoricalNumpy(DistributionNumpy):
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_constraint.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_constraint.py
@@ -21,6 +21,7 @@ from paddle.distribution import constraint
 import config
 import parameterize as param
 
+np.random.seed(2022)
 
 @param.param_cls((param.TEST_CASE_NAME, 'value'),
                  [('NotImplement', np.random.rand(2, 3))])

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet.py
@@ -22,6 +22,7 @@ import config
 from config import ATOL, DEVICES, RTOL
 import parameterize as param
 
+np.random.seed(2022)
 
 @param.place(DEVICES)
 @param.param_cls(

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet_static.py
@@ -23,6 +23,7 @@ from parameterize import TEST_CASE_NAME, parameterize_cls, place, xrand
 
 paddle.enable_static()
 
+np.random.seed(2022)
 
 @place(DEVICES)
 @parameterize_cls((TEST_CASE_NAME, 'concentration'),

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily.py
@@ -22,6 +22,7 @@ import config
 import mock_data as mock
 import parameterize
 
+np.random.seed(2022)
 
 @parameterize.place(config.DEVICES)
 @parameterize.parameterize_cls(

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily_static.py
@@ -22,8 +22,8 @@ import config
 import mock_data as mock
 import parameterize
 
+np.random.seed(2022)
 paddle.enable_static()
-
 
 @parameterize.place(config.DEVICES)
 class TestExponentialFamily(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent.py
@@ -21,6 +21,7 @@ import scipy.stats
 import config
 import parameterize as param
 
+np.random.seed(2022)
 
 @param.place(config.DEVICES)
 @param.param_cls(

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent_static.py
@@ -23,6 +23,7 @@ import parameterize as param
 
 paddle.enable_static()
 
+np.random.seed(2022)
 
 @param.place(config.DEVICES)
 @param.param_cls(

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_normal.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_normal.py
@@ -23,6 +23,7 @@ from paddle.fluid import layers
 
 from test_distribution import DistributionNumpy
 
+np.random.seed(2022)
 
 class NormalNumpy(DistributionNumpy):
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform.py
@@ -22,6 +22,8 @@ from paddle.distribution import constraint, transform, variable
 import config
 import parameterize as param
 
+np.random.seed(2022)
+paddle.seed(2022)
 
 @param.place(config.DEVICES)
 class TestTransform(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform_static.py
@@ -21,8 +21,9 @@ from paddle.distribution import transform, variable, constraint
 import config
 import parameterize as param
 
+np.random.seed(2022)
+paddle.seed(2022)
 paddle.enable_static()
-
 
 @param.place(config.DEVICES)
 class TestTransform(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_uniform.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_uniform.py
@@ -23,6 +23,7 @@ from paddle.fluid import layers
 
 from test_distribution import DistributionNumpy
 
+np.random.seed(2022)
 
 class UniformNumpy(DistributionNumpy):
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_variable.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_variable.py
@@ -22,6 +22,7 @@ from paddle.distribution import constraint
 import config
 import parameterize as param
 
+paddle.seed(2022)
 
 @param.param_cls(
     (param.TEST_CASE_NAME, 'is_discrete', 'event_rank', 'constraint'),

--- a/python/paddle/fluid/tests/unittests/distribution/test_kl.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_kl.py
@@ -25,8 +25,9 @@ import config
 import mock_data as mock
 import parameterize as param
 
+np.random.seed(2022)
+paddle.seed(2022)
 paddle.set_default_dtype('float64')
-
 
 @param.place(config.DEVICES)
 @param.parameterize_cls((param.TEST_CASE_NAME, 'a1', 'b1', 'a2', 'b2'), [

--- a/python/paddle/fluid/tests/unittests/distribution/test_kl_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_kl_static.py
@@ -25,8 +25,9 @@ import config
 import parameterize as param
 import mock_data as mock
 
+np.random.seed(2022)
+paddle.seed(2022)
 paddle.enable_static()
-
 
 @param.place(config.DEVICES)
 @param.param_cls((param.TEST_CASE_NAME, 'a1', 'b1', 'a2', 'b2'), [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
`test_distribution_*` UTs are occasionally failed in our CI due to unfixed random seed.
So I fix all random seeds for distribution test.

For example, I run `test_distribution_beta_static` for 100 times using different random seeds, only 1 test failed.    
Here is error info:
```
W0718 06:14:08.528863 465289 gpu_context.cc:278] Please NOTE: device: 0, GPU Compute Capability: 8.0, Driver API Version: 11.7, Runtime API Version: 11.7
W0718 06:14:08.533295 465289 gpu_context.cc:306] device: 0, cuDNN Version: 8.4.
test_distribution_beta_static failed
 ........................F.....F.....
======================================================================
FAIL: test_entropy (test_distribution_beta_static.TestBeta2.test-larger-data.CPUPlace)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/paddle/paddle/build/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta_static.py", line 110, in test_entropy
    np.testing.assert_allclose(
  File "/usr/local/lib/python3.8/dist-packages/numpy/testing/_private/utils.py", line 1530, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/usr/local/lib/python3.8/dist-packages/numpy/testing/_private/utils.py", line 844, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-05, atol=0
Mismatched elements: 1 / 200 (0.5%)
Max absolute difference: 5.68842804e-07
Max relative difference: 0.00013598
 x: array([[-0.378639, -0.778235, -1.146565, -0.482547, -0.600791, -0.433996,
        -0.236634, -0.270078, -0.726501, -0.675643, -0.8747  , -0.301857,
        -1.138727, -0.740302, -0.753849, -0.786167, -0.693487, -0.717977,...
 y: array([[-0.378639, -0.778235, -1.146565, -0.482547, -0.600791, -0.433996,
        -0.236634, -0.270078, -0.726501, -0.675643, -0.8747  , -0.301857,
        -1.138727, -0.740302, -0.753849, -0.786167, -0.693487, -0.717977,...
======================================================================
FAIL: test_entropy (test_distribution_beta_static.TestBeta2.test-larger-data.CUDAPlace)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/paddle/paddle/build/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta_static.py", line 110, in test_entropy
    np.testing.assert_allclose(
  File "/usr/local/lib/python3.8/dist-packages/numpy/testing/_private/utils.py", line 1530, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/usr/local/lib/python3.8/dist-packages/numpy/testing/_private/utils.py", line 844, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-05, atol=0
Mismatched elements: 1 / 200 (0.5%)
Max absolute difference: 5.68842804e-07
Max relative difference: 0.00013598
 x: array([[-0.378639, -0.778235, -1.146565, -0.482547, -0.600791, -0.433996,
        -0.236634, -0.270078, -0.726501, -0.675643, -0.8747  , -0.301857,
        -1.138727, -0.740302, -0.753849, -0.786167, -0.693487, -0.717977,...
 y: array([[-0.378639, -0.778235, -1.146565, -0.482547, -0.600791, -0.433996,
        -0.236634, -0.270078, -0.726501, -0.675643, -0.8747  , -0.301857,
        -1.138727, -0.740302, -0.753849, -0.786167, -0.693487, -0.717977,...
----------------------------------------------------------------------
Ran 36 tests in 3.605s
FAILED (failures=2)
```