### PR TITLE
fix bug of external_error.pb.h not found

### DIFF
--- a/paddle/fluid/distributed/auto_parallel/CMakeLists.txt
+++ b/paddle/fluid/distributed/auto_parallel/CMakeLists.txt
@@ -3,21 +3,21 @@ proto_library(auto_parallel_proto SRCS auto_parallel.proto)
 cc_library(
   device_mesh
   SRCS device_mesh.cc
-  DEPS auto_parallel_proto)
+  DEPS auto_parallel_proto phi_enforce)
 
 cc_library(
   process_mesh
   SRCS process_mesh.cc
-  DEPS auto_parallel_proto)
+  DEPS auto_parallel_proto phi_enforce)
 
 cc_library(
   dist_attr
   SRCS dist_attr.cc
-  DEPS process_mesh auto_parallel_proto proto_desc)
+  DEPS process_mesh auto_parallel_proto proto_desc phi_enforce)
 
 cc_library(
   dist_mapper
   SRCS dist_mapper.cc
-  DEPS device_mesh auto_parallel_proto)
+  DEPS device_mesh auto_parallel_proto phi_enforce)
 
 cc_library(auto_parallel DEPS device_mesh process_mesh dist_attr dist_mapper)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix bug of external_error.pb.h not found. device_mesh depends on phi_enforce but not set dependency, so phi_enforce may not compiled when device_mesh is compiling, as a result paddle/fluid/platform/external_error.pb.h has not been generated.
<img width="1320" alt="image" src="https://user-images.githubusercontent.com/51314274/184872618-688b523a-9eb4-4f16-85bd-47c58e727b15.png">
