### PR TITLE
[Eager] fix expand_grad, fill zero for empty grads

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
@@ -32,7 +32,7 @@ ops_to_fill_zero_for_empty_grads = set([
     "square_double_grad", "celu_double_grad", "pad_double_grad",
     "pad3d_double_grad", "squeeze_double_grad", "unsqueeze_double_grad",
     "instance_norm_double_grad", "conv3d_double_grad",
-    "depthwise_conv2d_grad_grad", "concat_double_grad"
+    "depthwise_conv2d_grad_grad", "concat_double_grad", "expand_grad"
 ])
 
 # For API dispatch used at python-level


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复 expand_grad kernel 反向 grad_in 未补 0，导致新动态图下 PaddleGan 模型失败问题