### PR TITLE
[cherry-pick] Open the clip_extra flag in save_inference_model

### DIFF
--- a/paddle/fluid/operators/rnn_op.cc
+++ b/paddle/fluid/operators/rnn_op.cc
@@ -103,6 +103,9 @@ class RNNOpMaker : public framework::OpProtoAndCheckerMaker {
         "mode",
         "(string) rnn types, including: LSTM, GRU, RNN_RELU, RNN_TANH.");
     AddAttr<int>("seed", "seed to used if fix_seed is True").SetDefault(0);
+    AddAttr<bool>("is_test", "True if in test phase.")
+        .SetDefault(false)
+        .AsExtra();
     AddComment(R"DOC(
 )DOC");
   }

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -1,3 +1,8 @@
+# - op : rnn
+#   backward : rnn_grad
+#   extra :
+#     attrs : [bool is_test = false]
+
 - op : abs
   backward : abs_grad
   extra :
@@ -550,11 +555,6 @@
   backward : renorm_grad
   extra :
     attrs : [bool use_mkldnn = false, bool use_cudnn = false]
-
-- op : rnn
-  backward : rnn_grad
-  extra :
-    attrs : [bool is_test = false]
 
 - op : round
   backward : round_grad

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -397,7 +397,7 @@ def _parse_save_configs(configs):
     inner_config.output_spec = configs.get('output_spec', None)
     inner_config.with_hook = configs.get('with_hook', False)
     inner_config.combine_params = configs.get("combine_params", False)
-    inner_config.clip_extra = configs.get("clip_extra", False)
+    inner_config.clip_extra = configs.get("clip_extra", True)
     inner_config.skip_forward = configs.get("skip_forward", False)
 
     return inner_config

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -1650,7 +1650,7 @@ class TracedLayer(object):
                 check_type(
                     f, "each element of fetch", int,
                     "fluid.dygraph.jit.TracedLayer.save_inference_model")
-        clip_extra = kwargs.get('clip_extra', False)
+        clip_extra = kwargs.get('clip_extra', True)
         # path check
         file_prefix = os.path.basename(path)
         if file_prefix == "":

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5867,9 +5867,7 @@ class Program(object):
 
         # Note: The op_role and op_role_var cann't be deleted currently,
         # and we will try to remove them in the future.
-        common_clipped_attrs_list = [
-            'op_namescope', 'op_callstack', 'op_device', 'with_quant_attr'
-        ]
+        common_clipped_attrs_list = ['op_callstack', 'with_quant_attr']
 
         for i in six.moves.range(res.desc.num_blocks()):
             block = res.desc.block(i)
@@ -5898,8 +5896,9 @@ class Program(object):
                         break
                     if not find:
                         remove_input_list.append(name)
-                for name in remove_input_list:
-                    op.remove_input(name)
+                # The extra input of op will be removed in the future
+                # for name in remove_input_list:
+                #     op.remove_input(name)
 
                 remove_output_list = []
                 for name in op.output_names():
@@ -5913,10 +5912,10 @@ class Program(object):
                         break
                     if not find:
                         remove_output_list.append(name)
-                for name in remove_output_list:
-                    op.remove_output(name)
+                # The extra output of op will be removed in the future
+                # for name in remove_output_list:
+                #     op.remove_output(name)
 
-                remove_attr_list = []
                 op_quant_name = core.op_proto_and_checker_maker.kOpWithQuantAttrName(
                 )
                 quant = bool(op.attr(op_quant_name)
@@ -5926,6 +5925,7 @@ class Program(object):
                     "activation_bits", "bit_length", "quantize_weight_bits",
                     "weight_quant_scale"
                 ]
+                remove_attr_list = []
                 for name in op.attr_names():
                     if quant:
                         if name in quant_attrs:
@@ -5940,8 +5940,6 @@ class Program(object):
                     for attr_proto in proto.attrs:
                         if attr_proto.name != name:
                             continue
-                        if attr_proto.extra:
-                            remove_attr_list.append(name)
                         find = True
                         break
                     if not find:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5925,6 +5925,8 @@ class Program(object):
                     "activation_bits", "bit_length", "quantize_weight_bits",
                     "weight_quant_scale"
                 ]
+                for extra_attr_name in extra_attrs_map.keys():
+                    op.remove_attr(extra_attr_name)
                 remove_attr_list = []
                 for name in op.attr_names():
                     if quant:
@@ -5933,7 +5935,7 @@ class Program(object):
                         if name.endswith("_threshold"):
                             continue
                     if len(extra_attrs_map) > 0:
-                        if name in extra_attrs_map or name in common_clipped_attrs_list:
+                        if name in common_clipped_attrs_list:
                             op.remove_attr(name)
                         continue
                     find = False

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1232,7 +1232,7 @@ def save_inference_model(dirname,
                          params_filename=None,
                          export_for_deployment=True,
                          program_only=False,
-                         clip_extra=False):
+                         clip_extra=True):
     """
     Prune the given `main_program` to build a new program especially for inference,
     and then save it and all related parameters to given `dirname` .

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -534,7 +534,7 @@ def save_inference_model(path_prefix, feed_vars, fetch_vars, executor,
     _check_vars('fetch_vars', fetch_vars)
 
     program = _get_valid_program(kwargs.get('program', None))
-    clip_extra = kwargs.get('clip_extra', False)
+    clip_extra = kwargs.get('clip_extra', True)
     program = normalize_program(program, feed_vars, fetch_vars)
     # serialize and save program
     program_bytes = _serialize_program(

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -454,8 +454,6 @@ def save_to_file(path, content):
 def save_inference_model(path_prefix, feed_vars, fetch_vars, executor,
                          **kwargs):
     """
-    :api_attr: Static Graph
-
     Save current model and its parameters to given path. i.e.
     Given path_prefix = "/path/to/modelname", after invoking
     save_inference_model(path_prefix, feed_vars, fetch_vars, executor),
@@ -472,7 +470,7 @@ def save_inference_model(path_prefix, feed_vars, fetch_vars, executor,
 
             - program(Program): specify a program if you don't want to use default main program.
 
-            - clip_extra(bool): set to True if you want to clip extra information for every operator.
+            - clip_extra(bool): the flag indicating whether to clip extra information for every operator. Default: True.
 
     Returns:
         None


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
将`paddle.static.save_inference_model`,`fluid.io.save_inference_model`,`paddle.jit.save`和`TracedLayer.save_inference_model`中的`clip_extra`参数默认值修改为True。

使用上述接口保存模型Program时将默认开启Extra类型参数的裁剪。

相关PR：
[PR46151](https://github.com/PaddlePaddle/Paddle/pull/46151), [PR46456](https://github.com/PaddlePaddle/Paddle/pull/46456), [PR46473](https://github.com/PaddlePaddle/Paddle/pull/46473), [PR46484](https://github.com/PaddlePaddle/Paddle/pull/46484), [PR46534](https://github.com/PaddlePaddle/Paddle/pull/46534)