### PR TITLE
Improve some test conditions of bfloat16 OP unittest

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -108,8 +108,10 @@ class TestFP16ElementwiseAddOp(TestElementwiseAddOp):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.cudnn_version() < 8100,
-    "core is not compiled with CUDA and cudnn version need larger than 8.1.0")
+    not core.is_compiled_with_cuda() or core.cudnn_version() < 8100
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "only support compiled with CUDA and cudnn version need larger than 8.1.0 and device's compute capability is at least 8.0"
+)
 class TestBF16ElementwiseAddOp(OpTest):
 
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
@@ -62,9 +62,11 @@ class TestElementwiseOp(OpTest):
                         no_grad_set=set('Y'))
 
 
-@unittest.skipIf(
-    core.is_compiled_with_cuda() and core.cudnn_version() < 8100,
-    "run test when gpu is availble and the minimum cudnn version is 8.1.0.")
+@unittest.skipIf(core.is_compiled_with_cuda() and (
+    core.cudnn_version() < 8100
+    or paddle.device.cuda.get_device_capability()[0] < 8
+), "run test when gpu is availble and the minimum cudnn version is 8.1.0 and gpu's compute capability is at least 8.0."
+                 )
 class TestElementwiseBF16Op(OpTest):
 
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -417,7 +417,9 @@ class TestBF16ScaleBiasLayerNorm(unittest.TestCase):
         return y_np, x_g_np, w_g_np, b_g_np
 
     def test_main(self):
-        if (not core.is_compiled_with_cuda()) or (core.cudnn_version() < 8100):
+        if (not core.is_compiled_with_cuda()) or (
+                core.cudnn_version() <
+                8100) or (paddle.device.cuda.get_device_capability()[0] < 8):
             return
         x_np = np.random.random([10, 20]).astype('float32')
         weight_np = np.random.random([20]).astype('float32')

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -360,8 +360,10 @@ class TestSoftmaxBF16Op(OpTest):
 
 
 @unittest.skipIf(
-    not core.is_compiled_with_cuda() or core.cudnn_version() < 8100,
-    "core is not compiled with CUDA and cudnn version need larger than 8.1.0")
+    not core.is_compiled_with_cuda() or core.cudnn_version() < 8100
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "only support compiled with CUDA and cudnn version need larger than 8.1.0 and device's compute capability is at least 8.0"
+)
 class TestSoftmaxBF16CUDNNOp(TestSoftmaxBF16Op):
 
     def init_cudnn(self):


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
完善如下op的 cudnn bfloat16 kernel 单测执行条件（elementwise_add、elementwise_max、layer_norm、softmax）：
要求cdunn版本至少为8.1.0，GPU算力至少为8.0