### PR TITLE
[Dy2St]Fix abnormal format of message when raise KeyError in Dy2St

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -143,6 +143,9 @@ class SuggestionDict(object):
         return self.suggestion_dict[key]
 
 
+class Dy2StKeyError(Exception):
+    pass
+
 class ErrorData(object):
     """
     Error data attached to an exception which is raised in un-transformed code.
@@ -159,7 +162,10 @@ class ErrorData(object):
 
     def create_exception(self):
         message = self.create_message()
-        new_exception = self.error_type(message)
+        if self.error_type is KeyError:
+            new_exception = Dy2StKeyError(message)
+        else:
+            new_exception = self.error_type(message)
         setattr(new_exception, ERROR_DATA, self)
         return new_exception
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -164,7 +164,6 @@ class ErrorData(object):
     def create_exception(self):
         message = self.create_message()
         if self.error_type is KeyError:
-
             new_exception = Dy2StKeyError(message)
         else:
             new_exception = self.error_type(message)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -146,6 +146,7 @@ class SuggestionDict(object):
 class Dy2StKeyError(Exception):
     pass
 
+
 class ErrorData(object):
     """
     Error data attached to an exception which is raised in un-transformed code.
@@ -163,6 +164,7 @@ class ErrorData(object):
     def create_exception(self):
         message = self.create_message()
         if self.error_type is KeyError:
+
             new_exception = Dy2StKeyError(message)
         else:
             new_exception = self.error_type(message)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -443,6 +443,20 @@ class TestSuggestionErrorInRuntime(TestErrorBase):
         for disable_new_error in [0, 1]:
             self._test_raise_new_exception(disable_new_error)
 
+@paddle.jit.to_static
+def func_ker_error(x):
+    d = {
+        'x': x
+    }
+    y = d['y'] + x
+    return y
+
+class TestKeyError(unittest.TestCase):
+    def test(self):
+        paddle.disable_static()
+        with self.assertRaises(error.Dy2StKeyError):
+            x = paddle.to_tensor([1])
+            func_ker_error(x)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -452,7 +452,7 @@ def func_ker_error(x):
     return y
 
 class TestKeyError(unittest.TestCase):
-    def test(self):
+    def test_key_error(self):
         paddle.disable_static()
         with self.assertRaises(error.Dy2StKeyError):
             x = paddle.to_tensor([1])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dy2St]Fix abnormal format of message when raise KeyError in Dy2St
KeyError(message)会将message视为出错的key，所以在之前KeyError报错中报错信息不会换行：
![image](https://user-images.githubusercontent.com/23097963/183554768-c76fac70-f6ec-4183-8400-ae30fce1493d.png)
修复后报错信息能够正常显示：
![image](https://user-images.githubusercontent.com/23097963/183554860-f5a7e390-f54c-4074-a9ab-2c13808d43f0.png)

