### PR TITLE
[Opt interpolate] Opt GetExpectedKernelType code of interp

### DIFF
--- a/paddle/fluid/operators/interpolate_op.cc
+++ b/paddle/fluid/operators/interpolate_op.cc
@@ -342,10 +342,11 @@ class InterpolateOp : public framework::OperatorWithKernel {
     auto data_type = OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
 #ifdef PADDLE_WITH_MKLDNN
-    const auto& interp_method = ctx.Attr<std::string>("interp_method");
     // TODO(danqing): support other interp_method
-    if (this->CanMKLDNNBeUsed(ctx, data_type) &&
-        (interp_method == "nearest" || interp_method == "bilinear")) {
+    // (https://github.com/PaddlePaddle/Paddle/pull/30016/files)
+    // NOTE(jiahy0825): currently only support interp_method = nearest or
+    // interp_method = bilinear
+    if (this->CanMKLDNNBeUsed(ctx, data_type)) {
       return framework::OpKernelType(data_type,
                                      ctx.GetPlace(),
                                      framework::DataLayout::kMKLDNN,

--- a/paddle/fluid/operators/interpolate_v2_op.cc
+++ b/paddle/fluid/operators/interpolate_v2_op.cc
@@ -446,10 +446,11 @@ class InterpolateV2Op : public framework::OperatorWithKernel {
     auto data_type = OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
 #ifdef PADDLE_WITH_MKLDNN
-    const auto& interp_method = ctx.Attr<std::string>("interp_method");
     // TODO(danqing): support other interp_method
-    if (this->CanMKLDNNBeUsed(ctx, data_type) &&
-        (interp_method == "nearest" || interp_method == "bilinear")) {
+    // (https://github.com/PaddlePaddle/Paddle/pull/30016/files)
+    // NOTE(jiahy0825): currently only support interp_method = nearest or
+    // interp_method = bilinear
+    if (this->CanMKLDNNBeUsed(ctx, data_type)) {
       return framework::OpKernelType(data_type,
                                      ctx.GetPlace(),
                                      framework::DataLayout::kMKLDNN,


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
Opt GetExpectedKernelType code of `interp`

Both fluid and phi search kernel by `type(op name)`, the logic of `CanMKLDNNBeUsed` covers original `if` logic (if interp_method == 'other interp methods which do not support mkldnn', `CanMKLDNNBeUsed` will return false), thus original `if` logic can be cleaned safely.

The goal of this PR: keep outside codes clean and clear when the logic within `if` condition or `#ifdef PADDLE WITH MKLDNN` is removed to other places later.

fluid和phi都是根据`type(op name)`来搜索kernel的，`CanMKLDNNBeUsed`函数中已经包含了是否更改MKLDNN layout的判断（对于`nearest`和`bilinear`的kernel才会返回true），因此可以精简现有的`if`逻辑。