### PR TITLE
[Change Layout] Change mkldnn kernel layout (part2), ALL_LAYOUT->ONEDNN

### DIFF
--- a/paddle/phi/kernels/onednn/clip_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/clip_grad_kernel.cc
@@ -48,7 +48,7 @@ void ClipGradKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(clip_grad,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::ClipGradKernel,
                    float,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/clip_kernel.cc
+++ b/paddle/phi/kernels/onednn/clip_kernel.cc
@@ -43,4 +43,4 @@ void ClipKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    clip, OneDNN, ALL_LAYOUT, phi::ClipKernel, float, phi::dtype::bfloat16) {}
+    clip, OneDNN, ONEDNN, phi::ClipKernel, float, phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/concat_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/concat_grad_kernel.cc
@@ -78,7 +78,7 @@ void ConcatGradKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(concat_grad,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::ConcatGradKernel,
                    float,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/concat_kernel.cc
+++ b/paddle/phi/kernels/onednn/concat_kernel.cc
@@ -156,7 +156,7 @@ void ConcatKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(concat,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::ConcatKernel,
                    float,
                    phi::dtype::bfloat16,

--- a/paddle/phi/kernels/onednn/expand_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/expand_grad_kernel.cc
@@ -86,7 +86,7 @@ void ExpandGradKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(expand_grad,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::ExpandGradKernel,
                    float,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/expand_kernel.cc
+++ b/paddle/phi/kernels/onednn/expand_kernel.cc
@@ -75,9 +75,5 @@ void ExpandKernel(const Context& dev_ctx,
 }
 }  // namespace phi
 
-PD_REGISTER_KERNEL(expand,
-                   OneDNN,
-                   ALL_LAYOUT,
-                   phi::ExpandKernel,
-                   float,
-                   phi::dtype::bfloat16) {}
+PD_REGISTER_KERNEL(
+    expand, OneDNN, ONEDNN, phi::ExpandKernel, float, phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/log_softmax_kernel.cc
+++ b/paddle/phi/kernels/onednn/log_softmax_kernel.cc
@@ -65,7 +65,7 @@ void LogSoftmaxKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(log_softmax,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::LogSoftmaxKernel,
                    float,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/pad3d_kernel.cc
+++ b/paddle/phi/kernels/onednn/pad3d_kernel.cc
@@ -31,4 +31,4 @@ void Pad3dKernel(const Context& dev_ctx,
 }
 }  // namespace phi
 
-PD_REGISTER_KERNEL(pad3d, OneDNN, ALL_LAYOUT, phi::Pad3dKernel, float) {}
+PD_REGISTER_KERNEL(pad3d, OneDNN, ONEDNN, phi::Pad3dKernel, float) {}

--- a/paddle/phi/kernels/onednn/pad_kernel.cc
+++ b/paddle/phi/kernels/onednn/pad_kernel.cc
@@ -34,4 +34,4 @@ void PadKernel(const Context& dev_ctx,
 }
 }  // namespace phi
 
-PD_REGISTER_KERNEL(pad, OneDNN, ALL_LAYOUT, phi::PadKernel, float) {}
+PD_REGISTER_KERNEL(pad, OneDNN, ONEDNN, phi::PadKernel, float) {}

--- a/paddle/phi/kernels/onednn/slice_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/slice_grad_kernel.cc
@@ -80,7 +80,7 @@ void SliceGradRawKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(slice_grad,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::SliceGradRawKernel,
                    float,
                    phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/onednn/slice_kernel.cc
+++ b/paddle/phi/kernels/onednn/slice_kernel.cc
@@ -101,7 +101,7 @@ void SliceRawKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(slice,
                    OneDNN,
-                   ALL_LAYOUT,
+                   ONEDNN,
                    phi::SliceRawKernel,
                    float,
                    int8_t,

--- a/paddle/phi/kernels/onednn/softmax_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/softmax_grad_kernel.cc
@@ -50,4 +50,4 @@ void SoftmaxGradKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    softmax_grad, OneDNN, ALL_LAYOUT, phi::SoftmaxGradKernel, float) {}
+    softmax_grad, OneDNN, ONEDNN, phi::SoftmaxGradKernel, float) {}


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
Change mkldnn kernel layout (part2), `ALL_LAYOUT->ONEDNN`
Relevant op: `clip_grad`, `clip`, `concat_grad`, `concat`, `expand_grad`, `expand`, `log_softmax`, `pad3d`, `pad`, `slice_grad`, `slice`, `softmax_grad`