### PR TITLE
[dygraph hybrid pp for interleave] Virtual pipeline layer forward function

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -534,17 +534,15 @@ class PipelineLayer(Layer):
             assert chunk_id < len(self._model_chunks), \
                 "only {} chunks, but received chunk_id {}".format(len(self._model_chunks), chunk_id)
             model_chunk = self._model_chunks[chunk_id]
-            run_function = model_chunk.get_run_function()
-        else:
-            run_function = self.run_function
+            self.run_function = model_chunk.get_run_function()
 
         if self._recompute_interval == 0:
-            input = self.forward_function(0, len(run_function))(input)
+            input = self.forward_function(0, len(self.run_function))(input)
         else:
-            num_layers = len(run_function)
+            num_layers = len(self.run_function)
             for start_idx in range(0, num_layers, self._recompute_interval):
                 end_idx = min(start_idx + self._recompute_interval, num_layers)
-                funcs = run_function[start_idx:end_idx]
+                funcs = self.run_function[start_idx:end_idx]
 
                 if not isinstance(input, tuple):
                     input = (input, )

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -187,8 +187,8 @@ class PipelineLayerChunk(Layer):
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError(
-            "The forward function of PipelineLayerChunk cannot be called directly."
-        )
+            "The forward function of PipelineLayerChunk cannot be called directly. "
+            "Please call forward function of PipelineLayer.")
 
 
 class PipelineLayer(Layer):
@@ -534,6 +534,7 @@ class PipelineLayer(Layer):
             assert chunk_id < len(self._model_chunks), \
                 "only {} chunks, but received chunk_id {}".format(len(self._model_chunks), chunk_id)
             model_chunk = self._model_chunks[chunk_id]
+            # update the self.run_function to the target run functions
             self.run_function = model_chunk.get_run_function()
 
         if self._recompute_interval == 0:

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
@@ -89,6 +89,7 @@ class TestPipeLayerAPI(unittest.TestCase):
         for i in range(len(model_chunks)):
             out = pipe_model(paddle.to_tensor([1., 2.]), chunk_id=i)
             assert list(out.shape) == [2]
+            out = F.relu(out)
             loss = paddle.mean(out)
             loss.backward()
 

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer_with_virtual_stage.py
@@ -73,7 +73,7 @@ class TestPipeLayerAPI(unittest.TestCase):
             "pp_degree": self.pipeline_parallel_size
         }
         fleet.init(is_collective=True, strategy=strategy)
-        self.rank = fleet.get_rank()
+        self.rank = fleet.worker_index()
         self.hcg = fleet.get_hybrid_communicate_group()
 
     def test_pipelayer_desc(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Support forward function for pipeline layer with virtual stage.
Introduce a new parameter `chunk_id` to the origin forward function of class `PipelineLayer`, which is used for running forward function of virtual pipeline stage.

All works for supporting interleave scheduler for pipeline:
- [x] Support virtual pipeline layer spit (https://github.com/PaddlePaddle/Paddle/pull/45402)
- [x] Support virtual pipeline layer forward function (compatible with recompute) (https://github.com/PaddlePaddle/Paddle/pull/45444)
- [ ] Implement interleave scheduler in pipeline_parallel
- [ ] Implement save/load function for pipeline_parallel with virtual stage
- [ ] All necessary UT relating with recompute, AMP and etc.
- [ ] Some other functions but not sure yet
