### PR TITLE
Fix OCR set_value error with dtype of source tensor as fp16

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1217,7 +1217,14 @@ static PyObject* tensor_method__setitem_eager_tensor(TensorObject* self,
         } else if (self->tensor.dtype() ==
                    paddle::experimental::DataType::BOOL) {
           attrs["bool_values"] = std::vector<int>{value_obj_tmp.cast<bool>()};
+        } else if (self->tensor.dtype() ==
+                   paddle::experimental::DataType::FLOAT16) {
+          std::cout << "yes here is fp16 branch" << std::endl;
+          attrs["fp16_values"] =
+              std::vector<float>{value_obj_tmp.cast<float>()};
         } else {
+          std::cout << "the type of this tensor is: " << self->tensor.dtype()
+                    << std::endl;
           PADDLE_THROW(platform::errors::InvalidArgument(
               "When assign a value to a paddle.Tensor, "
               "the data type of the paddle.Tensor must be bool, "

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -98,6 +98,7 @@ void FlipKernel(const Context& dev_ctx,
   const size_t total_dims = x.dims().size();
   switch (total_dims) {
     case 1:
+<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -123,6 +124,33 @@ void FlipKernel(const Context& dev_ctx,
       break;
     case 9:
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
+=======
+      launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
+      break;
+    case 2:
+      launch_flip_cuda_kernel<T, Context, 2>(dev_ctx, x, axis, out);
+      break;
+    case 3:
+      launch_flip_cuda_kernel<T, Context, 3>(dev_ctx, x, axis, out);
+      break;
+    case 4:
+      launch_flip_cuda_kernel<T, Context, 4>(dev_ctx, x, axis, out);
+      break;
+    case 5:
+      launch_flip_cuda_kernel<T, Context, 5>(dev_ctx, x, axis, out);
+      break;
+    case 6:
+      launch_flip_cuda_kernel<T, Context, 6>(dev_ctx, x, axis, out);
+      break;
+    case 7:
+      launch_flip_cuda_kernel<T, Context, 7>(dev_ctx, x, axis, out);
+      break;
+    case 8:
+      launch_flip_cuda_kernel<T, Context, 8>(dev_ctx, x, axis, out);
+      break;
+    case 9:
+      launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
+>>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -58,8 +58,17 @@ void LaunchFlipCudaKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const std::vector<int>& axis,
                           DenseTensor* out) {
+<<<<<<< HEAD
 
   std::vector<int> flip_dims_v = axis;
+=======
+  auto* in_data = x.data<T>();
+  auto* out_data = dev_ctx.template Alloc<T>(out);
+
+  auto x_dims = x.dims();
+  const int total_dims = x_dims.size();
+  const int64_t numel = x.numel();
+>>>>>>> fix extra flip_dims_v
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   auto x_stride = phi::stride(x_dims);
 
@@ -98,8 +107,6 @@ void FlipKernel(const Context& dev_ctx,
   const size_t total_dims = x.dims().size();
   switch (total_dims) {
     case 1:
-<<<<<<< HEAD
-<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -125,40 +132,6 @@ void FlipKernel(const Context& dev_ctx,
       break;
     case 9:
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
-=======
-      launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
-=======
-      LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
->>>>>>> fix function name
-      break;
-    case 2:
-      LaunchFlipCudaKernel<T, Context, 2>(dev_ctx, x, axis, out);
-      break;
-    case 3:
-      LaunchFlipCudaKernel<T, Context, 3>(dev_ctx, x, axis, out);
-      break;
-    case 4:
-      LaunchFlipCudaKernel<T, Context, 4>(dev_ctx, x, axis, out);
-      break;
-    case 5:
-      LaunchFlipCudaKernel<T, Context, 5>(dev_ctx, x, axis, out);
-      break;
-    case 6:
-      LaunchFlipCudaKernel<T, Context, 6>(dev_ctx, x, axis, out);
-      break;
-    case 7:
-      LaunchFlipCudaKernel<T, Context, 7>(dev_ctx, x, axis, out);
-      break;
-    case 8:
-      LaunchFlipCudaKernel<T, Context, 8>(dev_ctx, x, axis, out);
-      break;
-    case 9:
-<<<<<<< HEAD
-      launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
->>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
-=======
-      LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
->>>>>>> fix function name
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -99,6 +99,7 @@ void FlipKernel(const Context& dev_ctx,
   switch (total_dims) {
     case 1:
 <<<<<<< HEAD
+<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -126,31 +127,38 @@ void FlipKernel(const Context& dev_ctx,
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
 =======
       launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
+=======
+      LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
+>>>>>>> fix function name
       break;
     case 2:
-      launch_flip_cuda_kernel<T, Context, 2>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 2>(dev_ctx, x, axis, out);
       break;
     case 3:
-      launch_flip_cuda_kernel<T, Context, 3>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 3>(dev_ctx, x, axis, out);
       break;
     case 4:
-      launch_flip_cuda_kernel<T, Context, 4>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 4>(dev_ctx, x, axis, out);
       break;
     case 5:
-      launch_flip_cuda_kernel<T, Context, 5>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 5>(dev_ctx, x, axis, out);
       break;
     case 6:
-      launch_flip_cuda_kernel<T, Context, 6>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 6>(dev_ctx, x, axis, out);
       break;
     case 7:
-      launch_flip_cuda_kernel<T, Context, 7>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 7>(dev_ctx, x, axis, out);
       break;
     case 8:
-      launch_flip_cuda_kernel<T, Context, 8>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 8>(dev_ctx, x, axis, out);
       break;
     case 9:
+<<<<<<< HEAD
       launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
 >>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
+=======
+      LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
+>>>>>>> fix function name
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -58,12 +58,8 @@ void LaunchFlipCudaKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const std::vector<int>& axis,
                           DenseTensor* out) {
-  auto* in_data = x.data<T>();
-  auto* out_data = dev_ctx.template Alloc<T>(out);
 
-  auto x_dims = x.dims();
-  const int total_dims = x_dims.size();
-  const int64_t numel = x.numel();
+  std::vector<int> flip_dims_v = axis;
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   auto x_stride = phi::stride(x_dims);
 

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -58,17 +58,12 @@ void LaunchFlipCudaKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const std::vector<int>& axis,
                           DenseTensor* out) {
-<<<<<<< HEAD
-
-  std::vector<int> flip_dims_v = axis;
-=======
   auto* in_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
 
   auto x_dims = x.dims();
   const int total_dims = x_dims.size();
   const int64_t numel = x.numel();
->>>>>>> fix extra flip_dims_v
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   auto x_stride = phi::stride(x_dims);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
OCR模型在混精度训练的时候会挂掉
<img width="826" alt="image" src="https://user-images.githubusercontent.com/28504079/192993120-a38c5d90-4806-402e-b8bf-4a25d88c3d51.png">
后续检查发现是模型调用的时候不支持fp16类型，添加后如下图
<img width="640" alt="image" src="https://user-images.githubusercontent.com/28504079/192993723-28273b2e-1a6c-423b-b113-f366f073e7ff.png">
添加后调用流程走入fp16分支填入tensor值到attr中，最终进去set_value__dygraph_function中去调用对应的kernel,这里之所以写成.cast<float>是因为PyObject的cast是pybind11::cast，这个不支持fp16，另一方面，attr不支持vector<float16>，所以这边想先能够运行，然后再去调整
<img width="760" alt="image" src="https://user-images.githubusercontent.com/28504079/192994076-94d172f9-6a00-456b-96da-8d415e47351c.png">
然而此时的报错变为了
![image](https://user-images.githubusercontent.com/28504079/192999092-ff1b1218-7868-422e-a216-c02c02f2bfe6.png)
