### PR TITLE
Fix mkldnn interpolate ops

### DIFF
--- a/paddle/fluid/operators/mkldnn/interpolate_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/interpolate_mkldnn_op.cc
@@ -105,7 +105,8 @@ class InterpolateMKLDNNKernel : public framework::OpKernel<T> {
           }
         }
       }
-      if (scale[0] > 0.0f && scale[1] > 0.0f && scale[2] > 0.0f) {
+      if (scale.size() == 3 && scale[0] > 0.0f && scale[1] > 0.0f &&
+          scale[2] > 0.0f) {
         int j = 0;
         std::vector<int64_t> in_dhw_vec = phi::vectorize(in_dhw_dims);
         std::transform(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
When the interpolate OP only specifies the output dim but does not specify the scale, the value of the scale is illegally accessed, resulting in an incorrect output shape.
![image](https://user-images.githubusercontent.com/30516196/183591096-cd18f36f-456c-4dbb-b97e-95a2ef17e92e.png)

