### PR TITLE
[Profiler] support profiler summaryview instance

### DIFF
--- a/python/paddle/distributed/launch/context/node.py
+++ b/python/paddle/distributed/launch/context/node.py
@@ -78,19 +78,6 @@ class Node(object):
 
         return self._port_cur
 
-    '''
-    def get_free_port2(self):
-        # for loop to avoid port conflict
-        for _ in range(100):
-            port = self._get_free_port()
-            if port in self._allocated_ports:
-                continue
-            else:
-                self._allocated_ports.append(port)
-                return port
-        return port
-    '''
-
     @classmethod
     def is_server_ready(self, ip, port):
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
@@ -103,8 +90,3 @@ class Node(object):
                 return True
             else:
                 return False
-
-
-if __name__ == '__main__':
-    n = Node()
-    print(n.get_free_ports(10))

--- a/python/paddle/profiler/profiler.py
+++ b/python/paddle/profiler/profiler.py
@@ -38,6 +38,23 @@ class SummaryView(Enum):
     r"""
     SummaryView define the summary view of different contents.
 
+    - **SummaryView.DeviceView** : The device summary view.
+
+    - **SummaryView.OverView** : The overview summary view.
+
+    - **SummaryView.ModelView** : The model summary view.
+
+    - **SummaryView.DistributedView** : The distributed summary view.
+
+    - **SummaryView.KernelView** : The kernel summary view.
+
+    - **SummaryView.OperatorView** : The operator summary view.
+
+    - **SummaryView.MemoryView** : The memory summary view.
+
+    - **SummaryView.MemoryManipulationView** : The meomory manipulation summary view.
+
+    - **SummaryView.UDFView** : The user defined summary view.
     """
     DeviceView = 0
     OverView = 1
@@ -760,7 +777,7 @@ class Profiler:
             op_detail(bool, optional): expand each operator detail information, default value is True.
             thread_sep(bool, optional): print op table each thread, default value is False.
             time_unit(str, optional): time unit for display, can be chosen form ['s', 'ms', 'us', 'ns'], default value is 'ms'.
-            views(list[SummaryView], optional): summary tables to print, default to None means all views to be printed.
+            views(SummaryView|list[SummaryView], optional): summary tables to print, default to None means all views to be printed.
 
         Examples:
             .. code-block:: python
@@ -779,6 +796,9 @@ class Profiler:
                 prof.stop()
                 prof.summary(sorted_by=profiler.SortedKeys.CPUTotal, op_detail=True, thread_sep=False, time_unit='ms')
         """
+        if isinstance(views, SummaryView):
+            views = [views]
+
         if self.profiler_result:
             statistic_data = StatisticData(
                 self.profiler_result.get_data(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
* add doc for `SummaryView` enum
* support `SummaryView` instance in api
