### PR TITLE
[inference] CPU-> GPU async io copy for TensorRT using ShareExternalData API

### DIFF
--- a/paddle/fluid/framework/data_device_transform.cc
+++ b/paddle/fluid/framework/data_device_transform.cc
@@ -29,7 +29,10 @@ void TransDataDevice(const phi::DenseTensor &in,
                                     "supported between CPU and CUDA."));
 
   // NOTE(zhiqiu): Special case for CPU->NPU, avoid stream sync.
-  if (platform::is_cpu_place(in.place()) && platform::is_npu_place(dst_place)) {
+  if ((platform::is_cpu_place(in.place()) &&
+       platform::is_npu_place(dst_place)) ||
+      (platform::is_cpu_place(in.place()) &&
+       platform::is_gpu_place(dst_place))) {
     paddle::framework::TensorCopy(
         in,
         dst_place,

--- a/paddle/fluid/framework/data_device_transform.cc
+++ b/paddle/fluid/framework/data_device_transform.cc
@@ -29,10 +29,7 @@ void TransDataDevice(const phi::DenseTensor &in,
                                     "supported between CPU and CUDA."));
 
   // NOTE(zhiqiu): Special case for CPU->NPU, avoid stream sync.
-  if ((platform::is_cpu_place(in.place()) &&
-       platform::is_npu_place(dst_place)) ||
-      (platform::is_cpu_place(in.place()) &&
-       platform::is_gpu_place(dst_place))) {
+  if (platform::is_cpu_place(in.place()) && platform::is_npu_place(dst_place)) {
     paddle::framework::TensorCopy(
         in,
         dst_place,

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -501,8 +501,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
       // check the input_tensor
       if (!platform::is_gpu_place(t.place())) {
         phi::DenseTensor out;
-        platform::CUDAPlace dst_place;
-        framework::TensorCopy(t, dst_place, dev_ctx, &out);
+        framework::TensorCopy(t, dev_place, dev_ctx, &out);
         t.ShareDataWith(out);
       }
       auto t_shape = phi::vectorize<int64_t>(t.dims());

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -502,7 +502,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
       if (!platform::is_gpu_place(t.place())) {
         phi::DenseTensor out;
         platform::CUDAPlace dst_place;
-        framework::TransDataDevice(t, dst_place, &out);
+        framework::TensorCopy(t, dst_place, dev_ctx, &out);
         t.ShareDataWith(out);
       }
       auto t_shape = phi::vectorize<int64_t>(t.dims());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- CPU -> GPU async io for  TensorRT 
- fix copy core dump using `ShareExternalData` if GPU id is not 0