### PR TITLE
[Eager] forward_only interface add dygraph forward function

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/CMakeLists.txt
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/CMakeLists.txt
@@ -38,7 +38,7 @@ add_custom_target(
   COMMAND
     "${PYTHON_EXECUTABLE}"
     "${PADDLE_SOURCE_DIR}/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py"
-    "--api_yaml_path=${api_yaml_path}"
+    "--api_yaml_path=${api_yaml_path},${fwd_api_yaml_path}"
     "--backward_yaml_path=${backward_yaml_path}"
     "--forwards_cc_path=${tmp_forwards_cc_path}"
     "--forwards_h_path=${tmp_forwards_h_path}"

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
@@ -18,6 +18,13 @@ import re
 import argparse
 import os
 
+import sys
+# sys.path.append('../../../phi/api/yaml/generator/')
+# from api_gen import ForwardAPI
+# from paddle.phi.api.yaml.generator.api_gen import *
+# paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
+# paddle/phi/api/yaml/generator/api_gen.py##
+# /home/develop/dev_tmp5/Paddle/paddle/phi/api/yaml/generator/api_gen.py
 ########################
 ### Global Variables ###
 ########################
@@ -352,6 +359,9 @@ class FunctionGeneratorBase:
     def __init__(self, forward_api_contents, namespace):
         self.forward_api_contents = forward_api_contents
         self.namespace = namespace
+
+        self.is_forward_only = False if 'backward' in forward_api_contents.keys(
+        ) else True
 
         self.forward_api_name = ""
 

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
@@ -18,13 +18,6 @@ import re
 import argparse
 import os
 
-import sys
-# sys.path.append('../../../phi/api/yaml/generator/')
-# from api_gen import ForwardAPI
-# from paddle.phi.api.yaml.generator.api_gen import *
-# paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
-# paddle/phi/api/yaml/generator/api_gen.py##
-# /home/develop/dev_tmp5/Paddle/paddle/phi/api/yaml/generator/api_gen.py
 ########################
 ### Global Variables ###
 ########################

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/eager_gen.py
@@ -342,6 +342,7 @@ FORWARD_H_FILE_TEMPLATE = \
 #include "paddle/fluid/eager/to_static/run_program_op_func.h"
 #include "paddle/fluid/eager/api/manual/eager_manual/dygraph_forward_api.h"
 
+using CPUPlace = phi::CPUPlace;
 {}
 {}
 """

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
@@ -411,12 +411,12 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         amp_dygraph_function_call_str = ",".join(amp_dygraph_function_call_list)
 
         # Generate Python-C Function Definitions
-        if is_forward_only:
-            fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                "paddle::experimental::", namespace, forward_api_name)
-        else:
-            fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                "::", namespace, GetForwardFunctionName(forward_api_name))
+        # if is_forward_only:
+        #     fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+        #         "paddle::experimental::", namespace, forward_api_name)
+        # else:
+        fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+            "::", namespace, GetForwardFunctionName(forward_api_name))
 
         return_str = "    return ToPyObject(out);"
 
@@ -489,17 +489,17 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             dygraph_function_call_str)
 
         # Generate Python-C Function Definetion
-        if (is_forward_only) and (len(amp_tensors_vector_list) >
-                                  0) and (forward_api_name not in no_amp_list):
-            self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-                forward_api_name, pythonc_record_event_str, forward_api_name,
-                get_eager_tensor_str, parse_attributes_str, set_device_str,
-                amp_dygraph_function_str, return_str)
-        else:
-            self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-                forward_api_name, pythonc_record_event_str, forward_api_name,
-                get_eager_tensor_str, parse_attributes_str, set_device_str,
-                noamp_dygraph_function_str, return_str)
+        # if (len(amp_tensors_vector_list) >
+        #                           0) and (forward_api_name not in no_amp_list):
+        #     self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
+        #         forward_api_name, pythonc_record_event_str, forward_api_name,
+        #         get_eager_tensor_str, parse_attributes_str, set_device_str,
+        #         amp_dygraph_function_str, return_str)
+        # else:
+        self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
+            forward_api_name, pythonc_record_event_str, forward_api_name,
+            get_eager_tensor_str, parse_attributes_str, set_device_str,
+            noamp_dygraph_function_str, return_str)
 
         # Set prefix of forward_api_name to avoid conflicts
         prefix = self.namespace.strip("::")
@@ -513,14 +513,14 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         if forward_inplace_map:
             inplaced_forward_api_name = GetInplacedFunctionName(
                 self.forward_api_name)
-            if is_forward_only:
-                inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                    "paddle::experimental::", namespace,
-                    inplaced_forward_api_name)
-            else:
-                inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-                    "::", namespace,
-                    GetForwardFunctionName(inplaced_forward_api_name))
+            # if is_forward_only:
+            #     inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+            #         "paddle::experimental::", namespace,
+            #         inplaced_forward_api_name)
+            # else:
+            inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
+                "::", namespace,
+                GetForwardFunctionName(inplaced_forward_api_name))
 
             inplace_noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
                 inplaced_fwd_function_name, dygraph_function_call_str,
@@ -542,19 +542,19 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             return_str += "    return ToPyObject(out, args, inplace_var_idx_map);"
 
             # Generate Python-C Function Definetion
-            if (is_forward_only) and (len(amp_tensors_vector_list) > 0) and (
-                    inplaced_forward_api_name not in no_amp_list):
-                python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-                    inplaced_forward_api_name, pythonc_record_event_str,
-                    inplaced_forward_api_name, get_eager_tensor_str,
-                    parse_attributes_str, set_device_str,
-                    inplace_amp_dygraph_function_str, return_str)
-            else:
-                python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-                    inplaced_forward_api_name, pythonc_record_event_str,
-                    inplaced_forward_api_name, get_eager_tensor_str,
-                    parse_attributes_str, set_device_str,
-                    inplace_noamp_dygraph_function_str, return_str)
+            # if (len(amp_tensors_vector_list) > 0) and (
+            #         inplaced_forward_api_name not in no_amp_list):
+            #     python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
+            #         inplaced_forward_api_name, pythonc_record_event_str,
+            #         inplaced_forward_api_name, get_eager_tensor_str,
+            #         parse_attributes_str, set_device_str,
+            #         inplace_amp_dygraph_function_str, return_str)
+            # else:
+            python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
+                inplaced_forward_api_name, pythonc_record_event_str,
+                inplaced_forward_api_name, get_eager_tensor_str,
+                parse_attributes_str, set_device_str,
+                inplace_noamp_dygraph_function_str, return_str)
 
             python_c_inplace_func_reg_str = PYTHON_C_FUNCTION_REG_TEMPLATE.format(
                 forward_api_name_prefix, inplaced_forward_api_name, namespace,

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
@@ -411,10 +411,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         amp_dygraph_function_call_str = ",".join(amp_dygraph_function_call_list)
 
         # Generate Python-C Function Definitions
-        # if is_forward_only:
-        #     fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-        #         "paddle::experimental::", namespace, forward_api_name)
-        # else:
         fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
             "::", namespace, GetForwardFunctionName(forward_api_name))
 
@@ -489,13 +485,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             dygraph_function_call_str)
 
         # Generate Python-C Function Definetion
-        # if (len(amp_tensors_vector_list) >
-        #                           0) and (forward_api_name not in no_amp_list):
-        #     self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-        #         forward_api_name, pythonc_record_event_str, forward_api_name,
-        #         get_eager_tensor_str, parse_attributes_str, set_device_str,
-        #         amp_dygraph_function_str, return_str)
-        # else:
         self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
             forward_api_name, pythonc_record_event_str, forward_api_name,
             get_eager_tensor_str, parse_attributes_str, set_device_str,
@@ -513,11 +502,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         if forward_inplace_map:
             inplaced_forward_api_name = GetInplacedFunctionName(
                 self.forward_api_name)
-            # if is_forward_only:
-            #     inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
-            #         "paddle::experimental::", namespace,
-            #         inplaced_forward_api_name)
-            # else:
             inplaced_fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
                 "::", namespace,
                 GetForwardFunctionName(inplaced_forward_api_name))
@@ -542,14 +526,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             return_str += "    return ToPyObject(out, args, inplace_var_idx_map);"
 
             # Generate Python-C Function Definetion
-            # if (len(amp_tensors_vector_list) > 0) and (
-            #         inplaced_forward_api_name not in no_amp_list):
-            #     python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
-            #         inplaced_forward_api_name, pythonc_record_event_str,
-            #         inplaced_forward_api_name, get_eager_tensor_str,
-            #         parse_attributes_str, set_device_str,
-            #         inplace_amp_dygraph_function_str, return_str)
-            # else:
             python_c_inplace_func_str = PYTHON_C_FUNCTION_TEMPLATE.format(
                 inplaced_forward_api_name, pythonc_record_event_str,
                 inplaced_forward_api_name, get_eager_tensor_str,

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
@@ -53,17 +53,17 @@ atype_to_parsing_function = {
 
 # This list contains ops that do not need to generate amp logic
 # All optimizer ops in this list
-no_amp_list = [
-    'adam_', 'adam', 'adamw_', 'adamw', 'average_accumulates',
-    'average_accumulates_', 'decayed_adagrad_', 'decayed_adagrad',
-    'dgc_momentum_', 'dgc_momentum', 'distributed_fused_lamb_',
-    'distributed_fused_lamb', 'dpsgd_', 'dpsgd', 'ftrl_', 'ftrl', 'lamb_',
-    'lamb', 'lars_momentum_', 'lars_momentum', 'merged_adam_', 'merged_adam',
-    'merged_momentum_', 'merged_momentum', 'momentum_', 'momentum',
-    'proximal_adagrad_', 'proximal_adagrad', 'proximal_gd_', 'proximal_gd',
-    'rmsprop_', 'rmsprop', 'sgd_', 'sgd', 'lamb_', 'lamb', 'assign_value_',
-    'sparse_momentum_', 'sparse_momentum', 'full_'
-]
+# no_amp_list = [
+#     'adam_', 'adam', 'adamw_', 'adamw', 'average_accumulates',
+#     'average_accumulates_', 'decayed_adagrad_', 'decayed_adagrad',
+#     'dgc_momentum_', 'dgc_momentum', 'distributed_fused_lamb_',
+#     'distributed_fused_lamb', 'dpsgd_', 'dpsgd', 'ftrl_', 'ftrl', 'lamb_',
+#     'lamb', 'lars_momentum_', 'lars_momentum', 'merged_adam_', 'merged_adam',
+#     'merged_momentum_', 'merged_momentum', 'momentum_', 'momentum',
+#     'proximal_adagrad_', 'proximal_adagrad', 'proximal_gd_', 'proximal_gd',
+#     'rmsprop_', 'rmsprop', 'sgd_', 'sgd', 'lamb_', 'lamb', 'assign_value_',
+#     'sparse_momentum_', 'sparse_momentum', 'full_'
+# ]
 
 
 def FindParsingFunctionFromAttributeType(atype):
@@ -131,41 +131,41 @@ static PyObject * eager_final_state_api_{}(PyObject *self, PyObject *args, PyObj
 
 NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) out = {}({});\n"
 
-AMP_DYGRAPH_FUNCTION_TEMPLATE = \
-"""
-    decltype({}({})) out;
-    // AMP Logic
-    if (egr::Controller::Instance().GetAMPLevel() != paddle::imperative::AmpLevel::O0) {{
-        VLOG(5) << "Check and Prepare For AMP";
-        {}
-        paddle::small_vector<std::vector<paddle::experimental::Tensor>, egr::kSlotSmallVectorSize> amp_tensors_vector = {};
-        {}
-        {}
-        {}
-        out = {}({});
-    }} else {{
-        out = {}({});
-    }}
-"""
+# AMP_DYGRAPH_FUNCTION_TEMPLATE = \
+# """
+#     decltype({}({})) out;
+#     // AMP Logic
+#     if (egr::Controller::Instance().GetAMPLevel() != paddle::imperative::AmpLevel::O0) {{
+#         VLOG(5) << "Check and Prepare For AMP";
+#         {}
+#         paddle::small_vector<std::vector<paddle::experimental::Tensor>, egr::kSlotSmallVectorSize> amp_tensors_vector = {};
+#         {}
+#         {}
+#         {}
+#         out = {}({});
+#     }} else {{
+#         out = {}({});
+#     }}
+# """
 
-INPLACE_AMP_DYGRAPH_FUNCTION_TEMPLATE = \
-"""
-    using result_type = decltype({}({}));
-    std::unique_ptr<result_type> out_ptr;
-    // AMP Logic
-    if (egr::Controller::Instance().GetAMPLevel() != paddle::imperative::AmpLevel::O0) {{
-        VLOG(5) << "Check and Prepare For AMP";
-        {}
-        paddle::small_vector<std::vector<paddle::experimental::Tensor>, egr::kSlotSmallVectorSize> amp_tensors_vector = {};
-        {}
-        {}
-        {}
-        out_ptr = std::make_unique<result_type>({}({}));
-    }} else {{
-        out_ptr = std::make_unique<result_type>({}({}));
-    }}
-    result_type& out = *out_ptr;
-"""
+# INPLACE_AMP_DYGRAPH_FUNCTION_TEMPLATE = \
+# """
+#     using result_type = decltype({}({}));
+#     std::unique_ptr<result_type> out_ptr;
+#     // AMP Logic
+#     if (egr::Controller::Instance().GetAMPLevel() != paddle::imperative::AmpLevel::O0) {{
+#         VLOG(5) << "Check and Prepare For AMP";
+#         {}
+#         paddle::small_vector<std::vector<paddle::experimental::Tensor>, egr::kSlotSmallVectorSize> amp_tensors_vector = {};
+#         {}
+#         {}
+#         {}
+#         out_ptr = std::make_unique<result_type>({}({}));
+#     }} else {{
+#         out_ptr = std::make_unique<result_type>({}({}));
+#     }}
+#     result_type& out = *out_ptr;
+# """
 
 FUNCTION_SET_DEVICE_TEMPLATE = \
 """{}    if (paddle::platform::is_gpu_place(place)) {{
@@ -400,15 +400,15 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         num_args = len(
             forward_inputs_position_map.keys()) + len(orig_forward_attrs_list)
         dygraph_function_call_list = ["" for i in range(num_args)]
-        amp_dygraph_function_call_list = ["" for i in range(num_args)]
+        # amp_dygraph_function_call_list = ["" for i in range(num_args)]
         for name, (_, pos) in forward_inputs_position_map.items():
             dygraph_function_call_list[pos] = f"{name}"
-            amp_dygraph_function_call_list[pos] = f"NEW_{name}"
+            # amp_dygraph_function_call_list[pos] = f"NEW_{name}"
         for name, _, _, pos in orig_forward_attrs_list:
             dygraph_function_call_list[pos] = f"{name}"
-            amp_dygraph_function_call_list[pos] = f"{name}"
+            # amp_dygraph_function_call_list[pos] = f"{name}"
         dygraph_function_call_str = ",".join(dygraph_function_call_list)
-        amp_dygraph_function_call_str = ",".join(amp_dygraph_function_call_list)
+        # amp_dygraph_function_call_str = ",".join(amp_dygraph_function_call_list)
 
         # Generate Python-C Function Definitions
         fwd_function_name = FUNCTION_NAME_TEMPLATE.format(
@@ -421,68 +421,68 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             "pythonc_record_event", forward_api_name, "pybind_imperative_func")
 
         # Forward amp logic
-        amp_tensors_vector_list = []
-        amp_tensors_vector_optional_list = []
-        amp_autocast_list = []
-        amp_autocast_optional_list = []
+        # amp_tensors_vector_list = []
+        # amp_tensors_vector_optional_list = []
+        # amp_autocast_list = []
+        # amp_autocast_optional_list = []
 
-        for name, (ttype, pos) in forward_inputs_position_map.items():
-            is_optional = (name in optional_inputs)
-            if IsVectorTensorType(ttype):
-                if is_optional:
-                    amp_tensors_vector_optional_list.append(
-                        f"if ({name}.is_initialized()) amp_tensors_vector.push_back({name}.get());\n"
-                    )
-                    amp_autocast_optional_list.append(
-                        f"auto NEW_{name} = {name}.is_initialized() ? egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false) : {name};\n"
-                    )
-                else:
-                    amp_tensors_vector_list.append(f"{name}")
-                    amp_autocast_list.append(
-                        f"auto NEW_{name} = egr::EagerAmpAutoCasts(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
-                    )
-            else:
-                if is_optional:
-                    amp_tensors_vector_optional_list.append(
-                        f"if ({name}.is_initialized()) amp_tensors_vector.push_back({{{name}.get()}});\n"
-                    )
-                    amp_autocast_optional_list.append(
-                        f"auto NEW_{name} = {name}.is_initialized() ? egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false) : {name};\n"
-                    )
-                else:
-                    if forward_inplace_map and name in forward_inplace_map.keys(
-                    ):
-                        amp_tensors_vector_list.append(f"{{{name}}}")
-                        amp_autocast_list.append(
-                            f"auto NEW_{name} = egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
-                        )
-                    else:
-                        amp_tensors_vector_list.append(f"{{{name}}}")
-                        amp_autocast_list.append(
-                            f"auto NEW_{name} = egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
-                        )
-        amp_tensors_vector_list_str = "{ " + ",".join(
-            amp_tensors_vector_list) + " }"
-        amp_tensors_vector_optional_list_str = "".join(
-            amp_tensors_vector_optional_list)
-        amp_autocast_list_str = "    ".join(
-            amp_autocast_list) + "        " + "    ".join(
-                amp_autocast_optional_list)
+        # for name, (ttype, pos) in forward_inputs_position_map.items():
+        #     is_optional = (name in optional_inputs)
+        #     if IsVectorTensorType(ttype):
+        #         if is_optional:
+        #             amp_tensors_vector_optional_list.append(
+        #                 f"if ({name}.is_initialized()) amp_tensors_vector.push_back({name}.get());\n"
+        #             )
+        #             amp_autocast_optional_list.append(
+        #                 f"auto NEW_{name} = {name}.is_initialized() ? egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false) : {name};\n"
+        #             )
+        #         else:
+        #             amp_tensors_vector_list.append(f"{name}")
+        #             amp_autocast_list.append(
+        #                 f"auto NEW_{name} = egr::EagerAmpAutoCasts(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
+        #             )
+        #     else:
+        #         if is_optional:
+        #             amp_tensors_vector_optional_list.append(
+        #                 f"if ({name}.is_initialized()) amp_tensors_vector.push_back({{{name}.get()}});\n"
+        #             )
+        #             amp_autocast_optional_list.append(
+        #                 f"auto NEW_{name} = {name}.is_initialized() ? egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false) : {name};\n"
+        #             )
+        #         else:
+        #             if forward_inplace_map and name in forward_inplace_map.keys(
+        #             ):
+        #                 amp_tensors_vector_list.append(f"{{{name}}}")
+        #                 amp_autocast_list.append(
+        #                     f"auto NEW_{name} = egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
+        #                 )
+        #             else:
+        #                 amp_tensors_vector_list.append(f"{{{name}}}")
+        #                 amp_autocast_list.append(
+        #                     f"auto NEW_{name} = egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
+        #                 )
+        # amp_tensors_vector_list_str = "{ " + ",".join(
+        #     amp_tensors_vector_list) + " }"
+        # amp_tensors_vector_optional_list_str = "".join(
+        #     amp_tensors_vector_optional_list)
+        # amp_autocast_list_str = "    ".join(
+        #     amp_autocast_list) + "        " + "    ".join(
+        #         amp_autocast_optional_list)
 
-        kernel_trans2_op_name_str = f"auto op_name = phi::TransToFluidOpName(\"{forward_api_name}\");"
-        amp_get_dst_dtype_str = f"auto amp_dst_dtype = egr::GetAmpDestDtype(op_name, amp_tensors_vector);\n"
+        # kernel_trans2_op_name_str = f"auto op_name = phi::TransToFluidOpName(\"{forward_api_name}\");"
+        # amp_get_dst_dtype_str = f"auto amp_dst_dtype = egr::GetAmpDestDtype(op_name, amp_tensors_vector);\n"
 
         noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
             fwd_function_name, dygraph_function_call_str, fwd_function_name,
             dygraph_function_call_str)
 
-        amp_dygraph_function_str = AMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-            fwd_function_name, dygraph_function_call_str,
-            kernel_trans2_op_name_str, amp_tensors_vector_list_str,
-            amp_tensors_vector_optional_list_str, amp_get_dst_dtype_str,
-            amp_autocast_list_str, fwd_function_name,
-            amp_dygraph_function_call_str, fwd_function_name,
-            dygraph_function_call_str)
+        # amp_dygraph_function_str = AMP_DYGRAPH_FUNCTION_TEMPLATE.format(
+        #     fwd_function_name, dygraph_function_call_str,
+        #     kernel_trans2_op_name_str, amp_tensors_vector_list_str,
+        #     amp_tensors_vector_optional_list_str, amp_get_dst_dtype_str,
+        #     amp_autocast_list_str, fwd_function_name,
+        #     amp_dygraph_function_call_str, fwd_function_name,
+        #     dygraph_function_call_str)
 
         # Generate Python-C Function Definetion
         self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
@@ -510,13 +510,13 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
                 inplaced_fwd_function_name, dygraph_function_call_str,
                 inplaced_fwd_function_name, dygraph_function_call_str)
 
-            inplace_amp_dygraph_function_str = INPLACE_AMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-                inplaced_fwd_function_name, dygraph_function_call_str,
-                kernel_trans2_op_name_str, amp_tensors_vector_list_str,
-                amp_tensors_vector_optional_list_str, amp_get_dst_dtype_str,
-                amp_autocast_list_str, inplaced_fwd_function_name,
-                amp_dygraph_function_call_str, inplaced_fwd_function_name,
-                dygraph_function_call_str)
+            # inplace_amp_dygraph_function_str = INPLACE_AMP_DYGRAPH_FUNCTION_TEMPLATE.format(
+            #     inplaced_fwd_function_name, dygraph_function_call_str,
+            #     kernel_trans2_op_name_str, amp_tensors_vector_list_str,
+            #     amp_tensors_vector_optional_list_str, amp_get_dst_dtype_str,
+            #     amp_autocast_list_str, inplaced_fwd_function_name,
+            #     amp_dygraph_function_call_str, inplaced_fwd_function_name,
+            #     dygraph_function_call_str)
 
             return_str = "    std::map<ssize_t, ssize_t> inplace_var_idx_map;"
             for inplace_input, inplace_output in forward_inplace_map.items():

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
@@ -351,15 +351,11 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         num_args = len(
             forward_inputs_position_map.keys()) + len(orig_forward_attrs_list)
         dygraph_function_call_list = ["" for i in range(num_args)]
-        # amp_dygraph_function_call_list = ["" for i in range(num_args)]
         for name, (_, pos) in forward_inputs_position_map.items():
             dygraph_function_call_list[pos] = f"{name}"
-            # amp_dygraph_function_call_list[pos] = f"NEW_{name}"
         for name, _, _, pos in orig_forward_attrs_list:
             dygraph_function_call_list[pos] = f"{name}"
-            # amp_dygraph_function_call_list[pos] = f"{name}"
         dygraph_function_call_str = ",".join(dygraph_function_call_list)
-        # amp_dygraph_function_call_str = ",".join(amp_dygraph_function_call_list)
 
         # Generate Python-C Function Definitions
         fwd_function_name = FUNCTION_NAME_TEMPLATE.format(

--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/python_c_gen.py
@@ -51,20 +51,6 @@ atype_to_parsing_function = {
     "paddle::experimental::DataType": "CastPyArg2DataType",
 }
 
-# This list contains ops that do not need to generate amp logic
-# All optimizer ops in this list
-# no_amp_list = [
-#     'adam_', 'adam', 'adamw_', 'adamw', 'average_accumulates',
-#     'average_accumulates_', 'decayed_adagrad_', 'decayed_adagrad',
-#     'dgc_momentum_', 'dgc_momentum', 'distributed_fused_lamb_',
-#     'distributed_fused_lamb', 'dpsgd_', 'dpsgd', 'ftrl_', 'ftrl', 'lamb_',
-#     'lamb', 'lars_momentum_', 'lars_momentum', 'merged_adam_', 'merged_adam',
-#     'merged_momentum_', 'merged_momentum', 'momentum_', 'momentum',
-#     'proximal_adagrad_', 'proximal_adagrad', 'proximal_gd_', 'proximal_gd',
-#     'rmsprop_', 'rmsprop', 'sgd_', 'sgd', 'lamb_', 'lamb', 'assign_value_',
-#     'sparse_momentum_', 'sparse_momentum', 'full_'
-# ]
-
 
 def FindParsingFunctionFromAttributeType(atype):
     if atype not in atype_to_parsing_function.keys():
@@ -131,41 +117,6 @@ static PyObject * eager_final_state_api_{}(PyObject *self, PyObject *args, PyObj
 
 NOAMP_DYGRAPH_FUNCTION_TEMPLATE = "decltype({}({})) out = {}({});\n"
 
-# AMP_DYGRAPH_FUNCTION_TEMPLATE = \
-# """
-#     decltype({}({})) out;
-#     // AMP Logic
-#     if (egr::Controller::Instance().GetAMPLevel() != paddle::imperative::AmpLevel::O0) {{
-#         VLOG(5) << "Check and Prepare For AMP";
-#         {}
-#         paddle::small_vector<std::vector<paddle::experimental::Tensor>, egr::kSlotSmallVectorSize> amp_tensors_vector = {};
-#         {}
-#         {}
-#         {}
-#         out = {}({});
-#     }} else {{
-#         out = {}({});
-#     }}
-# """
-
-# INPLACE_AMP_DYGRAPH_FUNCTION_TEMPLATE = \
-# """
-#     using result_type = decltype({}({}));
-#     std::unique_ptr<result_type> out_ptr;
-#     // AMP Logic
-#     if (egr::Controller::Instance().GetAMPLevel() != paddle::imperative::AmpLevel::O0) {{
-#         VLOG(5) << "Check and Prepare For AMP";
-#         {}
-#         paddle::small_vector<std::vector<paddle::experimental::Tensor>, egr::kSlotSmallVectorSize> amp_tensors_vector = {};
-#         {}
-#         {}
-#         {}
-#         out_ptr = std::make_unique<result_type>({}({}));
-#     }} else {{
-#         out_ptr = std::make_unique<result_type>({}({}));
-#     }}
-#     result_type& out = *out_ptr;
-# """
 
 FUNCTION_SET_DEVICE_TEMPLATE = \
 """{}    if (paddle::platform::is_gpu_place(place)) {{
@@ -420,69 +371,9 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
         pythonc_record_event_str = RECORD_EVENT_TEMPLATE.format(
             "pythonc_record_event", forward_api_name, "pybind_imperative_func")
 
-        # Forward amp logic
-        # amp_tensors_vector_list = []
-        # amp_tensors_vector_optional_list = []
-        # amp_autocast_list = []
-        # amp_autocast_optional_list = []
-
-        # for name, (ttype, pos) in forward_inputs_position_map.items():
-        #     is_optional = (name in optional_inputs)
-        #     if IsVectorTensorType(ttype):
-        #         if is_optional:
-        #             amp_tensors_vector_optional_list.append(
-        #                 f"if ({name}.is_initialized()) amp_tensors_vector.push_back({name}.get());\n"
-        #             )
-        #             amp_autocast_optional_list.append(
-        #                 f"auto NEW_{name} = {name}.is_initialized() ? egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false) : {name};\n"
-        #             )
-        #         else:
-        #             amp_tensors_vector_list.append(f"{name}")
-        #             amp_autocast_list.append(
-        #                 f"auto NEW_{name} = egr::EagerAmpAutoCasts(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
-        #             )
-        #     else:
-        #         if is_optional:
-        #             amp_tensors_vector_optional_list.append(
-        #                 f"if ({name}.is_initialized()) amp_tensors_vector.push_back({{{name}.get()}});\n"
-        #             )
-        #             amp_autocast_optional_list.append(
-        #                 f"auto NEW_{name} = {name}.is_initialized() ? egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false) : {name};\n"
-        #             )
-        #         else:
-        #             if forward_inplace_map and name in forward_inplace_map.keys(
-        #             ):
-        #                 amp_tensors_vector_list.append(f"{{{name}}}")
-        #                 amp_autocast_list.append(
-        #                     f"auto NEW_{name} = egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
-        #                 )
-        #             else:
-        #                 amp_tensors_vector_list.append(f"{{{name}}}")
-        #                 amp_autocast_list.append(
-        #                     f"auto NEW_{name} = egr::EagerAmpAutoCast(\"{name}\", {name}, amp_dst_dtype, op_name, false);\n"
-        #                 )
-        # amp_tensors_vector_list_str = "{ " + ",".join(
-        #     amp_tensors_vector_list) + " }"
-        # amp_tensors_vector_optional_list_str = "".join(
-        #     amp_tensors_vector_optional_list)
-        # amp_autocast_list_str = "    ".join(
-        #     amp_autocast_list) + "        " + "    ".join(
-        #         amp_autocast_optional_list)
-
-        # kernel_trans2_op_name_str = f"auto op_name = phi::TransToFluidOpName(\"{forward_api_name}\");"
-        # amp_get_dst_dtype_str = f"auto amp_dst_dtype = egr::GetAmpDestDtype(op_name, amp_tensors_vector);\n"
-
         noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
             fwd_function_name, dygraph_function_call_str, fwd_function_name,
             dygraph_function_call_str)
-
-        # amp_dygraph_function_str = AMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-        #     fwd_function_name, dygraph_function_call_str,
-        #     kernel_trans2_op_name_str, amp_tensors_vector_list_str,
-        #     amp_tensors_vector_optional_list_str, amp_get_dst_dtype_str,
-        #     amp_autocast_list_str, fwd_function_name,
-        #     amp_dygraph_function_call_str, fwd_function_name,
-        #     dygraph_function_call_str)
 
         # Generate Python-C Function Definetion
         self.python_c_function_str = PYTHON_C_FUNCTION_TEMPLATE.format(
@@ -509,14 +400,6 @@ class PythonCSingleFunctionGenerator(FunctionGeneratorBase):
             inplace_noamp_dygraph_function_str = NOAMP_DYGRAPH_FUNCTION_TEMPLATE.format(
                 inplaced_fwd_function_name, dygraph_function_call_str,
                 inplaced_fwd_function_name, dygraph_function_call_str)
-
-            # inplace_amp_dygraph_function_str = INPLACE_AMP_DYGRAPH_FUNCTION_TEMPLATE.format(
-            #     inplaced_fwd_function_name, dygraph_function_call_str,
-            #     kernel_trans2_op_name_str, amp_tensors_vector_list_str,
-            #     amp_tensors_vector_optional_list_str, amp_get_dst_dtype_str,
-            #     amp_autocast_list_str, inplaced_fwd_function_name,
-            #     amp_dygraph_function_call_str, inplaced_fwd_function_name,
-            #     dygraph_function_call_str)
 
             return_str = "    std::map<ssize_t, ssize_t> inplace_var_idx_map;"
             for inplace_input, inplace_output in forward_inplace_map.items():

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -84,7 +84,9 @@ AutogradMeta* EagerUtils::nullable_autograd_meta(
 AutogradMeta* EagerUtils::nullable_autograd_meta(
     paddle::optional<paddle::experimental::Tensor>* target) {
   if (target != nullptr) {
-    return EagerUtils::nullable_autograd_meta(*(target->get_ptr()));
+    if (target->get_ptr() != nullptr) {
+      return EagerUtils::nullable_autograd_meta(*(target->get_ptr()));
+    }
   }
   return nullptr;
 }

--- a/paddle/fluid/eager/utils.cc
+++ b/paddle/fluid/eager/utils.cc
@@ -81,6 +81,14 @@ AutogradMeta* EagerUtils::nullable_autograd_meta(
   return nullptr;
 }
 
+AutogradMeta* EagerUtils::nullable_autograd_meta(
+    paddle::optional<paddle::experimental::Tensor>* target) {
+  if (target != nullptr) {
+    return EagerUtils::nullable_autograd_meta(*(target->get_ptr()));
+  }
+  return nullptr;
+}
+
 std::vector<AutogradMeta*> EagerUtils::nullable_autograd_meta(
     const std::vector<paddle::experimental::Tensor>& targets) {
   std::vector<AutogradMeta*> metas;

--- a/paddle/fluid/eager/utils.h
+++ b/paddle/fluid/eager/utils.h
@@ -125,6 +125,8 @@ class EagerUtils {
       const paddle::experimental::Tensor& target);
   static AutogradMeta* nullable_autograd_meta(
       const paddle::optional<paddle::experimental::Tensor>& target);
+  static AutogradMeta* nullable_autograd_meta(
+      paddle::optional<paddle::experimental::Tensor>* target);
   static std::vector<AutogradMeta*> nullable_autograd_meta(
       const std::vector<paddle::experimental::Tensor>& targets);
   static std::vector<AutogradMeta*> nullable_autograd_meta(

--- a/paddle/phi/api/yaml/api.yaml
+++ b/paddle/phi/api/yaml/api.yaml
@@ -9,7 +9,7 @@
 
 - api : bernoulli
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : UnchangedInferMeta
   kernel :

--- a/paddle/phi/api/yaml/legacy_api.yaml
+++ b/paddle/phi/api/yaml/legacy_api.yaml
@@ -179,7 +179,7 @@
 
 - api : arange
   args : (Tensor start, Tensor end, Tensor step, DataType dtype, Place place={})
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ArangeInferMeta
     param : [start, end, step]
@@ -194,7 +194,7 @@
 # arg_max
 - api : argmax
   args : (Tensor x, int64_t axis, bool keepdims, bool flatten, int dtype)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ArgMinMaxInferMeta
   kernel :
@@ -203,7 +203,7 @@
 # arg_min
 - api : argmin
   args : (Tensor x, int64_t axis, bool keepdims, bool flatten, int dtype)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ArgMinMaxInferMeta
   kernel :
@@ -361,7 +361,7 @@
 # bitwise_and
 - api : bitwise_and
   args : (Tensor x, Tensor y)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ElementwiseInferMeta
   kernel :
@@ -370,7 +370,7 @@
 # bitwise_not
 - api : bitwise_not
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : UnchangedInferMeta
   kernel :
@@ -379,7 +379,7 @@
 # bitwise_or
 - api : bitwise_or
   args : (Tensor x, Tensor y)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ElementwiseInferMeta
   kernel :
@@ -388,7 +388,7 @@
 # bitwise_xor
 - api : bitwise_xor
   args : (Tensor x, Tensor y)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ElementwiseInferMeta
   kernel :
@@ -544,7 +544,7 @@
 
 - api : copy_to
   args : (Tensor x, Place place, bool blocking)
-  output : Tensor
+  output : Tensor(out)
   invoke : copy_to_impl(x, place, blocking)
 
 # cos
@@ -659,7 +659,7 @@
 
 - api : diag_embed
   args : (Tensor x, int offset, int dim1, int dim2)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : DiagEmbedInferMeta
   kernel :
@@ -707,7 +707,7 @@
 
 - api : eigvals
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : EigvalsInferMeta
   kernel :
@@ -759,8 +759,8 @@
   backward : embedding_grad
 
 - api : empty
-  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
-  output: Tensor
+  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  output: Tensor(out)
   infer_meta :
     func : CreateInferMeta
     param : [shape, dtype]
@@ -772,7 +772,7 @@
 
 - api : empty_like
   args : (Tensor x, DataType dtype = DataType::UNDEFINED, Place place = {})
-  output: Tensor
+  output: Tensor(out)
   infer_meta :
     func : CreateLikeInferMeta
     param : [x, dtype]
@@ -784,7 +784,7 @@
 
 - api : equal
   args : (Tensor x, Tensor y, int axis = -1)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : CompareInferMeta
   kernel :
@@ -792,7 +792,7 @@
 
 - api : equal_all
   args : (Tensor x, Tensor y)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : CompareAllInferMeta
   kernel :
@@ -972,8 +972,8 @@
   backward : frobenius_norm_grad
 
 - api : full
-  args : (IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
-  output: Tensor
+  args : (IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  output: Tensor(out)
   infer_meta :
     func : CreateInferMeta
     param : [shape, dtype]
@@ -985,7 +985,7 @@
 
 # full
 - api : full_
-  args : (Tensor output, IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
+  args : (Tensor output, IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
   output : Tensor(out)
   inplace : (output -> out)
   infer_meta :
@@ -998,8 +998,8 @@
     backend : place
 
 - api : full_batch_size_like
-  args : (Tensor input, int[] shape, DataType dtype, Scalar value, int input_dim_idx, int output_dim_idx, Place place=CPUPlace())
-  output: Tensor
+  args : (Tensor input, int[] shape, DataType dtype, Scalar value, int input_dim_idx, int output_dim_idx, Place place=phi::CPUPlace())
+  output: Tensor(out)
   infer_meta :
     func : FullBatchSizeLikeInferMeta
     param : [input, shape, value, dtype, input_dim_idx, output_dim_idx]
@@ -1011,7 +1011,7 @@
 
 - api : full_like
   args : (Tensor x, Scalar value, DataType dtype = DataType::UNDEFINED, Place place = {})
-  output: Tensor
+  output: Tensor(out)
   infer_meta :
     func : CreateLikeInferMeta
     param : [x, dtype]
@@ -1045,7 +1045,7 @@
 
 - api : gather_tree
   args : (Tensor ids, Tensor parents)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : GatherTreeMeta
   kernel :
@@ -1053,7 +1053,7 @@
 
 - api : gaussian_random
   args : (IntArray shape, float mean, float std, int seed, DataType dtype, Place place={})
-  output: Tensor
+  output: Tensor(out)
   infer_meta :
     func : GaussianRandomInferMeta
     param : [shape, mean, std, seed, dtype]
@@ -1094,7 +1094,7 @@
 
 - api : greater_equal
   args : (Tensor x, Tensor y, int axis = -1)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : CompareInferMeta
   kernel :
@@ -1102,7 +1102,7 @@
 
 - api : greater_than
   args : (Tensor x, Tensor y, int axis = -1)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : CompareInferMeta
   kernel :
@@ -1187,7 +1187,7 @@
 # histogram
 - api : histogram
   args : (Tensor x, int64_t bins, int min, int max)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : HistogramInferMeta
   kernel :
@@ -1214,7 +1214,7 @@
 # increment
 - api : increment
   args : (Tensor x, float value)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : IncrementInferMeta
   kernel :
@@ -1264,7 +1264,7 @@
 # is_empty
 - api : is_empty
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : IsEmptyInferMeta
   kernel :
@@ -1282,7 +1282,7 @@
 # isfinite
 - api : isfinite
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : IsfiniteInferMeta
   kernel :
@@ -1292,7 +1292,7 @@
 # isinf
 - api : isinf
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : IsfiniteInferMeta
   kernel :
@@ -1302,7 +1302,7 @@
 # isnan
 - api : isnan
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : IsfiniteInferMeta
   kernel :
@@ -1395,7 +1395,7 @@
 
 - api : less_equal
   args : (Tensor x, Tensor y, int axis = -1)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : CompareInferMeta
   kernel :
@@ -1403,7 +1403,7 @@
 
 - api : less_than
   args : (Tensor x, Tensor y, int axis = -1)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : CompareInferMeta
   kernel :
@@ -1411,7 +1411,7 @@
 
 - api : linspace
   args : (Tensor start, Tensor stop, Tensor number, DataType dtype)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : LinspaceInferMeta
   kernel :
@@ -1485,7 +1485,7 @@
 # logical_and
 - api : logical_and
   args : (Tensor x, Tensor y)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ElementwiseInferMeta
   kernel :
@@ -1494,7 +1494,7 @@
 # logical_not
 - api : logical_not
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : UnchangedInferMeta
   kernel :
@@ -1503,7 +1503,7 @@
 # logical_or
 - api : logical_or
   args : (Tensor x, Tensor y)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ElementwiseInferMeta
   kernel :
@@ -1512,7 +1512,7 @@
 # logical_xor
 - api : logical_xor
   args : (Tensor x, Tensor y)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ElementwiseInferMeta
   kernel :
@@ -1787,7 +1787,7 @@
 # multinomial
 - api : multinomial
   args : (Tensor x, int num_samples, bool replacement)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : MultinomialInferMeta
   kernel :
@@ -1844,7 +1844,7 @@
 
 - api : not_equal
   args : (Tensor x, Tensor y, int axis = -1)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : CompareInferMeta
   kernel :
@@ -1852,20 +1852,20 @@
 
 - api : one_hot
   args : (Tensor x, Scalar(int) num_classes)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : OneHotInferMeta
   kernel :
     func : one_hot
 
 - api : ones
-  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
-  output : Tensor
+  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  output : Tensor(out)
   invoke : full(shape, 1, dtype, place)
 
 - api : ones_like
   args : (Tensor x, DataType dtype=DataType::UNDEFINED, Place place={})
-  output : Tensor
+  output : Tensor(out)
   invoke : full_like(x, 1, dtype, place)
 
 - api : p_norm
@@ -2010,7 +2010,7 @@
 
 - api : randperm
   args : (int n, DataType dtype, Place place={})
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : RandpermInferMeta
     param : [n, dtype]
@@ -2271,7 +2271,7 @@
 
 - api : shape
   args : (Tensor input)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ShapeInferMeta
   kernel :
@@ -2283,7 +2283,7 @@
 # shard_index
 - api : shard_index
   args : (Tensor in, int index_num, int nshards, int shard_id, int ignore_value)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : ShardIndexInferMeta
   kernel :
@@ -2311,7 +2311,7 @@
 
 - api : sign
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : UnchangedInferMeta
   kernel :
@@ -2350,7 +2350,7 @@
 # size
 - api : size
   args : (Tensor x)
-  output : Tensor
+  output : Tensor(size)
   infer_meta :
     func : SizeInferMeta
   kernel :
@@ -2664,7 +2664,7 @@
 # python API: paddle.nn.initializer.TruncatedNormal
 - api : truncated_gaussian_random
   args : (int[] shape, float mean, float std, int seed, DataType dtype=DataType::FLOAT32, Place place={})
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : TruncatedGaussianRandomInferMeta
     param : [shape, mean, std, seed, dtype]
@@ -2779,7 +2779,7 @@
 # where_index
 - api : where_index
   args : (Tensor condition)
-  output : Tensor
+  output : Tensor(out)
   infer_meta :
     func : WhereIndexInferMeta
   kernel :
@@ -2808,13 +2808,13 @@
   backward : yolov3_loss_grad
 
 - api : zeros
-  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
-  output : Tensor
+  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  output : Tensor(out)
   invoke : full(shape, 0, dtype, place)
 
 - api : zeros_like
   args : (Tensor x, DataType dtype=DataType::UNDEFINED, Place place = {})
-  output : Tensor
+  output : Tensor(out)
   invoke : full_like(x, 0, dtype, place)
 
 - api: broadcast_tensors
@@ -2829,7 +2829,7 @@
 # dirichlet
 - api: dirichlet
   args: (Tensor alpha)
-  output: Tensor
+  output: Tensor(out)
   infer_meta:
     func: DirichletInferMeta
   kernel:

--- a/paddle/phi/api/yaml/legacy_api.yaml
+++ b/paddle/phi/api/yaml/legacy_api.yaml
@@ -759,7 +759,7 @@
   backward : embedding_grad
 
 - api : empty
-  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
   output: Tensor(out)
   infer_meta :
     func : CreateInferMeta
@@ -972,7 +972,7 @@
   backward : frobenius_norm_grad
 
 - api : full
-  args : (IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  args : (IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
   output: Tensor(out)
   infer_meta :
     func : CreateInferMeta
@@ -985,7 +985,7 @@
 
 # full
 - api : full_
-  args : (Tensor output, IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  args : (Tensor output, IntArray shape, Scalar value, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
   output : Tensor(out)
   inplace : (output -> out)
   infer_meta :
@@ -998,7 +998,7 @@
     backend : place
 
 - api : full_batch_size_like
-  args : (Tensor input, int[] shape, DataType dtype, Scalar value, int input_dim_idx, int output_dim_idx, Place place=phi::CPUPlace())
+  args : (Tensor input, int[] shape, DataType dtype, Scalar value, int input_dim_idx, int output_dim_idx, Place place=CPUPlace())
   output: Tensor(out)
   infer_meta :
     func : FullBatchSizeLikeInferMeta
@@ -1859,7 +1859,7 @@
     func : one_hot
 
 - api : ones
-  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
   output : Tensor(out)
   invoke : full(shape, 1, dtype, place)
 
@@ -2808,7 +2808,7 @@
   backward : yolov3_loss_grad
 
 - api : zeros
-  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=phi::CPUPlace())
+  args : (IntArray shape, DataType dtype=DataType::FLOAT32, Place place=CPUPlace())
   output : Tensor(out)
   invoke : full(shape, 0, dtype, place)
 

--- a/paddle/phi/api/yaml/strings_api.yaml
+++ b/paddle/phi/api/yaml/strings_api.yaml
@@ -1,5 +1,5 @@
 - api : empty
-  args : (IntArray shape, Place place=CPUPlace())
+  args : (IntArray shape, Place place=phi::CPUPlace())
   output : Tensor(out@StringTensor)
   infer_meta :
     func : strings::CreateInferMeta

--- a/python/paddle/fluid/tests/unittests/test_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_slice_op.py
@@ -638,6 +638,7 @@ class TestSliceApiEager(unittest.TestCase):
                 np.testing.assert_array_equal(a_1.numpy(), a_2.numpy())
                 a_1.backward()
                 grad_truth = paddle.zeros_like(a)
+                grad_truth.stop_gradient = True
                 grad_truth[-3:3, 0:2, 2:4] = 1
                 np.testing.assert_array_equal(grad_truth, a.gradient())
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
本 PR 主要做以下几件事：
1. 原 forward-only 的 python-c 接口的 amp 逻辑移除（相关 no_amp_list 等逻辑迁移到 eager_gen.py）
2. 原 forward-only 的算子，除了 python-c 层有接口，另在 dygraph function 层增加对应接口(包括原本在 python-c层的 amp 逻辑)
3. forward-only 在 dygraph function 层增加的接口，不需要获取 input/output meta，不需要 compute_require_grad，不需要 pass_stop_gradient 等操作，即不需要传递输入 tensor 的 stop_gradient 属性给输出。