### PR TITLE
Add int16 support for xpu one_hot

### DIFF
--- a/paddle/fluid/operators/one_hot_op_xpu.cc
+++ b/paddle/fluid/operators/one_hot_op_xpu.cc
@@ -73,5 +73,6 @@ namespace ops = paddle::operators;
 REGISTER_OP_XPU_KERNEL(
     one_hot,
     ops::OneHotXPUKernel<paddle::platform::XPUDeviceContext, int>,
-    ops::OneHotXPUKernel<paddle::platform::XPUDeviceContext, int64_t>);
+    ops::OneHotXPUKernel<paddle::platform::XPUDeviceContext, int64_t>,
+    ops::OneHotXPUKernel<paddle::platform::XPUDeviceContext, int16_t>);
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe
Register int16 for one_hot xpu kernel.
