### PR TITLE
Modify PE Engine thread from 2 into 1 in JitLayer

### DIFF
--- a/paddle/fluid/jit/engine/pe_engine.cc
+++ b/paddle/fluid/jit/engine/pe_engine.cc
@@ -31,7 +31,7 @@ static ExecutionStrategy GetExecutionStrategy(const platform::Place &place) {
   auto device_type = platform::Place2DeviceType(place);
   switch (device_type) {
     case platform::DeviceType::CPU: {
-      execution_strategy.num_threads_ = 2;
+      execution_strategy.num_threads_ = 1;
       break;
     }
     case platform::DeviceType::CUDA: {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

 
* conformer RTF from 1.65(2 thread) to 0.83(1 thread)   

Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz   64 cpus