### PR TITLE
Revert the change of remove_training_info

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5865,29 +5865,17 @@ class Program(object):
         ]
         res._sync_with_cpp()
 
-        # Note: The op_role and op_role_var cann't be deleted currently,
-        # and we will try to remove them in the future.
-        common_clipped_attrs_list = ['op_namescope', 'op_callstack']
-
         for i in six.moves.range(res.desc.num_blocks()):
             block = res.desc.block(i)
             for var in block.all_vars():
                 var.clear_is_parameter()
                 var.clear_stop_gradient()
+            if not clip_extra:
+                continue
             for op_idx in range(0, block.op_size()):
                 op = block.op(op_idx)
                 if op.type() not in OpProtoHolder.instance().op_proto_map:
                     continue
-
-                if not clip_extra:
-                    continue
-
-                extra_attrs_map = core.get_op_extra_attrs(op.type())
-                for name in op.attr_names():
-                    if name in extra_attrs_map:
-                        op.remove_attr(name)
-                        continue
-
                 proto = OpProtoHolder.instance().get_op_proto(op.type())
                 remove_input_list = []
                 for name in op.input_names():
@@ -5901,9 +5889,8 @@ class Program(object):
                         break
                     if not find:
                         remove_input_list.append(name)
-                # The extra input of op will be removed in the future
-                # for name in remove_input_list:
-                #     op.remove_input(name)
+                for name in remove_input_list:
+                    op.remove_input(name)
 
                 remove_output_list = []
                 for name in op.output_names():
@@ -5917,10 +5904,10 @@ class Program(object):
                         break
                     if not find:
                         remove_output_list.append(name)
-                # The extra input of op will be removed in the future
-                # for name in remove_output_list:
-                #     op.remove_output(name)
+                for name in remove_output_list:
+                    op.remove_output(name)
 
+                remove_attr_list = []
                 op_quant_name = core.op_proto_and_checker_maker.kOpWithQuantAttrName(
                 )
                 quant = bool(op.attr(op_quant_name)
@@ -5930,21 +5917,18 @@ class Program(object):
                     "activation_bits", "bit_length", "quantize_weight_bits",
                     "weight_quant_scale"
                 ]
-                remove_attr_list = []
                 for name in op.attr_names():
                     if quant:
                         if name in quant_attrs:
                             continue
                         if name.endswith("_threshold"):
                             continue
-                    if name in common_clipped_attrs_list:
-                        remove_attr_list.append(name)
-                        continue
-
                     find = False
                     for attr_proto in proto.attrs:
                         if attr_proto.name != name:
                             continue
+                        if attr_proto.extra:
+                            remove_attr_list.append(name)
                         find = True
                         break
                     if not find:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5876,6 +5876,15 @@ class Program(object):
                 op = block.op(op_idx)
                 if op.type() not in OpProtoHolder.instance().op_proto_map:
                     continue
+
+                extra_attrs_map = core.get_op_extra_attrs(op.type())
+                if len(extra_attrs_map) > 0:
+                    for name in op.attr_names():
+                        if name in extra_attrs_map:
+                            op.remove_attr(name)
+                            continue
+                    continue
+
                 proto = OpProtoHolder.instance().get_op_proto(op.type())
                 remove_input_list = []
                 for name in op.input_names():

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5865,6 +5865,12 @@ class Program(object):
         ]
         res._sync_with_cpp()
 
+        # Note: The op_role and op_role_var cann't be deleted currently,
+        # and we will try to remove them in the future.
+        common_clipped_attrs_list = [
+            'op_namescope', 'op_callstack', 'op_device', 'with_quant_attr'
+        ]
+
         for i in six.moves.range(res.desc.num_blocks()):
             block = res.desc.block(i)
             for var in block.all_vars():
@@ -5878,12 +5884,6 @@ class Program(object):
                     continue
 
                 extra_attrs_map = core.get_op_extra_attrs(op.type())
-                if len(extra_attrs_map) > 0:
-                    for name in op.attr_names():
-                        if name in extra_attrs_map:
-                            op.remove_attr(name)
-                            continue
-                    continue
 
                 proto = OpProtoHolder.instance().get_op_proto(op.type())
                 remove_input_list = []
@@ -5932,6 +5932,10 @@ class Program(object):
                             continue
                         if name.endswith("_threshold"):
                             continue
+                    if len(extra_attrs_map) > 0:
+                        if name in extra_attrs_map or name in common_clipped_attrs_list:
+                            op.remove_attr(name)
+                        continue
                     find = False
                     for attr_proto in proto.attrs:
                         if attr_proto.name != name:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
在[PR44310](https://github.com/PaddlePaddle/Paddle/pull/44310)中修改了`remove_training_info`接口的行为，为了减少对推理全量模型测试的影响，本PR对`clip_extra`开启时的行为进行了修改，调整后为：如果一个op在yaml中配置了extra属性，则只裁剪Yaml中配置的属性和部分公共extra属性，否则仍按原来的方式进行裁剪。