### PR TITLE
[dygraph hybrid pp for interleave] Virtual pp stage layer split

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -279,12 +279,13 @@ class PipelineLayer(Layer):
 
     def get_stage_from_index(self, layer_idx):
         assert 0 <= layer_idx < self._num_layers, "layer_idx is out of bound"
-        for stage in range(self._num_stages):
-            for i in range(stage, self._total_stages_with_virtual_stages,
-                           self._num_virtual_pipeline_stages):
+        for virtual_pp_offset in range(self._num_virtual_pipeline_stages):
+            start_idx = virtual_pp_offset * self._num_virtual_pipeline_stages
+            for stage in range(self._num_stages):
                 # mapping the virtual pipeline stage to the real pipeline stage
-                if self.segment_parts[i] <= layer_idx < self.segment_parts[i +
-                                                                           1]:
+                if self.segment_parts[start_idx +
+                                      stage] <= layer_idx < self.segment_parts[
+                                          start_idx + stage + 1]:
                     return stage
 
     def _construct_shared_comm(self):

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -175,7 +175,8 @@ class PipelineLayerChunk(Layer):
         self.functions = []
 
     def append(self, sublayer):
-        self.add_sublayer(str(len(self.functions)), sublayer)
+        if isinstance(sublayer, Layer):
+            self.add_sublayer(str(len(self.functions)), sublayer)
         self.functions.append(sublayer)
 
 
@@ -432,6 +433,7 @@ class PipelineLayer(Layer):
             end = self._end_poss[i]
             chunk = self._build_layer_impl(start, end)
             self._model_chunks.append(chunk)
+            self.add_sublayer(str(start), chunk)
 
     def _build_layer(self):
         start = self._start_pos
@@ -487,6 +489,7 @@ class PipelineLayer(Layer):
         return execute_func
 
     def forward(self, input):
+        # TODO(Yuang Liu): forward function for interleave scheduler
         if self._recompute_interval == 0:
             input = self.forward_function(0, len(self.run_function))(input)
         else:

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -61,6 +61,8 @@ list(APPEND DIST_TEST_OPS test_parallel_dygraph_no_sync)
 list(APPEND DIST_TEST_OPS test_parallel_dygraph_no_sync_gradient_check)
 list(APPEND DIST_TEST_OPS test_parallel_dygraph_dataparallel)
 list(APPEND DIST_TEST_OPS test_parallel_dygraph_pipeline_parallel)
+list(APPEND DIST_TEST_OPS
+     test_parallel_dygraph_pipeline_parallel_with_virtual_stage)
 list(APPEND DIST_TEST_OPS test_parallel_dygraph_tensor_parallel)
 list(APPEND DIST_TEST_OPS test_parallel_dygraph_sharding_parallel)
 list(APPEND DIST_TEST_OPS test_dygraph_sharding_optimizer_stage2)
@@ -311,6 +313,8 @@ if((NOT WITH_GPU) AND (NOT WITH_ROCM))
   list(REMOVE_ITEM TEST_OPS test_parallel_dygraph_no_sync_gradient_check)
   list(REMOVE_ITEM TEST_OPS test_parallel_dygraph_dataparallel)
   list(REMOVE_ITEM TEST_OPS test_parallel_dygraph_pipeline_parallel)
+  list(REMOVE_ITEM TEST_OPS
+       test_parallel_dygraph_pipeline_parallel_with_virtual_stage)
   list(REMOVE_ITEM TEST_OPS test_parallel_dygraph_tensor_parallel)
   list(REMOVE_ITEM TEST_OPS test_parallel_dygraph_sharding_parallel)
   list(REMOVE_ITEM TEST_OPS test_dygraph_sharding_optimizer_stage2)
@@ -1577,6 +1581,9 @@ if(WITH_DISTRIBUTE
                        PROPERTIES TIMEOUT 60)
   set_tests_properties(test_parallel_dygraph_pipeline_parallel
                        PROPERTIES TIMEOUT 500)
