### PR TITLE
Delete gpu_memory information of every unnitest to less time consuming

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1837,14 +1837,10 @@ EOF
 }
 
 function insert_pile_to_h_cu_diff {
-    # TODO get develop h/cu md5
+    # get all .cu files of develop branch
     cd ${PADDLE_ROOT}
     find ${PADDLE_ROOT} -name '*.cu'| grep -v ${PADDLE_ROOT}/build >> ${PADDLE_ROOT}/tools/h_cu_files.log
-    python ${PADDLE_ROOT}/tools/handle_h_cu_file.py 'get_h_file_md5' ${PADDLE_ROOT}
-    
-    # TODO insert pile to diff h/cu file 
-
-    #insert pile to full h/cu file 
+    #insert pile to all .cu files
     python ${PADDLE_ROOT}/tools/handle_h_cu_file.py 'insert_pile_to_h_file' ${PADDLE_ROOT}
 }
 
@@ -1886,12 +1882,11 @@ function parallel_card_test_single {
     num=$2
     for case in $(echo $testcases | tr "$|^" "\n")
     do
-        cd ${PADDLE_ROOT}/build
-        precise_card_test "^${case}$" $num
+        cd ${PADDLE_ROOT}/build 
+        parallel_card_test "^${case}$" $num 
     done
 }
