### PR TITLE
[error msg] update error msg of user call numpy api and set_state_dict in dy2static

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -66,6 +66,7 @@ class TraceBackFrame(OriginInfo):
         self.location = location
         self.function_name = function_name
         self.source_code = source_code
+        self.error_line = ''
 
     def formated_message(self):
         # self.source_code may be empty in some functions.
@@ -85,6 +86,7 @@ class TraceBackFrameRange(OriginInfo):
         self.location = location
         self.function_name = function_name
         self.source_code = []
+        self.error_line = ''
         blank_count = []
         begin_lineno = max(1, self.location.lineno - int(SOURCE_CODE_RANGE / 2))
 
@@ -98,6 +100,7 @@ class TraceBackFrameRange(OriginInfo):
                 blank_count.append(len(line) - len(line_lstrip))
 
             if i == self.location.lineno:
+                self.error_line = self.source_code[-1]
                 hint_msg = '~' * len(self.source_code[-1]) + ' <--- HERE'
                 self.source_code.append(hint_msg)
                 blank_count.append(blank_count[-1])
@@ -170,6 +173,27 @@ class ErrorData(object):
         setattr(new_exception, ERROR_DATA, self)
         return new_exception
 
+    def numpy_api_check(self, format_exception, error_line):
+        if self.error_type is not TypeError:
+            return format_exception
+        tb = self.origin_traceback
+        is_numpy_api_err = False
+        np_api_name = ''
+        for frame in tb:
+            if 'site-packages/numpy/' in frame.filename:
+                if 'np.' + frame.name in error_line or 'numpy.' + frame.name in error_line:
+                    is_numpy_api_err = True
+                    np_api_name = frame.name
+                    break
+        if is_numpy_api_err:
+            return [
+                "TypeError: Variables created in dy2static process will be an unexpected keyword for numpy API",
+                "           Code '{}' called numpy API {}, please use Paddle API to replace it"
+                .format(error_line, np_api_name),
+            ]
+        else:
+            return format_exception
+
     def create_message(self):
         """
         Creates a custom error message which includes trace stack with source code information of dygraph from user.
@@ -213,6 +237,7 @@ class ErrorData(object):
                     dygraph_func_info.source_code)
 
             message_lines.append(traceback_frame.formated_message())
+            error_line = traceback_frame.error_line
         message_lines.append("")
 
         # Add paddle traceback after user code traceback
@@ -230,6 +255,9 @@ class ErrorData(object):
         # is gather than 1, for example, the error_type is IndentationError.
         format_exception = traceback.format_exception_only(
             self.error_type, self.error_value)
+
+        format_exception = self.numpy_api_check(format_exception, error_line)
+
         error_message = [
             " " * BLANK_COUNT_BEFORE_FILE_STR + line
             for line in format_exception

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -194,15 +194,13 @@ class ErrorData(object):
             is_numpy_api_err = module_result or (func_str.startswith("numpy.")
                                                  or func_str.startswith("np."))
         except Exception:
-            # np is imported, so if the name func_str is not defined
-            # it is not a numpy api
             is_numpy_api_err = False
 
         if is_numpy_api_err and func_str:
             return [
-                "TypeError: Variables created in dy2static process will be an unexpected keyword for numpy API",
-                "           Code '{}' called numpy API {}, please use Paddle API to replace it"
+                "TypeError: Code '{}' called numpy API {}, please use Paddle API to replace it."
                 .format(error_line, func_str),
+                "           values will be changed to variables by dy2static, numpy api can not handle variables"
             ]
         else:
             return format_exception

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -204,6 +204,7 @@ class ErrorData(object):
         header_message = "In transformed code:"
         message_lines.append(header_message)
         message_lines.append("")
+        error_line = None
 
         # Simplify error value to improve readability if error is raised in runtime
         if self.in_runtime:
@@ -255,8 +256,9 @@ class ErrorData(object):
         # is gather than 1, for example, the error_type is IndentationError.
         format_exception = traceback.format_exception_only(
             self.error_type, self.error_value)
-
-        format_exception = self.numpy_api_check(format_exception, error_line)
+        if error_line is not None:
+            format_exception = self.numpy_api_check(format_exception,
+                                                    error_line)
 
         error_message = [
             " " * BLANK_COUNT_BEFORE_FILE_STR + line

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -18,6 +18,7 @@ import sys
 import traceback
 import linecache
 import re
+import numpy as np
 
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import Location, OriginInfo, global_origin_info_map
 from paddle.fluid.dygraph.dygraph_to_static.utils import _is_api_in_module_helper, RE_PYMODULE
@@ -188,7 +189,6 @@ class ErrorData(object):
                 func_str = searched_name.group(0)
                 break
         try:
-            import numpy as np
             module_result = eval("_is_api_in_module_helper({}, '{}')".format(
                 func_str, "numpy"))
             is_numpy_api_err = module_result or (func_str.startswith("numpy.")

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -92,6 +92,9 @@ FOR_ITER_VAR_LEN_PREFIX = '__for_loop_var_len'
 FOR_ITER_VAR_NAME_PREFIX = '__for_loop_iter_var'
 FOR_ITER_ZIP_TO_LIST_PREFIX = '__for_loop_iter_zip'
 
+RE_PYNAME = '[a-zA-Z0-9_]+'
+RE_PYMODULE = '[a-zA-Z0-9_]+\.'
+
 # FullArgSpec is valid from Python3. Defined a Namedtuple to
 # to make it available in Python2.
 FullArgSpec = collections.namedtuple('FullArgSpec', [

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -320,8 +320,8 @@ def is_numpy_api(node):
             func_str, "numpy"))
         # BUG: np.random.uniform doesn't have module and cannot be analyzed
         # TODO: find a better way
-        if not module_result:
-            return func_str.startswith("numpy.") or func_str.startswith("np.")
+        return module_result or (func_str.startswith("numpy.")
+                                 or func_str.startswith("np."))
     except Exception:
         return False
 

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1538,13 +1538,18 @@ class Layer(object):
                     place = core.CUDAPlace(p.gpu_device_id())
                 t.set(ndarray, place)
 
-            executor = Executor(_get_device())._default_executor
-            # restore parameter states
-            core._create_loaded_parameter(
-                [param for param, state in matched_param_state], global_scope(),
-                executor)
-            for param, state in matched_param_state:
-                _set_var(param, state)
+            try:
+                executor = Executor(_get_device())._default_executor
+                # restore parameter states
+                core._create_loaded_parameter(
+                    [param for param, state in matched_param_state],
+                    global_scope(), executor)
+                for param, state in matched_param_state:
+                    _set_var(param, state)
+            except ValueError as e:
+                raise ValueError(
+                    "This error might happens in dy2static, while calling 'set_state_dict' dynamicly in 'forward', which is not supported. If you only need call 'set_state_dict' once, move it to '__init__'."
+                )
 
     def to(self, device=None, dtype=None, blocking=None):
         '''

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -470,5 +470,41 @@ class TestNumpyApiErr(unittest.TestCase):
         self.assertIn("TypeError: Variables created in dy2static process will be an unexpected keyword for numpy API", error_message)
 
 
+class test_set_state_dict_err_layer(paddle.nn.Layer):
+    def __init__(self):
+        super(test_set_state_dict_err_layer, self).__init__()
+        self.linear = paddle.nn.Linear(5, 2)
+
+    @paddle.jit.to_static
+    def forward(self, x):
+        old_dict = self.state_dict()
+        wgt = old_dict['linear.weight']
+        drop_w = paddle.nn.functional.dropout(wgt)
+        old_dict['linear.weight'] = drop_w
+        # old_dict['linear.weight'][0][0] = 0.01
+        self.set_state_dict(old_dict)
+
+        y = self.linear(x)
+
+        return y
+
+
+class TestSetStateDictErr(unittest.TestCase):
+    def test_numpy_api_err(self):
+        with self.assertRaises(ValueError) as e:
+            layer = test_set_state_dict_err_layer()
+            x = paddle.to_tensor([1.,2.,3.,4.,5.])
+            y = layer(x)
+
+        new_exception = e.exception
+
+        error_data = getattr(new_exception, error.ERROR_DATA, None)
+        self.assertIsInstance(error_data, error.ErrorData)
+
+        error_message = str(new_exception)
+
+        self.assertIn("This error might happens in dy2static, while calling 'set_state_dict' dynamicly in 'forward', which is not supported. If you only need call 'set_state_dict' once, move it to '__init__'.", error_message)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -457,14 +457,18 @@ def NpApiErr():
 
 class TestNumpyApiErr(unittest.TestCase):
     def test_numpy_api_err(self):
-        flag = False
-        try:
+        with self.assertRaises(TypeError) as e:
             NpApiErr()
-        except TypeError as e:
-            self.assertTrue("TypeError: Variables created in dy2static process will be an unexpected keyword for numpy API" in e.args[0])
-            flag = True
-        finally:
-            self.assertTrue(flag)
+
+        new_exception = e.exception
+
+        error_data = getattr(new_exception, error.ERROR_DATA, None)
+        self.assertIsInstance(error_data, error.ErrorData)
+
+        error_message = str(new_exception)
+
+        self.assertIn("TypeError: Variables created in dy2static process will be an unexpected keyword for numpy API", error_message)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -448,5 +448,23 @@ class TestKeyError(unittest.TestCase):
             x = paddle.to_tensor([1])
             func_ker_error(x)
 
+
+@paddle.jit.to_static
+def NpApiErr():
+    a = paddle.to_tensor([1,2])
+    b = np.sum(a.numpy())
+    print(b)
+
+class TestNumpyApiErr(unittest.TestCase):
+    def test_numpy_api_err(self):
+        flag = False
+        try:
+            NpApiErr()
+        except TypeError as e:
+            self.assertTrue("TypeError: Variables created in dy2static process will be an unexpected keyword for numpy API" in e.args[0])
+            flag = True
+        finally:
+            self.assertTrue(flag)
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -467,7 +467,7 @@ class TestNumpyApiErr(unittest.TestCase):
 
         error_message = str(new_exception)
 
-        self.assertIn("TypeError: Variables created in dy2static process will be an unexpected keyword for numpy API", error_message)
+        self.assertIn("values will be changed to variables by dy2static, numpy api can not handle variables", error_message)
 
 
 class test_set_state_dict_err_layer(paddle.nn.Layer):
@@ -490,7 +490,7 @@ class test_set_state_dict_err_layer(paddle.nn.Layer):
 
 
 class TestSetStateDictErr(unittest.TestCase):
-    def test_numpy_api_err(self):
+    def test_set_state_dict_err(self):
         with self.assertRaises(ValueError) as e:
             layer = test_set_state_dict_err_layer()
             x = paddle.to_tensor([1.,2.,3.,4.,5.])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
updated the error msg when user call numpy api and set_state_dict in dy2static, numpy api should be replaced with paddle api. Use set_state_dict in ‘forward’ is not supported