### PR TITLE
[Change Layout] Change mkldnn kernel layout (part1), ALL_LAYOUT->ONEDNN

### DIFF
--- a/paddle/phi/kernels/onednn/add_n_kernel.cc
+++ b/paddle/phi/kernels/onednn/add_n_kernel.cc
@@ -132,4 +132,4 @@ void AddNKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    add_n, OneDNN, ALL_LAYOUT, phi::AddNKernel, float, phi::dtype::bfloat16) {}
+    add_n, OneDNN, ONEDNN, phi::AddNKernel, float, phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/cast_kernel.cc
+++ b/paddle/phi/kernels/onednn/cast_kernel.cc
@@ -56,4 +56,4 @@ void CastKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    cast, OneDNN, ALL_LAYOUT, phi::CastKernel, float, phi::dtype::bfloat16) {}
+    cast, OneDNN, ONEDNN, phi::CastKernel, float, phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/full_kernel.cc
+++ b/paddle/phi/kernels/onednn/full_kernel.cc
@@ -85,4 +85,4 @@ void FullKernel(const Context& dev_ctx,
 }
 }  // namespace phi
 
-PD_REGISTER_KERNEL(full, OneDNN, ALL_LAYOUT, phi::FullKernel, float) {}
+PD_REGISTER_KERNEL(full, OneDNN, ONEDNN, phi::FullKernel, float) {}

--- a/paddle/phi/kernels/onednn/gaussian_random_kernel.cc
+++ b/paddle/phi/kernels/onednn/gaussian_random_kernel.cc
@@ -47,4 +47,4 @@ void GaussianRandomKernel(const Context& ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    gaussian_random, OneDNN, ALL_LAYOUT, phi::GaussianRandomKernel, float) {}
+    gaussian_random, OneDNN, ONEDNN, phi::GaussianRandomKernel, float) {}

--- a/paddle/phi/kernels/onednn/interpolate_kernel.cc
+++ b/paddle/phi/kernels/onednn/interpolate_kernel.cc
@@ -228,11 +228,11 @@ void NearestInterpKernel(
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    bilinear_interp, OneDNN, ALL_LAYOUT, phi::BilinearInterpKernel, float) {}
+    bilinear_interp, OneDNN, ONEDNN, phi::BilinearInterpKernel, float) {}
 
 PD_REGISTER_KERNEL(nearest_interp,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::NearestInterpKernel,
                    float,
                    phi::dtype::bfloat16,

--- a/paddle/phi/kernels/onednn/scale_kernel.cc
+++ b/paddle/phi/kernels/onednn/scale_kernel.cc
@@ -59,4 +59,4 @@ void ScaleKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    scale, OneDNN, ALL_LAYOUT, phi::ScaleKernel, float, phi::dtype::bfloat16) {}
+    scale, OneDNN, ONEDNN, phi::ScaleKernel, float, phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/sgd_kernel.cc
+++ b/paddle/phi/kernels/onednn/sgd_kernel.cc
@@ -82,12 +82,11 @@ void SGDDenseParamSparseGradKernel(
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    sgd, OneDNN, ALL_LAYOUT, phi::SGDDenseKernel, float, phi::dtype::bfloat16) {
-}
+    sgd, OneDNN, ONEDNN, phi::SGDDenseKernel, float, phi::dtype::bfloat16) {}
 
 PD_REGISTER_KERNEL(sgd_dense_param_sparse_grad,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::SGDDenseParamSparseGradKernel,
                    float,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/split_kernel.cc
+++ b/paddle/phi/kernels/onednn/split_kernel.cc
@@ -80,11 +80,11 @@ void SplitWithNumKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    split, OneDNN, ALL_LAYOUT, phi::SplitKernel, float, phi::dtype::bfloat16) {}
+    split, OneDNN, ONEDNN, phi::SplitKernel, float, phi::dtype::bfloat16) {}
 
 PD_REGISTER_KERNEL(split_with_num,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::SplitWithNumKernel,
                    float,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/stack_kernel.cc
+++ b/paddle/phi/kernels/onednn/stack_kernel.cc
@@ -124,4 +124,4 @@ void StackKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(stack, OneDNN, ALL_LAYOUT, phi::StackKernel, float) {}
+PD_REGISTER_KERNEL(stack, OneDNN, ONEDNN, phi::StackKernel, float) {}


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
Change mkldnn kernel layout (part1), `ALL_LAYOUT->ONEDNN`
Relevant op: `add_n`, `cast`, `full`, `gaussian_random`, `bilinear_interp`, `nearest_interp`, `scale`, `sgd`, `sgd_dense_param_sparse_grad`, `split`, `split_with_num`, `stack`