### PR TITLE
Move some singleton to cc file

### DIFF
--- a/paddle/fluid/framework/op_version_registry.cc
+++ b/paddle/fluid/framework/op_version_registry.cc
@@ -70,6 +70,11 @@ OpVersionDesc&& OpVersionDesc::DeleteOutput(const std::string& name,
   return std::move(*this);
 }
 
+OpVersionRegistrar& OpVersionRegistrar::GetInstance() {
+  static OpVersionRegistrar instance;
+  return instance;
+}
+
 OpVersion& OpVersionRegistrar::Register(const std::string& op_type) {
   PADDLE_ENFORCE_EQ(
       op_version_map_.find(op_type),
@@ -87,6 +92,11 @@ uint32_t OpVersionRegistrar::version_id(const std::string& op_type) const {
       platform::errors::InvalidArgument(
           "The version of operator type %s has not been registered.", op_type));
   return op_version_map_.find(op_type)->second.version_id();
+}
+
+PassVersionCheckerRegistrar& PassVersionCheckerRegistrar::GetInstance() {
+  static PassVersionCheckerRegistrar instance;
+  return instance;
 }
 
 // Provide a fake registration item for pybind testing.

--- a/paddle/fluid/framework/op_version_registry.h
+++ b/paddle/fluid/framework/op_version_registry.h
@@ -230,10 +230,8 @@ class OpVersion {
 
 class OpVersionRegistrar {
  public:
-  static OpVersionRegistrar& GetInstance() {
-    static OpVersionRegistrar instance;
-    return instance;
-  }
+  static OpVersionRegistrar& GetInstance();
+
   OpVersion& Register(const std::string& op_type);
   const std::unordered_map<std::string, OpVersion>& GetVersionMap() {
     return op_version_map_;
@@ -365,10 +363,8 @@ class PassVersionCheckers {
 
 class PassVersionCheckerRegistrar {
  public:
-  static PassVersionCheckerRegistrar& GetInstance() {
-    static PassVersionCheckerRegistrar instance;
-    return instance;
-  }
+  static PassVersionCheckerRegistrar& GetInstance();
+
   PassVersionCheckers& Register(const std::string& pass_name) {
     PADDLE_ENFORCE_EQ(pass_version_checkers_map_.find(pass_name),
                       pass_version_checkers_map_.end(),

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -73,7 +73,30 @@ DeviceType Place2DeviceType(const platform::Place& place) {
   }
 }
 
-DeviceContextPool* DeviceContextPool::pool = nullptr;
+static DeviceContextPool* pool = nullptr;
+
+DeviceContextPool& DeviceContextPool::Instance() {
+  PADDLE_ENFORCE_NOT_NULL(pool,
+                          phi::errors::PreconditionNotMet(
+                              "Need to Create DeviceContextPool firstly!"));
+  return *pool;
+}
+
+/*! \brief  Create should only called by Init function */
+DeviceContextPool& DeviceContextPool::Init(
+    const std::vector<platform::Place>& places) {
+  if (pool == nullptr) {
+    pool = new DeviceContextPool(places);
+  }
+  return *pool;
+}
+
+bool DeviceContextPool::IsInitialized() { return pool != nullptr; }
+
+void DeviceContextPool::SetPool(DeviceContextPool* dev_pool) {
+  pool = dev_pool;
+}
+
 thread_local const std::map<Place,
                             std::shared_future<std::unique_ptr<DeviceContext>>>*
     DeviceContextPool::external_device_contexts_ = nullptr;

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -339,24 +339,14 @@ void EmplaceDeviceContexts(
 /*! \brief device context pool singleton */
 class DeviceContextPool {
  public:
-  static DeviceContextPool& Instance() {
-    PADDLE_ENFORCE_NOT_NULL(pool,
-                            platform::errors::PreconditionNotMet(
-                                "Need to Create DeviceContextPool firstly!"));
-    return *pool;
-  }
+  static DeviceContextPool& Instance();
 
   /*! \brief  Create should only called by Init function */
-  static DeviceContextPool& Init(const std::vector<platform::Place>& places) {
-    if (pool == nullptr) {
-      pool = new DeviceContextPool(places);
-    }
-    return *pool;
-  }
+  static DeviceContextPool& Init(const std::vector<platform::Place>& places);
 
-  static bool IsInitialized() { return pool != nullptr; }
+  static bool IsInitialized();
 
-  static void SetPool(DeviceContextPool* dev_pool) { pool = dev_pool; }
+  static void SetPool(DeviceContextPool* dev_pool);
 
   /*! \brief  Return handle of single device context. */
   platform::DeviceContext* Get(const platform::Place& place);
@@ -380,7 +370,6 @@ class DeviceContextPool {
  private:
   explicit DeviceContextPool(const std::vector<platform::Place>& places);
 
-  static DeviceContextPool* pool;
   std::map<Place, std::shared_future<std::unique_ptr<DeviceContext>>>
       device_contexts_;
   static thread_local const std::


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Move some singleton implementation method from header file to source file. 

If some external C++ source codes are built upon the pre-built `libpaddle.so` and include the header file containing the singleton implementation method, multiple singleton would be generated in the built so file. This PR is used to avoid this error.