+  set_tests_properties(
+    test_parallel_dygraph_pipeline_parallel_with_virtual_stage
+    PROPERTIES TIMEOUT 500)
   set_tests_properties(test_parallel_dygraph_tensor_parallel PROPERTIES TIMEOUT
                                                                         200)
   set_tests_properties(test_parallel_dygraph_sharding_parallel

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -1581,9 +1581,6 @@ if(WITH_DISTRIBUTE
                        PROPERTIES TIMEOUT 60)
   set_tests_properties(test_parallel_dygraph_pipeline_parallel
                        PROPERTIES TIMEOUT 500)
-  set_tests_properties(
-    test_parallel_dygraph_pipeline_parallel_with_virtual_stage
-    PROPERTIES TIMEOUT 500)
   set_tests_properties(test_parallel_dygraph_tensor_parallel PROPERTIES TIMEOUT
                                                                         200)
   set_tests_properties(test_parallel_dygraph_sharding_parallel

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -1581,6 +1581,9 @@ if(WITH_DISTRIBUTE
                        PROPERTIES TIMEOUT 60)
   set_tests_properties(test_parallel_dygraph_pipeline_parallel
                        PROPERTIES TIMEOUT 500)
+  set_tests_properties(
+    test_parallel_dygraph_pipeline_parallel_with_virtual_stage
+    PROPERTIES TIMEOUT 500)
   set_tests_properties(test_parallel_dygraph_tensor_parallel PROPERTIES TIMEOUT
                                                                         200)
   set_tests_properties(test_parallel_dygraph_sharding_parallel

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import os
+import paddle
+from paddle.distributed import fleet
+import paddle.nn as nn
+from paddle.fluid.dygraph.layers import Layer
+from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer
+import paddle.nn.functional as F
+
+
+class ReshapeHelp(Layer):
+
+    def __init__(self, shape):
+        super(ReshapeHelp, self).__init__()
+        self.shape = shape
+
+    def forward(self, x):
+        return x.reshape(shape=self.shape)
+
+
+class FakeAlexNetPipeDesc(PipelineLayer):
+
+    def __init__(self, num_classes=10, **kwargs):
+        self.num_classes = num_classes
+        decs = [
+            LayerDesc(nn.Conv2D, 1, 64, kernel_size=11, stride=4, padding=5),
+            LayerDesc(nn.Conv2D, 64, 64, kernel_size=11, stride=4, padding=5),
+            LayerDesc(nn.ReLU),
+            LayerDesc(nn.MaxPool2D, kernel_size=2, stride=2),
+            LayerDesc(nn.Conv2D, 64, 192, kernel_size=5, padding=2),
+            LayerDesc(nn.Conv2D, 192, 192, kernel_size=5, padding=2),
+            F.relu,
+            LayerDesc(nn.MaxPool2D, kernel_size=2, stride=2),
+            LayerDesc(nn.Conv2D, 192, 384, kernel_size=3, padding=1),
+            F.relu,
+            LayerDesc(nn.Conv2D, 384, 256, kernel_size=3, padding=1),
+            F.relu,
+            LayerDesc(nn.Conv2D, 256, 256, kernel_size=3, padding=1),
+            LayerDesc(nn.Conv2D, 256, 256, kernel_size=3, padding=1),
+            F.relu,
+            LayerDesc(nn.MaxPool2D, kernel_size=2, stride=2),
+            LayerDesc(ReshapeHelp, shape=[-1, 256]),
+            LayerDesc(nn.Linear, 256, self.num_classes),  # classifier
+        ]
+        super(FakeAlexNetPipeDesc, self).__init__(layers=decs,
+                                                  loss_fn=nn.CrossEntropyLoss(),
+                                                  **kwargs)
+
+
+class TestPipeLayerAPI(unittest.TestCase):
+
+    def setUp(self):
+        strategy = fleet.DistributedStrategy()
+        self.pipeline_parallel_size = 2
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": self.pipeline_parallel_size
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+        self.hcg = fleet.get_hybrid_communicate_group()
+
+    def test_pipelayer_desc(self):
+        pipe_model = FakeAlexNetPipeDesc(seg_method="layer:Conv2D",
+                                         num_stages=self.pipeline_parallel_size,
+                                         num_virtual_pipeline_stages=2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
@@ -80,6 +80,9 @@ class TestPipeLayerAPI(unittest.TestCase):
                                          num_stages=self.pipeline_parallel_size,
                                          num_virtual_pipeline_stages=2)
         assert len(pipe_model.parameters()) > 0
+        model_chunks = pipe_model.get_model_chunks()
+        assert model_chunks is not None
+        assert len(model_chunks) == 2
         dist_model = fleet.distributed_model(pipe_model)
 
 

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
@@ -79,6 +79,7 @@ class TestPipeLayerAPI(unittest.TestCase):
         pipe_model = FakeAlexNetPipeDesc(seg_method="layer:Conv2D",
                                          num_stages=self.pipeline_parallel_size,
                                          num_virtual_pipeline_stages=2)
+        assert len(pipe_model.parameters()) > 0
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
@@ -80,6 +80,7 @@ class TestPipeLayerAPI(unittest.TestCase):
                                          num_stages=self.pipeline_parallel_size,
                                          num_virtual_pipeline_stages=2)
         assert len(pipe_model.parameters()) > 0
+        dist_model = fleet.distributed_model(pipe_model)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
@@ -27,6 +27,10 @@ class TestHybridPipeParallel(TestMultipleGpus):
         self.run_mnist_2gpu('hybrid_parallel_pp_layer.py')
         self.run_mnist_2gpu('hybrid_parallel_pp_layer.py', eager_mode=False)
 
+    def test_hybrid_parallel_pp_layer_with_virtual_stage(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py', eager_mode=False)
+
     def test_hybrid_parallel_pp_tuple_inputs(self):
         self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py')
         self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py', eager_mode=False)

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
@@ -62,14 +62,6 @@ class TestHybridPipeParallel(TestMultipleGpus):
         self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py', eager_mode=False)
 
 
-class TestHybridPipeParallelWithVirtualStage(TestMultipleGpus):
-
-    def test_hybrid_parallel_pp_layer_with_virtual_stage(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_layer_with_virtual_stage.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_layer_with_virtual_stage.py',
-                            eager_mode=False)
-
-
 if __name__ == "__main__":
     os.environ["FLAGS_enable_eager_mode"] = "1"
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
@@ -20,45 +20,46 @@ import os
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 
-# class TestHybridPipeParallel(TestMultipleGpus):
-#
-#     def test_hybrid_parallel_pp_layer(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_layer.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_layer.py', eager_mode=False)
-#
-#     def test_hybrid_parallel_pp_tuple_inputs(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py', eager_mode=False)
-#
-#     def test_hybrid_parallel_shared_weight(self):
-#         self.run_mnist_2gpu('hybrid_parallel_shared_weight.py')
-#         self.run_mnist_2gpu('hybrid_parallel_shared_weight.py',
-#                             eager_mode=False)
-#
-#     def test_pipeline_parallel_amp(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_amp.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_amp.py', eager_mode=False)
-#
-#     def test_pipeline_parallel_fp16(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py', eager_mode=False)
-#
-#     def test_hybrid_parallel_transformer(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py',
-#                             eager_mode=False)
-#
-#     def test_hybrid_parallel_save_load(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py', eager_mode=False)
-#
-#     def test_hybrid_parallel_recompute(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py', eager_mode=False)
-#
-#     def test_hybrid_parallel_pp_clip_grad(self):
-#         self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py')
-#         self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py', eager_mode=False)
+
+class TestHybridPipeParallel(TestMultipleGpus):
+
+    def test_hybrid_parallel_pp_layer(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py', eager_mode=False)
+
+    def test_hybrid_parallel_pp_tuple_inputs(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py', eager_mode=False)
+
+    def test_hybrid_parallel_shared_weight(self):
+        self.run_mnist_2gpu('hybrid_parallel_shared_weight.py')
+        self.run_mnist_2gpu('hybrid_parallel_shared_weight.py',
+                            eager_mode=False)
+
+    def test_pipeline_parallel_amp(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_amp.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_amp.py', eager_mode=False)
+
+    def test_pipeline_parallel_fp16(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py', eager_mode=False)
+
+    def test_hybrid_parallel_transformer(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py',
+                            eager_mode=False)
+
+    def test_hybrid_parallel_save_load(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py', eager_mode=False)
+
+    def test_hybrid_parallel_recompute(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py', eager_mode=False)
+
+    def test_hybrid_parallel_pp_clip_grad(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py', eager_mode=False)
 
 
 class TestHybridPipeParallelWithVirtualStage(TestMultipleGpus):

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel.py
@@ -20,50 +20,53 @@ import os
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 
+# class TestHybridPipeParallel(TestMultipleGpus):
+#
+#     def test_hybrid_parallel_pp_layer(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_layer.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_layer.py', eager_mode=False)
+#
+#     def test_hybrid_parallel_pp_tuple_inputs(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py', eager_mode=False)
+#
+#     def test_hybrid_parallel_shared_weight(self):
+#         self.run_mnist_2gpu('hybrid_parallel_shared_weight.py')
+#         self.run_mnist_2gpu('hybrid_parallel_shared_weight.py',
+#                             eager_mode=False)
+#
+#     def test_pipeline_parallel_amp(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_amp.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_amp.py', eager_mode=False)
+#
+#     def test_pipeline_parallel_fp16(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py', eager_mode=False)
+#
+#     def test_hybrid_parallel_transformer(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py',
+#                             eager_mode=False)
+#
+#     def test_hybrid_parallel_save_load(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py', eager_mode=False)
+#
+#     def test_hybrid_parallel_recompute(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py', eager_mode=False)
+#
+#     def test_hybrid_parallel_pp_clip_grad(self):
+#         self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py')
+#         self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py', eager_mode=False)
 
-class TestHybridPipeParallel(TestMultipleGpus):
 
-    def test_hybrid_parallel_pp_layer(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py', eager_mode=False)
+class TestHybridPipeParallelWithVirtualStage(TestMultipleGpus):
 
     def test_hybrid_parallel_pp_layer_with_virtual_stage(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_layer.py', eager_mode=False)
-
-    def test_hybrid_parallel_pp_tuple_inputs(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_embedding.py', eager_mode=False)
-
-    def test_hybrid_parallel_shared_weight(self):
-        self.run_mnist_2gpu('hybrid_parallel_shared_weight.py')
-        self.run_mnist_2gpu('hybrid_parallel_shared_weight.py',
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer_with_virtual_stage.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer_with_virtual_stage.py',
                             eager_mode=False)
-
-    def test_pipeline_parallel_amp(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_amp.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_amp.py', eager_mode=False)
-
-    def test_pipeline_parallel_fp16(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_fp16.py', eager_mode=False)
-
-    def test_hybrid_parallel_transformer(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_transformer.py',
-                            eager_mode=False)
-
-    def test_hybrid_parallel_save_load(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_save_load.py', eager_mode=False)
-
-    def test_hybrid_parallel_recompute(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_recompute.py', eager_mode=False)
-
-    def test_hybrid_parallel_pp_clip_grad(self):
-        self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py')
-        self.run_mnist_2gpu('hybrid_parallel_pp_clip_grad.py', eager_mode=False)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import paddle.fluid as fluid
+import os
+
+from test_parallel_dygraph_dataparallel import TestMultipleGpus
+
+
+class TestHybridPipeParallelWithVirtualStage(TestMultipleGpus):
+
+    def test_hybrid_parallel_pp_layer_with_virtual_stage(self):
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer_with_virtual_stage.py')
+        self.run_mnist_2gpu('hybrid_parallel_pp_layer_with_virtual_stage.py',
+                            eager_mode=False)
+
+
+if __name__ == "__main__":
+    os.environ["FLAGS_enable_eager_mode"] = "1"
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Support virtual pp stage layer split.
This is one of the pre-work for interleave scheduler for pipeline.
Add a new param to pp_layer, `num_virtual_pipeline_stages`, which means virtual pipeline stage on each real pipeline stage.
As we known, for a model with 8 layers, if real pipeline stage is 2, layers `[0, 1, 2, 3]` will be assigned to the first pipeline stage and layers `[4, 5, 6, 7]` will be assigned to the second pipeline stage.
Take the same model with 8 layers as an example, if the real pipeline stage is 2 and the `num_virtual_pipeline_stages` is also set to 2, layers `[0, 1]` and layers `[4, 5]` will be assigned to the first pipeline stage, while layers `[2, 3]` and layers `[6, 7]` will be assigned to the second pipeline stage. Each real pipeline stage has two separate model chunks, which are called virtual pipeline stage.

All works for supporting interleave scheduler for pipeline:
- [x] Support virtual pipeline layer spit (https://github.com/PaddlePaddle/Paddle/pull/45402)
- [ ] Support virtual pipeline layer forward function (compatible with recompute)
- [ ] Implement interleave scheduler in pipeline_parallel
- [ ] Implement save/load function for pipeline_parallel with virtual stage
- [ ] All necessary UT relating with recompute, AMP and etc.
- [ ] Some other functions but not sure yet