### PR TITLE
fix distributed bug caused by fill_any_like (#45978)

### DIFF
--- a/python/paddle/distributed/auto_parallel/completion.py
+++ b/python/paddle/distributed/auto_parallel/completion.py
@@ -1037,7 +1037,7 @@ class Completer:
                     grad_op_dist_attr.set_output_dims_mapping(
                         output_name, ref_fwd_dims_mapping)
 
-                elif grad_op.type == 'fill_zeros_like':
+                elif grad_op.type == 'fill_any_like':
                     ref_var_name = grad_op.input_arg_names[0]
                     ref_var = vars[ref_var_name]
                     ref_dist_attr = self._dist_context.get_tensor_dist_attr_for_program(
@@ -1274,7 +1274,7 @@ class Completer:
                     grad_op_dist_attr.impl_type = "default"
                     grad_op_dist_attr.impl_idx = 0
 
-                elif grad_op.type == 'fill_zeros_like':
+                elif grad_op.type == 'fill_any_like':
                     ref_var_name = grad_op.input_arg_names[0]
                     ref_var = vars[ref_var_name]
                     ref_dist_attr = self._dist_context.get_tensor_dist_attr_for_program(

--- a/python/paddle/distributed/auto_parallel/operators/dist_default.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_default.py
@@ -348,7 +348,7 @@ class DistributedDefaultImpl0(DistributedOperatorImpl):
             else:
                 batch_dim_mappings.append(dims_mapping[1])
         for arg_name in op_desc.output_arg_names():
-            if op_desc.type() == "fill_zeros_like":
+            if op_desc.type() == 'fill_any_like':
                 input_tensor = dist_op.get_serial_input(
                     op_desc.input_arg_names()[0])
                 if input_tensor.is_parameter:
@@ -387,7 +387,7 @@ class DistributedDefaultImpl0(DistributedOperatorImpl):
                     dims_mapping[1] = compatible_dim_mapping
                     changed = True
         for arg_name in op_desc.output_arg_names():
-            if op_desc.type() == "fill_zeros_like":
+            if op_desc.type() == 'fill_any_like':
                 input_tensor = dist_op.get_serial_input(
                     op_desc.input_arg_names()[0])
                 if input_tensor.is_parameter:

--- a/python/paddle/distributed/auto_parallel/utils.py
+++ b/python/paddle/distributed/auto_parallel/utils.py
@@ -1040,7 +1040,7 @@ def set_grad_var_shape(program, dist_context):
 
             if op.type in [
                     "c_allreduce_sum", "c_identity", "scale", "cast",
-                    "fill_zeros_like"
+                    'fill_any_like'
             ]:
                 forward_var_name = op.input_arg_names[0]
             elif op.type == "matmul_v2_grad" or op.type == "matmul_grad" or op.type == "mul_grad":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
科学计算模块在调用分布式代码时会报错，主要是不认识fill_zeros_like这个op，报错如下
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/56987902/189840421-558a27c0-2b40-4e3b-8fe1-04cb95ee438b.png">
本次pr是对这个问题进行了修复，将原先对fill_zeros_like的判断全部替换成fill_any_like
修复后运行科学计算相应代码后正常，结果如下
<img width="1206" alt="image" src="https://user-images.githubusercontent.com/56987902/189894700-8da8fa58-4024-4a2c-b7d6-a4e3c0271519.png"> 

