### PR TITLE
【Hackathon No.34】优化 poisson op

### DIFF
--- a/paddle/phi/backends/gpu/gpu_launch_config.h
+++ b/paddle/phi/backends/gpu/gpu_launch_config.h
@@ -229,6 +229,14 @@ inline GpuLaunchConfig GetGpuLaunchConfig3D(const phi::GPUContext& context,
   return config;
 }
 
+template <typename Context>
+void LimitGridDim(const Context& ctx, dim3* grid_dim) {
+  auto max_grid_dim =
+      reinterpret_cast<const phi::GPUContext&>(ctx).GetCUDAMaxGridDimSize();
+  grid_dim->x = grid_dim->x < max_grid_dim[0] ? grid_dim->x : max_grid_dim[0];
+  grid_dim->y = grid_dim->y < max_grid_dim[1] ? grid_dim->y : max_grid_dim[1];
+  grid_dim->z = grid_dim->z < max_grid_dim[2] ? grid_dim->z : max_grid_dim[2];
+}
 }  // namespace gpu
 }  // namespace backends
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/poisson_kernel.cu
+++ b/paddle/phi/kernels/gpu/poisson_kernel.cu
@@ -19,18 +19,18 @@ limitations under the License. */
 #include <hiprand_kernel.h>
 #endif
 
+#include "paddle/fluid/platform/device/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
 #include "paddle/phi/kernels/poisson_kernel.h"
