### PR TITLE
Enable OMP multithreading in lookup_table_v2

### DIFF
--- a/paddle/fluid/operators/lookup_table_v2_op.h
+++ b/paddle/fluid/operators/lookup_table_v2_op.h
@@ -14,7 +14,6 @@ limitations under the License. */
 
 #pragma once
 
-#include <omp.h>
 #include <algorithm>
 #include <string>
 #include <vector>
@@ -43,7 +42,6 @@ static std::vector<OutT> CopyIdsToVector(const Tensor &ids) {
   if (std::is_same<InT, OutT>::value) {
     std::memcpy(ret.data(), src, numel * sizeof(InT));
   } else {
-#pragma omp parallel for
     for (decltype(numel) i = 0; i < numel; ++i) {
       ret[i] = src[i];
     }
@@ -74,7 +72,7 @@ struct LookupTableV2CPUFunctor {
 
       auto *table = table_t.template data<T>();
       auto *output = output_t->template mutable_data<T>(context_.GetPlace());
-#pragma omp parallel for
+
       for (int64_t i = 0; i < ids_numel; ++i) {
         if (padding_idx != kNoPadding && ids[i] == padding_idx) {
           memset(output + i * row_width, 0, row_width * sizeof(T));
@@ -110,7 +108,6 @@ struct LookupTableV2CPUFunctor {
       auto input_data_type =
           framework::TransToProtoVarType(table_t.value().dtype());
 
-#pragma omp parallel for
       for (int64_t i = 0; i < ids_numel; ++i) {
         if (padding_idx != kNoPadding && ids[i] == padding_idx) {
           memset(output + i * row_width, 0, row_width * sizeof(T));
@@ -235,7 +232,6 @@ struct LookupTableV2GradCPUFunctor {
 
       memset(d_table_data, 0, d_table->numel() * sizeof(T));
 
-#pragma omp parallel for
       for (int64_t i = 0; i < ids_num; ++i) {
         if (padding_idx != kNoPadding && ids_data[i] == padding_idx) {
           // the gradient of padding_idx should be 0, already done by memset, so
@@ -259,8 +255,6 @@ struct LookupTableV2GradCPUFunctor {
                   "value.",
                   N,
                   ids_data[i]));
-
-#pragma omp parallel for
           for (int j = 0; j < D; ++j) {
             d_table_data[ids_data[i] * D + j] += d_output_data[i * D + j];
           }

--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -48,8 +48,10 @@ struct EmbeddingCPUFunctor {
     dev_ctx_.template Alloc<T>(out_);
     auto* output = out_->data<T>();
 
+#if defined _OPENMP
 #ifndef PADDLE_WITH_GPU
 #pragma omp parallel for
+#endif
 #endif
     for (int64_t i = 0; i < ids_numel; ++i) {
       if (padding_idx_ != kNoPadding && ids[i] == padding_idx_) {

--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -48,6 +48,7 @@ struct EmbeddingCPUFunctor {
     dev_ctx_.template Alloc<T>(out_);
     auto* output = out_->data<T>();
 
+#pragma omp parallel for
     for (int64_t i = 0; i < ids_numel; ++i) {
       if (padding_idx_ != kNoPadding && ids[i] == padding_idx_) {
         memset(output + i * row_width, 0, row_width * sizeof(T));

--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -48,11 +48,10 @@ struct EmbeddingCPUFunctor {
     dev_ctx_.template Alloc<T>(out_);
     auto* output = out_->data<T>();
 
-#if defined _OPENMP
-#ifndef PADDLE_WITH_CUDA
+#if defined(_OPENMP) && !defined(PADDLE_WITH_CUDA)
 #pragma omp parallel for
 #endif
-#endif
+
     for (int64_t i = 0; i < ids_numel; ++i) {
       if (padding_idx_ != kNoPadding && ids[i] == padding_idx_) {
         memset(output + i * row_width, 0, row_width * sizeof(T));

--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -48,7 +48,9 @@ struct EmbeddingCPUFunctor {
     dev_ctx_.template Alloc<T>(out_);
     auto* output = out_->data<T>();
 
+#if defined _OPENMP
 #pragma omp parallel for
+#endif
     for (int64_t i = 0; i < ids_numel; ++i) {
       if (padding_idx_ != kNoPadding && ids[i] == padding_idx_) {
         memset(output + i * row_width, 0, row_width * sizeof(T));

--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -48,7 +48,7 @@ struct EmbeddingCPUFunctor {
     dev_ctx_.template Alloc<T>(out_);
     auto* output = out_->data<T>();
 
-#if defined _OPENMP
+#ifndef PADDLE_WITH_GPU
 #pragma omp parallel for
 #endif
     for (int64_t i = 0; i < ids_numel; ++i) {

--- a/paddle/phi/kernels/cpu/embedding_kernel.cc
+++ b/paddle/phi/kernels/cpu/embedding_kernel.cc
@@ -49,7 +49,7 @@ struct EmbeddingCPUFunctor {
     auto* output = out_->data<T>();
 
 #if defined _OPENMP
-#ifndef PADDLE_WITH_GPU
+#ifndef PADDLE_WITH_CUDA
 #pragma omp parallel for
 #endif
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
This PR enables OMP multithreading on the lookup_table_v2 operator which makes the operator take less time when running the ernie 3.0 model with more than 1 thread,

The results of the speedup on SPR with FP32 datatype are as follows (Total execution time measured by the Paddle profiler. Before all the times were similar to the 1 thread time):

1 thread: 727.331
2 threads: 483.426
5 threads: 374.056

The change allows for a 2x speedup of the operator after increasing the number of threads.

