### PR TITLE
fix multi stream error.

### DIFF
--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h"
+#include <thread>
 
 #include "paddle/fluid/platform/profiler/event_tracing.h"
 
@@ -194,8 +195,9 @@ phi::Allocation* StreamSafeCUDAAllocator::AllocateImpl(size_t size) {
       static_unique_ptr_cast<Allocation>(std::move(underlying_allocation)),
       default_stream_,
       this);
-  VLOG(8) << "Allocate " << allocation->size() << " bytes at address "
-          << allocation->ptr() << "  , stream: " << default_stream_;
+  VLOG(8) << "Thread " << std::this_thread::get_id() << " Allocate "
+          << allocation->size() << " bytes at address " << allocation->ptr()
+          << "  , stream: " << default_stream_;
   return allocation;
 }
 

--- a/paddle/fluid/operators/fc_op.h
+++ b/paddle/fluid/operators/fc_op.h
@@ -69,8 +69,7 @@ class FCOpKernel : public framework::OpKernel<T> {
     auto w_dims = w->dims();
     bool padding_weights = ctx.Attr<bool>("padding_weights");
 
-    auto& device_ctx = ctx.template device_context<DeviceContext>();
-    auto* allocator = const_cast<phi::Allocator*>(&device_ctx.GetAllocator());
+    auto& dev_ctx = ctx.template device_context<DeviceContext>();
 
     std::vector<int64_t> output_dims;
     FCOutputSize(
@@ -85,12 +84,9 @@ class FCOpKernel : public framework::OpKernel<T> {
 
     const T* input_data = input->data<T>();
     const T* w_data = w->data<T>();
-    auto* output_data = reinterpret_cast<T*>(
-        output->AllocateFrom(allocator,
-                             paddle::experimental::CppTypeToDataType<T>::Type(),
-                             output->numel() * sizeof(T)));
+    auto* output_data =
+        dev_ctx.template Alloc<T>(output, output->numel() * sizeof(T));
 
-    auto& dev_ctx = ctx.template device_context<DeviceContext>();
     phi::funcs::FCFunctor<DeviceContext, T> fc;
     fc(dev_ctx,
        M,

--- a/paddle/fluid/operators/fc_op.h
+++ b/paddle/fluid/operators/fc_op.h
@@ -69,6 +69,9 @@ class FCOpKernel : public framework::OpKernel<T> {
     auto w_dims = w->dims();
     bool padding_weights = ctx.Attr<bool>("padding_weights");
 
+    auto& device_ctx = ctx.template device_context<DeviceContext>();
+    auto* allocator = const_cast<phi::Allocator*>(&device_ctx.GetAllocator());
+
     std::vector<int64_t> output_dims;
     FCOutputSize(
         input->dims(), w_dims, output_dims, in_num_col_dims, padding_weights);
@@ -82,7 +85,10 @@ class FCOpKernel : public framework::OpKernel<T> {
 
     const T* input_data = input->data<T>();
     const T* w_data = w->data<T>();
-    T* output_data = output->mutable_data<T>(ctx.GetPlace());
+    auto* output_data = reinterpret_cast<T*>(
+        output->AllocateFrom(allocator,
+                             paddle::experimental::CppTypeToDataType<T>::Type(),
+                             output->numel() * sizeof(T)));
 
     auto& dev_ctx = ctx.template device_context<DeviceContext>();
     phi::funcs::FCFunctor<DeviceContext, T> fc;

--- a/paddle/fluid/operators/fused/multihead_matmul_op.cu
+++ b/paddle/fluid/operators/fused/multihead_matmul_op.cu
@@ -304,7 +304,10 @@ class MultiHeadMatMulV2Kernel : public framework::OpKernel<T> {
     if (!bias_qk) {
       int size = batch * head_number * seq_len * seq_len;
       temp_bias_tensor.Resize({size});
-      auto *temp_qk_bias = temp_bias_tensor.mutable_data<T>(context.GetPlace());
+      auto *temp_qk_bias = reinterpret_cast<T *>(temp_bias_tensor.AllocateFrom(
+          allocator,
+          paddle::experimental::CppTypeToDataType<T>::Type(),
+          temp_bias_tensor.numel() * sizeof(T)));
 #ifdef PADDLE_WITH_HIP
       hipMemset(temp_qk_bias, 0, sizeof(float) * size);
 #else

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -15,8 +15,6 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/op_version_registry.h"
-#include "paddle/phi/common/data_type.h"
-#include "paddle/phi/core/allocator.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
@@ -68,11 +66,8 @@ class MatMulKernel : public framework::OpKernel<T> {
         context.Input<framework::Tensor>("Y"), "Input", "Y", "MatMul");
     auto *out = context.Output<framework::Tensor>("Out");
 
-    auto &device_ctx = context.template device_context<DeviceContext>();
-    auto *allocator = const_cast<phi::Allocator *>(&device_ctx.GetAllocator());
-    out->AllocateFrom(allocator,
-                      paddle::experimental::CppTypeToDataType<T>::Type(),
-                      out->numel() * sizeof(T));
+    auto &dev_ctx = context.template device_context<DeviceContext>();
+    dev_ctx.template Alloc<T>(out, out->numel() * sizeof(T));
 
     auto blas = phi::funcs::GetBlas<DeviceContext, T>(context);
     auto mat_dim_a = phi::funcs::CreateMatrixDescriptor(

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -15,6 +15,8 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/op_version_registry.h"
+#include "paddle/phi/common/data_type.h"
+#include "paddle/phi/core/allocator.h"
 #include "paddle/phi/kernels/funcs/blas/blas.h"
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
@@ -65,7 +67,12 @@ class MatMulKernel : public framework::OpKernel<T> {
     auto &y = GET_DATA_SAFELY(
         context.Input<framework::Tensor>("Y"), "Input", "Y", "MatMul");
     auto *out = context.Output<framework::Tensor>("Out");
-    out->mutable_data<T>(context.GetPlace());
+
+    auto &device_ctx = context.template device_context<DeviceContext>();
+    auto *allocator = const_cast<phi::Allocator *>(&device_ctx.GetAllocator());
+    out->AllocateFrom(allocator,
+                      paddle::experimental::CppTypeToDataType<T>::Type(),
+                      out->numel() * sizeof(T));
 
     auto blas = phi::funcs::GetBlas<DeviceContext, T>(context);
     auto mat_dim_a = phi::funcs::CreateMatrixDescriptor(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
旧算子体系 mutable_data 没有走 stream_safe_allocator，会导致多stream可能出现随机挂的问题，先修复 ernie 模型用到的算子，其余算子后期修复