### PR TITLE
trt engine input data type should be consistent with trt input bindin…

### DIFF
--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -186,25 +186,32 @@ inline std::string Vec2Str(const std::vector<T>& vec) {
 }
 
 static inline nvinfer1::DataType PhiType2NvType(phi::DataType type) {
+  nvinfer1::DataType nv_type = nvinfer1::DataType::kFLOAT;
   switch (type) {
     case phi::DataType::FLOAT32:
-      return nvinfer1::DataType::kFLOAT;
+      nv_type = nvinfer1::DataType::kFLOAT;
+      break;
     case phi::DataType::FLOAT16:
-      return nvinfer1::DataType::kHALF;
+      nv_type = nvinfer1::DataType::kHALF;
+      break;
     case phi::DataType::INT32:
     case phi::DataType::INT64:
-      return nvinfer1::DataType::kINT32;
+      nv_type = nvinfer1::DataType::kINT32;
+      break;
     case phi::DataType::INT8:
-      return nvinfer1::DataType::kINT8;
+      nv_type = nvinfer1::DataType::kINT8;
+      break;
 #if IS_TRT_VERSION_GE(7000)
     case phi::DataType::BOOL:
-      return nvinfer1::DataType::kBOOL;
+      nv_type = nvinfer1::DataType::kBOOL;
+      break;
 #endif
     default:
       paddle::platform::errors::InvalidArgument(
           "phi::DataType not supported data type %s.", type);
-      return nvinfer1::DataType::kFLOAT;
+      break;
   }
+  return nv_type;
 }
 }  // namespace tensorrt
 }  // namespace inference

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -203,7 +203,7 @@ static inline nvinfer1::DataType PhiType2NvType(phi::DataType type) {
     default:
       paddle::platform::errors::InvalidArgument(
           "phi::DataType not supported data type %s.", type);
-      break;
+      return nvinfer1::DataType::kFLOAT;
   }
 }
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -24,6 +24,7 @@
 
 #include "paddle/fluid/platform/dynload/tensorrt.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/phi/common/data_type.h"
 
 namespace paddle {
 namespace inference {
@@ -182,6 +183,28 @@ inline std::string Vec2Str(const std::vector<T>& vec) {
   }
   os << vec[vec.size() - 1] << ")";
   return os.str();
+}
+
+static inline nvinfer1::DataType PhiType2NvType(phi::DataType type) {
+  switch (type) {
+    case phi::DataType::FLOAT32:
+      return nvinfer1::DataType::kFLOAT;
+    case phi::DataType::FLOAT16:
+      return nvinfer1::DataType::kHALF;
+    case phi::DataType::INT32:
+    case phi::DataType::INT64:
+      return nvinfer1::DataType::kINT32;
+    case phi::DataType::INT8:
+      return nvinfer1::DataType::kINT8;
+#if IS_TRT_VERSION_GE(7000)
+    case phi::DataType::BOOL:
+      return nvinfer1::DataType::kBOOL;
+#endif
+    default:
+      paddle::platform::errors::InvalidArgument(
+          "phi::DataType not supported data type %s.", type);
+      break;
+  }
 }
 }  // namespace tensorrt
 }  // namespace inference

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -562,6 +562,14 @@ class TensorRTEngineOp : public framework::OperatorBase {
       }
       runtime_batch = t_shape[0];
       VLOG(1) << "trt input [" << x << "] dtype is " << t.dtype();
+      auto indata_type = inference::tensorrt::PhiType2NvType(t.dtype());
+      auto intrt_index = engine->engine()->getBindingIndex(x.c_str());
+      auto intrt_type = engine->engine()->getBindingDataType(idx);
+      PADDLE_ENFORCE_EQ(indata_type,
+                        intrt_type,
+                        platform::errors::InvalidArgument(
+                            "The TRT Engine OP's input type should equal "
+                            "to the input data type"));
       auto type = framework::TransToProtoVarType(t.dtype());
       if (type == framework::proto::VarType::FP32) {
         buffers[bind_index] = static_cast<void *>(t.data<float>());

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -564,7 +564,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
       VLOG(1) << "trt input [" << x << "] dtype is " << t.dtype();
       auto indata_type = inference::tensorrt::PhiType2NvType(t.dtype());
       auto intrt_index = engine->engine()->getBindingIndex(x.c_str());
-      auto intrt_type = engine->engine()->getBindingDataType(idx);
+      auto intrt_type = engine->engine()->getBindingDataType(intrt_index);
       PADDLE_ENFORCE_EQ(indata_type,
                         intrt_type,
                         platform::errors::InvalidArgument(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
trt engine input data type should be consistent with trt input binding type.
当进入trt engine的子图的输入数据类型（用户提供的）与trt engine实际绑定的输入类型不一致时，计算结果会出错。因此，增加了判等代码。