### PR TITLE
Fix python link order error on cc_test test_egr_performance_benchmark_eager_cpu

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -388,7 +388,8 @@ function(cc_library TARGET_NAME)
           target_link_libraries(${TARGET_NAME} "-Wl,-undefined,dynamic_lookup")
         endif()
       endif()
-      target_link_libraries(${TARGET_NAME} ${cc_library_DEPS})
+      target_link_libraries(${TARGET_NAME} ${cc_library_DEPS}
+                            ${PYTHON_LIBRARIES})
       common_link(${TARGET_NAME})
     endif()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Due to https://github.com/PaddlePaddle/Paddle/issues/46097
test_egr_performance_benchmark_eager_cpu 这个单元测试的库链接顺序有问题
它的依赖performance_benchmark_utils使用cc_library函数构建，
其中python的link顺序太靠前，导致libfinal_dygraph_function.a找不到python的ABI接口
这里改成在link的末端加入python的依赖。