### PR TITLE
[Dy2St]Raise TypeError when call to_static to convert a method of a common class

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -257,6 +257,9 @@ class StaticFunction(object):
             self._dygraph_function = getattr(function, '__func__')
             self._class_instance = getattr(function, '__self__')
 
+            if not hasattr(self._class_instance, '_original_funcs'):
+                setattr(self._class_instance, '_original_funcs',
+                        collections.OrderedDict())
             self._class_instance._original_funcs[
                 function.__name__] = self._dygraph_function
         else:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -258,8 +258,9 @@ class StaticFunction(object):
             self._class_instance = getattr(function, '__self__')
 
             if not hasattr(self._class_instance, '_original_funcs'):
-                setattr(self._class_instance, '_original_funcs',
-                        collections.OrderedDict())
+                raise TypeError(
+                    "When using 'to_static' to convert method of a class, "
+                    "please ensure the class inherits from nn.Layer")
             self._class_instance._original_funcs[
                 function.__name__] = self._dygraph_function
         else:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -410,6 +410,10 @@ class StaticFunction(object):
 
     def _is_train_mode(self):
         if self._class_instance is not None:
+            if not hasattr(self._class_instance, 'training'):
+                raise TypeError(
+                    "When using 'to_static' to convert method of a class, "
+                    "please ensure the class inherits from nn.Layer")
             return self._class_instance.training
         else:
             return self._training

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
@@ -478,5 +478,21 @@ class TestSetBuffers(unittest.TestCase):
         paddle.enable_static()
 
 
+class ClassNoInheritLayer:
+
+    def func(self, x):
+        return x + 1
+
+
+class TestClassNoInheritLayer(unittest.TestCase):
+
+    def test_to_static(self):
+        paddle.disable_static()
+        net = ClassNoInheritLayer()
+        input_spec = [paddle.static.InputSpec(name='x', shape=[1])]
+        with self.assertRaises(TypeError):
+            static_func = paddle.jit.to_static(net.func, input_spec=input_spec)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dy2St]Fix to_static error when call to_static to convert a method of a common class