### PR TITLE
fix_bug_for_prec_test

### DIFF
--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -355,14 +355,22 @@ class PRChecker(object):
                         if f_judge.find('test_') != -1 or f_judge.find(
                                 '_test') != -1:
                             check_added_ut = True
-                        if file_dict[f] not in ['removed']:
+                        if file_dict[f] in ['added']:
+                            if f_judge.find('test_') != -1 or f_judge.find(
+                                    '_test') != -1:
+                                print(
+                                    "Adding new unit tests not hit mapFiles: %s"
+                                    % f_judge)
+                            else:
+                                notHitMapFiles.append(f_judge)
+                        elif file_dict[f] in ['removed']:
+                            print("remove file not hit mapFiles: %s" % f_judge)
+                        else:
                             if self.is_only_comment(f):
                                 ut_list.append('comment_placeholder')
                                 onlyCommentsFilesOrXpu.append(f_judge)
                             else:
                                 notHitMapFiles.append(f_judge)
-                        else:
-                            print("remove file not hit mapFiles: %s" % f_judge)
                     else:
                         notHitMapFiles.append(
                             f_judge) if file_dict[f] != 'removed' else print(


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
此PR修复精准测试存在的问题，即当所提PR新增一个单测文件时，不应该影响精准测试的触发。
解决方法：若新增文件的状态是added时，判断是否为单测文件，如果是，则过滤掉，不应影响精准测试的触发。
