### PR TITLE
[LazyInit]Support LazyGuard and Polish interface code

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -36,7 +36,7 @@ from .framework import disable_static  # noqa: F401
 from .framework import enable_static  # noqa: F401
 from .framework import in_dynamic_mode  # noqa: F401
 from .fluid.dataset import *  # noqa: F401
-from .fluid.lazy_init import LazyInit  # noqa: F401
+from .fluid.lazy_init import LazyGuard  # noqa: F401
 
 from .framework.dtype import dtype as dtype  # noqa: F401
 from .framework.dtype import uint8  # noqa: F401
@@ -416,7 +416,7 @@ __all__ = [  # noqa
     'cumprod',
     'logcumsumexp',
     'logit',
-    'LazyInit',
+    'LazyGuard',
     'sign',
     'is_empty',
     'equal',

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -38,6 +38,7 @@ from paddle.fluid import framework
 from ..param_attr import ParamAttr
 from paddle.fluid.executor import Executor, global_scope
 from paddle.fluid.framework import _non_static_mode, convert_np_dtype_to_dtype_, in_dygraph_mode
+from paddle.fluid.framework import Program, program_guard
 from paddle.fluid.framework import _current_expected_place as _get_device
 from paddle.fluid.core import VarDesc
 from paddle.fluid.dygraph import no_grad
@@ -1730,6 +1731,18 @@ class Layer(object):
 
         self._dtype = dtype
         return self
+
+    def _startup_program(self):
+        """
+        Return starup program containing initialization operations of all parameters.
+
+        NOTE(dev): This is a very low level API and only for inner developer.
+        """
+        startup_program = Program()
+        for param in self.parameters():
+            param._create_init_op(startup_program.global_block())
+
+        return startup_program
 
     # [aliases] Compatible with old method names
     set_dict = set_state_dict


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->


### What's New?

+ 移除了 `LazyInit(Model)`的用法，升级为 `with LazyGuard(): `
+ 将LazyInit 的API 名称调整为 LazyGuard
+ **支持guard语义下每一层Layer的均可以获取对应的startup_program**，故给`nn.Layer`基类新增了一个非公开的`_startup_program()` 接口

### Usage Example

如下是一个guard语义下支持任意一层Layer的startup_program获取：

```python
class NestModel(Layer):

    def __init__(self, base_model):
        super(NestModel, self).__init__()
        self.base_model = base_model
        self.fc = Linear(10, 10)

    def forward(self, x):
        x = self.base_model(x)
        x = self.fc(x)
        return x

with LazyGuard():
    base_model = Linear(10, 10)           # <----- 延迟初始化
    nest_model = NestModel(base_model)    # <----- 延迟初始化

print(nest_model._startup_program())   # 获取最外层model的startup_program，包含4个初始化op

print(base_model._startup_program())   # 获取内层model的startup_program，包含2个初始化op
```