### PR TITLE
[cherry-pick] Clear extra attrs of some ops in OpMaker (#46150, #46321, #46418, #46451, #46457)

### DIFF
--- a/paddle/fluid/operators/controlflow/conditional_block_op.h
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.h
@@ -119,11 +119,6 @@ class ConditionalBlockOpProtoMaker : public framework::OpProtoAndCheckerMaker {
                   "The conditional variable (Cond) is used as scalar "
                   "condition.")
         .SetDefault(false);
-    AddAttr<std::vector<std::string>>(ConditionalOp::kSkipEagerDeletionVars,
-                                      "Vars that would not be deleted when "
-                                      "garbage collection strategy enables")
-        .SetDefault(std::vector<std::string>())
-        .AsExtra();
     AddComment(R"DOC(Conditional block operator
 
 If `is_scalar_condition` is True, the conditional variable (Cond) is a scalar,

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -221,11 +221,6 @@ class WhileOpMaker : public framework::OpProtoAndCheckerMaker {
                   "(bool, default false) Set to true for inference only, false "
                   "for training. Some layers may run faster when this is true.")
         .SetDefault(false);
-    AddAttr<std::vector<std::string>>(kSkipEagerDeletionVars,
-                                      "Vars that would skip eager deletion."
-                                      "Users should not set this manually.")
-        .SetDefault(std::vector<std::string>())
-        .AsExtra();
     AddComment(R"DOC(
 )DOC");
   }

--- a/paddle/fluid/operators/fake_quantize_op.cc
+++ b/paddle/fluid/operators/fake_quantize_op.cc
@@ -432,24 +432,6 @@ class FakeQuantOrWithDequantAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<int>(
-        "round_type",
-        "(int, default 1) The round type of fp32 to int."
-        "0: rounding to nearest ties to even. Eg: round(1.5)=2, round(2.5)=2"
-        "1: rounding to nearest ties away from zero. Eg: round(1.5)=2, "
-        "round(2.5)=3")
-        .SetDefault(1)
-        .AddCustomChecker([](const int &round_type) {
-          PADDLE_ENFORCE_EQ(
-              round_type == 0 || round_type == 1,
-              true,
-              platform::errors::InvalidArgument(
-                  "'round_type' should be 0 or 1, 0 rounding to "
-                  "nearest ties to even and 1 is rounding to nearest "
-                  "ties away from zero.but the received is %d",
-                  round_type));
-        })
-        .AsExtra();
     AddComment(R"DOC(
 This is a Base Op which supports FakeQuantAbsMaxOpMaker and FakeQuantDequantAbsMaxOpMaker.
 FakeQuantAbsMaxOp operator is used in the dynamic quantization.
@@ -529,24 +511,6 @@ class FakeChannelWiseQuantizeAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<int>(
-        "round_type",
-        "(int, default 1) The round type of fp32 to int."
-        "0: rounding to nearest ties to even. Eg: round(1.5)=2, round(2.5)=2"
-        "1: rounding to nearest ties away from zero. Eg: round(1.5)=2, "
-        "round(2.5)=3")
-        .SetDefault(1)
-        .AddCustomChecker([](const int &round_type) {
-          PADDLE_ENFORCE_EQ(
-              round_type == 0 || round_type == 1,
-              true,
-              platform::errors::InvalidArgument(
-                  "'round_type' should be 0 or 1, 0 rounding to "
-                  "nearest ties to even and 1 is rounding to nearest "
-                  "ties away from zero.but the received is %d",
-                  round_type));
-        })
-        .AsExtra();
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
                   "for training. Some layers may run faster when this is true.")
@@ -628,24 +592,6 @@ class FakeChannelWiseQuantizeDequantizeAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<int>(
-        "round_type",
-        "(int, default 1) The round type of fp32 to int."
-        "0: rounding to nearest ties to even. Eg: round(1.5)=2, round(2.5)=2"
-        "1: rounding to nearest ties away from zero. Eg: round(1.5)=2, "
-        "round(2.5)=3")
-        .SetDefault(1)
-        .AddCustomChecker([](const int &round_type) {
-          PADDLE_ENFORCE_EQ(
-              round_type == 0 || round_type == 1,
-              true,
-              platform::errors::InvalidArgument(
-                  "'round_type' should be 0 or 1, 0 rounding to "
-                  "nearest ties to even and 1 is rounding to nearest "
-                  "ties away from zero.but the received is %d",
-                  round_type));
-        })
-        .AsExtra();
     AddComment(R"DOC(
 The scale of FakeChannelWiseQuantize operator is a vector.
 In detail, each channel of the input X has a scale value.
@@ -715,24 +661,6 @@ class FakeQuantizeRangeAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<int>(
-        "round_type",
-        "(int, default 1) The round type of fp32 to int."
-        "0: rounding to nearest ties to even. Eg: round(1.5)=2, round(2.5)=2"
-        "1: rounding to nearest ties away from zero. Eg: round(1.5)=2, "
-        "round(2.5)=3")
-        .SetDefault(1)
-        .AddCustomChecker([](const int &round_type) {
-          PADDLE_ENFORCE_EQ(
-              round_type == 0 || round_type == 1,
-              true,
-              platform::errors::InvalidArgument(
-                  "'round_type' should be 0 or 1, 0 rounding to "
-                  "nearest ties to even and 1 is rounding to nearest "
-                  "ties away from zero.but the received is %d",
-                  round_type));
-        })
-        .AsExtra();
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
                   "for training. Some layers may run faster when this is true.")
@@ -815,24 +743,6 @@ class FakeQuantOrWithDequantMovingAverageAbsMaxOpMaker
                                 "the received is %d",
                                 bit_length));
         });
