### PR TITLE
Set clip_extra in save_inference_model to true

### DIFF
--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -397,7 +397,7 @@ def _parse_save_configs(configs):
     inner_config.output_spec = configs.get('output_spec', None)
     inner_config.with_hook = configs.get('with_hook', False)
     inner_config.combine_params = configs.get("combine_params", False)
-    inner_config.clip_extra = configs.get("clip_extra", False)
+    inner_config.clip_extra = configs.get("clip_extra", True)
     inner_config.skip_forward = configs.get("skip_forward", False)
 
     return inner_config

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5873,9 +5873,7 @@ class Program(object):
 
         # Note: The op_role and op_role_var cann't be deleted currently,
         # and we will try to remove them in the future.
-        common_clipped_attrs_list = [
-            'op_namescope', 'op_callstack', 'op_device', 'with_quant_attr'
-        ]
+        common_clipped_attrs_list = ['op_callstack', 'with_quant_attr']
 
         for i in six.moves.range(res.desc.num_blocks()):
             block = res.desc.block(i)
@@ -5904,8 +5902,9 @@ class Program(object):
                         break
                     if not find:
                         remove_input_list.append(name)
-                for name in remove_input_list:
-                    op.remove_input(name)
+                # The extra input of op will be removed in the future
+                # for name in remove_input_list:
+                #     op.remove_input(name)
 
                 remove_output_list = []
                 for name in op.output_names():
@@ -5919,10 +5918,10 @@ class Program(object):
                         break
                     if not find:
                         remove_output_list.append(name)
-                for name in remove_output_list:
-                    op.remove_output(name)
+                # The extra output of op will be removed in the future
+                # for name in remove_output_list:
+                #     op.remove_output(name)
 
-                remove_attr_list = []
                 op_quant_name = core.op_proto_and_checker_maker.kOpWithQuantAttrName(
                 )
                 quant = bool(op.attr(op_quant_name)
@@ -5932,6 +5931,7 @@ class Program(object):
                     "activation_bits", "bit_length", "quantize_weight_bits",
                     "weight_quant_scale"
                 ]
+                remove_attr_list = []
                 for name in op.attr_names():
                     if quant:
                         if name in quant_attrs:
@@ -5946,8 +5946,6 @@ class Program(object):
                     for attr_proto in proto.attrs:
                         if attr_proto.name != name:
                             continue
-                        if attr_proto.extra:
-                            remove_attr_list.append(name)
                         find = True
                         break
                     if not find:

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1232,7 +1232,7 @@ def save_inference_model(dirname,
                          params_filename=None,
                          export_for_deployment=True,
                          program_only=False,
-                         clip_extra=False):
+                         clip_extra=True):
     """
     Prune the given `main_program` to build a new program especially for inference,
     and then save it and all related parameters to given `dirname` .


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
将`save_inference_model`和`paddle.jit.save`中的`clip_extra`参数默认值修改为`True`。

从本PR开始使用`save_inference_model`和`paddle.jit.save`接口保存模型Program时将默认开启Extra类型参数的裁剪:

1. 对`op_compat.yaml`中Op配置的Extra属性全部裁剪，`OpMaker`中Extra类型的`Input`和`Output`目前不会裁剪。

2. 对于所有Op的公共Extra属性：
  - `op_role`,`op_role_var`, `op_namescope`, `op_device`由于在分布式中有依赖，目前保存Program时将会保留
  - `op_callstack`保存Program时会被裁剪
  - `with_quant_attr`会根据属性值来决定是否进行裁剪。


相关PR：[PR46456](https://github.com/PaddlePaddle/Paddle/pull/46456), [PR46473](https://github.com/PaddlePaddle/Paddle/pull/46473)