### PR TITLE
fix: test_eager_guard won't restore in_eager_mode when exited

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -246,12 +246,13 @@ def _test_eager_guard(place=None):
     # FIXME(dev): We haven't fully verified eager mode on NPU et.al but
     # only GPU/CPU/XPU. Remove this after we improve this feature.
     already_fallback = _fallback_legacy_dygraph()
-    if not already_fallback:
+    original_legacy_state = _in_legacy_dygraph()
+    if not already_fallback and not original_legacy_state:
         _disable_legacy_dygraph()
     try:
         yield
     finally:
-        if not already_fallback:
+        if not already_fallback and not original_legacy_state:
             _enable_legacy_dygraph()
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
When `_test_eager_guard` exits, it will set `_in_eager_mode_` to `false` whatever it was before `_test_eager_guard` enters when `already_fallback` is satisfied. This is not what we expected a `guard` does.
A Testcase is shown below:

```
  import unittest
  import numpy as np
  
  import paddle
  import paddle.fluid.core as core
  import paddle.fluid as fluid
  from paddle.fluid.framework import Program, program_guard, in_dygraph_mode, _in_legacy_dygraph, _test_eager_guard
  from op_test import OpTest
  
  class TestEagerGuard(OpTest):
      def setUp(self):
          paddle.disable_static()
          assert in_dygraph_mode() == True
  
          self.op_type = "exp"
          self.dtype = np.float64
          self.check_eager = True
          self.python_api = paddle.exp
  
          np.random.seed(2049)
          x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
          out = np.exp(x)
  
          self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
          self.outputs = {'Out': out}
  
          self.__class__.no_need_check_grad = True
  
      def test_check_output_with_eager(self):
          assert in_dygraph_mode() == True
          assert _in_legacy_dygraph() == False
  
          paddle.enable_static()
          self.check_output()
          paddle.disable_static()
  
          assert in_dygraph_mode() == True
          assert _in_legacy_dygraph() == False
          
          paddle.enable_static()
          self.check_output(check_eager=True)
          paddle.disable_static()
  
          assert in_dygraph_mode() == False # Not expected
          assert _in_legacy_dygraph() == True # Not expected
      
      # cannot run with the testcase above simultaneously because of side effect
      # comment one before run
      def test_test_eager_guard(self):
          self.__class__.op_type = self.op_type
  
          assert in_dygraph_mode() == True
          assert _in_legacy_dygraph() == False
          
          with _test_eager_guard():
              pass
          assert in_dygraph_mode() == False # Not expected
          assert _in_legacy_dygraph() == True # Not expected
          
  if __name__ == '__main__':
      unittest.main()
```
Potential Problem:
1. may cause some unit tests run in legacy dynamic graph mode unexpectedly.