### PR TITLE
[XPU] fp16 for layer_norm op

### DIFF
--- a/paddle/fluid/operators/layer_norm_op_xpu.cc
+++ b/paddle/fluid/operators/layer_norm_op_xpu.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+/* Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@ limitations under the License. */
 #ifdef PADDLE_WITH_XPU
 
 #include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/platform/device/device_wrapper.h"
 
 namespace paddle {
 namespace operators {
@@ -48,6 +49,9 @@ class LayerNormXPUKernel : public framework::OpKernel<T> {
     auto* mean_data = mean->mutable_data<float>(ctx.GetPlace());
     auto* variance_data = variance->mutable_data<float>(ctx.GetPlace());
     auto& dev_ctx = ctx.template device_context<DeviceContext>();
+
+    // int layer_norm(Context* ctx, const T* x, T* y, int m, int n, float eps,
+    // const float* scale, const float* bias, float* mean, float* var);
     int r = xpu::layer_norm(dev_ctx.x_context(),
                             reinterpret_cast<const XPUType*>(x_data),
                             reinterpret_cast<XPUType*>(y_data),
@@ -58,12 +62,7 @@ class LayerNormXPUKernel : public framework::OpKernel<T> {
                             bias_data,
                             mean_data,
                             variance_data);
-    PADDLE_ENFORCE_EQ(r,
-                      XPU_SUCCESS,
-                      platform::errors::External(
-                          "XPU layer_norm kernel return wrong value[%d %s]",
-                          r,
-                          XPUAPIErrorMsg[r]));
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "layer_norm");
   }
 };
 
@@ -103,6 +102,9 @@ class LayerNormGradXPUKernel : public framework::OpKernel<T> {
         (dx == nullptr ? nullptr : dx->mutable_data<T>(ctx.GetPlace()));
     auto& dev_ctx = ctx.template device_context<DeviceContext>();
 
+    // int layer_norm_grad(Context* ctx, const T* x, const T* dy, T* dx, int m,
+    // int n, float eps, const float* scale, const float* mean, const float*
+    // var, float* dscale, float* dbias);
     int r = xpu::layer_norm_grad(dev_ctx.x_context(),
                                  reinterpret_cast<const XPUType*>(x_data),
                                  reinterpret_cast<const XPUType*>(dy_data),
@@ -115,13 +117,7 @@ class LayerNormGradXPUKernel : public framework::OpKernel<T> {
                                  variance_data,
                                  dscale_data,
                                  dbias_data);
-    PADDLE_ENFORCE_EQ(
-        r,
-        XPU_SUCCESS,
-        platform::errors::External(
-            "XPU layer_norm_grad kernel return wrong value[%d %s]",
-            r,
-            XPUAPIErrorMsg[r]));
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "layer_norm_grad");
   }
 };
 

