### PR TITLE
Clear extra attrs of distribute op in OpMaker

### DIFF
--- a/paddle/fluid/operators/nce_op.cc
+++ b/paddle/fluid/operators/nce_op.cc
@@ -207,34 +207,6 @@ class NCEOpMaker : public framework::OpProtoAndCheckerMaker {
 
     // for parameter prefetch
     AddAttr<bool>("remote_prefetch", "").SetDefault(false);
-    AddAttr<int>("trainer_id", "trainer id from 0 ~ worker_num.")
-        .SetDefault(0)
-        .AsExtra();
-    AddAttr<std::vector<int64_t>>("height_sections",
-                                  "Height for each output SelectedRows.")
-        .SetDefault(std::vector<int64_t>({}))
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "epmap",
-        "(string vector, default 127.0.0.1:6164)"
-        "Server endpoints in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "table_names",
-        "(string vector, the split table names that will be fetched from "
-        "parameter server)"
-        "in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-
-    AddAttr<std::vector<int>>("custom_neg_classes",
-                              "This attribute only be used in unitest. Classes "
-                              "in this list wiil be used as negative classes "
-                              "for every samples. Under normal conditions, "
-                              "user should avoid setting this attribute.")
-        .SetDefault({})
-        .AsExtra();
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference "
                   "only, false for training.")

--- a/paddle/fluid/operators/pscore/distributed_push_sparse_op.cc
+++ b/paddle/fluid/operators/pscore/distributed_push_sparse_op.cc
@@ -113,11 +113,6 @@ class DistributedPushSparseOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("use_cvm_op", "(boolean, default false) Use cvm op or not.")
         .SetDefault(false);
 
-    AddAttr<std::vector<int>>("slots",
-                              "[slot_id1, slot_id2] Slots array of Ids.")
-        .SetDefault({})
-        .AsExtra();
-
     AddComment(R"DOC(
 Lookup Tablel Prefetch Operator.
 This operator is used to perform lookup on parameter W,

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -208,6 +208,10 @@
   outputs :
     out : Out
 
+- op : distributed_push_sparse
+  extra :
+    attrs : ['int[] slots = {}']
+
 - op : divide (elementwise_div)
   backward : divide_grad (elementwise_div)
   extra :
@@ -484,6 +488,12 @@
     {x : X, vec : Vec}
   outputs :
     out : Out
+
+- op : nce
+  backward : nce_grad
+  extra :
+    attrs : [int trainer_id = 0, 'int64_t[] height_sections = {}', 'str[] epmap = {}',
+             'str[] table_names = {}', 'int[] custom_neg_classes = {}']
 
 - op : nearest_interp (nearest_interp_v2)
   backward : nearest_interp_grad (nearest_interp_v2_grad)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
`distributed_push_sparse`和`nce`算子OpMaker的Extra属性清理。

相关PR：
第一批算子OpMaker清理: [PR45613](https://github.com/PaddlePaddle/Paddle/pull/45613)
第二批算子OpMaker清理: [PR45684](https://github.com/PaddlePaddle/Paddle/pull/45684)
第三批算子OpMaker清理: [PR45758](https://github.com/PaddlePaddle/Paddle/pull/45758)
第四批算子OpMaker清理: [PR 46060](https://github.com/PaddlePaddle/Paddle/pull/46060)
`matmul_v2`算子OpMaker清理: [PR45708](https://github.com/PaddlePaddle/Paddle/pull/45708)
`activation`算子OpMaker清理: [PR45772](https://github.com/PaddlePaddle/Paddle/pull/45772)
`reduce`算子OpMaker清理: [PR45786](https://github.com/PaddlePaddle/Paddle/pull/45786)
`elementwise`算子OpMaker清理: [PR45845](https://github.com/PaddlePaddle/Paddle/pull/45845)
`scale`算子OpMaker清理: [PR45984](https://github.com/PaddlePaddle/Paddle/pull/45984)
`condition `算子OpMaker清理: [PR46150](https://github.com/PaddlePaddle/Paddle/pull/46150)
`quantize `相关算子OpMaker清理: [PR46418](https://github.com/PaddlePaddle/Paddle/pull/46418)