### PR TITLE
[API] fix bug in to_tensor which returns err dtype

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_to_tensor.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_to_tensor.py
@@ -82,6 +82,13 @@ def case5(x):
     return a
 
 
+def case6(x):
+    na = numpy.array([1, 2], dtype='int32')
+    a = paddle.to_tensor(na)
+
+    return a
+
+
 class TestToTensorReturnVal(unittest.TestCase):
 
     def test_to_tensor_badreturn(self):
@@ -120,6 +127,12 @@ class TestToTensorReturnVal(unittest.TestCase):
 
         a = paddle.jit.to_static(case5)(x)
         b = case5(x)
+        self.assertTrue(a.dtype == b.dtype)
+        self.assertTrue(a.stop_gradient == b.stop_gradient)
+        self.assertTrue(a.place._equals(b.place))
+
+        a = paddle.jit.to_static(case6)(x)
+        b = case6(x)
         self.assertTrue(a.dtype == b.dtype)
         self.assertTrue(a.stop_gradient == b.stop_gradient)
         self.assertTrue(a.place._equals(b.place))

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_to_tensor.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_to_tensor.py
@@ -33,7 +33,7 @@ def case0(x):
 
 def case1(x):
     paddle.set_default_dtype("float64")
-    a = paddle.to_tensor([1.0, 2.0, 3.0], stop_gradient=False)
+    a = paddle.to_tensor([1, 2, 3], stop_gradient=False, dtype='float32')
 
     return a
 
@@ -68,11 +68,18 @@ def case4(x):
         place = paddle.CUDAPlace(0)
     else:
         place = paddle.CPUPlace()
-    a = paddle.to_tensor([1.0], place=place, dtype="float64")
-    b = paddle.to_tensor([2], place=place, stop_gradient=False, dtype="int64")
+    a = paddle.to_tensor([1], place=place)
+    b = paddle.to_tensor([2.1], place=place, stop_gradient=False, dtype="int64")
     c = paddle.to_tensor([a, b, [1]], dtype="float32")
 
     return c
+
+
+def case5(x):
+    paddle.set_default_dtype("float64")
+    a = paddle.to_tensor([1, 2])
+
+    return a
 
 
 class TestToTensorReturnVal(unittest.TestCase):
@@ -107,6 +114,12 @@ class TestToTensorReturnVal(unittest.TestCase):
 
         a = paddle.jit.to_static(case4)(x)
         b = case4(x)
+        self.assertTrue(a.dtype == b.dtype)
+        self.assertTrue(a.stop_gradient == b.stop_gradient)
+        self.assertTrue(a.place._equals(b.place))
+
+        a = paddle.jit.to_static(case5)(x)
+        b = case5(x)
         self.assertTrue(a.dtype == b.dtype)
         self.assertTrue(a.stop_gradient == b.stop_gradient)
         self.assertTrue(a.place._equals(b.place))

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -368,12 +368,7 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
                         'float16', 'float32', 'float64', 'complex64',
                         'complex128'
                 ]:
-                    target_dtype = paddle.get_default_dtype()
-                    if np.iscomplexobj(data):
-                        target_dtype = 'complex64' if target_dtype in [
-                            'float16', 'float32'
-                        ] else 'complex128'
-                    data = data.astype(target_dtype)
+                    data = data.astype(paddle.get_default_dtype())
                 elif data.dtype in ['int32']:
                     data = data.astype('int64')
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -356,22 +356,25 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
         output = data
     else:
 
+        if dtype:
+            target_dtype = dtype
+        elif hasattr(data, 'dtype') and data.dtype != 'object':
+            target_dtype = data.dtype
+        else:
+            target_dtype = paddle.get_default_dtype()
+
         if not isinstance(data, np.ndarray):
             if np.isscalar(data) and not isinstance(data, str):
                 data = np.array([data])
             elif isinstance(data, (list, tuple)):
                 data = np.array(data)
 
-        if dtype:
-            target_dtype = dtype
-        elif hasattr(data, 'dtype') and data.dtype != 'object':
-            target_dtype = data.dtype
             # Windows default type is 'int32', while Linux/Mac is 'int64'. Unify they.
-            if data.dtype in ['int32']:
-                default_type = "int64"
-                data = data.astype(default_type)
-        else:
-            target_dtype = paddle.get_default_dtype()
+            if isinstance(data,
+                          np.ndarray) and not dtype and data.dtype != 'object':
+                if data.dtype in ['int32']:
+                    data = data.astype("int64")
+                target_dtype = data.dtype
 
         target_dtype = convert_dtype(target_dtype)
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -364,10 +364,7 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
 
             if isinstance(data,
                           np.ndarray) and not dtype and data.dtype != 'object':
-                if data.dtype in [
-                        'float16', 'float32', 'float64', 'complex64',
-                        'complex128'
-                ]:
+                if data.dtype in ['float16', 'float32', 'float64']:
                     data = data.astype(paddle.get_default_dtype())
                 elif data.dtype in ['int32']:
                     data = data.astype('int64')

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -356,25 +356,33 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
         output = data
     else:
 
-        if dtype:
-            target_dtype = dtype
-        elif hasattr(data, 'dtype') and data.dtype != 'object':
-            target_dtype = data.dtype
-        else:
-            target_dtype = paddle.get_default_dtype()
-
         if not isinstance(data, np.ndarray):
             if np.isscalar(data) and not isinstance(data, str):
                 data = np.array([data])
             elif isinstance(data, (list, tuple)):
                 data = np.array(data)
 
-            # Windows default type is 'int32', while Linux/Mac is 'int64'. Unify they.
             if isinstance(data,
                           np.ndarray) and not dtype and data.dtype != 'object':
-                if data.dtype in ['int32']:
-                    data = data.astype("int64")
-                target_dtype = data.dtype
+                if data.dtype in [
+                        'float16', 'float32', 'float64', 'complex64',
+                        'complex128'
+                ]:
+                    target_dtype = paddle.get_default_dtype()
+                    if np.iscomplexobj(data):
+                        target_dtype = 'complex64' if target_dtype in [
+                            'float16', 'float32'
+                        ] else 'complex128'
+                    data = data.astype(target_dtype)
+                elif data.dtype in ['int32']:
+                    data = data.astype('int64')
+
+        if dtype:
+            target_dtype = dtype
+        elif hasattr(data, 'dtype') and data.dtype != 'object':
+            target_dtype = data.dtype
+        else:
+            target_dtype = paddle.get_default_dtype()
 
         target_dtype = convert_dtype(target_dtype)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others

### Describe
<!-- Describe what this PR does -->
fixed the bug : to_tensor will return wrong dtype in static mode (if input is transformed to numpy array, its dtype should be used)