### PR TITLE
Add get_phi_kernel_name python interface

### DIFF
--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -403,7 +403,7 @@ void BindInferenceApi(py::module *m) {
            return pred;
          });
   m->def(
-      "get_phi_kernel_name",
+      "_get_phi_kernel_name",
       [](const std::string &fluid_op_name) {
         return phi::TransToPhiKernelName(fluid_op_name);
       },

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -35,6 +35,7 @@
 #include "paddle/fluid/inference/api/paddle_inference_api.h"
 #include "paddle/fluid/inference/api/paddle_pass_builder.h"
 #include "paddle/fluid/inference/utils/io_utils.h"
+#include "paddle/phi/core/compat/convert_utils.h"
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/core/cuda_stream.h"
@@ -401,6 +402,12 @@ void BindInferenceApi(py::module *m) {
                new paddle_infer::Predictor(config));
            return pred;
          });
+  m->def(
+      "get_phi_kernel_name",
+      [](const std::string &fluid_op_name) {
+        return phi::TransToPhiKernelName(fluid_op_name);
+      },
+      py::return_value_policy::reference);
   m->def("copy_tensor", &CopyPaddleInferTensor);
   m->def("paddle_dtype_size", &paddle::PaddleDtypeSize);
   m->def("paddle_tensor_to_bytes", &SerializePDTensorToBytes);

--- a/python/paddle/fluid/inference/__init__.py
+++ b/python/paddle/fluid/inference/__init__.py
@@ -15,4 +15,4 @@
 from .wrapper import Config, DataType, PlaceType, PrecisionType, BackendType, Tensor, Predictor
 from .wrapper import convert_to_mixed_precision
 
-from ..core import create_predictor, get_version, get_num_bytes_of_data_type, PredictorPool, get_trt_compile_version, get_trt_runtime_version
+from ..core import create_predictor, get_version, get_phi_kernel_name, get_num_bytes_of_data_type, PredictorPool, get_trt_compile_version, get_trt_runtime_version

--- a/python/paddle/fluid/inference/__init__.py
+++ b/python/paddle/fluid/inference/__init__.py
@@ -15,4 +15,4 @@
 from .wrapper import Config, DataType, PlaceType, PrecisionType, BackendType, Tensor, Predictor
 from .wrapper import convert_to_mixed_precision
 
-from ..core import create_predictor, get_version, get_phi_kernel_name, get_num_bytes_of_data_type, PredictorPool, get_trt_compile_version, get_trt_runtime_version
+from ..core import create_predictor, get_version, _get_phi_kernel_name, get_num_bytes_of_data_type, PredictorPool, get_trt_compile_version, get_trt_runtime_version

--- a/python/paddle/inference/__init__.py
+++ b/python/paddle/inference/__init__.py
@@ -20,7 +20,7 @@ from ..fluid.inference import BackendType  # noqa: F401
 from ..fluid.inference import Tensor  # noqa: F401
 from ..fluid.inference import Predictor  # noqa: F401
 from ..fluid.inference import create_predictor  # noqa: F401
-from ..fluid.inference import get_phi_kernel_name
+from ..fluid.inference import _get_phi_kernel_name
 from ..fluid.inference import get_version  # noqa: F401
 from ..fluid.inference import get_trt_compile_version  # noqa: F401
 from ..fluid.inference import get_trt_runtime_version  # noqa: F401
@@ -30,7 +30,7 @@ from ..fluid.inference import PredictorPool  # noqa: F401
 
 __all__ = [  # noqa
     'Config', 'DataType', 'PlaceType', 'PrecisionType', 'BackendType', 'Tensor',
-    'Predictor', 'create_predictor', 'get_phi_kernel_name', 'get_version',
+    'Predictor', 'create_predictor', '_get_phi_kernel_name', 'get_version',
     'get_trt_compile_version', 'convert_to_mixed_precision',
     'get_trt_runtime_version', 'get_num_bytes_of_data_type', 'PredictorPool'
 ]

--- a/python/paddle/inference/__init__.py
+++ b/python/paddle/inference/__init__.py
@@ -20,6 +20,7 @@ from ..fluid.inference import BackendType  # noqa: F401
 from ..fluid.inference import Tensor  # noqa: F401
 from ..fluid.inference import Predictor  # noqa: F401
 from ..fluid.inference import create_predictor  # noqa: F401
+from ..fluid.inference import get_phi_kernel_name
 from ..fluid.inference import get_version  # noqa: F401
 from ..fluid.inference import get_trt_compile_version  # noqa: F401
 from ..fluid.inference import get_trt_runtime_version  # noqa: F401
@@ -29,7 +30,7 @@ from ..fluid.inference import PredictorPool  # noqa: F401
 
 __all__ = [  # noqa
     'Config', 'DataType', 'PlaceType', 'PrecisionType', 'BackendType', 'Tensor',
-    'Predictor', 'create_predictor', 'get_version', 'get_trt_compile_version',
-    'convert_to_mixed_precision', 'get_trt_runtime_version',
-    'get_num_bytes_of_data_type', 'PredictorPool'
+    'Predictor', 'create_predictor', 'get_phi_kernel_name', 'get_version',
+    'get_trt_compile_version', 'convert_to_mixed_precision',
+    'get_trt_runtime_version', 'get_num_bytes_of_data_type', 'PredictorPool'
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
添加 get_phi_kernel_name 的 python 接口，用于获取模型中 op 对应的 phi kernel
