### PR TITLE
Fix custom_raw_op_kernel ut by adding macro THRUST_IGNORE_CUB_VERSION_CHECK

### DIFF
--- a/python/paddle/fluid/tests/custom_op/custom_raw_op_kernel_op_setup.py
+++ b/python/paddle/fluid/tests/custom_op/custom_raw_op_kernel_op_setup.py
@@ -38,6 +38,7 @@ if core.is_compiled_with_mkldnn():
     macros.append(("PADDLE_WITH_MKLDNN", None))
 if core.is_compiled_with_nccl():
     macros.append(("PADDLE_WITH_NCCL", None))
+macros.append(("THRUST_IGNORE_CUB_VERSION_CHECK", None))
 
 include_dirs = list(paddle_includes) + [cwd]
 setup(name=os.getenv("MODULE_NAME", "custom_raw_op_kernel_op_setup"),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
Fix custom_raw_op_kernel ut by adding macro THRUST_IGNORE_CUB_VERSION_CHECK.
![74f4a2d7c8f45919f61c99ec1b96dd14](https://user-images.githubusercontent.com/32832641/188357044-a2a37e68-4801-4152-a551-536f2fea6648.png)
