### PR TITLE
Clear extra attrs of sequence_softmax op in OpMaker

### DIFF
--- a/paddle/fluid/operators/sequence_ops/sequence_softmax_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_softmax_op.cc
@@ -73,14 +73,6 @@ class SequenceSoftmaxOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) Only used in cudnn kernel, need install cudnn")
         .SetDefault(false)
         .AsExtra();
-    AddAttr<std::string>(
-        "data_format",
-        "(string, default NCHW) Only used in "
-        "An optional string from: \"NHWC\", \"NCHW\". "
-        "Defaults to \"NHWC\". Specify the data format of the output data, "
-        "the input will be transformed automatically. ")
-        .SetDefault("AnyLayout")
-        .AsExtra();
     AddComment(R"DOC(
 Sequence Softmax Operator.
 

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -622,6 +622,11 @@
   extra :
     attrs : [bool deterministic = false, str rng_name = "", bool force_cpu = false]
 
+- op : sequence_softmax
+  backward : sequence_softmax_grad
+  extra :
+    attrs : [str data_format = "AnyLayout"]
+
 - op : shape
   extra :
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
`sequence_softmax`算子OpMaker的Extra属性清理。

相关PR：
第一批算子OpMaker清理: [PR45613](https://github.com/PaddlePaddle/Paddle/pull/45613)
第二批算子OpMaker清理: [PR45684](https://github.com/PaddlePaddle/Paddle/pull/45684)
第三批算子OpMaker清理: [PR45758](https://github.com/PaddlePaddle/Paddle/pull/45758)
第四批算子OpMaker清理: [PR 46060](https://github.com/PaddlePaddle/Paddle/pull/46060)
`matmul_v2`算子OpMaker清理: [PR45708](https://github.com/PaddlePaddle/Paddle/pull/45708)
`activation`算子OpMaker清理: [PR45772](https://github.com/PaddlePaddle/Paddle/pull/45772)
`reduce`算子OpMaker清理: [PR45786](https://github.com/PaddlePaddle/Paddle/pull/45786)
`elementwise`算子OpMaker清理: [PR45845](https://github.com/PaddlePaddle/Paddle/pull/45845)
`scale`算子OpMaker清理: [PR45984](https://github.com/PaddlePaddle/Paddle/pull/45984)
`condition `算子OpMaker清理: [PR46150](https://github.com/PaddlePaddle/Paddle/pull/46150)
`quantize `相关算子OpMaker清理: [PR46418](https://github.com/PaddlePaddle/Paddle/pull/46418)
`distribute `相关算子OpMaker清理: [PR46451](https://github.com/PaddlePaddle/Paddle/pull/46451)