### PR TITLE
[CherryPick] fix shard_index's assert error

### DIFF
--- a/paddle/phi/kernels/gpu/shard_index_kernel.cu
+++ b/paddle/phi/kernels/gpu/shard_index_kernel.cu
@@ -33,7 +33,15 @@ __global__ void ShardIndexInner(const T* in_data,
   int shard_size = (index_num + nshards - 1) / nshards;
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < numel) {
-    assert(in_data[idx] >= 0 && in_data[idx] < index_num);
+    PADDLE_ENFORCE(in_data[idx] >= 0,
+                   "The input_index for Op(shard_index) must be "
+                   "greater or equal to 0, but the value given is %d.",
+                   in_data[idx]);
+    PADDLE_ENFORCE(in_data[idx] < index_num,
+                   "The input_index for Op(shard_index) must be less "
+                   "than index_num (%d), but the value given is %d.",
+                   index_num,
+                   in_data[idx]);
     if (in_data[idx] / shard_size == shard_id) {
       out_data[idx] = in_data[idx] % shard_size;
     } else {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- 修复 shard_index op 的 gpu kernel 报错与 cpu kernel 保持一致。在 input 值大于或等于 index_num 时抛出异常 [#46491](https://github.com/PaddlePaddle/Paddle/pull/46491)