### PR TITLE
Fix bug of reduce_sum op.

### DIFF
--- a/paddle/phi/kernels/kps/reduce_sum_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_sum_kernel.cu
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <climits>
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
+#include <climits>
+#include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/kernels/funcs/eigen/common.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
-#include "paddle/fluid/framework/eigen.h"
-#include "paddle/fluid/platform/enforce.h"
 
 namespace phi {
 
@@ -30,14 +30,13 @@ void ReduceSumEigen(const KPDevice& dev_ctx,
                     bool reduce_all,
                     const std::vector<int64_t>& dims,
                     DataType out_dtype,
-                    DenseTensor* out) {
+                    DenseTensor* out,
+                    std::vector<int>* reduce_dims) {
   // Resize Input Tensor
   auto new_x = x;
-  std::vector<int> reduce_dims =
-  phi::funcs::details::GetReduceDim(dims, x.dims().size(), reduce_all);
   int added_dims = EigenDimSize - x.dims().size();
   std::vector<int64_t> new_dim(added_dims, 1);
-  for (int i=0; i<x.dims().size(); i++) {
+  for (int i = 0; i < x.dims().size(); i++) {
     new_dim.push_back(x.dims().at(i));
   }
   new_x.Resize(phi::make_ddim(new_dim));
@@ -47,21 +46,22 @@ void ReduceSumEigen(const KPDevice& dev_ctx,
   dev_ctx.Alloc<T>(out);
   // Resize Out Tensor
   std::vector<int64_t> new_reduced_dim(added_dims, 1);
-  for (int i=0; i<out->dims().size(); i++) {
+  for (int i = 0; i < out->dims().size(); i++) {
     new_reduced_dim.push_back(out->dims().at(i));
   }
   out->Resize(phi::make_ddim(new_reduced_dim));
-  constexpr int kReduceOutRank = ReduceAll ? 1
-                                           : EigenDimSize - ReducedDimSize;
+  constexpr int kReduceOutRank = ReduceAll ? 1 : EigenDimSize - ReducedDimSize;
   auto eigen_out_tensor = EigenTensor<T, kReduceOutRank>::From(*out);
-  for (int i=0; i<ReducedDimSize; i++) {
-    reduce_dims[i] += added_dims;
+  for (int i = 0; i < ReducedDimSize; i++) {
+    (*reduce_dims)[i] += added_dims;
   }
-  auto eigen_reduce_dim = EigenDim<ReducedDimSize>::From(phi::make_ddim(reduce_dims));
+  auto eigen_reduce_dim =
+      EigenDim<ReducedDimSize>::From(phi::make_ddim(*reduce_dims));
   // Caculate
-  eigen_out_tensor.device(*dev_ctx.eigen_device()) = eigen_x_tensor.sum(eigen_reduce_dim);
+  eigen_out_tensor.device(*dev_ctx.eigen_device()) =
+      eigen_x_tensor.sum(eigen_reduce_dim);
   std::vector<int64_t> final_out_dim;
-  for (int i=added_dims; i<out->dims().size(); i++) {
+  for (int i = added_dims; i < out->dims().size(); i++) {
     final_out_dim.push_back(out->dims().at(i));
   }
   out->Resize(phi::make_ddim(final_out_dim));
@@ -79,23 +79,33 @@ void SumRawKernel(const Context& dev_ctx,
     out_dtype = out->dtype();
   }
   if (x.numel() > INT_MAX) {
-    #ifndef PADDLE_WITH_XPU_KP
-    std::vector<int> reduce_dims =
-        phi::funcs::details::GetReduceDim(dims.GetData(), x.dims().size(), reduce_all);
+#ifndef PADDLE_WITH_XPU_KP
+    std::vector<int> reduce_dims = phi::funcs::details::GetReduceDim(
+        dims.GetData(), x.dims().size(), reduce_all);
 
-    #define CALL_EIGEN_REDUCE_SUM_KERNEL(reduce_rank) \
-      case reduce_rank: { \
-        if (reduce_all) { \
-          ReduceSumEigen<T, 5, reduce_rank, true>(dev_ctx, x, reduce_all, \
-                                                  dims.GetData(), out_dtype, out); \
-        } else { \
-          ReduceSumEigen<T, 5, reduce_rank, false>(dev_ctx, x, reduce_all, \
-                                                   dims.GetData(), out_dtype, out); \
-        } \
-        break; \
-      }
-  
-    switch(reduce_dims.size()) {
+#define CALL_EIGEN_REDUCE_SUM_KERNEL(reduce_rank)              \
+  case reduce_rank: {                                          \
+    if (reduce_all) {                                          \
+      ReduceSumEigen<T, 5, reduce_rank, true>(dev_ctx,         \
+                                              x,               \
+                                              reduce_all,      \
+                                              dims.GetData(),  \
+                                              out_dtype,       \
+                                              out,             \
+                                              &reduce_dims);   \
+    } else {                                                   \
+      ReduceSumEigen<T, 5, reduce_rank, false>(dev_ctx,        \
+                                               x,              \
+                                               reduce_all,     \
+                                               dims.GetData(), \
+                                               out_dtype,      \
+                                               out,            \
+                                               &reduce_dims);  \
+    }                                                          \
+    break;                                                     \
+  }
+
+    switch (reduce_dims.size()) {
       CALL_EIGEN_REDUCE_SUM_KERNEL(1);
       CALL_EIGEN_REDUCE_SUM_KERNEL(2);
       CALL_EIGEN_REDUCE_SUM_KERNEL(3);
@@ -103,15 +113,16 @@ void SumRawKernel(const Context& dev_ctx,
       CALL_EIGEN_REDUCE_SUM_KERNEL(5);
       default:
         PADDLE_THROW(phi::errors::Fatal(
-          "If Input.numel() > INT32_MAX, reduce_sum kernel uses EigenTensor "
-          "sum for reduce_sum function. As a result, its dim should be <= 5."));
+            "If Input.numel() > INT32_MAX, reduce_sum kernel uses EigenTensor "
+            "sum for reduce_sum function. As a result, its dim should be <= "
+            "5."));
         break;
     }
-    #undef CALL_EIGEN_REDUCE_SUM_KERNEL
-    #endif
+#undef CALL_EIGEN_REDUCE_SUM_KERNEL
+#endif
   } else {
     phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor>(
-      dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
+        dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
   }
 }
 }  // namespace phi

--- a/paddle/phi/kernels/kps/reduce_sum_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_sum_kernel.cu
@@ -126,6 +126,11 @@ void SumRawKernel(const Context& dev_ctx,
         break;
     }
 #undef CALL_EIGEN_REDUCE_SUM_KERNEL
+#else
+    PADDLE_THROW(phi::errors::Fatal(
+        "If Input.numel() > INT32_MAX, reduce_sum kernel uses EigenTensor "
+        "sum for reduce_sum function. Such case is only supported on GPU "
+        "now."));
 #endif
   } else {
     phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor>(

--- a/paddle/phi/kernels/kps/reduce_sum_kernel.cu
+++ b/paddle/phi/kernels/kps/reduce_sum_kernel.cu
@@ -12,11 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <climits>
 #include "paddle/phi/kernels/reduce_sum_kernel.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/gpu/reduce.h"
+#include "paddle/fluid/framework/eigen.h"
+#include "paddle/fluid/platform/enforce.h"
 
 namespace phi {
+
+template <typename T,
+          int EigenDimSize = 5,
+          int ReducedDimSize = 1,
+          bool ReduceAll = false>
+void ReduceSumEigen(const KPDevice& dev_ctx,
+                    const DenseTensor& x,
+                    bool reduce_all,
+                    const std::vector<int64_t>& dims,
+                    DataType out_dtype,
+                    DenseTensor* out) {
+  // Resize Input Tensor
+  auto new_x = x;
+  std::vector<int> reduce_dims =
+  phi::funcs::details::GetReduceDim(dims, x.dims().size(), reduce_all);
+  int added_dims = EigenDimSize - x.dims().size();
+  std::vector<int64_t> new_dim(added_dims, 1);
+  for (int i=0; i<x.dims().size(); i++) {
+    new_dim.push_back(x.dims().at(i));
+  }
+  new_x.Resize(phi::make_ddim(new_dim));
+  auto eigen_x_tensor = EigenTensor<T, EigenDimSize>::From(x);
+
+  // Create Out Tensor
+  dev_ctx.Alloc<T>(out);
+  // Resize Out Tensor
+  std::vector<int64_t> new_reduced_dim(added_dims, 1);
+  for (int i=0; i<out->dims().size(); i++) {
+    new_reduced_dim.push_back(out->dims().at(i));
+  }
+  out->Resize(phi::make_ddim(new_reduced_dim));
+  constexpr int kReduceOutRank = ReduceAll ? 1
+                                           : EigenDimSize - ReducedDimSize;
+  auto eigen_out_tensor = EigenTensor<T, kReduceOutRank>::From(*out);
+  for (int i=0; i<ReducedDimSize; i++) {
+    reduce_dims[i] += added_dims;
+  }
+  auto eigen_reduce_dim = EigenDim<ReducedDimSize>::From(phi::make_ddim(reduce_dims));
+  // Caculate
+  eigen_out_tensor.device(*dev_ctx.eigen_device()) = eigen_x_tensor.sum(eigen_reduce_dim);
+  std::vector<int64_t> final_out_dim;
+  for (int i=added_dims; i<out->dims().size(); i++) {
+    final_out_dim.push_back(out->dims().at(i));
+  }
+  out->Resize(phi::make_ddim(final_out_dim));
+}
 
 template <typename T, typename Context>
 void SumRawKernel(const Context& dev_ctx,
@@ -29,10 +78,42 @@ void SumRawKernel(const Context& dev_ctx,
   if (out_dtype == DataType::UNDEFINED && out->dtype() != x.dtype()) {
     out_dtype = out->dtype();
   }
-  phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor>(
-      dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
-}
+  if (x.numel() > INT_MAX) {
+    #ifndef PADDLE_WITH_XPU_KP
+    std::vector<int> reduce_dims =
+        phi::funcs::details::GetReduceDim(dims.GetData(), x.dims().size(), reduce_all);
 
+    #define CALL_EIGEN_REDUCE_SUM_KERNEL(reduce_rank) \
+      case reduce_rank: { \
+        if (reduce_all) { \
+          ReduceSumEigen<T, 5, reduce_rank, true>(dev_ctx, x, reduce_all, \
+                                                  dims.GetData(), out_dtype, out); \
+        } else { \
+          ReduceSumEigen<T, 5, reduce_rank, false>(dev_ctx, x, reduce_all, \
+                                                   dims.GetData(), out_dtype, out); \
+        } \
+        break; \
+      }
+  
+    switch(reduce_dims.size()) {
+      CALL_EIGEN_REDUCE_SUM_KERNEL(1);
+      CALL_EIGEN_REDUCE_SUM_KERNEL(2);
+      CALL_EIGEN_REDUCE_SUM_KERNEL(3);
+      CALL_EIGEN_REDUCE_SUM_KERNEL(4);
+      CALL_EIGEN_REDUCE_SUM_KERNEL(5);
+      default:
+        PADDLE_THROW(phi::errors::Fatal(
+          "If Input.numel() > INT32_MAX, reduce_sum kernel uses EigenTensor "
+          "sum for reduce_sum function. As a result, its dim should be <= 5."));
+        break;
+    }
+    #undef CALL_EIGEN_REDUCE_SUM_KERNEL
+    #endif
+  } else {
+    phi::Reduce<T, kps::AddFunctor, kps::IdentityFunctor>(
+      dev_ctx, x, reduce_all, dims.GetData(), keep_dim, out_dtype, out);
+  }
+}
 }  // namespace phi
 
 #ifdef PADDLE_WITH_XPU_KP


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix bug of reduce_sum op. When `input.numel() > INT32_MAX`, its result is wrong. Use eigen tensor sum function to caculate in such case.