### PR TITLE
fix arm compile error due to immintrin.h

### DIFF
--- a/paddle/phi/common/float16.h
+++ b/paddle/phi/common/float16.h
@@ -14,7 +14,9 @@
 
 #pragma once
 
+#ifndef PADDLE_WITH_ARM
 #include <immintrin.h>
+#endif
 #include <stdint.h>
 
 #include <cmath>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
 Others

### Describe
Fix ARM compile error: https://github.com/PaddlePaddle/Paddle/pull/45873 adds `#include <immintrin.h>` in `paddle/phi/common/float16.h`, but ARM doesn't support `immintrin`. This PR adds the conditional compilation. 
