### PR TITLE
fix a syntax error in CspFileReader

### DIFF
--- a/tools/CrossStackProfiler/CspFileReader.py
+++ b/tools/CrossStackProfiler/CspFileReader.py
@@ -206,12 +206,12 @@ class FileReader(object):
             prefix_str = fileName.split(sed)[-1]
             try:
                 return int(prefix_str)
-            except ValueError, Argument:
-                print(Argument)
+            except ValueError as e:
+                print(e)
                 raise TypeError("invalid fileName [%s]" % fileName)
 
-        except IndexError, Argument:
-            print(Argument)
+        except IndexError as e:
+            print(e)
             raise TypeError(
                 "invalid fileName [%s], the prefix should be a number!" %
                 fileName)
@@ -363,8 +363,8 @@ def getLogger():
 def test_FileReader(args):
     try:
         testReader = FileReader(None, args)
-    except Exception, Argument:
-        print(Argument)
+    except Exception as e:
+        print(e)
     else:
         testReader.printArgs()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

```
  File "/Users/username/Projects/Paddle/tools/CrossStackProfiler/CspFileReader.py", line 366
    except Exception, Argument:
           ^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

一个语法错误，之前全量扫描解析 AST 时就发现该文件是无法解析的了（更别说运行时了），flake8 和 black 也都会因为其语法错误而无法成功解析 AST 进一步分析。