### PR TITLE
[NPU] fix CI error in new executor. test=develop

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -566,12 +566,16 @@ void InterpreterCore::RunInstruction(const Instruction& instr_node) {
                                            : var_scope_.GetMutableScope();
 
 #ifdef PADDLE_WITH_ASCEND_CL
-  // NOTE(wangxi): nan/inf cannot be detected on NPU by checking the variable
-  // values, but only through special `float_status` to checks whether
-  // the operation is overflow. More about `float_status`, see:
-  // https://gitee.com/ascend/modelzoo/issues/I3NF8V?from=project-issue
-  if (FLAGS_check_nan_inf) {
-    framework::details::NPUAllocAndClearFloatStatus(*op, *local_scope, place);
+  if (platform::is_npu_place(place)) {
+    auto dev_id = place.device;
+    platform::SetNPUDeviceId(dev_id);
+    // NOTE(wangxi): nan/inf cannot be detected on NPU by checking the variable
+    // values, but only through special `float_status` to checks whether
+    // the operation is overflow. More about `float_status`, see:
+    // https://gitee.com/ascend/modelzoo/issues/I3NF8V?from=project-issue
+    if (FLAGS_check_nan_inf) {
+      framework::details::NPUAllocAndClearFloatStatus(*op, *local_scope, place);
+    }
   }
 #endif
 

--- a/python/paddle/fluid/tests/unittests/npu/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/npu/CMakeLists.txt
@@ -6,8 +6,7 @@ string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
 if(WITH_ASCEND_CL)
   foreach(TEST_OP ${TEST_OPS})
-    py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS
-                    FLAGS_USE_STANDALONE_EXECUTOR=0)
+    py_test_modules(${TEST_OP} MODULES ${TEST_OP})
   endforeach()
 
   # NOTE: NPU `get_float_status` read the value from register, During the test,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others
### Describe
<!-- Describe what this PR does -->

在[PR45370](https://github.com/PaddlePaddle/Paddle/pull/45370)中，由于npu ci过不了，npu ci 执行器被切换回了旧执行器。 
在本pr中修复静态图新执行器下的npu ci失败问题。并将npu ci切换回新执行器。


