### PR TITLE
[CodeStyle] fix remove-crlf hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: v1.1.14
     hooks:
     -   id: remove-crlf
-        files: (?!.*third_party)^.*$ | (?!.*book)^.*$
 -   repo: https://github.com/google/yapf
     rev: v0.32.0
     hooks:
@@ -21,7 +20,6 @@ repos:
     -   id: check-merge-conflict
     -   id: check-symlinks
     -   id: detect-private-key
-        files: (?!.*third_party)^.*$ | (?!.*book)^.*$
     -   id: end-of-file-fixer
     -   id: sort-simple-yaml
         files: (op|backward|op_[a-z_]+)\.yaml$


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

- Flake8 tracking issue: #46039
- Python 存量：#46155
- C++ 存量：#46156

修复 remove-crlf 和 detect-private-key 两个 hook 配置的 `files` 字段