### PR TITLE
[unittest]Fix test_reinforment_learing unittest failure

### DIFF
--- a/python/unittest_py/requirements.txt
+++ b/python/unittest_py/requirements.txt
@@ -3,7 +3,7 @@ PyGithub
 coverage==5.5
 pycrypto ; platform_system != "Windows"
 mock
-gym
+gym==0.25.2
 pygame==2.1.0
 hypothesis
 opencv-python<=4.2.0.32


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
gym 昨天发布了新版本 0.26，存在不兼容性升级，移除了seed函数，导致单测失败
<img width="1313" alt="21e34fd3e0813164ff7367f8d4c5dd6c" src="https://user-images.githubusercontent.com/9301846/189028477-2bf8808c-f8b6-4b8b-b924-25fc6fc5e3db.png">
