### PR TITLE
[XPU] fix typo in unit tests.

### DIFF
--- a/python/paddle/fluid/tests/unittests/xpu/get_test_cover_info.py
+++ b/python/paddle/fluid/tests/unittests/xpu/get_test_cover_info.py
@@ -245,13 +245,13 @@ def create_test_class(func_globals,
                       test_class,
                       test_type,
                       test_grad=True,
-                      ignore_deivce_version=[],
-                      test_deivce_version=[]):
+                      ignore_device_version=[],
+                      test_device_version=[]):
     xpu_version = core.get_xpu_device_version(0)
-    if xpu_version in ignore_deivce_version:
+    if xpu_version in ignore_device_version:
         return
 
-    if len(test_deivce_version) != 0 and xpu_version not in test_deivce_version:
+    if len(test_device_version) != 0 and xpu_version not in test_device_version:
         return
 
     test_class_obj = test_class()

--- a/python/paddle/fluid/tests/unittests/xpu/test_conv2d_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_conv2d_op_xpu.py
@@ -532,7 +532,7 @@ for stype in ['float32']:
     create_test_class(globals(),
                       XPUTestConv2DOp_NHWC,
                       stype,
-                      ignore_deivce_version=[core.XPUVersion.XPU1])
+                      ignore_device_version=[core.XPUVersion.XPU1])
 
 #---------- test SAME VALID -----------
 #create_test_padding_SAME_class(TestConv2DOp_AsyPadding)

--- a/python/paddle/fluid/tests/unittests/xpu/test_fused_resnet_basic_block_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_fused_resnet_basic_block_op_xpu.py
@@ -266,7 +266,7 @@ for stype in support_types:
     create_test_class(globals(),
                       XPUTestResNetBasicBlockOp,
                       stype,
-                      ignore_deivce_version=[core.XPUVersion.XPU1])
+                      ignore_device_version=[core.XPUVersion.XPU1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/xpu/test_generate_proposals_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_generate_proposals_v2_op_xpu.py
@@ -549,7 +549,7 @@ for stype in support_types:
                       XPUGenerateProposalsV2Op,
                       stype,
                       test_grad=False,
-                      ignore_deivce_version=[core.XPUVersion.XPU1])
+                      ignore_device_version=[core.XPUVersion.XPU1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/xpu/test_refactor_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_refactor_op_xpu.py
@@ -301,7 +301,7 @@ for stype in support_types:
     create_test_class(globals(),
                       XPUTestHuberLossOp,
                       stype,
-                      ignore_deivce_version=[core.XPUVersion.XPU1])
+                      ignore_device_version=[core.XPUVersion.XPU1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/xpu/test_rnn_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_rnn_op_xpu.py
@@ -207,7 +207,7 @@ for stype in support_types:
     create_test_class(globals(),
                       XPUTestRNNOp,
                       stype,
-                      ignore_deivce_version=[core.XPUVersion.XPU1])
+                      ignore_device_version=[core.XPUVersion.XPU1])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
xpu的单测里面，有若干处deivce应该是device。简单修一下。
之所以单独修，是因为修一个typo需要改好几个文件。和其它的修改混在一起就容易触发“单次PR超过20个文件需要approve”的限制。
