### PR TITLE
【bugFix】added dtype 'float16' when check_variable_and_dtype the input of softmax_cross_entropy

### DIFF
--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2416,7 +2416,7 @@ def cross_entropy(input,
                 out = paddle.squeeze(out, axis=axis)
             return out
 
-    check_variable_and_dtype(input, 'input', ['float32', 'float64'],
+    check_variable_and_dtype(input, 'input', ['float16', 'float32', 'float64'],
                              'softmax_cross_entropy')
     check_variable_and_dtype(
         label, 'label',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
softmax_cross_entropy will not accept float16 input because of dtype check when it is in static mode.
however float16 is ok in dygraph mode