### PR TITLE
[AMP]Use empty set for amp black/white list

### DIFF
--- a/python/paddle/fluid/dygraph/amp/auto_cast.py
+++ b/python/paddle/fluid/dygraph/amp/auto_cast.py
@@ -76,7 +76,7 @@ AMP_RELATED_FLAGS_SETTING = {
     'FLAGS_cudnn_batchnorm_spatial_persistent': 1,
 }
 
-PURE_FP16_WHITE_LIST = {''}
+PURE_FP16_WHITE_LIST = set()
 PURE_FP16_BLACK_LIST = {
     'lookup_table',
     'lookup_table_v2',
@@ -91,10 +91,10 @@ PURE_FP16_BLACK_LIST = {
 }
 
 BF16_WHITE_LIST = {'conv2d', 'matmul_v2'}
-BF16_BLACK_LIST = {''}
+BF16_BLACK_LIST = set()
 
-PURE_BF16_WHITE_LIST = {''}
-PURE_BF16_BLACK_LIST = {''}
+PURE_BF16_WHITE_LIST = set()
+PURE_BF16_BLACK_LIST = set()
 
 _g_amp_state_ = None
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
AMP的PURE_FP16_WHITE_LIST、BF16_BLACK_LIST、PURE_BF16_WHITE_LIST、PURE_BF16_BLACK_LIST四个名单默认为空，使用`set()`代替`{''}`