### PR TITLE
fix uniform_rand fp16 Dtype support

### DIFF
--- a/paddle/phi/capi/include/c_scalar.h
+++ b/paddle/phi/capi/include/c_scalar.h
@@ -46,6 +46,8 @@ float PD_ScalarGetFloat32Data(PD_Scalar *scalar);
 
 double PD_ScalarGetFloat64Data(PD_Scalar *scalar);
 
+phi::dtype::float16 PD_ScalarGetFloat16Data(PD_Scalar *scalar);
+
 PD_DataType PD_ScalarGetDataType(PD_Scalar *scalar);
 
 #ifdef __cplusplus

--- a/paddle/phi/capi/include/wrapper_base.h
+++ b/paddle/phi/capi/include/wrapper_base.h
@@ -370,6 +370,11 @@ inline int64_t Scalar::to<int64_t>() const {
   return PD_ScalarGetInt64Data(raw_data());
 }
 
+template <>
+inline phi::dtype::float16 Scalar::to<phi::dtype::float16>() const {
+  return PD_ScalarGetFloat16Data(raw_data());
+}
+
 class IntArray : WrapperBase<PD_IntArray> {
  public:
   explicit IntArray(PD_IntArray* int_array)

--- a/paddle/phi/capi/lib/c_scalar.cc
+++ b/paddle/phi/capi/lib/c_scalar.cc
@@ -78,4 +78,9 @@ double PD_ScalarGetFloat64Data(PD_Scalar* scalar) {
   return cc_scalar->to<double>();
 }
 
+phi::dtype::float16 PD_ScalarGetFloat16Data(PD_Scalar* scalar) {
+  auto cc_scalar = reinterpret_cast<phi::Scalar*>(scalar);
+  return cc_scalar->to<phi::dtype::float16>();
+}
+
 PD_REGISTER_CAPI(scalar);

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -98,6 +98,7 @@ void FlipKernel(const Context& dev_ctx,
   const size_t total_dims = x.dims().size();
   switch (total_dims) {
     case 1:
+<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -123,6 +124,33 @@ void FlipKernel(const Context& dev_ctx,
       break;
     case 9:
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
+=======
+      launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
+      break;
+    case 2:
+      launch_flip_cuda_kernel<T, Context, 2>(dev_ctx, x, axis, out);
+      break;
+    case 3:
+      launch_flip_cuda_kernel<T, Context, 3>(dev_ctx, x, axis, out);
+      break;
+    case 4:
+      launch_flip_cuda_kernel<T, Context, 4>(dev_ctx, x, axis, out);
+      break;
+    case 5:
+      launch_flip_cuda_kernel<T, Context, 5>(dev_ctx, x, axis, out);
+      break;
+    case 6:
+      launch_flip_cuda_kernel<T, Context, 6>(dev_ctx, x, axis, out);
+      break;
+    case 7:
+      launch_flip_cuda_kernel<T, Context, 7>(dev_ctx, x, axis, out);
+      break;
+    case 8:
+      launch_flip_cuda_kernel<T, Context, 8>(dev_ctx, x, axis, out);
+      break;
+    case 9:
+      launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
+>>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -99,6 +99,7 @@ void FlipKernel(const Context& dev_ctx,
   switch (total_dims) {
     case 1:
 <<<<<<< HEAD
+<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -126,31 +127,38 @@ void FlipKernel(const Context& dev_ctx,
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
 =======
       launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
+=======
+      LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
+>>>>>>> fix function name
       break;
     case 2:
-      launch_flip_cuda_kernel<T, Context, 2>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 2>(dev_ctx, x, axis, out);
       break;
     case 3:
-      launch_flip_cuda_kernel<T, Context, 3>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 3>(dev_ctx, x, axis, out);
       break;
     case 4:
-      launch_flip_cuda_kernel<T, Context, 4>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 4>(dev_ctx, x, axis, out);
       break;
     case 5:
-      launch_flip_cuda_kernel<T, Context, 5>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 5>(dev_ctx, x, axis, out);
       break;
     case 6:
-      launch_flip_cuda_kernel<T, Context, 6>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 6>(dev_ctx, x, axis, out);
       break;
     case 7:
-      launch_flip_cuda_kernel<T, Context, 7>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 7>(dev_ctx, x, axis, out);
       break;
     case 8:
-      launch_flip_cuda_kernel<T, Context, 8>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 8>(dev_ctx, x, axis, out);
       break;
     case 9:
+<<<<<<< HEAD
       launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
 >>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
+=======
+      LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
+>>>>>>> fix function name
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -23,7 +23,7 @@
 namespace phi {
 
 template <typename T, size_t Rank>
-__global__ void flip_cuda_kernel(const int N,
+__global__ void flip_cuda_kernel(const int64_t N,
                                  const T* in_data,
                                  T* out_data,
                                  phi::Array<int64_t, Rank> shape,
@@ -53,17 +53,17 @@ __global__ void flip_cuda_kernel(const int N,
 }
 
 template <typename T, typename Context, size_t N>
-void launch_flip_cuda_kernel(const Context& dev_ctx,
-                             const DenseTensor& x,
-                             const std::vector<int>& axis,
-                             DenseTensor* out) {
+void LaunchFlipCudaKernel(const Context& dev_ctx,
+                          const DenseTensor& x,
+                          const std::vector<int>& axis,
+                          DenseTensor* out) {
   std::vector<int> flip_dims_v = axis;
   auto* in_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
 
   auto x_dims = x.dims();
   const int total_dims = x_dims.size();
-  const int numel = x.numel();
+  const int64_t numel = x.numel();
 
   int block_size = 512;
   dim3 dim_block(block_size);
@@ -98,31 +98,31 @@ void FlipKernel(const Context& dev_ctx,
   const size_t total_dims = x.dims().size();
   switch (total_dims) {
     case 1:
-      launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
-      launch_flip_cuda_kernel<T, Context, 2>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 2>(dev_ctx, x, axis, out);
       break;
     case 3:
-      launch_flip_cuda_kernel<T, Context, 3>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 3>(dev_ctx, x, axis, out);
       break;
     case 4:
-      launch_flip_cuda_kernel<T, Context, 4>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 4>(dev_ctx, x, axis, out);
       break;
     case 5:
-      launch_flip_cuda_kernel<T, Context, 5>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 5>(dev_ctx, x, axis, out);
       break;
     case 6:
-      launch_flip_cuda_kernel<T, Context, 6>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 6>(dev_ctx, x, axis, out);
       break;
     case 7:
-      launch_flip_cuda_kernel<T, Context, 7>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 7>(dev_ctx, x, axis, out);
       break;
     case 8:
-      launch_flip_cuda_kernel<T, Context, 8>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 8>(dev_ctx, x, axis, out);
       break;
     case 9:
-      launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/uniform_random_kernel.cu
+++ b/paddle/phi/kernels/gpu/uniform_random_kernel.cu
@@ -74,8 +74,15 @@ void UniformRandomRawKernel(const Context& dev_ctx,
     funcs::distribution_and_transform<T>(dev_ctx, out, dist, trans);
   } else {
     // Use OP seed
-    auto func = UniformGenerator<T>(
-        min.to<float>(), max.to<float>(), seed, diag_num, diag_step, diag_val);
+    // auto func = UniformGenerator<T>(
+    //     min.to<float>(), max.to<float>(), seed, diag_num, diag_step,
+    //     diag_val);
+    auto func = UniformGenerator<T>(min.to<T>(),
+                                    max.to<T>(),
+                                    seed,
+                                    diag_num,
+                                    diag_step,
+                                    static_cast<T>(diag_val));
     IndexKernel<T, UniformGenerator<T>>(dev_ctx, out, func);
   }
 }
@@ -87,4 +94,5 @@ PD_REGISTER_KERNEL(uniform_random_raw,
                    ALL_LAYOUT,
                    phi::UniformRandomRawKernel,
                    float,
-                   double) {}
+                   double,
+                   phi::dtype::float16) {}

--- a/paddle/phi/kernels/uniform_random_kernel.cc
+++ b/paddle/phi/kernels/uniform_random_kernel.cc
@@ -51,8 +51,13 @@ PD_REGISTER_KERNEL(uniform_random,
                    phi::dtype::bfloat16) {}
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-PD_REGISTER_KERNEL(
-    uniform_random, GPU, ALL_LAYOUT, phi::UniformRandomKernel, float, double) {}
+PD_REGISTER_KERNEL(uniform_random,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::UniformRandomKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}
 #endif
 
 #ifdef PADDLE_WITH_XPU


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix unifom_rand kernel and make paddle.rand support dype fp16