### PR TITLE
Fix undefined reference PD_IntArrayGetElementCount

### DIFF
--- a/paddle/phi/capi/lib/c_int_array.cc
+++ b/paddle/phi/capi/lib/c_int_array.cc
@@ -26,6 +26,11 @@ PD_List PD_IntArrayGetDataPointer(PD_IntArray* int_array) {
   return list;
 }
 
+size_t PD_IntArrayGetElementCount(PD_IntArray* int_array) {
+  auto cc_int_array = reinterpret_cast<phi::IntArray*>(int_array);
+  return cc_int_array->size();
+}
+
 size_t PD_IntArrayGetSize(PD_IntArray* int_array) {
   auto cc_int_array = reinterpret_cast<phi::IntArray*>(int_array);
   return cc_int_array->size();

--- a/paddle/phi/capi/lib/c_int_array.cc
+++ b/paddle/phi/capi/lib/c_int_array.cc
@@ -31,9 +31,4 @@ size_t PD_IntArrayGetElementCount(PD_IntArray* int_array) {
   return cc_int_array->size();
 }
 
-size_t PD_IntArrayGetSize(PD_IntArray* int_array) {
-  auto cc_int_array = reinterpret_cast<phi::IntArray*>(int_array);
-  return cc_int_array->size();
-}
-
 PD_REGISTER_CAPI(int_array);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix undefined reference PD_IntArrayGetElementCount
PD_IntArrayGetElementCount 在头文件#include "paddle/phi/capi/include/c_int_array.h"存在，但是没有定义
使用capi::IntArray; 会找不到符号  

```
#include "paddle/phi/capi/all.h"
capi::IntArray a;
a.size();
```
这可能是PD_IntArrayGetSize改名引起的
这里的修改保留了PD_IntArrayGetSize定义兼容旧code
PD_IntArrayGetElementCount的定义复制了PD_IntArrayGetSize的内容，来修复BUG
