### PR TITLE
bind trt engine context memory and predictor id

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1630,6 +1630,13 @@ bool AnalysisPredictor::ZeroCopyRun() {
     MkldnnPreSet(shape_vector);
   }
 #endif
+
+#ifdef PADDLE_WITH_TENSORRT
+  inference::tensorrt::TensorRTEngine::predictor_id_per_thread = predictor_id_;
+  VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
+          << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
+#endif
+
   executor_->Run();
 
   if (config_.shape_range_info_collected()) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -907,6 +907,12 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
     return false;
   }
 
+#ifdef PADDLE_WITH_TENSORRT
+  inference::tensorrt::TensorRTEngine::predictor_id_per_thread = predictor_id_;
+  VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
+          << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
+#endif
+
   // Run the inference program
   // if share variables, we need not create variables
   executor_->Run();

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -908,9 +908,12 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
   }
 
 #ifdef PADDLE_WITH_TENSORRT
-  inference::tensorrt::TensorRTEngine::predictor_id_per_thread = predictor_id_;
-  VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
-          << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
+  if (config_.tensorrt_engine_enabled()) {
+    inference::tensorrt::TensorRTEngine::predictor_id_per_thread =
+        predictor_id_;
+    VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
+            << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
+  }
 #endif
 
   // Run the inference program
