### PR TITLE
[Opt Code] Opt GetExpectedKernelType code of fill_constant_op

### DIFF
--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -70,11 +70,12 @@ class FillConstantOp : public framework::OperatorWithKernel {
 
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
-    framework::OpKernelType kt = framework::OpKernelType(
-        framework::proto::VarType::Type(ctx.Attr<int>("dtype")),
-        ctx.GetPlace());
-    // TODO(zyfncg) The force_cpu and place_type are conflicted, it's a issue
-    // lefted before, and we may merge them in the future.
+    auto input_data_type =
+        framework::proto::VarType::Type(ctx.Attr<int>("dtype"));
+    framework::OpKernelType kt =
+        framework::OpKernelType(input_data_type, ctx.GetPlace());
+    // TODO(zyfncg) The force_cpu and place_type are conflicted, it's an issue
+    // left before, and we may merge them in the future.
     // In order to invoke new fill_constant kernel, the place of OpKernelType
     // will be setted by force_cpu and place_type here.
     if (ctx.Attr<bool>("force_cpu")) {
@@ -104,9 +105,6 @@ class FillConstantOp : public framework::OperatorWithKernel {
     }
 
 #ifdef PADDLE_WITH_MKLDNN
-    auto input_data_type =
-        framework::proto::VarType::Type(ctx.Attr<int>("dtype"));
-
     if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
       return framework::OpKernelType(input_data_type,
                                      ctx.GetPlace(),


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
Opt GetExpectedKernelType code of `fill_constant_op`

The goal of this PR: when the code within `if` condition or `#ifdef PADDLE_WITH_MKLDNN` is deleted later, it can be deleted directly while keeping outside codes clean and clear