### PR TITLE
Fix record operator input shapes segment fault in new dygraph

### DIFF
--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -673,11 +673,12 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 {code_indent}     std::vector<std::pair<const char*, std::vector<phi::DDim>>> input_shapes;"""
         else:
             for input_name in single_tensor_names:
-                input_tensors = input_name_tensor_map[input_name]
-                input_tensor_code = input_tensor_code + f"""
-{code_indent}     std::vector<phi::DDim> {input_name}_record_shapes;"""
-                for input_tensor, _ in input_tensors:
+                if input_name in self.optional_vars:
+                    input_tensors = input_name_tensor_map[input_name]
                     input_tensor_code = input_tensor_code + f"""
+{code_indent}     std::vector<phi::DDim> {input_name}_record_shapes;"""
+                    for input_tensor, _ in input_tensors:
+                        input_tensor_code = input_tensor_code + f"""
 {code_indent}     if({input_tensor}){{
 {code_indent}       {input_name}_record_shapes.push_back((*{input_tensor}).dims());
 {code_indent}     }}"""
@@ -685,12 +686,31 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
             input_tensor_code = input_tensor_code + f"""
 {code_indent}     std::vector<std::pair<const char*, std::vector<phi::DDim>>> input_shapes{{"""
             for input_name in single_tensor_names[:-1]:
-                input_tensor_code = input_tensor_code + f"""            
+                if input_name in self.optional_vars:
+                    input_tensor_code = input_tensor_code + f"""            
 {code_indent}     {{"{input_name}", {input_name}_record_shapes}},"""
-            input_tensors = input_name_tensor_map[single_tensor_names[-1]]
-            input_tensor_code = input_tensor_code + f"""            
+                else:
+                    input_tensor_code = input_tensor_code + f"""            
+{code_indent}     {{"{input_name}", {{"""
+                    input_tensors = input_name_tensor_map[input_name]
+                    for input_tensor, _ in input_tensors[:-1]:
+                        input_tensor_code = input_tensor_code + f"""            
+{code_indent}     (*{input_tensor}).dims(),"""
+                    input_tensor_code = input_tensor_code + f"""            
+{code_indent}     (*{input_tensors[-1][0]}).dims()}}}},"""
+            if single_tensor_names[-1] in self.optional_vars:
+                input_tensor_code = input_tensor_code + f"""            
 {code_indent}     {{"{single_tensor_names[-1]}",         
 {code_indent}     {single_tensor_names[-1]}_record_shapes}}}};"""
+            else:
+                input_tensor_code = input_tensor_code + f"""            
+{code_indent}     {{"{single_tensor_names[-1]}", {{"""
+                input_tensors = input_name_tensor_map[single_tensor_names[-1]]
+                for input_tensor, _ in input_tensors[:-1]:
+                    input_tensor_code = input_tensor_code + f"""            
+{code_indent}     (*{input_tensor}).dims(),"""
+                input_tensor_code = input_tensor_code + f"""            
+{code_indent}     (*{input_tensors[-1][0]}).dims()}}}}}};"""
         if list_tensor_names:
             input_tensor_code = input_tensor_code + f"""
 {code_indent}     std::vector<phi::DDim> ddims_vec;"""

--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -672,25 +672,25 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
             input_tensor_code = input_tensor_code + f"""
 {code_indent}     std::vector<std::pair<const char*, std::vector<phi::DDim>>> input_shapes;"""
         else:
+            for input_name in single_tensor_names:
+                input_tensors = input_name_tensor_map[input_name]
+                input_tensor_code = input_tensor_code + f"""
+{code_indent}     std::vector<phi::DDim> {input_name}_record_shapes;"""
+                for input_tensor, _ in input_tensors:
+                    input_tensor_code = input_tensor_code + f"""
+{code_indent}     if({input_tensor}){{
+{code_indent}       {input_name}_record_shapes.push_back((*{input_tensor}).dims());
+{code_indent}     }}"""
+
             input_tensor_code = input_tensor_code + f"""
 {code_indent}     std::vector<std::pair<const char*, std::vector<phi::DDim>>> input_shapes{{"""
             for input_name in single_tensor_names[:-1]:
-                input_tensors = input_name_tensor_map[input_name]
                 input_tensor_code = input_tensor_code + f"""            
-{code_indent}     {{"{input_name}", {{"""
-                for input_tensor, _ in input_tensors[:-1]:
-                    input_tensor_code = input_tensor_code + f"""            
-{code_indent}     (*{input_tensor}).dims(),"""
-                input_tensor_code = input_tensor_code + f"""            
-{code_indent}     (*{input_tensors[-1][0]}).dims()}}}},"""
+{code_indent}     {{"{input_name}", {input_name}_record_shapes}},"""
             input_tensors = input_name_tensor_map[single_tensor_names[-1]]
             input_tensor_code = input_tensor_code + f"""            
-{code_indent}     {{"{single_tensor_names[-1]}", {{"""
-            for input_tensor, _ in input_tensors[:-1]:
-                input_tensor_code = input_tensor_code + f"""            
-{code_indent}     (*{input_tensor}).dims(),"""
-            input_tensor_code = input_tensor_code + f"""            
-{code_indent}     (*{input_tensors[-1][0]}).dims()}}}}}};"""
+{code_indent}     {{"{single_tensor_names[-1]}",         
+{code_indent}     {single_tensor_names[-1]}_record_shapes}}}};"""
         if list_tensor_names:
             input_tensor_code = input_tensor_code + f"""
 {code_indent}     std::vector<phi::DDim> ddims_vec;"""
@@ -720,8 +720,8 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
             input_tensor_code = input_tensor_code + f"""
 {code_indent}     input_shapes.emplace_back("{input_name}", ddims_vec);"""
 
-        input_tensor_code = input_tensor_code + f"""
-{code_indent}     platform::RecordOpInfoSupplement("{self.api}", input_shapes);
+        input_tensor_code = input_tensor_code + f"""  
+{code_indent}     platform::RecordOpInfoSupplement("{self.api}", input_shapes);  
 {code_indent}  }}"""
         kernel_args = ["*dev_ctx"]
         for param in kernel_param:
