### PR TITLE
Fix test case in multi_transformer on A100

### DIFF
--- a/python/paddle/fluid/tests/unittests/static_model_parallel_fused_attention.py
+++ b/python/paddle/fluid/tests/unittests/static_model_parallel_fused_attention.py
@@ -36,7 +36,7 @@ def get_param_attr(weight, bias):
 DTYPE = "float32"
 MODEL_PARALLEL_SIZE = 2
 n_head = 2 * MODEL_PARALLEL_SIZE
-d_key = 4
+d_key = 2
 hidden = n_head * d_key
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
在A100上，这个测试用例会因为模型并行切分，导致矩阵乘进入了不同kernel，从而影响精度没办法达到10-5，采用减小测试规模的方法修复该测试用例。