### PR TITLE
Layernorm trt scale bias opt

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
@@ -160,18 +160,6 @@ nvinfer1::DataType LayerNormPluginDynamic::getOutputDataType(
   return input_types[0];
 }
 
-// TODO wangbojun for debug
-template<typename T>
-__global__ void print_float(const T *src, int start_index, int end_index, int numPerRow=49, int stride=1){
-  printf("start print float \r\n");
-  for (int i=start_index;i<end_index;i+=stride){
-    printf("%f, ",static_cast<double>(src[i]));
-    if((i-start_index)/stride%numPerRow==numPerRow-1){
-      printf("\r\n");
-    }
-  }
-}
-
 int LayerNormPluginDynamic::enqueue(
     const nvinfer1::PluginTensorDesc *input_desc,
     const nvinfer1::PluginTensorDesc *output_desc,
@@ -232,40 +220,12 @@ int LayerNormPluginDynamic::enqueue(
     mean_t.Resize(phi::make_ddim(mean_shape_));
     variance_t.Resize(phi::make_ddim(variance_shape_));
 
-    // float *scale_d =
-    //     scale_t.mutable_data<float>(platform::CUDAPlace(device_id));
-    // float *bias_d = bias_t.mutable_data<float>(platform::CUDAPlace(device_id));
     float * scale_d = reinterpret_cast<float *>(scale_d_init_);
     float * bias_d = reinterpret_cast<float *>(bias_d_init_);
-
-    // printf("@@@ scale_d address : %X - %X , bias_d address :%X - %X \r\n",
-    //         scale_d,scale_d+feature_size,bias_d,bias_d+feature_size);
-    // printf("@@@ scale data \r\n");
-    // cudaDeviceSynchronize();
-    // print_float<<<1,1>>>(scale_d,0,5);
-    // cudaDeviceSynchronize();
-    // printf("\r\n");
-    // printf("@@@ bias data \r\n");
-
-    // cudaDeviceSynchronize();
-    // print_float<<<1,1>>>(bias_d,0,5);
-    // cudaDeviceSynchronize();
-    // printf("\r\n");
 
     float *mean_d = mean_t.mutable_data<float>(platform::CUDAPlace(device_id));
     float *variance_d =
         variance_t.mutable_data<float>(platform::CUDAPlace(device_id));
-
-    // cudaMemcpyAsync(scale_d,
-    //                 scale_.data(),
-    //                 sizeof(float) * feature_size,
-    //                 cudaMemcpyHostToDevice,
-    //                 stream);
-    // cudaMemcpyAsync(bias_d,
-    //                 bias_.data(),
-    //                 sizeof(float) * feature_size,
-    //                 cudaMemcpyHostToDevice,
-    //                 stream);
 
     phi::LayerNormDirectCUDAFunctor<float> layer_norm;
     layer_norm(stream,

--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.cu
@@ -215,13 +215,12 @@ int LayerNormPluginDynamic::enqueue(
     VLOG(1) << "TRT Plugin DataType selected. LayerNorm-->fp32";
     const float *input = reinterpret_cast<const float *>(inputs[0]);
     float *output = static_cast<float *>(outputs[0]);
-    // scale_t.Resize(phi::make_ddim({feature_size}));
-    // bias_t.Resize(phi::make_ddim({feature_size}));
+
     mean_t.Resize(phi::make_ddim(mean_shape_));
     variance_t.Resize(phi::make_ddim(variance_shape_));
 
-    float * scale_d = reinterpret_cast<float *>(scale_d_init_);
-    float * bias_d = reinterpret_cast<float *>(bias_d_init_);
+    float *scale_d = reinterpret_cast<float *>(scale_d_init_);
+    float *bias_d = reinterpret_cast<float *>(bias_d_init_);
 
     float *mean_d = mean_t.mutable_data<float>(platform::CUDAPlace(device_id));
     float *variance_d =

--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.h
@@ -192,8 +192,6 @@ class LayerNormPluginDynamic : public DynamicPluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &eps_);
     DeserializeValue(&serialData, &serialLength, &mean_shape_);
     DeserializeValue(&serialData, &serialLength, &variance_shape_);
-    DeserializeValue(&serialData, &serialLength, &bias_d_init_);
-    DeserializeValue(&serialData, &serialLength, &scale_d_init_);
   }
   nvinfer1::IPluginV2DynamicExt* clone() const TRT_NOEXCEPT override {
     return new LayerNormPluginDynamic(bias_.data(),

--- a/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/layer_norm_op_plugin.h
@@ -155,12 +155,12 @@ class LayerNormPluginDynamic : public DynamicPluginTensorRT {
         eps_(eps),
         mean_shape_(mean_shape),
         variance_shape_(variance_shape) {
-    // printf("@@@ in layernorm plugin call LayerNormPluginDynamic\r\n");
     bias_.resize(bias_num);
     scale_.resize(scale_num);
     std::copy(bias, bias + bias_num, bias_.data());
     std::copy(scale, scale + scale_num, scale_.data());
   }
+
   //for clone
   LayerNormPluginDynamic(const float* bias,
                          const int bias_num,
@@ -178,7 +178,6 @@ class LayerNormPluginDynamic : public DynamicPluginTensorRT {
         variance_shape_(variance_shape),
         bias_d_init_(bias_d_init),
         scale_d_init_(scale_d_init) {
-    // printf("@@@ in layernorm plugin call LayerNormPluginDynamic for clone \r\n");
 
     bias_.resize(bias_num);
     scale_.resize(scale_num);
@@ -224,11 +223,7 @@ class LayerNormPluginDynamic : public DynamicPluginTensorRT {
     long feature_size = scale_.size();
     scale_t.Resize({feature_size});
     bias_t.Resize({feature_size});
-    // todo wangbojun with fp16
-    // printf("@@@ in layernorm plugin init, feature_size: %ld\r\n",
-    //       feature_size);
-    // printf("@@@ scale[0]: %f, bias[0]: %f \r\n",
-    //       scale_[0],bias_[0]);
+    // for now, layernorm trt plugin only support fp32
     scale_d_init_ = reinterpret_cast<void *>(scale_t.mutable_data<float>(platform::CUDAPlace(device_id)));
     bias_d_init_ = reinterpret_cast<void *>(bias_t.mutable_data<float>(platform::CUDAPlace(device_id)));
     cudaMemcpyAsync(scale_d_init_,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
OPs

### Describe
Move data copy of bias/scale in layer_norm tensorrt plugin (fp32)  from enqueue to init. prevent the unnecessary data coping of bias/scale in every Execution. A 50% time reduction is expected.

before:
<img width="280" alt="image" src="https://user-images.githubusercontent.com/105858416/186581997-7aa990de-d4ff-4cf0-812a-002f410fd0ce.png">

after:
<img width="361" alt="image" src="https://user-images.githubusercontent.com/105858416/186581854-fa25055f-48d9-43b6-88c0-e621f4c1ea72.png">
