### PR TITLE
Refine timeout for TCPStore, add friendly log.

### DIFF
--- a/paddle/fluid/distributed/store/store.h
+++ b/paddle/fluid/distributed/store/store.h
@@ -37,7 +37,7 @@ class Store {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "Implement the add method in the subclass."));
   }
-  virtual void wait(const std::string& key) {
+  virtual void wait(const std::string& key, int refresh_interval = 500) {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "Implement the add method in the subclass."));
   }

--- a/paddle/fluid/distributed/store/tcp_store.h
+++ b/paddle/fluid/distributed/store/tcp_store.h
@@ -130,7 +130,7 @@ class TCPStore : public Store {
 
   int64_t add(const std::string& key, int64_t value) override;
   std::vector<uint8_t> get(const std::string& key) override;
-  void wait(const std::string& key) override;
+  void wait(const std::string& key, int refresh_interval = 500) override;
   void set(const std::string& key, const std::vector<uint8_t>& value) override;
 
  private:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPS

### Describe
<!-- Describe what this PR does -->
Refine the timeout strategy of TCPStore:
- Set timeout for TCPStore wait. Once we cannot find the key in TCPStore during specific time, close the socket and print friendly log to notify user the reason.

完善TCPStore的超时机制：
- 之前TCPStore在找不到对应key时，会循环直到找到为止，本PR设置超时机制，超时后会关闭socket，并打印友好的提示