### PR TITLE
[CodeStyle][F401] remove unused imports in unittests/collective

### DIFF
--- a/python/paddle/fluid/tests/unittests/collective/collective_allgather_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_allgather_api.py
@@ -12,26 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
 import os
 import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
 import pickle
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 import test_collective_api_base as test_base
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_allgather_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_allgather_api_dygraph.py
@@ -14,7 +14,6 @@
 
 import paddle
 import paddle.fluid as fluid
-import unittest
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_allreduce_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_allreduce_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_allreduce_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_allreduce_api_dygraph.py
@@ -14,7 +14,6 @@
 
 import paddle
 import paddle.fluid as fluid
-import unittest
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_allreduce_new_group_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_allreduce_new_group_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_allreduce_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_allreduce_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_allreduce_op_wait.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_allreduce_op_wait.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_alltoall_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_alltoall_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_alltoall_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_alltoall_api_dygraph.py
@@ -12,25 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_alltoall_single.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_alltoall_single.py
@@ -16,11 +16,7 @@ import unittest
 
 import paddle
 import numpy as np
-import random
 import paddle.distributed as dist
-import paddle.fluid as fluid
-import paddle.distributed.fleet as fleet
-from paddle import framework
 
 
 class TestCollectiveAllToAllSingle(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/collective/collective_barrier_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_barrier_api.py
@@ -12,25 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_batch_isend_irecv.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_batch_isend_irecv.py
@@ -16,11 +16,7 @@ import unittest
 
 import paddle
 import numpy as np
-import random
 import paddle.distributed as dist
-import paddle.fluid as fluid
-import paddle.distributed.fleet as fleet
-from paddle import framework
 
 
 class TestCollectiveBatchIsendIrecv(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/collective/collective_broadcast_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_broadcast_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_broadcast_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_broadcast_api_dygraph.py
@@ -14,7 +14,6 @@
 
 import paddle
 import paddle.fluid as fluid
-import unittest
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_broadcast_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_broadcast_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_concat_op.py
@@ -12,24 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_global_gather.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_global_gather.py
@@ -17,8 +17,6 @@ import os
 import sys
 import paddle
 import paddle.fluid as fluid
-import unittest
-import paddle.fluid.layers as layers
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 import pickle
 from paddle.fluid.framework import _enable_legacy_dygraph

--- a/python/paddle/fluid/tests/unittests/collective/collective_global_gather_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_global_gather_dygraph.py
@@ -14,11 +14,8 @@
 
 import numpy as np
 import os
-import sys
 import paddle
 import paddle.fluid as fluid
-import unittest
-import paddle.fluid.layers as layers
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 import paddle.distributed.utils.moe_utils as moe_utils
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_global_scatter.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_global_scatter.py
@@ -17,8 +17,6 @@ import os
 import sys
 import paddle
 import paddle.fluid as fluid
-import unittest
-import paddle.fluid.layers as layers
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 import pickle
 import paddle.distributed.utils.moe_utils as moe_utils

--- a/python/paddle/fluid/tests/unittests/collective/collective_global_scatter_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_global_scatter_dygraph.py
@@ -14,11 +14,8 @@
 
 import numpy as np
 import os
-import sys
 import paddle
 import paddle.fluid as fluid
-import unittest
-import paddle.fluid.layers as layers
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 import paddle.distributed.utils.moe_utils as moe_utils
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_identity_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_identity_op.py
@@ -12,24 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_isend_irecv_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_isend_irecv_api_dygraph.py
@@ -14,7 +14,6 @@
 
 import paddle
 import paddle.fluid as fluid
-import unittest
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_reduce_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_reduce_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_reduce_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_reduce_api_dygraph.py
@@ -14,7 +14,6 @@
 
 import paddle
 import paddle.fluid as fluid
-import unittest
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_reduce_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_reduce_op_calc_stream.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_reduce_op_calc_stream.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_reduce_scatter.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_reduce_scatter.py
@@ -16,11 +16,7 @@ import unittest
 
 import paddle
 import numpy as np
-import random
 import paddle.distributed as dist
-import paddle.fluid as fluid
-import paddle.distributed.fleet as fleet
-from paddle import framework
 
 
 class TestCollectiveReduceScatter(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/collective/collective_reduce_scatter_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_reduce_scatter_api_dygraph.py
@@ -14,7 +14,6 @@
 
 import paddle
 import paddle.fluid as fluid
-import unittest
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_scatter_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_scatter_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_scatter_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_scatter_api_dygraph.py
@@ -14,7 +14,6 @@
 
 import paddle
 import paddle.fluid as fluid
-import unittest
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_scatter_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_api_dygraph.py
@@ -12,25 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 

--- a/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_op.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_op_array.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_op_array.py
@@ -13,24 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_op_dynamic_shape.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_sendrecv_op_dynamic_shape.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/collective_split_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/collective_split_op.py
@@ -12,24 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/column_parallel_linear_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/column_parallel_linear_api.py
@@ -13,26 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
 import paddle.distributed.fleet as fleet
-from paddle.fluid.incubate.fleet.base import role_maker
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/communication_stream_allreduce_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_stream_allreduce_api_dygraph.py
@@ -15,9 +15,7 @@
 import os
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 import paddle.distributed as dist
-import test_communication_api_base as test_base
 import test_collective_api_base as test_collective_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/communication_stream_sendrecv_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_stream_sendrecv_api_dygraph.py
@@ -16,9 +16,7 @@ import os
 import numpy as np
 import paddle
 import paddle.distributed as dist
-import paddle.fluid as fluid
 import test_collective_api_base as test_collective_base
-import test_communication_api_base as test_base
 
 
 class StreamSendRecvTestCase():

--- a/python/paddle/fluid/tests/unittests/collective/fleet/auto_parallel_parallelizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/auto_parallel_parallelizer.py
@@ -22,7 +22,6 @@ import paddle.utils as utils
 from paddle.fluid import layers
 from paddle.distributed import fleet
 from paddle.distributed.fleet import auto
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 import paddle.fluid.core as core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/c_comm_init_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/c_comm_init_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import os
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.distributed.fleet.base.private_helper_function import wait_server_ready
 import paddle

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import shutil
 import tempfile
 import numpy as np
@@ -21,7 +20,6 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
 from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 from paddle.distributed.sharding import group_sharded_parallel, save_group_sharded_model
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_api_eager.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_api_eager.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-import shutil
 import tempfile
 import numpy as np
 
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
-from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 from paddle.distributed.sharding import group_sharded_parallel, save_group_sharded_model
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2.py
@@ -17,15 +17,10 @@
 import os
 import shutil
 import numpy as np
-import argparse
 import tempfile
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
-from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_stage2 import GroupShardedOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
@@ -17,15 +17,10 @@
 import os
 import shutil
 import numpy as np
-import argparse
 import tempfile
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
-from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_stage2 import GroupShardedOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_offload.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_offload.py
@@ -15,14 +15,7 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid.dygraph.nn import Linear
-from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_stage2 import GroupShardedOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage3.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage3.py
@@ -18,14 +18,9 @@ import os
 import shutil
 import tempfile
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
-from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_stage2 import GroupShardedOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage3_offload.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage3_offload.py
@@ -15,14 +15,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
-from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_stage3 import GroupShardedStage3

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_optimizer_stage2.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_optimizer_stage2.py
@@ -14,11 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage2.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage2.py
@@ -17,15 +17,11 @@
 import os
 import shutil
 import numpy as np
-import argparse
 import tempfile
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
 from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.sharding_optimizer_stage2 import ShardingOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage2_offload.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage2_offload.py
@@ -15,14 +15,8 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid.dygraph.nn import Linear
 from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.sharding_optimizer_stage2 import ShardingOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage3.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage3.py
@@ -18,14 +18,10 @@ import os
 import shutil
 import tempfile
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
 from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.sharding_optimizer_stage2 import ShardingOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage3_offload.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_sharding_stage3_offload.py
@@ -15,14 +15,10 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
 from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_parallel.sharding.sharding_stage3 import ShardingStage3

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_communicate_group.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_communicate_group.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import os
 import paddle
 from paddle.distributed import fleet
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_inference_helper.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_inference_helper.py
@@ -17,12 +17,8 @@ import unittest
 import os
 import paddle
 import numpy as np
-import random
 import paddle.fluid.layers as layers
-import paddle.distributed as dist
-import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle import framework
 from paddle.distributed.fleet.utils.hybrid_parallel_inference import HybridParallelInferenceHelper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_amp.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_amp.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import paddle
-import numpy as np
 from hybrid_parallel_mp_model import TestDistMPTraning
 import paddle.distributed.fleet as fleet
 import unittest

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_clip_grad.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_clip_grad.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 
 import paddle
-import numpy as np
 from hybrid_parallel_mp_model import TestDistMPTraning
 import unittest
-import logging
 
 #log = logging.getLogger("HybridParallel")
 #log.setLevel(logging.WARNING)

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_fp16.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_fp16.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import paddle
-import numpy as np
 from hybrid_parallel_mp_model import TestDistMPTraning
 import paddle.distributed.fleet as fleet
 import unittest

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_layers.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_layers.py
@@ -20,7 +20,6 @@ import random
 import paddle.distributed as dist
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle import framework
 
 
 def set_random_seed(seed):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_model.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_model.py
@@ -18,7 +18,6 @@ import random
 import paddle.distributed as dist
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle.io import DataLoader, Dataset
 import unittest
 
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_random.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_mp_random.py
@@ -16,10 +16,7 @@ import unittest
 
 import paddle
 import numpy as np
-import paddle.distributed as dist
-import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-import random
 
 
 class TestDistTraning(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_pp_layer_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_pp_layer_with_virtual_stage.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
-import os
 import paddle
 from paddle.distributed import fleet
 import paddle.nn as nn

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_pp_save_load.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_pp_save_load.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 import numpy as np
-import random
 import os
 import shutil
 import tempfile

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_pp_save_load_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_pp_save_load_with_virtual_stage.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 import numpy as np
-import random
 import os
 import shutil
 import tempfile

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_qat.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_qat.py
@@ -12,18 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import paddle
 import numpy as np
 import random
 import paddle.distributed as dist
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle.io import DataLoader, Dataset
 import unittest
 import paddle.nn as nn
 from paddle.fluid.contrib.slim.quantization import ImperativeQuantAware
-from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+from paddle.distributed.utils.launch_utils import find_free_ports, get_cluster
 
 
 def set_random_seed(seed, dp_id, rank_id):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_sharding_model.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_sharding_model.py
@@ -18,7 +18,6 @@ import random
 import paddle.distributed as dist
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle.io import DataLoader, Dataset
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import DygraphShardingOptimizer
 import unittest
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_shared_weight.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/hybrid_parallel_shared_weight.py
@@ -19,7 +19,6 @@ import random
 import paddle
 import paddle.distributed as dist
 import paddle.distributed.fleet as fleet
-from paddle.fluid.dygraph.container import Sequential
 from paddle.distributed.fleet.meta_parallel import PipelineLayer
 from paddle.fluid.dygraph.layers import Layer
 import paddle.nn as nn

--- a/python/paddle/fluid/tests/unittests/collective/fleet/new_group.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/new_group.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import os
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_class_center_sample.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_class_center_sample.py
@@ -18,9 +18,7 @@ import paddle
 import numpy as np
 import random
 import paddle.distributed as dist
-import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle import framework
 
 
 def set_random_seed(seed):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_control_flow_different.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_control_flow_different.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import numpy as np
-import paddle.distributed as dist
 
 import paddle
 import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_control_flow_same.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_control_flow_same.py
@@ -12,15 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
-import unittest
 import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
-from paddle.fluid.optimizer import SGDOptimizer
 from paddle.fluid.dygraph.nn import Linear
 from paddle.fluid.dygraph.base import to_variable
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_no_sync.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_no_sync.py
@@ -13,21 +13,13 @@
 # limitations under the License.
 
 import os
-import contextlib
-import unittest
 import numpy as np
-import six
-import pickle
 import random
 
 import paddle
 import paddle.fluid as fluid
 import paddle.distributed as dist
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid.dygraph.parallel import ParallelEnv
-from paddle.fluid import core
 from paddle.fluid.dygraph.nn import Linear
-from paddle.fluid.framework import _test_eager_guard
 from test_dist_base import print_to_err, print_to_out, runtime_main, TestParallelDyGraphRunnerBase
 
 seed = 90

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_no_sync_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_no_sync_control_flow.py
@@ -12,19 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import contextlib
-import unittest
 import numpy as np
-import six
-import pickle
-import random
 
 import paddle
 import paddle.fluid as fluid
-import paddle.distributed as dist
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
 from paddle.fluid.dygraph.nn import Linear
 from test_dist_base import runtime_main
 from parallel_dygraph_no_sync import TestNoSync

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_no_sync_unused_params.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_no_sync_unused_params.py
@@ -12,19 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import contextlib
-import unittest
 import numpy as np
-import six
-import pickle
-import random
 
 import paddle
 import paddle.fluid as fluid
-import paddle.distributed as dist
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
 from paddle.fluid.dygraph.nn import Linear
 from test_dist_base import runtime_main
 from parallel_dygraph_no_sync import TestNoSync

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_se_resnext.py
@@ -12,22 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import contextlib
-import unittest
 import numpy as np
-import six
-import pickle
-import sys
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
-from paddle.fluid.optimizer import SGDOptimizer
-from paddle.fluid.dygraph.nn import Conv2D, Pool2D, Linear, BatchNorm
+from paddle.fluid.dygraph.nn import Conv2D, Linear, Pool2D
 from paddle.fluid.dygraph.base import to_variable
-from paddle.fluid.layer_helper import LayerHelper
 import math
 from test_dist_base import runtime_main, TestParallelDyGraphRunnerBase
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_sync_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_dygraph_sync_batch_norm.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import contextlib
-import unittest
 import numpy as np
-import six
-import pickle
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
-from paddle.fluid.optimizer import SGDOptimizer
-from paddle.nn import Conv2D, Linear, SyncBatchNorm
+from paddle.nn import Conv2D, SyncBatchNorm
 from paddle.fluid.dygraph.base import to_variable
 
 from test_dist_base import runtime_main, TestParallelDyGraphRunnerBase

--- a/python/paddle/fluid/tests/unittests/collective/fleet/parallel_margin_cross_entropy.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/parallel_margin_cross_entropy.py
@@ -18,9 +18,7 @@ import paddle
 import numpy as np
 import random
 import paddle.distributed as dist
-import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle import framework
 
 
 def set_random_seed(seed):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/pipeline_mnist.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/pipeline_mnist.py
@@ -12,19 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 import paddle.distributed.fleet as fleet

--- a/python/paddle/fluid/tests/unittests/collective/fleet/pipeline_mnist_multi_device.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/pipeline_mnist_multi_device.py
@@ -12,19 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 import paddle.distributed.fleet as fleet

--- a/python/paddle/fluid/tests/unittests/collective/fleet/pipeline_mnist_one_device.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/pipeline_mnist_one_device.py
@@ -12,19 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 import paddle.distributed.fleet as fleet

--- a/python/paddle/fluid/tests/unittests/collective/fleet/static_model_parallel_by_col.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/static_model_parallel_by_col.py
@@ -13,19 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import time
-import math
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
-from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 import paddle.distributed.fleet as fleet
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/static_model_parallel_by_row.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/static_model_parallel_by_row.py
@@ -13,19 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import time
-import math
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
-from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 import paddle.distributed.fleet as fleet
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/static_model_parallel_embedding.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/static_model_parallel_embedding.py
@@ -13,19 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import time
-import math
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
-from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 import paddle.distributed.fleet as fleet
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint.py
@@ -14,20 +14,11 @@
 
 import unittest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
 from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
 import paddle.fluid.incubate.checkpoint.auto_checkpoint as acp
 from paddle.fluid.incubate.checkpoint.checkpoint_saver import PaddleModel
-from paddle.fluid.framework import program_guard
-from paddle.fluid import unique_name
-
-import numpy as np
-from paddle.io import Dataset, BatchSampler, DataLoader
 
 from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint1.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint1.py
@@ -14,22 +14,9 @@
 
 import unittest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
-import paddle.fluid.incubate.checkpoint.auto_checkpoint as acp
-from paddle.fluid.incubate.checkpoint.checkpoint_saver import PaddleModel
-from paddle.fluid.framework import program_guard
-from paddle.fluid import unique_name
-
-import numpy as np
-from paddle.io import Dataset, BatchSampler, DataLoader
-
-from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
+from paddle.fluid.tests.unittests.auto_checkpoint_utils import get_logger
 from test_auto_checkpoint import AutoCheckPointACLBase
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint2.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint2.py
@@ -14,22 +14,9 @@
 
 import unittest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
-import paddle.fluid.incubate.checkpoint.auto_checkpoint as acp
-from paddle.fluid.incubate.checkpoint.checkpoint_saver import PaddleModel
-from paddle.fluid.framework import program_guard
-from paddle.fluid import unique_name
-
-import numpy as np
-from paddle.io import Dataset, BatchSampler, DataLoader
-
-from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
+from paddle.fluid.tests.unittests.auto_checkpoint_utils import get_logger
 from test_auto_checkpoint import AutoCheckPointACLBase
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint3.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint3.py
@@ -14,22 +14,9 @@
 
 import unittest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
-import paddle.fluid.incubate.checkpoint.auto_checkpoint as acp
-from paddle.fluid.incubate.checkpoint.checkpoint_saver import PaddleModel
-from paddle.fluid.framework import program_guard
-from paddle.fluid import unique_name
-
-import numpy as np
-from paddle.io import Dataset, BatchSampler, DataLoader
-
-from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
+from paddle.fluid.tests.unittests.auto_checkpoint_utils import get_logger
 from test_auto_checkpoint import AutoCheckPointACLBase
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint_dist_basic.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint_dist_basic.py
@@ -16,20 +16,13 @@ import unittest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
+from paddle.fluid.incubate.fleet.collective import fleet
 import os
-import sys
 
 from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
 import paddle.fluid.incubate.checkpoint.auto_checkpoint as acp
-from paddle.fluid.incubate.checkpoint.checkpoint_saver import PaddleModel
-from paddle.fluid.framework import program_guard
-from paddle.fluid import unique_name
 
-import numpy as np
-from paddle.io import Dataset, BatchSampler, DataLoader
-
-from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
+from paddle.fluid.tests.unittests.auto_checkpoint_utils import get_logger
 from test_auto_checkpoint import AutoCheckPointACLBase
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint_multiple.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_checkpoint_multiple.py
@@ -14,22 +14,12 @@
 
 import unittest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
 from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
 import paddle.fluid.incubate.checkpoint.auto_checkpoint as acp
-from paddle.fluid.incubate.checkpoint.checkpoint_saver import PaddleModel
-from paddle.fluid.framework import program_guard
-from paddle.fluid import unique_name
 
-import numpy as np
-from paddle.io import Dataset, BatchSampler, DataLoader
-
-from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
+from paddle.fluid.tests.unittests.auto_checkpoint_utils import get_logger
 from test_auto_checkpoint import AutoCheckPointACLBase
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_parallel_parallelizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_auto_parallel_parallelizer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_communicator_half_async.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_communicator_half_async.py
@@ -14,8 +14,6 @@
 
 import os
 import sys
-import time
-import threading
 import subprocess
 import unittest
 import numpy

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dgc_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dgc_optimizer.py
@@ -19,8 +19,6 @@ import paddle.fluid.framework as framework
 import paddle.fluid.optimizer as optimizer
 import paddle.fluid.regularizer as regularizer
 import paddle.fluid.clip as clip
-import paddle.compat as cpt
-from paddle.fluid.backward import append_backward
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_group_sharded_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_group_sharded_api.py
@@ -17,7 +17,6 @@ import os
 os.environ['FLAGS_enable_eager_mode'] = '0'
 
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_group_sharded_api_for_eager.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_group_sharded_api_for_eager.py
@@ -17,7 +17,6 @@ import os
 os.environ['FLAGS_enable_eager_mode'] = '1'
 
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_recompute.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_recompute.py
@@ -16,12 +16,9 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.autograd import PyLayer
 from paddle.distributed.fleet.utils import recompute
 import random
 from paddle.incubate.distributed.fleet import recompute_sequential
-
-import paddle.fluid.layers as layers
 
 
 def get_fc_block(block_idx, input_size, is_last=False):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_recompute_for_eager.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_recompute_for_eager.py
@@ -20,12 +20,8 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.autograd import PyLayer
 from paddle.distributed.fleet.utils import recompute
 import random
-from paddle.incubate.distributed.fleet import recompute_sequential
-
-import paddle.fluid.layers as layers
 
 
 def get_fc_block(block_idx, input_size, is_last=False):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_optimizer_stage2.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_optimizer_stage2.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_stage2.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_stage2.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_stage3.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_stage3.py
@@ -17,7 +17,6 @@ import os
 os.environ['FLAGS_enable_eager_mode'] = '0'
 
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_stage3_for_eager.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dygraph_sharding_stage3_for_eager.py
@@ -18,7 +18,6 @@ os.environ['FLAGS_enable_eager_mode'] = '1'
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_amp_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_amp_meta_optimizer.py
@@ -17,7 +17,6 @@ import paddle
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
 from paddle.distributed.fleet.meta_optimizers import AMPOptimizer
-import os
 from fleet_meta_optimizer_base import TestFleetMetaOptimizer
 import paddle.distributed.fleet.base.role_maker as role_maker
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_checkpoint.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_checkpoint.py
@@ -16,11 +16,10 @@ import unittest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
+from paddle.fluid.incubate.fleet.collective import fleet
 from paddle.fluid.incubate.checkpoint.auto_checkpoint import ExeTrainStatus
 from paddle.fluid.incubate.checkpoint.checkpoint_saver import CheckpointSaver
 import os
-import sys
 
 from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
 from paddle.fluid.incubate.checkpoint.checkpoint_saver import CheckpointSaver

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_distributed_strategy.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_distributed_strategy.py
@@ -14,7 +14,6 @@
 
 import unittest
 import paddle
-import os
 
 
 class TestStrategyConfig(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_gradient_merge_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_gradient_merge_meta_optimizer.py
@@ -14,9 +14,6 @@
 
 import unittest
 import paddle
-import os
-import paddle.distributed.fleet as fleet
-import paddle.distributed.fleet.base.role_maker as role_maker
 
 from fleet_meta_optimizer_base import TestFleetMetaOptimizer
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_localsgd_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_localsgd_meta_optimizer.py
@@ -14,12 +14,9 @@
 
 import unittest
 import paddle
-import os
 
 import paddle
 import paddle.fluid as fluid
-import paddle.distributed.fleet as fleet
-import paddle.distributed.fleet.base.role_maker as role_maker
 from fleet_meta_optimizer_base import TestFleetMetaOptimizer
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_log.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_log.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 from paddle.distributed import fleet
 from paddle.distributed.fleet.utils.log_util import logger
 import logging

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_meta_optimizer_base.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_meta_optimizer_base.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 from paddle import fluid
-import os
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
 from paddle.distributed.fleet.meta_optimizers.meta_optimizer_base import MetaOptimizerBase

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_private_function.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_private_function.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import unittest
-import os
-import paddle
 import socket
 import threading
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_recompute_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_recompute_meta_optimizer.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 import paddle.fluid as fluid
-import os
 from fleet_meta_optimizer_base import TestFleetMetaOptimizer
 from paddle.distributed.fleet.meta_optimizers import RecomputeOptimizer
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_sharding_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_sharding_meta_optimizer.py
@@ -16,8 +16,6 @@
 import unittest
 import paddle
 import os
-import paddle.distributed.fleet as fleet
-import paddle.fluid as fluid
 
 from fleet_meta_optimizer_base import TestFleetMetaOptimizer
 import paddle.distributed.fleet.meta_optimizers.sharding as sharding

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_static_mp_layers.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_static_mp_layers.py
@@ -15,12 +15,8 @@
 import unittest
 
 import paddle
-import numpy as np
-import random
-import paddle.distributed as dist
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-from paddle import framework
 import os
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_utils.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_utils.py
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
-import paddle.fluid as fluid
 import unittest
 import numpy as np
 import tarfile
 import tempfile
 import os
 import sys
-from paddle.dataset.common import download, DATA_HOME
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
+from paddle.dataset.common import download
 from paddle.fluid.incubate.fleet.utils.fleet_util import FleetUtil
 import paddle.fluid.incubate.fleet.utils.utils as utils
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_hdfs1.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_hdfs1.py
@@ -15,12 +15,9 @@
 from paddle.fluid.tests.unittests.hdfs_test_utils import FSTestBase
 import unittest
 import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient, FSTimeOut, FSFileExistsError, FSFileNotExistsError
+from paddle.distributed.fleet.utils.fs import FSTimeOut, HDFSClient
 
 java_home = os.environ["JAVA_HOME"]
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_hdfs2.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_hdfs2.py
@@ -14,13 +14,9 @@
 
 from paddle.fluid.tests.unittests.hdfs_test_utils import FSTestBase
 import unittest
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient, FSTimeOut, FSFileExistsError, FSFileNotExistsError
+from paddle.distributed.fleet.utils.fs import HDFSClient, LocalFS
 
 java_home = os.environ["JAVA_HOME"]
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_hdfs3.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_hdfs3.py
@@ -14,13 +14,9 @@
 
 from paddle.fluid.tests.unittests.hdfs_test_utils import FSTestBase
 import unittest
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient, FSTimeOut, FSFileExistsError, FSFileNotExistsError
+from paddle.distributed.fleet.utils.fs import HDFSClient, LocalFS
 
 java_home = os.environ["JAVA_HOME"]
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_hybrid_parallel_inference_helper.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_hybrid_parallel_inference_helper.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_imperative_auto_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_imperative_auto_mixed_precision.py
@@ -21,10 +21,8 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import numpy as np
-import six
-import cv2
 import tempfile
-from test_imperative_resnet import ResNet, BottleneckBlock, ConvBNLayer, train_parameters, optimizer_setting
+from test_imperative_resnet import ResNet, optimizer_setting, train_parameters
 import paddle.nn as nn
 from paddle.static import InputSpec
 from paddle.autograd import PyLayer

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_imperative_auto_mixed_precision_for_eager.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_imperative_auto_mixed_precision_for_eager.py
@@ -20,10 +20,8 @@ import unittest
 import paddle
 import paddle.fluid as fluid
 import numpy as np
-import six
-import cv2
 import tempfile
-from test_imperative_resnet import ResNet, BottleneckBlock, ConvBNLayer, train_parameters, optimizer_setting
+from test_imperative_resnet import ResNet, optimizer_setting, train_parameters
 import paddle.nn as nn
 from paddle.static import InputSpec
 from paddle.autograd import PyLayer

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_mixed_precision.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_mixed_precision.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
-from paddle.fluid import core
-from paddle.fluid.contrib.mixed_precision import fp16_utils
 import paddle
 import paddle.nn as nn
 import paddle.static as static

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_class_center_sample.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_class_center_sample.py
@@ -14,10 +14,8 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
-from paddle.fluid.framework import _test_eager_guard
 
 
 class TestParallelClassCenterSample(TestMultipleGpus):

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_control_flow.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 import paddle.fluid as fluid
 from test_dist_base import TestDistBase
-from spawn_runner_base import TestDistSpawnRunner
 
 flag_name = os.path.splitext(__file__)[0]
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_mp_layers.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_mp_layers.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_no_sync_gradient_check.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_no_sync_gradient_check.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_pipeline_parallel.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_pipeline_parallel.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
 import os
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_pipeline_parallel_with_virtual_stage.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
 import os
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_qat.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_qat.py
@@ -14,7 +14,6 @@
 
 import unittest
 import time
-import paddle
 import paddle.fluid as fluid
 import copy
 import os

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_sharding_parallel.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_sharding_parallel.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_sparse_embedding.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_sparse_embedding.py
@@ -20,7 +20,6 @@ import paddle.fluid as fluid
 from test_dist_base import TestDistBase
 from spawn_runner_base import TestDistSpawnRunner
 from parallel_dygraph_sparse_embedding import TestSparseEmbedding
-from parallel_dygraph_sparse_embedding_fp64 import TestSparseEmbeddingFP64
 
 flag_name = os.path.splitext(__file__)[0]
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_tensor_parallel.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_tensor_parallel.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_transformer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_dygraph_transformer.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
 
 import paddle.fluid as fluid
 from test_dist_base import TestDistBase
-from spawn_runner_base import TestDistSpawnRunner
-from parallel_dygraph_transformer import TestTransformer
 
 flag_name = os.path.splitext(__file__)[0]
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_margin_cross_entropy.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_parallel_margin_cross_entropy.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_recv_save_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_recv_save_op.py
@@ -25,7 +25,6 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 from paddle.fluid.framework import Program, program_guard
-from paddle.fluid.transpiler.details import VarStruct, VarsDistributed
 from dist_test_utils import *
 from paddle.fluid.incubate.fleet.parameter_server.mode import DistributedMode
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_rnn_dp.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_rnn_dp.py
@@ -16,12 +16,9 @@ import unittest
 import paddle
 import os
 
-import numpy as np
 import paddle
 import paddle.static as static
-import paddle.distributed.fleet as fleet
 import paddle.nn as nn
-import paddle.nn.functional as F
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_tcp_store.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_tcp_store.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import datetime
 import paddle
 import os
 

--- a/python/paddle/fluid/tests/unittests/collective/init_process_group.py
+++ b/python/paddle/fluid/tests/unittests/collective/init_process_group.py
@@ -13,18 +13,9 @@
 # limitations under the License.
 
 import unittest
-import random
-import numpy as np
-import os
-import shutil
 
 import paddle
-from paddle.fluid import core
-import datetime
-from datetime import timedelta
-import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
-from paddle.fluid.dygraph.parallel import ParallelEnv
 
 
 class TestProcessGroupFp32(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_dp.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_dp.py
@@ -12,27 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
-import paddle
-import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import paddle.distributed.fleet as fleet
-from paddle.fluid.incubate.fleet.base import role_maker
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_multi_nodes import TestCollectiveAPIRunnerBase, runtime_main
 
 
@@ -44,7 +23,6 @@ class TestDygrapgHybridDP(TestCollectiveAPIRunnerBase):
     def check_pass(self, *args, **kwargs):
         from common import init_parallel_env
         import paddle
-        from paddle.distributed import fleet
         hcg = init_parallel_env("DP16-MP1-PP1-SH1-O1", 2)
         import numpy as np
         dp_group = hcg.get_data_parallel_group()

--- a/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_dpppmp.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_dpppmp.py
@@ -13,26 +13,8 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
 import paddle.distributed.fleet as fleet
-from paddle.fluid.incubate.fleet.base import role_maker
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_multi_nodes import TestCollectiveAPIRunnerBase, runtime_main
 from paddle import nn
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_fp16.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_fp16.py
@@ -13,26 +13,8 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
 import paddle.distributed.fleet as fleet
-from paddle.fluid.incubate.fleet.base import role_maker
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_multi_nodes import TestCollectiveAPIRunnerBase, runtime_main
 from paddle import nn
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_recompute.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/dygraph_hybrid_recompute.py
@@ -13,26 +13,8 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
 import paddle.distributed.fleet as fleet
-from paddle.fluid.incubate.fleet.base import role_maker
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_multi_nodes import TestCollectiveAPIRunnerBase, runtime_main
 from paddle import nn
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/collective/multinode/mn_dygraph_group_sharded_stage3.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/mn_dygraph_group_sharded_stage3.py
@@ -18,14 +18,9 @@ import os
 import shutil
 import tempfile
 import numpy as np
-import argparse
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
-from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_stage2 import GroupShardedOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/multinode/mn_dygraph_sharding_stage2.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/mn_dygraph_sharding_stage2.py
@@ -17,15 +17,11 @@
 import os
 import shutil
 import numpy as np
-import argparse
 import tempfile
-import ast
-import time
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
 from paddle.distributed import fleet
-from paddle.fluid.dygraph import nn
 from paddle.fluid.framework import _test_eager_guard
 
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.sharding_optimizer_stage2 import ShardingOptimizerStage2

--- a/python/paddle/fluid/tests/unittests/collective/multinode/test_collective_multi_nodes.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/test_collective_multi_nodes.py
@@ -12,23 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import unittest
-import time
-import argparse
 import os
 import sys
 import subprocess
-import traceback
-import functools
-import pickle
 import tempfile
-from contextlib import closing
-import paddle
-import paddle.fluid as fluid
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import socket
 
 
 class TestCollectiveAPIRunnerBase(object):

--- a/python/paddle/fluid/tests/unittests/collective/multinode/test_multinode_dygraph_hybrid_dp.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/test_multinode_dygraph_hybrid_dp.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
-import paddle
 
 from test_collective_multi_nodes import TestDistBase
 

--- a/python/paddle/fluid/tests/unittests/collective/multinode/test_multinode_dygraph_hybrid_dpppmp.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/test_multinode_dygraph_hybrid_dpppmp.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
-import paddle
 
 from test_collective_multi_nodes import TestDistBase
 

--- a/python/paddle/fluid/tests/unittests/collective/multinode/test_multinode_dygraph_sharding.py
+++ b/python/paddle/fluid/tests/unittests/collective/multinode/test_multinode_dygraph_sharding.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
-import paddle
 
 from test_collective_multi_nodes import TestDistBase
 

--- a/python/paddle/fluid/tests/unittests/collective/parallel_embedding_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/parallel_embedding_api.py
@@ -13,26 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
 import paddle.distributed.fleet as fleet
-from paddle.fluid.incubate.fleet.base import role_maker
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/process_group_gloo.py
+++ b/python/paddle/fluid/tests/unittests/collective/process_group_gloo.py
@@ -15,13 +15,9 @@
 import unittest
 import random
 import numpy as np
-import os
-import shutil
 
 import paddle
 from paddle.fluid import core
-import datetime
-from datetime import timedelta
 import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.dygraph.parallel import ParallelEnv

--- a/python/paddle/fluid/tests/unittests/collective/process_group_mpi.py
+++ b/python/paddle/fluid/tests/unittests/collective/process_group_mpi.py
@@ -15,17 +15,12 @@
 import unittest
 import random
 import numpy as np
-import os
-import shutil
 
 import paddle
 from paddle.fluid import core
-from datetime import timedelta
 import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
-from paddle.fluid.dygraph.parallel import ParallelEnv
 from paddle.distributed.collective import Group
-from paddle.distributed.collective import _group_map_by_name
 from paddle.distributed.collective import _default_group_name
 from paddle.distributed.collective import _set_group_map
 from paddle.distributed.collective import _set_group_map_by_name

--- a/python/paddle/fluid/tests/unittests/collective/process_group_nccl.py
+++ b/python/paddle/fluid/tests/unittests/collective/process_group_nccl.py
@@ -15,13 +15,8 @@
 import unittest
 import random
 import numpy as np
-import os
-import shutil
 
 import paddle
-from paddle.fluid import core
-from datetime import timedelta
-import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.dygraph.parallel import ParallelEnv
 import paddle.distributed as dist

--- a/python/paddle/fluid/tests/unittests/collective/row_parallel_linear_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/row_parallel_linear_api.py
@@ -13,26 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
 import paddle.distributed.fleet as fleet
-from paddle.fluid.incubate.fleet.base import role_maker
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective/test_allreduce.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_allreduce.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_broadcast.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_broadcast.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_c_concat.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_c_concat.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_c_identity.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_c_identity.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_c_split.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_c_split.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_allgather_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_allgather_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_allgather_object_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_allgather_object_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_allreduce_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_allreduce_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_alltoall_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_alltoall_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_alltoall_single.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_alltoall_single.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_alltoall_single_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_alltoall_single_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_barrier_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_barrier_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_batch_isend_irecv.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_batch_isend_irecv.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_broadcast_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_broadcast_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_cpu_barrier_with_gloo.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_cpu_barrier_with_gloo.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import unittest
-import os
-import sys
 import time
 import multiprocessing
 from contextlib import closing

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_global_gather.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_global_gather.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase
-import os
 
 
 class TestCollectiveGlobalGatherAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_global_scatter.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_global_scatter.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase
-import os
 
 
 class TestCollectiveSelectScatterAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_isend_irecv_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_isend_irecv_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_reduce.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_reduce.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_reduce_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_reduce_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_reduce_scatter.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_reduce_scatter.py
@@ -14,7 +14,6 @@
 
 import os
 import unittest
-import paddle.fluid as fluid
 
 from test_parallel_dygraph_dataparallel import TestMultipleGpus
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_reduce_scatter_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_reduce_scatter_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import test_collective_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_scatter.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_scatter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_scatter_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_scatter_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_sendrecv.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_sendrecv.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_sendrecv_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_sendrecv_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_split_col_linear.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_split_col_linear.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_split_embedding.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_split_embedding.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_split_embedding_none_divisible.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_split_embedding_none_divisible.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 from paddle.distributed import fleet
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_split_row_linear.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_split_row_linear.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_wait.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_wait.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/test_communication_stream_allreduce_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_communication_stream_allreduce_api.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
-import itertools
 import test_communication_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/test_communication_stream_sendrecv_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_communication_stream_sendrecv_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import test_communication_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/test_gen_nccl_id_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_gen_nccl_id_op.py
@@ -14,10 +14,8 @@
 
 import unittest
 import os
-import copy
 from launch_function_helper import wait, _find_free_port
-from multiprocessing import Pool, Process
-from threading import Thread
+from multiprocessing import Process
 
 os.environ['GLOG_vmodule'] = str("gen_nccl_id_op*=10,gen_comm_id*=10")
 

--- a/python/paddle/fluid/tests/unittests/collective/test_new_group_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_new_group_api.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base import TestDistBase

--- a/python/paddle/fluid/tests/unittests/collective/world_size_and_rank.py
+++ b/python/paddle/fluid/tests/unittests/collective/world_size_and_rank.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import paddle.distributed as dist
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 `python/paddle/fluid/tests/unittests/collective/` 目录 F401 unused import 存量 python 代码

```bash
autoflake --in-place --remove-all-unused-imports --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/collective/
```

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4/views/1
- 配置文件更新: #46616
- fixes https://github.com/cattidea/paddle-flake8-project/issues/28