### PR TITLE
Fix cannot import `paddle.distributed` in python 3.6

### DIFF
--- a/python/paddle/distributed/communication/stream/all_reduce.py
+++ b/python/paddle/distributed/communication/stream/all_reduce.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.distributed.collective as collective
 import paddle.fluid.framework as framework
+from paddle.distributed import collective
 
 
 def _all_reduce_in_dygraph(tensor, op, group, sync_op, use_calc_stream):

--- a/python/paddle/distributed/communication/stream/recv.py
+++ b/python/paddle/distributed/communication/stream/recv.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.distributed.collective as collective
 import paddle.fluid.framework as framework
+from paddle.distributed import collective
 
 
 def _recv_in_dygraph(tensor, src, group, sync_op, use_calc_stream):

--- a/python/paddle/distributed/communication/stream/send.py
+++ b/python/paddle/distributed/communication/stream/send.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.distributed.collective as collective
 import paddle.fluid.framework as framework
+from paddle.distributed import collective
 
 
 def _send_in_dygraph(tensor, dst, group, sync_op, use_calc_stream):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix cannot import `paddle.distributed` in python 3.6.