### PR TITLE
Fix random op dependency and lr_shedule bugs for standalone executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -273,20 +273,18 @@ void DependencyBuilder::AddDependencyForCommunicationOp() {
 
 // make sure that the random op is scheduled sequentially
 void DependencyBuilder::AddDependencyForRandomOp() {
-  const std::set<std::string> random_op_set = {
-      "bernoulli",
-      "poisson",
-      "multinomial",
-      "gaussian_random",
-      "truncated_gaussian_random",
-      "uniform_random",
-      "randint",
-      "randperm",
-      "exponential",
-      "sampling_id",
-      "dropout",
-      "class_center_sample"
-  };
+  const std::set<std::string> random_op_set = {"bernoulli",
+                                               "poisson",
+                                               "multinomial",
+                                               "gaussian_random",
+                                               "truncated_gaussian_random",
+                                               "uniform_random",
+                                               "randint",
+                                               "randperm",
+                                               "exponential",
+                                               "sampling_id",
+                                               "dropout",
+                                               "class_center_sample"};
 
   int dependence_op_idx = -1;
   for (size_t op_idx = 0; op_idx < op_num_; ++op_idx) {

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -283,9 +283,9 @@ void DependencyBuilder::AddDependencyForRandomOp() {
       "randint",
       "randperm",
       "exponential",
-      "sampling_id"
+      "sampling_id",
       "dropout",
-      "class_center_sample",
+      "class_center_sample"
   };
 
   int dependence_op_idx = -1;

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1497,9 +1497,9 @@ class Executor(object):
                         # print(f"Program before convert:\n {inner_program}", flush=True)
                         program._compile(scope, self.place)
                         ir_graph = framework.IrGraph(program._graph)
-                        converted_program = ir_graph.to_program()
-                        if hasattr(inner_program, 'lr_sheduler'):
-                            converted_program.lr_sheduler = inner_program.lr_sheduler
+                        inner_program = ir_graph.to_program()
+                        if hasattr(program._program, 'lr_sheduler'):
+                            converted_program.lr_sheduler = program._program.lr_sheduler
                         # print(f"Program after convert:\n {inner_program}", flush=True)
                         logging.warning(
                             "FLAGS_USE_STANDALONE_EXECUTOR and FLAGS_CONVERT_GRAPH_TO_PROGRAM is set to 1. Graph will be converted to Program and executed using new executor."
@@ -1510,7 +1510,7 @@ class Executor(object):
                             prim2orig()
 
                     program = self._add_feed_fetch_ops(
-                        program=converted_program,
+                        program=inner_program,
                         feed=feed,
                         fetch_list=fetch_list,
                         feed_var_name=feed_var_name,

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1499,7 +1499,7 @@ class Executor(object):
                         ir_graph = framework.IrGraph(program._graph)
                         inner_program = ir_graph.to_program()
                         if hasattr(program._program, 'lr_sheduler'):
-                            converted_program.lr_sheduler = program._program.lr_sheduler
+                            inner_program.lr_sheduler = program._program.lr_sheduler
                         # print(f"Program after convert:\n {inner_program}", flush=True)
                         logging.warning(
                             "FLAGS_USE_STANDALONE_EXECUTOR and FLAGS_CONVERT_GRAPH_TO_PROGRAM is set to 1. Graph will be converted to Program and executed using new executor."

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1497,7 +1497,9 @@ class Executor(object):
                         # print(f"Program before convert:\n {inner_program}", flush=True)
                         program._compile(scope, self.place)
                         ir_graph = framework.IrGraph(program._graph)
-                        inner_program = ir_graph.to_program()
+                        converted_program = ir_graph.to_program()
+                        if hasattr(inner_program, 'lr_sheduler'):
+                            converted_program.lr_sheduler = inner_program.lr_sheduler
                         # print(f"Program after convert:\n {inner_program}", flush=True)
                         logging.warning(
                             "FLAGS_USE_STANDALONE_EXECUTOR and FLAGS_CONVERT_GRAPH_TO_PROGRAM is set to 1. Graph will be converted to Program and executed using new executor."
@@ -1508,7 +1510,7 @@ class Executor(object):
                             prim2orig()
 
                     program = self._add_feed_fetch_ops(
-                        program=inner_program,
+                        program=converted_program,
                         feed=feed,
                         fetch_list=fetch_list,
                         feed_var_name=feed_var_name,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
Fix two bugs for standalone executor:
1. Fix bug for building random-op dependency where the sampling_id and dropout ops are not identified as random because of a typo
2. Add lr_shedule to the converted Program from the Compiled Program, the missing of lr_shedule make Transformer not converge