### PR TITLE
fix split bug

### DIFF
--- a/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
+++ b/paddle/fluid/eager/auto_code_generator/final_state_generator/codegen_utils.py
@@ -22,16 +22,16 @@ import os
 ### Global Variables ###
 ########################
 ops_to_fill_zero_for_empty_grads = set([
-    "split_grad", "rnn_grad", "matmul_double_grad", "matmul_triple_grad",
-    "sigmoid_double_grad", "sigmoid_triple_grad", "add_double_grad",
-    "add_triple_grad", "multiply_grad", "multiply_double_grad",
-    "multiply_triple_grad", "conv2d_grad_grad", "batch_norm_double_grad",
-    "tanh_double_grad", "tanh_triple_grad", "subtract_double_grad",
-    "divide_double_grad", "log_double_grad", "elu_double_grad",
-    "leaky_relu_double_grad", "sqrt_double_grad", "rsqrt_double_grad",
-    "square_double_grad", "celu_double_grad", "pad_double_grad",
-    "pad3d_double_grad", "squeeze_double_grad", "unsqueeze_double_grad",
-    "instance_norm_double_grad", "conv3d_double_grad",
+    "split_grad", "split_with_num_grad", "rnn_grad", "matmul_double_grad",
+    "matmul_triple_grad", "sigmoid_double_grad", "sigmoid_triple_grad",
+    "add_double_grad", "add_triple_grad", "multiply_grad",
+    "multiply_double_grad", "multiply_triple_grad", "conv2d_grad_grad",
+    "batch_norm_double_grad", "tanh_double_grad", "tanh_triple_grad",
+    "subtract_double_grad", "divide_double_grad", "log_double_grad",
+    "elu_double_grad", "leaky_relu_double_grad", "sqrt_double_grad",
+    "rsqrt_double_grad", "square_double_grad", "celu_double_grad",
+    "pad_double_grad", "pad3d_double_grad", "squeeze_double_grad",
+    "unsqueeze_double_grad", "instance_norm_double_grad", "conv3d_double_grad",
     "depthwise_conv2d_grad_grad", "concat_double_grad", "expand_grad"
 ])
 

--- a/paddle/phi/api/yaml/legacy_api.yaml
+++ b/paddle/phi/api/yaml/legacy_api.yaml
@@ -2514,10 +2514,22 @@
   backward : spectral_norm_grad
 
 - api : split
-  args : (Tensor x, IntArray num_or_sections, Scalar(int) axis)
-  output : Tensor[]
-  invoke : split_impl(x, num_or_sections, axis)
+  args : (Tensor x, IntArray sections, Scalar(int) axis)
+  output : Tensor[]{sections.size()}
+  infer_meta :
+    func : SplitInferMeta
+  kernel :
+    func : split
   backward : split_grad
+
+- api : split_with_num
+  args : (Tensor x, int num, Scalar(int) axis)
+  output : Tensor[]{num}
+  infer_meta :
+    func : SplitWithNumInferMeta
+  kernel :
+    func : split_with_num
+  backward : split_with_num_grad
 
 - api : sqrt
   args : (Tensor x)

--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -2288,6 +2288,12 @@
   args : (Tensor[] out_grad, Scalar axis = -1)
   output : Tensor(x_grad)
   invoke : concat( out_grad, axis)
