### PR TITLE
Clear extra attrs of lookup_table_v2 in OpMaker

### DIFF
--- a/paddle/fluid/operators/lookup_table_v2_op.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op.cc
@@ -84,46 +84,12 @@ class LookupTableV2OpMaker : public framework::OpProtoAndCheckerMaker {
              "An input with type int64 "
              "contains the ids to be looked up in W.");
     AddOutput("Out", "The lookup results, which have the same type as W.");
-    AddAttr<bool>("is_sparse",
-                  "(boolean, default false) "
-                  "Sparse update.")
-        .SetDefault(false)
-        .AsExtra();
-    AddAttr<bool>("is_distributed",
-                  "(boolean, default false) distributed lookup table.")
-        .SetDefault(false)
-        .AsExtra();
     AddAttr<int64_t>("padding_idx",
                      "(int64, default -1) "
                      "If the value is -1, it makes no effect to lookup. "
                      "Otherwise the given value indicates padding the output "
                      "with zeros whenever lookup encounters it in Ids.")
         .SetDefault(kNoPadding);
-
-    // for parameter prefetch
-    AddAttr<bool>("remote_prefetch", "").SetDefault(false).AsExtra();
-    AddAttr<int>("trainer_id", "trainer id from 0 ~ worker_num.")
-        .SetDefault(0)
-        .AsExtra();
-    AddAttr<int>("slot", "slot of id").SetDefault(0).AsExtra();
-    AddAttr<std::vector<int64_t>>("height_sections",
-                                  "Height for each output SelectedRows.")
-        .SetDefault(std::vector<int64_t>({}))
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "epmap",
-        "(string vector, default 127.0.0.1:6164)"
-        "Server endpoints in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "table_names",
-        "(string vector, the split table names that will be fetched from "
-        "parameter server)"
-        "in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-
     AddComment(R"DOC(
 Lookup Table V2 Operator.
 

--- a/paddle/phi/api/yaml/generator/ops_extra_info_gen.py
+++ b/paddle/phi/api/yaml/generator/ops_extra_info_gen.py
@@ -59,7 +59,7 @@ ATTR_TYPE_STRING_MAP = {
 
 def parse_attr(attr_str):
     result = re.search(
-        r"(?P<attr_type>[a-z[\]]+)\s+(?P<name>[a-zA-Z0-9_]+)\s*=\s*(?P<default_val>\S+)",
+        r"(?P<attr_type>[a-zA-Z0-9_[\]]+)\s+(?P<name>[a-zA-Z0-9_]+)\s*=\s*(?P<default_val>\S+)",
         attr_str)
     return ATTR_TYPE_STRING_MAP[result.group('attr_type')], result.group(
         'name'), result.group('default_val')

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -237,6 +237,13 @@
   extra :
     attrs : [bool use_mkldnn = false]
 
+- op : embedding (lookup_table_v2)
+  backward : embedding_grad (lookup_table_v2_grad)
+  extra :
+    attrs : [bool is_sparse = false, bool is_distributed = false, bool remote_prefetch = false,
+             int trainer_id = 0, int slot = 0, 'int64_t[] height_sections  = {}', 'str epmap = {}',
+             'str table_names = {}']
+
 - op : erf
   inputs :
     x : X

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -241,8 +241,8 @@
   backward : embedding_grad (lookup_table_v2_grad)
   extra :
     attrs : [bool is_sparse = false, bool is_distributed = false, bool remote_prefetch = false,
-             int trainer_id = 0, int slot = 0, 'int64_t[] height_sections  = {}', 'str epmap = {}',
-             'str table_names = {}']
+             int trainer_id = 0, int slot = 0, 'int64_t[] height_sections = {}', 'str[] epmap = {}',
+             'str[] table_names = {}']
 
 - op : erf
   inputs :


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
`lookup_table_v2`算子OpMaker清理


相关PR：
第一批算子OpMaker清理: [PR45613](https://github.com/PaddlePaddle/Paddle/pull/45613)
第二批算子OpMaker清理: [PR45684](https://github.com/PaddlePaddle/Paddle/pull/45684)
第三批算子OpMaker清理: [PR45758](https://github.com/PaddlePaddle/Paddle/pull/45758)
第四批算子OpMaker清理: [PR 46060](https://github.com/PaddlePaddle/Paddle/pull/46060)
`matmul_v2`算子OpMaker清理: [PR45708](https://github.com/PaddlePaddle/Paddle/pull/45708)
`activation`算子OpMaker清理: [PR45772](https://github.com/PaddlePaddle/Paddle/pull/45772)
`reduce`算子OpMaker清理: [PR45786](https://github.com/PaddlePaddle/Paddle/pull/45786)
`elementwise`算子OpMaker清理: [PR45845](https://github.com/PaddlePaddle/Paddle/pull/45845)
`scale`算子OpMaker清理: [PR45984](https://github.com/PaddlePaddle/Paddle/pull/45984)
`condition `算子OpMaker清理: [PR46150](https://github.com/PaddlePaddle/Paddle/pull/46150)