### PR TITLE
Fix syntax errors of args name in int_array.h

### DIFF
--- a/paddle/phi/common/int_array.h
+++ b/paddle/phi/common/int_array.h
@@ -35,12 +35,12 @@ class IntArrayBase {
   IntArrayBase(std::initializer_list<int64_t> array_list)
       : array_(array_list) {}
 
-  IntArrayBase(const int64_t* date_value, int64_t n) {
-    AssignData(date_value, n);
+  IntArrayBase(const int64_t* data_value, int64_t n) {
+    AssignData(data_value, n);
   }
 
-  IntArrayBase(const int32_t* date_value, int64_t n) {
-    AssignData(date_value, n);
+  IntArrayBase(const int32_t* data_value, int64_t n) {
+    AssignData(data_value, n);
   }
 
   bool FromTensor() const { return is_from_tensor_; }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
`int_array.h`中拼写错误的变量名修改：`date_value`->`data_value`。
