### PR TITLE
Clear extra attrs of reduce op  in OpMaker

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op.cc
@@ -79,6 +79,7 @@ class ReduceMeanDoubleGradOpBaseMaker : public imperative::GradOpBaseMakerBase {
         op.SetType("reduce_mean");
         op.SetInput("X", x_gg);
         op.SetAttrMap(Attrs());
+        op.SetDefaultAttrsMap(DefaultAttrsMap());
         op.SetOutput("Out", out_grads);
       }
       return node;

--- a/paddle/fluid/operators/reduce_ops/reduce_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.h
@@ -718,10 +718,6 @@ class ReduceOpMaker : public framework::OpProtoAndCheckerMaker {
         "(int, default -1)"
         "The dtype of output, default value is -1, the dtype is same as intput")
         .SetDefault(-1);
-    AddAttr<bool>("use_mkldnn",
-                  "(bool, default false) Only used in mkldnn kernel")
-        .SetDefault(false)
-        .AsExtra();
     AddComment(string::Sprintf(R"DOC(
 %s Operator.
 

--- a/paddle/phi/api/yaml/api_compat.yaml
+++ b/paddle/phi/api/yaml/api_compat.yaml
@@ -203,6 +203,11 @@
   inputs: {x: X}
   outputs: {out: Out}
 
+- api : frobenius_norm
+  backward : frobenius_norm_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
 - api : gelu
   backward : gelu_grad
   extra :
@@ -287,6 +292,49 @@
     x : X
   outputs :
     out : Out
+
+- api : reduce_all
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_amax
+  backward : reduce_amax_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_amin
+  backward : reduce_amin_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_any
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_max
+  backward : reduce_max_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_mean
+  backward : reduce_mean_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_min
+  backward : reduce_min_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_prod
+  backward : reduce_prod_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- api : reduce_sum
+  backward : reduce_sum_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
 
 - api : renorm
   backward : renorm_grad


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Reduce相关算子OpMaker的Extra参数清理

相关PR：
第一批算子OpMaker清理: [PR45613](https://github.com/PaddlePaddle/Paddle/pull/45613)
第二批算子OpMaker清理: [PR45684](https://github.com/PaddlePaddle/Paddle/pull/45684)
第三批算子OpMaker清理: [PR45684](https://github.com/PaddlePaddle/Paddle/pull/45758)
`matmul_v2`算子OpMaker清理: [PR45684](https://github.com/PaddlePaddle/Paddle/pull/45708)