### PR TITLE
make selected_row not depend on fluid

### DIFF
--- a/paddle/phi/core/CMakeLists.txt
+++ b/paddle/phi/core/CMakeLists.txt
@@ -65,7 +65,7 @@ cc_library(
 cc_library(
   selected_rows
   SRCS selected_rows_impl.cc selected_rows.cc
-  DEPS tensor_base dense_tensor phi_enforce ddim memcpy)
+  DEPS tensor_base dense_tensor phi_enforce ddim)
 cc_library(
   phi_device_context
   SRCS device_context.cc

--- a/paddle/phi/core/selected_rows_impl.cc
+++ b/paddle/phi/core/selected_rows_impl.cc
@@ -58,11 +58,9 @@ struct TensorCopyVisitor {
   void apply() const {
     // TODO(Yancey1989): support other place
     phi::CPUPlace cpu;
-    paddle::memory::Copy(cpu,
-                         dst_->mutable_data<T>(cpu) + dst_offset_,
-                         cpu,
-                         src_.data<T>() + src_offset_,
-                         size_ * sizeof(T));
+    std::memcpy(dst_->mutable_data<T>(cpu) + dst_offset_,
+                src_.data<T>() + src_offset_,
+                size_ * sizeof(T));
   }
 
   phi::DenseTensor* dst_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
make selected_row not depend on fluid

otherwise, they cannot be compiled parallelly 
<img width="850" alt="image" src="https://user-images.githubusercontent.com/6888866/182515386-923ca791-9c4c-4c86-92aa-12bbd057ec86.png">
