### PR TITLE
[CodeStyle] use np.testing.assert_array_equal(...) instead of self.assertTrue(np.array_equal(...)) (part 3)

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -1147,7 +1147,7 @@ class TestDropOutWithProbTensor(unittest.TestCase):
         for x in self.inputs:
             static_res = self.run_static(x)
             dygraph_res = self.run_dygraph(x)
-            self.assertTrue(np.array_equal(static_res, dygraph_res))
+            np.testing.assert_array_equal(static_res, dygraph_res)
 
 
 class TestRandomValue(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

使用 `np.testing.assert_array_equal(...)` 替换 `self.assertTrue(np.array_equal(...))`，以优化单测报错信息

- 问题来源于 #44641
- RFC：https://github.com/PaddlePaddle/community/pull/198
- Part1: #44988
- Part2: #45213

### Changes

- [x] #44947 merge 后，#45126 merge 前的一个增量 `self.assertTrue(np.array_equal(...))`

本 PR merge 后应可 close #44641
