### PR TITLE
[BUG FIX]Fix Bugs when select mkldnn kernel

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1328,8 +1328,10 @@ bool OperatorWithKernel::SupportsMKLDNN(
   auto has_phi_kernel =
       std::any_of(phi_kernels.begin(),
                   phi_kernels.end(),
-                  [](phi::KernelKeyMap::const_reference kern_pair) {
-                    return kern_pair.first.backend() == phi::Backend::ONEDNN;
+                  [data_type](phi::KernelKeyMap::const_reference kern_pair) {
+                    return kern_pair.first.backend() == phi::Backend::ONEDNN &&
+                           kern_pair.first.dtype() ==
+                               framework::TransToPhiDataType(data_type);
                   });
   if (has_phi_kernel) {
     return true;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复mkldnn迁移到phi下后，如果未注册某个type的kernel，抛出找不到Mkldnn kernel的异常

This PR work:
Fix bugs that paddle can't find kernels when mkldnn kernel migrate to PHI

related PR : 
- https://github.com/PaddlePaddle/Paddle/pull/45537
- https://github.com/PaddlePaddle/Paddle/pull/45536