### PR TITLE
Support both use_calc_stream and sync_op in allgather API

### DIFF
--- a/paddle/fluid/distributed/collective/ProcessGroup.h
+++ b/paddle/fluid/distributed/collective/ProcessGroup.h
@@ -193,7 +193,16 @@ class ProcessGroup {
       std::vector<phi::DenseTensor>&,    // NOLINT
       std::vector<phi::DenseTensor>&) {  // NOLINT
     PADDLE_THROW(platform::errors::InvalidArgument(
-        "ProcessGroup%s does not support AllGather", GetBackendName()));
+        "ProcessGroup%s does not support all_gather", GetBackendName()));
+  }
+
+  virtual std::shared_ptr<ProcessGroup::Task> AllGather(
+      std::vector<phi::DenseTensor>&,  // NOLINT
+      std::vector<phi::DenseTensor>&,  // NOLINT
+      bool) {
+    PADDLE_THROW(platform::errors::InvalidArgument(
+        "ProcessGroup%s does not support all_gather with sync_op flag",
+        GetBackendName()));
   }
 
   virtual std::shared_ptr<ProcessGroup::Task> AllGather_Partial(

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
@@ -1283,13 +1283,22 @@ ncclComm_t ProcessGroupNCCL::NCCLComm(const Place& place) const {
 
 phi::DeviceContext* ProcessGroupNCCL::GetDeviceContext(
     const Place& place) const {
-  std::vector<Place> places = {place};
-  const auto& iter = places_to_ctx_.find(GetKeyFromPlaces(places));
-  PADDLE_ENFORCE_NE(iter,
-                    places_to_ctx_.end(),
-                    platform::errors::InvalidArgument(
-                        "Cannot find device context in process group."));
-  return iter->second[0].get();
+  return GetDeviceContext(place, /*use_calc_stream*/ false);
+}
+
+phi::DeviceContext* ProcessGroupNCCL::GetDeviceContext(
+    const Place& place, bool use_calc_stream) const {
+  if (use_calc_stream) {
+    return platform::DeviceContextPool::Instance().Get(place);
+  } else {
+    std::vector<Place> places = {place};
+    const auto& iter = places_to_ctx_.find(GetKeyFromPlaces(places));
+    PADDLE_ENFORCE_NE(iter,
+                      places_to_ctx_.end(),
+                      platform::errors::InvalidArgument(
+                          "Cannot find device context in process group."));
+    return iter->second[0].get();
+  }
 }
 
 }  //  namespace distributed

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
@@ -263,6 +263,27 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
     CommType comm_type,
     bool sync_op,
     bool use_calc_stream) {
+  return Collective(
+      inputs,
+      outputs,
+      [&](const std::vector<Place>& places, const std::string& places_key) {},
+      fn,
+      [&](const std::vector<Place>& places, const std::string& places_key) {},
+      comm_type,
+      sync_op,
+      use_calc_stream);
+}
+
+template <typename PreFn, typename Fn, typename PostFn>
+std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
+    std::vector<phi::DenseTensor>& inputs,
+    std::vector<phi::DenseTensor>& outputs,
+    PreFn pre,
+    Fn fn,
+    PostFn post,
+    CommType comm_type,
+    bool sync_op,
+    bool use_calc_stream) {
   const auto& places = GetPlaceList(inputs);
   const auto& key = GetKeyFromPlaces(places);
 
@@ -283,6 +304,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
       CreateTask(places, rank_, comm_type, inputs, sync_op, use_calc_stream);
 
   platform::CUDADeviceGuard cuda_guard;
+
+  pre(places, key);
 
   {
     platform::NCCLGroupGuard nccl_guard;
@@ -320,6 +343,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Collective(
       memory::RecordStream(inputs[i].Holder(), nccl_stream);
     }
   }
+
+  post(places, key);
 
   // Adding stream event dependency only when use comm stream
   if (!use_calc_stream) {
@@ -423,6 +448,27 @@ template <typename Fn>
 std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::PointToPoint(
     std::vector<phi::DenseTensor>& tensors,
     Fn fn,
+    int dst_rank,
+    CommType op_type,
+    bool sync_op,
+    bool use_calc_stream) {
+  return PointToPoint(
+      tensors,
+      [&](const std::vector<Place>& places, const std::string& places_key) {},
+      fn,
+      [&](const std::vector<Place>& places, const std::string& places_key) {},
+      dst_rank,
+      op_type,
+      sync_op,
+      use_calc_stream);
+}
+
+template <typename PreFn, typename Fn, typename PostFn>
+std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::PointToPoint(
+    std::vector<phi::DenseTensor>& tensors,
+    PreFn pre,
+    Fn fn,
+    PostFn post,
     int dst_rank,
     CommType op_type,
     bool sync_op,
@@ -934,6 +980,70 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllGather(
             stream);
       },
       CommType::ALLGATHER);
+}
+
+phi::DenseTensor EmptyLikeFlatten(
+    const std::vector<phi::DenseTensor>& tensors_list) {
+  platform::CUDADeviceGuard cuda_guard;
+  const auto& place = tensors_list[0].place();
+  cuda_guard.SetDevice(place);
+
+  auto dtype = tensors_list[0].dtype();
+  auto dims = phi::vectorize(tensors_list[0].dims());
+  dims[0] *= tensors_list.size();
+  phi::DenseTensorMeta meta(dtype, phi::make_ddim(dims));
+  auto allocator = std::unique_ptr<phi::Allocator>(
+      new experimental::DefaultAllocator(place));
+
+  return phi::DenseTensor(allocator.get(), meta);
+}
+
+std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllGather(
+    std::vector<phi::DenseTensor>& in_tensors,
+    std::vector<phi::DenseTensor>& out_tensors,
+    bool sync_op,
+    bool use_calc_stream) {
+  std::vector<phi::DenseTensor> flattened_out = {EmptyLikeFlatten(out_tensors)};
+
+  return Collective(
+      in_tensors,
+      flattened_out,
+      [&](const std::vector<Place>& places, const std::string& places_key) {},
+      [&](const phi::DenseTensor& input,
+          phi::DenseTensor& output,
+          ncclComm_t comm,
+          const gpuStream_t& stream) {
+        return platform::dynload::ncclAllGather(
+            input.data(),
+            output.data(),
+            input.numel(),
+            platform::ToNCCLDataType(input.dtype()),
+            comm,
+            stream);
+      },
+      [&](const std::vector<Place>& places, const std::string& places_key) {
+        platform::CUDADeviceGuard cuda_guard;
+        for (size_t i = 0; i < flattened_out.size(); ++i) {
+          cuda_guard.SetDevice(places[i]);
+
+          if (!use_calc_stream) {
+            SyncDefaultStream(places,
+                              places_to_events_[places_key],
+                              places_to_ctx_[places_key]);
+          }
+
+          std::vector<phi::DenseTensor> res;
+          auto dims = flattened_out[i].dims();
+          for (size_t j = 0; j < size_t(dims[0]); ++j) {
+            framework::TensorCopy(flattened_out[i].Slice(j, j + 1),
+                                  out_tensors[j].place(),
+                                  &out_tensors[j]);
+          }
+        }
+      },
+      CommType::ALLGATHER,
+      sync_op,
+      use_calc_stream);
 }
 
 void* GetPointerByOffset(void* raw_pointer,

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
@@ -167,6 +167,12 @@ class ProcessGroupNCCL : public ProcessGroupStream {
       std::vector<phi::DenseTensor>& in_tensors,
       std::vector<phi::DenseTensor>& out_tensors) override;
 
+  std::shared_ptr<ProcessGroup::Task> AllGather(
+      std::vector<phi::DenseTensor>& in_tensors,
+      std::vector<phi::DenseTensor>& out_tensors,
+      bool sync_op,
+      bool use_calc_stream) override;
+
   std::shared_ptr<ProcessGroup::Task> AllGather_Partial(
       std::vector<phi::DenseTensor>& in_tensors,
       std::vector<phi::DenseTensor>& out_tensors,
@@ -256,6 +262,17 @@ class ProcessGroupNCCL : public ProcessGroupStream {
       bool sync_op,
       bool use_calc_stream);
 
+  template <typename PreFn, typename Fn, typename PostFn>
+  std::shared_ptr<ProcessGroupStream::Task> Collective(
+      std::vector<phi::DenseTensor>& inputs,   // NOLINT
+      std::vector<phi::DenseTensor>& outputs,  // NOLINT
+      PreFn pre,
+      Fn fn,
+      PostFn post,
+      CommType comm_type,
+      bool sync_op,
+      bool use_calc_stream);
+
   template <typename Fn>
   void Collective(const phi::DenseTensor*,
                   phi::DenseTensor*,
@@ -273,6 +290,17 @@ class ProcessGroupNCCL : public ProcessGroupStream {
   std::shared_ptr<ProcessGroup::Task> PointToPoint(
       std::vector<phi::DenseTensor>& tensors,  // NOLINT
       Fn fn,
+      int dst_rank,
+      CommType op_type,
+      bool sync_op,
+      bool use_calc_stream);
+
+  template <typename PreFn, typename Fn, typename PostFn>
+  std::shared_ptr<ProcessGroup::Task> PointToPoint(
+      std::vector<phi::DenseTensor>& tensors,  // NOLINT
+      PreFn pre,
+      Fn fn,
+      PostFn post,
       int dst_rank,
       CommType op_type,
       bool sync_op,

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
@@ -98,6 +98,9 @@ class ProcessGroupNCCL : public ProcessGroupStream {
 
   phi::DeviceContext* GetDeviceContext(const Place& place) const override;
 
+  phi::DeviceContext* GetDeviceContext(const Place& place,
+                                       bool use_calc_stream) const override;
+
   std::shared_ptr<ProcessGroup::Task> AllReduce(
       std::vector<phi::DenseTensor>& in_tensors,   // NOLINT
       std::vector<phi::DenseTensor>& out_tensors,  // NOLINT

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
@@ -262,17 +262,6 @@ class ProcessGroupNCCL : public ProcessGroupStream {
       bool sync_op,
       bool use_calc_stream);
 
-  template <typename PreFn, typename Fn, typename PostFn>
-  std::shared_ptr<ProcessGroupStream::Task> Collective(
-      std::vector<phi::DenseTensor>& inputs,   // NOLINT
-      std::vector<phi::DenseTensor>& outputs,  // NOLINT
-      PreFn pre,
-      Fn fn,
-      PostFn post,
-      CommType comm_type,
-      bool sync_op,
-      bool use_calc_stream);
-
   template <typename Fn>
   void Collective(const phi::DenseTensor*,
                   phi::DenseTensor*,
@@ -290,17 +279,6 @@ class ProcessGroupNCCL : public ProcessGroupStream {
   std::shared_ptr<ProcessGroup::Task> PointToPoint(
       std::vector<phi::DenseTensor>& tensors,  // NOLINT
       Fn fn,
-      int dst_rank,
-      CommType op_type,
-      bool sync_op,
-      bool use_calc_stream);
-
-  template <typename PreFn, typename Fn, typename PostFn>
-  std::shared_ptr<ProcessGroup::Task> PointToPoint(
-      std::vector<phi::DenseTensor>& tensors,  // NOLINT
-      PreFn pre,
-      Fn fn,
-      PostFn post,
       int dst_rank,
       CommType op_type,
       bool sync_op,

--- a/paddle/fluid/distributed/collective/ProcessGroupStream.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupStream.cc
@@ -23,6 +23,12 @@ ProcessGroupStream::ProcessGroupStream(int rank,
                                        int gid)
     : ProcessGroup(rank, size, place, gid) {}
 
+phi::DeviceContext* ProcessGroupStream::GetDeviceContext(
+    const Place& place, bool use_calc_stream) const {
+  PADDLE_THROW(platform::errors::InvalidArgument(
+      "ProcessGroup%s does not support get device_context.", GetBackendName()));
+}
+
 std::shared_ptr<ProcessGroup::Task> ProcessGroupStream::AllGather(
     std::vector<phi::DenseTensor>& input_tensors,   // NOLINT
     std::vector<phi::DenseTensor>& output_tensors,  // NOLINT

--- a/paddle/fluid/distributed/collective/ProcessGroupStream.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupStream.cc
@@ -23,6 +23,25 @@ ProcessGroupStream::ProcessGroupStream(int rank,
                                        int gid)
     : ProcessGroup(rank, size, place, gid) {}
 
+std::shared_ptr<ProcessGroup::Task> ProcessGroupStream::AllGather(
+    std::vector<phi::DenseTensor>& input_tensors,   // NOLINT
+    std::vector<phi::DenseTensor>& output_tensors,  // NOLINT
+    bool sync_op) {
+  return AllGather(input_tensors,
+                   output_tensors,
+                   sync_op,
+                   /*use_calc_stream*/ false);
+}
+
+std::shared_ptr<ProcessGroup::Task> ProcessGroupStream::AllGather(
+    std::vector<phi::DenseTensor>& input_tensors,   // NOLINT
+    std::vector<phi::DenseTensor>& output_tensors,  // NOLINT
+    bool sync_op,
+    bool use_calc_stream) {
+  PADDLE_THROW(platform::errors::InvalidArgument(
+      "ProcessGroup%s does not support do all_gather", GetBackendName()));
+}
+
 std::shared_ptr<ProcessGroup::Task> ProcessGroupStream::AllReduce(
     std::vector<phi::DenseTensor>& input_tensors,   // NOLINT
     std::vector<phi::DenseTensor>& output_tensors,  // NOLINT
@@ -42,7 +61,7 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupStream::AllReduce(
     bool sync_op,
     bool use_calc_stream) {
   PADDLE_THROW(platform::errors::InvalidArgument(
-      "ProcessGroup%s does not support do allreduce", GetBackendName()));
+      "ProcessGroup%s does not support do all_reduce", GetBackendName()));
 }
 
 std::shared_ptr<ProcessGroup::Task> ProcessGroupStream::Send(

--- a/paddle/fluid/distributed/collective/ProcessGroupStream.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupStream.h
@@ -54,6 +54,17 @@ class ProcessGroupStream : public ProcessGroup {
   ProcessGroupStream(int rank, int size, const platform::Place& place, int gid);
   virtual ~ProcessGroupStream() = default;
 
+  std::shared_ptr<ProcessGroup::Task> AllGather(
+      std::vector<phi::DenseTensor>& in_tensors,   // NOLINT
+      std::vector<phi::DenseTensor>& out_tensors,  // NOLINT
+      bool sync_op) override;
+
+  virtual std::shared_ptr<ProcessGroup::Task> AllGather(
+      std::vector<phi::DenseTensor>& in_tensors,   // NOLINT
+      std::vector<phi::DenseTensor>& out_tensors,  // NOLINT
+      bool sync_op,
+      bool use_calc_stream);
+
   std::shared_ptr<ProcessGroup::Task> AllReduce(
       std::vector<phi::DenseTensor>& input_tensors,   // NOLINT
       std::vector<phi::DenseTensor>& output_tensors,  // NOLINT

--- a/paddle/fluid/distributed/collective/ProcessGroupStream.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupStream.h
@@ -54,6 +54,9 @@ class ProcessGroupStream : public ProcessGroup {
   ProcessGroupStream(int rank, int size, const platform::Place& place, int gid);
   virtual ~ProcessGroupStream() = default;
 
+  virtual phi::DeviceContext* GetDeviceContext(const Place& place,
+                                               bool use_calc_stream) const;
+
   std::shared_ptr<ProcessGroup::Task> AllGather(
       std::vector<phi::DenseTensor>& in_tensors,   // NOLINT
       std::vector<phi::DenseTensor>& out_tensors,  // NOLINT

--- a/paddle/fluid/distributed/collective/SplitOp.h
+++ b/paddle/fluid/distributed/collective/SplitOp.h
@@ -24,7 +24,7 @@ namespace distributed {
 template <typename DeviceContext, typename T>
 struct SplitDenseTensor {
   void operator()(const DeviceContext *context,
-                  const phi::DenseTensor *in,
+                  const phi::DenseTensor &in,
                   std::vector<phi::DenseTensor *> *out,
                   int axis = 0) {
     std::vector<const phi::DenseTensor *> shape_refer;
@@ -33,13 +33,13 @@ struct SplitDenseTensor {
       shape_refer.emplace_back(p_tensor);
     }
     phi::funcs::SplitFunctor<DeviceContext, T> split_functor_;
-    split_functor_(*context, *in, shape_refer, axis, out);
+    split_functor_(*context, in, shape_refer, axis, out);
   }
 };
 
 template <typename DeviceContext>
 void SplitDenseTensorWithType(const DeviceContext *dev_ctx,
-                              const phi::DenseTensor *p_dense,
+                              const phi::DenseTensor &p_dense,
                               std::vector<phi::DenseTensor *> *p_list,
                               phi::DataType type) {
   switch (type) {
@@ -89,14 +89,14 @@ void SplitTensor(const phi::DeviceContext *dev_ctx,
   const auto &place = dev_ctx->GetPlace();
   if (platform::is_gpu_place(place)) {
     SplitDenseTensorWithType(static_cast<const phi::GPUContext *>(dev_ctx),
-                             &tensor,
+                             tensor,
                              &dense_list,
                              tensor.dtype());
   } else if (platform::is_custom_place(place)) {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
     SplitDenseTensorWithType(
         static_cast<const platform::CustomDeviceContext *>(dev_ctx),
-        &tensor,
+        tensor,
         &dense_list,
         tensor.dtype());
 #else
@@ -106,7 +106,7 @@ void SplitTensor(const phi::DeviceContext *dev_ctx,
 #endif
   } else if (platform::is_cpu_place(place)) {
     SplitDenseTensorWithType(static_cast<const phi::CPUContext *>(dev_ctx),
-                             &tensor,
+                             tensor,
                              &dense_list,
                              tensor.dtype());
   } else {

--- a/paddle/fluid/distributed/collective/SplitOp.h
+++ b/paddle/fluid/distributed/collective/SplitOp.h
@@ -1,0 +1,120 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/api/include/tensor.h"
+#include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
+
+namespace paddle {
+namespace distributed {
+
+template <typename DeviceContext, typename T>
+struct SplitDense2Dense {
+  void operator()(const DeviceContext *context,
+                  phi::DenseTensor *in,
+                  std::vector<phi::DenseTensor *> *out,
+                  int axis = 0) {
+    std::vector<const phi::DenseTensor *> shape_refer;
+    shape_refer.reserve(out->size());
+    for (auto &p_tensor : *out) {
+      shape_refer.emplace_back(p_tensor);
+    }
+    phi::funcs::SplitFunctor<DeviceContext, T> split_functor_;
+    split_functor_(*context, *in, shape_refer, axis, out);
+  }
+};
+
+template <typename DeviceContext>
+void SplitDense2DenseWithType(const DeviceContext *dev_ctx,
+                              phi::DenseTensor *p_dense,
+                              std::vector<phi::DenseTensor *> *p_list,
+                              phi::DataType type) {
+  switch (type) {
+    case phi::DataType::BOOL:
+      SplitDense2Dense<DeviceContext, bool>()(dev_ctx, p_dense, p_list);
+      break;
+    case phi::DataType::UINT8:
+      SplitDense2Dense<DeviceContext, uint8_t>()(dev_ctx, p_dense, p_list);
+      break;
+    case phi::DataType::INT8:
+      SplitDense2Dense<DeviceContext, int8_t>()(dev_ctx, p_dense, p_list);
+      break;
+    case phi::DataType::INT32:
+      SplitDense2Dense<DeviceContext, int32_t>()(dev_ctx, p_dense, p_list);
+      break;
+    case phi::DataType::INT64:
+      SplitDense2Dense<DeviceContext, int64_t>()(dev_ctx, p_dense, p_list);
+      break;
+    case phi::DataType::FLOAT16:
+      SplitDense2Dense<DeviceContext, platform::float16>()(
+          dev_ctx, p_dense, p_list);
+      break;
+    case phi::DataType::FLOAT32:
+      SplitDense2Dense<DeviceContext, float>()(dev_ctx, p_dense, p_list);
+      break;
+    case phi::DataType::FLOAT64:
+      SplitDense2Dense<DeviceContext, double>()(dev_ctx, p_dense, p_list);
+      break;
+    default:
+      PADDLE_THROW(platform::errors::Unimplemented(
+          "Data type (%s) is not supported when it splits tensors for "
+          "allgather.",
+          type));
+  }
+}
+
+void SplitDense2Tensor(
+    phi::DenseTensor &tensor,                        // NOLINT
+    std::vector<experimental::Tensor> &tensor_list,  // NOLINT
+    const phi::DeviceContext *dev_ctx) {
+  std::vector<phi::DenseTensor *> dense_list;
+  for (auto &tensor : tensor_list) {
+    auto p_tensor =
+        std::dynamic_pointer_cast<phi::DenseTensor>(tensor.impl()).get();
+    dense_list.emplace_back(p_tensor);
+  }
+
+  const auto &place = dev_ctx->GetPlace();
+  if (platform::is_gpu_place(place)) {
+    SplitDense2DenseWithType(static_cast<const phi::GPUContext *>(dev_ctx),
+                             &tensor,
+                             &dense_list,
+                             tensor.dtype());
+  } else if (platform::is_custom_place(place)) {
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+    SplitDense2DenseWithType(
+        static_cast<const platform::CustomDeviceContext *>(dev_ctx),
+        &tensor,
+        &dense_list,
+        tensor.dtype());
+#else
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "Paddle can't split tensor since it's not compiled with CUSTOM_DEVICE,"
+        "Please recompile or reinstall Paddle with CUSTOM_DEVICE support."));
+#endif
+  } else if (platform::is_cpu_place(place)) {
+    SplitDense2DenseWithType(static_cast<const phi::CPUContext *>(dev_ctx),
+                             &tensor,
+                             &dense_list,
+                             tensor.dtype());
+  } else {
+    PADDLE_THROW(platform::errors::Unimplemented(
+        "Split tensor not supported on place (%s)", place));
+  }
+}
+
+}  //  namespace distributed
+}  //  namespace paddle

--- a/paddle/fluid/distributed/collective/Utils.h
+++ b/paddle/fluid/distributed/collective/Utils.h
@@ -108,7 +108,7 @@ void SplitTensor(const phi::DeviceContext *dev_ctx,
 
   const auto &place = dev_ctx->GetPlace();
   if (platform::is_gpu_place(place)) {
-#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+#ifdef PADDLE_WITH_GPU
     SplitDenseTensorWithType(static_cast<const phi::GPUContext *>(dev_ctx),
                              tensor,
                              &dense_list,

--- a/paddle/fluid/distributed/collective/Utils.h
+++ b/paddle/fluid/distributed/collective/Utils.h
@@ -108,7 +108,7 @@ void SplitTensor(const phi::DeviceContext *dev_ctx,
 
   const auto &place = dev_ctx->GetPlace();
   if (platform::is_gpu_place(place)) {
-#ifdef PADDLE_WITH_GPU
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
     SplitDenseTensorWithType(static_cast<const phi::GPUContext *>(dev_ctx),
                              tensor,
                              &dense_list,

--- a/paddle/fluid/pybind/distributed_py.cc
+++ b/paddle/fluid/pybind/distributed_py.cc
@@ -23,8 +23,8 @@ limitations under the License. */
 
 #include "paddle/fluid/distributed/collective/ProcessGroup.h"
 #include "paddle/fluid/distributed/collective/ProcessGroupStream.h"
-#include "paddle/fluid/distributed/collective/SplitOp.h"
 #include "paddle/fluid/distributed/collective/Types.h"
+#include "paddle/fluid/distributed/collective/Utils.h"
 #include "paddle/fluid/distributed/collective/reducer.h"
 #include "paddle/fluid/framework/lod_tensor.h"
 #include "paddle/fluid/framework/tensor.h"

--- a/python/paddle/distributed/communication/stream/__init__.py
+++ b/python/paddle/distributed/communication/stream/__init__.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .all_gather import all_gather
 from .all_reduce import all_reduce
 from .send import send
 from .recv import recv
 
-__all__ = ["all_reduce", "send", "recv"]
+__all__ = ["all_gather", "all_reduce", "send", "recv"]

--- a/python/paddle/distributed/communication/stream/all_gather.py
+++ b/python/paddle/distributed/communication/stream/all_gather.py
@@ -22,7 +22,7 @@ def _all_gather_in_dygraph(tensor_list, tensor, group, sync_op,
     group = collective._get_default_group() if group is None else group
 
     if len(tensor_list) == 0:
-        tensor_list = [paddle.empty_like(tensor) for _ in range(group.nranks)]
+        tensor_list += [paddle.empty_like(tensor) for _ in range(group.nranks)]
 
     if use_calc_stream:
         return group.process_group.allgather_on_calc_stream(tensor, tensor_list)

--- a/python/paddle/distributed/communication/stream/all_gather.py
+++ b/python/paddle/distributed/communication/stream/all_gather.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import paddle
-import paddle.distributed.collective as collective
 import paddle.fluid.framework as framework
+from paddle.distributed import collective
 
 
 def _check_tensor_shape(tensor, shape, nranks=1):
@@ -70,7 +70,6 @@ def _all_gather_in_dygraph(tensor_list, tensor, group, sync_op,
     return task
 
 
-# TODO: 文档需要更新
 def all_gather(tensor_or_tensor_list,
                tensor,
                group=None,
@@ -81,7 +80,7 @@ def all_gather(tensor_or_tensor_list,
     Gather tensors across devices to a correctly-sized tensor or a tensor list.
 
     Args:
-        tensor_or_tensor_list (Union[Tensor, List[Tensor]]): The gather output. If it is a tensor, it should be correctly-sized. If it is a list, it
+        tensor_or_tensor_list (Union[Tensor, List[Tensor]]): The output. If it is a tensor, it should be correctly-sized. If it is a list, it
             should be empty or contain correctly-sized tensors.
         tensor (Tensor): The input tensor on each rank. The result will overwrite this tenor after communication. Support
             float16, float32, float64, int32 or int64 as the input data type.

--- a/python/paddle/distributed/communication/stream/all_gather.py
+++ b/python/paddle/distributed/communication/stream/all_gather.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddle.distributed.collective as collective
+import paddle.fluid.framework as framework
+
+
+def _all_gather_in_dygraph(tensor_list, tensor, group, sync_op,
+                           use_calc_stream):
+    group = collective._get_default_group() if group is None else group
+
+    if len(tensor_list) == 0:
+        tensor_list = [paddle.empty_like(tensor) for _ in range(group.nranks)]
+
+    if use_calc_stream:
+        return group.process_group.allgather_on_calc_stream(tensor, tensor_list)
+
+    task = group.process_group.allgather(tensor, tensor_list, sync_op)
+    if sync_op:
+        task.wait()
+
+    return task
+
+
+def all_gather(tensor_list,
+               tensor,
+               group=None,
+               sync_op=True,
+               use_calc_stream=False):
+    """
+
+    Perform specific reduction (for example, sum, max) on inputs across devices.
+
+    Args:
+        tensor (Tensor): The input tensor on each rank. The result will overwrite this tenor after communication. Support
+            float16, float32, float64, int32 or int64 as the input data type.
+        group (Group, optional): Communicate in which group. If none is given, use the global group as default.
+        sync_op (bool, optional): Indicate whether the communication is sync or not. If none is given, use true as default.
+        use_calc_stream (bool, optional): Indicate whether the communication is done on calculation stream. If none is given, use false as default. This
+            option is designed for high performance demand, be careful to turn it on except you are clearly know its meaning.
+
+    Returns:
+        Return a task object.
+
+    Warning:
+        This API only supports the dygraph mode now.
+
+    Examples:
+        .. code-block:: python
+
+            # required: distributed
+            import paddle
+            import paddle.distributed as dist
+
+            dist.init_parallel_env()
+            local_rank = dist.get_rank()
+            data = None
+            if local_rank == 0:
+                data = paddle.to_tensor([[4, 5, 6], [4, 5, 6]])
+            else:
+                data = paddle.to_tensor([[1, 2, 3], [1, 2, 3]])
+            task = dist.stream.all_reduce(data, sync_op=False)
+            task.wait()
+            out = data.numpy()
+            # [[5, 7, 9], [5, 7, 9]]
+    """
+    if group is not None and not group.is_member():
+        raise RuntimeError(
+            "The group should not be None and all ranks which invoke this operation should be the member of this group."
+        )
+
+    if not sync_op and use_calc_stream:
+        raise RuntimeError(
+            "use_calc_stream can only be true in sync op behavior.")
+
+    if framework.in_dygraph_mode():
+        return _all_gather_in_dygraph(tensor_list, tensor, group, sync_op,
+                                      use_calc_stream)
+
+    raise RuntimeError(
+        "paddle.distributed.stream.all_gather is only supported in dygraph mode now."
+    )

--- a/python/paddle/fluid/tests/unittests/collective/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/collective/CMakeLists.txt
@@ -268,6 +268,14 @@ if((WITH_GPU OR WITH_ROCM) AND (LINUX))
 endif()
 if((WITH_GPU OR WITH_ROCM) AND (LINUX))
   py_test_modules(
+    test_communication_stream_allgather_api MODULES
+    test_communication_stream_allgather_api ENVS
+    "PYTHONPATH=..:${PADDLE_BINARY_DIR}/python;http_proxy=;https_proxy=")
+  set_tests_properties(test_communication_stream_allgather_api
+                       PROPERTIES TIMEOUT "120" LABELS "RUN_TYPE=DIST")
+endif()
+if((WITH_GPU OR WITH_ROCM) AND (LINUX))
+  py_test_modules(
     test_communication_stream_allreduce_api MODULES
     test_communication_stream_allreduce_api ENVS
     "PYTHONPATH=..:${PADDLE_BINARY_DIR}/python;http_proxy=;https_proxy=")

--- a/python/paddle/fluid/tests/unittests/collective/communication_stream_allgather_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_stream_allgather_api_dygraph.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+import paddle.distributed as dist
+import test_communication_api_base as test_base
+import test_collective_api_base as test_collective_base
+
+
+class StreamAllReduceTestCase():
+
+    def __init__(self):
+        self._sync_op = eval(os.getenv("sync_op"))
+        self._use_calc_stream = eval(os.getenv("use_calc_stream"))
+        self._backend = os.getenv("backend")
+        self._shape = eval(os.getenv("shape"))
+        self._dtype = os.getenv("dtype")
+        self._seeds = eval(os.getenv("seeds"))
+        if self._backend not in ["nccl", "gloo"]:
+            raise NotImplementedError(
+                "Only support nccl and gloo as the backend for now.")
+        os.environ["PADDLE_DISTRI_BACKEND"] = self._backend
+
+    def run_test_case(self):
+        dist.init_parallel_env()
+
+        test_data_list = []
+        for seed in self._seeds:
+            test_data_list.append(
+                test_collective_base.create_test_data(shape=self._shape,
+                                                      dtype=self._dtype,
+                                                      seed=seed))
+
+        rank = dist.get_rank()
+        tensor = paddle.to_tensor(test_data_list[rank])
+        tensor_list = []
+        task = dist.stream.all_gather(tensor_list,
+                                      tensor,
+                                      sync_op=self._sync_op,
+                                      use_calc_stream=self._use_calc_stream)
+        if not self._sync_op:
+            task.wait()
+
+        result = test_data_list
+        assert np.allclose(tensor_list, result, rtol=1e-05, atol=1e-05)
+
+
+if __name__ == "__main__":
+    StreamAllReduceTestCase().run_test_case()

--- a/python/paddle/fluid/tests/unittests/collective/communication_stream_allgather_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_stream_allgather_api_dygraph.py
@@ -21,7 +21,7 @@ import test_communication_api_base as test_base
 import test_collective_api_base as test_collective_base
 
 
-class StreamAllReduceTestCase():
+class StreamAllgatherTestCase():
 
     def __init__(self):
         self._sync_op = eval(os.getenv("sync_op"))
@@ -60,4 +60,4 @@ class StreamAllReduceTestCase():
 
 
 if __name__ == "__main__":
-    StreamAllReduceTestCase().run_test_case()
+    StreamAllgatherTestCase().run_test_case()

--- a/python/paddle/fluid/tests/unittests/collective/test_communication_stream_allgather_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_communication_stream_allgather_api.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import paddle
+import itertools
+import test_communication_api_base as test_base
+
+
+class TestCommunicationStreamAllgatherAPI(test_base.CommunicationTestDistBase):
+
+    def setUp(self):
+        super(TestCommunicationStreamAllgatherAPI, self).setUp(num_of_devices=2,
+                                                               timeout=120)
+        self._default_envs = {
+            "backend": "nccl",
+            "shape": "(100, 200)",
+            "dtype": "float32",
+            "seeds": str(self._seeds)
+        }
+        self._changeable_envs = {
+            "sync_op": ["True", "False"],
+            "use_calc_stream": ["True", "False"]
+        }
+
+    def test_allgather_stream(self):
+        envs_list = test_base.gen_product_envs_list(self._default_envs,
+                                                    self._changeable_envs)
+        for envs in envs_list:
+            if eval(envs["use_calc_stream"]) and not eval(envs["sync_op"]):
+                continue
+            self.run_test_case("communication_stream_allgather_api_dygraph.py",
+                               user_defined_envs=envs)
+
+    def tearDown(self):
+        super(TestCommunicationStreamAllgatherAPI, self).tearDown()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/collective/testslist.csv
+++ b/python/paddle/fluid/tests/unittests/collective/testslist.csv
@@ -32,6 +32,7 @@ test_collective_split_col_linear,linux,gpu;rocm,300,DIST,test_runner.py,2,,http_
 test_collective_split_embedding_none_divisible,linux,gpu;rocm,300,DIST,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=..,
 test_collective_split_row_linear,linux,gpu;rocm,300,DIST,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=..,
 test_collective_wait,linux,gpu;rocm,300,DIST,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=..,
+test_communication_stream_allgather_api,linux,gpu;rocm,120,DIST,,2,,PYTHONPATH=..;http_proxy=;https_proxy=,
 test_communication_stream_allreduce_api,linux,gpu;rocm,120,DIST,,2,,PYTHONPATH=..;http_proxy=;https_proxy=,
 test_communication_stream_sendrecv_api,linux,gpu;rocm,120,DIST,,2,,PYTHONPATH=..;http_proxy=;https_proxy=,
 test_eager_dist_api,linux,gpu;rocm,120,DIST,test_runner.py,2,,http_proxy=;https_proxy=;PYTHONPATH=..,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
In the new communication library, we designed ProcessGroup to manage different communication group. Inside each process_group has its own stream which all communications in this group will be done on this stream. For high level API, like `distributed.all_reduce`, we use `use_calc_stream` to indicate whether this operation is sync or not. Notice that frequently add unnecessary cuda events may lead to low performance on some model. In order to achieve high performance, this pr add a new API name distributed.stream.all_reduce. This new API provided `use_calc_stream` and `sync_op` both.

- `sync_op`, indicate whether communication is sync or not.
- `use_calc_stream`, do communicate on calc stream, save the time of switching stream. Only work when `sync_op` is true.