### PR TITLE
[dygraph sharding stage 2] sharding broadcast overlap

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
@@ -504,8 +504,7 @@ class GroupShardedOptimizerStage2(Optimizer):
                 tasks = []
                 for param in layer.parameters():
                     if param.trainable:
-                        if param.name in self._broadcast_order_params:
-                            assert param.name in param2task
+                        if param.name in param2task:
                             tasks.append(param2task[param.name])
                 self._forward_pre_hook_remove_helper.append(
                     layer.register_forward_pre_hook(

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_optimizer_stage2.py
@@ -504,8 +504,9 @@ class GroupShardedOptimizerStage2(Optimizer):
                 tasks = []
                 for param in layer.parameters():
                     if param.trainable:
-                        assert param.name in param2task
-                        tasks.append(param2task[param.name])
+                        if param.name in self._broadcast_order_params:
+                            assert param.name in param2task
+                            tasks.append(param2task[param.name])
                 self._forward_pre_hook_remove_helper.append(
                     layer.register_forward_pre_hook(
                         self._forward_pre_hook_function(tasks)))

--- a/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage2.py
+++ b/python/paddle/distributed/fleet/meta_parallel/sharding/group_sharded_stage2.py
@@ -101,7 +101,7 @@ class GroupShardedStage2(nn.Layer):
             self._all_params.extend(list(optim.local_params))
 
         # sharing stage 2 comm overlap flag
-        self._comm_overlap = False
+        self._reduce_overlap = False
 
         self._trainable_params = []
         self._grad_reduced = []
@@ -309,17 +309,17 @@ class GroupShardedStage2(nn.Layer):
             for grad_storage in self._grad_storage_list:
                 grad_storage.reset_checked_in()
 
-    def _set_comm_overlap(self, comm_overlap):
+    def _set_reduce_overlap(self, reduce_overlap):
         # Hacky way to not add an extra parameter to the `group_sharded_parallel` funct.
         # User should use this like:
         # model, optimizer, scaler = group_sharded_parallel(...)
-        # model._set_comm_overlap(True)
-        self._comm_overlap = comm_overlap
-        if self._comm_overlap:
+        # model._set_reduce_overlap(True)
+        self._reduce_overlap = reduce_overlap
+        if self._reduce_overlap:
             assert len(
                 self._sharding_optimizers
             ) == 1, "Only support comm overlap strategy for single optimizer"
-        self._sharding_optimizers[0]._set_comm_overlap(comm_overlap)
+        self._sharding_optimizers[0]._set_reduce_overlap(reduce_overlap)
 
     def _get_reduce_fn(self, index, param, dst_rank):
         """
@@ -357,7 +357,7 @@ class GroupShardedStage2(nn.Layer):
                         collective.reduce(tensor=param.grad,
                                           dst=self._group.ranks[dst_rank],
                                           group=self._group,
-                                          sync_op=not self._comm_overlap))
+                                          sync_op=not self._reduce_overlap))
 
                     # Clear the task flow and trigger callback to clear the redundant gradient
                     # self._clear_task_flow()
@@ -407,7 +407,7 @@ class GroupShardedStage2(nn.Layer):
                                 tensor=grad_storage.buffer,
                                 dst=self._group.ranks[grad_storage.destination],
                                 group=self._group,
-                                sync_op=not self._comm_overlap))
+                                sync_op=not self._reduce_overlap))
 
                         cleanup()
 
@@ -545,7 +545,7 @@ class GroupShardedStage2(nn.Layer):
             opt_step = opt.step
 
             def _opt_step(self):
-                if self._comm_overlap:
+                if self._reduce_overlap:
                     # Wait for the last reduce task. This wait must before grad scale function.
                     assert self._comm_task is not None
                     self._comm_task.wait()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
@@ -92,12 +92,14 @@ def train_mlp(model,
         optimizer = optimizer_setting(model=model, use_pure_fp16=use_pure_fp16)
 
     if sharding_stage == 2:
+        origin_model = model
         optimizer = GroupShardedOptimizerStage2(
             params=optimizer._parameter_list, optim=optimizer, group=group)
         model = GroupShardedStage2(model,
                                    optimizer,
                                    group=group,
                                    buffer_max_size=2**21)
+        optimizer._set_overlap_broadcast(True, model)
         model._set_comm_overlap(True)
     else:
         model = paddle.DataParallel(model)
@@ -148,6 +150,8 @@ def train_mlp(model,
         if accumulate_grad:
             optimizer.step()
             optimizer.clear_grad()
+
+    paddle.device.cuda.synchronize()
 
     if save_model:
         return model, optimizer

--- a/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/dygraph_group_sharded_stage2_comm_overlap.py
@@ -99,8 +99,8 @@ def train_mlp(model,
                                    optimizer,
                                    group=group,
                                    buffer_max_size=2**21)
-        optimizer._set_overlap_broadcast(True, model)
-        model._set_comm_overlap(True)
+        model._set_reduce_overlap(True)
+        optimizer._set_broadcast_overlap(True, model)
     else:
         model = paddle.DataParallel(model)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Support sharding broadcast overlap for stage 2.

#### Usage

```python
origin_model = model
model, optimizer, scaler = group_sharded_parallel(model=model)
# need pass the origin model to the function.
model._set_broadcast_overlap(True, origin_model)
```

#### 6.7B Loss Compare
<img width="400" alt="image" src="https://user-images.githubusercontent.com/25279174/194679674-2e5668c4-232a-468a-b455-884f34233b23.png">


#### 6.7. Speed Compare
| No broadcast overlap | Broadcast overlap | Gain |
|:--:|:--:|:--:|
|40077 |43507 | +8.6% |
