### PR TITLE
add a wrap_decorator decorator to keep the __doc__ attr

### DIFF
--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -634,6 +634,7 @@ def _remove_save_pre_hook(hook):
     _save_pre_hooks_lock.release()
 
 
+@wrap_decorator
 def _run_save_pre_hooks(func):
 
     def wrapper(layer, path, input_spec=None, **configs):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

try to fix the missing docstring of paddle.jit.save, the details describe in https://github.com/PaddlePaddle/docs/discussions/5243#discussioncomment-3554826

目前通过 `paddle.jit.save.__doc__` 无法获取到 docstring，原因是装饰器没有传递内层函数的 `__doc__` 属性

https://github.com/PaddlePaddle/Paddle/blob/fd56f08e57e1894c3ee86b33a7c4ebd9a387a8df/python/paddle/fluid/dygraph/jit.py#L682-L687

其中 `switch_to_static_graph` 已经使用 `wrap_decorator` 装饰过，因此不会造成 `__doc__` 等属性的丢失，而 `_run_save_pre_hooks` 没有，因此使用 `wrap_decorator` 装饰下，尝试下效果