### PR TITLE
[Paddle Inference]Disable skip layernorm half

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
@@ -163,8 +163,9 @@ class SkipLayerNormOpConverter : public OpConverter {
       auto scale_weight = GetFp32Weight("Scale").get();
 
       float eps = PADDLE_GET_CONST(float, op_desc.GetAttr("epsilon"));
-      bool with_fp16 =
-          engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
+      // bool with_fp16 =
+      //     engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
+      bool with_fp16 = false;
       plugin::SkipLayerNormPluginDynamic* plugin =
           new plugin::SkipLayerNormPluginDynamic(
               static_cast<const float*>(bias_weight.values),

--- a/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/skip_layernorm.cc
@@ -166,6 +166,7 @@ class SkipLayerNormOpConverter : public OpConverter {
       // bool with_fp16 =
       //     engine_->WithFp16() && !engine_->disable_trt_plugin_fp16();
       bool with_fp16 = false;
+
       plugin::SkipLayerNormPluginDynamic* plugin =
           new plugin::SkipLayerNormPluginDynamic(
               static_cast<const float*>(bias_weight.values),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
临时禁用 skip_layernorm fp16 kernel