### PR TITLE
[ Dy2Static ] fix bugs in prepare_gradient_aggregation

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -287,7 +287,8 @@ class PartialProgramLayer:
 
         return main_program
 
-    def prepare_gradient_aggregation(self, main_program, target_program):
+    def prepare_gradient_aggregation(self, start_idx, main_program,
+                                     target_program):
         """
         Why we need add gradient aggregation operation ?
         In some cases, if non leaf nodes are used as output, gradient overwriting will occur, such as
@@ -323,7 +324,7 @@ class PartialProgramLayer:
             new_grad_name = var.name + suffix + "@GRAD"
             finded_ops = list(
                 filter(
-                    lambda x: any([
+                    lambda x: x[0] >= start_idx and any([
                         out_arg == var_grad_name
                         for out_arg in x[1].output_arg_names
                     ]), enumerate(target_program.block(0).ops)))
@@ -367,7 +368,10 @@ class PartialProgramLayer:
         if targets and self._params:
             backward.gradients(targets=targets, inputs=[])
 
-        self.prepare_gradient_aggregation(main_program, program)
+        start_idx = len(
+            main_program.block(0).ops) + 2 * len(self._outputs.tolist())
+
+        self.prepare_gradient_aggregation(start_idx, main_program, program)
 
         return program
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复了一些段错误的问题，之前的prepare_gradient_aggregation没有考虑到动转静会跳过append backward中插入的一些成对的shape + fill_constant的Op，因此会找到这类fill constant，所以出现段错误，具体的在RunProgramGradKernel中。

TODO：直接在Program中进行删除，减少这种表示和执行的差异（trick方法），可以减少系统的复杂度。希望Python端最后执行的Program是啥样，跑的就是啥样，C++端进行选择跳过容易造成后续人员的误解。