### PR TITLE
Fix slice bugs in MKLDNN when input dims are zeros

### DIFF
--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -155,7 +155,14 @@ class SliceOp : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
       auto input_data_type =
           framework::OperatorWithKernel::IndicateVarDataType(ctx, "Input");
-
+      auto vec_dims = phi::vectorize(in_tensor.dims());
+      bool all_zeros = true;
+      for (auto &dim : vec_dims) {
+        if (dim != 0) {
+          all_zeros = false;
+          break;
+        }
+      }
       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
         // OneDNN uses blocking format, which cannot be always supported with
         // reorders, because if blocked dimension is not divisible by 8 or
@@ -165,7 +172,7 @@ class SliceOp : public framework::OperatorWithKernel {
             phi::vectorize(ctx.Input<phi::DenseTensor>("Input")->dims()),
             dnnl::memory::data_type::f32,
             ctx.Input<phi::DenseTensor>("Input")->format());
-        if (tmp_md.data.format_desc.blocking.inner_nblks == 0)
+        if (tmp_md.data.format_desc.blocking.inner_nblks == 0 && !all_zeros)
           return framework::OpKernelType(input_data_type,
                                          ctx.GetPlace(),
                                          framework::DataLayout::kMKLDNN,

--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -156,9 +156,9 @@ class SliceOp : public framework::OperatorWithKernel {
       auto input_data_type =
           framework::OperatorWithKernel::IndicateVarDataType(ctx, "Input");
       auto vec_dims = phi::vectorize(in_tensor.dims());
-      bool not_all_zero_dims = std::all_of(
-          vec_dims.cbegin(), vec_dims.cend(), [](int64_t i) { return i != 0; });
-      if (!not_all_zero_dims && this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      bool all_zero_dims = std::all_of(
+          vec_dims.cbegin(), vec_dims.cend(), [](int64_t i) { return i == 0; });
+      if (!all_zero_dims && this->CanMKLDNNBeUsed(ctx, input_data_type)) {
         // OneDNN uses blocking format, which cannot be always supported with
         // reorders, because if blocked dimension is not divisible by 8 or
         // 16(depending on which blocking format is used) submemory cannot be

--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -156,13 +156,8 @@ class SliceOp : public framework::OperatorWithKernel {
       auto input_data_type =
           framework::OperatorWithKernel::IndicateVarDataType(ctx, "Input");
       auto vec_dims = phi::vectorize(in_tensor.dims());
-      bool all_zeros = true;
-      for (auto &dim : vec_dims) {
-        if (dim != 0) {
-          all_zeros = false;
-          break;
-        }
-      }
+      bool not_all_zero_dim = std::all_of(
+          vec_dims.cbegin(), vec_dims.cend(), [](int64_t i) { return i != 0; });
       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
         // OneDNN uses blocking format, which cannot be always supported with
         // reorders, because if blocked dimension is not divisible by 8 or
@@ -172,7 +167,8 @@ class SliceOp : public framework::OperatorWithKernel {
             phi::vectorize(ctx.Input<phi::DenseTensor>("Input")->dims()),
             dnnl::memory::data_type::f32,
             ctx.Input<phi::DenseTensor>("Input")->format());
-        if (tmp_md.data.format_desc.blocking.inner_nblks == 0 && !all_zeros)
+        if (tmp_md.data.format_desc.blocking.inner_nblks == 0 &&
+            not_all_zero_dim)
           return framework::OpKernelType(input_data_type,
                                          ctx.GetPlace(),
                                          framework::DataLayout::kMKLDNN,

--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -156,7 +156,7 @@ class SliceOp : public framework::OperatorWithKernel {
       auto input_data_type =
           framework::OperatorWithKernel::IndicateVarDataType(ctx, "Input");
       auto vec_dims = phi::vectorize(in_tensor.dims());
-      bool not_all_zero_dim = std::all_of(
+      bool not_all_zero_dims = std::all_of(
           vec_dims.cbegin(), vec_dims.cend(), [](int64_t i) { return i != 0; });
       if (!not_all_zero_dims && this->CanMKLDNNBeUsed(ctx, input_data_type)) {
         // OneDNN uses blocking format, which cannot be always supported with


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix slice bugs in MKLDNN when input dims are zeros, like [0, 0, 0, 0]