### PR TITLE
Support using init_process_group

### DIFF
--- a/paddle/fluid/pybind/communication.cc
+++ b/paddle/fluid/pybind/communication.cc
@@ -47,7 +47,22 @@ void BindTCPStore(py::module *m) {
               },
               py::arg("key"),
               py::arg("value"),
-              py::call_guard<py::gil_scoped_release>())
+              py::call_guard<py::gil_scoped_release>(),
+              R"DOC(
+      Insert the key-value pair into the store. If key already exists in the store, it will overwrite the old value with the new supplied value.
+
+      Parameters:
+        key(str): The key to be added to the store.
+        value(str): The value associated with key to be added to the store.
+
+      Examples:
+        .. code-block:: python
+        import paddle.distributed as dist
+
+        store = dist.TCPStore("localhost", 0, 1, True)
+        store.set("first_key", "first_value")
+        store.get("first_key") # return "b'first_value"
+)DOC")
           .def(
               "get",
               [](distributed::Store &self,
@@ -57,15 +72,89 @@ void BindTCPStore(py::module *m) {
                                  data.size());
               },
               py::arg("key"),
-              py::call_guard<py::gil_scoped_release>())
+              py::call_guard<py::gil_scoped_release>(),
+              R"DOC(
+      Get the value associated with the given key in the store. If key is not present in the store, this method will wait for timeout before throwing an exception.
+
+      Parameters:
+        key(str): This method will return the value associated with this key.
+
+      Return:
+        byte_str: Value associated with key if key is in the store.
+
+      Examples:
+        .. code-block:: python
+        import paddle.distributed as dist
+
+        store = dist.TCPStore("localhost", 0, 1, True)
+        store.set("first_key", "first_value")
+        store.get("first_key") # return "b'first_value"
+)DOC")
           .def("add",
                &distributed::Store::add,
-               py::call_guard<py::gil_scoped_release>())
+               py::call_guard<py::gil_scoped_release>(),
+               R"DOC(
+      Find the value associated with the specifc key and increase it using the specified value. If the key not exists, initialized it using the specified value.
+
+      Parameters:
+        key(str): The key in the store which value will be incremented.
+        value(int): The value to be increased.
+
+      Return:
+        byte_str: Value associated with key after increment.
+
+      Examples:
+        .. code-block:: python
+        import paddle.distributed as dist
+
+        store = dist.TCPStore("localhost", 0, 1, True)
+        store.add("first_key", 1)
+        store.add("first_key", 6)
+        store.get("first_key") # return "b'7"
+)DOC")
           .def("wait",
                &distributed::Store::wait,
-               py::call_guard<py::gil_scoped_release>());
+               py::call_guard<py::gil_scoped_release>(),
+               R"DOC(
+      Wait for the key to be set in the store. This method will wait for timeout before throwing an exception.
 