-#include "paddle/fluid/platform/device/gpu/gpu_launch_config.h"
 
 namespace phi {
 
 template <typename T>
 __global__ void GetPoisson(
     const T* in, T* out, const int N, unsigned int seed, unsigned int offset) {
-    CUDA_KERNEL_LOOP_TYPE(idx, N, int64_t){
+  CUDA_KERNEL_LOOP_TYPE(idx, N, int64_t) {
 #ifdef __NVCC__
     curandStatePhilox4_32_10_t state;
     curand_init(seed, idx, offset, &state);

--- a/paddle/phi/kernels/gpu/poisson_kernel.cu
+++ b/paddle/phi/kernels/gpu/poisson_kernel.cu
@@ -31,16 +31,16 @@ template <typename T>
 __global__ void GetPoisson(
     const T* in, T* out, const int N, unsigned int seed, unsigned int offset) {
     CUDA_KERNEL_LOOP_TYPE(idx, N, int64_t){
-      #ifdef __NVCC__
-          curandStatePhilox4_32_10_t state;
-          curand_init(seed, idx, offset, &state);
-          out[idx] = static_cast<T>(curand_poisson(&state, in[idx]));
-      #elif __HIPCC__
-          hiprandStatePhilox4_32_10_t state;
-          hiprand_init(seed, idx, offset, &state);
-          out[idx] = static_cast<T>(hiprand_poisson(&state, in[idx]));
-      #endif
-    }
+#ifdef __NVCC__
+    curandStatePhilox4_32_10_t state;
+    curand_init(seed, idx, offset, &state);
+    out[idx] = static_cast<T>(curand_poisson(&state, in[idx]));
+#elif __HIPCC__
+    hiprandStatePhilox4_32_10_t state;
+    hiprand_init(seed, idx, offset, &state);
+    out[idx] = static_cast<T>(hiprand_poisson(&state, in[idx]));
+#endif
+  }
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/gpu/poisson_kernel.cu
+++ b/paddle/phi/kernels/gpu/poisson_kernel.cu
@@ -19,7 +19,7 @@ limitations under the License. */
 #include <hiprand_kernel.h>
 #endif
 
-#include "paddle/fluid/platform/device/gpu/gpu_launch_config.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/for_range.h"

--- a/paddle/phi/kernels/gpu/poisson_kernel.cu
+++ b/paddle/phi/kernels/gpu/poisson_kernel.cu
@@ -53,7 +53,7 @@ void PoissonKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   int block_size = std::min(kMaxBlockDim, ctx.GetMaxThreadsPerBlock());
   dim3 dim_block(block_size);
   dim3 dim_grid((size + block_size - 1) / block_size);
-  paddle::platform::LimitGridDim(ctx, &dim_grid);
+  phi::backends::gpu::LimitGridDim(ctx, &dim_grid);
 
   auto gen_cuda = ctx.GetGenerator();
   auto seed_offset = gen_cuda->IncrementOffset(20);

--- a/paddle/phi/kernels/gpu/poisson_kernel.cu
+++ b/paddle/phi/kernels/gpu/poisson_kernel.cu
@@ -19,8 +19,8 @@ limitations under the License. */
 #include <hiprand_kernel.h>
 #endif
 
-#include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/for_range.h"
 #include "paddle/phi/kernels/poisson_kernel.h"

--- a/paddle/phi/kernels/gpu/poisson_kernel.cu
+++ b/paddle/phi/kernels/gpu/poisson_kernel.cu
@@ -27,13 +27,10 @@ limitations under the License. */
 namespace phi {
 
 template <typename T>
-__global__ void get_poisson(const int N,
-                            const T* in,
-                            T* out,
-                            unsigned int seed,
-                            unsigned int offset) {
+__global__ void get_poisson(
+    const int N, const T* in, T* out, unsigned int seed, unsigned int offset) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx < N){
+  if (idx < N) {
 //
 //    curandStatePhilox4_32_10_t state;
 //    curand_init(seed, idx, offset, &state);
@@ -47,7 +44,6 @@ __global__ void get_poisson(const int N,
     hiprand_init(seed, idx, offset, &state);
     out[idx] = static_cast<T>(hiprand_poisson(&state, in[idx]));
 #endif
-
   }
 }
 
@@ -57,9 +53,7 @@ void PoissonKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   T* out_data = ctx.template Alloc<T>(out);
   const int size = x.numel();
 
-  int block_size =
-      std::min(256, ctx.GetMaxThreadsPerBlock());
-//  int block_size = ;
+  int block_size = std::min(256, ctx.GetMaxThreadsPerBlock());
   dim3 dim_block(block_size);
   dim3 dim_grid((size + block_size - 1) / block_size);
 
@@ -67,8 +61,7 @@ void PoissonKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   auto seed_offset = gen_cuda->IncrementOffset(20);
   uint64_t seed = seed_offset.first;
   uint64_t offset = seed_offset.second;
-  get_poisson<T><<<dim_grid,dim_block>>>(size, x_data, out_data, seed, offset);
-
+  get_poisson<T><<<dim_grid, dim_block>>>(size, x_data, out_data, seed, offset);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/poisson_kernel.cu
+++ b/paddle/phi/kernels/gpu/poisson_kernel.cu
@@ -27,48 +27,48 @@ limitations under the License. */
 namespace phi {
 
 template <typename T>
-struct PoissonCudaFunctor {
- public:
-  PoissonCudaFunctor(const T* in,
-                     T* out,
-                     unsigned int seed,
-                     unsigned int offset)
-      : in_(in), out_(out), seed_(seed), offset_(offset) {}
-
-  __device__ void operator()(int64_t idx) {
+__global__ void get_poisson(const int N,
+                            const T* in,
+                            T* out,
+                            unsigned int seed,
+                            unsigned int offset) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx < N){
+//
+//    curandStatePhilox4_32_10_t state;
+//    curand_init(seed, idx, offset, &state);
+//    out[idx] = curand_poisson(&state, in[idx]);
 #ifdef __NVCC__
     curandStatePhilox4_32_10_t state;
-    curand_init(seed_, idx, offset_, &state);
-    out_[idx] = static_cast<T>(curand_poisson(&state, in_[idx]));
+    curand_init(seed, idx, offset, &state);
+    out[idx] = static_cast<T>(curand_poisson(&state, in[idx]));
 #elif __HIPCC__
     hiprandStatePhilox4_32_10_t state;
-    hiprand_init(seed_, idx, offset_, &state);
-    out_[idx] = static_cast<T>(hiprand_poisson(&state, in_[idx]));
+    hiprand_init(seed, idx, offset, &state);
+    out[idx] = static_cast<T>(hiprand_poisson(&state, in[idx]));
 #endif
-  }
 
- private:
-  const T* in_;
-  T* out_;
-  const unsigned int seed_;
-  const unsigned int offset_;
-};
+  }
+}
 
 template <typename T, typename Context>
 void PoissonKernel(const Context& ctx, const DenseTensor& x, DenseTensor* out) {
   const T* x_data = x.data<T>();
   T* out_data = ctx.template Alloc<T>(out);
-  auto size = x.numel();
+  const int size = x.numel();
+
+  int block_size =
+      std::min(256, ctx.GetMaxThreadsPerBlock());
+//  int block_size = ;
+  dim3 dim_block(block_size);
+  dim3 dim_grid((size + block_size - 1) / block_size);
 
   auto gen_cuda = ctx.GetGenerator();
   auto seed_offset = gen_cuda->IncrementOffset(20);
   uint64_t seed = seed_offset.first;
   uint64_t offset = seed_offset.second;
+  get_poisson<T><<<dim_grid,dim_block>>>(size, x_data, out_data, seed, offset);
 
-  phi::funcs::ForRange<Context> for_range(ctx, size);
-
-  PoissonCudaFunctor<T> functor(x_data, out_data, seed, offset);
-  for_range(functor);
 }
 
 }  // namespace phi


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
OPs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
实验开发环境：
硬件：Tesla-P4
软件环境：CUDA 11.2，CuDNN 8


对于Poisson算子优化方案有以下两种
方案一：通过paddle已实现的gpu_launch_config.h中GetGpuLaunchConfig1D方法获得较优的参数配置。
    性能效果：
        该方案经过测试在float32数据上有5%左右的性能提升，float64数据上有10%左右的性能下降。故不作为首选方案。
Tesla-P4:
        | Case No. | input_shape | data_type | Paddle_modify Perf(s) |Perf_over_paddle_origin(%)|Perf_over_pytorch(%)
|---|---|---|---|---|---|
| 1 | [16, 16, 16, 16] |float32|0.3190 | +8.00|-2.00
| 2 | [16, 35, 1500] |float32| 2.7361|+8.17|-2.34
| 3 | [16, 16, 16, 16] |float64 |0.3261|-13.78|-1.86


Tesla-P40:
        | Case No. | input_shape | data_type | Paddle_modify Perf(s) |Perf_over_paddle_origin(%)|Perf_over_pytorch(%)
|---|---|---|---|---|---|
| 1 | [16, 16, 16, 16] |float32|0.1684| -5.00|+1.00
| 2 | [16, 35, 1500] |float32| 1.3766|+8.74|-1.28
| 3 | [16, 16, 16, 16] |float64 |0.1743|+5.27|-19.1

方案二：通过手动测试在该场景下更优的配置参数，BlockSize性能较优的取值通常为[128, 256,512]。对这三者进行实验并测试性能，结果显示是用一维Grid，且BlockSize=256时，均有大幅性能提升。
    性能效果：

Tesla-P4:
        | Case No. | input_shape | data_type | Paddle_modify Perf(s) |Perf_over_paddle_origin(%)|Perf_over_pytorch(%)
|---|---|---|---|---|---|
| 1 | [16, 16, 16, 16] |float32|0.2205 | +36.62|+29.27
| 2 | [16, 35, 1500] |float32| 2.044|+31.40|+23.54
| 3 | [16, 16, 16, 16] |float64 |0.2159|+24.68|+32.57


Tesla-P40:
        | Case No. | input_shape | data_type | Paddle_modify Perf(s) |Perf_over_paddle_origin(%)|Perf_over_pytorch(%)
|---|---|---|---|---|---|
| 1 | [16, 16, 16, 16] |float32|0.1323 | +17.29|+20.94
| 2 | [16, 35, 1500] |float32| 1.0011|+33.63|+26.34
| 3 | [16, 16, 16, 16] |float64 |0.1324|+28.00|+9.49


根据比较，最终选择方案二。