### PR TITLE
[Paddle-Inference] Fix nvcc_lazy compile error.

### DIFF
--- a/tools/nvcc_lazy.sh
+++ b/tools/nvcc_lazy.sh
@@ -18,6 +18,11 @@ echo "#!/usr/bin/env bash" >> $1
 echo "unset GREP_OPTIONS" >> $1
 echo "set -e" >> $1
 echo -e >> $1 
+echo "if [[ \$# -le 8 ]]; then" >> $1
+echo "  nvcc \"\$@\"" >> $1
+echo "  exit 0" >> $1
+echo "fi" >> $1
+echo -e >> $1
 echo "# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved." >> $1
 echo "#" >> $1
 echo "# Licensed under the Apache License, Version 2.0 (the \"License\");" >> $1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix nvcc_lazy compile error
在预编译阶段，将无法通过nvcc_lazy运行的部分转换为nvcc运行