### PR TITLE
[MKLDNN] Delete #ifdef MKLDNN in prelu GetKernelTypeForVar

### DIFF
--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -52,17 +52,6 @@ class PReluOp : public framework::OperatorWithKernel {
       const std::string &var_name,
       const Tensor &tensor,
       const framework::OpKernelType &expected_kernel_type) const override {
-#ifdef PADDLE_WITH_MKLDNN
-    // All inputs (including alpha) need shape rotating
-    if ((expected_kernel_type.data_layout_ == framework::DataLayout::kMKLDNN) &&
-        (tensor.layout() != framework::DataLayout::kMKLDNN) &&
-        paddle::platform::MKLDNNDeviceContext::tls()
-                .get_cur_paddle_data_layout() == framework::DataLayout::kNHWC) {
-      return framework::OpKernelType(expected_kernel_type.data_type_,
-                                     tensor.place(),
-                                     framework::DataLayout::kNHWC);
-    }
-#endif
     return framework::OpKernelType(
         expected_kernel_type.data_type_, tensor.place(), tensor.layout());
   }
@@ -143,17 +132,6 @@ class PReluGradOp : public framework::OperatorWithKernel {
       const std::string &var_name,
       const Tensor &tensor,
       const framework::OpKernelType &expected_kernel_type) const override {
-#ifdef PADDLE_WITH_MKLDNN
-    // All inputs (including alpha) need shape rotating
-    if ((expected_kernel_type.data_layout_ == framework::DataLayout::kMKLDNN) &&
-        (tensor.layout() != framework::DataLayout::kMKLDNN) &&
-        paddle::platform::MKLDNNDeviceContext::tls()
-                .get_cur_paddle_data_layout() == framework::DataLayout::kNHWC) {
-      return framework::OpKernelType(expected_kernel_type.data_type_,
-                                     tensor.place(),
-                                     framework::DataLayout::kNHWC);
-    }
-#endif
     return framework::OpKernelType(
         expected_kernel_type.data_type_, tensor.place(), tensor.layout());
   }


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
In `PADDLE_WITH_MKLDNN` mode, the layout result of `GetExpectedKernelType` is **kMKLDNN**. Either the layout result of `GetKernelTypeForVar` is **kNHWC** or **tensor.layout()**, tensor needs to transform to **kMKLDNN**. Therefore, the hard code within `#ifdef PADDLE_WITH_MKLDNN` of `GetKernelTypeForVar` can be deleted directly.

在`PADDLE_WITH_MKLDNN`模式下，`GetExpectedKernelType`的layout结果是**kMKLDNN**。不管`GetKernelTypeForVar`的返回值是**kNHWC**还是**tensor.layout()**，tensor都需要转换成**kMKLDNN**，因此可以直接删除`GetKernelTypeForVar`中的硬编码