### PR TITLE
Update layoutautotune for inplace

### DIFF
--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -51,17 +51,17 @@ paddle::experimental::Tensor conv2d_ad_func(
 
     auto amp_dst_dtype = egr::GetAmpDestDtype(op_name, amp_tensors_vector);
 
-    auto NEW_input =
+    auto new_input =
         egr::EagerAmpAutoCast("input", input, amp_dst_dtype, op_name);
-    auto NEW_filter =
+    auto new_filter =
         egr::EagerAmpAutoCast("filter", filter, amp_dst_dtype, op_name);
 
     {
       paddle::imperative::AutoCastGuard guard(
           egr::Controller::Instance().GetCurrentTracer(),
           paddle::imperative::AmpLevel::O0);
-      return conv2d_ad_func(NEW_input,
-                            NEW_filter,
+      return conv2d_ad_func(new_input,
+                            new_filter,
                             strides,
                             paddings,
                             paddding_algorithm,
@@ -76,7 +76,7 @@ paddle::experimental::Tensor conv2d_ad_func(
 
   // Layout autotune
 
-  if (paddle::imperative::LayoutAutoTune::Instance().UseLayoutAutoTune()) {
+  if (egr::Controller::Instance().UseLayoutAutoTune()) {
     VLOG(5) << "Check and Prepare For LAYOUT";
     paddle::small_vector<std::vector<paddle::experimental::Tensor>,
                          egr::kSlotSmallVectorSize>
@@ -85,11 +85,10 @@ paddle::experimental::Tensor conv2d_ad_func(
     auto op_name = phi::TransToFluidOpName("conv2d");
     auto transformer = egr::EagerLayoutAutotune<std::string>(
         op_name, tensors_vector, &data_format);
-    auto NEW_input = transformer->TransInTensor("input", input);
-    bool is_enable_tune =
-        paddle::imperative::LayoutAutoTune::Instance().UseLayoutAutoTune();
-    paddle::imperative::LayoutAutoTune::Instance().DisableLayoutAutoTune();
-    auto out = conv2d_ad_func(NEW_input,
+    auto new_input = transformer->TransInTensor("input", input);
+    paddle::imperative::LayoutAutotuneGuard guard(
+        egr::Controller::Instance().GetCurrentTracer(), false);
+    auto out = conv2d_ad_func(new_input,
                               filter,
                               strides,
                               paddings,
@@ -101,9 +100,6 @@ paddle::experimental::Tensor conv2d_ad_func(
                               workspace_size_MB,
                               exhaustive_search);
     transformer->SetOutTensorLayout(&out);
-    if (is_enable_tune) {
-      paddle::imperative::LayoutAutoTune::Instance().EnableLayoutAutoTune();
-    }
     // Returns
     return out;
   }

--- a/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
+++ b/paddle/fluid/eager/api/manual/eager_manual/forwards/conv2d_fwd_function.cc
@@ -86,8 +86,8 @@ paddle::experimental::Tensor conv2d_ad_func(
     auto transformer = egr::EagerLayoutAutotune<std::string>(
         op_name, tensors_vector, &data_format);
     auto new_input = transformer->TransInTensor("input", input);
-    paddle::imperative::LayoutAutotuneGuard guard(
-        egr::Controller::Instance().GetCurrentTracer(), false);
+    bool need_tune = egr::Controller::Instance().UseLayoutAutoTune();
+    egr::Controller::Instance().DisableLayoutAutoTune();
     auto out = conv2d_ad_func(new_input,
                               filter,
                               strides,
@@ -100,6 +100,9 @@ paddle::experimental::Tensor conv2d_ad_func(
                               workspace_size_MB,
                               exhaustive_search);
     transformer->SetOutTensorLayout(&out);
+    if (need_tune) {
+      egr::Controller::Instance().EnableLayoutAutoTune();
+    }
     // Returns
     return out;
   }

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -57,13 +57,15 @@ class Controller {
   }
 
   bool UseLayoutAutoTune() {
+    bool use_autotune = false;
 #if defined(PADDLE_WITH_CUDA)
-    if (paddle::platform::is_gpu_place(tracer_->ExpectedPlace())) {
-      return tracer_->UseLayoutAutoTune();
+    auto place = tracer_->ExpectedPlace();
+    bool is_gpu_place = paddle::platform::is_gpu_place(place);
+    if (is_gpu_place) {
+      use_autotune = tracer_->UseLayoutAutoTune();
     }
 #endif
-    tracer_->DisableLayoutAutoTune();
-    return false;
+    return use_autotune;
   }
 
   void DisableLayoutAutoTune() { tracer_->DisableLayoutAutoTune(); }

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -56,7 +56,14 @@ class Controller {
     return tracer_->GetAmpLevel();
   }
 
-  bool UseLayoutAutoTune() { return tracer_->UseLayoutAutoTune(); }
+  bool UseLayoutAutoTune() {
+#if defined(PADDLE_WITH_CUDA)
+    if (paddle::platform::is_gpu_place(tracer_->ExpectedPlace())) {
+      return tracer_->UseLayoutAutoTune();
+    }
+#endif
+    return false;
+  }
 
   void DisableLayoutAutoTune() { tracer_->DisableLayoutAutoTune(); }
 

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -55,6 +55,13 @@ class Controller {
   paddle::imperative::AmpLevel GetAMPLevel() const {
     return tracer_->GetAmpLevel();
   }
+
+  bool UseLayoutAutoTune() { return tracer_->UseLayoutAutoTune(); }
+
+  void DisableLayoutAutoTune() { tracer_->DisableLayoutAutoTune(); }
+
+  void EnableLayoutAutoTune() { tracer_->EnableLayoutAutoTune(); }
+
   bool HasGrad() const { return tracer_->HasGrad(); }
   void SetHasGrad(bool has_grad) { tracer_->SetHasGrad(has_grad); }
   std::string GenerateUniqueName(std::string key = "eager_in_tmp") {

--- a/paddle/fluid/eager/api/utils/global_utils.h
+++ b/paddle/fluid/eager/api/utils/global_utils.h
@@ -62,6 +62,7 @@ class Controller {
       return tracer_->UseLayoutAutoTune();
     }
 #endif
+    tracer_->DisableLayoutAutoTune();
     return false;
   }
 

--- a/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
+++ b/paddle/fluid/eager/auto_code_generator/generator/eager_gen.py
@@ -423,7 +423,7 @@ LAYOUT_LOGIC_TEMPLATE=\
 """
   if (egr::Controller::Instance().UseLayoutAutoTune()) {{
     paddle::small_vector<std::vector<paddle::experimental::Tensor>, egr::kSlotSmallVectorSize> tensors_vector = {};
-    {} 
+    {}
     {}
     VLOG(5) << "Check and Prepare For LAYOUT "<< op_name;
     paddle::imperative::LayoutAutotuneGuard guard(egr::Controller::Instance().GetCurrentTracer(), false);

--- a/paddle/fluid/eager/eager_layout_auto_tune.h
+++ b/paddle/fluid/eager/eager_layout_auto_tune.h
@@ -19,18 +19,64 @@
 #include "paddle/fluid/imperative/layout_autotune.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 namespace egr {
+inline bool NeedTransLayout(
+    const paddle::small_vector<std::vector<paddle::experimental::Tensor>,
+                               kSlotSmallVectorSize>& tensors_vector,
+    const paddle::experimental::DataLayout& layout) {
+  for (size_t i = 0; i < tensors_vector.size(); i++) {
+    for (size_t idx = 0; idx < tensors_vector[0].size(); idx++) {
+      if (layout != tensors_vector[i][idx].layout()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+inline std::shared_ptr<EagerLayoutTransformer> BaseTransformer(
+    const std::string& op_name,
+    const paddle::small_vector<std::vector<paddle::experimental::Tensor>,
+                               kSlotSmallVectorSize>& tensors_vector) {
+  std::shared_ptr<EagerLayoutTransformer> transposer = nullptr;
+  bool unstart =
+      (paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout() ==
+       paddle::experimental::DataLayout::UNDEFINED);
+  auto first_layout = tensors_vector[0][0].layout();
+  if (unstart) {
+    VLOG(3) << "Layout autotune was not started " << op_name << " layout is "
+            << first_layout;
+  }
+  transposer = std::make_shared<EagerLayoutTransformer>(
+      op_name, tensors_vector, first_layout);
+  return transposer;
+}
 
-// layout_agnostic_ops_
-// For agnostic op like add / relu
+// For agnostic op like add, relu, exp
 inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune(
     const std::string& op_name,
     const paddle::small_vector<std::vector<paddle::experimental::Tensor>,
                                kSlotSmallVectorSize>& tensors_vector) {
-  VLOG(3) << " Optimze Layout agnostic op: " << op_name;
-  std::shared_ptr<EagerLayoutTransformer> transposer = nullptr;
-  transposer =
-      std::make_shared<EagerLayoutTransformer>(op_name, tensors_vector);
-  return transposer;
+  auto desired_layout =
+      paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout();
+  auto default_layout =
+      paddle::imperative::LayoutAutoTune::Instance().GetDefaultLayout();
+  auto first_layout = tensors_vector[0][0].layout();
+  if (NeedTransLayout(tensors_vector, first_layout)) {
+    bool need_trans_back = false;
+    for (size_t i = 0; i < tensors_vector.size(); i++) {
+      for (size_t idx = 0; idx < tensors_vector[0].size(); idx++) {
+        if (4 != tensors_vector[i][idx].shape().size()) {
+          need_trans_back = true;
+          VLOG(3) << "EagerLayoutAutotune agnostic op's shape is "
+                  << tensors_vector[i][idx].shape().size() << " and layout is "
+                  << tensors_vector[i][idx].layout();
+        }
+      }
+    }
+    auto final_layout = need_trans_back ? default_layout : desired_layout;
+    return std::make_shared<EagerLayoutTransformer>(
+        op_name, tensors_vector, final_layout);
+  }
+  return BaseTransformer(op_name, tensors_vector);
 }
 
 // For lightly op like reduce
@@ -41,15 +87,6 @@ inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune(
                                kSlotSmallVectorSize>& tensors_vector,
     T* attr) {
   std::shared_ptr<EagerLayoutTransformer> transposer = nullptr;
-  bool unstart =
-      (paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout() ==
-       paddle::experimental::DataLayout::UNDEFINED);
-  if (unstart) {
-    VLOG(3) << "Optimze Layout was not started" << op_name;
-    transposer =
-        std::make_shared<EagerLayoutTransformer>(op_name, tensors_vector);
-    return transposer;
-  }
   transposer =
       std::make_shared<EagerLightlyLayoutSensitiveOpTransformer>(op_name);
   return transposer;
@@ -66,30 +103,23 @@ inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune(
   return EagerLayoutAutotune<T1>(op_name, tensors_vector, axis);
 }
 
-// heavily string data_format data_layout
+// heavily string data_format, data_layout
 template <>
 inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune(
     const std::string& op_name,
     const paddle::small_vector<std::vector<paddle::experimental::Tensor>,
                                kSlotSmallVectorSize>& tensors_vector,
     std::string* attr) {
-  VLOG(3) << " Optimze Layout heavily op: " << op_name;
-  auto transposer =
-      std::make_shared<EagerLayoutTransformer>(op_name, tensors_vector);
+  auto first_layout = tensors_vector[0][0].layout();
+  auto transposer = std::make_shared<EagerLayoutTransformer>(
+      op_name, tensors_vector, first_layout);
   if (paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout() ==
       paddle::experimental::DataLayout::UNDEFINED) {
     // Layout autotune only supports model with convolutional layers
-    VLOG(3) << "Optimze Layout was not started" << op_name;
+    VLOG(3) << "Optimze Layout was not started " << op_name;
     if (op_name != "conv2d") {
       return transposer;
     } else {
-#if defined(PADDLE_WITH_CUDA)
-      if (paddle::platform::is_gpu_place(tensors_vector[0][0].place()) &&
-          !phi::backends::gpu::TensorCoreAvailable()) {
-        paddle::imperative::LayoutAutoTune::Instance().DisableLayoutAutoTune();
-        return transposer;
-      }
-#endif
       auto data_type = tensors_vector[0][0].dtype();
       bool is_tune_fp32 =
           (data_type == paddle::experimental::DataType::FLOAT32) &&
@@ -109,13 +139,12 @@ inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune(
         paddle::imperative::LayoutAutoTune::Instance().SetDefaultLayout(
             paddle::experimental::DataLayout::NCHW);
       } else {
-        paddle::imperative::LayoutAutoTune::Instance().DisableLayoutAutoTune();
+        egr::Controller::Instance().DisableLayoutAutoTune();
         return transposer;
       }
-      VLOG(3) << "Tune the layout from " << attr << " to "
-              << paddle::framework::DataLayoutToString(
-                     paddle::imperative::LayoutAutoTune::Instance()
-                         .GetDesiredLayout());
+      VLOG(3)
+          << "Tune the layout from " << *attr << " to "
+          << paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout();
     }
   }
 
@@ -126,9 +155,7 @@ inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune(
                                                                    attr);
     return heavily_transposer;
   }
-  VLOG(3) << op_name
-          << "'s LayoutTransformer is unimplemented. Use default "
-             "LayoutTransformer instead.";
+  VLOG(3) << op_name << "'s LayoutTransformer is unimplemented. Use default.";
   return transposer;
 }
 
@@ -139,24 +166,23 @@ inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune(
     const paddle::small_vector<std::vector<paddle::experimental::Tensor>,
                                kSlotSmallVectorSize>& tensors_vector,
     std::vector<int>* attr) {
+  auto first_layout = tensors_vector[0][0].layout();
   std::shared_ptr<EagerLayoutTransformer> transposer = nullptr;
   if (paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout() ==
       paddle::experimental::DataLayout::UNDEFINED) {
-    VLOG(3) << " Optimze Layout Unstarted : " << op_name;
-    transposer =
-        std::make_shared<EagerLayoutTransformer>(op_name, tensors_vector);
+    VLOG(3) << "Optimze Layout was not started" << op_name;
+    transposer = std::make_shared<EagerLayoutTransformer>(
+        op_name, tensors_vector, first_layout);
     return transposer;
   }
-  VLOG(3) << " Optimze Layout lightly op: " << op_name;
-  if (op_name == "transpose2") {
+  if (op_name == "transpose2" &&
+      (tensors_vector[0][0].layout() ==
+       paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout())) {
     auto trans = std::make_shared<EagerTransposeOpTransformer>(op_name);
-    if (tensors_vector[0][0].layout() ==
-        paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout()) {
-      trans->SetAttr(attr,
-                     tensors_vector[0][0].layout() ==
-                         paddle::experimental::DataLayout::NHWC);
-      return trans;
-    }
+    trans->SetAttr(attr,
+                   tensors_vector[0][0].layout() ==
+                       paddle::experimental::DataLayout::NHWC);
+    return trans;
   }
   transposer =
       std::make_shared<EagerLightlyLayoutSensitiveOpTransformer>(op_name);
@@ -172,33 +198,32 @@ EagerLayoutAutotune<paddle::experimental::Scalar, bool>(
                                kSlotSmallVectorSize>& tensors_vector,
     paddle::experimental::Scalar* axis,
     bool* keep_dim) {
+  auto first_layout = tensors_vector[0][0].layout();
   std::shared_ptr<EagerLayoutTransformer> transposer = nullptr;
   if (paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout() ==
       paddle::experimental::DataLayout::UNDEFINED) {
-    VLOG(3) << " Optimze Layout Unstarted : " << op_name;
-    transposer =
-        std::make_shared<EagerLayoutTransformer>(op_name, tensors_vector);
+    VLOG(3) << "Optimze Layout was not started" << op_name;
+    transposer = std::make_shared<EagerLayoutTransformer>(
+        op_name, tensors_vector, first_layout);
     return transposer;
   }
   auto desired_layout =
       paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout();
-  if (op_name == "argmax") {
+  if (op_name == "argmax" &&
+      (tensors_vector[0][0].layout() == desired_layout) && (*keep_dim)) {
     std::shared_ptr<EagerArgmaxOpTransformer> argmax_transform = nullptr;
     argmax_transform = std::make_shared<EagerArgmaxOpTransformer>(op_name);
-    if ((tensors_vector[0][0].layout() == desired_layout) && (*keep_dim)) {
-      argmax_transform->SetAttr(axis,
-                                tensors_vector[0][0].layout() ==
-                                    paddle::experimental::DataLayout::NHWC);
-      return argmax_transform;
-    }
+    argmax_transform->SetAttr(axis,
+                              tensors_vector[0][0].layout() ==
+                                  paddle::experimental::DataLayout::NHWC);
+    return argmax_transform;
   }
-  VLOG(3) << " Optimze Layout lightly op: " << op_name;
   transposer =
       std::make_shared<EagerLightlyLayoutSensitiveOpTransformer>(op_name);
   return transposer;
 }
 
-// lightly int flatten
+// lightly for flatten
 template <>
 inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune<int, int>(
     const std::string& op_name,
@@ -206,17 +231,17 @@ inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune<int, int>(
                                kSlotSmallVectorSize>& tensors_vector,
     int* start_axis,
     int* stop_axis) {
+  auto first_layout = tensors_vector[0][0].layout();
   std::shared_ptr<EagerLayoutTransformer> transposer = nullptr;
-  if (paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout() ==
-      paddle::experimental::DataLayout::UNDEFINED) {
-    VLOG(3) << " Optimze Layout Unstarted : " << op_name;
-    transposer =
-        std::make_shared<EagerLayoutTransformer>(op_name, tensors_vector);
+  auto desired_layout =
+      paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout();
+  if (desired_layout == paddle::experimental::DataLayout::UNDEFINED) {
+    VLOG(3) << "Optimze Layout was not started" << op_name;
+    transposer = std::make_shared<EagerLayoutTransformer>(
+        op_name, tensors_vector, first_layout);
     return transposer;
   }
-  bool no_tranpose =
-      tensors_vector[0][0].layout() ==
-      paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout();
+  bool no_tranpose = tensors_vector[0][0].layout() == desired_layout;
   bool is_valid = ((*start_axis) == 1 && (*stop_axis) == 3);
   if (op_name == "flatten" || op_name == "flatten_contiguous_range") {
     if (no_tranpose && is_valid) {
@@ -226,15 +251,13 @@ inline std::shared_ptr<EagerLayoutTransformer> EagerLayoutAutotune<int, int>(
     }
   }
 
-  VLOG(3) << " Optimze Layout lightly op: " << op_name;
   transposer =
       std::make_shared<EagerLightlyLayoutSensitiveOpTransformer>(op_name);
   return transposer;
 }
 
 // lightly int Concat
-// lightly T can be int vector<int> vector<int64_t> IntArray
-template <>  // default int
+template <>
 inline std::shared_ptr<EagerLayoutTransformer>
 EagerLayoutAutotune<paddle::experimental::Scalar>(
     const std::string& op_name,
@@ -243,30 +266,21 @@ EagerLayoutAutotune<paddle::experimental::Scalar>(
     paddle::experimental::Scalar* axis) {
   auto desired_layout =
       paddle::imperative::LayoutAutoTune::Instance().GetDesiredLayout();
+  auto first_layout = tensors_vector[0][0].layout();
   std::shared_ptr<EagerLayoutTransformer> transposer = nullptr;
   if (desired_layout == paddle::experimental::DataLayout::UNDEFINED) {
-    VLOG(3) << " Optimze Layout Unstarted : " << op_name;
-    transposer =
-        std::make_shared<EagerLayoutTransformer>(op_name, tensors_vector);
+    VLOG(3) << "Optimze Layout was not started" << op_name;
+    transposer = std::make_shared<EagerLayoutTransformer>(
+        op_name, tensors_vector, first_layout);
     return transposer;
   }
 
-  bool need_transpose = false;
-  for (size_t i = 0; i < tensors_vector.size(); i++) {
-    for (size_t idx = 0; idx < tensors_vector[0].size(); idx++) {
-      if (desired_layout != tensors_vector[i][idx].layout()) {
-        need_transpose = true;
-      }
-    }
-  }
-
-  if (need_transpose) {
-    VLOG(3) << "Concat need transpose to NCHW " << op_name;
+  if (NeedTransLayout(tensors_vector, desired_layout)) {
+    VLOG(3) << op_name << " need transpose to default layout";
     transposer =
         std::make_shared<EagerLightlyLayoutSensitiveOpTransformer>(op_name);
     return transposer;
   } else {
-    VLOG(3) << " Optimze Layout lightly op: " << op_name;
     auto trans = std::make_shared<EagerConcatOpTransformer>(op_name);
     trans->SetAttr(axis, desired_layout);
     return trans;

--- a/paddle/fluid/imperative/layout_autotune.cc
+++ b/paddle/fluid/imperative/layout_autotune.cc
@@ -14,22 +14,14 @@
 
 #include "paddle/fluid/imperative/layout_autotune.h"
 
+#include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/framework/op_info.h"
 #include "paddle/fluid/imperative/layout_transformer.h"
 #include "paddle/phi/backends/gpu/gpu_info.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/errors.h"
-
 namespace paddle {
 namespace imperative {
-
-bool LayoutAutoTune::UseLayoutAutoTune() const {
-#if defined(PADDLE_WITH_CUDA)
-  return use_layout_autotune_;
-#else
-  return false;
-#endif
-}
 
 LayoutAutoTune::LayoutAutoTune() {
   const auto& op_info = paddle::framework::OpInfoMap::Instance().map();
@@ -140,6 +132,27 @@ paddle::imperative::NameVarMap<VarType> DealLightlyLayoutSensitive(
   return transposer->Apply(ins, outs, attrs, tracer);
 }
 
+LayoutAutotuneGuard::LayoutAutotuneGuard(std::shared_ptr<Tracer> tracer,
+                                         bool use_autotune)
+    : tracer_(tracer) {
+  pre_layout_autotune_ = tracer_->UseLayoutAutoTune();
+  if (pre_layout_autotune_ != use_autotune) {
+    if (use_autotune) {
+      tracer_->EnableLayoutAutoTune();
+    } else {
+      tracer_->DisableLayoutAutoTune();
+    }
+  }
+}
+
+LayoutAutotuneGuard::~LayoutAutotuneGuard() {
+  if (pre_layout_autotune_) {
+    tracer_->EnableLayoutAutoTune();
+  } else {
+    tracer_->DisableLayoutAutoTune();
+  }
+}
+
 template <typename VarType>
 paddle::imperative::NameVarMap<VarType> AutoTuneLayout(
     const std::string& op_type,
@@ -147,7 +160,7 @@ paddle::imperative::NameVarMap<VarType> AutoTuneLayout(
     const paddle::imperative::NameVarMap<VarType>& outs,
     paddle::framework::AttributeMap* attrs,
     const std::shared_ptr<imperative::Tracer>& tracer) {
-  if (!LayoutAutoTune::Instance().UseLayoutAutoTune()) {
+  if (!tracer->UseLayoutAutoTune()) {
     return ins;
   }
   // When layout autotuning is enabled, the tuner will check the desired layout.
@@ -165,7 +178,7 @@ paddle::imperative::NameVarMap<VarType> AutoTuneLayout(
     } else {
 #if defined(PADDLE_WITH_CUDA)
       if (!phi::backends::gpu::TensorCoreAvailable()) {
-        LayoutAutoTune::Instance().DisableLayoutAutoTune();
+        tracer->DisableLayoutAutoTune();
         return ins;
       }
 #endif
@@ -185,7 +198,7 @@ paddle::imperative::NameVarMap<VarType> AutoTuneLayout(
       } else if (is_tune_fp16) {
         LayoutAutoTune::Instance().SetDesiredLayout(DataLayout::NHWC);
       } else {
-        LayoutAutoTune::Instance().DisableLayoutAutoTune();
+        tracer->DisableLayoutAutoTune();
         return ins;
       }
       VLOG(3) << "Tune the layout from "

--- a/paddle/fluid/imperative/layout_autotune.cc
+++ b/paddle/fluid/imperative/layout_autotune.cc
@@ -137,9 +137,8 @@ LayoutAutotuneGuard::LayoutAutotuneGuard(std::shared_ptr<Tracer> tracer,
     : tracer_(tracer) {
   pre_layout_autotune_ = tracer_->UseLayoutAutoTune();
   if (pre_layout_autotune_ != use_autotune) {
-    if (use_autotune) {
-      tracer_->EnableLayoutAutoTune();
-    } else {
+    tracer_->EnableLayoutAutoTune();
+    if (!use_autotune) {
       tracer_->DisableLayoutAutoTune();
     }
   }

--- a/paddle/fluid/imperative/layout_transformer.h
+++ b/paddle/fluid/imperative/layout_transformer.h
@@ -19,8 +19,22 @@
 #include "paddle/fluid/imperative/var_helper.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/errors.h"
+#include "paddle/phi/core/tensor_utils.h"
 namespace paddle {
 namespace imperative {
+template <typename VarType>
+void SetOutDataLayout(std::shared_ptr<VarType> var,
+                      const paddle::experimental::DataLayout layout) {
+  if (var != nullptr && (var->MutableVar()->IsInitialized())) {
+    paddle::imperative::SetDataLayout(var, layout);
+    // 1.get out_tensor
+    paddle::framework::Variable* tmp_var = var->MutableVar();
+    auto* out = tmp_var->GetMutable<framework::LoDTensor>();
+    phi::DenseTensorUtils::GetMutableMeta(
+        static_cast<framework::LoDTensor*>(out))
+        ->layout = layout;
+  }
+}
 
 template <typename VarType>
 std::shared_ptr<VarType> TraceTransposeOp(
@@ -118,7 +132,7 @@ class LayoutTransformer {
           auto out_vars = outs.at(name);
           for (auto& var : out_vars) {
             if (var != nullptr) {
-              paddle::imperative::SetDataLayout(var, layout);
+              paddle::imperative::SetOutDataLayout(var, layout);
             }
           }
           not_in_out = false;
@@ -130,7 +144,7 @@ class LayoutTransformer {
       for (auto& pair : outs) {
         for (auto& var : pair.second) {
           if (var != nullptr) {
-            paddle::imperative::SetDataLayout(var, layout);
+            paddle::imperative::SetOutDataLayout(var, layout);
           }
         }
       }

--- a/paddle/fluid/imperative/layout_transformer.h
+++ b/paddle/fluid/imperative/layout_transformer.h
@@ -25,14 +25,16 @@ namespace imperative {
 template <typename VarType>
 void SetOutDataLayout(std::shared_ptr<VarType> var,
                       const paddle::experimental::DataLayout layout) {
-  if (var != nullptr && (var->MutableVar()->IsInitialized())) {
+  if (var != nullptr) {
     paddle::imperative::SetDataLayout(var, layout);
-    // 1.get out_tensor
-    paddle::framework::Variable* tmp_var = var->MutableVar();
-    auto* out = tmp_var->GetMutable<framework::LoDTensor>();
-    phi::DenseTensorUtils::GetMutableMeta(
-        static_cast<framework::LoDTensor*>(out))
-        ->layout = layout;
+    // set out_tensor's layout
+    if (var->MutableVar()->IsInitialized()) {
+      paddle::framework::Variable* tmp_var = var->MutableVar();
+      auto* out = tmp_var->GetMutable<framework::LoDTensor>();
+      phi::DenseTensorUtils::GetMutableMeta(
+          static_cast<framework::LoDTensor*>(out))
+          ->layout = layout;
+    }
   }
 }
 

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -42,6 +42,8 @@ thread_local bool Tracer::enable_program_desc_tracing_ = false;
 
 thread_local bool Tracer::has_grad_ = true;
 
+thread_local bool Tracer::use_layout_autotune_ = false;
+
 thread_local AmpLevel Tracer::amp_level_ = AmpLevel::O0;
 
 thread_local phi::DataType Tracer::amp_dtype_ = phi::DataType::FLOAT32;

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -28,9 +28,9 @@
 #include "paddle/fluid/imperative/basic_engine.h"
 #include "paddle/fluid/imperative/jit/program_desc_tracer.h"
 #include "paddle/fluid/imperative/layer.h"
+#include "paddle/fluid/imperative/layout_autotune.h"
 #include "paddle/fluid/platform/macros.h"
 #include "paddle/phi/core/compat/arg_map_context.h"
-
 namespace paddle {
 namespace imperative {
 
@@ -184,6 +184,24 @@ class Tracer {
     }
   }
 
+  void DisableLayoutAutoTune() { use_layout_autotune_ = false; }
+
+  void EnableLayoutAutoTune() { use_layout_autotune_ = true; }
+
+  bool UseLayoutAutoTune() {
+#if defined(PADDLE_WITH_CUDA)
+    if (paddle::platform::is_gpu_place(expected_place_) &&
+        !phi::backends::gpu::TensorCoreAvailable()) {
+      DisableLayoutAutoTune();
+      return false;
+    } else {
+      return use_layout_autotune_;
+    }
+#else
+    return false;
+#endif
+  }
+
   phi::KernelSignature GetExpectedKernelSignature(
       const std::string& type,
       const NameTensorMap& ins,
@@ -199,8 +217,8 @@ class Tracer {
   std::unique_ptr<UniqueNameGenerator> generator_;
   platform::Place expected_place_;
   GarbageCollectorMap gcs_;
-
   static thread_local bool enable_program_desc_tracing_;
+  static thread_local bool use_layout_autotune_;
   static thread_local bool has_grad_;
   static thread_local AmpLevel amp_level_;
   static thread_local phi::DataType amp_dtype_;

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -190,16 +190,12 @@ class Tracer {
 
   bool UseLayoutAutoTune() {
 #if defined(PADDLE_WITH_CUDA)
-    if (paddle::platform::is_gpu_place(expected_place_) &&
-        !phi::backends::gpu::TensorCoreAvailable()) {
-      DisableLayoutAutoTune();
-      return false;
-    } else {
+    if (phi::backends::gpu::TensorCoreAvailable()) {
       return use_layout_autotune_;
     }
-#else
-    return false;
 #endif
+    use_layout_autotune_ = false;
+    return false;
   }
 
   phi::KernelSignature GetExpectedKernelSignature(

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2499,19 +2499,14 @@ All parameter, weight, gradient are variables in Paddle.
     return res;
   });
 
-  m.def("enable_layout_autotune", [] {
-    return paddle::imperative::LayoutAutoTune::Instance()
-        .EnableLayoutAutoTune();
-  });
+  m.def("enable_layout_autotune",
+        [] { return egr::Controller::Instance().EnableLayoutAutoTune(); });
 
-  m.def("disable_layout_autotune", [] {
-    return paddle::imperative::LayoutAutoTune::Instance()
-        .DisableLayoutAutoTune();
-  });
+  m.def("disable_layout_autotune",
+        [] { return egr::Controller::Instance().DisableLayoutAutoTune(); });
 
-  m.def("use_layout_autotune", [] {
-    return paddle::imperative::LayoutAutoTune::Instance().UseLayoutAutoTune();
-  });
+  m.def("use_layout_autotune",
+        [] { return egr::Controller::Instance().UseLayoutAutoTune(); });
 
   BindFleetWrapper(&m);
   BindIO(&m);

--- a/paddle/phi/api/lib/data_transform.cc
+++ b/paddle/phi/api/lib/data_transform.cc
@@ -52,9 +52,9 @@ inline bool NeedTransformPlace(const paddle::platform::Place& input,
   return ret;
 }
 
-inline bool NeedTransformLayout(const paddle::platform::Place& place,
-                                const DataLayout& input,
+inline bool NeedTransformLayout(const DataLayout& input,
                                 const DataLayout& target,
+                                const paddle::platform::Place& place,
                                 const TransformFlag& transform_flag) {
   bool ret = transform_flag.need_trans_layout() &&
              (input != DataLayout::ALL_LAYOUT &&
@@ -202,9 +202,9 @@ phi::DenseTensor TransformData(phi::DenseTensor* tensor,
   bool trans_layout = false;
   bool trans_dtype = false;
 
-  if (NeedTransformLayout(tensor->place(),
-                          tensor->layout(),
+  if (NeedTransformLayout(tensor->layout(),
                           target_args_def.layout,
+                          tensor->place(),
                           transform_flag)) {
     out = TransDataLayout(out, target_args_def.layout);
     trans_layout = true;
@@ -240,9 +240,9 @@ std::shared_ptr<phi::DenseTensor> PrepareData(
              dense_tensor.place(), target_args_def.backend, transform_flag) &&
          !NeedTransformDataType(
              dense_tensor.dtype(), target_args_def.dtype, transform_flag) &&
-         !NeedTransformLayout(dense_tensor.place(),
-                              dense_tensor.layout(),
+         !NeedTransformLayout(dense_tensor.layout(),
                               target_args_def.layout,
+                              dense_tensor.place(),
                               transform_flag))) {
       return std::static_pointer_cast<phi::DenseTensor>(tensor_in);
     }
@@ -277,9 +277,9 @@ std::unique_ptr<std::vector<phi::DenseTensor>> PrepareData(
              tensor_in->place(), target_args_def.backend, transform_flag) &&
          !NeedTransformDataType(
              tensor_in->dtype(), target_args_def.dtype, transform_flag) &&
-         !NeedTransformLayout(tensor_in->place(),
-                              tensor_in->layout(),
+         !NeedTransformLayout(tensor_in->layout(),
                               target_args_def.layout,
+                              tensor_in->place(),
                               transform_flag))) {
       pt_tensors->emplace_back(
           *std::dynamic_pointer_cast<phi::DenseTensor>(tensor_in));

--- a/python/paddle/fluid/tests/unittests/test_layout_autotune.py
+++ b/python/paddle/fluid/tests/unittests/test_layout_autotune.py
@@ -48,9 +48,9 @@ class LayoutAutoTune(unittest.TestCase):
 
     def test_config(self):
         paddle.fluid.core.enable_layout_autotune()
-        self.assertEqual(paddle.fluid.core.use_layout_autotune(), True)
-
-        paddle.fluid.core.disable_layout_autotune()
+        if self.use_autoune():
+            self.assertEqual(paddle.fluid.core.use_layout_autotune(), True)
+            paddle.fluid.core.disable_layout_autotune()
         self.assertEqual(paddle.fluid.core.use_layout_autotune(), False)
 
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_layout_autotune.py
+++ b/python/paddle/fluid/tests/unittests/test_layout_autotune.py
@@ -46,6 +46,13 @@ class SimpleNet(paddle.nn.Layer):
 
 class LayoutAutoTune(unittest.TestCase):
 
+    def test_config(self):
+        paddle.fluid.core.enable_layout_autotune()
+        self.assertEqual(paddle.fluid.core.use_layout_autotune(), True)
+
+        paddle.fluid.core.disable_layout_autotune()
+        self.assertEqual(paddle.fluid.core.use_layout_autotune(), False)
+
     def setUp(self):
         self.use_autoune()
 

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -130,15 +130,13 @@ def _conv_nd(x,
         if bias is not None:
             channel_dim = channel_dim + len(
                 x.shape) if channel_dim < 0 else channel_dim
-            if pre_bias.layout == "NHWC":
-                channel_dim = 3  # last dim
             if isinstance(x, tuple):
                 x = x[0]
             if isinstance(bias, tuple):
                 bias = bias[0]
             if len(bias.shape) < len(x.shape):
                 tmp_bias = _C_ops.reshape(
-                    bias, bias.shape +
+                    bias, [1 for i in range(channel_dim)] + bias.shape +
                     [1 for i in range(len(x.shape) - channel_dim - 1)])
                 return _C_ops.add(pre_bias, tmp_bias)
             else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. LayoutAutotune 支持 inplace 类型的OP
2. 根据 https://github.com/PaddlePaddle/Paddle/pull/45409 修改意见调整UseAutotune
3. 将LayoutAutotune判断放到controller中，与AMP 判断保持一致
当前PR在resnet50上的性能数据如下：
<img width="834" alt="image" src="https://user-images.githubusercontent.com/51102941/189293515-f04725c8-4aa4-4646-b4d9-da7da1cee1e5.png">
