### PR TITLE
phi fix header

### DIFF
--- a/paddle/phi/kernels/affine_grid_impl.h
+++ b/paddle/phi/kernels/affine_grid_impl.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include "paddle/fluid/operators/eigen/eigen_function.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
paddle/phi/kernels/affine_grid_impl.h includes fluid header which caused CustomDevice compiling fail.

related: https://github.com/PaddlePaddle/Paddle/pull/44663  https://xly.bce.baidu.com/paddlepaddle/paddle-custom-device/newipipe/detail/6266204/job/17211412
