### PR TITLE
restore the mapping between unnittests and .cu files

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2007,13 +2007,14 @@ set -x
     precise_card_test_single "$exclusive_tests"
     wait;
     python ${PADDLE_ROOT}/tools/get_ut_file_map.py 'get_not_success_ut' ${PADDLE_ROOT}
-    
+
+    get_failedUts_precise_map_file
+
     #analy h/cu to Map file
     python ${PADDLE_ROOT}/tools/handle_h_cu_file.py 'analy_h_cu_file' $tmp_dir ${PADDLE_ROOT}
 
     wait;
-    get_failedUts_precise_map_file
-
+   
     #generate python coverage and generate python file to tests_map_file
     python ${PADDLE_ROOT}/tools/pyCov_multithreading.py ${PADDLE_ROOT}
     wait;
@@ -2114,16 +2115,8 @@ set -x
 function get_failedUts_precise_map_file {
     if [[ -f "${PADDLE_ROOT}/build/utNotSuccess" ]]; then
         rerun_tests=`cat ${PADDLE_ROOT}/build/utNotSuccess`
-        #remove pile to full h/cu file
-        python ${PADDLE_ROOT}/tools/handle_h_cu_file.py 'remove_pile_from_h_file' ${PADDLE_ROOT}
-        cd ${PADDLE_ROOT}/build
-        cmake_base ${PYTHON_ABI:-""}
-        build ${parallel_number}
-        pip uninstall -y paddlepaddle-gpu
-        pip install ${PADDLE_ROOT}/build/python/dist/*whl
         precise_card_test_single "$rerun_tests"
         wait;
-        
     fi
 }
 

--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -425,7 +425,8 @@ class PRChecker(object):
                     if ret:
                         with open('prec_delta') as delta:
                             for ut in delta:
-                                ut_list.append(ut.rstrip('\r\n'))
+                                if ut not in ut_list:
+                                    ut_list.append(ut.rstrip('\r\n'))
                     else:
                         print('PREC download prec_delta failed')
                         exit(1)


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others 

### Describe
此PR主要做了两件事：

1 单测与.cu文件之间的映射关系存在问题。对失败的单测prec_delta中的单测进行重跑前，取消了对.cu文件的插桩并且重新编译了一次paddle，取消对.cu文件的插桩会丢失失败单测和.cu文件之间的映射关系，重新编译也是多余的，编译耗时很长，本PR修复了此问题；
 收益：精准测试map更新的时间缩短了1小时51分1秒

2 coverage流水线中，精准测试的单测ut_list里面可能会包含prec_delta里面的单测，在将prec_delta里的单测添加到ut_list之前需要进行判断，否则可能导致同一个单测跑了两边的情况出现
