### PR TITLE
【cherry-pick】cherry-pick 'update for py3.6 bug' PR to release/2.4

### DIFF
--- a/python/paddle/incubate/optimizer/distributed_fused_lamb.py
+++ b/python/paddle/incubate/optimizer/distributed_fused_lamb.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import os
+import paddle
 from paddle.fluid import framework, core, layers, unique_name
 from paddle.fluid.framework import Variable
 from paddle.fluid.clip import ClipGradByGlobalNorm
 from paddle.fluid.initializer import Constant
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.optimizer import Optimizer
-import paddle.distributed as dist
 from paddle.distributed.collective import new_group
 from paddle.fluid.executor import global_scope
 from paddle.fluid.framework import name_scope
@@ -288,8 +288,8 @@ class DistributedFusedLamb(Optimizer):
 
         step = self._get_or_create_step()
 
-        rank = dist.get_rank()
-        nranks = dist.get_world_size()
+        rank = paddle.distributed.get_rank()
+        nranks = paddle.distributed.get_world_size()
         if self._nproc_per_node is None:
             nproc_per_node = nranks
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
modify  a code for python3.6,  CI can not detect the code which is not supported by python3.6.

```
import paddle.distributed as dist
```
