### PR TITLE
Modify callstacklevel flag for c++

### DIFF
--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -659,7 +659,11 @@ PADDLE_DEFINE_EXPORTED_bool(use_mkldnn, false, "Use MKLDNN to run");
  * If FLAGS_call_stack_level == 2, the python stack, c++ stack, and error
  * message summary will be shown.
  */
+#ifdef PADDLE_NO_PYTHON
+static const int32_t kDefaultCallStackLevel = 2;
+#else
 static const int32_t kDefaultCallStackLevel = 1;
+#endif
 
 PADDLE_DEFINE_EXPORTED_int32(
     call_stack_level,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
编 python 包时，callstacklevel 取值为1；编 c++ 包时，callstacklevel 取值为2