### PR TITLE
optimization of depthwise_conv2d grad

### DIFF
--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -176,7 +176,8 @@ __device__ __inline__ void KernelDepthwiseConvNCHW(
         int offset = in_offset + h_in * input_width + w_in;
         T in_data = input_data[offset];
         if (fuse_relu_before_conv) {
-          value += weight[weight_offset] * T(max(0.0f, double(in_data)));
+          value += weight[weight_offset] *
+                   T(max(0.0f, static_cast<double>(in_data)));
         } else {
           value += weight[weight_offset] * in_data;
         }
@@ -228,7 +229,7 @@ __device__ __inline__ void KernelDepthwiseConvNHWC(
         T in_data = input_data[offset];
         const T* weight = filter_data + weight_offset * output_channels + c_out;
         if (fuse_relu_before_conv) {
-          value += weight[0] * T(max(0.0f, double(in_data)));
+          value += weight[0] * T(max(0.0f, static_cast<double>(in_data)));
         } else {
           value += weight[0] * in_data;
         }
@@ -281,7 +282,7 @@ __device__ __inline__ void KernelDepthwiseConvCFilterNCHW(
             int offset = in_offset + h_in * input_width + w_in;
             if (fuse_relu_before_conv) {
               value += r_weight[h_f * c_filter + w_f] *
-                       T(max(0.0f, double(input_data[offset])));
+                       T(max(0.0f, static_cast<double>(input_data[offset])));
             } else {
               value += r_weight[h_f * c_filter + w_f] * input_data[offset];
             }
@@ -337,7 +338,7 @@ __device__ __inline__ void KernelDepthwiseConvCFilterNHWC(
                 in_offset + (h_in * input_width + w_in) * input_channels + c_in;
             if (fuse_relu_before_conv) {
               value += r_weight[h_f * c_filter + w_f] *
-                       T(max(0.0, double(input_data[offset])));
+                       T(max(0.0, static_cast<double>(input_data[offset])));
             } else {
               value += r_weight[h_f * c_filter + w_f] * input_data[offset];
             }
@@ -880,7 +881,7 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradNCHW(
                        image_wk;
         if (fuse_relu_before_conv) {
           s += output_grad_data[gaid(bid, kernel_id, image_h, image_w)] *
-               T(max(0.0f, double(input_data[input_id])));
+               T(max(0.0f, static_cast<double>(input_data[input_id])));
         } else {
           s += output_grad_data[gaid(bid, kernel_id, image_h, image_w)] *
                input_data[input_id];
@@ -891,7 +892,7 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradNCHW(
   }
 
   T val = BlockReduceSum(s);
-  platform::CudaAtomicAdd(&filter_grad_data[gbid], val);
+  if (threadIdx.y == 0 && threadIdx.x == 0) filter_grad_data[gbid] = val;
 }
 
 template <typename T, bool fuse_relu_before_conv>
@@ -941,7 +942,7 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradNHWC(
           kernel_id / filter_multiplier;
       if (fuse_relu_before_conv) {
         s += output_grad_data[gaid(bid, image_h, image_w, kernel_id)] *
-             T(max(0.0f, double(input_data[input_id])));
+             T(max(0.0f, static_cast<double>(input_data[input_id])));
       } else {
         s += output_grad_data[gaid(bid, image_h, image_w, kernel_id)] *
              input_data[input_id];
@@ -1013,7 +1014,7 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradCFilterNHWC(
           T s(0);
           if (fuse_relu_before_conv) {
             s = output_grad_data[output_id] *
-                T(max(0.0f, double(input_data[input_id])));
+                T(max(0.0f, static_cast<double>(input_data[input_id])));
           } else {
             s = output_grad_data[output_id] * input_data[input_id];
           }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
* Environment:
    * V100-32G, CUDA 11.2, cuDNN 8
* Feature：
    * For depthwise_conv2d grad in nchw format, replace the unnessary atomic add operation with if and assign operation.  It's unnessary to use atomic add operation for each fliter grad element, because the gradient of each fliter element is computed by one thread block according to the gpu launch config.
* Performance of depthwise_conv2d grad in nchw format after optimization (OP Benchmark): 

| Config ID | Perf Before(ms) | Perf After(ms) | Improvement | Perf Pytorch(ms) | Outperform | 
| :---- | :---- | :---- | :---- | :---- | :---- |
| 0 | 3.3735 | 1.1366 | 196.8% | 1.4876 | 30.9% | 
| 2 | 5.0860 | 1.9956 | 154.9% | 2.7723 | 38.9% | 
| 4 | 1.9932 | 0.9705 | 105.4% | 1.0652 | 9.8% |
| 6 | 1.1021 | 0.9002 | 22.4% | 1.2308 | 36.7% |
| 8 | 1.7422 | 1.3151 | 32.5% | 2.6702 | 103.0% |
| 10 | 1.4936 | 1.1460 | 30.3% | 2.1160 | 84.6% |
| 12 | 3.5876 | 2.1562 | 66.4% | 3.8364 | 77.9% |

* Performance of depthwise_conv2d compared with pytorch (OP Benchmark): 

| Config ID | Perf Paddle(ms) | Perf Pytorch(ms) | Outperform | 
| :---- | :---- | :---- | :---- |
| 0 | 2.7242 | 3.6453 | 33.8% |
| 1 | 2.7587 | - | - |
| 2 | 4.6421 | 7.0541 | 52.0% |
| 3 | 7.2652 | - | - | 
| 4 | 2.0535 | 2.6483 | 29.0% | 
| 5 | 2.6485 | - | - |
| 6 | 3.3847 | 4.4502 | 31.5% |
| 7 | 3.0287 | - | - |
| 8 | 3.0288 | 5.1939 | 71.5% | 
| 9 | 4.1266 | - | - |
| 10 | 2.6863 | 4.2438 | 58.0% | 
| 11 | 2.9651 | - | - |
| 12 | 5.0887 | 8.2912 | 62.9% | 
| 13 | 5.8193 | - | - |

The depthwise_conv2d of pytorch use 1D gpu launch config, which introduces significant overhead of index computation. Meawhile, paddle use 3D gpu launch config, therefore the depthwise_conv2d performance of paddle can outperform pytorch.