### PR TITLE
Requantize to use Memory Desc in Tensors

### DIFF
--- a/paddle/fluid/framework/data_layout_transform.cc
+++ b/paddle/fluid/framework/data_layout_transform.cc
@@ -201,8 +201,6 @@ void innerTransDataLayoutFromMKLDNN(DataLayout in_layout,
   platform::MatchShapeToLayout(out, in_layout, out_layout);
 
   out->set_layout(DataLayout::kNCHW);
-  // reset format since the out tensor will be feed to non-MKLDNN OPkernel
-  out->set_format(MKLDNNMemoryFormat::undef);
 }
 #endif
 

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -467,7 +467,9 @@ void TensorCopySync(const Tensor& src,
   dst->Resize(src.dims());
   dst->set_layout(src.layout());
 #ifdef PADDLE_WITH_MKLDNN
-  dst->set_format(src.format());
+  if (src.layout() == DataLayout::kMKLDNN ) {
+    dst->set_mem_desc(src.mem_desc());
+  }
 #endif
   auto src_place = src.place();
   auto src_ptr = src.data();

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -467,7 +467,7 @@ void TensorCopySync(const Tensor& src,
   dst->Resize(src.dims());
   dst->set_layout(src.layout());
 #ifdef PADDLE_WITH_MKLDNN
-  if (src.layout() == DataLayout::kMKLDNN ) {
+  if (src.layout() == DataLayout::kMKLDNN) {
     dst->set_mem_desc(src.mem_desc());
   }
 #endif

--- a/paddle/fluid/operators/mkldnn/requantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/requantize_mkldnn_op.cc
@@ -146,7 +146,7 @@ class ReQuantOpKernel : public framework::OpKernel<T> {
     reorder_p->execute(astream, *src_memory, *dst_memory);
     astream.wait();
 
-    output->set_mem_desc(dst_memory_p->get_desc());
+    output->set_mem_desc(dst_memory->get_desc());
   }
 };
 

--- a/paddle/fluid/operators/mkldnn/requantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/requantize_mkldnn_op.cc
@@ -146,8 +146,7 @@ class ReQuantOpKernel : public framework::OpKernel<T> {
     reorder_p->execute(astream, *src_memory, *dst_memory);
     astream.wait();
 
-    output->set_layout(framework::DataLayout::kMKLDNN);
-    output->set_format(platform::GetMKLDNNFormat(*dst_memory));
+    output->set_mem_desc(dst_memory_p->get_desc());
   }
 };
 

--- a/paddle/fluid/operators/transfer_layout_op.h
+++ b/paddle/fluid/operators/transfer_layout_op.h
@@ -95,7 +95,8 @@ class TransferLayoutFunctor {
         }
 
         auto out_tz = phi::vectorize<int64_t>(out_tensor.dims());
-        dnnl::memory::data_type in_type = ToMKLDNNDataType(framework::TransToProtoVarType(in_tensor.dtype()));
+        dnnl::memory::data_type in_type =
+            ToMKLDNNDataType(framework::TransToProtoVarType(in_tensor.dtype()));
 
         dnnl::memory::desc out_mem_desc(out_tz, in_type, out_format);
         out_tensor.set_mem_desc(out_mem_desc);

--- a/paddle/fluid/operators/transfer_layout_op.h
+++ b/paddle/fluid/operators/transfer_layout_op.h
@@ -93,8 +93,12 @@ class TransferLayoutFunctor {
           paddle::platform::MKLDNNDeviceContext::tls()
               .set_cur_paddle_data_layout(in_layout);
         }
-        out_tensor.set_layout(DataLayout::kMKLDNN);
-        out_tensor.set_format(out_format);
+
+        auto out_tz = phi::vectorize<int64_t>(out_tensor.dims());
+        dnnl::memory::data_type in_type = ToMKLDNNDataType(framework::TransToProtoVarType(in_tensor.dtype()));
+
+        dnnl::memory::desc out_mem_desc(out_tz, in_type, out_format);
+        out_tensor.set_mem_desc(out_mem_desc);
       } else {
         auto target_layout = paddle::platform::MKLDNNDeviceContext::tls()
                                  .get_cur_paddle_data_layout();
@@ -137,7 +141,7 @@ class TransferLayoutFunctor {
             in.dims()));
 
     auto src_dim = in.dims();
