### PR TITLE
fix mpi include bug

### DIFF
--- a/paddle/fluid/distributed/collective/ProcessGroupMPI.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupMPI.cc
@@ -15,7 +15,6 @@
 #include "paddle/fluid/distributed/collective/ProcessGroupMPI.h"
 #include <chrono>
 #include "paddle/fluid/distributed/collective/Common.h"
-#include "paddle/fluid/platform/cuda_device_guard.h"
 
 constexpr int64_t kWaitBlockTImeout = 10;
 namespace paddle {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
`ProcessGoupMPI.cc` include了多余的头文件["paddle/fluid/platform/cuda_device_guard.h"](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/distributed/collective/ProcessGroupMPI.cc#L18-L18)。当WITH_GPU=OFF, WITH_MPI=ON时会编译出错。因为[cuda_device_guard.h](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/platform/cuda_device_guard.h#L34-L34)依赖[gpu_info.h中的SetDeviceId](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/platform/device/gpu/gpu_info.h#L66-L66)，但是`SetDeviceId`需要在`WITH_GPU=ON`时才能被编译到library中。