### PR TITLE
modify op histogram to make the parameter bins support list and tensor

### DIFF
--- a/paddle/fluid/operators/histogram_op.cc
+++ b/paddle/fluid/operators/histogram_op.cc
@@ -18,7 +18,7 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/infershape_utils.h"
 #include "paddle/fluid/framework/op_registry.h"
-#include "paddle/phi/infermeta/unary.h"
+#include "paddle/phi/infermeta/binary.h"
 
 namespace paddle {
 namespace operators {
@@ -41,10 +41,11 @@ class HistogramOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
     AddInput("X", "(Tensor) The input tensor of Histogram op,");
+    AddInput("bins", "(Tensor) The input tensor of Histogram op,");
     AddOutput("Out", "(Tensor) The output tensor of Histogram op,");
-    AddAttr<int64_t>("bins", "(int) number of histogram bins")
-        .SetDefault(100)
-        .EqualGreaterThan(1);
+    // AddAttr<std::vector<float>>("bins", "histogram bins");
+    //     .SetDefault(100)
+    //     .EqualGreaterThan(1);
     AddAttr<int>("min", "(int) lower end of the range (inclusive)")
         .SetDefault(0);
     AddAttr<int>("max", "(int) upper end of the range (inclusive)")
@@ -52,8 +53,9 @@ class HistogramOpMaker : public framework::OpProtoAndCheckerMaker {
     AddComment(R"DOC(
           Histogram Operator.
           Computes the histogram of a tensor. The elements are sorted
-          into equal width bins between min and max. If min and max are
-          both zero, the minimum and maximum values of the data are used.
+          into equal width bins between min and max when bins is an integer. If min is equal to max, 
+          the minimum and maximum values of the data are used.
+          When bins is a list or a tensor, it stores the bin edges including the rightmost edge.
       )DOC");
   }
 };

--- a/paddle/phi/api/yaml/legacy_api.yaml
+++ b/paddle/phi/api/yaml/legacy_api.yaml
@@ -1163,7 +1163,7 @@
 
 # histogram
 - api : histogram
-  args : (Tensor x, int64_t bins, int min, int max)
+  args : (Tensor x, Tensor bins, int min, int max)
   output : Tensor
   infer_meta :
     func : HistogramInferMeta

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1324,6 +1324,27 @@ void GridSampleBaseInferMeta(const MetaTensor& x,
   out->share_lod(x);
 }
 
+void HistogramInferMeta(const MetaTensor& input,
+                        const MetaTensor& bins,
+                        int min,
+                        int max,
+                        MetaTensor* out) {
+  auto bins_dims = bins.numel();
+  if (bins_dims > 1) {
+    out->set_dims({bins_dims - 1});
+  } else {
+    PADDLE_ENFORCE_GE(
+        max,
+        min,
+        phi::errors::InvalidArgument("max must be larger or equal to min."
+                                     "But received max is %d, min is %d",
+                                     max,
+                                     min));
+    out->set_dims({-1});
+  }
+  out->share_lod(input);
+}
+
 void HuberLossInferMeta(const MetaTensor& input,
                         const MetaTensor& label,
                         float delta,

--- a/paddle/phi/infermeta/binary.h
+++ b/paddle/phi/infermeta/binary.h
@@ -207,6 +207,12 @@ void GridSampleBaseInferMeta(const MetaTensor& x,
                              MetaTensor* out,
                              MetaConfig config = MetaConfig());
 
+void HistogramInferMeta(const MetaTensor& input,
+                        const MetaTensor& bins,
+                        int min,
+                        int max,
+                        MetaTensor* out);
+
 void HuberLossInferMeta(const MetaTensor& input_meta,
                         const MetaTensor& label_meta,
                         float delta,

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -1214,26 +1214,6 @@ void GumbelSoftmaxInferMeta(const MetaTensor& x,
   UnchangedInferMetaCheckAxis(x, axis, out);
 }
 
-void HistogramInferMeta(
-    const MetaTensor& input, int64_t bins, int min, int max, MetaTensor* out) {
-  PADDLE_ENFORCE_GE(bins,
-                    1,
-                    phi::errors::InvalidArgument(
-                        "The bins should be greater than or equal to 1."
-                        "But received nbins is %d",
-                        bins));
-  PADDLE_ENFORCE_GE(
-      max,
-      min,
-      phi::errors::InvalidArgument("max must be larger or equal to min."
-                                   "But received max is %d, min is %d",
-                                   max,
-                                   min));
-
-  out->set_dims({bins});
-  out->share_lod(input);
-}
-
 void IncrementInferMeta(const MetaTensor& x, float value, MetaTensor* out) {
   PADDLE_ENFORCE_EQ(
       product(x.dims()),

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -193,8 +193,6 @@ void GumbelSoftmaxInferMeta(const MetaTensor& x,
                             bool hard,
                             int axis,
                             MetaTensor* out);
-void HistogramInferMeta(
-    const MetaTensor& input, int64_t bins, int min, int max, MetaTensor* out);
 
 void IncrementInferMeta(const MetaTensor& x, float value, MetaTensor* out);
 

--- a/paddle/phi/kernels/cpu/histogram_kernel.cc
+++ b/paddle/phi/kernels/cpu/histogram_kernel.cc
@@ -23,55 +23,104 @@ namespace phi {
 template <typename T, typename Context>
 void HistogramKernel(const Context& dev_ctx,
                      const DenseTensor& input,
-                     int64_t bins,
+                     const DenseTensor& bins,
                      int min,
                      int max,
                      DenseTensor* output) {
-  auto& nbins = bins;
-  auto& minval = min;
-  auto& maxval = max;
-
   const T* input_data = input.data<T>();
   auto input_numel = input.numel();
 
-  int64_t* out_data = output->mutable_data<int64_t>(dev_ctx.GetPlace());
-  phi::funcs::SetConstant<Context, int64_t>()(
-      dev_ctx, output, static_cast<int64_t>(0));
-
   if (input_data == nullptr) return;
 
-  T output_min = static_cast<T>(minval);
-  T output_max = static_cast<T>(maxval);
-  if (output_min == output_max) {
-    output_min = *std::min_element(input_data, input_data + input_numel);
-    output_max = *std::max_element(input_data, input_data + input_numel);
-  }
-  if (output_min == output_max) {
-    output_min = output_min - 1;
-    output_max = output_max + 1;
-  }
+  const T* bins_data = bins.data<T>();
 
-  PADDLE_ENFORCE_EQ((std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max)) ||
-                     std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max))),
-                    false,
-                    phi::errors::OutOfRange("range of min, max is not finite"));
-  PADDLE_ENFORCE_GE(
-      output_max,
-      output_min,
-      phi::errors::InvalidArgument(
-          "max must be larger or equal to min. If min and max are both zero, "
-          "the minimum and maximum values of the data are used. "
-          "But received max is %d, min is %d",
-          maxval,
-          minval));
+  auto bins_numel = bins.numel();
+  if (bins_numel == 1) {
+    int64_t nbins = static_cast<int64_t>(bins_data[0]);
+    PADDLE_ENFORCE_GE(
+        nbins,
+        1,
+        phi::errors::InvalidArgument(
+            "When bins is an int, it should be greater than or equal to 1, "
+            "but the value received is %d",
+            nbins));
 
-  for (int64_t i = 0; i < input_numel; i++) {
-    if (input_data[i] >= output_min && input_data[i] <= output_max) {
-      const int64_t bin = (int64_t)((input_data[i] - output_min) * nbins /
-                                    (output_max - output_min));
-      out_data[std::min(bin, nbins - 1)] += 1;
+    output->Resize(phi::make_ddim({static_cast<int64_t>(nbins)}));
+    int64_t* out_data = output->mutable_data<int64_t>(dev_ctx.GetPlace());
+    phi::funcs::SetConstant<Context, int64_t>()(
+        dev_ctx, output, static_cast<int64_t>(0));
+
+    auto& minval = min;
+    auto& maxval = max;
+
+    T output_min = static_cast<T>(minval);
+    T output_max = static_cast<T>(maxval);
+    if (output_min == output_max) {
+      output_min = *std::min_element(input_data, input_data + input_numel);
+      output_max = *std::max_element(input_data, input_data + input_numel);
+    }
+    if (output_min == output_max) {
+      output_min = output_min - 1;
+      output_max = output_max + 1;
+    }
+
+    PADDLE_ENFORCE_EQ(
+        (std::isinf(static_cast<float>(output_min)) ||
+         std::isnan(static_cast<float>(output_max)) ||
+         std::isinf(static_cast<float>(output_max)) ||
+         std::isnan(static_cast<float>(output_min))),
+        false,
+        phi::errors::OutOfRange("range of min, max is not finite"));
+    PADDLE_ENFORCE_GE(
+        output_max,
+        output_min,
+        phi::errors::InvalidArgument(
+            "max must be larger or equal to min. If min is equal to max, "
+            "the minimum and maximum values of the data are used. "
+            "But received max is %d, min is %d",
+            maxval,
+            minval));
+
+    for (int64_t i = 0; i < input_numel; i++) {
+      if (input_data[i] >= output_min && input_data[i] <= output_max) {
+        const int64_t bin = (int64_t)((input_data[i] - output_min) * nbins /
+                                      (output_max - output_min));
+        out_data[std::min(bin, nbins - 1)] += 1;
+      }
+    }
+  } else {
+    for (int64_t i = 0; i < bins_numel - 1; i++) {
+      PADDLE_ENFORCE_GT(bins_data[i + 1],
+                        bins_data[i],
+                        phi::errors::InvalidArgument(
+                            "When bins is a list or a Tensor, it should "
+                            "increase monotonically, "
+                            "but bins_%d is less than or equal to bins_%d",
+                            i + 1,
+                            i));
+    }
+
+    int64_t* out_data = output->mutable_data<int64_t>(dev_ctx.GetPlace());
+    phi::funcs::SetConstant<Context, int64_t>()(
+        dev_ctx, output, static_cast<int64_t>(0));
+
+    auto& output_min = bins_data[0];
+    auto& output_max = bins_data[bins_numel - 1];
+    for (int64_t i = 0; i < input_numel; i++) {
+      auto input_data_i = input_data[i];
+      if (input_data_i >= output_min && input_data_i <= output_max) {
+        int64_t l = 0;
+        int64_t r = bins_numel;
+        while (l < r) {
+          int mid = l + (r - l) / 2;
+          if (bins_data[mid] <= input_data_i) {
+            l = mid + 1;
+          } else {
+            r = mid;
+          }
+        }
+        out_data[std::min(l - 1, output->numel() - 1)] += 1;
+      }
     }
   }
 }

--- a/paddle/phi/kernels/gpu/histogram_kernel.cu
+++ b/paddle/phi/kernels/gpu/histogram_kernel.cu
@@ -43,9 +43,28 @@ __device__ static IndexType GetBin(T input_value,
 }
 
 template <typename T, typename IndexType>
+__device__ static IndexType GetBinForList(T input_value,
+                                          const T* bins,
+                                          const int64_t nbins) {
+  IndexType l = 0, r = nbins + 1;
+  while (l < r) {
+    IndexType mid = l + (r - l) / 2;
+    if (bins[mid] <= input_value) {
+      l = mid + 1;
+    } else {
+      r = mid;
+    }
+  }
+  IndexType output_index = (l - 1) < (nbins - 1) ? (l - 1) : (nbins - 1);
+  return output_index;
+}
+
+template <typename T, typename IndexType>
 __global__ void KernelHistogram(const T* input,
                                 const int total_elements,
-                                const int64_t nbins,
+                                const T* bins,
+                                const int nbins,
+                                bool islist,
                                 const T min_value,
                                 const T max_value,
                                 int64_t* output) {
@@ -56,12 +75,17 @@ __global__ void KernelHistogram(const T* input,
   __syncthreads();
 
   CUDA_KERNEL_LOOP(input_index, total_elements) {
-    // const IndexType input_index = threadIdx.x + blockIdx.x * blockDim.x;
     const auto input_value = input[input_index];
     if (input_value >= min_value && input_value <= max_value) {
-      const IndexType output_index =
-          GetBin<T, IndexType>(input_value, min_value, max_value, nbins);
-      paddle::platform::CudaAtomicAdd(&buf_hist[output_index], 1);
+      if (!islist) {
+        const IndexType output_index =
+            GetBin<T, IndexType>(input_value, min_value, max_value, nbins);
+        paddle::platform::CudaAtomicAdd(&buf_hist[output_index], 1);
+      } else {
+        const IndexType output_index =
+            GetBinForList<T, IndexType>(input_value, bins, nbins);
+        paddle::platform::CudaAtomicAdd(&buf_hist[output_index], 1);
+      }
     }
   }
   __syncthreads();
@@ -74,75 +98,132 @@ __global__ void KernelHistogram(const T* input,
 template <typename T, typename Context>
 void HistogramKernel(const Context& dev_ctx,
                      const DenseTensor& input,
-                     int64_t bins,
+                     const DenseTensor& bins,
                      int min,
                      int max,
                      DenseTensor* output) {
-  auto& nbins = bins;
-  auto& minval = min;
-  auto& maxval = max;
-
   const T* input_data = input.data<T>();
   const int input_numel = input.numel();
 
-  int64_t* out_data = output->mutable_data<int64_t>(dev_ctx.GetPlace());
-  phi::funcs::SetConstant<Context, int64_t>()(
-      dev_ctx, output, static_cast<int64_t>(0));
-
   if (input_data == nullptr) return;
 
-  T output_min = static_cast<T>(minval);
-  T output_max = static_cast<T>(maxval);
+  DenseTensor bins_cpu;
+  paddle::framework::TensorCopySync(bins, phi::CPUPlace(), &bins_cpu);
+  const T* bins_cpu_data = bins_cpu.data<T>();
 
-  if (output_min == output_max) {
-    auto input_x = phi::EigenVector<T>::Flatten(input);
+  if (bins.numel() == 1) {
+    int64_t nbins = static_cast<int64_t>(bins_cpu_data[0]);
+    auto& minval = min;
+    auto& maxval = max;
 
-    DenseTensor input_min_t, input_max_t;
-    auto* input_min_data = input_min_t.mutable_data<T>({1}, dev_ctx.GetPlace());
-    auto* input_max_data = input_max_t.mutable_data<T>({1}, dev_ctx.GetPlace());
-    auto input_min_scala = phi::EigenScalar<T>::From(input_min_t);
-    auto input_max_scala = phi::EigenScalar<T>::From(input_max_t);
+    PADDLE_ENFORCE_GE(
+        nbins,
+        1,
+        phi::errors::InvalidArgument(
+            "When bins is an int, it should be greater than or equal to 1, "
+            "but the value received is %d",
+            nbins));
 
-    auto* place = dev_ctx.eigen_device();
-    input_min_scala.device(*place) = input_x.minimum();
-    input_max_scala.device(*place) = input_x.maximum();
+    output->Resize(phi::make_ddim({nbins}));
+    int64_t* out_data = output->mutable_data<int64_t>(dev_ctx.GetPlace());
+    phi::funcs::SetConstant<Context, int64_t>()(
+        dev_ctx, output, static_cast<int64_t>(0));
 
-    DenseTensor input_min_cpu, input_max_cpu;
-    paddle::framework::TensorCopySync(
-        input_min_t, phi::CPUPlace(), &input_min_cpu);
-    paddle::framework::TensorCopySync(
-        input_max_t, phi::CPUPlace(), &input_max_cpu);
+    T output_min = static_cast<T>(minval);
+    T output_max = static_cast<T>(maxval);
 
-    output_min = input_min_cpu.data<T>()[0];
-    output_max = input_max_cpu.data<T>()[0];
+    if (output_min == output_max) {
+      auto input_x = phi::EigenVector<T>::Flatten(input);
+
+      DenseTensor input_min_t, input_max_t;
+      auto* input_min_data =
+          input_min_t.mutable_data<T>({1}, dev_ctx.GetPlace());
+      auto* input_max_data =
+          input_max_t.mutable_data<T>({1}, dev_ctx.GetPlace());
+      auto input_min_scala = phi::EigenScalar<T>::From(input_min_t);
+      auto input_max_scala = phi::EigenScalar<T>::From(input_max_t);
+
+      auto* place = dev_ctx.eigen_device();
+      input_min_scala.device(*place) = input_x.minimum();
+      input_max_scala.device(*place) = input_x.maximum();
+
+      DenseTensor input_min_cpu, input_max_cpu;
+      paddle::framework::TensorCopySync(
+          input_min_t, phi::CPUPlace(), &input_min_cpu);
+      paddle::framework::TensorCopySync(
+          input_max_t, phi::CPUPlace(), &input_max_cpu);
+
+      output_min = input_min_cpu.data<T>()[0];
+      output_max = input_max_cpu.data<T>()[0];
+    }
+    if (output_min == output_max) {
+      output_min = output_min - 1;
+      output_max = output_max + 1;
+    }
+    PADDLE_ENFORCE_EQ(
+        (std::isinf(static_cast<float>(output_min)) ||
+         std::isnan(static_cast<float>(output_max)) ||
+         std::isinf(static_cast<float>(output_max)) ||
+         std::isnan(static_cast<float>(output_min))),
+        false,
+        phi::errors::OutOfRange("range of min, max is not finite"));
+    PADDLE_ENFORCE_GE(
+        output_max,
+        output_min,
+        phi::errors::InvalidArgument(
+            "max must be larger or equal to min. If min is equal to max, "
+            "the minimum and maximum values of the data are used. "
+            "But received max is %d, min is %d",
+            maxval,
+            minval));
+
+    auto stream = dev_ctx.stream();
+    KernelHistogram<T, IndexType><<<GET_BLOCKS(input_numel),
+                                    PADDLE_CUDA_NUM_THREADS,
+                                    nbins * sizeof(int64_t),
+                                    stream>>>(input_data,
+                                              input_numel,
+                                              nullptr,
+                                              nbins,
+                                              false,
+                                              output_min,
+                                              output_max,
+                                              out_data);
+  } else {
+    int64_t* out_data = output->mutable_data<int64_t>(dev_ctx.GetPlace());
+    phi::funcs::SetConstant<Context, int64_t>()(
+        dev_ctx, output, static_cast<int64_t>(0));
+
+    auto nbins = bins.numel() - 1;
+
+    for (int64_t i = 0; i < nbins; i++) {
+      PADDLE_ENFORCE_GT(bins_cpu_data[i + 1],
+                        bins_cpu_data[i],
+                        phi::errors::InvalidArgument(
+                            "When bins is a list or a Tensor, it should "
+                            "increase monotonically, "
+                            "but bins_%d is less than or equal to bins_%d",
+                            i + 1,
+                            i));
+    }
+
+    const T* bins_data = bins.data<T>();
+    T output_min = bins_cpu_data[0];
+    T output_max = bins_cpu_data[nbins];
+
+    auto stream = dev_ctx.stream();
+    KernelHistogram<T, IndexType><<<GET_BLOCKS(input_numel),
+                                    PADDLE_CUDA_NUM_THREADS,
+                                    nbins * sizeof(int64_t),
+                                    stream>>>(input_data,
+                                              input_numel,
+                                              bins_data,
+                                              nbins,
+                                              true,
+                                              output_min,
+                                              output_max,
+                                              out_data);
   }
-  if (output_min == output_max) {
-    output_min = output_min - 1;
-    output_max = output_max + 1;
-  }
-
-  PADDLE_ENFORCE_EQ((std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max)) ||
-                     std::isinf(static_cast<float>(output_min)) ||
-                     std::isnan(static_cast<float>(output_max))),
-                    false,
-                    phi::errors::OutOfRange("range of min, max is not finite"));
-  PADDLE_ENFORCE_GE(
-      output_max,
-      output_min,
-      phi::errors::InvalidArgument(
-          "max must be larger or equal to min. If min and max are both zero, "
-          "the minimum and maximum values of the data are used. "
-          "But received max is %d, min is %d",
-          maxval,
-          minval));
-
-  auto stream = dev_ctx.stream();
-  KernelHistogram<T, IndexType><<<GET_BLOCKS(input_numel),
-                                  PADDLE_CUDA_NUM_THREADS,
-                                  nbins * sizeof(int64_t),
-                                  stream>>>(
-      input_data, input_numel, nbins, output_min, output_max, out_data);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/histogram_kernel.h
+++ b/paddle/phi/kernels/histogram_kernel.h
@@ -20,7 +20,7 @@ namespace phi {
 template <typename T, typename Context>
 void HistogramKernel(const Context& dev_ctx,
                      const DenseTensor& input,
-                     int64_t bins,
+                     const DenseTensor& bins,
                      int min,
                      int max,
                      DenseTensor* output);

--- a/paddle/phi/ops/compat/histogram_sig.cc
+++ b/paddle/phi/ops/compat/histogram_sig.cc
@@ -17,7 +17,7 @@
 namespace phi {
 
 KernelSignature HistogramOpArgumentMapping(const ArgumentMappingContext& ctx) {
-  return KernelSignature("histogram", {"X"}, {"bins", "min", "max"}, {"Out"});
+  return KernelSignature("histogram", {"X", "bins"}, {"min", "max"}, {"Out"});
 }
 
 }  // namespace phi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Modify op histogram to make the parameter bins support list and tensor. When bins is a list or a tensor, it should be 1D, contain at least 2 elements, increase monotonically, and have the same dtype with input.