### PR TITLE
[error msg] 'super()' used in py3 is not supported in dy2static, raise error here

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -507,19 +507,19 @@ class TestSetStateDictErr(unittest.TestCase):
 
 
 class _super_A(paddle.nn.Layer):
-	def __init__(self):
-		super().__init__()
-		self.linear = paddle.nn.Linear(10, 3)
+    def __init__(self):
+        super().__init__()
+        self.linear = paddle.nn.Linear(10, 3)
 
-	def forward(self, x):
-		out = self.linear(x)
-		return out
 
+    def forward(self, x):
+        out = self.linear(x)
+        return out
 
 
 class _super_B(_super_A):
-	def forward(self, x):
-		super().forward(x)
+    def forward(self, x):
+        super().forward(x)
 
 
 class TestSuperCallErr(unittest.TestCase):
@@ -533,7 +533,6 @@ class TestSuperCallErr(unittest.TestCase):
         error_message = str(new_exception)
 
         self.assertIn("'super()' is not supported in dy2static, please use 'super(Class, self)' or 'super(Class, cls)' instead.", error_message)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
'super()' used in py3 is not supported in dy2static, raise error here
use super(Class, self) or super(Class, cls)