### PR TITLE
add convert rules for fill_any_like op in paddle science

### DIFF
--- a/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
+++ b/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
@@ -18,6 +18,7 @@ import paddle
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.layers.utils import flatten
 from paddle.incubate.autograd.primrules import _orig2prim, _prim2orig, _jvp, _transpose
+import paddle.fluid.core as core
 
 paddle.enable_static()
 
@@ -357,6 +358,26 @@ class TestFillAnyLikeOrig2Prim(TestElementWiseAddOrig2Prim):
             self.layer_help.create_variable_for_type_inference(dtype=X.dtype)
         }
         self.attrs = {}
+
+        self.orig2prim_args = (X, )
+        self.all_ops = ['fill_any_like', 'fill_constant_p']
+        self.out_map = {0: self.output['Out']}
+
+
+class TestFillAnyLikeOrig2Prim2(TestElementWiseAddOrig2Prim):
+
+    def init_data(self):
+        self.op_type = 'fill_any_like'
+        X = paddle.static.data(name='X', shape=[5, 6], dtype='int64')
+
+        self.input = {
+            'X': X,
+        }
+        self.output = {
+            'Out':
+            self.layer_help.create_variable_for_type_inference(dtype=X.dtype)
+        }
+        self.attrs = {'dtype': int(core.VarDesc.VarType.FP32), 'value': 5}
 
         self.orig2prim_args = (X, )
         self.all_ops = ['fill_any_like', 'fill_constant_p']

--- a/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
+++ b/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
@@ -343,6 +343,26 @@ class TestFillZerosLikeOrig2Prim(TestElementWiseAddOrig2Prim):
         self.out_map = {0: self.output['Out']}
 
 
+class TestFillAnyLikeOrig2Prim(TestElementWiseAddOrig2Prim):
+
+    def init_data(self):
+        self.op_type = 'fill_any_like'
+        X = paddle.static.data(name='X', shape=[5, 6], dtype='int64')
+
+        self.input = {
+            'X': X,
+        }
+        self.output = {
+            'Out':
+            self.layer_help.create_variable_for_type_inference(dtype=X.dtype)
+        }
+        self.attrs = {}
+
+        self.orig2prim_args = (X, )
+        self.all_ops = ['fill_any_like', 'fill_constant_p']
+        self.out_map = {0: self.output['Out']}
+
+
 class TestSumOrig2Prim(TestElementWiseAddOrig2Prim):
 
     def init_data(self):

--- a/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
+++ b/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
@@ -377,7 +377,7 @@ class TestFillAnyLikeOrig2Prim2(TestElementWiseAddOrig2Prim):
             'Out':
             self.layer_help.create_variable_for_type_inference(dtype=X.dtype)
         }
-        self.attrs = {'dtype': int(core.VarDesc.VarType.FP32), 'value': 5}
+        self.attrs = {'dtype': X.dtype, 'value': 5}
 
         self.orig2prim_args = (X, )
         self.all_ops = ['fill_any_like', 'fill_constant_p']

--- a/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
+++ b/python/paddle/fluid/tests/unittests/autograd/test_orig2prim.py
@@ -377,7 +377,7 @@ class TestFillAnyLikeOrig2Prim2(TestElementWiseAddOrig2Prim):
             'Out':
             self.layer_help.create_variable_for_type_inference(dtype=X.dtype)
         }
-        self.attrs = {'dtype': X.dtype, 'value': 5}
+        self.attrs = {'dtype': paddle.float32, 'value': 5}
 
         self.orig2prim_args = (X, )
         self.all_ops = ['fill_any_like', 'fill_constant_p']

--- a/python/paddle/incubate/autograd/primrules.py
+++ b/python/paddle/incubate/autograd/primrules.py
@@ -187,6 +187,15 @@ def fill_zeros_like_orig2prim(op, x):
     return fill_const(value=0.0, shape=x.shape, dtype=x.dtype)
 
 
+@REGISTER_ORIG2PRIM('fill_any_like')
+def fill_any_like_orig2prim(op, x):
+    if op.attr('dtype') == -1:
+        return fill_const(value=op.attr('value'), shape=x.shape, dtype=x.dtype)
+    return fill_const(value=op.attr('value'),
+                      shape=x.shape,
+                      dtype=op.attr('dtype'))
+
+
 @REGISTER_ORIG2PRIM('sum')
 def sum_orig2prim(op, xs):
     x0 = xs[0]

--- a/python/paddle/incubate/autograd/primrules.py
+++ b/python/paddle/incubate/autograd/primrules.py
@@ -26,6 +26,8 @@ from .primreg import (REGISTER_JVP, REGISTER_ORIG2PRIM, REGISTER_PRIM2ORIG,
                       lookup_orig2prim, lookup_prim2orig, lookup_transpose,
                       op_position_inputs, op_position_output)
 from .utils import INT_DTYPE_2_STRING, get_input_var_list, get_output_var_list
+from paddle.fluid.data_feeder import convert_dtype
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 
 def _orig2prim(op, *args):
@@ -63,6 +65,7 @@ elementwise_sub
 elementwise_mul
 tanh
 fill_zeros_like
+fill_any_like
 sum
 index_select
 scale
@@ -191,7 +194,10 @@ def fill_zeros_like_orig2prim(op, x):
 def fill_any_like_orig2prim(op, x):
     if op.attr('dtype') == -1:
         return fill_const(value=op.attr('value'), shape=x.shape, dtype=x.dtype)
-    return fill_const(value=op.attr('value'), shape=x.shape, dtype=x.dtype)
+    return fill_const(value=op.attr('value'),
+                      shape=x.shape,
+                      dtype=convert_np_dtype_to_dtype_(
+                          convert_dtype(INT_DTYPE_2_STRING[op.attr('dtype')])))
 
 
 @REGISTER_ORIG2PRIM('sum')

--- a/python/paddle/incubate/autograd/primrules.py
+++ b/python/paddle/incubate/autograd/primrules.py
@@ -191,9 +191,7 @@ def fill_zeros_like_orig2prim(op, x):
 def fill_any_like_orig2prim(op, x):
     if op.attr('dtype') == -1:
         return fill_const(value=op.attr('value'), shape=x.shape, dtype=x.dtype)
-    return fill_const(value=op.attr('value'),
-                      shape=x.shape,
-                      dtype=op.attr('dtype'))
+    return fill_const(value=op.attr('value'), shape=x.shape, dtype=x.dtype)
 
 
 @REGISTER_ORIG2PRIM('sum')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add convert rules and unit test for fill_any_like op in paddle science.