### PR TITLE
fix bug with attributes that are marked as generated

### DIFF
--- a/paddle/fluid/framework/op_proto_maker.h
+++ b/paddle/fluid/framework/op_proto_maker.h
@@ -96,12 +96,10 @@ class OpProtoAndCheckerMaker {
 
   template <typename T>
   TypedAttrChecker<T> &AddAttr(const std::string &name,
-                               const std::string &comment,
-                               bool generated = false) {
+                               const std::string &comment) {
     auto *attr = proto_->add_attrs();
     attr->set_name(name);
     attr->set_comment(comment);
-    attr->set_generated(generated);
     attr->set_type(AttrTypeID<T>());
     return op_checker_->AddAttrChecker<T>(name, attr);
   }

--- a/paddle/fluid/operators/detection/distribute_fpn_proposals_op.cc
+++ b/paddle/fluid/operators/detection/distribute_fpn_proposals_op.cc
@@ -109,7 +109,7 @@ class DistributeFpnProposalsOpMaker : public framework::OpProtoAndCheckerMaker {
                  "The referring scale of FPN layer with"
                  " specified level");
     AddAttr<bool>("pixel_offset",
-                  "(bool, default True),",
+                  "(bool, default True),"
                   "If true, im_shape pixel offset is 1.")
         .SetDefault(true);
     AddComment(R"DOC(

--- a/paddle/fluid/operators/detection/generate_proposals_v2_op.cc
+++ b/paddle/fluid/operators/detection/generate_proposals_v2_op.cc
@@ -82,7 +82,7 @@ class GenerateProposalsV2OpMaker : public framework::OpProtoAndCheckerMaker {
                    "than this min_size.");
     AddAttr<float>("eta", "The parameter for adaptive NMS.");
     AddAttr<bool>("pixel_offset",
-                  "(bool, default True),",
+                  "(bool, default True),"
                   "If true, im_shape pixel offset is 1.")
         .SetDefault(true);
     AddComment(R"DOC(

--- a/paddle/fluid/operators/detection/matrix_nms_op.cc
+++ b/paddle/fluid/operators/detection/matrix_nms_op.cc
@@ -85,7 +85,7 @@ class MatrixNMSOpMaker : public framework::OpProtoAndCheckerMaker {
         .SetDefault(false);
     AddAttr<float>("gaussian_sigma",
                    "(float) "
-                   "Sigma for Gaussian decreasing function, only takes effect ",
+                   "Sigma for Gaussian decreasing function, only takes effect "
                    "when 'use_gaussian' is enabled.")
         .SetDefault(2.);
     AddOutput("Out",

--- a/paddle/fluid/operators/graph_sample_neighbors_op.cc
+++ b/paddle/fluid/operators/graph_sample_neighbors_op.cc
@@ -50,7 +50,7 @@ class GraphSampleNeighborsOpMaker : public framework::OpProtoAndCheckerMaker {
     AddOutput("Out_Eids", "The eids of the sample edges");
     AddAttr<int>(
         "sample_size",
-        "The sample size of graph sample neighbors method. ",
+        "The sample size of graph sample neighbors method. "
         "Set default value as -1, means return all neighbors of nodes.")
         .SetDefault(-1);
     AddAttr<bool>("return_eids",

--- a/paddle/fluid/operators/tdm_child_op.cc
+++ b/paddle/fluid/operators/tdm_child_op.cc
@@ -34,7 +34,7 @@ class TDMChildOpMaker : public framework::OpProtoAndCheckerMaker {
         "information in the following format: item_id(shape=1), "
         "layer_id(shape=1), parent_id(shape=1), child_id(shape=child_nums)");
     AddAttr<int>("child_nums",
-                 "child_nums(int)",
+                 "child_nums(int)"
                  "The child nums of one node, if the node hasn't enough child, "
                  "it should padding 0 until child nums equal to child_nums");
     AddOutput("Child",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
`OpProtoAndCheckerMaker::AddAttr` has three parameters. The third `generated` is a parameter that is never actually used. It defaults to false, and is a part ot the definition of an resultative `OpProto`, which is not easily changed. 

https://github.com/PaddlePaddle/Paddle/blob/d0cf9d9dc5d99f758cacab11c96f624d05bfd374/paddle/fluid/framework/op_proto_maker.h#L97

However, several operator pass some string literal to parameter `geneated` by mistake. The comment of an attribute is splitted by a comma, `,`, which makes the second part of the comment the third arguemnt. Thus, parametrer `generated` gets value `true`.

`generated` is never actually used. The introduction of generate dates back to this 

https://github.com/PaddlePaddle/Paddle/commit/2462d0c5fedb783a322170ff15f828e63b612ead#diff-a04cde249ab1b3c2b7aef7b1b1ba1a68d0726f4c7c3386b2bdae06ab4d92b14c
<img width="1068" alt="图片" src="https://user-images.githubusercontent.com/16222986/183064139-155b8f7f-242b-4665-b515-5418e559414a.png">


Its consideration in design is somehow doubtful. So we removed it from parameter list for `OpProtoAndCheckerMaker::AddAttr` to avoid more mistakes.

