### PR TITLE
[Paddle-TRT] fix conv2d/int64

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -605,6 +605,12 @@ bool OpTeller::Tell(const framework::ir::Node* node,
           return false;
         }
 #endif
+        auto* x_var_desc = block->FindVar(desc.Input("X")[0]);
+        auto dtype = x_var_desc->GetDataType();
+        // At present, forbid int64_t into trt.
+        if (dtype == 3) {
+          return false;
+        }
       }
     }
 
@@ -928,6 +934,19 @@ bool OpTeller::Tell(const framework::ir::Node* node,
           return false;
         }
       }
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
+      auto* x_var_desc = block->FindVar(desc.Input("X")[0]);
+      auto dtype = x_var_desc->GetDataType();
+      // At present, forbid int64_t into trt.
+      if (dtype == 3) {
+        return false;
+      }
     }
 
     if (op_type == "unsqueeze2") {
@@ -946,6 +965,19 @@ bool OpTeller::Tell(const framework::ir::Node* node,
                      "supported in static shape";
           return false;
         }
+      }
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
+      auto* x_var_desc = block->FindVar(desc.Input("X")[0]);
+      auto dtype = x_var_desc->GetDataType();
+      // At present, forbid int64_t into trt.
+      if (dtype == 3) {
+        return false;
       }
     }
 
@@ -1089,6 +1121,11 @@ bool OpTeller::Tell(const framework::ir::Node* node,
       auto x_var_name = desc.Input("X")[0];
       auto* x_var_desc = block->FindVar(x_var_name);
       const auto x_shape = x_var_desc->GetShape();
+      auto dtype = x_var_desc->GetDataType();
+      // At present, only support float32 or float16 into trt.
+      if (!(dtype == 5 || dtype == 4)) {
+        return false;
+      }
       if (!with_dynamic_shape && x_shape.size() == 1) {
         VLOG(3) << "Scale op does not support 1-dimensional input in tensorrt";
         return false;
@@ -1178,6 +1215,20 @@ bool OpTeller::Tell(const framework::ir::Node* node,
         if (desc.Input("EndsTensorList").size()) {
           return false;
         }
+      }
+
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
+      auto* x_var_desc = block->FindVar(desc.Input("Input")[0]);
+      auto dtype = x_var_desc->GetDataType();
+      // At present, forbid int64_t into trt.
+      if (dtype == 3) {
+        return false;
       }
     }
 

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -350,6 +350,19 @@ bool OpTeller::Tell(const framework::ir::Node* node,
         }
       }
 #endif
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
+      auto* filter_var_desc = block->FindVar(desc.Input("Filter")[0]);
+      if (!filter_var_desc->Persistable()) {
+        VLOG(3)
+            << "Trt not support filter is  a intermediate tensor in conv2d op.";
+        return false;
+      }
     }
 
     if (op_type == "deformable_conv") {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -350,7 +350,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
         }
       }
 #endif
-      // In fact, this should include all conv
+      // In fact, this should include all conv, not only conv2d
       if (op_type == "conv2d") {
         auto* block = desc.Block();
         if (block == nullptr) {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -350,18 +350,21 @@ bool OpTeller::Tell(const framework::ir::Node* node,
         }
       }
 #endif
-      auto* block = desc.Block();
-      if (block == nullptr) {
-        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
-                   "Developers need to check whether block_desc is passed in "
-                   "the pass.";
-        return false;
-      }
-      auto* filter_var_desc = block->FindVar(desc.Input("Filter")[0]);
-      if (!filter_var_desc->Persistable()) {
-        VLOG(3)
-            << "Trt not support filter is  a intermediate tensor in conv2d op.";
-        return false;
+      // In fact, this should include all conv
+      if (op_type == "conv2d") {
+        auto* block = desc.Block();
+        if (block == nullptr) {
+          VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                     "Developers need to check whether block_desc is passed in "
+                     "the pass.";
+          return false;
+        }
+        auto* filter_var_desc = block->FindVar(desc.Input("Filter")[0]);
+        if (!filter_var_desc->Persistable()) {
+          VLOG(3) << "Trt not support filter is  a intermediate tensor in "
+                     "conv2d op.";
+          return false;
+        }
       }
     }
 

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -605,12 +605,6 @@ bool OpTeller::Tell(const framework::ir::Node* node,
           return false;
         }
 #endif
-        auto* x_var_desc = block->FindVar(desc.Input("X")[0]);
-        auto dtype = x_var_desc->GetDataType();
-        // At present, forbid int64_t into trt.
-        if (dtype == 3) {
-          return false;
-        }
       }
     }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
When filter is not a persistable tensor, forbid it entering into trt
对于slice，squeeze，unsqueeze，暂时禁止让int64_t的输入进入trt
对于scale，只让float和fp16进入trt