### PR TITLE
summer-ospp 2022: 飞桨PaddlePaddle Sparse Conv开发和优化——hash table

### DIFF
--- a/paddle/phi/kernels/sparse/gpu/conv.cu.h
+++ b/paddle/phi/kernels/sparse/gpu/conv.cu.h
@@ -777,6 +777,7 @@ int ProductRuleBook(const Context& dev_ctx,
                                                             rulebook_ptr,
                                                             counter_ptr);
     }
+    if (hash) delete out_index_hash_table_ptr;
 
     out->SetMember(out_indices, out_values, out_dims, false);
 
@@ -802,7 +803,6 @@ int ProductRuleBook(const Context& dev_ctx,
                                              out_rulebook_ptr);
     *rulebook = out_rulebook;
 
-    if (hash) delete out_index_hash_table_ptr;
     return rulebook_len;
   } else {
     DenseTensor out_index_table = phi::Empty<int>(dev_ctx, {table_size});

--- a/paddle/phi/kernels/sparse/gpu/cudf/ LICENSE
+++ b/paddle/phi/kernels/sparse/gpu/cudf/ LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 NVIDIA Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/paddle/phi/kernels/sparse/gpu/cudf/concurrent_unordered_map.cuh.h
+++ b/paddle/phi/kernels/sparse/gpu/cudf/concurrent_unordered_map.cuh.h
@@ -1,0 +1,892 @@
+/*
+ * Copyright (c) 2017-2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This source code refers to https://github.com/rapidsai/cudf
+ * and is licensed under the license found in the LICENSE file
+ * in the root directory of this source tree.
+ */
+
+
+#include <thrust/pair.h>
+
+#include <cassert>
+#include <iostream>
+#include <iterator>
+#include <type_traits>
+
+#include "paddle/phi/kernels/sparse/gpu/cudf/hash_functions.cuh"
+#include "paddle/phi/kernels/sparse/gpu/cudf/managed.cuh"
+#include "paddle/phi/kernels/sparse/gpu/cudf/managed_allocator.cuh"
+
+// TODO: replace this with CUDA_TRY and propagate the error
+#ifndef CUDA_RT_CALL
+#define CUDA_RT_CALL(call)                                                    \
+  {                                                                           \
+    cudaError_t cudaStatus = call;                                            \
+    if (cudaSuccess != cudaStatus) {                                          \
+      fprintf(stderr,                                                         \
+              "ERROR: CUDA RT call \"%s\" in line %d of file %s failed with " \
+              "%s (%d).\n",                                                   \
+              #call,                                                          \
+              __LINE__,                                                       \
+              __FILE__,                                                       \
+              cudaGetErrorString(cudaStatus),                                 \
+              cudaStatus);                                                    \
+      exit(1);                                                                \
+    }                                                                         \
+  }
+#endif
+
+
+// TODO: can we do this more efficiently?
+__inline__ __device__ int8_t atomicCAS(int8_t* address,
+                                       int8_t compare,
+                                       int8_t val) {
+  int32_t* base_address = (int32_t*)((char*)address - ((size_t)address & 3));
+  int32_t int_val = (int32_t)val << (((size_t)address & 3) * 8);
+  int32_t int_comp = (int32_t)compare << (((size_t)address & 3) * 8);
+  return (int8_t)atomicCAS(base_address, int_comp, int_val);
+}
+
+// TODO: can we do this more efficiently?
+__inline__ __device__ int16_t atomicCAS(int16_t* address,
+                                        int16_t compare,
+                                        int16_t val) {
+  int32_t* base_address = (int32_t*)((char*)address - ((size_t)address & 2));
+  int32_t int_val = (int32_t)val << (((size_t)address & 2) * 8);
+  int32_t int_comp = (int32_t)compare << (((size_t)address & 2) * 8);
+  return (int16_t)atomicCAS(base_address, int_comp, int_val);
+}
+
+__inline__ __device__ int64_t atomicCAS(int64_t* address,
+                                        int64_t compare,
+                                        int64_t val) {
+  return (int64_t)atomicCAS((unsigned long long*)address,
+                            (unsigned long long)compare,
+                            (unsigned long long)val);
+}
+
+__inline__ __device__ uint64_t atomicCAS(uint64_t* address,
+                                         uint64_t compare,
+                                         uint64_t val) {
+  return (uint64_t)atomicCAS((unsigned long long*)address,
+                             (unsigned long long)compare,
+                             (unsigned long long)val);
+}
+
+__inline__ __device__ long long int atomicCAS(long long int* address,
+                                              long long int compare,
+                                              long long int val) {
+  return (long long int)atomicCAS((unsigned long long*)address,
+                                  (unsigned long long)compare,
+                                  (unsigned long long)val);
+}
+
+__inline__ __device__ double atomicCAS(double* address,
+                                       double compare,
+                                       double val) {
+  return __longlong_as_double(atomicCAS((unsigned long long int*)address,
+                                        __double_as_longlong(compare),
+                                        __double_as_longlong(val)));
+}
+
+__inline__ __device__ float atomicCAS(float* address,
+                                      float compare,
+                                      float val) {
+  return __int_as_float(
+      atomicCAS((int*)address, __float_as_int(compare), __float_as_int(val)));
+}
+
+__inline__ __device__ int64_t atomicAdd(int64_t* address, int64_t val) {
+  return (int64_t)atomicAdd((unsigned long long*)address,
+                            (unsigned long long)val);
+}
+
+__inline__ __device__ uint64_t atomicAdd(uint64_t* address, uint64_t val) {
+  return (uint64_t)atomicAdd((unsigned long long*)address,
+                             (unsigned long long)val);
+}
+
+template <typename pair_type>
+__forceinline__ __device__ pair_type
+load_pair_vectorized(const pair_type* __restrict__ const ptr) {
+  if (sizeof(uint4) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      uint4 vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0, 0, 0, 0};
+    converter.vec_val = *reinterpret_cast<const uint4*>(ptr);
+    return converter.pair_val;
+  } else if (sizeof(uint2) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      uint2 vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0, 0};
+    converter.vec_val = *reinterpret_cast<const uint2*>(ptr);
+    return converter.pair_val;
+  } else if (sizeof(int) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      int vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0};
+    converter.vec_val = *reinterpret_cast<const int*>(ptr);
+    return converter.pair_val;
+  } else if (sizeof(short) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      short vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0};
+    converter.vec_val = *reinterpret_cast<const short*>(ptr);
+    return converter.pair_val;
+  } else {
+    return *ptr;
+  }
+}
+
+template <typename pair_type>
+__forceinline__ __device__ void store_pair_vectorized(
+    pair_type* __restrict__ const ptr, const pair_type val) {
+  if (sizeof(uint4) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      uint4 vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0, 0, 0, 0};
+    converter.pair_val = val;
+    *reinterpret_cast<uint4*>(ptr) = converter.vec_val;
+  } else if (sizeof(uint2) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      uint2 vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0, 0};
+    converter.pair_val = val;
+    *reinterpret_cast<uint2*>(ptr) = converter.vec_val;
+  } else if (sizeof(int) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      int vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0};
+    converter.pair_val = val;
+    *reinterpret_cast<int*>(ptr) = converter.vec_val;
+  } else if (sizeof(short) == sizeof(pair_type)) {
+    union pair_type2vec_type {
+      short vec_val;
+      pair_type pair_val;
+    };
+    pair_type2vec_type converter = {0};
+    converter.pair_val = val;
+    *reinterpret_cast<short*>(ptr) = converter.vec_val;
+  } else {
+    *ptr = val;
+  }
+}
+
+template <typename value_type,
+          typename size_type,
+          typename key_type,
+          typename elem_type>
+__global__ void init_hashtbl(  // Init every entry of the table with
+                               // <unused_key, unused_value> pair
+    value_type* __restrict__ const hashtbl_values,
+    const size_type n,
+    const key_type key_val,
+    const elem_type elem_val) {
+  const size_type idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    store_pair_vectorized(
+        hashtbl_values + idx,
+        thrust::make_pair(
+            key_val, elem_val));  // Simply store every element a <K, V> pair
+  }
+}
+
+template <typename T>
+struct equal_to {
+  using result_type = bool;
+  using first_argument_type = T;
+  using second_argument_type = T;
+  __forceinline__ __host__ __device__ constexpr bool operator()(
+      const first_argument_type& lhs, const second_argument_type& rhs) const {
+    return lhs == rhs;
+  }
+};
+
+template <typename Iterator>
+class cycle_iterator_adapter {
+ public:
+  //using value_type = typename std::iterator_traits<Iterator>::value_type;
+  //using difference_type =
+      //typename std::iterator_traits<Iterator>::difference_type;
+  //using pointer = typename std::iterator_traits<Iterator>::pointer;
+  //using reference = typename std::iterator_traits<Iterator>::reference;
+  using iterator_type = Iterator;
+
+  cycle_iterator_adapter() = delete;
+
+  __host__ __device__ explicit cycle_iterator_adapter(
+      const iterator_type& begin,
+      const iterator_type& end,
+      const iterator_type& current)
+      : m_begin(begin), m_end(end), m_current(current) {}
+
+  __host__ __device__ cycle_iterator_adapter& operator++() {
+    if (m_end == (m_current + 1))
+      m_current = m_begin;
+    else
+      ++m_current;
+    return *this;
+  }
+
+  __host__ __device__ const cycle_iterator_adapter& operator++() const {
+    if (m_end == (m_current + 1))
+      m_current = m_begin;
+    else
+      ++m_current;
+    return *this;
+  }
+
+  __host__ __device__ cycle_iterator_adapter& operator++(int) {
+    cycle_iterator_adapter<iterator_type> old(m_begin, m_end, m_current);
+    if (m_end == (m_current + 1))
+      m_current = m_begin;
+    else
+      ++m_current;
+    return old;
+  }
+
+  __host__ __device__ const cycle_iterator_adapter& operator++(int) const {
+    cycle_iterator_adapter<iterator_type> old(m_begin, m_end, m_current);
+    if (m_end == (m_current + 1))
+      m_current = m_begin;
+    else
+      ++m_current;
+    return old;
+  }
+
+  __host__ __device__ bool equal(
+      const cycle_iterator_adapter<iterator_type>& other) const {
+    return m_current == other.m_current && m_begin == other.m_begin &&
+           m_end == other.m_end;
+  }
+
+  //__host__ __device__ reference& operator*() { return *m_current; }
+
+  //__host__ __device__ const reference& operator*() const { return *m_current; }
+
+  //__host__ __device__ const pointer operator->() const {
+    //return m_current.operator->();
+  //}
+
+  //__host__ __device__ pointer operator->() { return m_current; }
+
+  __host__ __device__ iterator_type getter() const { return m_current; }
+
+ private:
+  iterator_type m_current;
+  iterator_type m_begin;
+  iterator_type m_end;
+};
+
+//template <class T>
+//__host__ __device__ bool operator==(const cycle_iterator_adapter<T>& lhs,
+                                    //const cycle_iterator_adapter<T>& rhs) {
+  //return lhs.equal(rhs);
+//}
+
+//template <class T>
+//__host__ __device__ bool operator!=(const cycle_iterator_adapter<T>& lhs,
+                                    //const cycle_iterator_adapter<T>& rhs) {
+  //return !lhs.equal(rhs);
+//}
+
+/**
+ * Does support concurrent insert, but not concurrent insert and probping.
+ *
+ * TODO:
+ *  - add constructor that takes pointer to hash_table to avoid allocations
+ *  - extend interface to accept streams
+ */
+template <typename Key,
+          typename Element,
+          Key unused_key,
+          typename Hasher = default_hash<Key>,
+          typename Equality = equal_to<Key>,
+          typename Allocator = managed_allocator<thrust::pair<Key, Element>>>
+class concurrent_unordered_map : public managed {
+ public:
+  using size_type = size_t;
+  using hasher = Hasher;
+  using key_equal = Equality;
+  using allocator_type = Allocator;
+  using key_type = Key;
+  using value_type = thrust::pair<Key, Element>;
+  using mapped_type = Element;
+  using iterator = cycle_iterator_adapter<value_type*>;
+  using const_iterator = const cycle_iterator_adapter<value_type*>;
+
+ private:
+  union pair2longlong {
+    unsigned long long int longlong;
+    value_type pair;
+  };
+
+ public:
+  concurrent_unordered_map(const concurrent_unordered_map&) = delete;
+  concurrent_unordered_map& operator=(const concurrent_unordered_map&) = delete;
+  explicit concurrent_unordered_map(size_type n,
+                                    const mapped_type unused_element,
+                                    const Hasher& hf = hasher(),
+                                    const Equality& eql = key_equal(),
+                                    const allocator_type& a = allocator_type())
+      : m_hf(hf),
+        m_equal(eql),
+        m_allocator(a),
+        m_hashtbl_size(n),
+        m_hashtbl_capacity(n),
+        m_unused_element(unused_element),
+        m_enable_collision_stat(false),
+        m_insert_times(0),
+        m_insert_collisions(0),
+        m_query_times(0),
+        m_query_collisions(0) {  // allocate the raw data of hash table:
+    // m_hashtbl_values,pre-alloc it on current GPU if UM.
+    m_hashtbl_values = m_allocator.allocate(m_hashtbl_capacity);
+    constexpr int block_size = 128;
+    {
+      cudaPointerAttributes hashtbl_values_ptr_attributes;
+      cudaError_t status = cudaPointerGetAttributes(
+          &hashtbl_values_ptr_attributes, m_hashtbl_values);
+
+#if CUDART_VERSION >= 10000
+      if (cudaSuccess == status &&
+          hashtbl_values_ptr_attributes.type == cudaMemoryTypeManaged)
+#else
+      if (cudaSuccess == status && hashtbl_values_ptr_attributes.isManaged)
+#endif
+      {
+        int dev_id = 0;
+        CUDA_RT_CALL(cudaGetDevice(&dev_id));
+        CUDA_RT_CALL(cudaMemPrefetchAsync(
+            m_hashtbl_values, m_hashtbl_size * sizeof(value_type), dev_id, 0));
+      }
+    }
+    // Initialize kernel, set all entry to unused <K,V>
+    init_hashtbl<<<((m_hashtbl_size - 1) / block_size) + 1, block_size>>>(
+        m_hashtbl_values, m_hashtbl_size, unused_key, m_unused_element);
+    CUDA_RT_CALL(cudaStreamSynchronize(0));
+    CUDA_RT_CALL(cudaGetLastError());
+  }
+
+  ~concurrent_unordered_map() {
+    m_allocator.deallocate(m_hashtbl_values, m_hashtbl_capacity);
+  }
+
+  __host__ __device__ iterator begin() {
+    return iterator(
+        m_hashtbl_values, m_hashtbl_values + m_hashtbl_size, m_hashtbl_values);
+  }
+  __host__ __device__ const_iterator begin() const {
+    return const_iterator(
+        m_hashtbl_values, m_hashtbl_values + m_hashtbl_size, m_hashtbl_values);
+  }
+  __host__ __device__ iterator end() {
+    return iterator(m_hashtbl_values,
+                    m_hashtbl_values + m_hashtbl_size,
+                    m_hashtbl_values + m_hashtbl_size);
+  }
+  __host__ __device__ const_iterator end() const {
+    return const_iterator(m_hashtbl_values,
+                          m_hashtbl_values + m_hashtbl_size,
+                          m_hashtbl_values + m_hashtbl_size);
+  }
+  __host__ __device__ size_type size() const { return m_hashtbl_size; }
+  __host__ __device__ value_type* data() const { return m_hashtbl_values; }
+
+  __forceinline__ static constexpr __host__ __device__ key_type
+  get_unused_key() {
+    return unused_key;
+  }
+
+  // Generic update of a hash table value for any aggregator
+  __forceinline__ __device__ void
+  update_existing_value(mapped_type &existing_value,
+                        value_type const &insert_pair) {
+    // update without CAS
+    existing_value = insert_pair.second;
+  }
+
+  __forceinline__ __device__ void accum_existing_value_atomic(
+      mapped_type& existing_value, value_type const& accum_pair) {
+    // update with CAS
+    // existing_value = insert_pair.second;
+    int num_element =
+        sizeof(existing_value.data) / sizeof(*(existing_value.data));
+    const mapped_type& accumulator = accum_pair.second;
+
+    for (int i = 0; i < num_element; i++) {
+      atomicAdd(existing_value.data + i, accumulator.data[i]);
+    }
+
+    // atomicAdd(&existing_value, double val)
+  }
+
+  // TODO Overload atomicAdd for 1 byte and 2 byte types, until then, overload
+  // specifically for the
+  // types where atomicAdd already has an overload. Otherwise the generic
+  // update_existing_value will
+  // be used. Specialization for COUNT aggregator
+  /*
+  __forceinline__ __host__ __device__
+  void update_existing_value(mapped_type & existing_value, value_type const &
+  insert_pair,
+  count_op<int32_t> op)
+  {
+    atomicAdd(&existing_value, static_cast<mapped_type>(1));
+  }
+  // Specialization for COUNT aggregator
+  __forceinline__ __host__ __device__
+  void update_existing_value(mapped_type & existing_value, value_type const &
+  insert_pair,
+  count_op<int64_t> op)
+  {
+    atomicAdd(&existing_value, static_cast<mapped_type>(1));
+  }
+  // Specialization for COUNT aggregator
+  __forceinline__ __host__ __device__
+  void update_existing_value(mapped_type & existing_value, value_type const &
+  insert_pair,
+  count_op<float> op)
+  {
+    atomicAdd(&existing_value, static_cast<mapped_type>(1));
+  }
+  // Specialization for COUNT aggregator
+  __forceinline__ __host__ __device__
+  void update_existing_value(mapped_type & existing_value, value_type const &
+  insert_pair,
+  count_op<double> op)
+  {
+    atomicAdd(&existing_value, static_cast<mapped_type>(1));
+  }
+  */
+
+  /* --------------------------------------------------------------------------*/
+  /**
+   * @Synopsis  Inserts a new (key, value) pair. If the key already exists in
+   the map
+                an aggregation operation is performed with the new value and
+   existing value.
+                E.g., if the aggregation operation is 'max', then the maximum is
+   computed
+                between the new value and existing value and the result is
+   stored in the map.
+   *
+   * @Param[in] x The new (key, value) pair to insert
+   * @Param[in] op The aggregation operation to perform
+   * @Param[in] keys_equal An optional functor for comparing two keys
+   * @Param[in] precomputed_hash Indicates if a precomputed hash value is being
+   passed in to use
+   * to determine the write location of the new key
+   * @Param[in] precomputed_hash_value The precomputed hash value
+   * @tparam aggregation_type A functor for a binary operation that performs the
+   aggregation
+   * @tparam comparison_type A functor for comparing two keys
+   *
+   * @Returns An iterator to the newly inserted key,value pair
+   */
+  /* ----------------------------------------------------------------------------*/
+  template <class comparison_type = key_equal,
+            typename hash_value_type = typename Hasher::result_type>
+  __forceinline__ __device__ iterator
+  insert(const value_type &x, comparison_type keys_equal = key_equal(),
+         bool precomputed_hash = false,
+         hash_value_type precomputed_hash_value = 0) {
+    const size_type hashtbl_size = m_hashtbl_size;
+    value_type* hashtbl_values = m_hashtbl_values;
+
+    hash_value_type hash_value{0};
+
+    // If a precomputed hash value has been passed in, then use it to determine
+    // the write location of the new key
+    if (true == precomputed_hash) {
+      hash_value = precomputed_hash_value;
+    }
+    // Otherwise, compute the hash value from the new key
+    else {
+      hash_value = m_hf(x.first);
+    }
+
+    size_type current_index = hash_value % hashtbl_size;
+    value_type* current_hash_bucket = &(hashtbl_values[current_index]);
+
+    const key_type insert_key = x.first;
+
+    bool insert_success = false;
+
+    size_type counter = 0;
+    while (false == insert_success) {
+      if (counter++ >= hashtbl_size) {
+        return end();
+      }
+
+      key_type& existing_key = current_hash_bucket->first;
+      mapped_type& existing_value = current_hash_bucket->second;
+
+      // Try and set the existing_key for the current hash bucket to insert_key
+      const key_type old_key = atomicCAS(&existing_key, unused_key, insert_key);
+
+      // If old_key == unused_key, the current hash bucket was empty
+      // and existing_key was updated to insert_key by the atomicCAS.
+      // If old_key == insert_key, this key has already been inserted.
+      // In either case, perform the atomic aggregation of existing_value and
+      // insert_value
+      // Because the hash table is initialized with the identity value of the
+      // aggregation
+      // operation, it is safe to perform the operation when the existing_value
+      // still
+      // has its initial value
+      // TODO: Use template specialization to make use of native atomic
+      // functions
+      // TODO: How to handle data types less than 32 bits?
+      if (keys_equal(unused_key, old_key) || keys_equal(insert_key, old_key)) {
+        update_existing_value(existing_value, x);
+        insert_success = true;
+        if (m_enable_collision_stat) {
+          atomicAdd(&m_insert_times, 1);
+        }
+        break;
+      }
+
+      if (m_enable_collision_stat) {
+        atomicAdd(&m_insert_collisions, 1);
+      }
+      current_index = (current_index + 1) % hashtbl_size;
+      current_hash_bucket = &(hashtbl_values[current_index]);
+    }
+
+    return iterator(
+        m_hashtbl_values, m_hashtbl_values + hashtbl_size, current_hash_bucket);
+  }
+
+  /* This function is not currently implemented
+  __forceinline__
+  __host__ __device__ iterator insert(const value_type& x)
+  {
+      const size_type hashtbl_size    = m_hashtbl_size;
+      value_type* hashtbl_values      = m_hashtbl_values;
+      const size_type key_hash        = m_hf( x.first );
+      size_type hash_tbl_idx          = key_hash%hashtbl_size;
+      value_type* it = 0;
+      while (0 == it) {
+          value_type* tmp_it = hashtbl_values + hash_tbl_idx;
+#ifdef __CUDA_ARCH__
+          if ( std::numeric_limits<key_type>::is_integer &&
+std::numeric_limits<mapped_type>::is_integer && sizeof(unsigned long long int)
+== sizeof(value_type)
+)
+          {
+              pair2longlong converter = {0ull};
+              converter.pair = thrust::make_pair( unused_key, m_unused_element
+);
+              const unsigned long long int unused = converter.longlong;
+              converter.pair = x;
+              const unsigned long long int value = converter.longlong;
+              const unsigned long long int old_val = atomicCAS(
+reinterpret_cast<unsigned long long
+int*>(tmp_it), unused, value ); if ( old_val == unused ) { it = tmp_it;
+              }
+              else if ( m_enable_collision_stat )
+              {
+                  atomicAdd( &m_insert_collisions, 1 );
+              }
+          } else {
+              const key_type old_key = atomicCAS( &(tmp_it->first), unused_key,
+x.first );
+              if ( m_equal( unused_key, old_key ) ) {
+                  (m_hashtbl_values+hash_tbl_idx)->second = x.second;
+                  it = tmp_it;
+              }
+              else if ( m_enable_collision_stat )
+              {
+                  atomicAdd( &m_insert_collisions, 1 );
+              }
+          }
+#else
+          #pragma omp critical
+          {
+              if ( m_equal( unused_key, tmp_it->first ) ) {
+                  hashtbl_values[hash_tbl_idx] = thrust::make_pair( x.first,
+x.second );
+                  it = tmp_it;
+              }
+          }
+#endif
+          hash_tbl_idx = (hash_tbl_idx+1)%hashtbl_size;
+      }
+      return iterator( m_hashtbl_values,m_hashtbl_values+hashtbl_size,it);
+  }
+  */
+
+  __forceinline__ __device__ const_iterator find(const key_type& k) {
+    size_type key_hash = m_hf(k);
+    size_type hash_tbl_idx = key_hash % m_hashtbl_size;
+
+    value_type* begin_ptr = 0;
+
+    size_type counter = 0;
+    while (0 == begin_ptr) {
+      value_type* tmp_ptr = m_hashtbl_values + hash_tbl_idx;
+      const key_type tmp_val = tmp_ptr->first;
+      if (m_equal(k, tmp_val)) {
+        begin_ptr = tmp_ptr;
+        break;
+      }
+      if (m_equal(unused_key, tmp_val) || counter > m_hashtbl_size) {
+        begin_ptr = m_hashtbl_values + m_hashtbl_size;
+        break;
+      }
+      if (m_enable_collision_stat) {
+        atomicAdd(&m_query_collisions, 1);
+      }
+      hash_tbl_idx = (hash_tbl_idx + 1) % m_hashtbl_size;
+      ++counter;
+    }
+
+    if (m_enable_collision_stat) {
+      atomicAdd(&m_query_times, 1);
+    }
+
+    return const_iterator(
+        m_hashtbl_values, m_hashtbl_values + m_hashtbl_size, begin_ptr);
+  }
+
+  template <typename aggregation_type,
+            typename counter_type,
+            class comparison_type = key_equal,
+            typename hash_value_type = typename Hasher::result_type>
+  __forceinline__ __device__ iterator
+  get_insert(const key_type& k,
+             aggregation_type op,
+             counter_type* value_counter,
+             comparison_type keys_equal = key_equal(),
+             bool precomputed_hash = false,
+             hash_value_type precomputed_hash_value = 0) {
+    const size_type hashtbl_size = m_hashtbl_size;
+    value_type* hashtbl_values = m_hashtbl_values;
+
+    hash_value_type hash_value{0};
+
+    // If a precomputed hash value has been passed in, then use it to determine
+    // the write location of the new key
+    if (true == precomputed_hash) {
+      hash_value = precomputed_hash_value;
+    }
+    // Otherwise, compute the hash value from the new key
+    else {
+      hash_value = m_hf(k);
+    }
+
+    size_type current_index = hash_value % hashtbl_size;
+    value_type* current_hash_bucket = &(hashtbl_values[current_index]);
+
+    const key_type insert_key = k;
+
+    bool insert_success = false;
+
+    size_type counter = 0;
+    while (false == insert_success) {
+      // Situation %5: No slot: All slot in the hashtable is occupied by other
+      // key, both get and
+      // insert fail. Return empty iterator
+      if (counter++ >= hashtbl_size) {
+        return end();
+      }
+
+      key_type& existing_key = current_hash_bucket->first;
+      volatile mapped_type& existing_value = current_hash_bucket->second;
+
+      // Try and set the existing_key for the current hash bucket to insert_key
+      const key_type old_key = atomicCAS(&existing_key, unused_key, insert_key);
+
+      // If old_key == unused_key, the current hash bucket was empty
+      // and existing_key was updated to insert_key by the atomicCAS.
+      // If old_key == insert_key, this key has already been inserted.
+      // In either case, perform the atomic aggregation of existing_value and
+      // insert_value
+      // Because the hash table is initialized with the identity value of the
+      // aggregation
+      // operation, it is safe to perform the operation when the existing_value
+      // still
+      // has its initial value
+      // TODO: Use template specialization to make use of native atomic
+      // functions
+      // TODO: How to handle data types less than 32 bits?
+
+      // Situation #1: Empty slot: this key never exist in the table, ready to
+      // insert.
+      if (keys_equal(unused_key, old_key)) {
+        // update_existing_value(existing_value, x, op);
+        existing_value = (mapped_type)(atomicAdd(value_counter, 1));
+        break;
+
+      }  // Situation #2+#3: Target slot: This slot is the slot for this key
+      else if (keys_equal(insert_key, old_key)) {
+        while (existing_value == m_unused_element) {
+          // Situation #2: This slot is inserting by another CUDA thread and the
+          // value is not yet
+          // ready, just wait
+        }
+        // Situation #3: This slot is already ready, get successfully and return
+        // (iterator of) the
+        // value
+        break;
+      }
+      // Situation 4: Wrong slot: This slot is occupied by other key, get fail,
+      // do nothing and
+      // linear probing to next slot.
+
+      current_index = (current_index + 1) % hashtbl_size;
+      current_hash_bucket = &(hashtbl_values[current_index]);
+    }
+
+    return iterator(
+        m_hashtbl_values, m_hashtbl_values + hashtbl_size, current_hash_bucket);
+  }
+
+  int assign_async(const concurrent_unordered_map& other,
+                   cudaStream_t stream = 0) {
+    m_insert_collisions = other.m_insert_collisions;
+    if (other.m_hashtbl_size <= m_hashtbl_capacity) {
+      m_hashtbl_size = other.m_hashtbl_size;
+    } else {
+      m_allocator.deallocate(m_hashtbl_values, m_hashtbl_capacity);
+      m_hashtbl_capacity = other.m_hashtbl_size;
+      m_hashtbl_size = other.m_hashtbl_size;
+
+      m_hashtbl_values = m_allocator.allocate(m_hashtbl_capacity);
+    }
+    CUDA_RT_CALL(cudaMemcpyAsync(m_hashtbl_values,
+                                 other.m_hashtbl_values,
+                                 m_hashtbl_size * sizeof(value_type),
+                                 cudaMemcpyDefault,
+                                 stream));
+    return 0;
+  }
+
+  void clear_async(cudaStream_t stream = 0) {
+    constexpr int block_size = 128;
+    init_hashtbl<<<((m_hashtbl_size - 1) / block_size) + 1,
+                   block_size,
+                   0,
+                   stream>>>(
+        m_hashtbl_values, m_hashtbl_size, unused_key, m_unused_element);
+    if (m_enable_collision_stat) {
+      m_insert_times = 0;
+      m_insert_collisions = 0;
+      m_query_times = 0;
+      m_query_collisions = 0;
+    }
+  }
+
+  unsigned long long get_num_collisions() const { return m_insert_collisions; }
+
+  void print() {
+    for (size_type i = 0; i < 5; ++i) {
+      std::cout << i << ": " << m_hashtbl_values[i].first << ","
+                << m_hashtbl_values[i].second << std::endl;
+    }
+  }
+
+  int prefetch(const int dev_id, cudaStream_t stream = 0) {
+    cudaPointerAttributes hashtbl_values_ptr_attributes;
+    cudaError_t status = cudaPointerGetAttributes(
+        &hashtbl_values_ptr_attributes, m_hashtbl_values);
+
+#if CUDART_VERSION >= 10000
+    if (cudaSuccess == status &&
+        hashtbl_values_ptr_attributes.type == cudaMemoryTypeManaged)
+#else
+    if (cudaSuccess == status && hashtbl_values_ptr_attributes.isManaged)
+#endif
+    {
+      CUDA_RT_CALL(cudaMemPrefetchAsync(m_hashtbl_values,
+                                        m_hashtbl_size * sizeof(value_type),
+                                        dev_id,
+                                        stream));
+    }
+    CUDA_RT_CALL(cudaMemPrefetchAsync(this, sizeof(*this), dev_id, stream));
+
+    return 0;
+  }
+
+  template <class comparison_type = key_equal,
+            typename hash_value_type = typename Hasher::result_type>
+  __forceinline__ __device__ const_iterator
+  accum(const value_type& x,
+        comparison_type keys_equal = key_equal(),
+        bool precomputed_hash = false,
+        hash_value_type precomputed_hash_value = 0) {
+    const key_type& dst_key = x.first;
+    auto it = find(dst_key);
+
+    if (it == end()) {
+      return it;
+    }
+
+    value_type* dst = it.getter();
+
+    accum_existing_value_atomic(dst->second, x);
+
+    return it;
+  }
+
+  __host__ void print_collision(int id) {
+    if (m_enable_collision_stat) {
+      printf(
+          "collision stat for hbm table %d, insert(%lu:%lu:%.2f), "
+          "query(%lu:%lu:%.2f)\n",
+          id,
+          m_insert_times,
+          m_insert_collisions,
+          m_insert_collisions / (double)m_insert_times,
+          m_query_times,
+          m_query_collisions,
+          m_query_collisions / (double)m_query_times);
+    }
+  }
+
+ private:
+  const hasher m_hf;
+  const key_equal m_equal;
+
+  const mapped_type m_unused_element;
+
+  allocator_type m_allocator;
+
+  size_type m_hashtbl_size;
+  size_type m_hashtbl_capacity;
+  value_type* m_hashtbl_values;
+
+  bool m_enable_collision_stat;
+  uint64_t m_insert_times;
+  uint64_t m_insert_collisions;
+  uint64_t m_query_times;
+  uint64_t m_query_collisions;
+};

