### PR TITLE
[BugFix] fixed a bug in decorator transformer, it can not analyze decorator with params correctly

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -47,8 +47,6 @@ from paddle.fluid.dygraph.dygraph_to_static.utils import get_attribute_full_name
 
 __all__ = ['DygraphToStaticAst']
 
-DECORATOR_NAMES = ['declarative', 'to_static', 'dygraph_to_static_func']
-
 
 def apply_optimization(transformers):
     """

--- a/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
@@ -93,10 +93,6 @@ class DecoratorTransformer(BaseTransformer):
                     # '_jst.Call(deco)(5)'
                     rematch = re.match(r'\_jst\.Call\((.+?)\)\((.*)\)',
                                        deco_full_name)
-                    if not rematch:
-                        raise Dygraph2StaticException(
-                            '@{}: transform decorator with param failed during dy2static'
-                            .format(deco_full_name))
                     re_name = rematch.group(1)
                     re_args = rematch.group(2)
                     re_args_with_func = deco_target + ', ' + re_args
@@ -105,10 +101,6 @@ class DecoratorTransformer(BaseTransformer):
                 else:
                     # paddle api will not be transformed to '_jst.Call'
                     rematch = re.match(r'(.+?)\((.*)\)', deco_full_name)
-                    if not rematch:
-                        raise Dygraph2StaticException(
-                            '@{}: transform decorator with param failed during dy2static'
-                            .format(deco_full_name))
                     re_name = rematch.group(1)
                     re_args = rematch.group(2)
                     re_args_with_func = deco_target + ', ' + re_args

--- a/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
@@ -18,7 +18,8 @@ from __future__ import print_function
 from paddle.utils import gast
 from paddle.fluid.dygraph.dygraph_to_static.static_analysis import AstNodeWrapper
 from paddle.fluid.dygraph.dygraph_to_static.base_transformer import BaseTransformer
-from paddle.fluid.dygraph.dygraph_to_static.utils import create_funcDef_node, ast_to_source_code
+from paddle.fluid.dygraph.dygraph_to_static.utils import create_funcDef_node, ast_to_source_code, is_paddle_api
+import warnings
 
 import re
 
@@ -77,24 +78,43 @@ class DecoratorTransformer(BaseTransformer):
                 deco_name = deco.id
             if deco_name in IGNORE_NAMES:
                 continue
+            elif deco_name == 'contextmanager':
+                warnings.warn(
+                    "Dy2Static : A context manager decorator is used, this may not work correctly after transform."
+                )
+
+            deco_full_name = ast_to_source_code(deco).strip()
+            decoed_func = '_decoedby_' + deco_name
 
             # get function after decoration
-            deco_full_name = ast_to_source_code(deco).strip()
-            decoed_func = '_decoby_' + deco_name
-            if isinstance(deco, gast.Call) and '_jst\.Call' in deco_full_name:
-                # in this case , the deco_full_name will be like:
-                # '_jst.Call(deco)(5)'
-                rematch = re.match(r'\_jst\.Call\((.+?)\)\((.*?)\)',
-                                   deco_full_name)
-                if not rematch:
-                    raise NotImplementedError(
-                        '{}: transform decorator with param failed during dy2static'
-                        .format(deco_full_name))
-                re_name = rematch.group(1)
-                re_args = rematch.group(2)
-                re_args_with_func = deco_target + ', ' + re_args
-                decofun_str = 'try:\n\t{0} = _jst.Call({1})({2})\nexcept:\n\t{0} = _jst.Call({1})({3})({4})'\
-                    .format(decoed_func, re_name, re_args_with_func, re_args, deco_target)
+            if isinstance(deco, gast.Call):
+                if '_jst.Call' in deco_full_name:
+                    # in this case , the deco_full_name will be like:
+                    # '_jst.Call(deco)(5)'
+                    rematch = re.match(r'\_jst\.Call\((.+?)\)\((.*)\)',
+                                       deco_full_name)
+                    if not rematch:
+                        raise NotImplementedError(
+                            '@{}: transform decorator with param failed during dy2static'
+                            .format(deco_full_name))
+                    re_name = rematch.group(1)
+                    re_args = rematch.group(2)
+                    re_args_with_func = deco_target + ', ' + re_args
+                    decofun_str = 'try:\n\t{0} = _jst.Call({1})({2})\nexcept:\n\t{0} = _jst.Call({1})({3})({4})'\
+                        .format(decoed_func, re_name, re_args_with_func, re_args, deco_target)
+                else:
+                    # paddle api will not be transformed to '_jst.Call'
+                    rematch = re.match(r'(.+?)\((.*)\)', deco_full_name)
+                    if not rematch:
+                        raise NotImplementedError(
+                            '@{}: transform decorator with param failed during dy2static'
+                            .format(deco_full_name))
+                    re_name = rematch.group(1)
+                    re_args = rematch.group(2)
+                    re_args_with_func = deco_target + ', ' + re_args
+                    decofun_str = 'try:\n\t{0} = {1}({2})\nexcept:\n\t{0} = {1}({3})({4})'\
+                        .format(decoed_func, re_name, re_args_with_func, re_args, deco_target)
+
             else:
                 decofun_str = '{} = _jst.Call({})({})'.format(
                     decoed_func, deco_full_name, deco_target)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
@@ -81,7 +81,7 @@ class DecoratorTransformer(BaseTransformer):
             # get function after decoration
             deco_full_name = ast_to_source_code(deco).strip()
             decoed_func = '_decoby_' + deco_name
-            if isinstance(deco, gast.Call):
+            if isinstance(deco, gast.Call) and '_jst\.Call' in deco_full_name:
                 # in this case , the deco_full_name will be like:
                 # '_jst.Call(deco)(5)'
                 rematch = re.match(r'\_jst\.Call\((.+?)\)\((.*?)\)',

--- a/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 from paddle.utils import gast
 from paddle.fluid.dygraph.dygraph_to_static.static_analysis import AstNodeWrapper
 from paddle.fluid.dygraph.dygraph_to_static.base_transformer import BaseTransformer
-from paddle.fluid.dygraph.dygraph_to_static.utils import create_funcDef_node, ast_to_source_code, is_paddle_api
+from paddle.fluid.dygraph.dygraph_to_static.utils import create_funcDef_node, ast_to_source_code, is_paddle_api, Dygraph2StaticException
 import warnings
 
 import re
@@ -94,7 +94,7 @@ class DecoratorTransformer(BaseTransformer):
                     rematch = re.match(r'\_jst\.Call\((.+?)\)\((.*)\)',
                                        deco_full_name)
                     if not rematch:
-                        raise NotImplementedError(
+                        raise Dygraph2StaticException(
                             '@{}: transform decorator with param failed during dy2static'
                             .format(deco_full_name))
                     re_name = rematch.group(1)
@@ -106,7 +106,7 @@ class DecoratorTransformer(BaseTransformer):
                     # paddle api will not be transformed to '_jst.Call'
                     rematch = re.match(r'(.+?)\((.*)\)', deco_full_name)
                     if not rematch:
-                        raise NotImplementedError(
+                        raise Dygraph2StaticException(
                             '@{}: transform decorator with param failed during dy2static'
                             .format(deco_full_name))
                     re_name = rematch.group(1)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
@@ -24,7 +24,7 @@ import re
 
 IGNORE_NAMES = [
     'declarative', 'to_static', 'dygraph_to_static_func', 'wraps',
-    'staticmethod', 'classmethod'
+    'staticmethod', 'classmethod', 'decorator'
 ]
 
 
@@ -84,7 +84,7 @@ class DecoratorTransformer(BaseTransformer):
             if isinstance(deco, gast.Call):
                 # in this case , the deco_full_name will be like:
                 # '_jst.Call(deco)(5)'
-                rematch = re.match(r'\_jst\.Call\((.+?)\)\((.+?)\)',
+                rematch = re.match(r'\_jst\.Call\((.+?)\)\((.*?)\)',
                                    deco_full_name)
                 re_name = rematch.group(1)
                 re_args = rematch.group(2)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/decorator_transformer.py
@@ -86,6 +86,10 @@ class DecoratorTransformer(BaseTransformer):
                 # '_jst.Call(deco)(5)'
                 rematch = re.match(r'\_jst\.Call\((.+?)\)\((.*?)\)',
                                    deco_full_name)
+                if not rematch:
+                    raise NotImplementedError(
+                        '{}: transform decorator with param failed during dy2static'
+                        .format(deco_full_name))
                 re_name = rematch.group(1)
                 re_args = rematch.group(2)
                 re_args_with_func = deco_target + ', ' + re_args

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_decorator_transform.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_decorator_transform.py
@@ -177,6 +177,17 @@ def warn1():
     fun9()
 
 
+@paddle.no_grad()
+def fun10():
+    print('in fun10, paddle api decorated')
+    return True
+
+
+@paddle.jit.to_static
+def deco_with_paddle_api():
+    return fun10()
+
+
 class TestDecoratorTransform(unittest.TestCase):
 
     def test_deco_transform(self):
@@ -203,6 +214,9 @@ class TestDecoratorTransform(unittest.TestCase):
                     flag = True
                     break
             self.assertTrue(flag)
+
+    def test_deco_with_paddle_api(self):
+        self.assertTrue(deco_with_paddle_api())
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_decorator_transform.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_decorator_transform.py
@@ -83,20 +83,8 @@ def deco4(func=None, x=0):
         return decorated
     return decorated(func)
 
-class deco5:
-    def __call__(self, func):
-
-        @decorator.decorator
-        def _decorate_function(func, *args, **kwargs):
-            with self:
-                return func(*args, **kwargs)
-
-        return _decorate_function(func)
-    def __enter__(self):
-        pass
-
-    def __exit__(self, *args):
-        pass
+def deco5():
+    return deco2
 
 
 @deco2
@@ -129,7 +117,7 @@ def fun4(x, y=0):
 
 
 @deco2
-@deco4(x=5)
+@deco4()
 def fun5(x, y=0):
     a = paddle.to_tensor(y)
     print('in fun5, x=%d' % (x))
@@ -144,8 +132,10 @@ def fun6(x, y=0):
     return a
 
 @deco5()
-def fun7():
-    return paddle.to_tensor(1)
+def fun7(x, y=0):
+    a = paddle.to_tensor(y)
+    print('in fun6, x=%d' % (x))
+    return a
 
 
 
@@ -166,9 +156,9 @@ class TestDecoratorTransform(unittest.TestCase):
         np.testing.assert_allclose(outs[1], np.array(5), rtol=1e-05)
         np.testing.assert_allclose(outs[2], np.array(6), rtol=1e-05)
         np.testing.assert_allclose(outs[3], np.array(8), rtol=1e-05)
-        np.testing.assert_allclose(outs[4], np.array(12), rtol=1e-05)
+        np.testing.assert_allclose(outs[4], np.array(7), rtol=1e-05)
         np.testing.assert_allclose(outs[5], np.array(9), rtol=1e-05)
-        np.testing.assert_allclose(outs[6], np.array(1), rtol=1e-05)
+        np.testing.assert_allclose(outs[6], np.array(9), rtol=1e-05)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_decorator_transform.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_decorator_transform.py
@@ -83,6 +83,21 @@ def deco4(func=None, x=0):
         return decorated
     return decorated(func)
 
+class deco5:
+    def __call__(self, func):
+
+        @decorator.decorator
+        def _decorate_function(func, *args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+
+        return _decorate_function(func)
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args):
+        pass
+
 
 @deco2
 def fun1(x, y=0):
@@ -128,10 +143,15 @@ def fun6(x, y=0):
     print('in fun6, x=%d' % (x))
     return a
 
+@deco5()
+def fun7():
+    return paddle.to_tensor(1)
+
+
 
 @paddle.jit.to_static
 def forward():
-    funcs = [fun1, fun2, fun3, fun4, fun5, fun6]
+    funcs = [fun1, fun2, fun3, fun4, fun5, fun6, fun7]
     out = []
     for idx, fun in enumerate(funcs):
         out.append(fun(idx + 1, idx + 1))
@@ -148,6 +168,7 @@ class TestDecoratorTransform(unittest.TestCase):
         np.testing.assert_allclose(outs[3], np.array(8), rtol=1e-05)
         np.testing.assert_allclose(outs[4], np.array(12), rtol=1e-05)
         np.testing.assert_allclose(outs[5], np.array(9), rtol=1e-05)
+        np.testing.assert_allclose(outs[6], np.array(1), rtol=1e-05)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fixed a bug in decorator transformer， it can not analyze decorator with params correctly
error happens when the param is empty 

