### PR TITLE
fix memcpy_h2d bug related to cuda stream setting when allocate memory

### DIFF
--- a/paddle/phi/core/tensor_utils.cc
+++ b/paddle/phi/core/tensor_utils.cc
@@ -52,7 +52,6 @@ void Copy(const Context& dev_ctx,
           << dst_place;
 
   dst->Resize(src.dims());
-  dst->mutable_data(dst_place);
 
   void* dst_ptr = nullptr;
   if (paddle::platform::is_cpu_place(dst_place)) {

--- a/paddle/phi/kernels/memcpy_kernel.cc
+++ b/paddle/phi/kernels/memcpy_kernel.cc
@@ -25,6 +25,7 @@ namespace phi {
 
 static constexpr size_t WAIT_THRESHOLD = 64 * 1024;
 
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 template <>
 void MemcpyH2DKernel(const GPUContext& dev_ctx,
                      const DenseTensor& x,
@@ -41,12 +42,14 @@ void MemcpyH2DKernel(const GPUContext& dev_ctx,
       errors::OutOfRange("dst_place_type only support 0-3, but got: %d",
                          dst_place_type));
 
-  auto stream = static_cast<const phi::GPUContext*>(&dev_ctx)->stream();
+  auto stream = dev_ctx.stream();
   out->mutable_data(dev_ctx.GetPlace(),
                     x.dtype(),
                     phi::Stream(reinterpret_cast<phi::StreamId>(stream)));
+
   Copy(dev_ctx, x, dev_ctx.GetPlace(), false, out);
 }
+#endif
 
 template <typename Context>
 void MemcpyH2DKernel(const Context& dev_ctx,
@@ -74,6 +77,9 @@ void MemcpyD2HKernel(const Context& dev_ctx,
                      DenseTensor* out) {
   switch (dst_place_type) {
     case 0:
+      // NOTE(lvyongkang): phi::Copy will use DeviceContext.zero_allocator to
+      // alloc and assign DeviceContext.place to out, which causes place check
+      // fails. So we specify out's place here.
       out->mutable_data(CPUPlace());
       Copy(dev_ctx, x, CPUPlace(), false, out);
       // NOTE(copy from Aurelius84): host <-> device memory copies of a memory
@@ -85,6 +91,9 @@ void MemcpyD2HKernel(const Context& dev_ctx,
       break;
 
     case 1:
+      // NOTE(lvyongkang): phi::Copy will use DeviceContext.zero_allocator to
+      // alloc and assign DeviceContext.place to out, which causes place check
+      // fails. So we specify out's place here.
       out->mutable_data(GPUPinnedPlace());
       Copy(dev_ctx, x, GPUPinnedPlace(), false, out);
       // paddle::memory::Copy use async copy for GPUPinnedPlace
@@ -114,9 +123,9 @@ void MemcpyD2HMultiIOKernel(const Context& dev_ctx,
     PADDLE_ENFORCE_NOT_NULL(
         array[i],
         errors::PreconditionNotMet("input tesnor %d should not be nullptr", i));
-    PADDLE_ENFORCE_NOT_NULL(
-        out_array[i],
-        errors::PreconditionNotMet("input tesnor %d should not be nullptr", i));
+    PADDLE_ENFORCE_NOT_NULL(out_array[i],
+                            errors::PreconditionNotMet(
+                                "output tesnor %d should not be nullptr", i));
 
     const auto& x = *(array[i]);
     MemcpyD2HKernel<Context>(dev_ctx, x, dst_place_type, out_array[i]);

--- a/paddle/phi/kernels/memcpy_kernel.cc
+++ b/paddle/phi/kernels/memcpy_kernel.cc
@@ -16,8 +16,10 @@
 
 #include <vector>
 
+#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/stream.h"
 
 namespace phi {
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

**Problem**
[Transfer memcpy_h2d](related: #44932)
This commit did not correctly set the stream of the tensor when allocating, so may cause crash. 

Known problem includes cudaError(700) while training model (PaddleRec/models/rank/bst) using:
`python -u ../../../tools/static_trainer.py -m config.yaml -o runner.use_gpu=True`

**What this pr does?**
1. specify stream of the tensor while allocating for memcpy_h2d
2. revert changes of `phi::copy` in #45150 , and move the use of  `mutable_data` to `memcpy_kernel.cc`