### PR TITLE
[Polish typo] Polish typo error: emum->enum, defalutly->defaultly

### DIFF
--- a/paddle/phi/api/lib/data_transform.h
+++ b/paddle/phi/api/lib/data_transform.h
@@ -56,7 +56,7 @@ class TransformFlag {
   // the complex is always transferd, except stop_transform_ is true.
   bool trans_data_type_ = false;
 
-  // trans_backend_ and trans_layout_ are true defalutly,
+  // trans_backend_ and trans_layout_ are true defaultly,
   // and they can only be setted by global flag.
   bool trans_backend_ = true;
   bool trans_layout_ = true;

--- a/paddle/phi/common/place.h
+++ b/paddle/phi/common/place.h
@@ -226,7 +226,7 @@ using GPUPlace = phi::GPUPlace;
 
 /* NOTE [ Why need to temporarily adapt to PlaceType? ]
 
-`PlaceType` emum class is the place type used by custom operators since the
+`PlaceType` enum class is the place type used by custom operators since the
 release of 2.0. Since 2.3, we have refactored the operator library and designed
 a new external Place type. The original PlaceType is no longer suitable for use
 as an internal type of the framework, but immediately delete the PlaceType,


### PR DESCRIPTION
### PR types
Others

### PR changes
Docs

### Describe
Polish typo error: `emum->enum`, `defalutly->defaultly`