+
+- backward_api : split_with_num_grad
+  forward : split_with_num (Tensor x, int num, Scalar axis) -> Tensor[](out)
+  args : (Tensor[] out_grad, Scalar axis = -1)
+  output : Tensor(x_grad)
+  invoke : concat( out_grad, axis)
 # TODO(zhangyunfei) The config of double grad and triple grad will be supported in the future.
 
 - backward_api : sqrt_double_grad

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -429,11 +429,26 @@ void SliceRawInferMeta(const MetaTensor& input,
 
 void SoftmaxInferMeta(const MetaTensor& x, int axis, MetaTensor* out);
 
+int GetSplitAxisValue(const MetaTensor& x, const Scalar& axis);
+
+void FillSplitOutDims(const MetaTensor& x,
+                      const int axis_value,
+                      const int64_t input_axis_dim,
+                      const std::vector<int64_t>& sections_vec,
+                      std::vector<MetaTensor*>* out,
+                      MetaConfig config);
+
 void SplitInferMeta(const MetaTensor& x_meta,
-                    const IntArray& num_or_sections,
+                    const IntArray& sections,
                     const Scalar& axis,
                     std::vector<MetaTensor*> out,
                     MetaConfig config = MetaConfig());
+
+void SplitWithNumInferMeta(const MetaTensor& x_meta,
+                           int num,
+                           const Scalar& axis,
+                           std::vector<MetaTensor*> out,
+                           MetaConfig config = MetaConfig());
 
 void SquaredL2NormInferMeta(const MetaTensor& x, MetaTensor* out);
 

--- a/paddle/phi/kernels/cpu/split_kernel.cc
+++ b/paddle/phi/kernels/cpu/split_kernel.cc
@@ -13,60 +13,30 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/split_kernel.h"
+#include "paddle/phi/kernels/impl/split_kernel_impl.h"
 
-#include "paddle/fluid/operators/strided_memcpy.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/infermeta/unary.h"
-#include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
-namespace phi {
-
-template <typename T, typename Context>
-void SplitKernel(const Context& dev_ctx,
-                 const DenseTensor& x,
-                 const IntArray& num_or_sections,
-                 const Scalar& axis_scalar,
-                 std::vector<DenseTensor*> outs) {
-  // need to infershape output
-  if (num_or_sections.FromTensor() || axis_scalar.FromTensor()) {
-    std::vector<MetaTensor> out_metas;
-    out_metas.reserve(outs.size());
-    std::vector<MetaTensor*> out_metas_ptr;
-    for (size_t i = 0; i < outs.size(); ++i) {
-      out_metas.push_back(outs[i]);
-      out_metas_ptr.push_back(&out_metas.back());
-    }
-
-    phi::SplitInferMeta(x, num_or_sections, axis_scalar, out_metas_ptr);
-
-    for (size_t i = 0; i < out_metas.size(); ++i) {
-      outs[i]->Resize(out_metas[i].dims());
-    }
-  }
-
-  std::vector<const DenseTensor*> shape_refer;
-  for (size_t j = 0; j < outs.size(); ++j) {
-    dev_ctx.template Alloc<T>(outs[j]);
-    shape_refer.emplace_back(outs[j]);
-  }
-
-  int axis = axis_scalar.to<int>();
-  // Sometimes direct copies will be faster, this maybe need deeply analysis.
-  if (axis == 0 && outs.size() < 10) {
-    paddle::operators::StridedMemcpyWithAxis0<T>(
-        dev_ctx, x, shape_refer, &outs);
-  } else {
-    phi::funcs::SplitFunctor<Context, T> functor;
-    functor(dev_ctx, x, shape_refer, axis, &outs);
-  }
-}
-
-}  // namespace phi
 
 PD_REGISTER_KERNEL(split,
                    CPU,
                    ALL_LAYOUT,
                    phi::SplitKernel,
+                   float,
+                   double,
+                   int64_t,
+                   int,
+                   bool,
+                   uint8_t,
+                   int8_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}
+
+PD_REGISTER_KERNEL(split_with_num,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::SplitWithNumKernel,
                    float,
                    double,
                    int64_t,

--- a/paddle/phi/kernels/gpu/split_kernel.cu
+++ b/paddle/phi/kernels/gpu/split_kernel.cu
@@ -13,59 +13,29 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/split_kernel.h"
+#include "paddle/phi/kernels/impl/split_kernel_impl.h"
 
-#include "paddle/fluid/operators/strided_memcpy.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
-namespace phi {
-
-template <typename T, typename Context>
-void SplitKernel(const Context& dev_ctx,
-                 const DenseTensor& x,
-                 const IntArray& num_or_sections,
-                 const Scalar& axis_scalar,
-                 std::vector<DenseTensor*> outs) {
-  // need to infershape output
-  if (num_or_sections.FromTensor() || axis_scalar.FromTensor()) {
-    std::vector<MetaTensor> out_metas;
-    out_metas.reserve(outs.size());
-    std::vector<MetaTensor*> out_metas_ptr;
-    for (size_t i = 0; i < outs.size(); ++i) {
-      out_metas.push_back(outs[i]);
-      out_metas_ptr.push_back(&out_metas.back());
-    }
-
-    phi::SplitInferMeta(x, num_or_sections, axis_scalar, out_metas_ptr);
-
-    for (size_t i = 0; i < out_metas.size(); ++i) {
-      outs[i]->Resize(out_metas[i].dims());
-    }
-  }
-
-  std::vector<const DenseTensor*> shape_refer;
-  for (size_t j = 0; j < outs.size(); ++j) {
-    dev_ctx.template Alloc<T>(outs[j]);
-    shape_refer.emplace_back(outs[j]);
-  }
-
-  int axis = axis_scalar.to<int>();
-  // Sometimes direct copies will be faster, this maybe need deeply analysis.
-  if (axis == 0 && outs.size() < 10) {
-    paddle::operators::StridedMemcpyWithAxis0<T>(
-        dev_ctx, x, shape_refer, &outs);
-  } else {
-    phi::funcs::SplitFunctor<Context, T> functor;
-    functor(dev_ctx, x, shape_refer, axis, &outs);
-  }
-}
-
-}  // namespace phi
 
 PD_REGISTER_KERNEL(split,
                    GPU,
                    ALL_LAYOUT,
                    phi::SplitKernel,
+                   float,
+                   double,
+                   int64_t,
+                   int,
+                   bool,
+                   uint8_t,
+                   int8_t,
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}
+
+PD_REGISTER_KERNEL(split_with_num,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::SplitWithNumKernel,
                    float,
                    double,
                    int64_t,

--- a/paddle/phi/kernels/impl/split_kernel_impl.h
+++ b/paddle/phi/kernels/impl/split_kernel_impl.h
@@ -1,0 +1,188 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/operators/strided_memcpy.h"
+#include "paddle/phi/common/int_array.h"
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/infermeta/unary.h"
+#include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
+
+namespace phi {
+
+void SplitInferOutDims(const DenseTensor& x,
+                       const IntArray& sections,
+                       const Scalar& axis_scalar,
+                       std::vector<DenseTensor*>* outs) {
+  if (sections.FromTensor() || axis_scalar.FromTensor()) {
+    std::vector<MetaTensor> out_metas;
+    out_metas.reserve(outs->size());
+    for (size_t i = 0; i < outs->size(); ++i) {
+      out_metas.push_back((*outs)[i]);
+    }
+
+    // get axis_value
+    int axis_value = GetSplitAxisValue(x, axis_scalar);
+
+    auto input_axis_dim = x.dims().at(axis_value);
+    auto sections_data = sections.GetData();
+    // step1: get formated sections
+    std::vector<int64_t> sections_vec;
+    const int unknow_dim_val = -1;
+    int unknow_dim_idx = -1;
+    int num_of_unknow = 0;
+    int sum_of_section = 0;
+
+    for (size_t i = 0; i < sections_data.size(); ++i) {
+      sections_vec.push_back(sections_data[i]);
+
+      if (sections_data[i] == unknow_dim_val) {
+        num_of_unknow++;
+        unknow_dim_idx = i;
+      } else {
+        sum_of_section += sections_data[i];
+      }
+    }
+
+    if (unknow_dim_idx != -1) {
+      sections_vec[unknow_dim_idx] = input_axis_dim - sum_of_section;
+    }
+    // setp2: fill out dims
+    std::vector<phi::DDim> out_dims(sections_vec.size(), x.dims());
+    if (input_axis_dim > 0) {
+      for (size_t i = 0; i < sections_vec.size(); ++i) {
+        out_dims[i][axis_value] = sections_vec[i];
+      }
+    } else {
+      for (size_t i = 0; i < sections_vec.size(); ++i) {
+        out_dims[i][axis_value] = -1;
+      }
+    }
+
+    for (size_t i = 0; i < sections_vec.size(); ++i) {
+      if (axis_value != 0) {
+        // Only pass LoD when not spliting along the first dim.
+        out_metas[i].set_dtype(x.dtype());
+        out_metas[i].set_dims(out_dims[i]);
+        out_metas[i].set_layout(x.layout());
+      } else {
+        out_metas[i].set_dtype(x.dtype());
+        out_metas[i].set_dims(out_dims[i]);
+        out_metas[i].set_layout(x.layout());
+        out_metas[i].share_lod(x);
+      }
+    }
+  }
+}
+
+void SplitWithNumInferOutDims(const DenseTensor& x,
+                              int num,
+                              const Scalar& axis_scalar,
+                              std::vector<DenseTensor*>* outs) {
+  if (axis_scalar.FromTensor()) {
+    std::vector<MetaTensor> out_metas;
+    out_metas.reserve(outs->size());
+    for (size_t i = 0; i < outs->size(); ++i) {
+      out_metas.push_back((*outs)[i]);
+    }
+    int axis_value = GetSplitAxisValue(x, axis_scalar);
+    auto input_axis_dim = x.dims().at(axis_value);
+    // step1: get formated sections
+    std::vector<int64_t> sections_vec;
+    for (int i = 0; i < num; ++i) {
+      sections_vec.push_back(input_axis_dim / num);
+    }
+    // setp2: fill out dims
+    std::vector<phi::DDim> out_dims(sections_vec.size(), x.dims());
+    if (input_axis_dim > 0) {
+      for (size_t i = 0; i < sections_vec.size(); ++i) {
+        out_dims[i][axis_value] = sections_vec[i];
+      }
+    } else {
+      for (size_t i = 0; i < sections_vec.size(); ++i) {
+        out_dims[i][axis_value] = -1;
+      }
+    }
+
+    for (size_t i = 0; i < sections_vec.size(); ++i) {
+      if (axis_value != 0) {
+        // Only pass LoD when not spliting along the first dim.
+        out_metas[i].set_dtype(x.dtype());
+        out_metas[i].set_dims(out_dims[i]);
+        out_metas[i].set_layout(x.layout());
+      } else {
+        out_metas[i].set_dtype(x.dtype());
+        out_metas[i].set_dims(out_dims[i]);
+        out_metas[i].set_layout(x.layout());
+        out_metas[i].share_lod(x);
+      }
+    }
+  }
+}
+
+template <typename T, typename Context>
+void SplitKernel(const Context& dev_ctx,
+                 const DenseTensor& x,
+                 const IntArray& sections,
+                 const Scalar& axis_scalar,
+                 std::vector<DenseTensor*> outs) {
+  // need to infershape output
+  SplitInferOutDims(x, sections, axis_scalar, outs);
+
+  std::vector<const DenseTensor*> shape_refer;
+  for (size_t j = 0; j < outs.size(); ++j) {
+    dev_ctx.template Alloc<T>(outs[j]);
+    shape_refer.emplace_back(outs[j]);
+  }
+
+  int axis = axis_scalar.to<int>();
+  // Sometimes direct copies will be faster, this maybe need deeply analysis.
+  if (axis == 0 && outs.size() < 10) {
+    paddle::operators::StridedMemcpyWithAxis0<T>(
+        dev_ctx, x, shape_refer, &outs);
+  } else {
+    phi::funcs::SplitFunctor<Context, T> functor;
+    functor(dev_ctx, x, shape_refer, axis, &outs);
+  }
+}
+
+template <typename T, typename Context>
+void SplitWithNumKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        int num,
+                        const Scalar& axis_scalar,
+                        std::vector<DenseTensor*> outs) {
+  // need to infershape output
+  SplitWithNumInferOutDims(x, num, axis_scalar, outs);
+
+  std::vector<const DenseTensor*> shape_refer;
+  for (size_t j = 0; j < outs.size(); ++j) {
+    dev_ctx.template Alloc<T>(outs[j]);
+    shape_refer.emplace_back(outs[j]);
+  }
+
+  int axis = axis_scalar.to<int>();
+  // Sometimes direct copies will be faster, this maybe need deeply analysis.
+  if (axis == 0 && outs.size() < 10) {
+    paddle::operators::StridedMemcpyWithAxis0<T>(
+        dev_ctx, x, shape_refer, &outs);
+  } else {
+    phi::funcs::SplitFunctor<Context, T> functor;
+    functor(dev_ctx, x, shape_refer, axis, &outs);
+  }
+}
+
+}  // namespace phi

--- a/paddle/phi/kernels/split_kernel.h
+++ b/paddle/phi/kernels/split_kernel.h
@@ -18,28 +18,30 @@
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/infermeta/unary.h"
-#include "paddle/phi/kernels/empty_kernel.h"
 
 namespace phi {
 
 template <typename T, typename Context>
 void SplitKernel(const Context& dev_ctx,
                  const DenseTensor& x,
-                 const IntArray& num_or_sections,
+                 const IntArray& sections,
                  const Scalar& axis,
                  std::vector<DenseTensor*> out);
 
 template <typename T, typename Context>
+void SplitWithNumKernel(const Context& dev_ctx,
+                        const DenseTensor& x,
+                        int num,
+                        const Scalar& axis,
+                        std::vector<DenseTensor*> out);
+
+template <typename T, typename Context>
 std::vector<DenseTensor> Split(const Context& dev_ctx,
                                const DenseTensor& x,
-                               const IntArray& num_or_sections,
+                               const IntArray& sections,
                                const Scalar& axis) {
   size_t out_number;
-  if (num_or_sections.GetData().size() == 1) {
-    out_number = num_or_sections.GetData()[0];
-  } else {
-    out_number = num_or_sections.GetData().size();
-  }
+  out_number = sections.GetData().size();
 
   std::vector<MetaTensor> out_meta;
   std::vector<MetaTensor*> out_meta_ptr;
@@ -53,7 +55,7 @@ std::vector<DenseTensor> Split(const Context& dev_ctx,
     out_meta.emplace_back(&result.back());
     out_meta_ptr.push_back(&out_meta.back());
   }
-  SplitInferMeta(x, num_or_sections, axis, out_meta_ptr);
+  SplitInferMeta(x, sections, axis, out_meta_ptr);
 
   std::vector<DenseTensor*> outs;
   outs.reserve(out_meta.size());
@@ -61,7 +63,39 @@ std::vector<DenseTensor> Split(const Context& dev_ctx,
     outs.push_back(&result[i]);
   }
 
-  SplitKernel<T, Context>(dev_ctx, x, num_or_sections, axis, outs);
+  SplitKernel<T, Context>(dev_ctx, x, sections, axis, outs);
+
+  return result;
+}
+
+template <typename T, typename Context>
+std::vector<DenseTensor> SplitWithNum(const Context& dev_ctx,
+                                      const DenseTensor& x,
+                                      const int& num,
+                                      const Scalar& axis) {
+  size_t out_number = num;
+
+  std::vector<MetaTensor> out_meta;
+  std::vector<MetaTensor*> out_meta_ptr;
+  out_meta.reserve(out_number);
+  out_meta_ptr.reserve(out_number);
+  std::vector<DenseTensor> result;
+  result.reserve(out_number);
+
+  for (size_t i = 0; i < out_number; ++i) {
+    result.emplace_back(DenseTensor());
+    out_meta.emplace_back(&result.back());
+    out_meta_ptr.push_back(&out_meta.back());
+  }
+  SplitWithNumInferMeta(x, num, axis, out_meta_ptr);
+
+  std::vector<DenseTensor*> outs;
+  outs.reserve(out_meta.size());
+  for (size_t i = 0; i < out_meta.size(); ++i) {
+    outs.push_back(&result[i]);
+  }
+
+  SplitWithNumKernel<T, Context>(dev_ctx, x, num, axis, outs);
 
   return result;
 }

--- a/paddle/phi/ops/compat/split_sig.cc
+++ b/paddle/phi/ops/compat/split_sig.cc
@@ -21,9 +21,10 @@ KernelSignature SplitOpArgumentMapping(const ArgumentMappingContext& ctx) {
   // priority: AxisTensor > axis
   if (paddle::any_cast<int>(ctx.Attr("num")) > 0) {
     if (ctx.HasInput("AxisTensor")) {
-      return KernelSignature("split", {"X"}, {"num", "AxisTensor"}, {"Out"});
+      return KernelSignature(
+          "split_with_num", {"X"}, {"num", "AxisTensor"}, {"Out"});
     } else {
-      return KernelSignature("split", {"X"}, {"num", "axis"}, {"Out"});
+      return KernelSignature("split_with_num", {"X"}, {"num", "axis"}, {"Out"});
     }
   }
 

--- a/paddle/phi/tests/kernels/test_split_dev_api.cc
+++ b/paddle/phi/tests/kernels/test_split_dev_api.cc
@@ -22,6 +22,7 @@ limitations under the License. */
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/split_kernel.h"
+
 namespace phi {
 namespace tests {
 
@@ -50,6 +51,54 @@ TEST(DEV_API, split) {
 
   // 2. test API
   auto out = phi::Split<float>(dev_ctx, dense_x, {2, 2}, 0);
+
+  // 3. check result
+  ASSERT_EQ(out.size(), static_cast<size_t>(2));
+  ASSERT_EQ(out[0].dims().size(), 2);
+  ASSERT_EQ(out[0].dims()[0], 2);
+  ASSERT_EQ(out[0].dims()[1], 10);
+  ASSERT_EQ(out[0].meta().dtype, phi::DataType::FLOAT32);
+  ASSERT_EQ(out[0].meta().layout, phi::DataLayout::NCHW);
+
+  ASSERT_EQ(out[1].dims().size(), 2);
+  ASSERT_EQ(out[1].dims()[0], 2);
+  ASSERT_EQ(out[1].dims()[1], 10);
+  ASSERT_EQ(out[1].meta().dtype, phi::DataType::FLOAT32);
+  ASSERT_EQ(out[1].meta().layout, phi::DataLayout::NCHW);
+
+  auto out_data_0 = out[0].data<float>();
+  auto out_data_1 = out[1].data<float>();
+  for (size_t i = 0; i < 4; ++i) {
+    if (i < 20) {
+      ASSERT_NEAR(dense_x_data[i], out_data_0[i], 1e-6);
+    } else {
+      ASSERT_NEAR(dense_x_data[i], out_data_1[i - 20], 1e-6);
+    }
+  }
+}
+
+TEST(DEV_API, split_with_num) {
+  // 1. create tensor
+  const auto alloc =
+      std::make_unique<paddle::experimental::DefaultAllocator>(phi::CPUPlace());
+  phi::DenseTensor dense_x(alloc.get(),
+                           phi::DenseTensorMeta(phi::DataType::FLOAT32,
+                                                phi::make_ddim({4, 10}),
+                                                phi::DataLayout::NCHW));
+  phi::CPUContext dev_ctx;
+  dev_ctx.SetAllocator(paddle::memory::allocation::AllocatorFacade::Instance()
+                           .GetAllocator(paddle::platform::CPUPlace())
+                           .get());
+
+  auto* dense_x_data = dev_ctx.Alloc<float>(&dense_x);
+  for (size_t i = 0; i < 4; ++i) {
+    for (size_t j = 0; j < 10; ++j) {
+      dense_x_data[i * 10 + j] = (i * 10 + j) * 1.0;
+    }
+  }
+
+  // 2. test API
+  auto out = phi::SplitWithNum<float>(dev_ctx, dense_x, 2, 0);
 
   // 3. check result
   ASSERT_EQ(out.size(), static_cast<size_t>(2));

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1840,9 +1840,11 @@ def split(x, num_or_sections, axis=0, name=None):
                 "The type of 'num_or_sections' in split must be int, list or tuple in imperative mode, but "
                 "received %s." % (type(num_or_sections)))
         if in_dygraph_mode():
-            return _C_ops.final_state_split(
-                input, [num_or_sections]
-                if isinstance(num_or_sections, int) else num_or_sections, dim)
+            if isinstance(num_or_sections, int):
+                return _C_ops.final_state_split_with_num(
+                    input, num_or_sections, dim)
+            else:
+                return _C_ops.final_state_split(input, num_or_sections, dim)
         elif _in_legacy_dygraph():
             out = [_varbase_creator() for n in range(num)]
             _C_ops.split(input, out, *attrs)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
针对split api在新老动态图下行为不一致的问题进行修复，主要是由于新动态图在传入sections长度为1时直接当成了num进行处理，基于以上问题主要完成了以下几个工作：
a.拆分split kernel分别为split kernel与split_with_num kernel ，分别去支持传入参数为sections与num

b.拆分split infermeta分别为 split infermeta 和split_with_num infermeta，分别去支持传入参数为sections与num

c.将infermeta函数进行了功能拆分分别给 split infermeta 和split_with_num infermeta复用

d.由于kernel中逻辑不应该调用infermeta,但是spilt这个kernel中sections参数和axis_scalar参数可能是来自tensor构造的，在编译期进行infermeta推导的时候没有值，所以运行时要再进行infermeta的推导，因此根据infermeta逻辑抽出SplitInferOutDims和SplitWithNumInferOutDims给两个kernel调用，在运行期间计算infermeta信息。

e.split kernel与split_with_num在gpu与cpu实现是一致的，因此将kernel实现抽出来放在split_kernel_imp中。

f.新增spiltwithnum c++接口 与C++单测

g.新增split python单测中用户给出的动态图与静态图出问题的case单测。