-
-function precise_card_test() {
+function parallel_card_test() {
     set -m
     testcases=$1
     if (( $# > 1 )); then
@@ -1927,13 +1922,42 @@ function precise_card_test() {
     set +m
 }
 
+function precise_card_test() {
+    set -m
+    testcases=$1
+    if (( $# > 1 )); then
+        cardnumber=$2
+        cuda_list="0"
+        if [ $cardnumber -eq 2 ]; then
+            cuda_list=${CUDA_VISIBLE_DEVICES}
+        else
+            cuda_list="0"
+        fi
+    else
+        cardnumber=2
+        cuda_list=${CUDA_VISIBLE_DEVICES}
+    fi
+
+    if [[ "$testcases" == "" ]]; then
+        return 0
+    fi
+
+    echo "****************************************************************"
+    echo "***Running ut: $testcases***"
+    echo "****************************************************************"
+    
+    tmpfile=$tmp_dir/$testcases".log"
+    env CUDA_VISIBLE_DEVICES=$cuda_list ctest -I 0,,1 -R "($testcases)" --timeout 500 --output-on-failure -V -j 1 > $tmpfile 
+    set +m
+}
+
 function get_precise_tests_map_file {
     cd ${PADDLE_ROOT}/build
     pip install ${PADDLE_ROOT}/build/python/dist/*whl
     ut_total_startTime_s=`date +%s`
     EXIT_CODE=0;
     test_cases=$(ctest -N -V) # get all test cases
-    single_card_tests='' # all cases list which would take one graph card
+    single_card_tests=''      # all cases list which would take one graph card
     exclusive_tests=''        # cases list which would be run exclusively
     multiple_card_tests=''    # cases list which would take multiple GPUs, most cases would be two GPUs
     is_exclusive=''           # indicate whether the case is exclusive type
@@ -2000,18 +2024,20 @@ set +x
 set -x
     mkdir -p ${PADDLE_ROOT}/build/ut_map
     mkdir -p ${PADDLE_ROOT}/build/pytest
-
+    #run all unittest to get the coverage information of .c and .h files
     precise_card_test_single "$single_card_tests" 1
     precise_card_test_single "$single_card_tests_1" 1
     precise_card_test_single "$multiple_card_tests" 2
     precise_card_test_single "$exclusive_tests"
     wait;
+    #get notSuccessut including the failed uniitests and not executed unittests
     python ${PADDLE_ROOT}/tools/get_ut_file_map.py 'get_not_success_ut' ${PADDLE_ROOT}
     
-    #analy h/cu to Map file
+    #analyze the mapping between unit tests and .cu files
     python ${PADDLE_ROOT}/tools/handle_h_cu_file.py 'analy_h_cu_file' $tmp_dir ${PADDLE_ROOT}
 
     wait;
+    #rerun the notSuccessut and get the mapping between notSuccessut and .cu files
     get_failedUts_precise_map_file
 
     #generate python coverage and generate python file to tests_map_file

--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -138,7 +138,7 @@ function gen_diff_html_report() {
         --rc lcov_branch_coverage=0
         
     echo 'the following is test code..'
-    diff coverage-diff.info coverage_ljd.info > /dev/null
+    diff /paddle/build/coverage-diff.info /paddle/build/coverage_ljd.info > /dev/null
     if [ $? == 0 ]; then
         echo "Both file are same"
     else

--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -123,6 +123,7 @@ function gen_diff_html_report() {
     if [ "${GIT_PR_ID}" != "" ]; then
 
         COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
+        
         python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py diff ${GIT_PR_ID} > git-diff.out
     fi
 
@@ -136,15 +137,6 @@ function gen_diff_html_report() {
         ${COVERAGE_DIFF_PATTERN} \
         -o coverage_ljd.info \
         --rc lcov_branch_coverage=0
-        
-    echo 'the following is test code..'
-    diff /paddle/build/coverage-diff.info /paddle/build/coverage_ljd.info > /dev/null
-    if [ $? == 0 ]; then
-        echo "Both file are same"
-    else
-        echo "Both file are different"
-    fi
-
     python3.7 ${PADDLE_ROOT}/tools/coverage/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
 
     mv -f coverage-diff.tmp coverage-diff.info

--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -123,7 +123,6 @@ function gen_diff_html_report() {
     if [ "${GIT_PR_ID}" != "" ]; then
 
         COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
-        
         python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py diff ${GIT_PR_ID} > git-diff.out
     fi
 
@@ -132,11 +131,7 @@ function gen_diff_html_report() {
         -o coverage-diff.info \
         --rc lcov_branch_coverage=0
     COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
-    
-    lcov --extract coverage.info \
-        ${COVERAGE_DIFF_PATTERN} \
-        -o coverage_ljd.info \
-        --rc lcov_branch_coverage=0
+
     python3.7 ${PADDLE_ROOT}/tools/coverage/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
 
     mv -f coverage-diff.tmp coverage-diff.info

--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -36,11 +36,6 @@ cd /paddle/build
 python3.7 ${PADDLE_ROOT}/tools/coverage/gcda_clean.py ${GIT_PR_ID} || exit 101
 
 lcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0
-COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
-lcov --extract coverage.info \
-        ${COVERAGE_DIFF_PATTERN} \
-        -o coverage_ljd.info \
-        --rc lcov_branch_coverage=0
 # full html report
 
 function gen_full_html_report() {
@@ -135,6 +130,13 @@ function gen_diff_html_report() {
         ${COVERAGE_DIFF_PATTERN} \
         -o coverage-diff.info \
         --rc lcov_branch_coverage=0
+    COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
+    
+    lcov --extract coverage.info \
+        ${COVERAGE_DIFF_PATTERN} \
+        -o coverage_ljd.info \
+        --rc lcov_branch_coverage=0
+        
     echo 'the following is test code..'
     diff coverage-diff.info coverage_ljd.info > /dev/null
     if [ $? == 0 ]; then

--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -36,6 +36,7 @@ cd /paddle/build
 python3.7 ${PADDLE_ROOT}/tools/coverage/gcda_clean.py ${GIT_PR_ID} || exit 101
 
 lcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0
+
 # full html report
 
 function gen_full_html_report() {
@@ -123,6 +124,7 @@ function gen_diff_html_report() {
     if [ "${GIT_PR_ID}" != "" ]; then
 
         COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
+
         python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py diff ${GIT_PR_ID} > git-diff.out
     fi
 
@@ -130,7 +132,6 @@ function gen_diff_html_report() {
         ${COVERAGE_DIFF_PATTERN} \
         -o coverage-diff.info \
         --rc lcov_branch_coverage=0
-    COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
 
     python3.7 ${PADDLE_ROOT}/tools/coverage/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
 

--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -36,7 +36,11 @@ cd /paddle/build
 python3.7 ${PADDLE_ROOT}/tools/coverage/gcda_clean.py ${GIT_PR_ID} || exit 101
 
 lcov --capture -d ./ -o coverage.info --rc lcov_branch_coverage=0
-
+COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
+lcov --extract coverage.info \
+        ${COVERAGE_DIFF_PATTERN} \
+        -o coverage_ljd.info \
+        --rc lcov_branch_coverage=0
 # full html report
 
 function gen_full_html_report() {
@@ -124,7 +128,6 @@ function gen_diff_html_report() {
     if [ "${GIT_PR_ID}" != "" ]; then
 
         COVERAGE_DIFF_PATTERN="`python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py files ${GIT_PR_ID}`"
-
         python3.7 ${PADDLE_ROOT}/tools/coverage/pull_request.py diff ${GIT_PR_ID} > git-diff.out
     fi
 
@@ -132,6 +135,13 @@ function gen_diff_html_report() {
         ${COVERAGE_DIFF_PATTERN} \
         -o coverage-diff.info \
         --rc lcov_branch_coverage=0
+    echo 'the following is test code..'
+    diff coverage-diff.info coverage_ljd.info > /dev/null
+    if [ $? == 0 ]; then
+        echo "Both file are same"
+    else
+        echo "Both file are different"
+    fi
 
     python3.7 ${PADDLE_ROOT}/tools/coverage/coverage_diff.py coverage-diff.info git-diff.out > coverage-diff.tmp
 


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others 

### Describe
次PR主要做了四件事：

1 在对单测进行并行分组时需要利用每个单测所占gpu显存信息，然而在生成精准测试map时，是不需要利用显存信息的，在生成map时统计每个单测的显存信息会耗费大量时间，可以删除这部分逻辑在此PR中优化这个问题。

2由于并行分组跑单测(parallel_card_test_single)和精准测生成map(precise_card_test_single)跑单测均调用的同一个函数(precise_card_test)，本PR在paddle_build.sh中新加一个函数parallel_card_test，方便理解，也更加对称，方便后续维护;

3在对.cu文件插桩时，在拿到所有.cu文件的md5值这部操作是多余的，本PR删除此逻辑

4由于代码迭代多次，导致原来的同学留下来的一些注释和实际的逻辑并不匹配，本PR重新写了一些注释，方便后续理解和维护

