### PR TITLE
Update FLAGS for standalone executor

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1274,11 +1274,13 @@ class Executor(object):
                 #  [-0.44514108 -0.2345845 ]]
 
         """
-        # Temporary FLAGS, just for test the performance of program cache
+        # Temporary FLAGS, just for testing the performance of program cache
         force_use_program_cache = os.environ.get(
             'FLAGS_FORCE_USE_PROGRAM_CACHE', None)
         if force_use_program_cache is not None:
-            use_program_cache = force_use_program_cache
+            use_program_cache = force_use_program_cache in [
+                1, '1', True, 'True', 'true'
+            ]
             warnings.warn(
                 f"use_program_cache is force set to {use_program_cache} by FLAGS_FORCE_USE_PROGRAM_CACHE",
                 UserWarning)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
1. Enable standalone executor for fleet when the FLAGS_CONVERT_GRAPH_TO_PROGRAM is set to true.
2. Add FLAGS_FORCE_USE_PROGRAM_CACHE to force control the program cache for old executor by ENVs, this feature is just for QA testing and will be removed later.
3. Print warnings for the unsupported cases of standalone executor. 