### PR TITLE
remove const qualifier in function return

### DIFF
--- a/paddle/fluid/framework/details/nccl_op_handle.h
+++ b/paddle/fluid/framework/details/nccl_op_handle.h
@@ -71,7 +71,7 @@ class NCCLOpHandleBase : public OpHandleBase {
     return nccl_ctxs_;
   }
 
-  const ncclComm_t GetComm() const {
+  ncclComm_t GetComm() const {
     PADDLE_ENFORCE_EQ(
         places_.size(),
         1,

--- a/paddle/fluid/framework/ir/coalesce_grad_tensor_pass.cc
+++ b/paddle/fluid/framework/ir/coalesce_grad_tensor_pass.cc
@@ -560,7 +560,7 @@ class CoalesceGradTensorPass : public ir::Pass {
       }
     }
     VLOG(4) << "all_persistable:" << all_persistable;
-    VLOG(4) << "any_persistable:" << all_persistable;
+    VLOG(4) << "any_persistable:" << any_persistable;
     // NOTE. In scope_buffered_ssa_graph_executor, after each execution of
     // DropScope(), non persistable vars will be Erase or Clear. So
     // coalesce_tensor op needs to be executed again after the execution


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix compilation error in gcc-5.4 
![45ec6054677e4bed268b09ed31637496](https://user-images.githubusercontent.com/6888866/192477775-c035f28d-68d1-47e1-b7f2-3a72740a4219.png)
