### PR TITLE
[CodeStyle][F401] remove unused import in unittests/(!test_)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -92,4 +92,4 @@ per-file-ignores =
     python/paddle/fluid/tests/custom_op/*:F401
     python/paddle/fluid/tests/unittests/test_*:F401
     python/paddle/fluid/tests/test_*:F401
-    python/paddle/fluid/tests/unittests/dist_[m-w]*:F401
+    python/paddle/fluid/tests/unittests/dist_[t-w]*:F401

--- a/.flake8
+++ b/.flake8
@@ -92,4 +92,4 @@ per-file-ignores =
     python/paddle/fluid/tests/custom_op/*:F401
     python/paddle/fluid/tests/unittests/test_*:F401
     python/paddle/fluid/tests/test_*:F401
-    python/paddle/fluid/tests/*:F401
+    python/paddle/fluid/tests/unittests/dist_*:F401

--- a/.flake8
+++ b/.flake8
@@ -92,4 +92,4 @@ per-file-ignores =
     python/paddle/fluid/tests/custom_op/*:F401
     python/paddle/fluid/tests/unittests/test_*:F401
     python/paddle/fluid/tests/test_*:F401
-    python/paddle/fluid/tests/unittests/dist_[t-w]*:F401
+    python/paddle/fluid/tests/unittests/dist_[m-w]*:F401

--- a/.flake8
+++ b/.flake8
@@ -92,4 +92,4 @@ per-file-ignores =
     python/paddle/fluid/tests/custom_op/*:F401
     python/paddle/fluid/tests/unittests/test_*:F401
     python/paddle/fluid/tests/test_*:F401
-    python/paddle/fluid/tests/unittests/dist_[m-w]*:F401
+    python/paddle/fluid/tests/unittests/dist_sharding_save.py:F401

--- a/.flake8
+++ b/.flake8
@@ -92,4 +92,4 @@ per-file-ignores =
     python/paddle/fluid/tests/custom_op/*:F401
     python/paddle/fluid/tests/unittests/test_*:F401
     python/paddle/fluid/tests/test_*:F401
-    python/paddle/fluid/tests/unittests/dist_*:F401
+    python/paddle/fluid/tests/unittests/dist_[m-w]*:F401

--- a/.flake8
+++ b/.flake8
@@ -92,4 +92,4 @@ per-file-ignores =
     python/paddle/fluid/tests/custom_op/*:F401
     python/paddle/fluid/tests/unittests/test_*:F401
     python/paddle/fluid/tests/test_*:F401
-    python/paddle/fluid/tests/unittests/dist_sharding_save.py:F401
+    python/paddle/fluid/tests/*:F401

--- a/python/paddle/fluid/tests/unittests/ascend_group.py
+++ b/python/paddle/fluid/tests/unittests/ascend_group.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 import os
-import sys
-import time
 import paddle.fluid as fluid
 from paddle.fluid import unique_name
 import paddle.fluid.core as core
 import paddle
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.distributed import fleet
-from paddle.distributed.fleet.meta_optimizers.ascend import ascend_parser, ascend_optimizer
+from paddle.distributed.fleet.meta_optimizers.ascend import ascend_optimizer
 from collections import namedtuple
 
 Block = namedtuple('Block', ['program'])

--- a/python/paddle/fluid/tests/unittests/ascend_multi_process_collective.py
+++ b/python/paddle/fluid/tests/unittests/ascend_multi_process_collective.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import time
 
 
 def train(prefix):

--- a/python/paddle/fluid/tests/unittests/auto_checkpoint_utils.py
+++ b/python/paddle/fluid/tests/unittests/auto_checkpoint_utils.py
@@ -13,21 +13,14 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient
 import paddle.fluid.incubate.checkpoint.auto_checkpoint as acp
-from paddle.fluid.incubate.checkpoint.checkpoint_saver import PaddleModel
 from paddle.fluid.framework import program_guard
 from paddle.fluid import unique_name
 
 import numpy as np
-from paddle.io import Dataset, BatchSampler, DataLoader
 
 BATCH_NUM = 4
 BATCH_SIZE = 1

--- a/python/paddle/fluid/tests/unittests/auto_parallel_autoconvert.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel_autoconvert.py
@@ -16,7 +16,6 @@ import unittest
 import random
 import numpy as np
 import os
-import shutil
 
 import paddle
 import paddle.nn as nn

--- a/python/paddle/fluid/tests/unittests/auto_parallel_data_unshard.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel_data_unshard.py
@@ -14,13 +14,11 @@
 
 import unittest
 
-import copy
 import numpy as np
 import random
 
 import paddle
 import paddle.nn as nn
-import paddle.fluid.core as core
 from paddle.distributed.fleet import auto
 import paddle.nn.functional as F
 from paddle.distributed import fleet

--- a/python/paddle/fluid/tests/unittests/auto_parallel_gpt_model.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel_gpt_model.py
@@ -13,19 +13,14 @@
 # limitations under the License.
 
 import collections
-import random
-import numpy as np
 
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.tensor as tensor
 from paddle.distributed.fleet import auto
-from paddle import fluid
 from paddle.fluid import layers
-from paddle.distributed import fleet
 from paddle.nn.layer.transformer import _convert_param_attr_to_list
-from paddle.fluid.initializer import Normal, NumpyArrayInitializer
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/benchmark.py
+++ b/python/paddle/fluid/tests/unittests/benchmark.py
@@ -13,13 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import unittest
 import time
-import itertools
 import six
 
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/benchmark_sum_op.py
+++ b/python/paddle/fluid/tests/unittests/benchmark_sum_op.py
@@ -15,9 +15,7 @@
 import unittest
 import numpy as np
 
-import paddle.fluid as fluid
 from benchmark import BenchmarkSuite
-from op_test import OpTest
 
 # This is a demo op test case for operator benchmarking and high resolution number stability alignment.
 

--- a/python/paddle/fluid/tests/unittests/c_embedding_op_base.py
+++ b/python/paddle/fluid/tests/unittests/c_embedding_op_base.py
@@ -15,8 +15,6 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle
-import paddle.fluid as fluid
 from paddle.framework import core
 
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/check_nan_inf_base.py
+++ b/python/paddle/fluid/tests/unittests/check_nan_inf_base.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
-import time
 import numpy as np
 
 os.environ[str("FLAGS_check_nan_inf")] = str("1")
@@ -23,7 +21,6 @@ os.environ[str("GLOG_vmodule")] = str("nan_inf_utils_detail=10")
 import paddle.fluid.core as core
 import paddle
 import paddle.fluid as fluid
-import paddle.compat as cpt
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/check_nan_inf_base_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/check_nan_inf_base_dygraph.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import os
-import sys
-import time
 import numpy as np
 
 os.environ[str("FLAGS_check_nan_inf")] = str("1")

--- a/python/paddle/fluid/tests/unittests/collective/communication_stream_allgather_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_stream_allgather_api_dygraph.py
@@ -15,9 +15,7 @@
 import os
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 import paddle.distributed as dist
-import test_communication_api_base as test_base
 import test_collective_api_base as test_collective_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective/test_communication_stream_allgather_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_communication_stream_allgather_api.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
-import itertools
 import test_communication_api_base as test_base
 
 

--- a/python/paddle/fluid/tests/unittests/collective_allgather_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_allgather_op.py
@@ -12,24 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective_reducescatter.py
+++ b/python/paddle/fluid/tests/unittests/collective_reducescatter.py
@@ -12,24 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/collective_reducescatter_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_reducescatter_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/detected_gpu.py
+++ b/python/paddle/fluid/tests/unittests/detected_gpu.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 import sys
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/detected_gpu.py
+++ b/python/paddle/fluid/tests/unittests/detected_gpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import paddle
 import sys
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/detected_xpu.py
+++ b/python/paddle/fluid/tests/unittests/detected_xpu.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 import sys
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/detected_xpu.py
+++ b/python/paddle/fluid/tests/unittests/detected_xpu.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import paddle
 import sys
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/dist_allreduce_op.py
+++ b/python/paddle/fluid/tests/unittests/dist_allreduce_op.py
@@ -12,19 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 

--- a/python/paddle/fluid/tests/unittests/dist_allreduce_op.py
+++ b/python/paddle/fluid/tests/unittests/dist_allreduce_op.py
@@ -12,8 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import time
+import math
+
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
+import os
+import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_ctr.py
@@ -26,8 +26,6 @@ import numpy as np
 
 import ctr_dataset_reader
 from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
-from paddle.distributed.fleet.utils.ps_util import DistributedInfer
-import paddle.distributed.fleet as fleet
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_ctr.py
@@ -26,6 +26,8 @@ import numpy as np
 
 import ctr_dataset_reader
 from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
+from paddle.distributed.fleet.utils.ps_util import DistributedInfer
+import paddle.distributed.fleet as fleet
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_ctr_ps_gpu.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_ctr_ps_gpu.py
@@ -25,7 +25,7 @@ import os
 import numpy as np
 
 import ctr_dataset_reader
-from test_dist_fleet_base import runtime_main
+from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
 from dist_fleet_ctr import TestDistCTR2x2, fake_ctr_reader
 
 # Fix seed for test

--- a/python/paddle/fluid/tests/unittests/dist_fleet_ctr_ps_gpu.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_ctr_ps_gpu.py
@@ -25,7 +25,7 @@ import os
 import numpy as np
 
 import ctr_dataset_reader
-from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
+from test_dist_fleet_base import runtime_main
 from dist_fleet_ctr import TestDistCTR2x2, fake_ctr_reader
 
 # Fix seed for test

--- a/python/paddle/fluid/tests/unittests/dist_fleet_debug_gloo.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_debug_gloo.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import time
-import numpy as np
 import logging
-import paddle
-import paddle.fluid as fluid
 #import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet.base.role_maker as role_maker
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
-from paddle.fluid.transpiler.distribute_transpiler import DistributeTranspilerConfig
 
 logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("fluid")

--- a/python/paddle/fluid/tests/unittests/dist_fleet_debug_gloo.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_debug_gloo.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import time
+import numpy as np
 import logging
+import paddle
+import paddle.fluid as fluid
 #import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet.base.role_maker as role_maker
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
+from paddle.fluid.transpiler.distribute_transpiler import DistributeTranspilerConfig
 
 logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger("fluid")

--- a/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
@@ -15,18 +15,14 @@
 Distribute CTR model for test fleet api
 """
 
-import shutil
-import tempfile
 import time
 
 import paddle
 import paddle.fluid as fluid
 import os
-import numpy as np
 
 import ctr_dataset_reader
 from test_dist_fleet_heter_base import runtime_main, FleetDistHeterRunnerBase
-from dist_fleet_ctr import TestDistCTR2x2, fake_ctr_reader
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_heter_pipeline_ctr.py
@@ -15,14 +15,18 @@
 Distribute CTR model for test fleet api
 """
 
+import shutil
+import tempfile
 import time
 
 import paddle
 import paddle.fluid as fluid
 import os
+import numpy as np
 
 import ctr_dataset_reader
 from test_dist_fleet_heter_base import runtime_main, FleetDistHeterRunnerBase
+from dist_fleet_ctr import TestDistCTR2x2, fake_ctr_reader
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 from test_dist_base import TestDistRunnerBase, runtime_main
+import unittest
 import paddle
+import os
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
+import numpy as np
 from functools import reduce
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 from test_dist_base import TestDistRunnerBase, runtime_main
-import unittest
 import paddle
-import os
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
-import numpy as np
 from functools import reduce
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer_fuse_allreduce.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer_fuse_allreduce.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 from test_dist_base import TestDistRunnerBase, runtime_main
+import unittest
 import paddle
+import os
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
+import numpy as np
 from functools import reduce
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer_fuse_allreduce.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer_fuse_allreduce.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 from test_dist_base import TestDistRunnerBase, runtime_main
-import unittest
 import paddle
-import os
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
-import numpy as np
 from functools import reduce
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_simnet_bow.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_simnet_bow.py
@@ -13,11 +13,22 @@
 # limitations under the License.
 
 import numpy as np
+import argparse
 import time
+import math
+import random
+import shutil
+import tempfile
 
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
 import os
+import signal
+from functools import reduce
 from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/dist_fleet_simnet_bow.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_simnet_bow.py
@@ -13,22 +13,11 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
 import time
-import math
-import random
-import shutil
-import tempfile
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import os
-import signal
-from functools import reduce
 from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/dist_fleet_sparse_embedding_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_sparse_embedding_ctr.py
@@ -16,7 +16,9 @@ Distribute CTR model for test fleet api
 """
 
 import os
+import time
 
+import random
 import numpy as np
 
 import paddle

--- a/python/paddle/fluid/tests/unittests/dist_fleet_sparse_embedding_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_sparse_embedding_ctr.py
@@ -16,9 +16,7 @@ Distribute CTR model for test fleet api
 """
 
 import os
-import time
 
-import random
 import numpy as np
 
 import paddle

--- a/python/paddle/fluid/tests/unittests/dist_mnist.py
+++ b/python/paddle/fluid/tests/unittests/dist_mnist.py
@@ -12,22 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
-from paddle.fluid.incubate.fleet.collective import fleet, DistributedStrategy
+from paddle.fluid.incubate.fleet.collective import fleet
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/dist_mnist.py
+++ b/python/paddle/fluid/tests/unittests/dist_mnist.py
@@ -12,11 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import time
+import math
+
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
+import os
+import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
-from paddle.fluid.incubate.fleet.collective import fleet
+from paddle.fluid.incubate.fleet.collective import fleet, DistributedStrategy
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/dist_mnist_batch_merge.py
+++ b/python/paddle/fluid/tests/unittests/dist_mnist_batch_merge.py
@@ -12,8 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import time
+import math
+
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
+import os
+import signal
+from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 from dist_mnist import cnn_model
 

--- a/python/paddle/fluid/tests/unittests/dist_mnist_batch_merge.py
+++ b/python/paddle/fluid/tests/unittests/dist_mnist_batch_merge.py
@@ -12,20 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
-from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 from dist_mnist import cnn_model
 

--- a/python/paddle/fluid/tests/unittests/dist_mnist_lars.py
+++ b/python/paddle/fluid/tests/unittests/dist_mnist_lars.py
@@ -12,8 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import time
+import math
+
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
+import os
+import signal
+from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 from dist_mnist import cnn_model
 

--- a/python/paddle/fluid/tests/unittests/dist_mnist_lars.py
+++ b/python/paddle/fluid/tests/unittests/dist_mnist_lars.py
@@ -12,20 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import signal
-from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 from dist_mnist import cnn_model
 

--- a/python/paddle/fluid/tests/unittests/dist_save_load.py
+++ b/python/paddle/fluid/tests/unittests/dist_save_load.py
@@ -14,18 +14,9 @@
 
 import os
 import sys
-import signal
-import subprocess
-import argparse
-import time
-import math
-import random
-from multiprocessing import Process
-from functools import reduce
 
 import numpy as np
 import pickle
-import unittest
 import six
 
 import paddle
@@ -33,7 +24,7 @@ import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid import io
 
-from test_dist_base import TestDistRunnerBase, runtime_main, RUN_STEP
+from test_dist_base import RUN_STEP, runtime_main
 from dist_simnet_bow import TestDistSimnetBow2x2, DATA_URL, DATA_MD5
 
 

--- a/python/paddle/fluid/tests/unittests/dist_save_load.py
+++ b/python/paddle/fluid/tests/unittests/dist_save_load.py
@@ -14,9 +14,18 @@
 
 import os
 import sys
+import signal
+import subprocess
+import argparse
+import time
+import math
+import random
+from multiprocessing import Process
+from functools import reduce
 
 import numpy as np
 import pickle
+import unittest
 import six
 
 import paddle
@@ -24,7 +33,7 @@ import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid import io
 
-from test_dist_base import RUN_STEP, runtime_main
+from test_dist_base import TestDistRunnerBase, runtime_main, RUN_STEP
 from dist_simnet_bow import TestDistSimnetBow2x2, DATA_URL, DATA_MD5
 
 

--- a/python/paddle/fluid/tests/unittests/dist_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/dist_se_resnext.py
@@ -12,10 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import time
 import math
 
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
+import os
+import sys
+import signal
 from test_dist_base import TestDistRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/dist_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/dist_se_resnext.py
@@ -12,20 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
 import math
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import os
-import sys
-import signal
 from test_dist_base import TestDistRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/dist_sharding_save.py
+++ b/python/paddle/fluid/tests/unittests/dist_sharding_save.py
@@ -14,10 +14,7 @@
 
 import paddle
 import paddle.fluid as fluid
-# from test_dist_base import TestDistRunnerBase
-from dist_mnist import cnn_model
-# from paddle.fluid.incubate.fleet.collective import fleet
-# import paddle.distributed.fleet as fleet
+from dist_mnist import cnn_model  # noqa: F401
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet.meta_optimizers.sharding as sharding
 

--- a/python/paddle/fluid/tests/unittests/dist_sharding_save.py
+++ b/python/paddle/fluid/tests/unittests/dist_sharding_save.py
@@ -14,7 +14,7 @@
 
 import paddle
 import paddle.fluid as fluid
-from test_dist_base import TestDistRunnerBase
+# from test_dist_base import TestDistRunnerBase
 from dist_mnist import cnn_model
 # from paddle.fluid.incubate.fleet.collective import fleet
 import paddle.distributed.fleet as fleet

--- a/python/paddle/fluid/tests/unittests/dist_sharding_save.py
+++ b/python/paddle/fluid/tests/unittests/dist_sharding_save.py
@@ -14,10 +14,7 @@
 
 import paddle
 import paddle.fluid as fluid
-from test_dist_base import TestDistRunnerBase
-from dist_mnist import cnn_model
 # from paddle.fluid.incubate.fleet.collective import fleet
-import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet.meta_optimizers.sharding as sharding
 

--- a/python/paddle/fluid/tests/unittests/dist_sharding_save.py
+++ b/python/paddle/fluid/tests/unittests/dist_sharding_save.py
@@ -14,8 +14,8 @@
 
 import paddle
 import paddle.fluid as fluid
-# from test_dist_base import TestDistRunnerBase
-# from dist_mnist import cnn_model
+from test_dist_base import TestDistRunnerBase
+from dist_mnist import cnn_model
 # from paddle.fluid.incubate.fleet.collective import fleet
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker

--- a/python/paddle/fluid/tests/unittests/dist_sharding_save.py
+++ b/python/paddle/fluid/tests/unittests/dist_sharding_save.py
@@ -17,7 +17,7 @@ import paddle.fluid as fluid
 # from test_dist_base import TestDistRunnerBase
 from dist_mnist import cnn_model
 # from paddle.fluid.incubate.fleet.collective import fleet
-import paddle.distributed.fleet as fleet
+# import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet.meta_optimizers.sharding as sharding
 

--- a/python/paddle/fluid/tests/unittests/dist_sharding_save.py
+++ b/python/paddle/fluid/tests/unittests/dist_sharding_save.py
@@ -14,7 +14,10 @@
 
 import paddle
 import paddle.fluid as fluid
+from test_dist_base import TestDistRunnerBase
+from dist_mnist import cnn_model
 # from paddle.fluid.incubate.fleet.collective import fleet
+import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet.meta_optimizers.sharding as sharding
 

--- a/python/paddle/fluid/tests/unittests/dist_sharding_save.py
+++ b/python/paddle/fluid/tests/unittests/dist_sharding_save.py
@@ -14,8 +14,8 @@
 
 import paddle
 import paddle.fluid as fluid
-from test_dist_base import TestDistRunnerBase
-from dist_mnist import cnn_model
+# from test_dist_base import TestDistRunnerBase
+# from dist_mnist import cnn_model
 # from paddle.fluid.incubate.fleet.collective import fleet
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker

--- a/python/paddle/fluid/tests/unittests/dist_text_classification.py
+++ b/python/paddle/fluid/tests/unittests/dist_text_classification.py
@@ -12,13 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import time
+import math
+
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
 import os
+import signal
 import six
 import tarfile
 import string
 import re
+from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 
 DTYPE = "float32"

--- a/python/paddle/fluid/tests/unittests/dist_text_classification.py
+++ b/python/paddle/fluid/tests/unittests/dist_text_classification.py
@@ -12,24 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
-
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import os
-import signal
 import six
 import tarfile
 import string
 import re
-from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 
 DTYPE = "float32"

--- a/python/paddle/fluid/tests/unittests/dist_transformer.py
+++ b/python/paddle/fluid/tests/unittests/dist_transformer.py
@@ -13,9 +13,15 @@
 # limitations under the License.
 
 import numpy as np
+import argparse
 import time
+import math
 import os
+import sys
 import six
+import argparse
+import ast
+import multiprocessing
 import time
 from functools import partial
 from os.path import expanduser
@@ -23,11 +29,15 @@ import glob
 import random
 import tarfile
 
+import paddle
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
+from paddle.fluid import core
 from test_dist_base import TestDistRunnerBase, runtime_main, RUN_STEP
 import paddle.compat as cpt
 from paddle.compat import long_type
+
+import hashlib
 
 const_para_attr = fluid.ParamAttr(initializer=fluid.initializer.Constant(0.001))
 const_bias_attr = const_para_attr

--- a/python/paddle/fluid/tests/unittests/dist_transformer.py
+++ b/python/paddle/fluid/tests/unittests/dist_transformer.py
@@ -13,15 +13,9 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
 import time
-import math
 import os
-import sys
 import six
-import argparse
-import ast
-import multiprocessing
 import time
 from functools import partial
 from os.path import expanduser
@@ -29,15 +23,11 @@ import glob
 import random
 import tarfile
 
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
-from paddle.fluid import core
 from test_dist_base import TestDistRunnerBase, runtime_main, RUN_STEP
 import paddle.compat as cpt
 from paddle.compat import long_type
-
-import hashlib
 
 const_para_attr = fluid.ParamAttr(initializer=fluid.initializer.Constant(0.001))
 const_bias_attr = const_para_attr

--- a/python/paddle/fluid/tests/unittests/dist_word2vec.py
+++ b/python/paddle/fluid/tests/unittests/dist_word2vec.py
@@ -12,18 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import time
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import os
-import signal
 from test_dist_base import TestDistRunnerBase, runtime_main
 
 IS_SPARSE = True

--- a/python/paddle/fluid/tests/unittests/dist_word2vec.py
+++ b/python/paddle/fluid/tests/unittests/dist_word2vec.py
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import time
+import math
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
 import os
+import signal
 from test_dist_base import TestDistRunnerBase, runtime_main
 
 IS_SPARSE = True

--- a/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import os
 import paddle
 import paddle.fluid.core as core
@@ -21,11 +20,9 @@ from paddle.incubate import DistributedFusedLamb
 from paddle.vision.models import resnet18 as resnet
 from paddle.distributed.fleet.meta_optimizers.common import CollectiveHelper
 from paddle.fluid.clip import ClipGradBase
-import paddle.nn as nn
 import numpy as np
 import os
 import unittest
-from paddle.distributed.fleet.meta_optimizers.common import is_optimizer_op, is_backward_op
 from paddle.fluid.clip import _clip_by_global_norm_using_mp_type
 import distutils
 

--- a/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import os
 import paddle
 import paddle.fluid.core as core
@@ -20,9 +21,11 @@ from paddle.incubate import DistributedFusedLamb
 from paddle.vision.models import resnet18 as resnet
 from paddle.distributed.fleet.meta_optimizers.common import CollectiveHelper
 from paddle.fluid.clip import ClipGradBase
+import paddle.nn as nn
 import numpy as np
 import os
 import unittest
+from paddle.distributed.fleet.meta_optimizers.common import is_optimizer_op, is_backward_op
 from paddle.fluid.clip import _clip_by_global_norm_using_mp_type
 import distutils
 

--- a/python/paddle/fluid/tests/unittests/dygraph_fleet_api.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_fleet_api.py
@@ -15,9 +15,17 @@
 import unittest
 import random
 import numpy as np
+import os
+import shutil
 
 import paddle
+import paddle.nn as nn
+from paddle.fluid import core
+import datetime
+from datetime import timedelta
+import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
+from paddle.fluid.dygraph.parallel import ParallelEnv
 
 
 class TestDygraphFleetAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/dygraph_fleet_api.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_fleet_api.py
@@ -15,17 +15,9 @@
 import unittest
 import random
 import numpy as np
-import os
-import shutil
 
 import paddle
-import paddle.nn as nn
-from paddle.fluid import core
-import datetime
-from datetime import timedelta
-import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
-from paddle.fluid.dygraph.parallel import ParallelEnv
 
 
 class TestDygraphFleetAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/dygraph_recompute_hybrid.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_recompute_hybrid.py
@@ -16,13 +16,9 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.autograd import PyLayer
-from paddle.distributed.fleet.utils import recompute
 from paddle.incubate.distributed.fleet import recompute_hybrid
 import random
 from paddle.distributed import fleet
-
-import paddle.fluid.layers as layers
 
 
 def get_fc_block(block_idx, input_size, is_last=False):

--- a/python/paddle/fluid/tests/unittests/dygraph_recompute_hybrid.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_recompute_hybrid.py
@@ -16,9 +16,13 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.autograd import PyLayer
+from paddle.distributed.fleet.utils import recompute
 from paddle.incubate.distributed.fleet import recompute_hybrid
 import random
 from paddle.distributed import fleet
+
+import paddle.fluid.layers as layers
 
 
 def get_fc_block(block_idx, input_size, is_last=False):

--- a/python/paddle/fluid/tests/unittests/find_ports.py
+++ b/python/paddle/fluid/tests/unittests/find_ports.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import time
 
 
 def train():

--- a/python/paddle/fluid/tests/unittests/fleet_heter_ps_training.py
+++ b/python/paddle/fluid/tests/unittests/fleet_heter_ps_training.py
@@ -15,7 +15,6 @@
 import paddle
 import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
-import paddle.distributed.fleet.base.role_maker as role_maker
 
 fluid.disable_dygraph()
 

--- a/python/paddle/fluid/tests/unittests/gradient_checker.py
+++ b/python/paddle/fluid/tests/unittests/gradient_checker.py
@@ -13,16 +13,13 @@
 # limitations under the License.
 """This is the lib for gradient checker unittest."""
 
-import unittest
 import six
-import collections
 import numpy as np
 from itertools import product
 import paddle
 
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.executor import Executor
 from paddle.fluid.backward import _append_grad_suffix_, _as_list
 from paddle.fluid.framework import _test_eager_guard
 try:

--- a/python/paddle/fluid/tests/unittests/hccl_tools.py
+++ b/python/paddle/fluid/tests/unittests/hccl_tools.py
@@ -34,7 +34,6 @@ import sys
 import json
 import socket
 from argparse import ArgumentParser
-from typing import Dict, Any
 
 
 def parse_args():

--- a/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
+++ b/python/paddle/fluid/tests/unittests/hdfs_test_utils.py
@@ -13,13 +13,9 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
 import os
-import sys
 
-from paddle.distributed.fleet.utils.fs import LocalFS, HDFSClient, FSTimeOut, FSFileExistsError, FSFileNotExistsError
+from paddle.distributed.fleet.utils.fs import FSFileExistsError, FSFileNotExistsError, HDFSClient, LocalFS
 
 java_home = os.environ["JAVA_HOME"]
 

--- a/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer.py
+++ b/python/paddle/fluid/tests/unittests/hybrid_parallel_pp_layer.py
@@ -14,8 +14,6 @@
 
 import unittest
 import numpy as np
-import os
-import paddle
 from paddle.distributed import fleet
 from paddle.fluid.dygraph.container import Sequential
 import paddle.nn as nn

--- a/python/paddle/fluid/tests/unittests/ir_memory_optimize_net_base.py
+++ b/python/paddle/fluid/tests/unittests/ir_memory_optimize_net_base.py
@@ -14,11 +14,9 @@
 
 import os
 import sys
-import six
 import unittest
 import time
 import math
-import multiprocessing
 import numpy as np
 
 import paddle

--- a/python/paddle/fluid/tests/unittests/launch_function_helper.py
+++ b/python/paddle/fluid/tests/unittests/launch_function_helper.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from multiprocessing import Pool, Process
+from multiprocessing import Process
 import os
 import socket
 from contextlib import closing

--- a/python/paddle/fluid/tests/unittests/my_data_generator.py
+++ b/python/paddle/fluid/tests/unittests/my_data_generator.py
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import os
-import paddle
-import re
-import collections
-import time
 import paddle.distributed.fleet as fleet
 
 

--- a/python/paddle/fluid/tests/unittests/nproc_process.py
+++ b/python/paddle/fluid/tests/unittests/nproc_process.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import time
 import paddle.fluid as fluid
 
 

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -20,9 +20,6 @@ import numpy as np
 import random
 import six
 import struct
-import time
-import itertools
-import collections
 from collections import defaultdict
 from copy import copy
 
@@ -35,7 +32,7 @@ from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.backward import append_backward
 from paddle.fluid.op import Operator
 from paddle.fluid.executor import Executor
-from paddle.fluid.framework import Program, OpProtoHolder, Variable, _current_expected_place
+from paddle.fluid.framework import OpProtoHolder, Program, _current_expected_place
 from paddle.fluid import unique_name
 from paddle.fluid.dygraph.dygraph_to_static.utils import parse_arg_and_kwargs
 
@@ -1423,7 +1420,6 @@ class OpTest(unittest.TestCase):
                 judge whether convert current output and expect to uint16.
                 return True | False
                 """
-                pass
 
             def _is_skip_name(self, name):
                 if name not in self.expects:

--- a/python/paddle/fluid/tests/unittests/op_test_xpu.py
+++ b/python/paddle/fluid/tests/unittests/op_test_xpu.py
@@ -12,30 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import unittest
-import warnings
 import numpy as np
-import random
-import six
-import struct
-import time
-import itertools
-import collections
-from collections import defaultdict
 
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.backward import append_backward
-from paddle.fluid.op import Operator
-from paddle.fluid.executor import Executor
-from paddle.fluid.framework import Program, OpProtoHolder, Variable, convert_np_dtype_to_dtype_
-from testsuite import create_op, set_input, append_input_output, append_loss_ops
-from paddle.fluid import unique_name
-from white_list import op_accuracy_white_list, check_shape_white_list, compile_vs_runtime_white_list, no_check_set_white_list
+from paddle.fluid.framework import Program, convert_np_dtype_to_dtype_
+from testsuite import append_loss_ops, create_op, set_input
 from white_list import op_threshold_white_list, no_grad_set_white_list
-from op_test import OpTest, _set_use_system_allocator, get_numeric_gradient
+from op_test import OpTest
 from xpu.get_test_cover_info import is_empty_grad_op_type, get_xpu_op_support_types, type_dict_str_to_numpy
 
 

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_dataparallel_with_pylayer.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_dataparallel_with_pylayer.py
@@ -17,9 +17,7 @@ import unittest
 import paddle
 import numpy as np
 import paddle.distributed as dist
-from paddle.fluid.dygraph.nn import Linear
 from paddle.autograd import PyLayer
-from paddle.fluid.framework import in_dygraph_mode, _in_legacy_dygraph
 from paddle.distributed.fleet.utils.hybrid_parallel_util import fused_allreduce_gradients
 
 batch = 5

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_gradient_check.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_gradient_check.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import os
 
 import paddle
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_gradient_check_in_eager_mode.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_gradient_check_in_eager_mode.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import unittest
-import os
-import copy
 
 import paddle
 import numpy as np
@@ -22,8 +20,6 @@ import paddle.distributed as dist
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Linear
 from paddle.fluid.framework import _test_eager_guard
-from paddle.fluid.dygraph.parallel import ParallelEnv
-import paddle.fluid.core as core
 
 paddle.seed(1024)
 np.random.seed(2021)

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import contextlib
-import unittest
 import numpy as np
-import six
-import pickle
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
-from paddle.fluid.optimizer import SGDOptimizer
 from paddle.fluid.dygraph.nn import Conv2D, Pool2D, Linear
 from paddle.fluid.dygraph.base import to_variable
 

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_none_var.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_none_var.py
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
-import unittest
 import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
-from paddle.fluid.optimizer import SGDOptimizer
-from paddle.fluid.dygraph.nn import Linear
 
 from test_dist_base import runtime_main, TestParallelDyGraphRunnerBase
 

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_shared_unused_var.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_shared_unused_var.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid.optimizer import SGDOptimizer
-from paddle.fluid.dygraph.nn import Conv2D, Pool2D, Linear
+from paddle.fluid.dygraph.nn import Linear
 from paddle.fluid.dygraph.base import to_variable
 from test_dist_base import runtime_main, TestParallelDyGraphRunnerBase
 

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_sparse_embedding_over_height.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_sparse_embedding_over_height.py
@@ -16,7 +16,7 @@ import paddle
 import paddle.fluid as fluid
 from parallel_dygraph_sparse_embedding import SimpleNet, fake_sample_reader, TestSparseEmbedding
 
-from test_dist_base import runtime_main, TestParallelDyGraphRunnerBase
+from test_dist_base import runtime_main
 
 # global configs
 # using small `vocab_size` to test rows number over height

--- a/python/paddle/fluid/tests/unittests/ps_dnn_model.py
+++ b/python/paddle/fluid/tests/unittests/ps_dnn_model.py
@@ -14,9 +14,7 @@
 
 import paddle
 import paddle.nn as nn
-import paddle.nn.functional as F
 import math
-import paddle.distributed.fleet as fleet
 
 
 class DNNLayer(nn.Layer):

--- a/python/paddle/fluid/tests/unittests/seresnext_net.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_net.py
@@ -17,11 +17,9 @@ import paddle.fluid as fluid
 fluid.core._set_eager_deletion_mode(-1, -1, False)
 
 import paddle
-import paddle.fluid.layers.ops as ops
 from paddle.fluid.layers.learning_rate_scheduler import cosine_decay
 from simple_nets import init_data
 from seresnext_test_base import DeviceType
-import math
 import os
 
 os.environ['CPU_NUM'] = str(4)

--- a/python/paddle/fluid/tests/unittests/simnet_dataset_reader.py
+++ b/python/paddle/fluid/tests/unittests/simnet_dataset_reader.py
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
-import tarfile
 
-import random
-
-import paddle
 import paddle.distributed.fleet as fleet
 
 logging.basicConfig()

--- a/python/paddle/fluid/tests/unittests/static_model_parallel_fused_multi_transformer.py
+++ b/python/paddle/fluid/tests/unittests/static_model_parallel_fused_multi_transformer.py
@@ -20,12 +20,6 @@ from test_dist_base import TestDistRunnerBase, runtime_main
 from paddle.incubate.nn import FusedMultiTransformer
 import paddle.distributed.fleet as fleet
 
-from paddle.fluid.data_feeder import check_variable_and_dtype, check_dtype
-from paddle.fluid.dygraph.layers import Layer
-from paddle.fluid.layer_helper import LayerHelper
-from paddle.fluid import core
-from paddle.nn.initializer import Constant
-
 paddle.enable_static()
 
 

--- a/python/paddle/fluid/tests/unittests/transformer_model.py
+++ b/python/paddle/fluid/tests/unittests/transformer_model.py
@@ -15,7 +15,6 @@
 from functools import partial
 import numpy as np
 
-import os
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 

--- a/python/paddle/fluid/tests/unittests/utils.py
+++ b/python/paddle/fluid/tests/unittests/utils.py
@@ -14,12 +14,7 @@
 
 from paddle.fluid.framework import _dygraph_guard
 import paddle.fluid as fluid
-from paddle.fluid.framework import Variable
-import paddle.fluid.dygraph.jit as jit
-from paddle.fluid.dygraph.jit import extract_vars
 import numpy as np
-import os
-import time
 
 __all__ = ['DyGraphProgramDescTracerTestHelper', 'is_equal_program']
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 F401 unused import 存量 python 代码

`python/paddle/fluid/tests/unittests/` 非 `test_` 开头的文件以及 `python/paddle/fluid/tests/unittests/collective` 的一点增量

其中 `python/paddle/fluid/tests/unittests/dist_sharding_save.py` 需要在不可以直接删除的 import 上加 `noqa`

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4
- 配置文件更新：#46654
- fixes https://github.com/cattidea/paddle-flake8-project/issues/45