### PR TITLE
[Eager]Support Lazy initialization for nn.Layer

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -653,5 +653,5 @@ __all__ = [  # noqa
     'put_along_axis',
     'heaviside',
     'tril_indices',
-    'sgn'
+    'sgn',
 ]

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -36,6 +36,7 @@ from .framework import disable_static  # noqa: F401
 from .framework import enable_static  # noqa: F401
 from .framework import in_dynamic_mode  # noqa: F401
 from .fluid.dataset import *  # noqa: F401
+from .fluid.lazy_init import LazyInit  # noqa: F401
 
 from .framework.dtype import dtype as dtype  # noqa: F401
 from .framework.dtype import uint8  # noqa: F401

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -416,6 +416,7 @@ __all__ = [  # noqa
     'cumprod',
     'logcumsumexp',
     'logit',
+    'LazyInit',
     'sign',
     'is_empty',
     'equal',
@@ -652,5 +653,5 @@ __all__ = [  # noqa
     'put_along_axis',
     'heaviside',
     'tril_indices',
-    'sgn',
+    'sgn'
 ]

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -120,6 +120,10 @@ def monkey_patch_varbase():
         for attr in attr_keys:
             attr_kwargs[attr] = getattr(self, attr, None)
 
+        # If specify block, use it instead of self.block
+        if 'block' in kwargs:
+            attr_kwargs['block'] = kwargs['block']
+
         attr_kwargs.update(kwargs)
 
         if to_parameter or isinstance(self, (ParamBase, EagerParamBase)):

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -6795,6 +6795,17 @@ class EagerParamBase(_core_eager_eagertensor):
 
         self.is_distributed = kwargs.get('is_distributed', False)
         # self.block = default_main_program().global_block()
+        self.init_func = None
+
+    def set_init_func(self, obj):
+        self.init_func = obj
+
+    @dygraph_only
+    def initialize(self):
+        assert self.init_func is not None, "Required self.init_func is not None, but received None."
+        self.init_func()
+        # clear function handle to release resource
+        self.init_func = None
 
     @property
     def trainable(self):
@@ -7354,94 +7365,3 @@ def _get_paddle_place_list(places):
         ret.append(p)
 
     return ret
-
-
-class LazyGuard(object):
-    """
-    Guard Context to trigger switching mode between dygraph and static mode,
-    and holds the startup program resource.
-    """
-
-    def __init__(self):
-        self._init()
-        self.state = False
-        self._tracer = None
-        self._in_guard = False
-
-    def enable(self, clear_cache=True):
-        if self.state:
-            return
-        assert in_dygraph_mode(
-        ), "LazyInit.enable() is only available in dygraph mode."
-        self.state = True
-
-        if clear_cache:
-            self._init()
-
-    def disable(self):
-        if not self.state:
-            return
-        self.state = False
-
-    def _init(self):
-        self.startup_program = Program()
-
-    def __enter__(self):
-        self.enable(clear_cache=True)
-        if self._in_guard: return
-        global _dygraph_tracer_
-        self._tracer = _dygraph_tracer_
-        _dygraph_tracer_ = None
-        self._in_guard = True
-
-    def __exit__(self, *args, **kwargs):
-        self.disable()
-        if not self._in_guard: return
-        global _dygraph_tracer_
-        assert self._tracer is not None
-        _dygraph_tracer_ = self._tracer
-        self._tracer = None
-        self._in_guard = False
-
-
-_lazy_guard = LazyGuard()
-
-
-class LazyInit(object):
-    """
-    LazyInit is a wrapper interface for nn.Layer, it forwards the construct
-    process of user defined Layer. Meanwhile, it provides necessary API to
-    trigger EagerParamBase Lazy Initialization and get startup Program.
-    """
-
-    def __init__(self, class_obj=None, clear_cache=True):
-        self.class_obj = class_obj
-        self.clear_cache = clear_cache
-
-    def __call__(self, *args, **kwargs):
-        global _lazy_guard
-        _lazy_guard.enable(self.clear_cache)
-        instance = self.class_obj(*args, **kwargs)
-        _lazy_guard.disable()
-        instance.startup_program = _lazy_guard.startup_program
-
-        return instance
-
-    def __enter__(self):
-        _lazy_guard.__enter__()
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        _lazy_guard.__exit__(*args, **kwargs)
-
-    @staticmethod
-    def enable():
-        _lazy_guard.enable()
-
-    @staticmethod
-    def disable():
-        _lazy_guard.disable()
-
-    @staticmethod
-    def startup_program():
-        return _lazy_guard.startup_program

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -266,7 +266,7 @@ class UniformInitializer(Initializer):
             out_dtype = var.dtype
             out_var = var
 
-        if framework._non_static_mode() and not is_lazy_init():
+        if framework._non_static_mode():
             out_var = _C_ops.uniform_random(
                 'shape', var.shape, 'min', self._low, 'max', self._high, 'seed',
                 self._seed, 'dtype', out_dtype, 'diag_num', self._diag_num,
@@ -369,7 +369,7 @@ class NormalInitializer(Initializer):
         if self._seed == 0:
             self._seed = block.program.random_seed
 
-        if in_dygraph_mode() and not is_lazy_init():
+        if in_dygraph_mode():
             place = _current_expected_place()
             out_var = _C_ops.final_state_gaussian_random(
                 var.shape, self._mean, self._std_dev, self._seed, out_dtype,
@@ -382,7 +382,7 @@ class NormalInitializer(Initializer):
                 out_var._share_underline_tensor_to(var)
             return None
 
-        if _in_legacy_dygraph() and not is_lazy_init():
+        if _in_legacy_dygraph():
             out_var = _C_ops.gaussian_random('shape', var.shape, 'dtype',
                                              out_dtype, 'mean', self._mean,
                                              'std', self._std_dev, 'seed',
@@ -478,7 +478,7 @@ class TruncatedNormalInitializer(Initializer):
             out_dtype = var.dtype
             out_var = var
 
-        if in_dygraph_mode() and not is_lazy_init():
+        if in_dygraph_mode():
             out_var = _C_ops.final_state_truncated_gaussian_random(
                 var.shape, self._mean, self._std_dev, self._seed, out_dtype,
                 _current_expected_place())
@@ -489,7 +489,7 @@ class TruncatedNormalInitializer(Initializer):
                 out_var._share_underline_tensor_to(var)
             return None
 
-        if _in_legacy_dygraph() and not is_lazy_init():
+        if _in_legacy_dygraph():
             out_var = _C_ops.truncated_gaussian_random('shape', var.shape,
                                                        'dtype', out_dtype,
                                                        'mean', self._mean,
@@ -621,7 +621,7 @@ class XavierInitializer(Initializer):
             out_dtype = var.dtype
             out_var = var
 
-        if framework._non_static_mode() and not is_lazy_init():
+        if framework._non_static_mode():
             if self._uniform:
                 limit = math.sqrt(6.0 / float(fan_in + fan_out))
                 if in_dygraph_mode():
@@ -795,7 +795,7 @@ class MSRAInitializer(Initializer):
             out_dtype = var.dtype
             out_var = var
 
-        if framework._non_static_mode() and not is_lazy_init():
+        if framework._non_static_mode():
             if self._uniform:
                 gain = calculate_gain(self._nonlinearity, self._negative_slope)
                 limit = gain * math.sqrt(3.0 / float(fan_in))
@@ -980,7 +980,7 @@ class BilinearInitializer(Initializer):
         if np.prod(shape) > 1024 * 1024:
             raise ValueError("The size of input is too big. ")
 
-        if framework._non_static_mode() and not is_lazy_init():
+        if framework._non_static_mode():
             _C_ops.assign_value(out_var, 'shape', list(shape), 'dtype',
                                 out_dtype, value_name, values)
             if var.dtype in [
@@ -1087,7 +1087,7 @@ class NumpyArrayInitializer(Initializer):
             raise ValueError("The size of input is too big. Please consider "
                              "saving it to file and 'load_op' to load it")
 
-        if framework._non_static_mode() and not is_lazy_init():
+        if framework._non_static_mode():
             _C_ops.assign_value(out_var, 'shape', list(self._value.shape),
                                 'dtype', out_dtype, value_name, values)
             if var.dtype in [VarDesc.VarType.FP16, VarDesc.VarType.BF16]:

--- a/python/paddle/fluid/lazy_init.py
+++ b/python/paddle/fluid/lazy_init.py
@@ -100,9 +100,9 @@ class LazyInit(object):
     trigger EagerParamBase Lazy Initialization and get startup Program.
     """
 
-    def __init__(self, class_obj=None, clear_cache=True):
+    def __init__(self, class_obj=None, **kwargs):
         self.class_obj = class_obj
-        self.clear_cache = clear_cache
+        self.clear_cache = kwargs.get('clear_cache', True)
 
     def __call__(self, *args, **kwargs):
         """
@@ -117,8 +117,13 @@ class LazyInit(object):
                 
                 fc = LazyInit(Linear)(10, 10)
 
-                print(fc.startup_program)
+                for param in fc.parameters():
+                    param.initialize()
         """
+        assert issubclass(
+            self.class_obj, type
+        ), "Required class_obj must be a class type, but received %s." % self.class_obj
+        assert isinstance()
         global _lazy_guard
         _lazy_guard.enable(self.clear_cache)
         # construct Layer instance
@@ -147,7 +152,8 @@ class LazyInit(object):
                     print(lz.startup_program())
                 
                 # outer 'with'
-                print(LazyInit.startup_program())
+                for param in fc.parameters():
+                    param.initialize()
         """
         _lazy_guard.enable()
         return self

--- a/python/paddle/fluid/lazy_init.py
+++ b/python/paddle/fluid/lazy_init.py
@@ -123,7 +123,6 @@ class LazyInit(object):
         assert isinstance(
             self.class_obj, type
         ), "Required class_obj must be a class type, but received %s." % self.class_obj
-        assert isinstance()
         global _lazy_guard
         _lazy_guard.enable(self.clear_cache)
         # construct Layer instance

--- a/python/paddle/fluid/lazy_init.py
+++ b/python/paddle/fluid/lazy_init.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import framework
+
+__all__ = ["LazyInit"]
+
+
+class LazyGuard(object):
+    """
+    Guard Context to trigger switching mode between dygraph and static mode,
+    and holds the startup program resource.
+    """
+
+    def __init__(self):
+        self._init_program()
+
+        self._state = False
+        self._tracer = None
+        self._in_guard = False
+
+    def enable(self, clear_cache=True):
+        """
+        Switch into lazy mode.
+
+        NOTE(dev): This is a very low level API and not exposed for user.
+        """
+        if self._state:
+            return
+        assert framework.in_dygraph_mode(
+        ), "LazyInit.enable() is only available in dygraph mode."
+        self._state = True
+
+        if clear_cache:
+            self._init_program()
+
+    def disable(self):
+        """
+        Exit from lazy mode.
+
+        NOTE(dev): This is a very low level API and not exposed for user.
+        """
+        if not self._state:
+            return
+        self._state = False
+
+    def _init_program(self):
+        self.startup_program = framework.Program()
+
+    def __enter__(self):
+        """
+        Switch into lazy mode and set _dygraph_tracer_ with None to convert
+        dygraph mode into static mode.
+        """
+        self.enable(clear_cache=True)
+        if self._in_guard: return
+        self._tracer = framework._dygraph_tracer_
+        framework._dygraph_tracer_ = None
+        self._in_guard = True
+
+    def __exit__(self, *args, **kwargs):
+        """
+        Exit from lazy mode and recover _dygraph_tracer_.
+        """
+        self.disable()
+        if not self._in_guard: return
+        assert self._tracer is not None
+        framework._dygraph_tracer_ = self._tracer
+        self._tracer = None
+        self._in_guard = False
+
+    @property
+    def state(self):
+        return self._state
+
+
+_lazy_guard = LazyGuard()
+
+
+def lazy_guard():
+    global _lazy_guard
+    return _lazy_guard
+
+
+class LazyInit(object):
+    """
+    LazyInit is a wrapper interface for nn.Layer, it forwards the construct
+    process of user defined Layer. Meanwhile, it provides necessary API to
+    trigger EagerParamBase Lazy Initialization and get startup Program.
+    """
+
+    def __init__(self, class_obj=None, clear_cache=True):
+        self.class_obj = class_obj
+        self.clear_cache = clear_cache
+
+    def __call__(self, *args, **kwargs):
+        """
+        Construct instance from class_obj by Lazy Initializing parameters.
+
+        Examples:
+    
+            .. code-block:: python
+
+                from paddle import LazyInit
+                from paddle.nn import Linear
+                
+                fc = LazyInit(Linear)(10, 10)
+
+                print(fc.startup_program)
+        """
+        global _lazy_guard
+        _lazy_guard.enable(self.clear_cache)
+        # construct Layer instance
+        with framework.program_guard(framework.Program()):
+            instance = self.class_obj(*args, **kwargs)
+        _lazy_guard.disable()
+        # set @property dynamically to visit startup_program
+        instance.startup_program = _lazy_guard.startup_program
+
+        return instance
+
+    def __enter__(self):
+        """
+        Context manager to support 'with' keyword.
+
+        Examples:
+    
+            .. code-block:: python
+
+                from paddle import LazyInit
+                from paddle.nn import Linear
+
+                with LazyInit() as lz:
+                    fc = Linear(10, 10)
+
+                    print(lz.startup_program())
+                
+                # outer 'with'
+                print(LazyInit.startup_program())
+        """
+        _lazy_guard.enable()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        _lazy_guard.disable()
+
+    @staticmethod
+    def startup_program():
+        """
+        A static method to get startup program for the latest Layer.
+
+        Examples:
+    
+            .. code-block:: python
+
+                from paddle import LazyInit
+                from paddle.nn import Linear
+                
+                fc = LazyInit(Linear)(10, 10)
+
+                print(LazyInit.startup_program())
+            
+        """
+        return _lazy_guard.startup_program

--- a/python/paddle/fluid/lazy_init.py
+++ b/python/paddle/fluid/lazy_init.py
@@ -120,7 +120,7 @@ class LazyInit(object):
                 for param in fc.parameters():
                     param.initialize()
         """
-        assert issubclass(
+        assert isinstance(
             self.class_obj, type
         ), "Required class_obj must be a class type, but received %s." % self.class_obj
         assert isinstance()

--- a/python/paddle/fluid/lazy_init.py
+++ b/python/paddle/fluid/lazy_init.py
@@ -134,32 +134,6 @@ class LazyInit(object):
 
         return instance
 
-    def __enter__(self):
-        """
-        Context manager to support 'with' keyword.
-
-        Examples:
-    
-            .. code-block:: python
-
-                from paddle import LazyInit
-                from paddle.nn import Linear
-
-                with LazyInit() as lz:
-                    fc = Linear(10, 10)
-
-                    print(lz.startup_program())
-                
-                # outer 'with'
-                for param in fc.parameters():
-                    param.initialize()
-        """
-        _lazy_guard.enable()
-        return self
-
-    def __exit__(self, *args, **kwargs):
-        _lazy_guard.disable()
-
     @staticmethod
     def startup_program():
         """

--- a/python/paddle/fluid/lazy_init.py
+++ b/python/paddle/fluid/lazy_init.py
@@ -100,9 +100,9 @@ class LazyInit(object):
     trigger EagerParamBase Lazy Initialization and get startup Program.
     """
 
-    def __init__(self, class_obj=None, **kwargs):
+    def __init__(self, class_obj=None):
         self.class_obj = class_obj
-        self.clear_cache = kwargs.get('clear_cache', True)
+        self.clear_cache = True
 
     def __call__(self, *args, **kwargs):
         """

--- a/python/paddle/fluid/tests/unittests/test_lazy_init.py
+++ b/python/paddle/fluid/tests/unittests/test_lazy_init.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import unittest
+import numpy as np
+from paddle import LazyInit
+from paddle.nn import Linear
+from paddle.nn.initializer import *
+from paddle.fluid import unique_name
+
+
+class TestInitializerBase(unittest.TestCase):
+
+    def setUp(self):
+        self.set_initializer()
+        self.set_param_attr()
+        self.set_init_ops()
+        self.clear_nameset()
+
+    def set_initializer(self):
+        self.w_initializer = Constant(0.6)
+        self.b_initializer = Constant(0.3)
+
+    def set_param_attr(self):
+        self.weight_attr = paddle.ParamAttr(name="weight",
+                                            initializer=self.w_initializer)
+
+        self.bias_attr = paddle.ParamAttr(name="bias",
+                                          initializer=self.b_initializer)
+
+    def set_init_ops(self):
+        self.init_ops = ['fill_constant', 'fill_constant']
+
+    def clear_nameset(self):
+        unique_name.dygraph_parameter_name_checker._name_set = set()
+
+    def test_wrapper(self):
+        fc = LazyInit(Linear)(10,
+                              10,
+                              weight_attr=self.weight_attr,
+                              bias_attr=self.bias_attr)
+        print(fc.startup_program)
+
+        self.check_program(program)
+
+    def test_guard(self):
+
+        with LazyInit() as lz:
+            fc = Linear(10,
+                        10,
+                        weight_attr=self.weight_attr,
+                        bias_attr=self.bias_attr)
+            program = lz.startup_program()
+
+        self.check_program(program)
+
+    def check_program(self, program):
+        print(program)
+        self.assertEqual(program.block(0).var("weight").shape, (10, 10))
+        self.assertEqual(program.block(0).var("bias").shape, (10, ))
+        ops = [op.type for op in program.block(0).ops]
+        print(ops)
+        self.assertEqual(ops, self.init_ops)
+
+
+class TestDygraphLazy(TestInitializerBase):
+
+    def test_wrapper(self):
+        fc = LazyInit(Linear)(10,
+                              10,
+                              weight_attr=self.weight_attr,
+                              bias_attr=self.bias_attr)
+
+        self.check_data(fc)
+
+    def test_guard(self):
+        with LazyInit() as lz:
+            fc = Linear(10,
+                        10,
+                        weight_attr=self.weight_attr,
+                        bias_attr=self.bias_attr)
+
+        self.check_data(fc)
+
+    def check_data(self, model):
+        x = paddle.randn([2, 10])
+        # weight and bias have no memory
+        with self.assertRaises(RuntimeError):
+            out = model(x)
+
+        for param in model.parameters():
+            param.initialize()
+
+        out = model(x)
+        self.assertEqual(out.shape, [2, 10])
+
+        self.assertTrue(
+            np.array_equal(model.weight.numpy(),
+                           np.ones([10, 10], dtype=np.float32) * 0.6))
+        self.assertTrue(
+            np.array_equal(model.bias.numpy(),
+                           np.ones([10], dtype=np.float32) * 0.3))
+
+
+class TestUniform(TestInitializerBase):
+
+    def set_initializer(self):
+        self.w_initializer = Uniform()
+        self.b_initializer = Uniform()
+
+    def set_init_ops(self):
+        self.init_ops = ['uniform_random', 'uniform_random']
+
+
+class TestNormal(TestInitializerBase):
+
+    def set_initializer(self):
+        self.w_initializer = Normal()
+        self.b_initializer = Normal()
+
+    def set_init_ops(self):
+        self.init_ops = ['gaussian_random', 'gaussian_random']
+
+
+class TestTruncatedNormal(TestInitializerBase):
+
+    def set_initializer(self):
+        self.w_initializer = TruncatedNormal()
+        self.b_initializer = TruncatedNormal()
+
+    def set_init_ops(self):
+        self.init_ops = [
+            'truncated_gaussian_random', 'truncated_gaussian_random'
+        ]
+
+
+class TestXavierNormal(TestNormal):
+
+    def set_initializer(self):
+        self.w_initializer = XavierNormal()
+        self.b_initializer = XavierNormal()
+
+
+class TestXavierUniform(TestUniform):
+
+    def set_initializer(self):
+        self.w_initializer = XavierUniform()
+        self.b_initializer = XavierUniform()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_lazy_init.py
+++ b/python/paddle/fluid/tests/unittests/test_lazy_init.py
@@ -83,12 +83,10 @@ class TestDygraphLazy(TestInitializerBase):
         out = model(x)
         self.assertEqual(out.shape, [2, 10])
 
-        self.assertTrue(
-            np.array_equal(model.weight.numpy(),
-                           np.ones([10, 10], dtype=np.float32) * 0.6))
-        self.assertTrue(
-            np.array_equal(model.bias.numpy(),
-                           np.ones([10], dtype=np.float32) * 0.3))
+        np.testing.assert_array_equal(model.weight.numpy(),
+                                      np.ones([10, 10], dtype=np.float32) * 0.6)
+        np.testing.assert_array_equal(model.bias.numpy(),
+                                      np.ones([10], dtype=np.float32) * 0.3)
 
 
 class TestUniform(TestInitializerBase):

--- a/python/paddle/fluid/tests/unittests/test_lazy_init.py
+++ b/python/paddle/fluid/tests/unittests/test_lazy_init.py
@@ -54,17 +54,6 @@ class TestInitializerBase(unittest.TestCase):
         program = fc.startup_program
         self.check_program(program)
 
-    def test_guard(self):
-
-        with LazyInit() as lz:
-            fc = Linear(10,
-                        10,
-                        weight_attr=self.weight_attr,
-                        bias_attr=self.bias_attr)
-            program = lz.startup_program()
-
-        self.check_program(program)
-
     def check_program(self, program):
         self.assertEqual(program.block(0).var("weight").shape, (10, 10))
         self.assertEqual(program.block(0).var("bias").shape, (10, ))
@@ -79,15 +68,6 @@ class TestDygraphLazy(TestInitializerBase):
                               10,
                               weight_attr=self.weight_attr,
                               bias_attr=self.bias_attr)
-
-        self.check_data(fc)
-
-    def test_guard(self):
-        with LazyInit() as lz:
-            fc = Linear(10,
-                        10,
-                        weight_attr=self.weight_attr,
-                        bias_attr=self.bias_attr)
 
         self.check_data(fc)
 

--- a/python/paddle/fluid/tests/unittests/test_lazy_init.py
+++ b/python/paddle/fluid/tests/unittests/test_lazy_init.py
@@ -83,10 +83,10 @@ class TestDygraphLazy(TestInitializerBase):
         out = model(x)
         self.assertEqual(out.shape, [2, 10])
 
-        np.testing.assert_array_equal(model.weight.numpy(),
-                                      np.ones([10, 10], dtype=np.float32) * 0.6)
-        np.testing.assert_array_equal(model.bias.numpy(),
-                                      np.ones([10], dtype=np.float32) * 0.3)
+        np.testing.assert_allclose(model.weight.numpy(),
+                                   np.ones([10, 10], dtype=np.float32) * 0.6)
+        np.testing.assert_allclose(model.bias.numpy(),
+                                   np.ones([10], dtype=np.float32) * 0.3)
 
 
 class TestUniform(TestInitializerBase):

--- a/python/paddle/fluid/tests/unittests/test_lazy_init.py
+++ b/python/paddle/fluid/tests/unittests/test_lazy_init.py
@@ -51,8 +51,7 @@ class TestInitializerBase(unittest.TestCase):
                               10,
                               weight_attr=self.weight_attr,
                               bias_attr=self.bias_attr)
-        print(fc.startup_program)
-
+        program = fc.startup_program
         self.check_program(program)
 
     def test_guard(self):
@@ -67,11 +66,9 @@ class TestInitializerBase(unittest.TestCase):
         self.check_program(program)
 
     def check_program(self, program):
-        print(program)
         self.assertEqual(program.block(0).var("weight").shape, (10, 10))
         self.assertEqual(program.block(0).var("bias").shape, (10, ))
         ops = [op.type for op in program.block(0).ops]
-        print(ops)
         self.assertEqual(ops, self.init_ops)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->


### what's New?

+ 动态图 Layer 实例化时，新增模型参数延迟初始化功能
+ 新增 LazyInit 类接口，支持两种方式触发参数的Lazy初始化
  + 方式一：`LazyInit(Model)(...)`，即在实例化时，用 LazyInit 进行包裹
  + 方式二：`with LazyInit() as lz` 方式，在with block内的所有Parameter参数都会lazy初始化

+ 给EagerParamBase 新增一个initialize() 接口，用于应用Lazy hook函数，以自定义初始化param的数据.

```python
import paddle
from paddle import LazyInit
from paddle.nn import Linear
paddle.set_device('cpu')

weight_attr = paddle.ParamAttr(
    name="weight",
    initializer=paddle.nn.initializer.Constant(value=0.5))

bias_attr = paddle.ParamAttr(
    name="bias",
    initializer=paddle.nn.initializer.Constant(value=0.3))

# Usage 1:  LazyInit(Model)
model = LazyInit(Linear)(2, 4, weight_attr=weight_attr, bias_attr=bias_attr)

print(model.weight)       # <------ not initialized
program = model.startup_program

# initialize param
for param in model.parameters():
    param.initialize()     # <------ trigger lazy hook



# Usage 2: with context
with LazyInit() as lz:
     model = Linear(2, 4, weight_attr=weight_attr, bias_attr=bias_attr)
      
    print(model.weight)       # <------ not initialized
    print(lz.startup_program())


# initialize param
for param in model.parameters():
    param.initialize()     # <------ trigger lazy hook
```