### PR TITLE
[Fix] Fix `paddle.floor_divide` AssertionError when using CUDA 11.2

### DIFF
--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -21,7 +21,7 @@ limitations under the License. */
 #if defined(__xpu__)
 #include <xpu/runtime.h>
 
-#include "xpu/kernel/math_xpu2.h"  //pow()
+#include "xpu/kernel/math_xpu2.h"  // pow()
 #endif
 
 namespace phi {
@@ -557,7 +557,7 @@ struct FloorDivideFunctor {
 #ifndef PADDLE_WITH_XPU_KP
     PADDLE_ENFORCE(b != 0, DIV_ERROR_INFO);
 #endif
-    return static_cast<T>(std::trunc(a / b));
+    return static_cast<T>(a / b);
   }
 };
 
@@ -567,7 +567,7 @@ struct InverseFloorDivideFunctor {
 #ifndef PADDLE_WITH_XPU_KP
     PADDLE_ENFORCE(a != 0, DIV_ERROR_INFO);
 #endif
-    return static_cast<T>(std::trunc(b / a));
+    return static_cast<T>(b / a);
   }
 };
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe

#### How to reproduce

In an environment with **CUDA 11.2**, the bug can be reproduced by executing the following code:

```python
import paddle

import numpy as np

x = np.array([2, 3, 4])

y = np.array([1, 5, 2])

xp, yp = paddle.to_tensor(x), paddle.to_tensor(y)

rp = paddle.floor_divide(xp, yp)

print(rp)
```

The running result contains assertion errors even if `b` is a non-zero number:

<img width="1419" alt="07ba07639d544078fefe555c1804e80d" src="https://user-images.githubusercontent.com/21275753/183874761-8367788e-37bb-4f40-8761-896e108fd30d.png">


#### Causes

This bug is caused by the calls to`std::trunc()`, as the functor gives expected results when these calls are removed.

#### How I fixed it

My solution is to remove the calls to `std::trunc()`, since they are **NOT** necessary here. The reason is two-fold:

1. Currently, `paddle.floor_divide()` supports only int32 and int64 data, and rounding-to-zero is the defined behavior of integer division in C++.
2. According to [link](https://en.cppreference.com/w/cpp/numeric/math/trunc), calling `std::trunc()` can result in an extra type coercions when input arguments are of integral types, which brings overheads.

It is noteworthy that [the `floor_divide` implementation for integral types in PyTorch](https://github.com/pytorch/pytorch/blob/d9a7e93aaf3166e639ea413123bd6c38b9144adc/aten/src/ATen/native/cuda/BinaryDivFloorKernel.cu#L29) is also dependent on C++ integer division, and no `std::trunc()` is used.

Also note that the name `paddle.floor_divide` is not so accurate. For divisions involving a negative number and a positive number, the result is rounded to zero instead of performing actual floor division. This PR does not change this behavior.