@@ -1638,9 +1641,12 @@ bool AnalysisPredictor::ZeroCopyRun() {
 #endif
 
 #ifdef PADDLE_WITH_TENSORRT
-  inference::tensorrt::TensorRTEngine::predictor_id_per_thread = predictor_id_;
-  VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
-          << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
+  if (config_.tensorrt_engine_enabled()) {
+    inference::tensorrt::TensorRTEngine::predictor_id_per_thread =
+        predictor_id_;
+    VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
+            << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
+  }
 #endif
 
   executor_->Run();

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -911,7 +911,7 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
   if (config_.tensorrt_engine_enabled()) {
     inference::tensorrt::TensorRTEngine::predictor_id_per_thread =
         predictor_id_;
-    VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
+    VLOG(3) << "thread_local var predictor_id in TensorRTEngine is set to: "
             << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
   }
 #endif
@@ -1644,7 +1644,7 @@ bool AnalysisPredictor::ZeroCopyRun() {
   if (config_.tensorrt_engine_enabled()) {
     inference::tensorrt::TensorRTEngine::predictor_id_per_thread =
         predictor_id_;
-    VLOG(3) << "thread_local var predictor_id in TendorRTEngine is set to: "
+    VLOG(3) << "thread_local var predictor_id in TensorRTEngine is set to: "
             << inference::tensorrt::TensorRTEngine::predictor_id_per_thread;
   }
 #endif

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -177,6 +177,7 @@ class TRTInt8Calibrator;
 class TensorRTEngine {
   using DescType = ::paddle::framework::proto::BlockDesc;
   using ShapeMapType = std::map<std::string, std::vector<int>>;
+  using PredictorID = int;
 
  public:
   // Weight is model parameter.
@@ -286,9 +287,15 @@ class TensorRTEngine {
 
   nvinfer1::ICudaEngine* engine() { return infer_engine_.get(); }
   nvinfer1::IExecutionContext* context() {
+    PADDLE_ENFORCE_GT(
+        predictor_id_per_thread,
+        -1,
+        platform::errors::InvalidArgument(
+            "thread local var predictor_id_per_thread must be "
+            "initialized to >= 0, but now predictor_id_per_thread = %d",
+            predictor_id_per_thread));
     std::unique_lock<std::mutex> lock(mutex_);
-    const std::thread::id tid = std::this_thread::get_id();
-    if (infer_context_.find(tid) == infer_context_.end()) {
+    if (infer_context_.find(predictor_id_per_thread) == infer_context_.end()) {
       PADDLE_ENFORCE_NOT_NULL(
           infer_engine_,
           platform::errors::InvalidArgument(
@@ -296,24 +303,32 @@ class TensorRTEngine {
       // We may see trt warning: Profile 0 has been chosen by another
       // IExecutionContext...
       // It's ok. We will set it later.
-      infer_context_[tid].reset(infer_engine_->createExecutionContext());
+      infer_context_[predictor_id_per_thread].reset(
+          infer_engine_->createExecutionContext());
       if (with_dynamic_shape_) {
         // need new profile if it's not the first
         if (cur_profile_num_ > 0) {
-          infer_context_[tid]->setOptimizationProfile(cur_profile_num_);
+          infer_context_[predictor_id_per_thread]->setOptimizationProfile(
+              cur_profile_num_);
         }
-        profile_index_[tid] = cur_profile_num_;
+        profile_index_[predictor_id_per_thread] = cur_profile_num_;
         ++cur_profile_num_;
       }
     }
-    return infer_context_[tid].get();
+    return infer_context_[predictor_id_per_thread].get();
   }
 
   int GetProfileIndex() {
     if (max_profile_num_ > 1) {
+      PADDLE_ENFORCE_GT(
+          predictor_id_per_thread,
+          -1,
+          platform::errors::InvalidArgument(
+              "thread local var predictor_id_per_thread must be "
+              "initialized to >= 0, but now predictor_id_per_thread = %d",
+              predictor_id_per_thread));
       std::unique_lock<std::mutex> lock(mutex_);
-      const std::thread::id tid = std::this_thread::get_id();
-      return profile_index_[tid];
+      return profile_index_[predictor_id_per_thread];
     } else {
       return 0;
     }
@@ -326,14 +341,20 @@ class TensorRTEngine {
   int GetNbBindings() { return binding_num_; }
 
   void ResetContext() {
-    std::unique_lock<std::mutex> lock(mutex_);
-    const std::thread::id tid = std::this_thread::get_id();
     PADDLE_ENFORCE_NOT_NULL(
         infer_engine_,
         platform::errors::InvalidArgument(
             "You should build engine first and then set the context."));
-    infer_context_[tid].reset(nullptr);
-    infer_context_.erase(tid);
+    PADDLE_ENFORCE_GT(
+        predictor_id_per_thread,
+        -1,
+        platform::errors::InvalidArgument(
+            "thread local var predictor_id_per_thread must be "
+            "initialized to >= 0, but now predictor_id_per_thread = %d",
+            predictor_id_per_thread));
+    std::unique_lock<std::mutex> lock(mutex_);
+    infer_context_[predictor_id_per_thread].reset(nullptr);
+    infer_context_.erase(predictor_id_per_thread);
   }
 
   nvinfer1::IHostMemory* Serialize() {
@@ -686,7 +707,7 @@ class TensorRTEngine {
   int device_id_;
   int max_profile_num_{1};
   int cur_profile_num_{0};
-  std::unordered_map<std::thread::id, int> profile_index_;
+  std::unordered_map<PredictorID, int> profile_index_;
   ShapeMapType min_input_shape_;
   ShapeMapType max_input_shape_;
   ShapeMapType optim_input_shape_;
@@ -723,7 +744,7 @@ class TensorRTEngine {
   infer_ptr<nvinfer1::IBuilder> infer_builder_;
   infer_ptr<nvinfer1::INetworkDefinition> infer_network_;
   infer_ptr<nvinfer1::ICudaEngine> infer_engine_;
-  std::unordered_map<std::thread::id, infer_ptr<nvinfer1::IExecutionContext>>
+  std::unordered_map<PredictorID, infer_ptr<nvinfer1::IExecutionContext>>
       infer_context_;
   infer_ptr<nvinfer1::IHostMemory> ihost_memory_;
   std::unordered_map<nvinfer1::ITensor*, float> quant_dynamic_range_;
@@ -741,6 +762,9 @@ class TensorRTEngine {
 #endif
   std::mutex mutex_;
   bool use_inspector_;
+
+ public:
+  thread_local static int predictor_id_per_thread;
 };  // class TensorRTEngine
 
 // Add a layer__ into engine__ with args ARGS.

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -287,6 +287,7 @@ class TensorRTEngine {
 
   nvinfer1::ICudaEngine* engine() { return infer_engine_.get(); }
   nvinfer1::IExecutionContext* context() {
+#ifndef PADDLE_WITH_TESTING
     PADDLE_ENFORCE_GT(
         predictor_id_per_thread,
         -1,
@@ -294,6 +295,7 @@ class TensorRTEngine {
             "thread local var predictor_id_per_thread must be "
             "initialized to >= 0, but now predictor_id_per_thread = %d",
             predictor_id_per_thread));
+#endif
     std::unique_lock<std::mutex> lock(mutex_);
     if (infer_context_.find(predictor_id_per_thread) == infer_context_.end()) {
       PADDLE_ENFORCE_NOT_NULL(
@@ -320,6 +322,7 @@ class TensorRTEngine {
 
   int GetProfileIndex() {
     if (max_profile_num_ > 1) {
+#ifndef PADDLE_WITH_TESTING
       PADDLE_ENFORCE_GT(
           predictor_id_per_thread,
           -1,
@@ -327,6 +330,7 @@ class TensorRTEngine {
               "thread local var predictor_id_per_thread must be "
               "initialized to >= 0, but now predictor_id_per_thread = %d",
               predictor_id_per_thread));
+#endif
       std::unique_lock<std::mutex> lock(mutex_);
       return profile_index_[predictor_id_per_thread];
     } else {
@@ -345,6 +349,7 @@ class TensorRTEngine {
         infer_engine_,
         platform::errors::InvalidArgument(
             "You should build engine first and then set the context."));
+#ifndef PADDLE_WITH_TESTING
     PADDLE_ENFORCE_GT(
         predictor_id_per_thread,
         -1,
@@ -352,6 +357,7 @@ class TensorRTEngine {
             "thread local var predictor_id_per_thread must be "
             "initialized to >= 0, but now predictor_id_per_thread = %d",
             predictor_id_per_thread));
+#endif
     std::unique_lock<std::mutex> lock(mutex_);
     infer_context_[predictor_id_per_thread].reset(nullptr);
     infer_context_.erase(predictor_id_per_thread);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
原本trt engine的context memory是与线程id绑定的，有多少个线程就会有多少份context memory，predictor的trt engine在多线程场景下run时，这会带来较大的显存浪费。
现将trt engine的context memory与predictor id绑定，这样一来，无论有多少个线程，这个predictor的trt engine在run的时候，只会有一份context memory。
使用了thread_local变量，在predictor.run时，将自己的predictor id更新给thread_local变量。
