### PR TITLE
[Cherry pick] [error msg] update error msg of user call numpy api and set_state_dict in dy2static

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -324,8 +324,8 @@ def is_numpy_api(node):
             func_str, "numpy"))
         # BUG: np.random.uniform doesn't have module and cannot be analyzed
         # TODO: find a better way
-        if not module_result:
-            return func_str.startswith("numpy.") or func_str.startswith("np.")
+        return module_result or (func_str.startswith("numpy.")
+                                 or func_str.startswith("np."))
     except Exception:
         return False
 

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1538,13 +1538,18 @@ class Layer(object):
                     place = core.CUDAPlace(p.gpu_device_id())
                 t.set(ndarray, place)
 
-            executor = Executor(_get_device())._default_executor
-            # restore parameter states
-            core._create_loaded_parameter(
-                [param for param, state in matched_param_state], global_scope(),
-                executor)
-            for param, state in matched_param_state:
-                _set_var(param, state)
+            try:
+                executor = Executor(_get_device())._default_executor
+                # restore parameter states
+                core._create_loaded_parameter(
+                    [param for param, state in matched_param_state],
+                    global_scope(), executor)
+                for param, state in matched_param_state:
+                    _set_var(param, state)
+            except ValueError as e:
+                raise ValueError(
+                    "This error might happens in dy2static, while calling 'set_state_dict' dynamicly in 'forward', which is not supported. If you only need call 'set_state_dict' once, move it to '__init__'."
+                )
 
     def to(self, device=None, dtype=None, blocking=None):
         '''


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
updated the error msg when user call numpy api and set_state_dict in dy2static, numpy api should be replaced with paddle api. Use set_state_dict in ‘forward’ is not supported