### PR TITLE
Release memory cache after build_op_func_list in interpretercore

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -744,6 +744,12 @@ void build_op_func_list(const platform::Place& place,
 
     interpreter::LogDeviceMemoryStats(place);
   }
+
+  // NOTE(Ruibiao): Release memory cache to avoid memory fragments in Allocator.
+  // It reduce about 10% memory usage for V100 8-GPU training of
+  // transformer_base_bs4096_amp_fp16 and transformer_base_bs4096_pure_fp16
+  // model.
+  memory::Release(place);
 }
 
 void add_fetch(const std::vector<std::string>& fetch_names,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
The completely different OP running order between prepare (i.e., build_op_func_list) and real running (i.e., RunInstructionAsync) may lead to serious memory fragments in Allocator. Therefore, in this PR, we release memory cache after build_op_func_list to avoid memory fragments. It reduces about 10% memory usage for V100 8-GPU training of transformer_base_bs4096_amp_fp16 and transformer_base_bs4096_pure_fp16 models.