### PR TITLE
[ONNX]Remove cond_var from Input('X') in while_loop op

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1162,6 +1162,9 @@ class While(object):
                 out_vars.append(inner_var)
 
         x_name_list |= set(map(lambda x: x.name, out_vars))
+        # NOTE(dev): cond_var has been contained in Input('Condition'), so
+        # we remove it from Input('X')
+        x_name_list -= {self.cond_var.name}
 
         step_scope = parent_block.create_var(
             type=core.VarDesc.VarType.STEP_SCOPES)

--- a/python/paddle/fluid/tests/unittests/test_while_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_op.py
@@ -223,6 +223,7 @@ class TestOutputsMustExistsInputs(unittest.TestCase):
         for op in main_program.block(0).ops:
             if op.type == "while":
                 for out_name in op.output("Out"):
+                    if out_name in op.input("Condition"): continue
                     self.assertTrue(
                         out_name in op.input("X"),
                         "In while op, the variable in output(`Out`) must exists in inputs(`X`), but the variable with name `{}` not meet the precondition."


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
### What's New?

将 cond_var 从 while_loop 中 Input('X') 移除，因为其已经在 Input('Condition')中了。

对于如下Example:
```python
import paddle
paddle.enable_static()

def cond(i, ten):
    return i < ten

def body(i, ten):
    i = i + 1
    return [i, ten]

main_program = paddle.static.default_main_program()
startup_program = paddle.static.default_startup_program()
with paddle.static.program_guard(main_program, startup_program):
    i = paddle.full(shape=[1], fill_value=0, dtype='int64')     # loop counter
    ten = paddle.full(shape=[1], fill_value=10, dtype='int64')  # loop length
    i, ten = paddle.static.nn.while_loop(cond, body, [i, ten])
    print(main_program)

    exe = paddle.static.Executor(paddle.CPUPlace())
    res = exe.run(main_program, feed={}, fetch_list=[i])
    print(res) # [array([10])]
``` 

此PR 之前的program表示：
<img width="1924" alt="17a13fedb52d0d44e670379856852180" src="https://user-images.githubusercontent.com/9301846/188055959-f9c59d3b-d98c-4e72-bc45-a2cca09b746e.png">

此PR之后的Program表示：
<img width="986" alt="image" src="https://user-images.githubusercontent.com/9301846/188056087-9ae31b9b-9c9c-40e5-b715-8773f46ad8aa.png">
