### PR TITLE
[IPU] restore dockerfile to gcc8.2

### DIFF
--- a/tools/dockerfile/Dockerfile.ipu
+++ b/tools/dockerfile/Dockerfile.ipu
@@ -25,10 +25,16 @@ RUN apt-get update && apt-get install -y curl wget vim git unzip unrar tar xz-ut
     openssl libffi-dev pciutils libblas-dev gfortran libblas3 liblapack-dev liblapack3 default-jre screen tmux gdb lldb gcc g++
 RUN apt-get update && apt-get install -y rdma-core librdmacm1
 
-# install g++-8
-RUN apt install g++-8 gcc-8 -y
-RUN ln -sf /usr/bin/gcc-8 /usr/bin/gcc
-RUN ln -sf /usr/bin/g++-8 /usr/bin/g++
+# Downgrade gcc&&g++
+WORKDIR /usr/bin
+COPY tools/dockerfile/build_scripts /build_scripts 
+RUN bash /build_scripts/install_gcc.sh gcc82 && rm -rf /build_scripts 
+RUN cp gcc gcc.bak && cp g++ g++.bak && rm gcc && rm g++ 
+RUN ln -s /usr/local/gcc-8.2/bin/gcc /usr/local/bin/gcc 
+RUN ln -s /usr/local/gcc-8.2/bin/g++ /usr/local/bin/g++ 
+RUN ln -s /usr/local/gcc-8.2/bin/gcc /usr/bin/gcc 
+RUN ln -s /usr/local/gcc-8.2/bin/g++ /usr/bin/g++ 
+ENV PATH=/usr/local/gcc-8.2/bin:$PATH 
 
 # install cmake
 WORKDIR /home


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

ubuntu apt 源的 gcc/g++-8 默认的配置 在部分场景下与 手动编译的 gcc-8.2 表现不一致, 恢复使用 手动编译的 gcc8.2, 见
- https://gist.github.com/gglin001/7daabeb1512ad8f4e40f293f90ff28bd

