### PR TITLE
Fix fp16 compile error

### DIFF
--- a/paddle/phi/common/float16.h
+++ b/paddle/phi/common/float16.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <immintrin.h>
 #include <stdint.h>
 
 #include <cmath>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->

Fix fp16 compile error

When compile custom op in cuda11.2, it will failed with error like follows

`float16.h(112): error: identifier "_cvtss_sh" is undefined`

The issue seems to be that GCC (and also clang) define `__F16C__` even if none of the intrinsic headers are included. We don't add `#include <immintrin.h>`  in float16.h and thus triggering the error. This PR fix it.