### PR TITLE
Fix bugs in "test_custom_plugin_creater" unit test

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/CMakeLists.txt
+++ b/paddle/fluid/inference/tensorrt/convert/CMakeLists.txt
@@ -103,13 +103,7 @@ nv_test(
 nv_test(
   test_custom_plugin_creater
   SRCS test_custom_plugin_creater.cc
-  DEPS paddle_framework
-       ${GLOB_OPERATOR_DEPS}
-       tensorrt_engine
-       tensorrt_plugin
-       tensorrt_converter
-       op_meta_info
-       custom_operator)
+  DEPS paddle_framework tensorrt_converter op_meta_info custom_operator)
 
 if(WITH_ONNXRUNTIME AND WIN32)
   # Copy onnxruntime for some c++ test in Windows, since the test will

--- a/paddle/fluid/inference/tensorrt/convert/test_custom_plugin_creater.cc
+++ b/paddle/fluid/inference/tensorrt/convert/test_custom_plugin_creater.cc
@@ -102,6 +102,8 @@ TEST(CustomPluginCreater, StaticShapePlugin) {
 
   framework::Scope scope;
 
+  tensorrt::plugin::TrtPluginRegistry::Global()->RegistToTrt();
+
   auto &custom_plugin_tell = OpTeller::Global().GetCustomPluginTeller();
 
   framework::OpDesc custom_op(*op_desc, nullptr);
@@ -185,6 +187,8 @@ TEST(CustomPluginCreater, DynamicShapePlugin) {
       "X", nvinfer1::DataType::kFLOAT, nvinfer1::Dims4(-1, 2, 5, 5));
 
   framework::Scope scope;
+
+  tensorrt::plugin::TrtPluginRegistry::Global()->RegistToTrt();
 
   auto &custom_plugin_tell = OpTeller::Global().GetCustomPluginTeller();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
修复 单元测试 `test_custom_plugin_create`的问题。 在 @JZZ-NOTE  [pr](https://github.com/PaddlePaddle/Paddle/pull/45824) 合入之后， 注册 plugin 的方式发生了改变，从注册静态变量变成了注册方法。因此在 `test_custom_plugin_create.cc`代码内部，需要调用
`tensorrt::plugin::TrtPluginRegistry::Global()->RegistToTrt();`
才能看到注册的 `plugin`