### PR TITLE
add DCINN_GIT_TAG cmake flag to set cinn version

### DIFF
--- a/cmake/external/cinn.cmake
+++ b/cmake/external/cinn.cmake
@@ -16,6 +16,12 @@ if(NOT WITH_CINN)
   return()
 endif()
 
+if(NOT CINN_GIT_TAG)
+  set(CINN_GIT_TAG release/v0.2)
+endif()
+
+message(STATUS "CINN version: " ${CINN_GIT_TAG})
+
 # TODO(zhhsplendid): CINN has lots of warnings during early development.
 # They will be treated as errors under paddle. We set no-error now and we will
 # clean the code in the future.
@@ -26,7 +32,6 @@ add_definitions(-w)
 ######################################
 include(ExternalProject)
 set(CINN_PREFIX_DIR ${THIRD_PARTY_PATH}/CINN)
-set(CINN_GIT_TAG release/v0.2)
 set(CINN_OPTIONAL_ARGS
     -DPY_VERSION=${PY_VERSION}
     -DWITH_CUDA=${WITH_GPU}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修改`CINN_GIT_TAG`需要修改代码，十分不方便，改为可通过cmake flag `-DCINN_GIT_TAG=develop`设定。