### PR TITLE
[AutoParallel] fix reshard when train with eval

### DIFF
--- a/python/paddle/distributed/auto_parallel/reshard.py
+++ b/python/paddle/distributed/auto_parallel/reshard.py
@@ -1727,6 +1727,7 @@ class Resharder:
     def _remove_global_process_mesh(self):
         """Remove global process mesh from dist_context.process_meshes"""
         processes = set()
+        counts = 0
         process_mesh_count = len(self.dist_context.process_meshes)
         if process_mesh_count > 1:
             global_process_mesh_idx = None
@@ -1737,8 +1738,8 @@ class Resharder:
                     self.dist_context.process_meshes):
                 if len(set(process_mesh.processes)) == len(processes):
                     global_process_mesh_idx = idx
-                    break
-            if global_process_mesh_idx is not None:
+                    counts += 1
+            if counts == 1 and global_process_mesh_idx is not None:
                 self.dist_context.process_meshes.pop(idx)
 
     def _change_subblock_op_input_and_output(self, block_idx, block):

--- a/python/paddle/distributed/auto_parallel/reshard.py
+++ b/python/paddle/distributed/auto_parallel/reshard.py
@@ -1727,7 +1727,6 @@ class Resharder:
     def _remove_global_process_mesh(self):
         """Remove global process mesh from dist_context.process_meshes"""
         processes = set()
-        counts = 0
         process_mesh_count = len(self.dist_context.process_meshes)
         if process_mesh_count > 1:
             global_process_mesh_idx = None
@@ -1738,9 +1737,19 @@ class Resharder:
                     self.dist_context.process_meshes):
                 if len(set(process_mesh.processes)) == len(processes):
                     global_process_mesh_idx = idx
-                    counts += 1
-            if counts == 1 and global_process_mesh_idx is not None:
-                self.dist_context.process_meshes.pop(idx)
+                    break
+
+            if global_process_mesh_idx is not None:
+                is_removed = False
+                global_mesh = self.dist_context.process_meshes[idx]
+                for i, mesh in enumerate(self.dist_context.process_meshes):
+                    if i == idx:
+                        continue
+                    if set(mesh.processes) < set(global_mesh.processes):
+                        is_removed = True
+
+                if is_removed:
+                    self.dist_context.process_meshes.pop(idx)
 
     def _change_subblock_op_input_and_output(self, block_idx, block):
         if "var_reshard_mapping" in Resharder.while_block_info[block_idx]:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 修复在 dpmp + 边训边eval的场景下，reshard 会删除 process_mesh 的操作