### PR TITLE
[NPU] add npu&xpu kernel for share_buffer op. 

### DIFF
--- a/paddle/fluid/operators/share_buffer_op.cc
+++ b/paddle/fluid/operators/share_buffer_op.cc
@@ -66,3 +66,11 @@ REGISTER_OPERATOR(share_buffer, ops::ShareBufferOp, ops::ShareBufferOpMaker);
 
 // dtype is not important
 REGISTER_OP_CPU_KERNEL(share_buffer, ops::ShareBufferOpKernel<float>);
+
+#ifdef PADDLE_WITH_ASCEND_CL
+REGISTER_OP_NPU_KERNEL(share_buffer, ops::ShareBufferOpKernel<float>);
+#endif
+
+#ifdef PADDLE_WITH_XPU
+REGISTER_OP_XPU_KERNEL(share_buffer, ops::ShareBufferOpKernel<float>);
+#endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 npu 单测 test_rmsprop_op_npu 执行时的segment falut.

目前npu不支持多流allocator.  因此，当在多个线程同时执行npu kenel的时候，由于kernel执行的异步性。 存在kernel内临时tensor的内存已经被回收并被其它kernel线程再次重新使用的情况。  这个时候，两个kernel线程同时往一块内存里面写东西，会导致segment falut.

之前不存在这种情况，是因为我们认为cpu kernel和npu kernel执行之间，一定会存在一个 memcpy_h2d算子。 因而，不会存在两个npu计算kernel同时执行的情况。

但由于share_buffer 算子的引入，由于不存在npu kernel, 回退到cpu后，会直接后跟npu计算kernel.

因此，在本pr中，注册了 share buffer的npu kernel和xpu kernel.  来解决该bug。
