### PR TITLE
add interpolate op to default black lists

### DIFF
--- a/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
@@ -107,6 +107,11 @@ black_list = {
     # fp16 is slower than fp32, though fp16 is supported.
     'lookup_table',
     'lookup_table_v2',
+    'linear_interp_v2',
+    'nearest_interp_v2',
+    'bilinear_interp_v2',
+    'bicubic_interp_v2',
+    'trilinear_interp_v2',
     # default fp32 can avoid return inf when the sum value large than 65504
     'reduce_sum',
 }

--- a/python/paddle/fluid/contrib/tests/test_amp_list.py
+++ b/python/paddle/fluid/contrib/tests/test_amp_list.py
@@ -30,6 +30,13 @@ class TestAMPList(unittest.TestCase):
             self.assertTrue(op not in amp_list.black_list)
             self.assertTrue(op not in amp_list.unsupported_list)
 
+        default_black_list = [
+            'linear_interp_v2', 'nearest_interp_v2', 'bilinear_interp_v2',
+            'bicubic_interp_v2', 'trilinear_interp_v2'
+        ]
+        for op in default_black_list:
+            self.assertTrue(op in amp_list.black_list)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -56,6 +56,12 @@ BLACK_LIST = {
     'cross_entropy2',
     # default fp32 can avoid return inf when the sum value large than 65504
     'reduce_sum',
+    # FP16 performance of grad op is worse than that of FP32. Use FP32 by default.
+    'linear_interp_v2',
+    'nearest_interp_v2',
+    'bilinear_interp_v2',
+    'bicubic_interp_v2',
+    'trilinear_interp_v2',
 }
 
 AMP_RELATED_FLAGS = [
@@ -72,7 +78,16 @@ AMP_RELATED_FLAGS_SETTING = {
 
 PURE_FP16_WHITE_LIST = {' '}
 PURE_FP16_BLACK_LIST = {
-    'lookup_table', 'lookup_table_v2', 'scatter', 'scatter_grad'
+    'lookup_table',
+    'lookup_table_v2',
+    'scatter',
+    'scatter_grad',
+    # FP16 performance of grad op is worse than that of FP32. Use FP32 by default.
+    'linear_interp_v2',
+    'nearest_interp_v2',
+    'bilinear_interp_v2',
+    'bicubic_interp_v2',
+    'trilinear_interp_v2',
 }
 
 BF16_WHITE_LIST = {'conv2d', 'matmul_v2'}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Describe
<!-- Describe what this PR does --> add interpolate op to default black lists

由于插值算子反向 fp16性能不佳，目前因推理方向需要支持fp16功能，但反向算子暂未优化，故将该类算子暂时放入黑名单，之后性能优化完成再移除。
