### PR TITLE
【PaddlePaddle Hackathon 3 No.47】为 Paddle 新增 logsumexp support fp16

### DIFF
--- a/paddle/phi/kernels/gpu/logsumexp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/logsumexp_grad_kernel.cu
@@ -15,8 +15,16 @@
 #include "paddle/phi/kernels/logsumexp_grad_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/logsumexp_grad_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    logsumexp_grad, GPU, ALL_LAYOUT, phi::LogsumexpGradKernel, float, double) {}
+using float16 = phi::dtype::float16;
+
+PD_REGISTER_KERNEL(logsumexp_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::LogsumexpGradKernel,
+                   float,
+                   double,
+                   float16) {}

--- a/paddle/phi/kernels/gpu/logsumexp_kernel.cu
+++ b/paddle/phi/kernels/gpu/logsumexp_kernel.cu
@@ -15,8 +15,11 @@
 #include "paddle/phi/kernels/logsumexp_kernel.h"
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/logsumexp_kernel_impl.h"
 
+using float16 = phi::dtype::float16;
+
 PD_REGISTER_KERNEL(
-    logsumexp, GPU, ALL_LAYOUT, phi::LogsumexpKernel, float, double) {}
+    logsumexp, GPU, ALL_LAYOUT, phi::LogsumexpKernel, float, double, float16) {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
logsumexp support fp16


#### performance
| Case No. | input_shape  | FP32 Perf(us) | FP16 Perf(us) | diff |
|---|---|---|---|---|
| 0 | [1000, 130, 17] | 173.735 | 206.377 | 0.842 | 
| 1 | [1000, 100, 10, 10] | 576.93 | 651.485 | 0.886 | 
| 2 | [1000, 100, 200] | 1089.02 | 1219.52 | 0.893 | 
| 3 | [100, 1000, 25, 40] |5195 | 5766.75 | 0.901 |
| 4 | [100, 1000, 250, 40] |40763 | 39548.1 | 1.031 |
| 5 | [100, 1000, 250, 50] |64426 | 50173.5 | 1.284 |