### PR TITLE
[PHI] Add ones/zeros in tensor_compat.h

### DIFF
--- a/paddle/phi/api/ext/tensor_compat.h
+++ b/paddle/phi/api/ext/tensor_compat.h
@@ -101,6 +101,7 @@ using experimental::multiply;
 using experimental::mv;
 using experimental::nll_loss;
 using experimental::one_hot;
+using experimental::ones;
 using experimental::pixel_shuffle;
 using experimental::poisson;
 using experimental::qr;
@@ -133,5 +134,6 @@ using experimental::unbind;
 using experimental::unique;
 using experimental::unsqueeze;
 using experimental::where;
+using experimental::zeros;
 
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
[PHI] Add ones/zeros in tensor_compat.h