### PR TITLE
训练进程异常退出，但是分布式lanch进程是正常退出状态的问题修复 #44583

### DIFF
--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -658,7 +658,7 @@ def watch_local_trainers(procs, nranks):
             "ABORT!!! Out of all {} trainers, the trainer process with rank={} was aborted. Please check its log."
             .format(nranks, error_rank))
         terminate_local_procs(procs)
-        return
+        raise
     except:
         logger.error(
             "ABORT!!! Out of all {} trainers, the trainer process with rank={} was aborted. Please check its log."


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
start_local_trainers方法的创建的训练进程的异常退出，但是lanch进程却是正常退出，

def watch_local_trainers(procs, nranks):
...
if error:
terminate_local_procs(procs)
exit(1)
...
except SystemExit:
logger.error(
"ABORT!!! Out of all {} trainers, the trainer process with rank={} was aborted. Please check its log."
.format(nranks, error_rank))
terminate_local_procs(procs)
return

训练进程异常的 ret = p.proc.poll() 返回的是1，error为True, 会执行exit(1) 代码，抛出的异常被SystemExit捕获，然后直接return了，lanch的进程是正常退出了 退出码是0，训练进程的异常没有办法反映到lanch进程中


