### PR TITLE
Add use_hierarchical_allreduce for DistributedFusedLAMB

### DIFF
--- a/paddle/fluid/operators/optimizers/distributed_fused_lamb_op.cc
+++ b/paddle/fluid/operators/optimizers/distributed_fused_lamb_op.cc
@@ -152,6 +152,9 @@ class DistributedFusedLambOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::vector<int>>("ring_id",
                               "The ring id of the NCCL communicator.")
         .SetDefault({0});
+    AddAttr<bool>("use_hierarchical_allreduce",
+                  "Whether to use hierarchical allreduce")
+        .SetDefault(false);
     AddComment("The DistributedFusedLamb optimizer.");
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
OPs

### Describe
Add `use_hierarchical_allreduce` for `DistributedFusedLAMB`.

假设有N个节点，每个节点有M张GPU卡。当打开`use_hierarchical_allreduce=True`和设置`nproc_per_node=M`后，会建立链两个通信组：
- 第i + k * M (k = 0, 1, ..., N-1)号卡建立一个通信组A。现在该通信组A上做allreduce。
- 每个节点内的GPU卡建立一个通信组B。然后在通信组B上做allreduce。