### PR TITLE
Fix op_happen_before_ update bug for AddDownstreamOp

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -268,7 +268,7 @@ void create_all_ops(const framework::BlockDesc& block,
                     std::vector<std::unique_ptr<OperatorBase>>* ops) {
   for (auto& op : block.AllOps()) {
     auto op_type = op->Type();
-    VLOG(1) << "CreateOp from : " << op_type;
+    VLOG(8) << "CreateOp from : " << op_type;
 
     auto& info = OpInfoMap::Instance().Get(op_type);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
In DependencyBuilder, after we add a OP dependency _a_->_b_, the _op_happen_before_ in the following two cases need to be updated:
1. For all _c_ happens before _a_, it also happens before _b_, so _op_happen_before[c][b]_ should be set to True.
2. For all _c_ happens after _b_, it also happens after _a_, so _op_happen_before[a][c]_ should be set to True.

The previous code only deals with the latter situation, this PR adds consideration to the former one.