-    AddAttr<int>(
-        "round_type",
-        "(int, default 1) The round type of fp32 to int."
-        "0: rounding to nearest ties to even. Eg: round(1.5)=2, round(2.5)=2"
-        "1: rounding to nearest ties away from zero. Eg: round(1.5)=2, "
-        "round(2.5)=3")
-        .SetDefault(1)
-        .AddCustomChecker([](const int &round_type) {
-          PADDLE_ENFORCE_EQ(
-              round_type == 0 || round_type == 1,
-              true,
-              platform::errors::InvalidArgument(
-                  "'round_type' should be 0 or 1, 0 rounding to "
-                  "nearest ties to even and 1 is rounding to nearest "
-                  "ties away from zero.but the received is %d",
-                  round_type));
-        })
-        .AsExtra();
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
                   "for training. Some layers may run faster when this is true.")

--- a/paddle/fluid/operators/lookup_table_v2_op.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op.cc
@@ -84,46 +84,12 @@ class LookupTableV2OpMaker : public framework::OpProtoAndCheckerMaker {
              "An input with type int64 "
              "contains the ids to be looked up in W.");
     AddOutput("Out", "The lookup results, which have the same type as W.");
-    AddAttr<bool>("is_sparse",
-                  "(boolean, default false) "
-                  "Sparse update.")
-        .SetDefault(false)
-        .AsExtra();
-    AddAttr<bool>("is_distributed",
-                  "(boolean, default false) distributed lookup table.")
-        .SetDefault(false)
-        .AsExtra();
     AddAttr<int64_t>("padding_idx",
                      "(int64, default -1) "
                      "If the value is -1, it makes no effect to lookup. "
                      "Otherwise the given value indicates padding the output "
                      "with zeros whenever lookup encounters it in Ids.")
         .SetDefault(kNoPadding);
-
-    // for parameter prefetch
-    AddAttr<bool>("remote_prefetch", "").SetDefault(false).AsExtra();
-    AddAttr<int>("trainer_id", "trainer id from 0 ~ worker_num.")
-        .SetDefault(0)
-        .AsExtra();
-    AddAttr<int>("slot", "slot of id").SetDefault(0).AsExtra();
-    AddAttr<std::vector<int64_t>>("height_sections",
-                                  "Height for each output SelectedRows.")
-        .SetDefault(std::vector<int64_t>({}))
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "epmap",
-        "(string vector, default 127.0.0.1:6164)"
-        "Server endpoints in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "table_names",
-        "(string vector, the split table names that will be fetched from "
-        "parameter server)"
-        "in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-
     AddComment(R"DOC(
 Lookup Table V2 Operator.
 

--- a/paddle/fluid/operators/nce_op.cc
+++ b/paddle/fluid/operators/nce_op.cc
@@ -207,34 +207,6 @@ class NCEOpMaker : public framework::OpProtoAndCheckerMaker {
 
     // for parameter prefetch
     AddAttr<bool>("remote_prefetch", "").SetDefault(false);
-    AddAttr<int>("trainer_id", "trainer id from 0 ~ worker_num.")
-        .SetDefault(0)
-        .AsExtra();
-    AddAttr<std::vector<int64_t>>("height_sections",
-                                  "Height for each output SelectedRows.")
-        .SetDefault(std::vector<int64_t>({}))
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "epmap",
-        "(string vector, default 127.0.0.1:6164)"
-        "Server endpoints in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-    AddAttr<std::vector<std::string>>(
-        "table_names",
-        "(string vector, the split table names that will be fetched from "
-        "parameter server)"
-        "in the order of input variables for mapping")
-        .SetDefault({})
-        .AsExtra();
-
-    AddAttr<std::vector<int>>("custom_neg_classes",
-                              "This attribute only be used in unitest. Classes "
-                              "in this list wiil be used as negative classes "
-                              "for every samples. Under normal conditions, "
-                              "user should avoid setting this attribute.")
-        .SetDefault({})
-        .AsExtra();
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference "
                   "only, false for training.")

