### PR TITLE
Fix UpdateLossScalingKernel to prevent data transform error

### DIFF
--- a/paddle/phi/infermeta/multiary.cc
+++ b/paddle/phi/infermeta/multiary.cc
@@ -2479,8 +2479,10 @@ void UpdateLossScalingInferMeta(const std::vector<const MetaTensor*>& xs,
                         xs.size(),
                         outs.size()));
   for (size_t i = 0; i < xs.size(); ++i) {
-    outs[i]->set_dims(xs[i]->dims());
-    outs[i]->set_dtype(xs[i]->dtype());
+    if (xs[i] != nullptr && outs[i] != nullptr) {
+      outs[i]->set_dims(xs[i]->dims());
+      outs[i]->set_dtype(xs[i]->dtype());
+    }
   }
   loss_scaling->set_dims({1});
   out_good_steps->set_dims({1});

--- a/paddle/phi/kernels/gpu/amp_kernel.cu
+++ b/paddle/phi/kernels/gpu/amp_kernel.cu
@@ -365,4 +365,8 @@ PD_REGISTER_KERNEL(update_loss_scaling,
                    phi::UpdateLossScalingKernel,
                    float,
                    double,
-                   phi::dtype::float16) {}
+                   phi::dtype::float16) {
+#ifndef PADDLE_WITH_XPU
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
+#endif
+}

--- a/paddle/phi/kernels/gpu/amp_kernel.cu
+++ b/paddle/phi/kernels/gpu/amp_kernel.cu
@@ -366,7 +366,5 @@ PD_REGISTER_KERNEL(update_loss_scaling,
                    float,
                    double,
                    phi::dtype::float16) {
-#ifndef PADDLE_WITH_XPU
   kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
-#endif
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix UpdateLossScalingKernel to prevent the input `FoundInf` to be transformed from CPU to GPU.