-    std::vector<int64_t> dst_dim;
+    std::_tensorvector<int64_t> dst_dim;
 
     auto axis = framework::GetAxis(in.layout(), out->layout());
     dst_dim.resize(axis.size());

--- a/paddle/fluid/operators/transfer_layout_op.h
+++ b/paddle/fluid/operators/transfer_layout_op.h
@@ -95,7 +95,7 @@ class TransferLayoutFunctor {
         }
 
         auto out_tz = phi::vectorize<int64_t>(out_tensor.dims());
-        dnnl::memory::data_type in_type = phi::funcs::ToOneDNNDataType(
+        dnnl::memory::data_type in_type = framework::ToMKLDNNDataType(
             framework::TransToProtoVarType(in_tensor.dtype()));
 
         dnnl::memory::desc out_mem_desc(out_tz, in_type, out_format);

--- a/paddle/fluid/operators/transfer_layout_op.h
+++ b/paddle/fluid/operators/transfer_layout_op.h
@@ -95,8 +95,8 @@ class TransferLayoutFunctor {
         }
 
         auto out_tz = phi::vectorize<int64_t>(out_tensor.dims());
-        dnnl::memory::data_type in_type =
-            phi::funcs::ToOneDNNDataType(framework::TransToProtoVarType(in_tensor.dtype()));
+        dnnl::memory::data_type in_type = phi::funcs::ToOneDNNDataType(
+            framework::TransToProtoVarType(in_tensor.dtype()));
 
         dnnl::memory::desc out_mem_desc(out_tz, in_type, out_format);
         out_tensor.set_mem_desc(out_mem_desc);

--- a/paddle/fluid/operators/transfer_layout_op.h
+++ b/paddle/fluid/operators/transfer_layout_op.h
@@ -142,7 +142,7 @@ class TransferLayoutFunctor {
             in.dims()));
 
     auto src_dim = in.dims();
-    std::_tensorvector<int64_t> dst_dim;
+    std::vector<int64_t> dst_dim;
 
     auto axis = framework::GetAxis(in.layout(), out->layout());
     dst_dim.resize(axis.size());

--- a/paddle/fluid/operators/transfer_layout_op.h
+++ b/paddle/fluid/operators/transfer_layout_op.h
@@ -96,7 +96,7 @@ class TransferLayoutFunctor {
 
         auto out_tz = phi::vectorize<int64_t>(out_tensor.dims());
         dnnl::memory::data_type in_type =
-            ToMKLDNNDataType(framework::TransToProtoVarType(in_tensor.dtype()));
+            phi::funcs::ToOneDNNDataType(framework::TransToProtoVarType(in_tensor.dtype()));
 
         dnnl::memory::desc out_mem_desc(out_tz, in_type, out_format);
         out_tensor.set_mem_desc(out_mem_desc);

--- a/paddle/phi/kernels/funcs/data_layout_transform.cc
+++ b/paddle/phi/kernels/funcs/data_layout_transform.cc
@@ -115,8 +115,6 @@ void innerTransDataLayoutFromOneDNN(DataLayout in_layout,
   out->set_layout(DataLayout::kNCHW);
   VLOG(10) << "out->layout: " << out->layout() << " in->dims: " << in.dims()
            << " out->dims: " << out->dims();
-  // reset format since the out tensor will be feed to non-MKLDNN OPkernel
-  out->set_format(OneDNNMemoryFormat::undef);
 }
 
 #endif


### PR DESCRIPTION
### PR types
Others 

### PR changes
OPs 

### Describe
Requantize onednn kernel to use set_mem_desc and similar changes in Tensor Utils.
