### PR TITLE
Add op count by lib method

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_get_all_op_or_kernel_names.py
+++ b/python/paddle/fluid/tests/unittests/test_get_all_op_or_kernel_names.py
@@ -39,5 +39,19 @@ class TestGetAllRegisteredOpKernels(unittest.TestCase):
         self.assertTrue(core._get_all_register_op_kernels()['sign'])
 
 
+class TestGetAllOpNames(unittest.TestCase):
+
+    def test_get_all_op_names(self):
+        all_op_names = core.get_all_op_names()
+        all_op_with_phi_kernels = core.get_all_op_names("phi")
+        all_op_with_fluid_kernels = core.get_all_op_names("fluid")
+
+        self.assertTrue(
+            len(all_op_names) > len(
+                set(all_op_with_phi_kernels) | set(all_op_with_fluid_kernels)))
+        self.assertTrue("scale" in all_op_with_phi_kernels)
+        self.assertTrue("scale" in all_op_with_phi_kernels)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Add op count by lib method

```
import paddle

all_op_names = paddle.framework.core.get_all_op_names()
all_op_names_set = set(all_op_names)
print("Op numbers with phi kernel：", len(all_op_names_set))
# print(all_op_names_set)

all_phi_op_names = paddle.framework.core.get_all_op_names("phi")
all_phi_op_names_set = set(all_phi_op_names)
print("Op numbers with phi kernel：", len(all_phi_op_names_set))
# print(all_phi_op_names_set)

all_fluid_op_names = paddle.framework.core.get_all_op_names("fluid")
all_fluid_op_names_set = set(all_fluid_op_names)
print("Op numbers with fluid kernel：", len(all_fluid_op_names_set))
# print(all_fluid_op_names_set)

support_two_type_kernel_op_names_set = all_phi_op_names_set & all_fluid_op_names_set
print("Op numbers with fluid and phi kernel：", len(support_two_type_kernel_op_names_set))
# print(support_two_type_kernel_op_names_set)

```

```
Op numbers： 1062  // some op has no kernel
Op numbers with phi kernel： 604
Op numbers with fluid kernel： 456
Op numbers with fluid and phi kernel： 82 // most are mkldnn kernel
```