### PR TITLE
【Hackathon No.36】优化 lerp_grad op 在 GPU 上的计算性能

### DIFF
--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,279 @@
 #include "paddle/phi/kernels/lerp_grad_kernel.h"
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_launch_config.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/lerp_grad_kernel_impl.h"
+
+#include "paddle/phi/kernels/broadcast_tensors_kernel.h"
+#include "paddle/phi/kernels/empty_kernel.h"
+#include "paddle/phi/kernels/funcs/common_shape.h"
+#include "paddle/phi/kernels/funcs/eigen/common.h"
+
+namespace phi {
+
+template <typename T>
+__global__ void GetLerpGrad(const T* weight,
+                            const T* dout,
+                            T* dx,
+                            T* dy,
+                            const int out_size,
+                            const int x_size,
+                            const int y_size) {
+  CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
+    T temp_dx = weight[idx] * dout[idx];
+    if (idx < x_size) {
+      dx[idx] = dout[idx] - temp_dx;
+    }
+    if (idx < y_size) {
+      dy[idx] = temp_dx;
+    }
+  }
+}
+
+template <typename T>
+__global__ void GetLerpGradRankZero(const T* weight,
+                                    const T* dout,
+                                    T* dx,
+                                    T* dy,
+                                    const int out_size,
+                                    const int x_size,
+                                    const int y_size) {
+  CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
+    T temp_dx = weight[0] * dout[idx];
+    if (idx < x_size) {
+      dx[idx] = dout[idx] - temp_dx;
+    }
+    if (idx < y_size) {
+      dy[idx] = temp_dx;
+    }
+  }
+}
+
+template <typename T, typename Context, size_t D>
+void GetRduceResult(const Context& ctx,
+                    const DenseTensor& out_grad,
+                    const DenseTensor& b_xgrad,
+                    const DenseTensor& b_ygrad,
+                    DenseTensor* x_grad,
+                    DenseTensor* y_grad) {
+  auto& dout = out_grad;
+  auto dout_dims = dout.dims();
+  auto* dx = x_grad;
+  auto* dy = y_grad;
+  DDim dx_dims;
+  DDim dy_dims;
+  Eigen::DSizes<int, D * 2> dx_reshape_dims;
+  Eigen::DSizes<int, D * 2> dy_reshape_dims;
+  Eigen::DSizes<int, D> reduce_dims;
+  Eigen::DSizes<int, D> dx_bcast_dims;
+  Eigen::DSizes<int, D> dy_bcast_dims;
+
+  dx_dims = phi::funcs::ExtendDims2Rank(dx->dims(), D);
+  phi::funcs::GetBroadcastDims<D>(dx_dims, dout_dims, &dx_bcast_dims);
+  dy_dims = phi::funcs::ExtendDims2Rank(dy->dims(), D);
+  phi::funcs::GetBroadcastDims<D>(dy_dims, dout_dims, &dy_bcast_dims);
+  for (int i = 0; i < dout_dims.size(); ++i) {
+    dx_reshape_dims[2 * i] = dx_bcast_dims[i];
+    dx_reshape_dims[2 * i + 1] = dx_dims[i];
+
+    dy_reshape_dims[2 * i] = dy_bcast_dims[i];
+    dy_reshape_dims[2 * i + 1] = dy_dims[i];
+    reduce_dims[i] = 2 * i;
+  }
+
+  ctx.template Alloc<T>(dx);
+  ctx.template Alloc<T>(dy);
+  auto eigen_dx = phi::EigenTensor<T, D>::From(*dx, dx_dims);
+  auto eigen_dy = phi::EigenTensor<T, D>::From(*dy, dy_dims);
+  dx_dims = phi::funcs::ExtendDims2Rank(x_grad->dims(), D);
+  auto broad_dx = phi::EigenTensor<T, D>::From(b_xgrad);
+  auto broad_dy = phi::EigenTensor<T, D>::From(b_ygrad);
+
+  auto& place = *ctx.eigen_device();
+  eigen_dx.device(place) = broad_dx.reshape(dx_reshape_dims)
+                               .sum(reduce_dims)
+                               .reshape(eigen_dx.dimensions());
+  eigen_dy.device(place) = broad_dy.reshape(dy_reshape_dims)
+                               .sum(reduce_dims)
+                               .reshape(eigen_dy.dimensions());
+}
+
+int XYNeedReduce(const DenseTensor& x,
+                 const DenseTensor& y,
+                 const DenseTensor& out) {
+  // 不考虑不可broadcast的情况，在算子调用时已排除
+  auto x_dims = x.dims();
+  auto y_dims = y.dims();
+  auto out_dims = out.dims();
+  int x_rank = x_dims.size();
+  int y_rank = y_dims.size();
+  int out_rank = out_dims.size();
+  int smaller_rank = std::min(x_rank, y_rank);
+  if (std::max(x_rank, y_rank) < out_rank) {
+    return 1;
+  }
+  for (int i = 1; i <= smaller_rank; ++i) {
+    int x_idx = x_rank - i;
+    int y_idx = y_rank - i;
+    int out_idx = out_rank - i;
+    if (x_dims[x_idx] != y_dims[y_idx]) {
+      return 1;
+    }
+    if (x_dims[x_idx] == 1 && y_dims[y_idx] == 1 && out_dims[out_idx] != 1) {
+      return 1;
+    }
+  }
+  return 0;
+}
+
+template <typename T, typename Context>
+void SwitchKernel(const Context& ctx,
+                  const DenseTensor& weight,
+                  const DenseTensor& out_grad,
+                  const int x_grad_size,
+                  const int y_grad_size,
+                  T* x_grad_data,
+                  T* y_grad_data) {
+  if (weight.dims().size() == 1) {
+    const T* weight_data = weight.data<T>();
+    const T* out_grad_data = out_grad.data<T>();
+    const int out_size = out_grad.numel();
+    const int weight_size = weight.numel();
+    auto gpu_config = phi::backends::gpu::GetGpuLaunchConfig1D(ctx, out_size);
+    GetLerpGradRankZero<T><<<gpu_config.GetGridSize(),
+                             gpu_config.GetBlockSize(),
+                             0,
+                             ctx.stream()>>>(weight_data,
+                                             out_grad_data,
+                                             x_grad_data,
+                                             y_grad_data,
+                                             out_size,
+                                             x_grad_size,
+                                             y_grad_size);
+  } else {
+    // 首先对weight进行braodcast，使用
+    // phi::BroadcastTensorsKernel，使其维度和out_grad一致
+    const std::vector<const DenseTensor*> in_tensors = {&weight, &out_grad};
+    DenseTensor b_weight = phi::EmptyLike<T>(ctx, out_grad);
+    DenseTensor b_out = phi::EmptyLike<T>(ctx, out_grad);
+    std::vector<DenseTensor*> out_tensors = {&b_weight, &b_out};
+
+    phi::BroadcastTensorsKernel<T, Context>(ctx, in_tensors, out_tensors);
+
+    const T* weight_data = b_weight.data<T>();
+    const T* out_grad_data = b_out.data<T>();
+    const int out_size = out_grad.numel();
+    const int weight_size = weight.numel();
+
+    auto gpu_config = phi::backends::gpu::GetGpuLaunchConfig1D(ctx, out_size);
+    GetLerpGrad<T><<<gpu_config.GetGridSize(),
+                     gpu_config.GetBlockSize(),
+                     0,
+                     ctx.stream()>>>(weight_data,
+                                     out_grad_data,
+                                     x_grad_data,
+                                     y_grad_data,
+                                     out_size,
+                                     x_grad_size,
+                                     y_grad_size);
+  }
+}
+
+template <typename T, typename Context>
+void LerpGradKernel(const Context& ctx,
+                    const DenseTensor& x,
+                    const DenseTensor& y,
+                    const DenseTensor& weight,
+                    const DenseTensor& out,
+                    const DenseTensor& out_grad,
+                    DenseTensor* x_grad,
+                    DenseTensor* y_grad) {
+  const int rank = out.dims().size();
+  PADDLE_ENFORCE_GE(
+      rank,
+      1,
+      phi::errors::InvalidArgument(
+          "The number of dimensions for LerpGradOp must be "
+          "greater than or equal to 1, but the value received is %d.",
+          rank));
+  PADDLE_ENFORCE_LE(
+      rank,
+      6,
+      phi::errors::InvalidArgument(
+          "The number of dimensions for LerpGradOp must be "
+          "less than or equal to 6, but the value received is %d.",
+          rank));
+
+  // 判断x_grad, y_grad
+  // 是否需要reduce，需要reduce的话就先进行broadcast用b_xgrad,
+  // b_ygrad。不需要的话就用x_grad, y_grad。
+  // 如果x,y在中间有某个维度不一致，或者和weight的中间某个维度不一致，就需要先broadcast再reduce。
+  //  例如 case1:  x:2*1*3, y:2*2*3  w:2*2*3 => out: 2*2*3
+  //      case2:  x:2*1:3, y: 2*1*3 w:2*2*3 => out: 2*2*3
+  // 如果x,y在初始维度不一致，就无所谓，只要控制kernel写入的idx大小不越界访问内存就可以。例如
+  // x:1*2*3, y:2*2*3，无需reduce。
+
+  int reduce_flag = XYNeedReduce(x, y, out);
+  if (reduce_flag == 0) {
+    T* x_grad_data = ctx.template Alloc<T>(x_grad);
+    T* y_grad_data = ctx.template Alloc<T>(y_grad);
+    int x_grad_size = x.numel();
+    int y_grad_size = y.numel();
+
+    SwitchKernel<T, Context>(ctx,
+                             weight,
+                             out_grad,
+                             x_grad_size,
+                             y_grad_size,
+                             x_grad_data,
+                             y_grad_data);
+
+  } else {
+    DenseTensor b_xgrad = phi::EmptyLike<T, Context>(ctx, out_grad);
+    DenseTensor b_ygrad = phi::EmptyLike<T, Context>(ctx, out_grad);
+    T* x_grad_data = ctx.template Alloc<T>(&b_xgrad);
+    T* y_grad_data = ctx.template Alloc<T>(&b_ygrad);
+    int x_grad_size = out.numel();
+    int y_grad_size = out.numel();
+
+    SwitchKernel<T, Context>(ctx,
+                             weight,
+                             out_grad,
+                             x_grad_size,
+                             y_grad_size,
+                             x_grad_data,
+                             y_grad_data);
+
+    switch (rank) {
+      case 1:
+        GetRduceResult<T, Context, 1>(
+            ctx, out_grad, b_xgrad, b_ygrad, x_grad, y_grad);
+        break;
+      case 2:
+        GetRduceResult<T, Context, 2>(
+            ctx, out_grad, b_xgrad, b_ygrad, x_grad, y_grad);
+        break;
+      case 3:
+        GetRduceResult<T, Context, 3>(
+            ctx, out_grad, b_xgrad, b_ygrad, x_grad, y_grad);
+        break;
+      case 4:
+        GetRduceResult<T, Context, 4>(
+            ctx, out_grad, b_xgrad, b_ygrad, x_grad, y_grad);
+        break;
+      case 5:
+        GetRduceResult<T, Context, 5>(
+            ctx, out_grad, b_xgrad, b_ygrad, x_grad, y_grad);
+        break;
+      case 6:
+        GetRduceResult<T, Context, 6>(
+            ctx, out_grad, b_xgrad, b_ygrad, x_grad, y_grad);
+        break;
+    }
+  }
+}
+
+}  // namespace phi
 
 PD_REGISTER_KERNEL(
     lerp_grad, GPU, ALL_LAYOUT, phi::LerpGradKernel, float, double) {}

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -123,14 +123,14 @@ bool XYNeedReduce(const DenseTensor& x,
   int out_rank = out_dims.size();
   int smaller_rank = std::min(x_rank, y_rank);
   if (std::max(x_rank, y_rank) < out_rank) {
-    return 1;
+    return true;
   }
   for (int i = 1; i <= smaller_rank; ++i) {
     int x_idx = x_rank - i;
     int y_idx = y_rank - i;
     int out_idx = out_rank - i;
     if (x_dims[x_idx] != y_dims[y_idx]) {
-      return 1;
+      return true;
     }
     if (x_dims[x_idx] == 1 && y_dims[y_idx] == 1 && out_dims[out_idx] != 1) {
       return true;

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -150,6 +150,7 @@ void SwitchKernel(const Context& ctx,
   if (weight.dims().size() == 1) {
     //    condition when weight is a scalar
     const T* weight_data = weight.data<T>();
+    const T weight_scalar = weight_data[0];
     const T* out_grad_data = out_grad.data<T>();
     const int out_size = out_grad.numel();
     const int weight_size = weight.numel();
@@ -157,7 +158,7 @@ void SwitchKernel(const Context& ctx,
     LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
                                   gpu_config.GetBlockSize(),
                                   0,
-                                  ctx.stream()>>>(weight_data[0],
+                                  ctx.stream()>>>(weight_scalar,
                                                   out_grad_data,
                                                   x_grad_data,
                                                   y_grad_data,

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -101,13 +101,12 @@ void SwitchKernel(const Context& ctx,
                   const int y_grad_size,
                   T* x_grad_data,
                   T* y_grad_data) {
-  if (weight.dims().size() == 1) {
+  if (weight.numel() == 1) {
     //    condition when weight is a scalar
     const T* weight_data = weight.data<T>();
-    // const T weight_scalar = weight_data[0];
     const T* out_grad_data = out_grad.data<T>();
-    const int out_size = out_grad.numel();
-    const int weight_size = weight.numel();
+    const int64_t out_size = out_grad.numel();
+    const int64_t weight_size = weight.numel();
     auto gpu_config = phi::backends::gpu::GetGpuLaunchConfig1D(ctx, out_size);
     LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
                                   gpu_config.GetBlockSize(),

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -26,7 +26,7 @@
 namespace phi {
 
 template <typename T>
-__global__ void GetLerpGrad(const T* weight,
+__global__ void LerpGradKernelImpl(const T* weight,
                             const T* dout,
                             T* dx,
                             T* dy,
@@ -45,7 +45,7 @@ __global__ void GetLerpGrad(const T* weight,
 }
 
 template <typename T>
-__global__ void GetLerpGradRankZero(const T* weight,
+__global__ void LerpGradScalarKernelImpl(const T* weight,
                                     const T* dout,
                                     T* dx,
                                     T* dy,
@@ -154,7 +154,7 @@ void SwitchKernel(const Context& ctx,
     const int out_size = out_grad.numel();
     const int weight_size = weight.numel();
     auto gpu_config = phi::backends::gpu::GetGpuLaunchConfig1D(ctx, out_size);
-    GetLerpGradRankZero<T><<<gpu_config.GetGridSize(),
+    LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
                              gpu_config.GetBlockSize(),
                              0,
                              ctx.stream()>>>(weight_data,
@@ -179,7 +179,7 @@ void SwitchKernel(const Context& ctx,
     const int weight_size = weight.numel();
 
     auto gpu_config = phi::backends::gpu::GetGpuLaunchConfig1D(ctx, out_size);
-    GetLerpGrad<T><<<gpu_config.GetGridSize(),
+    LerpGradKernelImpl<T><<<gpu_config.GetGridSize(),
                      gpu_config.GetBlockSize(),
                      0,
                      ctx.stream()>>>(weight_data,

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -212,11 +212,19 @@ void LerpGradKernel(const Context& ctx,
     std::vector<int> reduce_axis_y =
         funcs::GetReduceDim(y_grad->dims(), b_ygrad.dims(), -1);
 
-    phi::funcs::ReduceKernel<T, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
-        ctx, b_xgrad, x_grad, kps::IdentityFunctor<T>(), reduce_axis_x);
+    if (!reduce_axis_x.empty()) {
+      phi::funcs::ReduceKernel<T, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
+          ctx, b_xgrad, x_grad, kps::IdentityFunctor<T>(), reduce_axis_x);
+    } else {
+      x_grad->ShareDataWith(b_xgrad);
+    }
 
-    phi::funcs::ReduceKernel<T, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
-        ctx, b_ygrad, y_grad, kps::IdentityFunctor<T>(), reduce_axis_y);
+    if (!reduce_axis_y.empty()) {
+      phi::funcs::ReduceKernel<T, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
+          ctx, b_ygrad, y_grad, kps::IdentityFunctor<T>(), reduce_axis_y);
+    } else {
+      y_grad->ShareDataWith(b_ygrad);
+    }
   }
 }
 

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -185,8 +185,8 @@ void LerpGradKernel(const Context& ctx,
   bool reduce_flag = XYNeedReduce(x, y, out);
   if (!reduce_flag) {
     int x_grad_size = 0, y_grad_size = 0;
-    T* x_grad_data;
-    T* y_grad_data;
+    T* x_grad_data = NULL;
+    T* y_grad_data = NULL;
 
     if (x_grad) {
       x_grad_data = ctx.template Alloc<T>(x_grad);
@@ -210,8 +210,8 @@ void LerpGradKernel(const Context& ctx,
     int x_grad_size = 0, y_grad_size = 0;
     DenseTensor b_xgrad = phi::EmptyLike<T, Context>(ctx, out_grad);
     DenseTensor b_ygrad = phi::EmptyLike<T, Context>(ctx, out_grad);
-    T* x_grad_data;
-    T* y_grad_data;
+    T* x_grad_data = NULL;
+    T* y_grad_data = NULL;
 
     if (x_grad) {
       x_grad_data = ctx.template Alloc<T>(&b_xgrad);

--- a/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/lerp_grad_kernel.cu
@@ -45,15 +45,16 @@ __global__ void LerpGradKernelImpl(const T* weight,
 }
 
 template <typename T>
-__global__ void LerpGradScalarKernelImpl(const T weight,
+__global__ void LerpGradScalarKernelImpl(const T* weight,
                                          const T* dout,
                                          T* dx,
                                          T* dy,
                                          const int out_size,
                                          const int x_size,
                                          const int y_size) {
+  T weight_scalar = weight[0];
   CUDA_KERNEL_LOOP_TYPE(idx, out_size, int64_t) {
-    T temp_dx = weight * dout[idx];
+    T temp_dx = weight_scalar * dout[idx];
     if (idx < x_size) {
       dx[idx] = dout[idx] - temp_dx;
     }
@@ -150,7 +151,7 @@ void SwitchKernel(const Context& ctx,
   if (weight.dims().size() == 1) {
     //    condition when weight is a scalar
     const T* weight_data = weight.data<T>();
-    const T weight_scalar = weight_data[0];
+    // const T weight_scalar = weight_data[0];
     const T* out_grad_data = out_grad.data<T>();
     const int out_size = out_grad.numel();
     const int weight_size = weight.numel();
@@ -158,7 +159,7 @@ void SwitchKernel(const Context& ctx,
     LerpGradScalarKernelImpl<T><<<gpu_config.GetGridSize(),
                                   gpu_config.GetBlockSize(),
                                   0,
-                                  ctx.stream()>>>(weight_scalar,
+                                  ctx.stream()>>>(weight_data,
                                                   out_grad_data,
                                                   x_grad_data,
                                                   y_grad_data,

--- a/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h
+++ b/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h
@@ -106,10 +106,11 @@ void BroadcastTensorsKernel(const Context& ctx,
       SWITCH_OUT_RANK_CASE(3)
       SWITCH_OUT_RANK_CASE(4)
       SWITCH_OUT_RANK_CASE(5)
+      SWITCH_OUT_RANK_CASE(6)
       default: {
         PADDLE_THROW(paddle::platform::errors::InvalidArgument(
             "Target tensor rank out of range"
-            "Maximum supported rank for broadcast is: 5"));
+            "Maximum supported rank for broadcast is: 6"));
       }
     }
   }

--- a/python/paddle/fluid/tests/unittests/test_lerp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lerp_op.py
@@ -47,7 +47,7 @@ class TestLerp(OpTest):
         self.check_output(check_eager=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out', check_eager=True)
+        self.check_grad(['X', 'Y'], 'Out', check_eager=True, max_relative_error=0.01)
 
 
 class TestLerpWithDim2(TestLerp):
@@ -87,8 +87,8 @@ class TestLerpBroadXY(TestLerp):
         self.python_api = paddle.lerp
         self.init_dtype()
         self.init_shape()
-        x = np.arange(1., 101.).astype(self.dtype).reshape([2, 2, 25])
-        y = np.full(150, 10.).astype(self.dtype).reshape([3, 2, 1, 25])
+        x = np.arange(1., 201.).astype(self.dtype).reshape([2, 1, 2, 50])
+        y = np.full(200, 10.).astype(self.dtype).reshape([2, 2, 1, 50])
         w = np.asarray([0.5]).astype(self.dtype)
         self.inputs = {'X': x, 'Y': y, 'Weight': w}
         self.outputs = {'Out': x + w * (y - x)}
@@ -101,9 +101,9 @@ class TestLerpBroadWToXY(TestLerp):
         self.python_api = paddle.lerp
         self.init_dtype()
         self.init_shape()
-        x = np.arange(1., 201.).astype(self.dtype).reshape([2, 2, 50])
-        y = np.full(100, 7.5).astype(self.dtype).reshape([1, 2, 50])
-        w = np.asarray([0.5]).astype(self.dtype)
+        x = np.full(600, 2.5).astype(self.dtype).reshape([3, 2, 2, 50])
+        y = np.full(600, 1.).astype(self.dtype).reshape([3, 2, 2, 50])
+        w = np.full(200, 0.5).astype(self.dtype).reshape([2, 2, 50])
         self.inputs = {'X': x, 'Y': y, 'Weight': w}
         self.outputs = {'Out': x + w * (y - x)}
 

--- a/python/paddle/fluid/tests/unittests/test_lerp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lerp_op.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import unittest
 import numpy as np
 from op_test import OpTest
@@ -76,6 +78,48 @@ class TestLerpWithDim6(TestLerp):
 
     def init_shape(self):
         self.shape = [2, 1, 2, 5, 1, 5]
+
+
+class TestLerpBroadXY(TestLerp):
+
+    def setUp(self):
+        self.op_type = "lerp"
+        self.python_api = paddle.lerp
+        self.init_dtype()
+        self.init_shape()
+        x = np.arange(1., 101.).astype(self.dtype).reshape([2, 2, 25])
+        y = np.full(150, 10.).astype(self.dtype).reshape([3, 2, 1, 25])
+        w = np.asarray([0.5]).astype(self.dtype)
+        self.inputs = {'X': x, 'Y': y, 'Weight': w}
+        self.outputs = {'Out': x + w * (y - x)}
+
+
+class TestLerpBroadWToXY(TestLerp):
+
+    def setUp(self):
+        self.op_type = "lerp"
+        self.python_api = paddle.lerp
+        self.init_dtype()
+        self.init_shape()
+        x = np.arange(1., 201.).astype(self.dtype).reshape([2, 2, 50])
+        y = np.full(100, 7.5).astype(self.dtype).reshape([1, 2, 50])
+        w = np.asarray([0.5]).astype(self.dtype)
+        self.inputs = {'X': x, 'Y': y, 'Weight': w}
+        self.outputs = {'Out': x + w * (y - x)}
+
+
+# class TestLerpBroadXYToW(TestLerp):
+
+#     def setUp(self):
+#         self.op_type = "lerp"
+#         self.python_api = paddle.lerp
+#         self.init_dtype()
+#         self.init_shape()
+#         x = np.arange(1., 101.).astype(self.dtype).reshape([2, 50])
+#         y = np.full(200, 7.5).astype(self.dtype).reshape([2, 2, 50])
+#         w = np.full(400, 0.225).astype(self.dtype).reshape([2, 2, 2, 50])
+#         self.inputs = {'X': x, 'Y': y, 'Weight': w}
+#         self.outputs = {'Out': x + w * (y - x)}
 
 
 class TestLerpAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_lerp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lerp_op.py
@@ -108,20 +108,6 @@ class TestLerpBroadWToXY(TestLerp):
         self.outputs = {'Out': x + w * (y - x)}
 
 
-# class TestLerpBroadXYToW(TestLerp):
-
-#     def setUp(self):
-#         self.op_type = "lerp"
-#         self.python_api = paddle.lerp
-#         self.init_dtype()
-#         self.init_shape()
-#         x = np.arange(1., 101.).astype(self.dtype).reshape([2, 50])
-#         y = np.full(200, 7.5).astype(self.dtype).reshape([2, 2, 50])
-#         w = np.full(400, 0.225).astype(self.dtype).reshape([2, 2, 2, 50])
-#         self.inputs = {'X': x, 'Y': y, 'Weight': w}
-#         self.outputs = {'Out': x + w * (y - x)}
-
-
 class TestLerpAPI(unittest.TestCase):
 
     def init_dtype(self):

--- a/python/paddle/fluid/tests/unittests/test_lerp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lerp_op.py
@@ -101,9 +101,9 @@ class TestLerpBroadWToXY(TestLerp):
         self.python_api = paddle.lerp
         self.init_dtype()
         self.init_shape()
-        x = np.full(600, 2.5).astype(self.dtype).reshape([3, 2, 2, 50])
-        y = np.full(600, 1.).astype(self.dtype).reshape([3, 2, 2, 50])
-        w = np.full(200, 0.5).astype(self.dtype).reshape([2, 2, 50])
+        x = np.full(600, 2.5).astype(self.dtype).reshape([50, 2, 2, 3])
+        y = np.full(600, 1.).astype(self.dtype).reshape([50, 2, 2, 3])
+        w = np.random.random([3]).astype(self.dtype)
         self.inputs = {'X': x, 'Y': y, 'Weight': w}
         self.outputs = {'Out': x + w * (y - x)}
 

--- a/python/paddle/fluid/tests/unittests/test_lerp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lerp_op.py
@@ -47,7 +47,7 @@ class TestLerp(OpTest):
         self.check_output(check_eager=True)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out', check_eager=True, max_relative_error=0.01)
+        self.check_grad(['X', 'Y'], 'Out', check_eager=True)
 
 
 class TestLerpWithDim2(TestLerp):


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
OPs 

### Describe
实验开发环境：
硬件：Tesla-P4
软件环境：CUDA 11.2，CuDNN 8

| Case No. | input_shape | data_type | Paddle_modify Perf(us) | Perf_over_paddle_origin(%) | Perf_over_pytorch(%)
|---|---|---|---|---|---|
| 1 | [16, 102400] |float32|134.98 | 65.56% | 41.04% ｜
| 2 | [16, 204800] |float64| 543.17 | 37.96% | 42.55% | 

代码逻辑简介：
对于cpu端，直接复制原本的逻辑，可以正常运行。
对于GPU端，需要考虑X，Y，W三者broadcoat的情况。
       1. 真正计算过程中只涉及W和Dout，如果w是单个值（大部分情况），可以不对weight进行broadcast，直接与dout相乘；
       2. 如果weight是矩阵，需要先broadcast到dout的维度然后对应相乘。
       3. 对于X，Y维度不同时，如果是类似（x: 1x2x3, y:2x2x3）这样只需要broadcast的维度在起始维度，那么可以不用将x拓展到y的维度。
       4.  如果是类似（x:2x1x3, y:2x2x3）这样需要拓展的维度在中间的话，就需要先将x拓展进行计算，计算完成后在reduce回自身维度。

4的计算时间与原始计算步骤相当，从1～4的计算过程逐渐增大。所以情况1的性能优化应该最好，4的最差

