### PR TITLE
[Dy2Stat]Filter UserWarings while @to_static

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -610,7 +610,7 @@ def _inject_import_statements():
         "import paddle", "from paddle import Tensor",
         "import paddle.fluid as fluid", "import paddle.jit.dy2static as _jst",
         "from typing import *", "import numpy as np", "import warnings",
-        "warnings.filterwarnings('ignore')"
+        "warnings.filterwarnings('ignore', category=DeprecationWarning)"
     ]
     return '\n'.join(import_statements) + '\n'
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -609,7 +609,8 @@ def _inject_import_statements():
     import_statements = [
         "import paddle", "from paddle import Tensor",
         "import paddle.fluid as fluid", "import paddle.jit.dy2static as _jst",
-        "from typing import *", "import numpy as np"
+        "from typing import *", "import numpy as np", "import warnings",
+        "warnings.filterwarnings('ignore')"
     ]
     return '\n'.join(import_statements) + '\n'
 

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -378,7 +378,8 @@ def monkey_patch_variable():
                     "If your code works well in the older versions but crashes in this version, try to use "
                     "%s(X, Y, axis=0) instead of %s. This transitional warning will be dropped in the future."
                     % (file_name, line_num, EXPRESSION_MAP[method_name],
-                       op_type, op_type, EXPRESSION_MAP[method_name]))
+                       op_type, op_type, EXPRESSION_MAP[method_name]),
+                    category=DeprecationWarning)
             current_block(self).append_op(type=op_type,
                                           inputs={
                                               'X': [self],

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_origin_info.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_origin_info.py
@@ -65,7 +65,7 @@ class TestOriginInfo(unittest.TestCase):
         self.func = simple_func
 
     def set_static_lineno(self):
-        self.static_abs_lineno_list = [7, 8, 9]
+        self.static_abs_lineno_list = [9, 10, 11]
 
     def set_dygraph_info(self):
         self.line_num = 3
@@ -149,7 +149,7 @@ class TestOriginInfoWithNestedFunc(TestOriginInfo):
         self.func = nested_func
 
     def set_static_lineno(self):
-        self.static_abs_lineno_list = [7, 9, 10, 11, 12]
+        self.static_abs_lineno_list = [9, 11, 12, 13, 14]
 
     def set_dygraph_info(self):
         self.line_num = 5
@@ -174,7 +174,7 @@ class TestOriginInfoWithDecoratedFunc(TestOriginInfo):
         self.func = decorated_func
 
     def set_static_lineno(self):
-        self.static_abs_lineno_list = [7, 8]
+        self.static_abs_lineno_list = [9, 10]
 
     def set_dygraph_info(self):
         self.line_num = 2
@@ -208,7 +208,7 @@ class TestOriginInfoWithDecoratedFunc2(TestOriginInfo):
         self.func = decorated_func2
 
     def set_static_lineno(self):
-        self.static_abs_lineno_list = [7, 8]
+        self.static_abs_lineno_list = [9, 10]
 
     def set_dygraph_info(self):
         self.line_num = 2


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

[Dy2Stat]Filter UserWarings while @to_static

**ONLY filter DeprecationWarning，it will not and shall not deal with other warnings.**

Before:
```bash
The behavior of expression A * B has been unified with elementwise_mul(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_mul(X, Y, axis=0) instead of A * B. This transitional warning will be dropped in the future.
  op_type, op_type, EXPRESSION_MAP[method_name]))
/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/math_op_patch.py:381: UserWarning: /tmp/tmpf_v49bn0.py:28
The behavior of expression A * B has been unified with elementwise_mul(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_mul(X, Y, axis=0) instead of A * B. This transitional warning will be dropped in the future.
  op_type, op_type, EXPRESSION_MAP[method_name]))
/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/math_op_patch.py:381: UserWarning: /tmp/tmpnxpgupfo.py:10
The behavior of expression A + B has been unified with elementwise_add(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_add(X, Y, axis=0) instead of A + B. This transitional warning will be dropped in the future.
  op_type, op_type, EXPRESSION_MAP[method_name]))
/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/math_op_patch.py:381: UserWarning: /tmp/tmp0nglhird.py:9
The behavior of expression A * B has been unified with elementwise_mul(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_mul(X, Y, axis=0) instead of A * B. This transitional warning will be dropped in the future.
  op_type, op_type, EXPRESSION_MAP[method_name]))
/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/math_op_patch.py:381: UserWarning: /tmp/tmp0nglhird.py:28
The behavior of expression A * B has been unified with elementwise_mul(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_mul(X, Y, axis=0) instead of A * B. This transitional warning will be dropped in the future.
  op_type, op_type, EXPRESSION_MAP[method_name]))
/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/math_op_patch.py:381: UserWarning: /tmp/tmp_b_3skv4.py:10
The behavior of expression A + B has been unified with elementwise_add(X, Y, axis=-1) from Paddle 2.0. If your code works well in the older versions but crashes in this version, try to use elementwise_add(X, Y, axis=0) instead of A + B. This transitional warning will be dropped in the future.
  op_type, op_type, EXPRESSION_MAP[method_name]))
```

