### PR TITLE
Enable Profiler to add nvtx tag.

### DIFF
--- a/python/paddle/profiler/profiler.py
+++ b/python/paddle/profiler/profiler.py
@@ -403,7 +403,8 @@ class Profiler:
                  on_trace_ready: Optional[Callable[..., Any]] = None,
                  record_shapes: Optional[bool] = False,
                  profile_memory=False,
-                 timer_only: Optional[bool] = False):
+                 timer_only: Optional[bool] = False,
+                 emit_nvtx: Optional[bool] = False):
         supported_targets = _get_supported_targets()
         if targets:
             self.targets = set(targets)
@@ -456,6 +457,7 @@ class Profiler:
         self.timer_only = timer_only
         self.record_shapes = record_shapes
         self.profile_memory = profile_memory
+        self.emit_nvtx = emit_nvtx
 
     def __enter__(self):
         self.start()
@@ -488,6 +490,8 @@ class Profiler:
         '''
         # Timing only without profiling
         benchmark().begin()
+        if not self.timer_only or self.emit_nvtx:
+            utils._is_profiler_used = True
         if self.timer_only:
             return
         if self.record_shapes:
@@ -495,7 +499,6 @@ class Profiler:
         if self.profile_memory:
             enable_memory_recorder()
         # CLOSED -> self.current_state
-        utils._is_profiler_used = True
         if self.current_state == ProfilerState.READY:
             self.profiler.prepare()
         elif self.current_state == ProfilerState.RECORD:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
当使用nsys分析时，自动为各Layer加上nvtx tag，效果如下图：

![image](https://user-images.githubusercontent.com/12538138/184644450-8a11a600-d89a-4131-b009-ec2445d18355.png)


TODO：

<img width="510" alt="image" src="https://user-images.githubusercontent.com/12538138/184787461-12230d65-d430-4d60-80eb-72ce1fa4c427.png">

<img width="668" alt="image" src="https://user-images.githubusercontent.com/12538138/184787483-929f68e2-4295-413c-85e7-930736effe37.png">

1. nvtx的启动和终止函数调用，实现到Profiler的step函数中，由Profiler的schedule统一控制收集区间
2. 补充emit_nvtx的参数文档