--- a/paddle/phi/kernels/sparse/gpu/cudf/hash_functions.cuh
+++ b/paddle/phi/kernels/sparse/gpu/cudf/hash_functions.cuh
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2017, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This source code refers to https://github.com/rapidsai/cudf
+ * and is licensed under the license found in the LICENSE file
+ * in the root directory of this source tree.
+ */
+
+using hash_value_type = uint32_t;
+
+// MurmurHash3_32 implementation from
+// https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+//-----------------------------------------------------------------------------
+// MurmurHash3 was written by Austin Appleby, and is placed in the public
+// domain. The author hereby disclaims copyright to this source code.
+// Note - The x86 and x64 versions do _not_ produce the same results, as the
+// algorithms are optimized for their respective platforms. You can still
+// compile and run any of them on any platform, but your performance with the
+// non-native version will be less than optimal.
+template <typename Key>
+struct MurmurHash3_32 {
+  using argument_type = Key;
+  using result_type = hash_value_type;
+
+  __forceinline__ __host__ __device__ MurmurHash3_32() : m_seed(0) {}
+
+  __forceinline__ __host__ __device__ uint32_t rotl32(uint32_t x,
+                                                      int8_t r) const {
+    return (x << r) | (x >> (32 - r));
+  }
+
+  __forceinline__ __host__ __device__ uint32_t fmix32(uint32_t h) const {
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+    return h;
+  }
+
+  /* --------------------------------------------------------------------------*/
+  /**
+   * @Synopsis  Combines two hash values into a new single hash value. Called
+   * repeatedly to create a hash value from several variables.
+   * Taken from the Boost hash_combine function
+   * https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+   *
+   * @Param lhs The first hash value to combine
+   * @Param rhs The second hash value to combine
+   *
+   * @Returns A hash value that intelligently combines the lhs and rhs hash
+   * values
+   */
+  /* ----------------------------------------------------------------------------*/
+  __host__ __device__ result_type hash_combine(result_type lhs,
+                                               result_type rhs) {
+    result_type combined{lhs};
+
+    combined ^= rhs + 0x9e3779b9 + (combined << 6) + (combined >> 2);
+
+    return combined;
+  }
+
+  __forceinline__ __host__ __device__ result_type
+  operator()(const Key& key) const {
+    constexpr int len = sizeof(argument_type);
+    const uint8_t* const data = (const uint8_t*)&key;
+    constexpr int nblocks = len / 4;
+    uint32_t h1 = m_seed;
+    constexpr uint32_t c1 = 0xcc9e2d51;
+    constexpr uint32_t c2 = 0x1b873593;
+    //----------
+    // body
+    const uint32_t* const blocks = (const uint32_t*)(data + nblocks * 4);
+    for (int i = -nblocks; i; i++) {
+      uint32_t k1 = blocks[i];  // getblock32(blocks,i);
+      k1 *= c1;
+      k1 = rotl32(k1, 15);
+      k1 *= c2;
+      h1 ^= k1;
+      h1 = rotl32(h1, 13);
+      h1 = h1 * 5 + 0xe6546b64;
+    }
+    //----------
+    // tail
+    const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
+    uint32_t k1 = 0;
+    switch (len & 3) {
+      case 3:
+        k1 ^= tail[2] << 16;
+      case 2:
+        k1 ^= tail[1] << 8;
+      case 1:
+        k1 ^= tail[0];
+        k1 *= c1;
+        k1 = rotl32(k1, 15);
+        k1 *= c2;
+        h1 ^= k1;
+    };
+    //----------
+    // finalization
+    h1 ^= len;
+    h1 = fmix32(h1);
+    return h1;
+  }
+
+ private:
+  const uint32_t m_seed;
+};
+
+template <typename Key>
+using default_hash = MurmurHash3_32<Key>;

