### PR TITLE
optimize device synchronization in profiler

### DIFF
--- a/paddle/fluid/platform/profiler/profiler.cc
+++ b/paddle/fluid/platform/profiler/profiler.cc
@@ -32,6 +32,9 @@
 #include "paddle/fluid/platform/profiler/mlu/mlu_tracer.h"
 #include "paddle/fluid/platform/profiler/trace_event_collector.h"
 #include "paddle/fluid/platform/profiler/utils.h"
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+#include "paddle/phi/backends/device_manager.h"
+#endif
 
 namespace paddle {
 namespace platform {
@@ -49,12 +52,9 @@ void SynchronizeDevice() {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   auto dev_types = phi::DeviceManager::GetAllCustomDeviceTypes();
   for (const auto& dev_type : dev_types) {
-    auto dev_cnt = phi::DeviceManager::GetDeviceCount(dev_type);
-    for (size_t i = 0; i < dev_cnt; i++) {
-      auto place = paddle::platform::CustomPlace(dev_type, i);
-      phi::DeviceManager::SetDevice(place);
-      phi::DeviceManager::SynchronizeDevice(place);
-    }
+    auto i = phi::DeviceManager::GetDevice(dev_type);
+    auto place = paddle::platform::CustomPlace(dev_type, i);
+    phi::DeviceManager::SynchronizeDevice(place);
   }
 #endif
 }

--- a/paddle/fluid/platform/profiler/profiler.h
+++ b/paddle/fluid/platform/profiler/profiler.h
@@ -37,6 +37,8 @@ static constexpr uint32_t kProfileGPUOptionBit = 1;
 static constexpr uint32_t kProfileMLUOptionBit = 2;
 static constexpr uint32_t kProfileCustomDeviceOptionBit = 3;
 
+void SynchronizeDevice();
+
 struct ProfilerOptions {
   uint32_t trace_switch = 0;  // bit 0: cpu, bit 1: gpu, bit 2: mlu
   uint32_t trace_level = FLAGS_host_trace_level;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Currently, when start or stop profiler, it will perform synchronization for all devices, which is unnecessary and sometimes causes out-of-memory problem. Actually, we only need to synchronize current device to gaurantee all profiler data collected.