### PR TITLE
[Paddle-TRT] add PADDLE_ENFORCE in reshape2

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/reshape_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/reshape_op.cc
@@ -70,6 +70,16 @@ class ReshapeOpConverter : public OpConverter {
       layer->setReshapeDimensions(reshape_dim);
     else
       layer->setInput(1, *real_shape_tensor);
+
+    PADDLE_ENFORCE_GE(
+        layer->getOutput(0)->getDimensions().nbDims,
+        0,
+        platform::errors::InvalidArgument(
+            "Errors occures in Paddle-TRT reshape2 op, try to use C++ Api "
+            "config.Exp_DisableTensorRtOPs({\"reshape2\"})\n; or Python Api "
+            "config.exp_disable_tensorrt_ops([\"reshape2\"]) to forbid "
+            "reshape2 op into "
+            "Paddle-TRT."));
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "reshape", {output_name}, test_mode);
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
有些版本的trt上，infer shape失败，提示用户禁用reshape2