-  py::class_<TCPStore, std::shared_ptr<TCPStore>>(*m, "TCPStore", Store)
+      Parameters:
+        key(str): This method will return the value associated with this key.
+
+      Examples:
+        .. code-block:: python
+        import paddle.distributed as dist
+
+        store = dist.TCPStore("localhost", 0, 1, True)
+        store.set("first_key", "first_value")
+        store.wait("first_key")
+)DOC");
+
+  py::class_<TCPStore, std::shared_ptr<TCPStore>>(*m, "TCPStore", Store, R"DOC(
+
+    TCPStore is a key-value store implementation based on TCP-based. There is only one server which holds the data, and the clients connect to the server based on TCP. There are several actions such as get() to retrieve the value of specific key, set() to insert a new key-value pair, etc.
+
+    Parameters:
+        hostname (string): The hostname or direct IP address indicate the server store should run on.
+        port (int): The listening port of server.
+        is_master (bool): Indicate the store is server or client. True for server, false for client.
+        world_size (int): The number of processes need to be connected.
+        timeout (int, optional): Timeout used by the store during initialization and for methods such as get() and wait(). Default is 900 seconds.
+
+    Examples:
+        .. code-block:: python
+
+          import paddle.distributed as dist
+          rank = dist.get_rank()
+          world_size = dist.get_world_size()
+          is_master = (rank == 0)
+          store = dist.TCPStore(hostname="localhost", port=12345, is_master=is_master, world_size=world_size)
+          if is_master:
+            store.get("first_key")
+          else:
+            store.set("first_key", "first_value")
+
+)DOC")
       .def(py::init([](std::string hostname,
                        uint16_t port,
                        bool is_master,

--- a/python/paddle/distributed/communication/__init__.py
+++ b/python/paddle/distributed/communication/__init__.py
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ["stream"]
+from .init import init_process_group
+from paddle.fluid.core import TCPStore
+
+__all__ = ["stream", "init_process_group", "TCPStore"]

--- a/python/paddle/distributed/communication/init.py
+++ b/python/paddle/distributed/communication/init.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.distributed as dist
+import paddle.fluid.framework as framework
+import paddle.fluid.core as core
+import paddle.distributed.communication.utils as utils
+import paddle.distributed.collective as collective
+
+
+def init_process_group(backend, store, rank, world_size):
+    """
+    Initialize the default distributed process group. This will also initialize the distributed package.
+
+    Args:
+        backend (string): A string represents the backend to use, should be one of 'gloo', 'nccl'.
+        store (Store): A key/value store accessible to all workers, only 'TCPStore' is supported for now.
+        rank (int): Represent the rank of the current process.
+        world_size (int): The total number of processes participating in this distributed job.
+
+    Returns:
+        Group: The global group instance.
+
+    Warning:
+        This API is only supported for dygraph mode for now.
+
+    Examples:
+        .. code-block:: python
+        # Execute this script using distributed launch with two devices.
+        import paddle
+        import paddle.distributed as dist
+
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        is_master = (rank == 0)
+        store = dist.TCPStore("localhost", 12345, is_master, world_size)
+
+        group = dist.init_process_group("nccl", store, rank, world_size)
+    """
+
+    valid_backend_list = utils._ProcessGroupManager.valid_backend_list
+    default_group_name = utils._ProcessGroupManager.default_group_name
+    global_group_id = utils._ProcessGroupManager.global_group_id
+
+    if backend not in valid_backend_list:
+        raise NotImplementedError(
+            "Valid backends are {}. But input {} as parameter.".format(
+                valid_backend_list, backend))
+
+    if dist.is_initialized():
+        raise RuntimeError(
+            "The default process group is already initialized. You are trying to init it twice."
+        )
+
+    if not framework.in_dygraph_mode():
+        raise NotImplementedError(
+            "This API is only supported in dygraph for now.")
+
+    utils._set_place(backend)
+    collective._set_default_store(store)
+
+    pg = collective._new_process_group_impl(backend,
+                                            store,
+                                            rank,
+                                            world_size,
+                                            default_group_name,
+                                            pg_options=None)
+
+    ranks = list(range(world_size))
+    group = collective.Group(rank,
+                             world_size,
+                             id=global_group_id,
+                             ranks=ranks,
+                             pg=pg,
+                             name=default_group_name)
+    collective._set_group_map_by_name(default_group_name, group)
+    collective._set_group_map(global_group_id, group)
+
+    dist.barrier(group=group)
+    return group

--- a/python/paddle/distributed/communication/utils.py
+++ b/python/paddle/distributed/communication/utils.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import paddle.fluid.core as core
+import paddle.fluid.framework as framework
+import paddle.distributed.parallel as parallel
+
+
+def _set_place(backend):
+    if parallel._is_cpuonly(backend):
+        place = core.CPUPlace()
+    elif core.is_compiled_with_cuda():
+        selected_gpus = os.getenv("FLAGS_selected_gpus", "0").split(",")
+        device_id = int(selected_gpus[0])
+        place = core.CUDAPlace(device_id)
+    else:
+        raise NotImplementedError(
+            "Valid backends are {}. But input {} as parameter.".format(
+                _ProcessGroupManager.valid_backend_list, backend))
+
+    framework._set_expected_place(place)
+
+
+class _ProcessGroupManager():
+    global_group_id = 0
+    valid_backend_list = ['nccl', 'gloo']
+    default_group_name = "_default_pg"

--- a/python/paddle/fluid/tests/unittests/collective/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/collective/CMakeLists.txt
@@ -304,6 +304,13 @@ if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   set_tests_properties(test_communication_stream_allreduce_api
                        PROPERTIES TIMEOUT "120" LABELS "RUN_TYPE=DIST")
 endif()
+if((WITH_GPU OR WITH_ROCM) AND (LINUX))
+  py_test_modules(
+    test_communication_init_api MODULES test_communication_init_api ENVS
+    "PYTHONPATH=..:${PADDLE_BINARY_DIR}/python;http_proxy=;https_proxy=")
+  set_tests_properties(test_communication_init_api
+                       PROPERTIES TIMEOUT "120" LABELS "RUN_TYPE=DIST")
+endif()
 if((WITH_ROCM OR WITH_GPU) AND (LINUX))
   bash_test_modules(
     test_world_size_and_rank

--- a/python/paddle/fluid/tests/unittests/collective/communication_init_process_group_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_init_process_group_api_dygraph.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import paddle.distributed as dist
+
+
+class InitProcessGroupTestCase():
+
+    def __init__(self):
+        self._backend = os.getenv("backend")
+        self._master_addr = os.getenv("PADDLE_MASTER").split(":")[0]
+        self._master_port = int(os.getenv("PADDLE_MASTER").split(":")[1])
+        self._rank = dist.get_rank()
+        self._world_size = dist.get_world_size()
+        self._is_master = (self._rank == 0)
+        if self._backend not in ["nccl", "gloo"]:
+            raise NotImplementedError(
+                "Only support nccl and gloo as the backend for now.")
+
+    def run_test_case(self):
+        store = dist.TCPStore(self._master_addr, self._master_port,
+                              self._is_master, self._world_size)
+        group = dist.init_process_group(self._backend, store, self._rank,
+                                        self._world_size)
+
+        assert group.is_member() is True
+        assert group.id == 0
+
+
+if __name__ == "__main__":
+    InitProcessGroupTestCase().run_test_case()

--- a/python/paddle/fluid/tests/unittests/collective/test_communication_init_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_communication_init_api.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import test_communication_api_base as test_base
+
+
+class TestCommunicationInitAPI(test_base.CommunicationTestDistBase):
+
+    def setUp(self):
+        super(TestCommunicationInitAPI, self).setUp(num_of_devices=2,
+                                                    timeout=120)
+        self._default_envs = {}
+        self._changeable_envs = {"backend": ["nccl", "gloo"]}
+
+    def test_init_process_group(self):
+        envs_list = test_base.gen_product_envs_list(self._default_envs,
+                                                    self._changeable_envs)
+        for envs in envs_list:
+            self.run_test_case(
+                "communication_init_process_group_api_dygraph.py",
+                user_defined_envs=envs)
+
+    def tearDown(self):
+        super(TestCommunicationInitAPI, self).tearDown()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/collective/testslist.csv
+++ b/python/paddle/fluid/tests/unittests/collective/testslist.csv
@@ -36,4 +36,5 @@ test_eager_dist_api,linux,gpu;rocm,120,DIST,test_runner.py,2,,http_proxy=;https_
 test_new_group_api,linux,gpu;rocm,120,DIST,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=..,
 test_gen_nccl_id_op,,gpu;rocm;ASCEND;ASCEND_CL,,DIST,../dist_test.sh,2,,http_proxy=;https_proxy=;PYTHONPATH=..,
 test_communication_stream_allreduce_api,linux,gpu;rocm,120,DIST,,2,,PYTHONPATH=..;http_proxy=;https_proxy=,
+test_communication_init_api,linux,gpu;rocm,120,DIST,,2,,PYTHONPATH=..;http_proxy=;https_proxy=,
 test_world_size_and_rank,linux,rocm;gpu,120,DIST,test_world_size_and_rank.sh,2,,http_proxy=;https_proxy=,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
- Add `init_process_group` api for low level communication initialized method. This api only supports nccl and gloo for now.
- Expose `TCPStore` under the distributed package.