### PR TITLE
Transpose autotuner optimize

### DIFF
--- a/paddle/fluid/operators/transpose_op.cu.h
+++ b/paddle/fluid/operators/transpose_op.cu.h
@@ -1196,8 +1196,7 @@ void TransposeGPUKernelDriver(const phi::GPUContext& ctx,
   if (!ret) {
     auto* tuner =
         phi::autotune::MakeTransposeTuner<T>(TransCompute<phi::GPUContext, T>);
-    tuner->AddCallBack(
-        phi::autotune::MakeCallback<T>(SimplifyThenLaunch<phi::GPUContext, T>));
+    tuner->AddCallBack(SimplifyThenLaunch<phi::GPUContext, T>);
 
     size_t key = phi::autotune::TransposeKey(
         phi::vectorize(in.dims()),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 每次调用TransposeAutoTuner时，都会首先创建回调函数，而回调函数仅在第一次创建TransposeAutoTuner时必须构造，其余则不是；修改后，仅仅会在第一次创建TransposeAutoTuner时，构造回调函数.
