### PR TITLE
modify slice op Infershape

### DIFF
--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -117,6 +117,10 @@ inline phi::DDim GetSliceDims(const phi::DDim in_dims,
       continue;
     }
 
+    if(in_dims[axis] == -1){
+      continue;
+    }
+    
     T start = starts[i];
     T end = ends[i];
     T step = steps == nullptr ? 1 : (*steps)[i];

--- a/paddle/phi/kernels/funcs/slice_utils.h
+++ b/paddle/phi/kernels/funcs/slice_utils.h
@@ -117,10 +117,10 @@ inline phi::DDim GetSliceDims(const phi::DDim in_dims,
       continue;
     }
 
-    if(in_dims[axis] == -1){
+    if (in_dims[axis] == -1) {
       continue;
     }
-    
+
     T start = starts[i];
     T end = ends[i];
     T step = steps == nullptr ? 1 : (*steps)[i];

--- a/python/paddle/fluid/tests/unittests/test_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_slice_op.py
@@ -784,7 +784,7 @@ class TestInferShape(unittest.TestCase):
         self.assertEqual(x.shape, (3, -1, 5))
 
         out0 = paddle.slice(x, axes=[1], starts=[0], ends=[3])
-        self.assertEqual(out0.shape, (3, 3, 5))
+        self.assertEqual(out0.shape, (3, -1, 5))
 
     def test_axis_less_than_zero(self):
         # Using paddle.disable_static will make other unittests fail.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
 Bug fixes

### PR changes
OPs 

### Describe
静态图使用动态shape组网时slice OP 会将shape的-1处理为最大值，影响后续OP shape的推断，此PR修改slice op 的 infershape处理逻辑，避免上述问题
