### PR TITLE
fix the Jacobian/Hessian API bugs when used in sub block

### DIFF
--- a/python/paddle/incubate/autograd/functional.py
+++ b/python/paddle/incubate/autograd/functional.py
@@ -633,7 +633,7 @@ def _single_separate(x):
     if x is None:  # x maybe none because grad input's v defaults to none.
         return x
     if not x.stop_gradient:
-        return paddle.clone(x)
+        return paddle.assign(x)
     else:  # use detach to share memory when no need gradients.
         x = x.detach()
         x.stop_gradient = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Currently, `Jacobian/Hessian` API use `clone` for copying a variable, which always generate new variable in block 0.  When using Jacobian/Hessian in sub block such as block 1, it's incorrect for it will make some new variable in block 0. So, we replace `clone` with`assign` which will create a new variable in current block.
clone: https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/framework.py#L2082
assign: https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/tensor/creation.py#L1691