### PR TITLE
fix bugs in codegen about return types

### DIFF
--- a/paddle/fluid/eager/nan_inf_utils.h
+++ b/paddle/fluid/eager/nan_inf_utils.h
@@ -62,4 +62,25 @@ void CheckTensorHasNanOrInf(
     const paddle::small_vector<std::vector<paddle::experimental::Tensor>,
                                egr::kSlotSmallVectorSize>& tensors);
 
+template <typename TupleT, size_t N, size_t Last>
+struct NanInfChecker {
+  void operator()(const std::string& api_name, const TupleT& tensors) {
+    CheckTensorHasNanOrInf(api_name, std::get<N>(tensors));
+    NanInfChecker<TupleT, N + 1, Last>()(api_name, tensors);
+  }
+};
+
+template <typename TupleT, size_t N>
+struct NanInfChecker<TupleT, N, N> {
+  void operator()(const std::string& api_name, const TupleT& tensors) {
+    CheckTensorHasNanOrInf(api_name, std::get<N>(tensors));
+  }
+};
+
+template <typename TupleT>
+void CheckTensorHasNanOrInf(const std::string& api_name,
+                            const TupleT& tensors) {
+  constexpr size_t size = std::tuple_size<TupleT>::value;
+  NanInfChecker<TupleT, 0, size - 1>()(api_name, tensors);
+}
 }  // namespace egr

--- a/paddle/phi/api/yaml/generator/api_gen.py
+++ b/paddle/phi/api/yaml/generator/api_gen.py
@@ -130,7 +130,7 @@ class ForwardAPI(BaseAPI):
                 selected_code = [
                     f"std::get<{i}>(api_output)" for i in return_out_list
                 ]
-            return 'return {' + ", ".join(selected_code) + '};'
+            return 'return std::make_tuple(' + ", ".join(selected_code) + ');'
 
     def gene_output(self,
                     out_dtype_list,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others


### Describe
<!-- Describe what this PR does -->
1. change the codegen code to avoid conversion from heterogeneous 'initializer list' to tuple, which fails on gcc 5.4; 
3. add a template CheckTensorHasNanOrInf to handle arbitary tuple of supported types.
