### PR TITLE
[OpAttr]Refine Teller logic if encounter OpDesc with Variable type Attribute

### DIFF
--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -793,7 +793,11 @@ Attribute OpDesc::GetAttr(const std::string &name, bool with_attr_var) const {
     PADDLE_ENFORCE_EQ(
         HasAttrVar(it->second),
         false,
-        platform::errors::NotFound("Attribute %s is not found.", name));
+        platform::errors::NotFound(
+            "Attribute %s with constant value is not found, but found it with "
+            "Variable(s) type, which maybe not supported in some scenarios "
+            "currently, such as TensorRT et.al",
+            name));
   }
   return it->second;
 }

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -2254,7 +2254,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
 
 bool OpTeller::HasUnsupportAttrVar(const framework::OpDesc& desc) const {
   const std::string op_type = desc.Type();
-  auto has_attr_var = [](const std::string& attr_name) {
+  auto has_attr_var = [&](const std::string& attr_name) -> bool {
     // If Attribute is Variable(s), HasAttr() will return False
     return !desc.HasAttr(attr_name, /*with_attr_var=*/false);
   };

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -2256,7 +2256,7 @@ bool OpTeller::HasUnsupportAttrVar(const framework::OpDesc& desc) const {
   const std::string op_type = desc.Type();
   auto has_attr_var = [](const std::string& attr_name) {
     // If Attribute is Variable(s), HasAttr() will return False
-    return !op_desc.HasAttr(attr_name, /*with_attr_var=*/false);
+    return !desc.HasAttr(attr_name, /*with_attr_var=*/false);
   };
   std::unordered_map<std::string, std::vector<std::string>> attrs_info = {
       {"dropout", {"dropout_prob"}},

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -2270,7 +2270,7 @@ bool OpTeller::HasUnsupportAttrVar(const framework::OpDesc& desc) const {
   bool flag = false;
   auto iter = attrs_info.find(op_type);
   if (iter != attrs_info.end()) {
-    for (auto& attr_name : iter.second) {
+    for (auto& attr_name : iter->second) {
       if (has_attr_var(attr_name)) {
         flag = true;
         break;

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -300,7 +300,7 @@ bool OpTeller::Tell(const framework::ir::Node* node,
     return false;
 
   // do not support Attribute with Variable(s) Type
-  if (HasUnsupportAttrVar(*desc)) return false;
+  if (HasUnsupportAttrVar(desc)) return false;
 
   for (auto& teller : tellers_) {
     std::unordered_set<std::string> act_op_list = {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -299,6 +299,9 @@ bool OpTeller::Tell(const framework::ir::Node* node,
       desc.HasAttr("skip_quant"))
     return false;
 
+  // do not support Attribute with Variable(s) Type
+  if (HasUnsupportAttrVar(*desc)) return false;
+
   for (auto& teller : tellers_) {
     std::unordered_set<std::string> act_op_list = {
         "relu",     "relu6", "sigmoid",
@@ -2248,6 +2251,35 @@ bool OpTeller::Tell(const framework::ir::Node* node,
 
   return false;
 }
+
+bool OpTeller::HasUnsupportAttrVar(const framework::OpDesc& desc) const {
+  const std::string op_type = desc.Type();
+  auto has_attr_var = [](const std::string& attr_name) {
+    // If Attribute is Variable(s), HasAttr() will return False
+    return !op_desc.HasAttr(attr_name, /*with_attr_var=*/false);
+  };
+  std::unordered_map<std::string, std::vector<std::string>> attrs_info = {
+      {"dropout", {"dropout_prob"}},
+      {"pool2d", {"ksize"}},
+      {"arg_max", {"axis"}},
+      {"reduce_mean", {"dim"}},
+      {"reduce_sum", {"dim"}},
+      {"squeeze2", {"axes"}},
+  };
+
+  bool flag = false;
+  auto iter = attrs_info.find(op_type);
+  if (iter != attrs_info.end()) {
+    for (auto& attr_name : iter.second) {
+      if (has_attr_var(attr_name)) {
+        flag = true;
+        break;
+      }
+    }
+  }
+  return flag;
+}
+
 OpTeller::OpTeller() { tellers_.emplace_back(new SimpleOpTypeSetTeller); }
 }  // namespace tensorrt
 }  // namespace inference

--- a/paddle/fluid/inference/tensorrt/op_teller.h
+++ b/paddle/fluid/inference/tensorrt/op_teller.h
@@ -73,6 +73,14 @@ class OpTeller {
  private:
   OpTeller();
 
+  /*
+   * Some OpDescs Attribute support both constant value and dynamic
+   * runtime value (which is a Variable(s) type). But TensorRT maybe
+   * only support constant value Attribute, so we shall distinguish
+   * this case in time and return False in OpTeller.Tell().
+   */
+  bool HasUnsupportAttrVar(const framework::OpDesc& desc) const;
+
  private:
   std::vector<std::unique_ptr<Teller>> tellers_;
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### What's New?

优化了飞桨TensorRT组件库中对于Variable可变类型的Attribute的OpTeller判断处理逻辑。主要改动包括：

+ 新增了 HasUnsupportAttrVar 函数，用于判断一个OpDesc是否包含dynamic的Variable类型Attribute
+ 在Tell函数中添加对应分支判断，对于包含可变Attribute的Op，跳过转TenosrRT