### PR TITLE
[BugFix]Fix bugs when run cliped xshape inference model 

### DIFF
--- a/paddle/phi/ops/compat/einsum_sig.cc
+++ b/paddle/phi/ops/compat/einsum_sig.cc
@@ -17,14 +17,10 @@ limitations under the License. */
 namespace phi {
 
 KernelSignature EinsumOpArgumentMapping(const ArgumentMappingContext& ctx) {
-  if (ctx.OutputSize("XShape") > 0 && ctx.OutputSize("InnerCache") > 0) {
-    return KernelSignature("einsum_raw",
-                           {"Operands"},
-                           {"equation"},
-                           {"Out", "InnerCache", "XShape"});
-  } else {
-    return KernelSignature("einsum", {"Operands"}, {"equation"}, {"Out"});
-  }
+  return KernelSignature("einsum_raw",
+                         {"Operands"},
+                         {"equation"},
+                         {"Out", "InnerCache", "XShape"});
 }
 
 KernelSignature EinsumGradOpArgumentMapping(const ArgumentMappingContext& ctx) {

--- a/paddle/phi/ops/compat/squeeze_sig.cc
+++ b/paddle/phi/ops/compat/squeeze_sig.cc
@@ -18,12 +18,8 @@
 namespace phi {
 
 KernelSignature SqueezeOpArgumentMapping(const ArgumentMappingContext& ctx) {
-  if (ctx.HasOutput("XShape")) {
-    return KernelSignature(
-        "squeeze_with_xshape", {"X"}, {"axes"}, {"Out", "XShape"});
-  } else {
-    return KernelSignature("squeeze", {"X"}, {"axes"}, {"Out"});
-  }
+  return KernelSignature(
+      "squeeze_with_xshape", {"X"}, {"axes"}, {"Out", "XShape"});
 }
 
 KernelSignature SqueezeGradOpArgumentMapping(

--- a/paddle/phi/ops/compat/unsqueeze_sig.cc
+++ b/paddle/phi/ops/compat/unsqueeze_sig.cc
@@ -18,33 +18,18 @@
 namespace phi {
 
 KernelSignature UnsqueezeOpArgumentMapping(const ArgumentMappingContext& ctx) {
-  if (ctx.HasOutput("XShape")) {
-    if (ctx.InputSize("AxesTensorList") > 0) {
-      VLOG(2) << "unsqueeze2 in AxesTensorList";
-      return KernelSignature("unsqueeze_with_xshape",
-                             {"X"},
-                             {"AxesTensorList"},
-                             {"Out", "XShape"});
-    } else if (ctx.InputSize("AxesTensor") > 0) {
-      VLOG(2) << "unsqueeze2 in AxesTensor";
-      return KernelSignature(
-          "unsqueeze_with_xshape", {"X"}, {"AxesTensor"}, {"Out", "XShape"});
-    } else {
-      VLOG(2) << "unsqueeze2 in axes";
-      return KernelSignature(
-          "unsqueeze_with_xshape", {"X"}, {"axes"}, {"Out", "XShape"});
-    }
+  if (ctx.InputSize("AxesTensorList") > 0) {
+    VLOG(2) << "unsqueeze2 in AxesTensorList";
+    return KernelSignature(
+        "unsqueeze_with_xshape", {"X"}, {"AxesTensorList"}, {"Out", "XShape"});
+  } else if (ctx.InputSize("AxesTensor") > 0) {
+    VLOG(2) << "unsqueeze2 in AxesTensor";
+    return KernelSignature(
+        "unsqueeze_with_xshape", {"X"}, {"AxesTensor"}, {"Out", "XShape"});
   } else {
-    if (ctx.InputSize("AxesTensorList") > 0) {
-      VLOG(2) << "unsqueeze2 in AxesTensorList";
-      return KernelSignature("unsqueeze", {"X"}, {"AxesTensorList"}, {"Out"});
-    } else if (ctx.InputSize("AxesTensor") > 0) {
-      VLOG(2) << "unsqueeze2 in AxesTensor";
-      return KernelSignature("unsqueeze", {"X"}, {"AxesTensor"}, {"Out"});
-    } else {
-      VLOG(2) << "unsqueeze2 in axes";
-      return KernelSignature("unsqueeze", {"X"}, {"axes"}, {"Out"});
-    }
+    VLOG(2) << "unsqueeze2 in axes";
+    return KernelSignature(
+        "unsqueeze_with_xshape", {"X"}, {"axes"}, {"Out", "XShape"});
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
裁剪xshape的inference模型会报segment fault的错误，该pr修复这个问题