### PR TITLE
FIx Bug of ShardingStage2 Test on A100

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -1606,6 +1606,10 @@ if(WITH_DISTRIBUTE
   set_tests_properties(test_collective_batch_isend_irecv PROPERTIES TIMEOUT 100)
   set_tests_properties(test_collective_reduce_scatter PROPERTIES TIMEOUT 100)
   set_tests_properties(test_parallel_dygraph_qat PROPERTIES TIMEOUT 120)
+  if(CUDA_VERSION GREATER_EQUAL 11.7)
+    set_tests_properties(test_dygraph_sharding_stage2
+                         PROPERTIES ENVIRONMENT "NVIDIA_TF32_OVERRIDE=1")
+  endif()
   if(${NCCL_VERSION} VERSION_GREATER_EQUAL 2212)
     set_tests_properties(test_parallel_dygraph_sparse_embedding
                          PROPERTIES TIMEOUT 200)


### PR DESCRIPTION


<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix test_dygraph_sharding_stage2 for cuda_version greater_equal 11.7 on A100 GPU