### PR TITLE
modified gcda_clean to make it more robust

### DIFF
--- a/tools/coverage/gcda_clean.py
+++ b/tools/coverage/gcda_clean.py
@@ -87,12 +87,15 @@ def clean(pull_id):
 
                 # convert paddle/fluid/imperative/CMakeFiles/layer.dir/layer.cc.gcda
                 # to paddle/fluid/imperative/layer.cc.gcda
-
-                if trimmed.endswith('.dir'):
-                    trimmed = os.path.dirname(trimmed)
-
-                if trimmed.endswith('CMakeFiles'):
-                    trimmed = os.path.dirname(trimmed)
+                # modifed to make it more robust
+                # covert /paddle/build/paddle/phi/backends/CMakeFiles/phi_backends.dir/gpu/cuda/cuda_info.cc.gcda
+                # to /paddle/build/paddle/phi/backends/gpu/cuda/cuda_info.cc.gcda
+                trimmed_tmp = []
+                for p in trimmed.split('/'):
+                    if p.endswith('.dir') or p.endswith('CMakeFiles'):
+                        continue
+                    trimmed_tmp.append(p)
+                trimmed = '/'.join(trimmed_tmp)
 
                 # remove no changed gcda
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复覆盖率显示不准确问题；
原因是在删除.gcda文件时，路径处理存在问题，