@@ -834,7 +834,6 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 {code_indent}  if (kernel_result.has_fallback_cpu) {{
 {fallback_kernel_output_trans}
 {code_indent}  }}
-
 {code_indent}  {self.gene_return_code()}"""
 
     def get_condition_code(self, kernel_name):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

1. In new dygraph, we collect operator's input shape one by one, and some optional variables may be null. The bug results from   no judgements for optional variables. After fix, the auto-generated code is as follows:
```c++
PADDLE_API Tensor nearest_interp(const Tensor& x, const paddle::optional<Tensor>& out_size, const paddle::optional<std::vector<Tensor>>& size_tensor, const paddle::optional<Tensor>& scale_tensor, const std::string& data_layout, int out_d, int out_h, int out_w, const std::vector<float>& scale, const std::string& interp_method, bool align_corners, int align_mode) {

  Backend kernel_backend = Backend::UNDEFINED;
  DataLayout kernel_layout = DataLayout::UNDEFINED;
  DataType kernel_data_type = DataType::UNDEFINED;

  kernel_data_type = ParseDataType(x);

  if (kernel_backend == Backend::UNDEFINED
        || kernel_layout == DataLayout::UNDEFINED
        || kernel_data_type == DataType::UNDEFINED ) {
    auto kernel_key_set = ParseKernelKeyByInputArgs(x, out_size, size_tensor, scale_tensor);
    auto kernel_key = kernel_key_set.GetHighestPriorityKernelKey();
    if (kernel_backend == Backend::UNDEFINED) {
      kernel_backend = kernel_key.backend();
    }
    if (kernel_layout == DataLayout::UNDEFINED) {
      kernel_layout = kernel_key.layout();
    }
    if (kernel_data_type == DataType::UNDEFINED) {
      kernel_data_type = kernel_key.dtype();
    }
  }

  VLOG(6) << "nearest_interp API kernel key: [" << kernel_backend << ", " << kernel_layout << ", "<< kernel_data_type << "]";
  auto kernel_result = phi::KernelFactory::Instance().SelectKernelOrThrowError(
      "nearest_interp", {kernel_backend, kernel_layout, kernel_data_type});
  const auto& kernel = kernel_result.kernel;
  VLOG(6) << "nearest_interp kernel: " << kernel;
  auto* dev_ctx = GetDeviceContextByBackend(kernel_result.has_fallback_cpu ? Backend::CPU : kernel_backend);

  auto input_x = PrepareData(x, kernel.InputAt(0), {});
  auto input_out_size = PrepareData(out_size, kernel.InputAt(1), {});
  auto input_size_tensor_vec = PrepareData(size_tensor, kernel.InputAt(2), {});
  paddle::optional<std::vector<const phi::DenseTensor*>> input_size_tensor;
  if (input_size_tensor_vec){
    input_size_tensor = paddle::optional<std::vector<const phi::DenseTensor*>>(input_size_tensor_vec->size());
    for (size_t i = 0; i < input_size_tensor_vec->size(); ++i) {
      input_size_tensor->at(i) = &input_size_tensor_vec->at(i);
    }
  }
  auto input_scale_tensor = PrepareData(scale_tensor, kernel.InputAt(3), {});
  if(platform::RecordOpInfoSupplement::IsEnabled()){
     std::vector<phi::DDim> out_size_record_shapes;
     if(input_out_size){
       out_size_record_shapes.push_back((*input_out_size).dims());
     }
     std::vector<phi::DDim> scale_tensor_record_shapes;
     if(input_scale_tensor){
       scale_tensor_record_shapes.push_back((*input_scale_tensor).dims());
     }
     std::vector<std::pair<const char*, std::vector<phi::DDim>>> input_shapes{            
     {"x", {            
     (*input_x).dims()}},            
     {"out_size", out_size_record_shapes},            
     {"scale_tensor",         
     scale_tensor_record_shapes}};
     std::vector<phi::DDim> ddims_vec;
     ddims_vec.clear();
     if (input_size_tensor){
       ddims_vec.reserve(input_size_tensor->size());
       for (size_t i = 0; i < input_size_tensor->size(); ++i) {
         ddims_vec.emplace_back((*input_size_tensor->at(i)).dims());
       }
     }
     input_shapes.emplace_back("size_tensor", ddims_vec);  
     platform::RecordOpInfoSupplement("nearest_interp", input_shapes);  
  }

  Tensor api_output;
  auto kernel_out = SetKernelOutput(kernel_backend, &api_output);
  paddle::platform::RecordEvent *infer_shape_record_event = nullptr;
  if(paddle::platform::RecordEvent::IsEnabled()){
    infer_shape_record_event = new paddle::platform::RecordEvent("nearest_interp infer_meta", paddle::platform::TracerEventType::OperatorInner, 1);
  }

  auto size_tensor_meta_vec = MakeMetaTensor(input_size_tensor);
  paddle::optional<std::vector<const phi::MetaTensor*>> size_tensor_metas(size_tensor_meta_vec.size());
  for (size_t i = 0; i < size_tensor_meta_vec.size(); ++i) {
    size_tensor_metas->at(i) = &size_tensor_meta_vec[i];
  }
  phi::MetaTensor meta_out(kernel_out);

  phi::InterpolateInferMeta(MakeMetaTensor(*input_x), MakeMetaTensor(input_out_size), size_tensor_metas, MakeMetaTensor(input_scale_tensor), data_layout, out_d, out_h, out_w, scale, interp_method, align_corners, align_mode, &meta_out);

  if(infer_shape_record_event != nullptr){
    delete infer_shape_record_event;
  }
  using kernel_signature = void(*)(const platform::DeviceContext&, const phi::DenseTensor&, const paddle::optional<phi::DenseTensor>&, const paddle::optional<std::vector<const phi::DenseTensor*>>&, const paddle::optional<phi::DenseTensor>&, const std::string&, int, int, int, const std::vector<float>&, const std::string&, bool, int, phi::DenseTensor*);
  auto* kernel_fn = kernel.GetVariadicKernelFn<kernel_signature>();
  paddle::platform::RecordEvent* kernel_record_event = nullptr;
  if(paddle::platform::RecordEvent::IsEnabled()){
    kernel_record_event = new paddle::platform::RecordEvent("nearest_interp compute", paddle::platform::TracerEventType::OperatorInner, 1);
  }
    (*kernel_fn)(*dev_ctx, *input_x, input_out_size, input_size_tensor, input_scale_tensor, data_layout, out_d, out_h, out_w, scale, interp_method, align_corners, align_mode, kernel_out);
  if(kernel_record_event != nullptr){
    delete kernel_record_event;
  }
  if (kernel_result.has_fallback_cpu) {

    TransDataBackend(kernel_out, kernel_backend, kernel_out);
  }
  return api_output;
}
```
2. The influence for speed without enabling profiler.  
run following code 10 times, we compare average run time for develop and this pr.
```python
import paddle
import numpy as np
import psutil
import time
p = psutil.Process()
p.cpu_affinity([0])
paddle.set_device("cpu")
input = paddle.rand([1,1],'float32')
grad_tensor = paddle.ones(input.shape, input.dtype)
input.stop_gradient=False
st = time.time()
for i in range(50000):
    output = paddle.trunc( input )
    output.backward(grad_tensor)
sp = time.time()
print(sp-st)
```
Result(Average time for 10 runs, unit:s ):
|  develop  | PR45360  |
| :-----| :---- |
| 2.57  | 2.61  |

