### PR TITLE
Set use_cudnn=true for conv2d in yaml

### DIFF
--- a/paddle/phi/api/yaml/api_compat.yaml
+++ b/paddle/phi/api/yaml/api_compat.yaml
@@ -30,7 +30,7 @@
 - api : conv2d
   backward : conv2d_grad
   extra :
-    attrs : [bool use_cudnn = false, bool fuse_relu_before_depthwise_conv = false, bool use_mkldnn = false,
+    attrs : [bool use_cudnn = true, bool fuse_relu_before_depthwise_conv = false, bool use_mkldnn = false,
              bool use_quantizer = false, str mkldnn_data_type = "float32", bool fuse_relu = false,
              str fuse_activation = "", float fuse_alpha = 0.0f, float fuse_beta = 0.0f, bool use_addto = false,
              bool fuse_residual_connection = false, float Scale_in = 1.0f, float Scale_out = 1.0f,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
`conv2d` 在 api_compat.yaml 中的 `use_cudnn` 默认值由`false`改为`true`，再执行推理时将优先选择 `conv2d` 的 cudnn kernel。