### PR TITLE
Fix conv_elementwise_add_mkldnn_fuse_pass when the dims of output and residual are not equal

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/conv_elementwise_add_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_elementwise_add_mkldnn_fuse_pass.cc
@@ -113,10 +113,17 @@ GraphWithStats ResidualConnectionMKLDNNFusePass::FuseConv(
     if (FindFuseOption(*conv_op, *elementwise_op) != FUSE_MKLDNN) return;
     if (!IsReachable(g, residual_data, conv_output)) return;
     if (HasFusedActivation(conv_op)) return;
+    if (HasFusedElementwiseAdd(conv_op)) return;
 
     if (!IsCompat(subgraph, g)) {
       LOG(WARNING)
           << "conv_elementwise_add_mkldnn_fuse_pass in op compat failed.";
+      return;
+    }
+
+    if (residual_data->Var()->GetShape() != conv_output->Var()->GetShape()) {
+      LOG(WARNING) << "conv_elementwise_add_mkldnn_fuse_pass doesn't support " -
+                          "broadcasting";
       return;
     }
 

--- a/paddle/fluid/framework/ir/mkldnn/conv_elementwise_add_mkldnn_fuse_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/conv_elementwise_add_mkldnn_fuse_pass.h
@@ -44,6 +44,9 @@ class ResidualConnectionMKLDNNFusePass : public FusePassBase {
                  ->GetAttrIfExists<std::string>("fuse_activation")
                  .empty());
   }
+  static bool HasFusedElementwiseAdd(Node* conv_node) {
+    return conv_node->Op()->GetAttrIfExists<bool>("fuse_residual_connection");
+  }
 
   const std::string name_scope_{"residual_connection_fuse_pass"};
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Fix conv_elementwise_add_mkldnn_fuse_pass when the dims of output and residual are not equal.