### PR TITLE
[ Dy2Static | Controlflow ]While + Cond support for python container.

### DIFF
--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -53,7 +53,7 @@ void DenseTensor::check_memory_size() const {
           "Tensor's dimension is out of bound."
           "Tensor's dimension must be equal or less than the size of its "
           "memory."
-          "But received Tensor's dimension is d%, memory's size is %d.",
+          "But received Tensor's dimension is %d, memory's size is %d.",
           numel() * SizeOf(dtype()),
           memory_size()));
 }

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -92,7 +92,10 @@ def _run_paddle_while(cond, body, getter, setter):
     # NOTE: loop_vars of Paddle op `control_flow.while_loop` must be Paddle Tensors.
     def new_body_fn(*args):
         """ wrap the body() and add return value for `while_loop`
+            the args may be differ from getter().
         """
+        mutable_loop_vars = args
+        setter(mutable_loop_vars)
         body()
         return getter()
 
@@ -110,7 +113,7 @@ def _run_paddle_while(cond, body, getter, setter):
     setter(loop_vars)  # change the non-local var to variable
     # variable maybe modified to inner var. change it into
     loop_vars = control_flow.while_loop(new_cond_fn, new_body_fn, loop_vars)
-    setter(loop_vars)  # change the non-local var to variable
+    setter(loop_vars)  # change back to loop_vars
     return loop_vars
 
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
@@ -21,6 +21,7 @@ from paddle.utils import gast
 from paddle.fluid import unique_name
 from paddle.fluid.framework import Variable
 from paddle.fluid.dygraph.dygraph_to_static.utils import UndefinedVar, create_undefined_variable
+from paddle.fluid.layers.utils import map_structure, is_sequence
 
 __all__ = [
     'create_bool_as_type',
@@ -63,9 +64,12 @@ def to_static_variable(x):
     if isinstance(x, six.integer_types):
         return paddle.full(shape=[1], dtype='int64', fill_value=x)
     if isinstance(x, UndefinedVar) or x is None:
-        """ for early return case, we need a variable to represent None, current we use data_layer_not_check.
+        """ 
+        for early return case, we need a variable to represent None, current we use data_layer_not_check.
         """
         return create_undefined_variable()
+    if is_sequence(x):
+        return map_structure(to_static_variable, x)
     return x
 
 

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1327,8 +1327,11 @@ def _deal_with_undefined_var(output_vars, loop_vars):
         if isinstance(o_var,
                       (Variable, ) + support_ret_buildin_type) or o_var is None:
             return create_undefined_variable()
-        if isinstance(o_var, (tuple, list)):
-            return [create_undefined_variable() for i in range(len(o_var))]
+        if is_sequence(o_var):
+            """ 
+            Create a complex container class inside the body of while, including Python list and python Dict
+            """
+            return map_structure(lambda x: create_undefined_variable(), o_var)
 
     if len(output_vars) != len(loop_vars):
         raise ValueError("The length of loop_vars should be the same.")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
While support for python container. It is convenient to convert more dynamic graph codes into static graphs.

support the following case:
```
for i in tensor:
    a = {'a': 1, 'b': 2, 'c': 3}
```
and 
```
  a = {"a": 3, "b": 4, "c": 9}                                                                                                                                                                                    
  for i in x:                                                                                           
      a = a  # make the a become loop vars. a will be convert into {'a', Tensor, 'b': Tensor, 'c': Tensor}                                                                            
      a['a'] = 12   
```