### PR TITLE
[ BugFix ] convert call: tranform the static func.

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -42,7 +42,7 @@ from paddle.fluid.dygraph.dygraph_to_static.utils import func_to_source_code
 from paddle.fluid.dygraph.dygraph_to_static.utils import input_specs_compatible
 from paddle.fluid.dygraph.dygraph_to_static.utils import type_name
 from paddle.fluid.dygraph.dygraph_to_static.utils import unwrap
-from paddle.fluid.dygraph.dygraph_to_static.utils import make_hashable
+from paddle.fluid.dygraph.dygraph_to_static.utils import make_hashable, ALREADY_D2S
 from paddle.fluid.dygraph.dygraph_to_static.function_spec import FunctionSpec, _hash_spec_names
 from paddle.fluid.dygraph.dygraph_to_static.function_spec import get_buffers, get_parameters
 from paddle.fluid.wrapped_decorator import signature_safe_contextmanager
@@ -136,8 +136,11 @@ def convert_to_static(function):
     Args:
         function(callable): The function with dygraph layers that will be converted into static layers.
     """
+    if getattr(function, ALREADY_D2S, None):
+        return function
     with _CACHE_LOCK:
         static_func = _FUNCTION_CACHE.convert_with_cache(function)
+        setattr(static_func, ALREADY_D2S, True)
         return static_func
 
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -44,6 +44,7 @@ DYGRAPH_MODULE_PREFIX = 'paddle.fluid.dygraph'
 DYGRAPH_TO_STATIC_MODULE_PREFIX = 'paddle.fluid.dygraph.dygraph_to_static'
 GET_ARGS_FUNC_PREFIX = 'get_args'
 SET_ARGS_FUNC_PREFIX = 'set_args'
+ALREADY_D2S = '__already_d2s'
 ARGS_NAME = '__args'
 # NOTE(liym27): Please use `getattr(ast_node, ORIGI_INFO)` instead of . operation to get the original information of ast node.
 ORIGI_INFO = "Original information of source code for ast node."


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix bug in convert call: tranform the static func.
解决了同一个Layer示例，多次forward的问题，之前会导致对StaticFunction进行动转静，会导致错误。
例如下面的代码：
```python
import paddle                                                                                                                                                                                                       

class SimpleNet(paddle.nn.Layer):                 
    def __init__(self):
        super(SimpleNet, self).__init__()

    def forward(self, x):
        a = [1]
        if True: 
            a.append(1)
        if True: 
            a.append(2)
        return a if True else 1 

snet = SimpleNet()
def vlist_of_dict(x):
    a = snet(paddle.ones([1,1]))
    a = snet(paddle.ones([2,2]))
    return a 

b = paddle.to_tensor([True, False, True])
x = paddle.to_tensor([3])
z = paddle.to_tensor([6])
y = paddle.rand((100, 2, 2))

#print(paddle.jit.to_static(vlist_of_dict).code)
print(paddle.jit.to_static(vlist_of_dict)(x))
```
第二次会对动转静之后的代码在进行动转静。添加了一个额外的字段，表示已经被转写过，如果转写过就直接return。

这里注意两个case：同一个Layer实例的多次forward，同一个Layer多个实例的多次forward