--- a/paddle/fluid/operators/pscore/distributed_push_sparse_op.cc
+++ b/paddle/fluid/operators/pscore/distributed_push_sparse_op.cc
@@ -113,11 +113,6 @@ class DistributedPushSparseOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("use_cvm_op", "(boolean, default false) Use cvm op or not.")
         .SetDefault(false);
 
-    AddAttr<std::vector<int>>("slots",
-                              "[slot_id1, slot_id2] Slots array of Ids.")
-        .SetDefault({})
-        .AsExtra();
-
     AddComment(R"DOC(
 Lookup Tablel Prefetch Operator.
 This operator is used to perform lookup on parameter W,

--- a/paddle/fluid/operators/quantize_linear_op.cc
+++ b/paddle/fluid/operators/quantize_linear_op.cc
@@ -134,10 +134,6 @@ class QuantizeLinearOpMaker : public framework::OpProtoAndCheckerMaker {
     AddOutput("OutScale", "(Tensor) Current scale")
         .AsDispensable()
         .AsExtra();  // only qat use
-    AddAttr<float>("moving_rate",
-                   "(float, default 0.9) moving rate.")  // only qat use
-        .SetDefault(0.9)
-        .AsExtra();
     AddAttr<int>("quant_axis",
                  "(int, default 0) The axis for quantization. "
                  "For conv2d, depthwise_conv2d, conv2d_transpose "

--- a/paddle/fluid/operators/sequence_ops/sequence_softmax_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_softmax_op.cc
@@ -73,14 +73,6 @@ class SequenceSoftmaxOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) Only used in cudnn kernel, need install cudnn")
         .SetDefault(false)
         .AsExtra();
-    AddAttr<std::string>(
-        "data_format",
-        "(string, default NCHW) Only used in "
-        "An optional string from: \"NHWC\", \"NCHW\". "
-        "Defaults to \"NHWC\". Specify the data format of the output data, "
-        "the input will be transformed automatically. ")
-        .SetDefault("AnyLayout")
-        .AsExtra();
     AddComment(R"DOC(
 Sequence Softmax Operator.
 

--- a/paddle/phi/api/yaml/generator/ops_extra_info_gen.py
+++ b/paddle/phi/api/yaml/generator/ops_extra_info_gen.py
@@ -59,7 +59,7 @@ ATTR_TYPE_STRING_MAP = {
 
 def parse_attr(attr_str):
     result = re.search(
-        r"(?P<attr_type>[a-z[\]]+)\s+(?P<name>[a-zA-Z0-9_]+)\s*=\s*(?P<default_val>\S+)",
+        r"(?P<attr_type>[a-zA-Z0-9_[\]]+)\s+(?P<name>[a-zA-Z0-9_]+)\s*=\s*(?P<default_val>\S+)",
         attr_str)
     return ATTR_TYPE_STRING_MAP[result.group('attr_type')], result.group(
         'name'), result.group('default_val')

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -237,6 +237,13 @@
   extra :
     attrs : [bool use_mkldnn = false]
 
+- op : embedding (lookup_table_v2)
+  backward : embedding_grad (lookup_table_v2_grad)
+  extra :
+    attrs : [bool is_sparse = false, bool is_distributed = false, bool remote_prefetch = false,
+             int trainer_id = 0, int slot = 0, 'int64_t[] height_sections = {}', 'str[] epmap = {}',
+             'str[] table_names = {}']
+
 - op : erf
   inputs :
     x : X

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -179,6 +179,10 @@
              str fuse_activation = "", float fuse_alpha = 0.0f, float fuse_beta = 0.0f,
              int workspace_size_MB = platform::GetDefaultConvWorkspaceSizeLimitMB()]
 
+- op : dequantize_linear
+  extra :
+    attrs : [float moving_rate = 0.9]
+
 - op : diag (diag_v2)
   backward : diag_grad (diag_v2_grad)
   inputs :
@@ -275,6 +279,34 @@
   backward : expm1_grad
   extra :
     attrs : [bool use_mkldnn = false, bool use_cudnn = false]
+
+- op : fake_channel_wise_quantize_abs_max
+  extra :
+    attrs : [int round_type = 1]
+
+- op : fake_channel_wise_quantize_dequantize_abs_max
+  extra :
+    attrs : [int round_type = 1]
+
+- op : fake_quantize_abs_max
+  extra :
+    attrs : [int round_type = 1]
+
+- op : fake_quantize_dequantize_abs_max
+  extra :
+    attrs : [int round_type = 1]
+
+- op : fake_quantize_dequantize_moving_average_abs_max
+  extra :
+    attrs : [int round_type = 1]
+
+- op : fake_quantize_moving_average_abs_max
+  extra :
+    attrs : [int round_type = 1]
+
+- op : fake_quantize_range_abs_max
+  extra :
+    attrs : [int round_type = 1]
 
 - op : fft_c2c
   inputs: {x: X}
@@ -520,6 +552,10 @@
   backward : prelu_grad
   extra :
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool is_test = false]
+
+- op : quantize_linear
+  extra :
+    attrs : [float moving_rate = 0.9]
 
 - op : reciprocal
   backward : reciprocal_grad

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -93,6 +93,11 @@
   extra :
     attrs : [bool use_mkldnn = false, bool use_quantizer = false, str mkldnn_data_type = "float32"]
 
+- op : conditional_block
+  backward : conditional_block_grad
+  extra :
+    attrs : ['str[] skip_eager_deletion_vars = {}']
+
 - op : conv2d
   backward : conv2d_grad
   extra :
@@ -504,11 +509,6 @@
   extra :
     attrs : [bool use_mkldnn = false]
 
-- op : pool3d
-  backward : pool3d_grad
-  extra :
-    attrs : [bool use_mkldnn = false]
-
 - op : prelu
   backward : prelu_grad
   extra :
@@ -750,3 +750,8 @@
     x : X
   outputs :
     out : Out
+
+- op : while
+  backward : while_grad
+  extra :
+    attrs : ['str[] skip_eager_deletion_vars = {}']

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -632,6 +632,11 @@
   extra :
     attrs : [bool deterministic = false, str rng_name = "", bool force_cpu = false]
 
+- op : sequence_softmax
+  backward : sequence_softmax_grad
+  extra :
+    attrs : [str data_format = "AnyLayout"]
+
 - op : shape
   extra :
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -208,6 +208,10 @@
   outputs :
     out : Out
 
+- op : distributed_push_sparse
+  extra :
+    attrs : ['int[] slots = {}']
+
 - op : divide (elementwise_div)
   backward : divide_grad (elementwise_div)
   extra :
@@ -484,6 +488,12 @@
     {x : X, vec : Vec}
   outputs :
     out : Out
+
+- op : nce
+  backward : nce_grad
+  extra :
+    attrs : [int trainer_id = 0, 'int64_t[] height_sections = {}', 'str[] epmap = {}',
+             'str[] table_names = {}', 'int[] custom_neg_classes = {}']
 
 - op : nearest_interp (nearest_interp_v2)
   backward : nearest_interp_grad (nearest_interp_v2_grad)

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -254,6 +254,11 @@
   extra :
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
 
+- op : expand (expand_v2)
+  backward : expand_grad (expand_v2_grad)
+  extra :
+    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
+
 - op : expm1
   backward : expm1_grad
   extra :
@@ -301,6 +306,15 @@
 - op : full (fill_constant)
   extra :
     attrs : [bool use_mkldnn = false]
+
+- op : full (fill_constant)
+  extra :
+    attrs : [bool use_mkldnn = false]
+
+- op : gather
+  backward : gather_grad
+  extra :
+    attrs : [bool overwrite = true]
 
 - op : gather
   backward : gather_grad
@@ -412,6 +426,12 @@
     attrs : [bool use_mkldnn = false, float scale_x = 1.0f, 'float[] scale_y = {1.0f}',
              float scale_out = 1.0f, bool force_fp32_output = false]
 
+- op : matmul_with_flatten (mul)
+  backward : matmul_with_flatten_grad (mul_grad)
+  extra :
+    attrs : [bool use_mkldnn = false, float scale_x = 1.0f, 'float[] scale_y = {1.0f}',
+             float scale_out = 1.0f, bool force_fp32_output = false]
+
 - op : maximum (elementwise_max)
   backward : maximum_grad (elementwise_max_grad)
   extra :
@@ -472,6 +492,17 @@
   extra :
     attrs : [bool use_mkldnn = false, bool use_quantizer = false,
               str mkldnn_data_type = "float32", bool is_test = false]
+
+- op : pool2d
+  backward : pool2d_grad
+  extra :
+    attrs : [bool use_mkldnn = false, bool use_quantizer = false,
+              str mkldnn_data_type = "float32", bool is_test = false]
+
+- op : pool3d
+  backward : pool3d_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
 
 - op : pool3d
   backward : pool3d_grad
@@ -655,6 +686,11 @@
   extra :
     attrs : [bool use_mkldnn = false]
 
+- op : stack
+  backward : stack_grad
+  extra :
+    attrs : [bool use_mkldnn = false]
+
 - op : subtract (elementwise_sub)
   backward : subtract_grad (elementwise_sub_grad)
   extra :
@@ -691,6 +727,12 @@
     x : Input
   outputs :
     out : Out
+
+- op : transpose (transpose2)
+  backward : transpose_grad (transpose2_grad)
+  extra :
+    attrs : [bool use_mkldnn = false, str data_format = "AnyLayout", bool use_quantizer = false,
+              str mkldnn_data_type = "float32"]
 
 - op : transpose (transpose2)
   backward : transpose_grad (transpose2_grad)

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -270,11 +270,6 @@
   extra :
     attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
 
-- op : expand (expand_v2)
-  backward : expand_grad (expand_v2_grad)
-  extra :
-    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32"]
-
 - op : expm1
   backward : expm1_grad
   extra :
@@ -350,15 +345,6 @@
 - op : full (fill_constant)
   extra :
     attrs : [bool use_mkldnn = false]
-
-- op : full (fill_constant)
-  extra :
-    attrs : [bool use_mkldnn = false]
-
-- op : gather
-  backward : gather_grad
-  extra :
-    attrs : [bool overwrite = true]
 
 - op : gather
   backward : gather_grad
@@ -470,12 +456,6 @@
     attrs : [bool use_mkldnn = false, float scale_x = 1.0f, 'float[] scale_y = {1.0f}',
              float scale_out = 1.0f, bool force_fp32_output = false]
 
-- op : matmul_with_flatten (mul)
-  backward : matmul_with_flatten_grad (mul_grad)
-  extra :
-    attrs : [bool use_mkldnn = false, float scale_x = 1.0f, 'float[] scale_y = {1.0f}',
-             float scale_out = 1.0f, bool force_fp32_output = false]
-
 - op : maximum (elementwise_max)
   backward : maximum_grad (elementwise_max_grad)
   extra :
@@ -530,12 +510,6 @@
     x : X
   outputs :
     out : Out
-
-- op : pool2d
-  backward : pool2d_grad
-  extra :
-    attrs : [bool use_mkldnn = false, bool use_quantizer = false,
-              str mkldnn_data_type = "float32", bool is_test = false]
 
 - op : pool2d
   backward : pool2d_grad
@@ -724,16 +698,6 @@
   extra :
     attrs : [bool use_mkldnn = false]
 
-- op : stack
-  backward : stack_grad
-  extra :
-    attrs : [bool use_mkldnn = false]
-
-- op : stack
-  backward : stack_grad
-  extra :
-    attrs : [bool use_mkldnn = false]
-
 - op : subtract (elementwise_sub)
   backward : subtract_grad (elementwise_sub_grad)
   extra :
@@ -770,12 +734,6 @@
     x : Input
   outputs :
     out : Out
-
-- op : transpose (transpose2)
-  backward : transpose_grad (transpose2_grad)
-  extra :
-    attrs : [bool use_mkldnn = false, str data_format = "AnyLayout", bool use_quantizer = false,
-              str mkldnn_data_type = "float32"]
 
 - op : transpose (transpose2)
   backward : transpose_grad (transpose2_grad)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
清理以下算子OpMaker的Extra属性：
`while`, `conditional_block`, `distributed_push_sparse`, `nce`,`lookup_table_v2 `和`quantize`相关算子。