### PR TITLE
Fix squared_l2_norm wrong stream bug

### DIFF
--- a/paddle/fluid/memory/buffer.h
+++ b/paddle/fluid/memory/buffer.h
@@ -50,7 +50,7 @@ class Buffer {
         allocation_ && allocation_->size() > 0 ? allocation_->ptr() : nullptr);
   }
 
-  size_t Size() const { return allocation_ ? 0 : allocation_->size(); }
+  size_t Size() const { return allocation_ ? allocation_->size() : 0; }
 
   platform::Place GetPlace() const { return place_; }
 

--- a/paddle/phi/kernels/funcs/squared_l2_norm.h
+++ b/paddle/phi/kernels/funcs/squared_l2_norm.h
@@ -82,7 +82,8 @@ void SquaredL2Norm(const phi::GPUContext& ctx,
                                                          y,
                                                          numel,
                                                          cub::Sum(),
-                                                         static_cast<T2>(0)));
+                                                         static_cast<T2>(0),
+                                                         stream));
   }
 }
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
The `squared_l2_norm` kernel use the default stream instead of the computational stream. This is a bug that should be fixed.