### PR TITLE
Add strongly typed functions to set attributes to avoid unexpected type conversions.

### DIFF
--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -96,6 +96,15 @@ class OpDesc {
   void SetAttr(const std::string &name, const Attribute &v);
   void RemoveAttr(const std::string &name);
 
+  // NOTE(chenfeiyu): this template is added to avoid using a variant(Attribute)
+  // as a parameter of a function which is bound to python, which causes
+  // unexpected type conversion due to the overload resolution mechanism
+  // https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers
+  template <typename T>
+  void SetPlainAttr(const std::string &name, const T &value) {
+    SetAttr(name, value);
+  }
+
   void SetVarAttr(const std::string &name, VarDesc *var);
 
   void SetVarsAttr(const std::string &name, std::vector<VarDesc *> vars);

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -286,6 +286,8 @@ void BindOpDesc(pybind11::module *m) {
       .value("LONGS", pd::proto::AttrType::LONGS)
       .value("FLOAT", pd::proto::AttrType::FLOAT)
       .value("FLOATS", pd::proto::AttrType::FLOATS)
+      //  .value("FLOAT64", pd::proto::AttrType::FLOAT64)
+      .value("FLOAT64S", pd::proto::AttrType::FLOAT64S)
       .value("STRING", pd::proto::AttrType::STRING)
       .value("STRINGS", pd::proto::AttrType::STRINGS)
       .value("BOOL", pd::proto::AttrType::BOOLEAN)
@@ -361,6 +363,21 @@ void BindOpDesc(pybind11::module *m) {
           py::arg("with_attr_var") = false)
       .def("_set_attr", &pd::OpDesc::SetAttr)
       .def("remove_attr", &pd::OpDesc::RemoveAttr)
+      .def("_set_bool_attr", &pd::OpDesc::SetPlainAttr<bool>)
+      .def("_set_int32_attr", &pd::OpDesc::SetPlainAttr<int>)
+      .def("_set_int64_attr", &pd::OpDesc::SetPlainAttr<int64_t>)
+      .def("_set_float32_attr", &pd::OpDesc::SetPlainAttr<float>)
+      //  .def("_set_float64_attr", &pd::OpDesc::SetPlainAttr<double>)
+      .def("_set_str_attr", &pd::OpDesc::SetPlainAttr<std::string>)
+
+      .def("_set_bools_attr", &pd::OpDesc::SetPlainAttr<std::vector<bool>>)
+      .def("_set_int32s_attr", &pd::OpDesc::SetPlainAttr<std::vector<int>>)
+      .def("_set_int64s_attr", &pd::OpDesc::SetPlainAttr<std::vector<int64_t>>)
+      .def("_set_float32s_attr", &pd::OpDesc::SetPlainAttr<std::vector<float>>)
+      .def("_set_float64s_attr", &pd::OpDesc::SetPlainAttr<std::vector<double>>)
+      .def("_set_strs_attr",
+           &pd::OpDesc::SetPlainAttr<std::vector<std::string>>)
+
       .def(
           "attr",
           [](pd::OpDesc &self, const std::string &name, bool with_attr_var) {

--- a/python/paddle/fluid/tests/unittests/test_fold_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fold_op.py
@@ -206,7 +206,7 @@ class TestFoldOpError(unittest.TestCase):
             self.assertRaises(AssertionError, test_dilations_shape)
             self.assertRaises(AssertionError, test_strides_shape)
             self.assertRaises(ValueError, test_output_size)
-            self.assertRaises(ValueError, test_output_size_2)
+            self.assertRaises(TypeError, test_output_size_2)
             self.assertRaises(ValueError, test_block_h_w)
             self.assertRaises(ValueError, test_GT_0)
 

--- a/python/paddle/fluid/tests/unittests/test_histogram_op.py
+++ b/python/paddle/fluid/tests/unittests/test_histogram_op.py
@@ -111,7 +111,7 @@ class TestHistogramOpError(unittest.TestCase):
                                                             value=3.0)
             paddle.histogram(input=input_value, bins=1, min=-np.inf, max=5)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.run_network(net_func)
 
     def test_type_errors(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

Add strongly typed functions to set attributes to avoid unexpected type conversions.

Paddle's API to construct Operator has an effect of building an OpDesc. During the contruction of an OpDesc, various attributes are stored in the OpDesc via a function `SetAttr`, this function is bound to python via pybind11. However, it has an parameter with Attr, which is a variant representing sevral possible types in paddle as operator attributes.

https://github.com/PaddlePaddle/Paddle/blob/34234282a65eab864460a476c9380f1d22fa4126/paddle/fluid/framework/op_desc.cc#L620
https://github.com/PaddlePaddle/Paddle/blob/34234282a65eab864460a476c9380f1d22fa4126/paddle/fluid/pybind/protobuf.cc#L361

It is okay to do so inside a single language, but between python and c++, there may be some unexpected type conversions. According to pybind11, type conversions for builtin primitive types like int, float from python to c++ may be a bit strange, because python types and c++ types do not have a one-to-one mapping. There is no straight way to bring python variable as-is to c++.

https://pybind11.readthedocs.io/en/stable/advanced/functions.html#overload-resolution-order
https://pybind11.readthedocs.io/en/stable/advanced/cast/stl.html#c-17-library-containers

Also, python does not natively handle overloaded function. Variant parameter in c++ functions bound to python has a similar effect as overload resolution. The argument is matched against each types in the variant from begining to end, once it is compatible with a type, the argument is converted to that type withou considering types after that. As a result, it adds extra semantics in the ordering of the types in a variant. It may not be a good idea to bind function with variant as parameters to python.

So we explicitly define several functions for different types to avoid unexpected type conversions. This will allow us to add double, complex, and vector of complex as possible attribute types.


