### PR TITLE
make memcpy op to support custom_device

### DIFF
--- a/paddle/fluid/operators/memcpy_op.cc
+++ b/paddle/fluid/operators/memcpy_op.cc
@@ -113,7 +113,9 @@ class MemcpyOpProtoMaker : public framework::OpProtoAndCheckerMaker {
                  "1: dst is on CUDAPlace. "
                  "2: dst is on CUDAPinnedPlace. "
                  "3: dst is on XPUPlace. "
-                 "4: dst is on NPUPlace. ");
+                 "4: dst is on NPUPlace. "
+                 "5: dst is on NPUPinnerPlace. "
+                 "6: dst is on CustomDevicePlace");
     AddComment(R"DOC(
     Memcpy Operator.
     By now, it ONLY supports the memcopy between CUDAPinnedPlace <-> CUDAPlace or 

--- a/paddle/fluid/operators/memcpy_op.h
+++ b/paddle/fluid/operators/memcpy_op.h
@@ -41,7 +41,7 @@ class MemcpyFunctor {
     XPU = 3,
     NPU = 4,
     NPU_PINNED = 5,
-    CUSTOM_DEVICE = 6
+    CUSTOM_DEVICE = 6,
   };
 
  public:
@@ -73,7 +73,6 @@ class MemcpyFunctor {
     } else if (dst_place_type_ == DeviceType::CUSTOM_DEVICE) {
       framework::TensorCopy(
           lod_tensor, dev_ctx_.GetPlace(), dev_ctx_, &out_tensor);
-    }
 #endif
     } else {
       PADDLE_THROW(platform::errors::Unimplemented(

--- a/paddle/fluid/operators/memcpy_op.h
+++ b/paddle/fluid/operators/memcpy_op.h
@@ -41,6 +41,7 @@ class MemcpyFunctor {
     XPU = 3,
     NPU = 4,
     NPU_PINNED = 5,
+    CUSTOM_DEVICE = 6
   };
 
  public:
@@ -67,6 +68,12 @@ class MemcpyFunctor {
     } else if (dst_place_type_ == DeviceType::NPU_PINNED) { /* npu->npu_pin */
       framework::TensorCopy(
           lod_tensor, platform::NPUPinnedPlace(), dev_ctx_, &out_tensor);
+#endif
+#ifdef PADDLE_WTIH_CUSTOM_DEVICE
+    } else if (dst_place_type_ == DeviceType::CUSTOM_DEVICE) {
+      framework::TensorCopy(
+          lod_tensor, dev_ctx_.GetPlace(), dev_ctx_, &out_tensor);
+    }
 #endif
     } else {
       PADDLE_THROW(platform::errors::Unimplemented(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features 

### PR changes
OPs 

### Describe

Make memcpy op to support custom_device by defining custom_device as 6 in fluid/operators/memcpy.h
