### PR TITLE
Do not set return_merge in test_parallel_executor_run_cinn

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_run_cinn.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_run_cinn.py
@@ -99,11 +99,8 @@ def train(dot_save_dir, prefix, seed=1234):
     feed = rand_data(img.name, label.name, iters)
     loss_values = []
     for step in range(iters):
-        loss_v = exe.run(compiled_program,
-                         feed=feed[step],
-                         fetch_list=[loss],
-                         return_merged=False)
-        loss_values.append(loss_v[0][0][0])
+        loss_v = exe.run(compiled_program, feed=feed[step], fetch_list=[loss])
+        loss_values.append(loss_v[0][0])
     return loss_values
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
executor的return_merged参数仅在多卡场景下使用，单机新执行器已不支持这种用法。
test_parallel_executor_run_cinn为单卡下的单测，不需要设置return_merged。