### PR TITLE
Add ci rule for blocking legacy kernel registration

### DIFF
--- a/paddle/fluid/operators/beam_search_op.cc
+++ b/paddle/fluid/operators/beam_search_op.cc
@@ -148,9 +148,3 @@ REGISTER_OP_CPU_KERNEL(beam_search,
                        ops::BeamSearchOpKernel<phi::CPUContext, double>,
                        ops::BeamSearchOpKernel<phi::CPUContext, int>,
                        ops::BeamSearchOpKernel<phi::CPUContext, int64_t>);
-
-REGISTER_OP_CUDA_KERNEL(beam_search,
-                        ops::BeamSearchOpKernel<phi::CPUContext, float>,
-                        ops::BeamSearchOpKernel<phi::CPUContext, double>,
-                        ops::BeamSearchOpKernel<phi::CPUContext, int>,
-                        ops::BeamSearchOpKernel<phi::CPUContext, int64_t>);

--- a/paddle/fluid/operators/beam_search_op.cc
+++ b/paddle/fluid/operators/beam_search_op.cc
@@ -148,3 +148,9 @@ REGISTER_OP_CPU_KERNEL(beam_search,
                        ops::BeamSearchOpKernel<phi::CPUContext, double>,
                        ops::BeamSearchOpKernel<phi::CPUContext, int>,
                        ops::BeamSearchOpKernel<phi::CPUContext, int64_t>);
+
+REGISTER_OP_CUDA_KERNEL(beam_search,
+                        ops::BeamSearchOpKernel<phi::CPUContext, float>,
+                        ops::BeamSearchOpKernel<phi::CPUContext, double>,
+                        ops::BeamSearchOpKernel<phi::CPUContext, int>,
+                        ops::BeamSearchOpKernel<phi::CPUContext, int64_t>);

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -216,7 +216,7 @@ fi
 FILTER=`git diff --name-only upstream/develop | grep -v "tools/"`
 HAS_LEGACY_KERNEL_REGISTRATION=`git diff -U0 upstream/$BRANCH $FILTER | grep '^\+' | grep -oE -m 1 "REGISTER_OP[A-Z_]{1,9}KERNEL[_FUNCTOR|_WITH_CUSTOM_TYPE|_EX]*" || true`
 if [ ${HAS_LEGACY_KERNEL_REGISTRATION} ] && [ "${GIT_PR_ID}" != "" ]; then
-    echo_line="In principle, adding an OpKernel needs to be in the phi/kernels directory. If you must add an OpKernel in the fluid/operators directory, you must have one of the RD (chenwhql, zyfncg, YuanRisheng, phlrain) approves.\n"
+    echo_line="In principle, adding an OpKernel needs to be in the phi/kernels directory. If you must add an OpKernel in the fluid/operators directory, please request one of the RD (chenwhql, zyfncg, YuanRisheng, phlrain) review and approve.\n"
     check_approval 1 chenwhql zyfncg YuanRisheng phlrain
 fi
 

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -213,6 +213,13 @@ if [ ${NO_INFRT_FILES} ] && [ ${HAS_LOG_FATAL} ] && [ "${GIT_PR_ID}" != "" ]; th
     check_approval 1 6836917 47554610 22561442
 fi
 
+FILTER=`git diff --name-only upstream/develop | grep -v "tools/"`
+HAS_LEGACY_KERNEL_REGISTRATION=`git diff -U0 upstream/$BRANCH $FILTER | grep '^\+' | grep -oE -m 1 "REGISTER_OP[A-Z_]{1,9}KERNEL[_FUNCTOR|_WITH_CUSTOM_TYPE|_EX]*" || true`
+if [ ${HAS_LEGACY_KERNEL_REGISTRATION} ] && [ "${GIT_PR_ID}" != "" ]; then
+    echo_line="In principle, adding an OpKernel needs to be in the phi/kernels directory. If you must add an OpKernel in the fluid/operators directory, you must have one of the RD (chenwhql, zyfncg, YuanRisheng, phlrain) approves.\n"
+    check_approval 1 chenwhql zyfncg YuanRisheng phlrain
+fi
+
 HAS_DEFINE_FLAG=`git diff -U0 upstream/$BRANCH |grep -o -m 1 "DEFINE_int32" |grep -o -m 1 "DEFINE_bool" | grep -o -m 1 "DEFINE_string" || true`
 if [ ${HAS_DEFINE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     echo_line="You must have one RD lanxianghit approval for the usage (either add or delete) of DEFINE_int32/DEFINE_bool/DEFINE_string flag.\n"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->

Add ci rule for blocking legacy kernel registration

本地正则表达式测试如下，可以拦截各种形式的fluid op kernel注册写法

![image](https://user-images.githubusercontent.com/22561442/189850451-d9327211-502d-43bc-8545-41d8954f5a96.png)

CI拦截测试效果如下

![image](https://user-images.githubusercontent.com/22561442/189853586-bdcf1715-b6d0-44c5-86cc-a8adc817cd8c.png)
