### PR TITLE
Open the clip_extra flag in paddle.static.save_inference_model

### DIFF
--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -517,7 +517,7 @@ def save_inference_model(path_prefix, feed_vars, fetch_vars, executor,
     _check_vars('fetch_vars', fetch_vars)
 
     program = _get_valid_program(kwargs.get('program', None))
-    clip_extra = kwargs.get('clip_extra', False)
+    clip_extra = kwargs.get('clip_extra', True)
     program = normalize_program(program, feed_vars, fetch_vars)
     # serialize and save program
     program_bytes = _serialize_program(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
将`paddle.static.save_inference_model`中的`clip_extra`参数默认值修改为True。
使用`paddle.static.save_inference_model`接口保存模型Program时将默认开启Extra类型参数的裁剪。

相关PR：
[PR46456](https://github.com/PaddlePaddle/Paddle/pull/46456), [PR46473](https://github.com/PaddlePaddle/Paddle/pull/46473)