### PR TITLE
print log while grad ops are used in new executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -412,6 +412,7 @@ void build_op_func_list(const platform::Place& place,
                                        : var_scope->GetMutableScope();
   std::vector<std::unique_ptr<OperatorBase>>
       ops_unique;  // its elements will be moved to vec_func_list
+  bool flag_log_is_printed = false;
   // Step 1: create all ops for current block.
   create_all_ops(block, &ops_unique);
   // If gc is enabled and block size > 1
@@ -437,6 +438,13 @@ void build_op_func_list(const platform::Place& place,
   for (size_t i = 0; i < ops.size(); ++i) {
     auto op = ops[i].get();
     VLOG(6) << "Build OpFuncNode from : " << op->Type();
+
+    // Print new executor log if grad op is used.
+    // It's only for test and will be removed later.
+    if (!flag_log_is_printed && op->Type().find("_grad") != std::string::npos) {
+      VLOG(0) << "Standalone Executor is Used.";
+      flag_log_is_printed = true;
+    }
 
     auto inputs_names = op->Inputs();
     auto outputs_names = op->Outputs();

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1527,7 +1527,7 @@ class Executor(object):
                             converted_program.lr_sheduler = inner_program.lr_sheduler
                         inner_program = converted_program
                         # print(f"Program after convert:\n {inner_program}", flush=True)
-                        logging.warning(
+                        warnings.warn(
                             "FLAGS_USE_STANDALONE_EXECUTOR and FLAGS_CONVERT_GRAPH_TO_PROGRAM is set to 1. Graph will be converted to Program and executed using new executor."
                         )
                     else:
@@ -1543,6 +1543,11 @@ class Executor(object):
                         feed_var_name=feed_var_name,
                         fetch_var_name=fetch_var_name,
                         use_fetch_v2=True)
+
+                    # If there are multiple blocks in the program, subblock will not be
+                    # executed with the new executor in temporary
+                    if program.num_blocks > 1:
+                        warnings.warn("There are more than 1 block in program.")
 
                     # standalone executor will apply buffer_shared_inplace_pass and
                     # inplace_addto_op_pass to program according to build_strategy


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

- 如果新执行器中执行了反向（grad）op，开GLOG_v=0时会打印`Standalone Executor is Used.`
- 新执行器执行的program中存在多个block时，会打印warning：`There are more than 1 block in program.`
