### PR TITLE
[JitLayer]Fix Function name error when Load program

### DIFF
--- a/paddle/fluid/jit/serializer_utils.cc
+++ b/paddle/fluid/jit/serializer_utils.cc
@@ -71,30 +71,31 @@ const std::vector<std::pair<std::string, std::string>> PdmodelFilePaths(
   ReplaceAll(&format_path, R"(\\)", "/");
   ReplaceAll(&format_path, R"(\)", "/");
 
-  std::string layer_prefix =
+  std::string layer_name =
       format_path.substr(format_path.find_last_of("/") + 1);
   std::string dir_path =
-      format_path.substr(0, format_path.length() - layer_prefix.length());
+      format_path.substr(0, format_path.length() - layer_name.length());
   DIR* dir = opendir(dir_path.c_str());
   struct dirent* ptr;
 
   while ((ptr = readdir(dir)) != nullptr) {
     std::string file_name = ptr->d_name;
 
-    if (StartsWith(file_name, layer_prefix) &&
+    if (StartsWith(file_name, layer_name) &&
         EndsWith(file_name, PDMODEL_SUFFIX)) {
       std::string prefix = file_name.substr(
           0, file_name.length() - std::string(PDMODEL_SUFFIX).length());
-      std::string func_name = prefix.substr(prefix.find_first_of(".") + 1);
-      VLOG(3) << "func_name:" << func_name << "path:" << dir_path + file_name;
 
-      if (func_name == layer_prefix) {
+      if (prefix == layer_name) {
         pdmodel_paths.emplace_back(
             std::make_pair("forward", dir_path + file_name));
       } else {
+        std::string func_name = prefix.substr(layer_name.size() + 1);
         pdmodel_paths.emplace_back(
             std::make_pair(func_name, dir_path + file_name));
       }
+      VLOG(3) << "func_name: " << pdmodel_paths.back().first
+              << ", path:" << dir_path + file_name;
     }
   }
   closedir(dir);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[JitLayer]Fix Function name error when Load program
修复当pdmodel文件例如export.jit.infer.pdmodel时，Function名字被错误处理成jit.infer的问题。