### PR TITLE
fix proto consistency bug

### DIFF
--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -179,15 +179,18 @@ void BlockDesc::Flush() {
   for (auto &op_desc : ops_) {
     op_desc->Flush();
   }
+  // no flush for var_desc? or is op_desc flush really needed?
 
   if (NeedUpdate(true)) {
     this->desc_->mutable_ops()->Clear();
     for (auto &op_desc : ops_) {
       this->desc_->mutable_ops()->Add()->CopyFrom(*op_desc->Proto());
+      // op_desc's need_update is set to false in op_desc->Flush();
     }
     this->desc_->mutable_vars()->Clear();
     for (auto &var_desc : vars_) {
       this->desc_->mutable_vars()->Add()->CopyFrom(*var_desc.second->Proto());
+      var_desc.second->SetNeedUpdate(false);
     }
     need_update_ = false;
   }

--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -180,7 +180,7 @@ void BlockDesc::Flush() {
     op_desc->Flush();
   }
 
-  if (need_update_) {
+  if (NeedUpdate(true)) {
     this->desc_->mutable_ops()->Clear();
     for (auto &op_desc : ops_) {
       this->desc_->mutable_ops()->Add()->CopyFrom(*op_desc->Proto());
@@ -297,6 +297,25 @@ void BlockDesc::MoveFrom(BlockDesc *block) {
   block->vars_.clear();
   block->need_update_ = true;
   block->Flush();
+}
+
+bool BlockDesc::NeedUpdate(bool include_subs) {
+  bool need = need_update_;
+  if (include_subs) {
+    for (const auto &op : ops_) {
+      if (op->NeedUpdate()) {
+        need = true;
+        break;
+      }
+    }
+    for (const auto &pair : vars_) {
+      if (pair.second->NeedUpdate()) {
+        need = true;
+        break;
+      }
+    }
+  }
+  return need;
 }
 
 }  // namespace framework

--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -176,12 +176,13 @@ std::vector<OpDesc *> BlockDesc::AllOps() const {
 }
 
 void BlockDesc::Flush() {
+  auto need_update = NeedUpdate(true);
   for (auto &op_desc : ops_) {
     op_desc->Flush();
   }
   // no flush for var_desc? or is op_desc flush really needed?
-
-  if (NeedUpdate(true)) {
+  VLOG(10) << "Flush " << NeedUpdate(true) << " " << need_update << std::endl;
+  if (need_update) {
     this->desc_->mutable_ops()->Clear();
     for (auto &op_desc : ops_) {
       this->desc_->mutable_ops()->Add()->CopyFrom(*op_desc->Proto());

--- a/paddle/fluid/framework/block_desc.h
+++ b/paddle/fluid/framework/block_desc.h
@@ -113,10 +113,13 @@ class BlockDesc {
 
   void MoveFrom(BlockDesc *block);
 
+  bool NeedUpdate(bool include_subs = true);
+
  private:
   ProgramDesc *prog_;       // not_own
   proto::BlockDesc *desc_;  // not_own
-  bool need_update_;
+  bool need_update_;  // block itself need_update, not aware of its ops_ and
+                      // vars_
 
   std::deque<std::unique_ptr<OpDesc>> ops_;
   std::unordered_map<std::string, std::unique_ptr<VarDesc>> vars_;

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -818,6 +818,8 @@ struct SetAttrDescVisitor {
 };
 
 void OpDesc::Flush() {
+  VLOG(4) << "Flush "
+          << " " << Type() << " " << need_update_;
   if (need_update_) {
     this->desc_.mutable_inputs()->Clear();
     for (auto &ipt : inputs_) {
@@ -836,6 +838,9 @@ void OpDesc::Flush() {
     this->desc_.mutable_attrs()->Clear();
     for (auto &attr : attrs_) {
       auto *attr_desc = desc_.add_attrs();
+      if (attr.first == "use_mkldnn") {
+        std::cout << PADDLE_GET_CONST(bool, attr.second) << std::endl;
+      }
       attr_desc->set_name(attr.first);
       attr_desc->set_type(
           static_cast<proto::AttrType>(attr.second.index() - 1));

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -838,9 +838,6 @@ void OpDesc::Flush() {
     this->desc_.mutable_attrs()->Clear();
     for (auto &attr : attrs_) {
       auto *attr_desc = desc_.add_attrs();
-      if (attr.first == "use_mkldnn") {
-        std::cout << PADDLE_GET_CONST(bool, attr.second) << std::endl;
-      }
       attr_desc->set_name(attr.first);
       attr_desc->set_type(
           static_cast<proto::AttrType>(attr.second.index() - 1));

--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -161,6 +161,8 @@ class OpDesc {
   uint64_t OriginalId() const { return original_id_; }
   void SetOriginalId(uint64_t original_id) { original_id_ = original_id; }
 
+  bool NeedUpdate() const { return need_update_; }
+
  private:
   template <typename MapType>
   static std::vector<typename MapType::key_type> MapKeys(const MapType &map) {
@@ -181,7 +183,7 @@ class OpDesc {
     // Must start from one
     return ++uid;
   }
-
+  // it it really needed? or just mantain a ptr from block?
   proto::OpDesc desc_;
   BlockDesc *block_{nullptr};  // not_own
   // input arg name => input variable names

--- a/paddle/fluid/framework/program_desc.cc
+++ b/paddle/fluid/framework/program_desc.cc
@@ -217,5 +217,16 @@ void ProgramDesc::SetFetchHolderName(const std::string &fetch_holder_name) {
   fetch_holder->SetPersistable(true);
 }
 
+bool ProgramDesc::NeedUpdate() const {
+  bool need = false;
+  for (auto &block : blocks_) {
+    if (block->NeedUpdate()) {
+      need = true;
+      break;
+    }
+  }
+  return need;
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/program_desc.h
+++ b/paddle/fluid/framework/program_desc.h
@@ -85,6 +85,8 @@ class ProgramDesc {
   // This function is used to change or unify the fetch_holder variables' name.
   void SetFetchHolderName(const std::string &fetch_holder_name);
 
+  bool NeedUpdate() const;
+
  private:
   void InitFromProto();
 

--- a/paddle/fluid/framework/var_desc.cc
+++ b/paddle/fluid/framework/var_desc.cc
@@ -25,10 +25,12 @@ proto::VarType::Type VarDesc::GetType() const { return desc_.type().type(); }
 
 void VarDesc::SetType(proto::VarType::Type type) {
   desc_.mutable_type()->set_type(type);
+  need_updated_ = true;
 }
 
 void VarDesc::SetShape(const std::vector<int64_t> &dims) {
   VectorToRepeated(dims, mutable_tensor_desc()->mutable_dims());
+  need_updated_ = true;
 }
 
 void VarDesc::SetTensorDescNum(size_t num) {
@@ -48,6 +50,7 @@ void VarDesc::SetTensorDescNum(size_t num) {
                                         "supported by the %s type variable.",
                                         this->Name()));
   }
+  need_updated_ = true;
 }
 
 size_t VarDesc::GetTensorDescNum() const {
@@ -76,6 +79,7 @@ void VarDesc::SetShapes(
   for (size_t i = 0; i < multiple_dims.size(); ++i) {
     VectorToRepeated(multiple_dims[i], tensors[i]->mutable_dims());
   }
+  need_updated_ = true;
 }
 
 std::vector<int64_t> VarDesc::GetShape() const {
@@ -94,6 +98,7 @@ std::vector<std::vector<int64_t>> VarDesc::GetShapes() const {
 
 void VarDesc::SetDataType(proto::VarType::Type data_type) {
   mutable_tensor_desc()->set_data_type(data_type);
+  need_updated_ = true;
 }
 
 void VarDesc::SetDataTypes(
@@ -111,6 +116,7 @@ void VarDesc::SetDataTypes(
   for (size_t i = 0; i < multiple_data_type.size(); ++i) {
     tensor_descs[i]->set_data_type(multiple_data_type[i]);
   }
+  need_updated_ = true;
 }
 
 proto::VarType::Type VarDesc::GetDataType() const {
@@ -144,6 +150,7 @@ void VarDesc::SetLoDLevel(int32_t lod_level) {
           "Setting 'lod_level' is not supported by the %s type variable.",
           this->Name()));
   }
+  need_updated_ = true;
 }
 
 void VarDesc::SetLoDLevels(const std::vector<int32_t> &multiple_lod_level) {
@@ -168,6 +175,7 @@ void VarDesc::SetLoDLevels(const std::vector<int32_t> &multiple_lod_level) {
           "Setting 'lod_levels' is not supported by the %s type variable",
           this->Name()));
   }
+  need_updated_ = true;
 }
 
 int32_t VarDesc::GetLoDLevel() const {
@@ -273,6 +281,7 @@ proto::VarType::TensorDesc *VarDesc::mutable_tensor_desc() {
                                         "supported by the %s type variable.",
                                         this->Name()));
   }
+  need_updated_ = true;
 }
 
 std::vector<proto::VarType::TensorDesc *> VarDesc::mutable_tensor_descs() {
@@ -298,6 +307,7 @@ std::vector<proto::VarType::TensorDesc *> VarDesc::mutable_tensor_descs() {
           "Getting 'tensor_descs' is not supported by the %s type variable.",
           this->Name()));
   }
+  need_updated_ = true;
 }
 
 std::vector<std::string> VarDesc::AttrNames() const {

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -85,7 +85,10 @@ class VarDesc {
     return *this;
   }
 
-  proto::VarDesc *Proto() { return &desc_; }
+  proto::VarDesc *Proto() {
+    return &desc_;
+    need_updated_ = true;
+  }
 
   const proto::VarDesc *Proto() const { return &desc_; }
 
@@ -133,15 +136,22 @@ class VarDesc {
 
   bool Persistable() const { return desc_.persistable(); }
 
-  void SetPersistable(bool persistable) { desc_.set_persistable(persistable); }
+  void SetPersistable(bool persistable) {
+    desc_.set_persistable(persistable);
+    need_updated_ = true;
+  }
 
   bool IsParameter() const { return desc_.is_parameter(); }
 
   void SetIsParameter(bool is_parameter) {
     desc_.set_is_parameter(is_parameter);
+    need_updated_ = true;
   }
 
-  void ClearIsParameter() { desc_.clear_is_parameter(); }
+  void ClearIsParameter() {
+    desc_.clear_is_parameter();
+    need_updated_ = true;
+  }
 
   bool HasIsParameter() const { return desc_.has_is_parameter(); }
 
@@ -149,9 +159,13 @@ class VarDesc {
 
   void SetStopGradient(bool stop_gradient) {
     desc_.set_stop_gradient(stop_gradient);
+    need_updated_ = true;
   }
 
-  void ClearStopGradient() { desc_.clear_stop_gradient(); }
+  void ClearStopGradient() {
+    desc_.clear_stop_gradient();
+    need_updated_ = true;
+  }
 
   bool HasStopGradient() const { return desc_.has_stop_gradient(); }
 
@@ -159,6 +173,7 @@ class VarDesc {
 
   void SetNeedCheckFeed(bool need_check_feed) {
     desc_.set_need_check_feed(need_check_feed);
+    need_updated_ = true;
   }
 
   bool HasAttr(const std::string &name) const {
@@ -175,9 +190,13 @@ class VarDesc {
   // The Id() and OriginalId() are only used for auto parallel.
   uint64_t Id() const { return id_; }
   uint64_t OriginalId() const { return original_id_; }
-  void SetOriginalId(uint64_t original_id) { original_id_ = original_id; }
+  void SetOriginalId(uint64_t original_id) {
+    original_id_ = original_id;
+    need_updated_ = true;
+  }
 
   bool NeedUpdate() const { return need_updated_; }
+  void SetNeedUpdate(bool need) { need_updated_ = need; }
 
  private:
   const proto::VarType::TensorDesc &tensor_desc() const;

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -69,7 +69,7 @@ class VarDesc {
   }
 
   explicit VarDesc(const proto::VarDesc &desc) : desc_(desc) {
-    need_updated_ = true;
+    // need_updated_ = true;
   }
 
   // Explicitly implement the copy constructor for auto parallel

--- a/paddle/fluid/framework/var_desc.h
+++ b/paddle/fluid/framework/var_desc.h
@@ -65,9 +65,12 @@ class VarDesc {
     desc_.set_name(name);
     // TODO(paddle-dev): Why default to lodtensor.
     desc_.mutable_type()->set_type(proto::VarType::LOD_TENSOR);
+    need_updated_ = true;
   }
 
-  explicit VarDesc(const proto::VarDesc &desc) : desc_(desc) {}
+  explicit VarDesc(const proto::VarDesc &desc) : desc_(desc) {
+    need_updated_ = true;
+  }
 
   // Explicitly implement the copy constructor for auto parallel
   VarDesc(const VarDesc &other)
@@ -78,6 +81,7 @@ class VarDesc {
     desc_ = other.desc_;
     attrs_ = other.attrs_;
     original_id_ = other.original_id_;
+    need_updated_ = true;
     return *this;
   }
 
@@ -87,7 +91,10 @@ class VarDesc {
 
   std::string Name() const { return desc_.name(); }
 
-  void SetName(std::string name) { desc_.set_name(name); }
+  void SetName(std::string name) {
+    desc_.set_name(name);
+    need_updated_ = true;
+  }
 
   void SetTensorDescNum(size_t num);
 
@@ -170,6 +177,8 @@ class VarDesc {
   uint64_t OriginalId() const { return original_id_; }
   void SetOriginalId(uint64_t original_id) { original_id_ = original_id; }
 
+  bool NeedUpdate() const { return need_updated_; }
+
  private:
   const proto::VarType::TensorDesc &tensor_desc() const;
   std::vector<proto::VarType::TensorDesc> tensor_descs() const;
@@ -183,8 +192,11 @@ class VarDesc {
     return ++uid;
   }
 
+  // it it really needed? or just mantain a ptr from block?
   proto::VarDesc desc_;
   AttributeMap attrs_;
+
+  bool need_updated_{false};
 
   // Note: the id_ is unique for all VarDesc (only for auto parallel).
   uint64_t id_ = GenerateId();

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -84,6 +84,7 @@ void BindProgramDesc(pybind11::module *m) {
       .def("get_feed_target_names", &pd::ProgramDesc::GetFeedTargetNames)
       .def("get_fetch_target_names", &pd::ProgramDesc::GetFetchTargetNames)
       .def("serialize_to_string", SerializeMessage<pd::ProgramDesc>)
+      .def("need_update", &pd::ProgramDesc::NeedUpdate)
       .def("parse_from_string",
            [](pd::ProgramDesc &program_desc, const std::string &data) {
              pd::proto::ProgramDesc *desc = program_desc.Proto();

--- a/python/paddle/fluid/tests/unittests/test_program.py
+++ b/python/paddle/fluid/tests/unittests/test_program.py
@@ -230,6 +230,16 @@ class TestProgramProto(unittest.TestCase):
         b = program.desc.serialize_to_string()
         self.assertFalse(a == b)
 
+    # it seems the attrs of framework::VarDesc is not write to proto,
+    # except for persistable/need_check_feed/is_parameter/stop_gradient
+    def test_update_var_attr(self):
+        program = build_program()
+        a = program.desc.serialize_to_string()
+        program.current_block().var("x").desc._set_attr("a", 1)
+        self.assertFalse(program.desc.need_update())
+        b = program.desc.serialize_to_string()
+        self.assertTrue(a == b)  # not affected
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_program.py
+++ b/python/paddle/fluid/tests/unittests/test_program.py
@@ -218,6 +218,7 @@ class TestProgramProto(unittest.TestCase):
         program = build_program()
         a = program.desc.serialize_to_string()
         program.current_block().ops[0]._set_attr('use_mkldnn', True)
+        self.assertTrue(program.desc.need_update())
         b = program.desc.serialize_to_string()
         self.assertFalse(a == b)
 
@@ -225,6 +226,7 @@ class TestProgramProto(unittest.TestCase):
         program = build_program()
         a = program.desc.serialize_to_string()
         program.current_block().var("x").desc.set_stop_gradient(False)
+        self.assertTrue(program.desc.need_update())
         b = program.desc.serialize_to_string()
         self.assertFalse(a == b)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

In Paddle, there are three copies of a Program/Block/Op/Var, i.e, Python side, C++ side, and Proto side.

However, there is a bug that proto side is not consistent with the C++ side. For example, updating C++ side OpDesc will not change the proto as below.

```
def build_program(self):
    main_program = paddle.static.Program()
    startuo_program = paddle.static.Program()
    with paddle.utils.unique_name.guard():
        with paddle.static.program_guard(main_program, startuo_program):
            x = paddle.static.data(name='x', shape=[3, 2, 1])
            out = paddle.static.nn.fc(x=x, size=1, num_flatten_dims=2)
    return main_program


class TestProgramProto(unittest.TestCase):

    def update_op(self):
        program = build_program()
        a = program.desc.serialize_to_string()
        program.current_block().ops[0]._set_attr('use_mkldnn', True)
        b = program.desc.serialize_to_string()
        self.assertFalse(a == b)  # before pr, it is failed

    def update_var(self):
        program = build_program()
        a = program.desc.serialize_to_string()
        program.current_block().vars("x").desc.set_stop_gradient(False)
        b = program.desc.serialize_to_string()  
        self.assertFalse(a == b)  # before pr, it is failed
```