### PR TITLE
Fix memory leak in processgroup

### DIFF
--- a/paddle/fluid/distributed/collective/ProcessGroupHCCL.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupHCCL.cc
@@ -197,17 +197,6 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupHCCL::Collective(
   SyncDefaultStream(places, places_to_events_[key], places_to_ctx_[key]);
 
   auto task = CreateTask(places, rank_, op_type, inputs);
-  task->SetOutputs(outputs);
-
-  // if (FLAGS_use_stream_safe_npu_allocator) {
-  //   for (size_t i = 0; i < inputs.size(); ++i) {
-  //     platform::NPUDeviceGuard guard(places[i].GetDeviceId());
-  //     auto dense_tensor =
-  //         std::dynamic_pointer_cast<phi::DenseTensor>(inputs[i].impl());
-  //     memory::RecordStream(dense_tensor->Holder(),
-  //                          places_to_ctx_[key][i]->stream());
-  //   }
-  // }
 
   for (size_t i = 0; i < inputs.size(); ++i) {
     platform::NPUDeviceGuard guard(places[i].GetDeviceId());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix memory leak bug in processgroup.

- The input tensor during communication must be destructed and released after the communication is completed. only support auto_growth allocation.
- Avoid tasks from increasing the reference count of the input.

After the PR, for example, in the following code, the peak memory is 2400000000 * 2 bytes, not 2400000000 bytes. Although the resources of a are released immediately after the communication, because the communication is not completed asynchronously, the next allocation will re-allocate new  memory.

```python
import paddle
import paddle.distributed as dist
from paddle.distributed import init_parallel_env
import time
paddle.seed(1024)
init_parallel_env()
paddle.set_device('gpu:%d'%paddle.distributed.ParallelEnv().dev_id)
a = paddle.rand(shape=[20000, 30000], dtype="float32")

t = dist.all_reduce(a, use_calc_stream=False)
a._clear()
print(t.is_completed())  # False
b = paddle.rand(shape=[20000, 30000], dtype="float32")

time.sleep(5)
print(">> finish")
```