--- a/paddle/phi/kernels/sparse/gpu/cudf/managed.cuh
+++ b/paddle/phi/kernels/sparse/gpu/cudf/managed.cuh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This source code refers to https://github.com/rapidsai/cudf
+ * and is licensed under the license found in the LICENSE file
+ * in the root directory of this source tree.
+ */
+
+#include <new>
+
+struct managed {
+  static void *operator new(size_t n) {
+    void *ptr = 0;
+    cudaError_t result = cudaMallocManaged(&ptr, n);
+    if (cudaSuccess != result || 0 == ptr) throw std::bad_alloc();
+    return ptr;
+  }
+
+  static void operator delete(void *ptr) noexcept { cudaFree(ptr); }
+};

--- a/paddle/phi/kernels/sparse/gpu/cudf/managed_allocator.cuh
+++ b/paddle/phi/kernels/sparse/gpu/cudf/managed_allocator.cuh
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This source code refers to https://github.com/rapidsai/cudf
+ * and is licensed under the license found in the LICENSE file
+ * in the root directory of this source tree.
+ */
+
+#include <new>
+
+template <class T>
+struct managed_allocator {
+  typedef T value_type;
+
+  managed_allocator() = default;
+
+  template <class U>
+  constexpr managed_allocator(const managed_allocator<U>&) noexcept {}
+
+  T* allocate(std::size_t n) const {
+    T* ptr = 0;
+    cudaError_t result = cudaMallocManaged(&ptr, n * sizeof(T));
+    if (cudaSuccess != result || nullptr == ptr) {
+      std::cerr << "ERROR: CUDA Runtime call in line " << __LINE__ << "of file "
+                << __FILE__ << " failed with " << cudaGetErrorString(result)
+                << " (" << result << ") "
+                << " Attempted to allocate: " << n * sizeof(T) << " bytes.\n";
+      throw std::bad_alloc();
+    }
+    return ptr;
+  }
+  void deallocate(T* p, std::size_t) const { cudaFree(p); }
+};
+
+template <class T, class U>
+bool operator==(const managed_allocator<T>&, const managed_allocator<U>&) {
+  return true;
+}
+template <class T, class U>
+bool operator!=(const managed_allocator<T>&, const managed_allocator<U>&) {
+  return false;
+}


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
1. Add a custom cudf (based on v0.6.1) to implement hash table on GPU (refer to [existing code in paddle](https://github.com/PaddlePaddle/Paddle/tree/798670bba6d720bebd3f07bf98b06622b2d864ea/paddle/fluid/framework/fleet/heter_ps/cudf)).
2. Optimize Conv3dCooGPUKernel with hash table when performing subm conv. Using a hash table for input with a large dense shape to avoid initializing a large index table. 
3. Dynamic choose hash table or normal index table for different input shapes (because hash computation is slow on GPU, hash table may hurt the performance for some input shapes). The condition needs to be tuned on different hardware. I choose the best one for GeForce RTX 3060 and the current test shape now.

Speed up about 15% on GeForce RTX 3060 Mobile GPU for some input when performing subm conv ( I perform the experiment by running 100 times warm up first, and testing the time of 500 times forward):
|(x, y, z, in_channel, out_channel, sparsity)|(41,1600,1408, 4, 16, 0.9985)|(41,1600,1408, 16, 16, 0.9985)|
|---|---|---|
|without hash table(sec)|1.01882895099993|1.05665245900002
|with hash table(sec)|0.86128283599879|0.9077350210000077

I overload some kernel to avoid performing if-else conditions on GPU. We could use Marco to restructure these overloaded functions later.