### PR TITLE
fix error: control reaches end of non-void function

### DIFF
--- a/paddle/fluid/eager/backward.cc
+++ b/paddle/fluid/eager/backward.cc
@@ -387,8 +387,8 @@ std::vector<paddle::experimental::Tensor> RunBackward(
   }
   egr::Controller::Instance().ClearFinalBackwardHooks();
   if (!is_general_grad) return {};
-  return GeneralGrad::Instance().GetResults(inputs, allow_unused, create_graph);
   VLOG(3) << "Finish Backward";
+  return GeneralGrad::Instance().GetResults(inputs, allow_unused, create_graph);
 }
 
 void Backward(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
当使用`Debug`模式编译`paddle`时，会出现如下错误:
```
error: control reaches end of non-void function [-Werror=return-type]
```
原因是因为[backward.cc](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/eager/backward.cc#L390-L391)中return后调用VLOG