### PR TITLE
[WIP][CodeStyle] use np.testing.assert_allclose instead of assertTrue(np.allclose(...)) in op_test

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/mkldnn_op_test.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/mkldnn_op_test.py
@@ -17,9 +17,12 @@ import paddle.fluid.core as core
 import paddle.fluid as fluid
 
 
-def __assert_close(test_case, tensor, np_array, msg, atol=1e-4):
-    test_case.assertTrue(np.allclose(np.array(tensor), np_array, atol=atol),
-                         msg)
+def __assert_close(tensor, np_array, msg, atol=1e-4, rtol=1e-5):
+    np.testing.allclose(np.array(tensor),
+                        np_array,
+                        atol=atol,
+                        rtol=rtol,
+                        err_msg=msg)
 
 
 def check_if_mkldnn_primitives_exist_in_bwd(test_case, op_type, x, out,
@@ -69,7 +72,7 @@ def check_if_mkldnn_primitives_exist_in_bwd(test_case, op_type, x, out,
                       for name in ['x', 'out@GRAD']},
                 fetch_list=['x@GRAD', 'out'])
 
-        __assert_close(test_case, x_grad, out[0], 'x@GRAD')
+        __assert_close(x_grad, out[0], 'x@GRAD')
 
 
 def check_if_mkldnn_batchnorm_primitives_exist_in_bwd(test_case, var_dict,
@@ -144,7 +147,7 @@ def check_if_mkldnn_batchnorm_primitives_exist_in_bwd(test_case, var_dict,
                 },
                 fetch_list=test_case.fetch_list)
             for id, name in enumerate(test_case.fetch_list):
-                __assert_close(test_case, var_dict[name], out[id], name)
+                __assert_close(var_dict[name], out[id], name)
 
         print("MKLDNN op test forward passed: ", str(place), data_layout)
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/mkldnn_op_test.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/mkldnn_op_test.py
@@ -18,11 +18,11 @@ import paddle.fluid as fluid
 
 
 def __assert_close(tensor, np_array, msg, atol=1e-4, rtol=1e-5):
-    np.testing.allclose(np.array(tensor),
-                        np_array,
-                        atol=atol,
-                        rtol=rtol,
-                        err_msg=msg)
+    np.testing.assert_allclose(np.array(tensor),
+                               np_array,
+                               atol=atol,
+                               rtol=rtol,
+                               err_msg=msg)
 
 
 def check_if_mkldnn_primitives_exist_in_bwd(test_case, op_type, x, out,

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -1438,14 +1438,14 @@ class OpTest(unittest.TestCase):
                 raise NotImplementedError("base class, not implement!")
 
             def _compare_numpy(self, name, actual_np, expect_np):
-                self.op_test.assertTrue(
-                    np.allclose(
-                        actual_np,
-                        expect_np,
-                        atol=atol,
-                        rtol=self.rtol if hasattr(self, 'rtol') else 1e-5,
-                        equal_nan=equal_nan), "Output (" + name +
-                    ") has diff at " + str(place) + " in " + self.checker_name)
+                np.testing.assert_allclose(
+                    actual_np,
+                    expect_np,
+                    atol=atol,
+                    rtol=self.rtol if hasattr(self, 'rtol') else 1e-5,
+                    equal_nan=equal_nan,
+                    err_msg="Output (" + name + ") has diff at " + str(place) +
+                    " in " + self.checker_name)
 
             def _compare_list(self, name, actual, expect):
                 """ if expect is a tuple, we need to compare list.
@@ -1584,15 +1584,14 @@ class OpTest(unittest.TestCase):
                                         1) == 0:
                     pass
                 else:
-                    self.op_test.assertTrue(
-                        np.allclose(
-                            actual_np,
-                            expect_np,
-                            atol=atol,
-                            rtol=self.rtol if hasattr(self, 'rtol') else 1e-5,
-                            equal_nan=equal_nan),
-                        "Output (" + name + ") has diff at " + str(place) +
-                        " in " + self.checker_name)
+                    np.testing.assert_allclose(
+                        actual_np,
+                        expect_np,
+                        atol=atol,
+                        rtol=self.rtol if hasattr(self, 'rtol') else 1e-5,
+                        equal_nan=equal_nan,
+                        err_msg="Output (" + name + ") has diff at " +
+                        str(place) + " in " + self.checker_name)
 
         class EagerChecker(DygraphChecker):
 

--- a/python/paddle/fluid/tests/unittests/test_isclose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_isclose_op.py
@@ -41,13 +41,11 @@ class TestIscloseOp(OpTest):
         self.attrs = {'equal_nan': self.equal_nan}
         self.outputs = {
             'Out':
-            np.array([
-                np.isclose(self.inputs['Input'],
-                           self.inputs['Other'],
-                           rtol=self.rtol,
-                           atol=self.atol,
-                           equal_nan=self.equal_nan)
-            ])
+            np.isclose(self.inputs['Input'],
+                       self.inputs['Other'],
+                       rtol=self.rtol,
+                       atol=self.atol,
+                       equal_nan=self.equal_nan)
         }
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/test_quantile_and_nanquantile.py
+++ b/python/paddle/fluid/tests/unittests/test_quantile_and_nanquantile.py
@@ -271,9 +271,8 @@ class TestQuantileRuntime(unittest.TestCase):
                     fetch_list=[results, results_fp64])
                 np_res = res_func(np_input_data, q=0.5, axis=1)
                 np_res_fp64 = res_func(np_input_data_fp64, q=0.5, axis=1)
-                self.assertTrue(
-                    np.allclose(paddle_res, np_res)
-                    and np.allclose(paddle_res_fp64, np_res_fp64))
+                np.testing.assert_allclose(paddle_res, np_res)
+                np.testing.assert_allclose(paddle_res_fp64, np_res_fp64)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -358,7 +358,7 @@ class TestAll8DOp(OpTest):
             'X': np.random.randint(0, 2,
                                    (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
         }
-        self.attrs = {'reduce_all': True, 'dim': (2, 3, 4)}
+        self.attrs = {'dim': (2, 3, 4)}
         self.outputs = {'Out': self.inputs['X'].all(axis=self.attrs['dim'])}
 
     def test_check_output(self):
@@ -464,7 +464,7 @@ class TestAny8DOp(OpTest):
             'X': np.random.randint(0, 2,
                                    (2, 5, 3, 2, 2, 3, 4, 2)).astype("bool")
         }
-        self.attrs = {'reduce_all': True, 'dim': (3, 5, 4)}
+        self.attrs = {'dim': (3, 5, 4)}
         self.outputs = {'Out': self.inputs['X'].any(axis=self.attrs['dim'])}
 
     def test_check_output(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

一些非 `self.assertTrue` 开头的「漏网之鱼」，如 `self.op_test.assertTrue`

做 #46686 时发现报错信息非常不友好，因此修一下

emmm，本地单测运行出了点问题，本地不方便调试，之后再说