--- a/paddle/fluid/platform/device/xpu/xpu2_op_list.h
+++ b/paddle/fluid/platform/device/xpu/xpu2_op_list.h
@@ -261,7 +261,6 @@ XPUOpMap& get_kl2_ops() {
       {"layer_norm_grad",
        XPUKernelSet({pOpKernelType(vartype::FP32, XPUPlace()),
                      pOpKernelType(vartype::FP16, XPUPlace())})},
-      {"layer_norm", XPUKernelSet({pOpKernelType(vartype::FP32, XPUPlace())})},
       {"layer_norm",
        XPUKernelSet({pOpKernelType(vartype::FP32, XPUPlace()),
                      pOpKernelType(vartype::FP16, XPUPlace())})},

--- a/python/paddle/fluid/tests/unittests/xpu/test_layer_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_layer_norm_op_xpu.py
@@ -1,10 +1,10 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#  Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,109 +12,183 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
+from __future__ import print_function
+
 import numpy as np
-import sys
 import unittest
-from functools import reduce
+import sys
 
 sys.path.append("..")
 from op_test import OpTest
-from op_test_xpu import XPUOpTest
+from functools import reduce
 from operator import mul
-from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from test_layer_norm_op import _reference_layer_norm_naive, _reference_layer_norm_grad
 
 paddle.enable_static()
 
 
-def ref_layer_norm(x, scale, bias, epsilon, begin_norm_axis=1):
-    x_shape = x.shape
-    left = reduce(mul, x_shape[0:begin_norm_axis], 1)
-    right = reduce(mul, x_shape[begin_norm_axis:len(x_shape)], 1)
-    x.shape = [left, right]
-    mean = np.mean(x, axis=1)
-    variance = np.var(x, axis=1) + epsilon
-    y = np.divide((x - mean.reshape([left, 1])),
-                  (np.sqrt(variance)).reshape([left, 1]))
-    if scale is not None:
-        y = scale.reshape([1, right]) * y
-    if bias is not None:
-        y = y + bias.reshape([1, right])
-    x.shape, y.shape = x_shape, x_shape
-    return y, mean, variance
+class TestLayerNormOp(unittest.TestCase):
+
+    def setUp(self):
+        self.use_cudnn = True
+        self.set_xpu()
+        self.init_dtype()
+
+    def set_xpu(self):
+        self.__class__.use_xpu = True
+        self.place = paddle.XPUPlace(0)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+        self.atol = 1e-4
+
+    def __assert_close(self, tensor, np_array, msg, atol=1e-4):
+        self.assertTrue(
+            np.allclose(np.array(tensor).astype(np_array.dtype),
+                        np_array,
+                        atol=atol), msg)
+
+    def check_forward_backward(self,
+                               shape,
+                               begin_norm_axis,
+                               has_scale=True,
+                               has_bias=True,
+                               y_grad_scale=1.0,
+                               use_mkldnn=False):
+
+        def test_with_place(place,
+                            shape,
+                            begin_norm_axis,
+                            use_mkldnn=use_mkldnn):
+            # attr
+            epsilon = 0.00001
+            x_shape = shape
+            D = reduce(mul, x_shape[begin_norm_axis:len(x_shape)], 1)
+            scale_shape = [D]
+
+            np.random.seed(123)
+            x = np.random.random_sample(x_shape).astype(self.dtype)
+            scale = np.random.random_sample(scale_shape).astype(
+                np.float32) if has_scale else None
+            bias = np.random.random_sample(scale_shape).astype(
+                np.float32) if has_bias else None
+            y_grad = (np.random.random_sample(x_shape) * y_grad_scale).astype(
+                self.dtype)
+
+            # reference forward & backward
+            y, mean, variance = _reference_layer_norm_naive(
+                x, scale, bias, epsilon, begin_norm_axis)
+            x_grad, scale_grad, bias_grad = _reference_layer_norm_grad(
+                x, y_grad, scale, bias, mean, variance, begin_norm_axis)
+
+            var_dict = locals()
+            var_dict['y@GRAD'] = y_grad
+            var_names = ['x', 'mean', 'variance', 'y', 'y@GRAD']
+            if has_scale:
+                var_names += ['scale']
+            if has_bias:
+                var_names += ['bias']
+            ground_truth = {name: var_dict[name] for name in var_names}
+
+            program = fluid.Program()
+            with fluid.program_guard(program):
+                block = program.global_block()
+                for name in ground_truth:
+                    block.create_var(name=name,
+                                     dtype=self.dtype,
+                                     shape=ground_truth[name].shape)
+                inputs = {"X": block.var('x')}
+                fetch_list = [
+                    'y',
+                    'mean',
+                    'variance',
+                    'x@GRAD',
+                ]
+                if has_scale:
+                    inputs["Scale"] = block.var('scale')
+                    fetch_list += ['scale@GRAD']
+                if has_bias:
+                    inputs["Bias"] = block.var('bias')
+                    fetch_list += ['bias@GRAD']
+                layer_norm_op = block.append_op(
+                    type="layer_norm",
+                    inputs=inputs,
+                    outputs={
+                        "Y": block.var('y'),
+                        "Mean": block.var('mean'),  # share the same memory
+                        "Variance":
+                        block.var('variance'),  # share the same memory
+                    },
+                    attrs={
+                        "epsilon": epsilon,
+                        "begin_norm_axis": begin_norm_axis,
+                        "use_mkldnn": use_mkldnn
+                    })
+                # generate backward op_desc
+                grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(
+                    layer_norm_op.desc, set(), [])
+                grad_op_desc = grad_op_desc_list[0]
+                new_op_desc = block.desc.append_op()
+                new_op_desc.copy_from(grad_op_desc)
+                for var_name in grad_op_desc.output_arg_names():
+                    block.desc.var(var_name.encode("ascii"))
+                grad_op_desc.infer_var_type(block.desc)
+                grad_op_desc.infer_shape(block.desc)
+                for arg in grad_op_desc.output_arg_names():
+                    grad_var = block.desc.find_var(arg.encode("ascii"))
+                    grad_var.set_dtype(core.VarDesc.VarType.FP32)
+
+                program._sync_with_cpp()
+                exe = fluid.Executor(place)
+                out = exe.run(program,
+                              feed={
+                                  name: var_dict[name]
+                                  for name in ['x', 'scale', 'bias', 'y@GRAD']
+                              },
+                              fetch_list=fetch_list)
+                self.__assert_close(y, out[0], "y", self.atol)
+                self.__assert_close(mean, out[1], "mean", 1e-3)
+                self.__assert_close(variance, out[2], "variance", 1e-3)
+                self.__assert_close(x_grad, out[3], "x_grad", 1e-2)
+                if has_scale:
+                    self.__assert_close(scale_grad,
+                                        out[fetch_list.index('scale@GRAD')],
+                                        "scale_grad", 1e-2)
+                if has_bias:
+                    self.__assert_close(bias_grad,
+                                        out[fetch_list.index('bias@GRAD')],
+                                        "bias_grad", self.atol)
+
+        test_with_place(self.place, shape, begin_norm_axis)
+
+    def test_check_forward_backward_with_scale_and_bias(self):
+        self.check_forward_backward(shape=[2, 3, 4, 5], begin_norm_axis=1)
+
+        # xpu does not support "no scale" and "no bias"
+        #self.check_forward_backward(shape=[2, 3, 4, 5],
+        #                            begin_norm_axis=1,
+        #                            has_scale=False,
+        #                            has_bias=True)
+        #self.check_forward_backward(shape=[2, 3, 4, 5],
+        #                            begin_norm_axis=1,
+        #                            has_scale=True,
+        #                            has_bias=False)
+        #self.check_forward_backward(shape=[2, 3, 4, 5],
+        #                            begin_norm_axis=1,
+        #                            has_scale=False,
+        #                            has_bias=False)
+        self.check_forward_backward(shape=[2, 3, 4, 5], begin_norm_axis=3)
 
 
-class XPUTestLayerNormOp(XPUOpTestWrapper):
+class TestLayerNormOpFP16(TestLayerNormOp):
 
-    def __init__(self):
-        self.op_name = 'layer_norm'
-        self.use_dynamic_create_class = False
-
-    class TestXPULayerNormOp(XPUOpTest):
-
-        def setUp(self):
-            self.op_type = "layer_norm"
-            self.dtype = self.in_type
-            self.shape = [2, 3, 4, 5]
-            self.epsilon = 1e-05
-            self.begin_norm_axis = 1
-            self.set_attrs()
-
-            right = reduce(mul,
-                           self.shape[self.begin_norm_axis:len(self.shape)], 1)
-            np.random.seed(10)
-            x_np = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
-            scale_np = np.random.uniform(0.1, 1, [right]).astype(self.dtype)
-            bias_np = np.random.uniform(0.1, 1, [right]).astype(self.dtype)
-            ref_y_np, ref_mean_np, ref_variance_np = ref_layer_norm(
-                x_np, scale_np, bias_np, self.epsilon, self.begin_norm_axis)
-
-            self.inputs = {'X': x_np, 'Scale': scale_np, 'Bias': bias_np}
-            self.outputs = {
-                'Y': ref_y_np,
-                'Mean': ref_mean_np,
-                'Variance': ref_variance_np
-            }
-            self.attrs = {
-                'begin_norm_axis': self.begin_norm_axis,
-                'use_xpu': True
-            }
-
-        def set_attrs(self):
-            pass
-
-        def test_check_output(self):
-            self.check_output_with_place(paddle.XPUPlace(0), atol=1e-4)
-
-        def test_check_grad(self):
-            self.check_grad_with_place(paddle.XPUPlace(0), ['X'],
-                                       'Y',
-                                       max_relative_error=0.02)
-
-    class TestXPULayerNormOpAxis2(TestXPULayerNormOp):
-
-        def set_attrs(self):
-            self.begin_norm_axis = 2
-
-    class TestXPULayerNormOpAxis3(TestXPULayerNormOp):
-
-        def set_attrs(self):
-            self.begin_norm_axis = 3
-
-    class TestXPULayerNormOp2D(TestXPULayerNormOp):
-
-        def set_attrs(self):
-            self.shape = [10, 12]
-
-    class TestXPULayerNormOp3D(TestXPULayerNormOp):
-
-        def set_attrs(self):
-            self.shape = [4, 5, 6]
+    def init_dtype(self):
+        self.dtype = np.float16
+        self.atol = 1e-2
 
 
-support_types = get_xpu_op_support_types('layer_norm')
-for stype in support_types:
-    create_test_class(globals(), XPUTestLayerNormOp, stype)
-
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/xpu/test_layer_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_layer_norm_op_xpu.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,14 +60,20 @@ class XPUTestLayerNormOp(XPUOpTestWrapper):
             self.begin_norm_axis = 1
             self.set_attrs()
 
+            self.atol = 1e-4
+            if self.dtype == np.float16:
+                self.atol = 1e-2
+
             right = reduce(mul,
                            self.shape[self.begin_norm_axis:len(self.shape)], 1)
             np.random.seed(10)
             x_np = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
-            scale_np = np.random.uniform(0.1, 1, [right]).astype(self.dtype)
-            bias_np = np.random.uniform(0.1, 1, [right]).astype(self.dtype)
+            scale_np = np.random.uniform(0.1, 1, [right]).astype('float32')
+            bias_np = np.random.uniform(0.1, 1, [right]).astype('float32')
             ref_y_np, ref_mean_np, ref_variance_np = ref_layer_norm(
                 x_np, scale_np, bias_np, self.epsilon, self.begin_norm_axis)
+
+            ref_y_np = ref_y_np.astype(self.dtype)
 
             self.inputs = {'X': x_np, 'Scale': scale_np, 'Bias': bias_np}
             self.outputs = {
@@ -84,12 +90,12 @@ class XPUTestLayerNormOp(XPUOpTestWrapper):
             pass
 
         def test_check_output(self):
-            self.check_output_with_place(paddle.XPUPlace(0), atol=1e-4)
+            self.check_output_with_place(paddle.XPUPlace(0), atol=self.atol)
 
         def test_check_grad(self):
             self.check_grad_with_place(paddle.XPUPlace(0), ['X'],
                                        'Y',
-                                       max_relative_error=0.02)
+                                       max_relative_error=self.atol)
 
     class TestXPULayerNormOpAxis2(TestXPULayerNormOp):
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_one_hot_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_one_hot_op_xpu.py
@@ -121,7 +121,6 @@ class XPUTestOneHotOP(XPUOpTestWrapper):
 
 
 support_types = get_xpu_op_support_types('one_hot')
-print("support_types: %s" % str(support_types))
 for stype in support_types:
     create_test_class(globals(), XPUTestOneHotOP, stype)
 


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
1、layer_norm算子在xpu上支持fp16。算子绑定部分没有实质性的修改，主要是修改了op_list，清理掉了不该出现的条目。单测也对应增加了针对fp16的一些特殊处理。
2、有一个之前的one_hot的单测里面多了一行调试信息，给去掉了。
