### PR TITLE
Mixed inference fix select fp16 kernel.

### DIFF
--- a/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
+++ b/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
@@ -677,6 +677,26 @@ void ConvertTensorDtype(
           OpSupportPrecision(op_type, backend, tensor_dtype, blacklist);
       VLOG(2) << " support low precision " << support_precision;
 
+      // if op not has float input, we will not choose the low precision kernel.
+      {
+        bool has_float_input{false};
+        for (auto in_node : op_node->inputs) {
+          auto* real_node =
+              GetRealNode(graphes, block_idx, in_node, vars_in_multi_block_map);
+          if (real_node->Var()->GetDataType() == proto::VarType::FP16 ||
+              real_node->Var()->GetDataType() == proto::VarType::FP32 ||
+              real_node->Var()->GetDataType() == proto::VarType::FP64 ||
+              real_node->Var()->GetDataType() == proto::VarType::BF16) {
+            has_float_input = true;
+            break;
+          }
+        }
+        if (!has_float_input) {
+          support_precision = false;
+          VLOG(2) << " op doesn't has float input, just skip.";
+        }
+      }
+
       if (support_precision) {
         HandleSpecialOps(op_node->Op());
         ++num_low_precision;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
是否选取fp16 kernel 还需要判断输入是否存在浮点，如不存在浮点输入，则不选低精度kernel.