### PR TITLE
[CodeStyle][F401] remove unused import in unittests/test_[f-j]

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_fake_dequantize_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fake_dequantize_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 import math
 from op_test import OpTest
-import paddle.fluid.core as core
 
 
 def quantize_max_abs(x, max_range):

--- a/python/paddle/fluid/tests/unittests/test_faster_tokenizer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_faster_tokenizer_op.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import io
 import os
 import unittest
 
 import numpy as np
 import paddle
 import paddle.nn as nn
-from paddle.dataset.common import DATA_HOME
 from paddle.fluid.framework import core, _non_static_mode, _test_eager_guard
 from paddle.fluid.layer_helper import LayerHelper
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 import sys
 import tempfile

--- a/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
+++ b/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
@@ -19,7 +19,6 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.compiler as compiler
 import paddle.fluid.core as core
-import six
 import unittest
 
 os.environ['CPU_NUM'] = str(4)

--- a/python/paddle/fluid/tests/unittests/test_fetch_lod_tensor_array.py
+++ b/python/paddle/fluid/tests/unittests/test_fetch_lod_tensor_array.py
@@ -15,8 +15,6 @@
 import os
 import numpy as np
 import unittest
-import random
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 from simple_nets import simple_fc_net_with_inputs, simple_fc_net

--- a/python/paddle/fluid/tests/unittests/test_fetch_unmerged.py
+++ b/python/paddle/fluid/tests/unittests/test_fetch_unmerged.py
@@ -14,10 +14,8 @@
 
 import os
 import unittest
-import random
 import numpy as np
 import paddle.fluid as fluid
-import six
 import paddle
 
 os.environ["CPU_NUM"] = "2"

--- a/python/paddle/fluid/tests/unittests/test_fetch_var.py
+++ b/python/paddle/fluid/tests/unittests/test_fetch_var.py
@@ -14,7 +14,6 @@
 
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
-import op_test
 import numpy as np
 import unittest
 

--- a/python/paddle/fluid/tests/unittests/test_fill_any_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_any_like_op.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
-import paddle.compat as cpt
 import unittest
 import numpy as np
 from op_test import OpTest, convert_float_to_uint16

--- a/python/paddle/fluid/tests/unittests/test_fill_any_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_any_op.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 import paddle
-import paddle.fluid.core as core
-from paddle.fluid.framework import _test_eager_guard, in_dygraph_mode
 import unittest
 import numpy as np
 from op_test import OpTest
-from paddle.tensor.manipulation import fill_
 
 
 class TestFillAnyOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_batch_size_like.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_batch_size_like.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import paddle
-import paddle.fluid.core as core
-from paddle.static import program_guard, Program
-import paddle.compat as cpt
 import unittest
 import numpy as np
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -21,7 +21,7 @@ import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import numpy as np
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 
 # Situation 1: Attr(shape) is a list(without tensor)

--- a/python/paddle/fluid/tests/unittests/test_fill_diagonal_tensor_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_diagonal_tensor_op.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.fluid as fluid
-import paddle.nn.functional as F
 import unittest
 import numpy as np
-import six
 import paddle
 from op_test import OpTest
-from paddle.fluid.layers import core
 
 
 def fill_diagonal_ndarray(x, value, offset=0, dim1=0, dim2=1):

--- a/python/paddle/fluid/tests/unittests/test_filter_by_instag_op.py
+++ b/python/paddle/fluid/tests/unittests/test_filter_by_instag_op.py
@@ -15,13 +15,7 @@
 
 import unittest
 import numpy as np
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-import paddle.fluid.layers as layers
 from op_test import OpTest
-import random
-from decorator_helper import prog_scope
-from paddle.fluid.op import Operator
 """This is Test Case 1"""
 
 

--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import paddle.fluid as fluid
 import paddle
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/test_fleet.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet.py
@@ -15,7 +15,6 @@
 
 import os
 import unittest
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 
 
 class TestFleet1(unittest.TestCase):
@@ -34,7 +33,6 @@ class TestFleet1(unittest.TestCase):
         """Test cases for pslib."""
         import paddle.fluid as fluid
         from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet
-        from paddle.fluid.incubate.fleet.parameter_server.pslib import PSLib
         from paddle.fluid.incubate.fleet.base.role_maker import GeneralRoleMaker
 
         os.environ["POD_IP"] = "127.0.0.1"

--- a/python/paddle/fluid/tests/unittests/test_fleet_ascend_utils.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_ascend_utils.py
@@ -12,14 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import os
-import time
-import six
-import copy
 import json
 import unittest
-import paddle.fluid as fluid
 
 import paddle.distributed.fleet.ascend_utils as ascend_utils
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_auto.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_auto.py
@@ -16,7 +16,6 @@ import unittest
 import paddle
 import os
 import paddle.distributed.fleet as fleet
-import paddle.distributed.fleet.base.role_maker as role_maker
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_base.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_base.py
@@ -18,7 +18,6 @@ import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
 import os
 import paddle.fluid as fluid
-import paddle.nn as nn
 import numpy as np
 
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_base_3.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_base_3.py
@@ -17,7 +17,6 @@ import os
 import paddle
 import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_base_4.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_base_4.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 import os
-import paddle.fluid as fluid
 import paddle.distributed.fleet as fleet
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/test_fleet_base_single.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_base_single.py
@@ -22,7 +22,6 @@ else:
     os.environ['CUDA_VISIBLE_DEVICES'] = cuda_visible_devices.split(',')[0]
 import paddle
 import paddle.distributed.fleet as fleet
-import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.fluid as fluid
 import unittest
 import paddle.nn as nn

--- a/python/paddle/fluid/tests/unittests/test_fleet_elastic_collective.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_elastic_collective.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 import os
-import time
-import json
 import unittest
-import argparse
 import tempfile
-import traceback
-from warnings import catch_warnings
 
 from paddle.distributed.fleet.elastic.collective import CollectiveLauncher
 from paddle.distributed.fleet.launch import launch_collective

--- a/python/paddle/fluid/tests/unittests/test_fleet_elastic_init.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_elastic_init.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import time
 import unittest
-import argparse
-from warnings import catch_warnings
 
 from paddle.distributed.fleet.elastic import enable_elastic, launch_elastic
 from paddle.distributed.fleet.launch_utils import DistributeMode

--- a/python/paddle/fluid/tests/unittests/test_fleet_elastic_manager.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_elastic_manager.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 
 import os
-import time
 import unittest
-import argparse
 
 from paddle.distributed.fleet.elastic.manager import ElasticManager
 from paddle.distributed.fleet.elastic.manager import LauncherInterface
-from paddle.distributed.fleet.elastic.manager import ELASTIC_TIMEOUT
 from paddle.distributed.fleet.elastic.manager import ELASTIC_AUTO_PARALLEL_EXIT_CODE
 
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_executor_utils.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_executor_utils.py
@@ -14,8 +14,7 @@
 
 import unittest
 import paddle
-import paddle.fluid.core as core
-from paddle.distributed.fleet.fleet_executor_utils import TaskNode, FleetExecutorUtils
+from paddle.distributed.fleet.fleet_executor_utils import FleetExecutorUtils
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_metric.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_metric.py
@@ -16,7 +16,6 @@
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import os
 import unittest
 import numpy as np
 import paddle.distributed.fleet.metrics.metric as metric
@@ -70,7 +69,6 @@ class TestFleetMetric(unittest.TestCase):
 
             def _barrier(self, comm_world="worker"):
                 """Fake barrier, do nothing."""
-                pass
 
         self.util = FakeUtil(FakeFleet())
         fleet.util = self.util

--- a/python/paddle/fluid/tests/unittests/test_fleet_metric.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_metric.py
@@ -69,6 +69,7 @@ class TestFleetMetric(unittest.TestCase):
 
             def _barrier(self, comm_world="worker"):
                 """Fake barrier, do nothing."""
+                pass
 
         self.util = FakeUtil(FakeFleet())
         fleet.util = self.util

--- a/python/paddle/fluid/tests/unittests/test_fleet_nocvm_1.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_nocvm_1.py
@@ -15,7 +15,6 @@
 
 import os
 import unittest
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 
 
 class TestFleet1(unittest.TestCase):
@@ -33,7 +32,6 @@ class TestFleet1(unittest.TestCase):
         """Test cases for pslib."""
         import paddle.fluid as fluid
         from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet
-        from paddle.fluid.incubate.fleet.parameter_server.pslib import PSLib
         from paddle.fluid.incubate.fleet.base.role_maker import GeneralRoleMaker
 
         os.environ["POD_IP"] = "127.0.0.1"

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker.py
@@ -61,7 +61,6 @@ class TestCloudRoleMaker(unittest.TestCase):
         """Test cases for pslib."""
         import paddle.fluid as fluid
         from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet
-        from paddle.fluid.incubate.fleet.parameter_server.pslib import PSLib
         from paddle.fluid.incubate.fleet.base.role_maker import GeneralRoleMaker
 
         os.environ["POD_IP"] = "127.0.0.1"

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_2.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_2.py
@@ -18,8 +18,6 @@ import os
 import unittest
 import tempfile
 
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-
 
 class TestCloudRoleMaker2(unittest.TestCase):
     """
@@ -190,13 +188,11 @@ class TestCloudRoleMaker2(unittest.TestCase):
                     input(None): fake input
                     output(None): fale output
                 """
-                pass
 
             def barrier_worker(self):
                 """
                 dummy barrier worker
                 """
-                pass
 
         from paddle.fluid.incubate.fleet.base.fleet_base import Fleet
 
@@ -213,7 +209,6 @@ class TestCloudRoleMaker2(unittest.TestCase):
                 """
                 dummy init worker
                 """
-                pass
 
             def init_server(self, model_dir=None):
                 """
@@ -222,19 +217,16 @@ class TestCloudRoleMaker2(unittest.TestCase):
                 Args:
                     model_dir(None): fake model_dir
                 """
-                pass
 
             def run_server(self):
                 """
                 dummy run server
                 """
-                pass
 
             def stop_worker(self):
                 """
                 dummy stop worker
                 """
-                pass
 
             def distributed_optimizer(self, optimizer, strategy=None):
                 """
@@ -244,19 +236,16 @@ class TestCloudRoleMaker2(unittest.TestCase):
                     optimizer(None): fake optimizer
                     strategy(None): fake strategy
                 """
-                pass
 
             def save_inference_model(self):
                 """
                 dummy save inference model
                 """
-                pass
 
             def save_persistables(self):
                 """
                 dummy save persistables
                 """
-                pass
 
         os.environ["TRAINING_ROLE"] = "TRAINER"
         tmp = TmpFleet()

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_2.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_2.py
@@ -188,11 +188,13 @@ class TestCloudRoleMaker2(unittest.TestCase):
                     input(None): fake input
                     output(None): fale output
                 """
+                pass
 
             def barrier_worker(self):
                 """
                 dummy barrier worker
                 """
+                pass
 
         from paddle.fluid.incubate.fleet.base.fleet_base import Fleet
 
@@ -209,6 +211,7 @@ class TestCloudRoleMaker2(unittest.TestCase):
                 """
                 dummy init worker
                 """
+                pass
 
             def init_server(self, model_dir=None):
                 """
@@ -217,16 +220,19 @@ class TestCloudRoleMaker2(unittest.TestCase):
                 Args:
                     model_dir(None): fake model_dir
                 """
+                pass
 
             def run_server(self):
                 """
                 dummy run server
                 """
+                pass
 
             def stop_worker(self):
                 """
                 dummy stop worker
                 """
+                pass
 
             def distributed_optimizer(self, optimizer, strategy=None):
                 """
@@ -236,16 +242,19 @@ class TestCloudRoleMaker2(unittest.TestCase):
                     optimizer(None): fake optimizer
                     strategy(None): fake strategy
                 """
+                pass
 
             def save_inference_model(self):
                 """
                 dummy save inference model
                 """
+                pass
 
             def save_persistables(self):
                 """
                 dummy save persistables
                 """
+                pass
 
         os.environ["TRAINING_ROLE"] = "TRAINER"
         tmp = TmpFleet()

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_3.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_3.py
@@ -15,7 +15,6 @@
 
 import os
 import unittest
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 
 
 class TestCloudRoleMaker(unittest.TestCase):
@@ -33,7 +32,6 @@ class TestCloudRoleMaker(unittest.TestCase):
         """Test cases for pslib."""
         import paddle.fluid as fluid
         from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet
-        from paddle.fluid.incubate.fleet.parameter_server.pslib import PSLib
         from paddle.fluid.incubate.fleet.base.role_maker import GeneralRoleMaker
 
         os.environ["POD_IP"] = "127.0.0.1"

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_4.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_4.py
@@ -15,7 +15,6 @@
 
 import os
 import unittest
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 
 
 class TestCloudRoleMaker(unittest.TestCase):
@@ -31,14 +30,8 @@ class TestCloudRoleMaker(unittest.TestCase):
 
     def test_pslib_1(self):
         """Test cases for pslib."""
-        import sys
         import threading
-        import paddle.fluid as fluid
         try:
-            from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet
-            from paddle.fluid.incubate.fleet.parameter_server.pslib import PSLib
-            from paddle.fluid.incubate.fleet.base.role_maker import \
-                GeneralRoleMaker
             from paddle.distributed.fleet.utils.http_server import KVHandler
             from paddle.distributed.fleet.utils.http_server import KVServer
             from paddle.distributed.fleet.utils.http_server import KVHTTPServer
@@ -58,7 +51,6 @@ class TestCloudRoleMaker(unittest.TestCase):
                 Args:
                     a(str): the string to write
                 """
-                pass
 
             def read(self, b):
                 """
@@ -73,8 +65,6 @@ class TestCloudRoleMaker(unittest.TestCase):
                 if b == 0:
                     raise ValueError("this is only for test")
                 return "fake"
-
-        import os
 
         try:
 
@@ -105,7 +95,6 @@ class TestCloudRoleMaker(unittest.TestCase):
                     Args:
                         code(int): error code
                     """
-                    pass
 
                 def send_header(self, a, b):
                     """
@@ -115,18 +104,14 @@ class TestCloudRoleMaker(unittest.TestCase):
                         a(str): some header
                         b(str): some header
                     """
-                    pass
 
                 def end_headers(self):
                     """
                     fake end header, it will do nothing.
                     """
-                    pass
         except:
             print("warning: no KVHandler, skip test_pslib_4")
             return
-
-        import sys
 
         try:
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_4.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_4.py
@@ -51,6 +51,7 @@ class TestCloudRoleMaker(unittest.TestCase):
                 Args:
                     a(str): the string to write
                 """
+                pass
 
             def read(self, b):
                 """
@@ -95,6 +96,7 @@ class TestCloudRoleMaker(unittest.TestCase):
                     Args:
                         code(int): error code
                     """
+                    pass
 
                 def send_header(self, a, b):
                     """
@@ -104,11 +106,13 @@ class TestCloudRoleMaker(unittest.TestCase):
                         a(str): some header
                         b(str): some header
                     """
+                    pass
 
                 def end_headers(self):
                     """
                     fake end header, it will do nothing.
                     """
+                    pass
         except:
             print("warning: no KVHandler, skip test_pslib_4")
             return

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_init.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_init.py
@@ -14,11 +14,7 @@
 """Test cloud role maker."""
 
 import os
-import platform
-import shutil
-import tempfile
 import unittest
-import paddle
 import paddle.distributed.fleet.base.role_maker as role_maker
 
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_runtime.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_runtime.py
@@ -14,7 +14,6 @@
 
 import unittest
 import paddle
-import os
 
 
 class TestFleetRuntime(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_fleet_unitaccessor.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_unitaccessor.py
@@ -15,7 +15,6 @@
 
 import os
 import unittest
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 
 
 class TestFleet1(unittest.TestCase):
@@ -33,7 +32,6 @@ class TestFleet1(unittest.TestCase):
         """Test cases for pslib."""
         import paddle.fluid as fluid
         from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet
-        from paddle.fluid.incubate.fleet.parameter_server.pslib import PSLib
         from paddle.fluid.incubate.fleet.base.role_maker import GeneralRoleMaker
 
         os.environ["POD_IP"] = "127.0.0.1"

--- a/python/paddle/fluid/tests/unittests/test_fleet_util.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_util.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
-import paddle.fluid as fluid
 import unittest
 import numpy as np
 import tarfile
 import tempfile
 import os
 import sys
-from paddle.dataset.common import download, DATA_HOME
+from paddle.dataset.common import download
 import paddle.distributed.fleet.base.role_maker as role_maker
 
 

--- a/python/paddle/fluid/tests/unittests/test_flip.py
+++ b/python/paddle/fluid/tests/unittests/test_flip.py
@@ -17,7 +17,6 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 from op_test import OpTest
 import gradient_checker
 from decorator_helper import prog_scope

--- a/python/paddle/fluid/tests/unittests/test_fold_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fold_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import numpy as np
 import unittest
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_fs_interface.py
+++ b/python/paddle/fluid/tests/unittests/test_fs_interface.py
@@ -13,14 +13,10 @@
 # limitations under the License.
 
 import unittest
-import paddle.fluid as fluid
-import paddle.fluid.incubate.fleet.base.role_maker as role_maker
-from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer, fleet
-import os
 import sys
 import inspect
 
-from paddle.distributed.fleet.utils.fs import LocalFS, FS, HDFSClient, FSTimeOut, FSFileExistsError, FSFileNotExistsError
+from paddle.distributed.fleet.utils.fs import FS
 
 
 class FSTest(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_fsp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fsp_op.py
@@ -15,9 +15,7 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 
 
 def fsp_matrix(a, b):

--- a/python/paddle/fluid/tests/unittests/test_full_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_full_like_op.py
@@ -15,7 +15,6 @@
 import paddle
 import paddle.fluid.core as core
 from paddle.static import program_guard, Program
-import paddle.compat as cpt
 import unittest
 import numpy as np
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_full_op.py
+++ b/python/paddle/fluid/tests/unittests/test_full_op.py
@@ -14,13 +14,10 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
 
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import paddle
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_function_hook.py
+++ b/python/paddle/fluid/tests/unittests/test_function_hook.py
@@ -16,8 +16,7 @@ import unittest
 import paddle
 import numpy as np
 
-import paddle.fluid.core as core
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_functional_conv1d.py
+++ b/python/paddle/fluid/tests/unittests/test_functional_conv1d.py
@@ -14,9 +14,7 @@
 
 import paddle
 import paddle.nn.functional as F
-from paddle import fluid
 import paddle.fluid.dygraph as dg
-import paddle.fluid.initializer as I
 import numpy as np
 import unittest
 from unittest import TestCase

--- a/python/paddle/fluid/tests/unittests/test_functional_conv1d_transpose.py
+++ b/python/paddle/fluid/tests/unittests/test_functional_conv1d_transpose.py
@@ -14,9 +14,7 @@
 
 import paddle
 import paddle.nn.functional as F
-from paddle import fluid
 import paddle.fluid.dygraph as dg
-import paddle.fluid.initializer as I
 import numpy as np
 import unittest
 from unittest import TestCase

--- a/python/paddle/fluid/tests/unittests/test_fuse_bn_add_act_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_bn_add_act_pass.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core

--- a/python/paddle/fluid/tests/unittests/test_fuse_gemm_epilogue_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_gemm_epilogue_pass.py
@@ -15,7 +15,6 @@
 """Test cases for role makers."""
 
 import paddle
-import os
 import unittest
 import numpy as np
 import paddle.fluid.core as core

--- a/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from simple_nets import simple_fc_net, fc_with_batchnorm, init_data, bow_net
+from simple_nets import bow_net, fc_with_batchnorm, init_data
 from fake_reader import fake_imdb_reader
 from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 from functools import partial

--- a/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
@@ -17,9 +17,7 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 import numpy as np
 import paddle
-import paddle.dataset.mnist as mnist
 import unittest
-import os
 
 
 def norm(*args, **kargs):

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
@@ -15,8 +15,6 @@
 import numpy as np
 
 import paddle
-import paddle.nn as nn
-import paddle.fluid.core as core
 import paddle.nn.functional as F
 import paddle.incubate.nn.functional as incubate_f
 from paddle.nn.layer.norm import LayerNorm

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op_api.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op_api.py
@@ -15,13 +15,8 @@
 import numpy as np
 
 import paddle
-import paddle.nn as nn
-import paddle.fluid.core as core
-import paddle.nn.functional as F
 from paddle.incubate.nn.layer.fused_transformer import FusedMultiHeadAttention
-from paddle import tensor
-from paddle.fluid import layers
-from paddle.static import Program, program_guard
+from paddle.static import Program
 import unittest
 
 

--- a/python/paddle/fluid/tests/unittests/test_fused_bias_dropout_residual_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_bias_dropout_residual_layer_norm_op.py
@@ -15,15 +15,9 @@
 import numpy as np
 
 import paddle
-import paddle.nn as nn
-import paddle.fluid.core as core
-import paddle.nn.functional as F
 import paddle.incubate.nn.functional as incubate_f
 from paddle.nn.layer.norm import LayerNorm
-from paddle.nn.layer.common import Linear, Dropout
-from paddle.nn.layer.transformer import _convert_attention_mask
-from paddle import tensor
-from paddle.fluid import layers
+from paddle.nn.layer.common import Dropout
 import unittest
 from op_test import OpTest
 from paddle.fluid.framework import default_main_program, _enable_legacy_dygraph

--- a/python/paddle/fluid/tests/unittests/test_fused_bias_dropout_residual_layer_norm_op_api.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_bias_dropout_residual_layer_norm_op_api.py
@@ -15,13 +15,8 @@
 import numpy as np
 
 import paddle
-import paddle.nn as nn
-import paddle.fluid.core as core
-import paddle.nn.functional as F
 from paddle.incubate.nn.layer.fused_transformer import FusedBiasDropoutResidualLayerNorm
-from paddle import tensor
-from paddle.fluid import layers
-from paddle.static import Program, program_guard
+from paddle.static import Program
 import unittest
 
 

--- a/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
@@ -16,10 +16,6 @@ import unittest
 import platform
 import numpy as np
 from op_test import OpTest, skip_check_grad_ci
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid.op import Operator
-import paddle.compat as cpt
 import paddle.version as ver
 
 

--- a/python/paddle/fluid/tests/unittests/test_fused_feedforward_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_feedforward_op.py
@@ -14,8 +14,6 @@
 import numpy as np
 
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.nn.layer import transformer
 import paddle.nn.functional as F
 import paddle.incubate.nn.functional as incubate_f

--- a/python/paddle/fluid/tests/unittests/test_fused_gate_attention_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_gate_attention_op.py
@@ -21,12 +21,10 @@ import numpy as np
 
 import paddle
 import paddle.nn as nn
-from paddle import tensor
 import unittest
 from op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
 from test_sparse_attention_op import get_cuda_version
-from paddle import _C_ops, _legacy_C_ops
-from paddle.fluid.framework import default_main_program
+from paddle import _legacy_C_ops
 from paddle.fluid import core
 
 

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_int8_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_int8_op.py
@@ -15,23 +15,15 @@
 import numpy as np
 
 import paddle
-import paddle.nn as nn
-import paddle.fluid.core as core
 import paddle.nn.functional as F
-import paddle.incubate.nn.functional as incubate_f
 from paddle.nn.layer.norm import LayerNorm
-from paddle.nn.layer.common import Linear, Dropout
+from paddle.nn.layer.common import Dropout
 from paddle.nn.layer.transformer import _convert_attention_mask
 from paddle import tensor
 from paddle.fluid import layers
 import unittest
-from op_test import OpTest
 from paddle.fluid.framework import default_main_program
-from paddle.fluid.dygraph.layers import Layer
-from paddle.fluid.layer_helper import LayerHelper
-from paddle.nn.initializer import Constant
-from paddle.fluid.data_feeder import check_variable_and_dtype, check_dtype
-from paddle.fluid.framework import _non_static_mode, default_main_program
+from paddle.fluid.framework import default_main_program
 from paddle import _legacy_C_ops
 
 default_main_program().random_seed = 42

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
@@ -15,10 +15,7 @@
 import numpy as np
 
 import paddle
-import paddle.nn as nn
-import paddle.fluid.core as core
 import paddle.nn.functional as F
-import paddle.incubate.nn.functional as incubate_f
 from paddle.nn.layer.norm import LayerNorm
 from paddle.nn.layer.common import Linear, Dropout
 from paddle.nn.layer.transformer import _convert_attention_mask
@@ -27,12 +24,7 @@ from paddle.fluid import layers
 import unittest
 from op_test import OpTest
 from paddle.fluid.framework import default_main_program
-from paddle.fluid.dygraph.layers import Layer
-from paddle.fluid.layer_helper import LayerHelper
-from paddle.nn.initializer import Constant
-from paddle.fluid.data_feeder import check_variable_and_dtype, check_dtype
-from paddle.fluid.framework import _non_static_mode, default_main_program
-from paddle import _C_ops, _legacy_C_ops
+from paddle.fluid.framework import default_main_program
 from paddle.incubate.nn.functional import fused_multi_transformer
 
 default_main_program().random_seed = 42

--- a/python/paddle/fluid/tests/unittests/test_fused_multihead_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multihead_matmul_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from op_test import OpTest
 from paddle.fluid import core
-import paddle.fluid as fluid
 
 np.random.random(123)
 

--- a/python/paddle/fluid/tests/unittests/test_fused_token_prune_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_token_prune_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import paddle
 from op_test import OpTest
 from paddle.framework import core
 

--- a/python/paddle/fluid/tests/unittests/test_fusion_gru_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_gru_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import math
 from op_test import OpTest
 from paddle.fluid.tests.unittests.test_gru_op import gru
 from paddle.fluid.tests.unittests.test_fusion_lstm_op import fc, ACTIVATION

--- a/python/paddle/fluid/tests/unittests/test_fusion_seqconv_eltadd_relu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_seqconv_eltadd_relu_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import random
 from op_test import OpTest
 from sequence.test_sequence_conv import seqconv
 

--- a/python/paddle/fluid/tests/unittests/test_gaussian_random_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gaussian_random_op.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-from paddle.fluid.executor import Executor
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_uint16_to_float
 from paddle.fluid.framework import _test_eager_guard
 import paddle

--- a/python/paddle/fluid/tests/unittests/test_gcd.py
+++ b/python/paddle/fluid/tests/unittests/test_gcd.py
@@ -17,8 +17,6 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
-from op_test import OpTest
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_generate_mask_labels_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_mask_labels_op.py
@@ -14,10 +14,8 @@
 
 import unittest
 import numpy as np
-import sys
 import math
 import six
-import paddle.fluid as fluid
 from op_test import OpTest
 '''
 # Equivalent code

--- a/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
@@ -14,9 +14,6 @@
 
 import unittest
 import numpy as np
-import sys
-import math
-import paddle.fluid as fluid
 from op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/test_generate_proposals_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_proposals_op.py
@@ -14,10 +14,8 @@
 
 import unittest
 import numpy as np
-import sys
 import math
 import paddle
-import paddle.fluid as fluid
 from op_test import OpTest
 from test_anchor_generator_op import anchor_generator_in_python
 import copy

--- a/python/paddle/fluid/tests/unittests/test_generate_proposals_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_proposals_v2_op.py
@@ -14,13 +14,9 @@
 
 import unittest
 import numpy as np
-import sys
-import math
 import paddle
-import paddle.fluid as fluid
 from op_test import OpTest
 from test_anchor_generator_op import anchor_generator_in_python
-import copy
 from test_generate_proposals_op import clip_tiled_boxes, box_coder, nms
 
 

--- a/python/paddle/fluid/tests/unittests/test_generator.py
+++ b/python/paddle/fluid/tests/unittests/test_generator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Test cloud role maker."""
 
-import os
 import unittest
 import paddle
 import paddle.fluid.generator as generator

--- a/python/paddle/fluid/tests/unittests/test_get_all_op_or_kernel_names.py
+++ b/python/paddle/fluid/tests/unittests/test_get_all_op_or_kernel_names.py
@@ -14,7 +14,6 @@
 
 import unittest
 from paddle.fluid import core
-from paddle import compat as cpt
 
 
 class TestGetAllRegisteredOpKernels(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_get_device_properties.py
+++ b/python/paddle/fluid/tests/unittests/test_get_device_properties.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 import unittest
 from paddle.fluid import core
 from paddle.device.cuda import device_count, get_device_properties

--- a/python/paddle/fluid/tests/unittests/test_gpu_package_without_gpu_device.py
+++ b/python/paddle/fluid/tests/unittests/test_gpu_package_without_gpu_device.py
@@ -16,9 +16,7 @@ import os
 import sys
 import subprocess
 import unittest
-import paddle
 import tempfile
-import paddle.fluid as fluid
 from paddle.fluid import core
 
 

--- a/python/paddle/fluid/tests/unittests/test_grad_clip_minimize.py
+++ b/python/paddle/fluid/tests/unittests/test_grad_clip_minimize.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
-import six
 
-import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 
 from paddle.fluid.dygraph.base import to_variable
 

--- a/python/paddle/fluid/tests/unittests/test_gradient_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_gradient_clip.py
@@ -17,7 +17,6 @@ import numpy as np
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-import six
 from fake_reader import fake_imdb_reader
 from paddle.fluid.clip import _allow_pure_fp16_global_norm_clip
 

--- a/python/paddle/fluid/tests/unittests/test_graph_reindex.py
+++ b/python/paddle/fluid/tests/unittests/test_graph_reindex.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 
 
 class TestGraphReindex(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_graph_send_recv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_graph_send_recv_op.py
@@ -16,7 +16,6 @@ import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid.framework import _test_eager_guard
 
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_graph_send_ue_recv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_graph_send_ue_recv_op.py
@@ -16,7 +16,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_graph_send_uv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_graph_send_uv_op.py
@@ -15,8 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
 
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_grid_sample_function.py
+++ b/python/paddle/fluid/tests/unittests/test_grid_sample_function.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 import paddle
-from paddle import fluid, nn
+from paddle import fluid
 import paddle.fluid.dygraph as dg
 import paddle.nn.functional as F
 import unittest

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 
-from operator import mul
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from op_test import OpTest, skip_check_grad_ci

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from op_test import OpTest, _set_use_system_allocator
-from paddle.fluid.framework import grad_var_name
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard

--- a/python/paddle/fluid/tests/unittests/test_gru_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gru_op.py
@@ -14,9 +14,8 @@
 
 import unittest
 import numpy as np
-import math
 import functools
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 from paddle.fluid.tests.unittests.test_lstm_op import ACTIVATION
 from paddle import fluid
 from paddle.fluid import Program, program_guard

--- a/python/paddle/fluid/tests/unittests/test_gru_rnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gru_rnn_op.py
@@ -14,13 +14,10 @@
 
 import unittest
 import numpy as np
-import math
 
 from op_test import OpTest
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import random
 import sys
 

--- a/python/paddle/fluid/tests/unittests/test_gumbel_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gumbel_softmax_op.py
@@ -13,10 +13,8 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.fluid.core as core
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/test_histogram_op.py
+++ b/python/paddle/fluid/tests/unittests/test_histogram_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard
 from op_test import OpTest
 from paddle.fluid.framework import _test_eager_guard

--- a/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 import paddle.nn.functional as F
 from paddle.fluid import Program, program_guard

--- a/python/paddle/fluid/tests/unittests/test_huber_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_huber_loss_op.py
@@ -17,7 +17,7 @@ import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
 import paddle
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 
 def huber_loss_forward(val, delta):

--- a/python/paddle/fluid/tests/unittests/test_hybrid_parallel_topology.py
+++ b/python/paddle/fluid/tests/unittests/test_hybrid_parallel_topology.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
-import paddle.nn as nn
 import unittest
 from paddle.distributed import fleet
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/test_identity_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_identity_loss_op.py
@@ -18,7 +18,6 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 from op_test import OpTest
-from paddle.fluid.framework import _test_eager_guard
 
 
 class TestIdentityLossOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_identity_op.py
+++ b/python/paddle/fluid/tests/unittests/test_identity_op.py
@@ -14,8 +14,6 @@
 
 import unittest
 import numpy as np
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_base.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_base.py
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 import contextlib
-import unittest
-import numpy as np
 
 import paddle.fluid as fluid
-from paddle.fluid import core
 
 
 @contextlib.contextmanager

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 
@@ -24,7 +23,7 @@ from test_imperative_base import new_program_scope
 import paddle.fluid.dygraph_utils as dygraph_utils
 from paddle.fluid.dygraph.layer_object_helper import LayerObjectHelper
 import paddle
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, _non_static_mode
+from paddle.fluid.framework import _in_legacy_dygraph, _test_eager_guard
 
 
 class MyLayer(fluid.Layer):

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerdict.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerdict.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 from collections import OrderedDict
 from paddle.fluid.framework import _test_eager_guard

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_parameterlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_parameterlist.py
@@ -16,7 +16,7 @@ import unittest
 import paddle.fluid as fluid
 import numpy as np
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_base.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_base.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 import numpy as np
 import paddle.fluid as fluid
-from paddle.fluid import core
 from paddle.fluid.reader import use_pinned_memory
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exception.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import time
 import unittest
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
@@ -26,7 +26,7 @@ if sys.version_info[0] == 2:
 else:
     import queue
 
-from paddle.fluid.reader import multiprocess_queue_set, CleanupFuncRegistrar, _cleanup  # noqa: F401
+from paddle.fluid.reader import multiprocess_queue_set, _cleanup, CleanupFuncRegistrar
 
 # NOTE: These special functions cannot be detected by the existing coverage mechanism,
 # so the following unittests are added for these internal functions.
@@ -39,7 +39,6 @@ class TestDygraphDataLoaderCleanUpFunc(unittest.TestCase):
 
     def func_test_clear_queue_set(self):
         test_queue = queue.Queue(self.capacity)
-        global multiprocess_queue_set
         multiprocess_queue_set.add(test_queue)
         for i in range(0, self.capacity):
             test_queue.put(i)

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
@@ -26,7 +26,7 @@ if sys.version_info[0] == 2:
 else:
     import queue
 
-from paddle.fluid.reader import CleanupFuncRegistrar, _cleanup
+from paddle.fluid.reader import multiprocess_queue_set, CleanupFuncRegistrar, _cleanup  # noqa: F401
 
 # NOTE: These special functions cannot be detected by the existing coverage mechanism,
 # so the following unittests are added for these internal functions.

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
@@ -26,7 +26,7 @@ if sys.version_info[0] == 2:
 else:
     import queue
 
-from paddle.fluid.reader import multiprocess_queue_set, _cleanup, CleanupFuncRegistrar
+from paddle.fluid.reader import CleanupFuncRegistrar, _cleanup
 
 # NOTE: These special functions cannot be detected by the existing coverage mechanism,
 # so the following unittests are added for these internal functions.

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_fds_clear.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_fds_clear.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 import numpy as np
 import paddle.fluid as fluid
-from paddle.fluid import core
 from paddle.io import Dataset, DataLoader
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_process.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_process.py
@@ -17,7 +17,6 @@ import unittest
 import multiprocessing
 import numpy as np
 import paddle.fluid as fluid
-from paddle.fluid import core
 from paddle.fluid.reader import _reader_process_loop
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_parallel.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_parallel.py
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
-import six
 import unittest
 
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.dygraph as dygraph
 from paddle.fluid.dygraph.nn import Linear

--- a/python/paddle/fluid/tests/unittests/test_imperative_double_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_double_grad.py
@@ -20,8 +20,7 @@ import unittest
 from unittest import TestCase
 import numpy as np
 import paddle.compat as cpt
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, _in_eager_without_dygraph_check
-import paddle.fluid.core as core
+from paddle.fluid.framework import _test_eager_guard
 
 
 def _dygraph_guard_(func):

--- a/python/paddle/fluid/tests/unittests/test_imperative_gan.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_gan.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six
-import sys
 
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.optimizer import SGDOptimizer
-from paddle.fluid import Conv2D, Pool2D, Linear
+from paddle.fluid import Linear
 from test_imperative_base import new_program_scope
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.framework import _test_eager_guard

--- a/python/paddle/fluid/tests/unittests/test_imperative_gnn.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_gnn.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import sys

--- a/python/paddle/fluid/tests/unittests/test_imperative_group.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_group.py
@@ -12,18 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
-import numpy as np
-import six
 import unittest
 
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid.dygraph.nn import Linear
 import paddle.fluid.core as core
-from paddle.fluid.optimizer import SGDOptimizer
 from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, in_dygraph_mode
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_hook_for_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_hook_for_layer.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
-import six
 
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import paddle.fluid.dygraph.base as base

--- a/python/paddle/fluid/tests/unittests/test_imperative_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_layers.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import paddle.nn as nn
-from paddle.fluid.framework import _test_eager_guard, _non_static_mode
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TestLayerPrint(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_imperative_lod_tensor_to_selected_rows.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_lod_tensor_to_selected_rows.py
@@ -17,7 +17,6 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.dygraph.nn import Embedding
-import paddle.fluid.framework as framework
 from paddle.fluid.optimizer import SGDOptimizer
 from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope

--- a/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six
@@ -22,9 +21,8 @@ import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.optimizer import SGDOptimizer
 from paddle.fluid.dygraph.nn import Conv2D, Pool2D, Linear
-from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
-from utils import DyGraphProgramDescTracerTestHelper, is_equal_program
+from utils import DyGraphProgramDescTracerTestHelper
 from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_mnist_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_mnist_sorted_gradient.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six

--- a/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 import paddle.fluid as fluid
 import paddle
-from paddle.fluid.framework import _test_eager_guard, _non_static_mode
+from paddle.fluid.framework import _test_eager_guard
 
 
 class MyLayer(fluid.Layer):

--- a/python/paddle/fluid/tests/unittests/test_imperative_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_optimizer.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six
@@ -24,7 +23,6 @@ from paddle.fluid import core
 from paddle.fluid.optimizer import SGDOptimizer, Adam, MomentumOptimizer, LarsMomentumOptimizer, AdagradOptimizer, AdamaxOptimizer, DpsgdOptimizer, DecayedAdagradOptimizer, AdadeltaOptimizer, RMSPropOptimizer, FtrlOptimizer, LambOptimizer
 from paddle.fluid.optimizer import ModelAverage, DGCMomentumOptimizer, ExponentialMovingAverage, PipelineOptimizer, LookaheadOptimizer, RecomputeOptimizer
 from paddle.fluid.dygraph import Linear
-from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_optimizer_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_optimizer_v2.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six
@@ -24,7 +23,6 @@ from paddle.fluid import core
 from paddle.fluid.optimizer import MomentumOptimizer, LarsMomentumOptimizer, AdagradOptimizer, AdamaxOptimizer, DpsgdOptimizer, DecayedAdagradOptimizer, AdadeltaOptimizer, RMSPropOptimizer, FtrlOptimizer
 from paddle.fluid.optimizer import ModelAverage, DGCMomentumOptimizer, ExponentialMovingAverage, PipelineOptimizer, LookaheadOptimizer, RecomputeOptimizer
 from paddle.fluid.dygraph import Linear
-from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_parallel_coalesce_split.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_parallel_coalesce_split.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 from collections import OrderedDict
 
-import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.dygraph.parallel import DataParallel

--- a/python/paddle/fluid/tests/unittests/test_imperative_ptb_rnn_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ptb_rnn_sorted_gradient.py
@@ -16,7 +16,6 @@ import unittest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.dygraph.nn import Embedding
 import paddle.fluid.framework as framework
 from paddle.fluid.optimizer import SGDOptimizer
 from paddle.fluid.dygraph.base import to_variable

--- a/python/paddle/fluid/tests/unittests/test_imperative_recurrent_usage.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_recurrent_usage.py
@@ -16,14 +16,10 @@ import unittest
 import paddle.fluid as fluid
 import paddle
 import paddle.fluid.core as core
-from paddle.fluid.dygraph.nn import Embedding
-import paddle.fluid.framework as framework
 from paddle.fluid.framework import _test_eager_guard
-from paddle.fluid.optimizer import SGDOptimizer
 from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
 import numpy as np
-import six
 
 
 class RecurrentTest(fluid.Layer):

--- a/python/paddle/fluid/tests/unittests/test_imperative_reinforcement.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_reinforcement.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six
@@ -21,9 +20,7 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.optimizer import SGDOptimizer
-from paddle.fluid.dygraph.nn import Conv2D, Pool2D, Linear
 import paddle.fluid.dygraph.nn as nn
-from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six

--- a/python/paddle/fluid/tests/unittests/test_imperative_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_save_load.py
@@ -16,14 +16,11 @@ import os
 import unittest
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.dygraph.nn import Embedding, Linear
-import paddle.fluid.framework as framework
+from paddle.fluid.dygraph.nn import Embedding
 from paddle.fluid.optimizer import Adam
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.dygraph.learning_rate_scheduler import LearningRateDecay
-from test_imperative_base import new_program_scope
 import numpy as np
-import six
 import paddle
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_save_load_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_save_load_v2.py
@@ -16,14 +16,11 @@ import os
 import unittest
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.dygraph.nn import Embedding, Linear
-import paddle.fluid.framework as framework
+from paddle.fluid.dygraph.nn import Embedding
 from paddle.optimizer import Adam
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.dygraph.learning_rate_scheduler import LearningRateDecay
-from test_imperative_base import new_program_scope
 import numpy as np
-import six
 import paddle
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import unittest
 import numpy as np
 import six
@@ -22,7 +21,6 @@ import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.dygraph.nn import Conv2D, Pool2D, BatchNorm, Linear
-from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_selected_rows.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_selected_rows.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.base import to_variable
-from paddle.fluid.dygraph.nn import Embedding
 from paddle.fluid.optimizer import SGDOptimizer
 import numpy as np
 import paddle.fluid.core as core

--- a/python/paddle/fluid/tests/unittests/test_imperative_star_gan_with_gradient_penalty.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_star_gan_with_gradient_penalty.py
@@ -16,8 +16,8 @@ import paddle
 import paddle.fluid as fluid
 import numpy as np
 import unittest
-from paddle import _C_ops, _legacy_C_ops
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, _in_eager_without_dygraph_check
+from paddle import _legacy_C_ops
+from paddle.fluid.framework import _test_eager_guard
 
 if fluid.is_compiled_with_cuda():
     fluid.core.globals()['FLAGS_cudnn_deterministic'] = True

--- a/python/paddle/fluid/tests/unittests/test_imperative_static_runner_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_static_runner_mnist.py
@@ -14,16 +14,13 @@
 
 import unittest
 
-import contextlib
 import numpy as np
 import six
 
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
-from paddle.fluid import unique_name
 from test_imperative_base import new_program_scope
-from jit_load_rename_var import rename_var_with_generator
 
 LOADED_VAR_SUFFIX = ".load_0"
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_static_runner_while.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_static_runner_while.py
@@ -14,7 +14,6 @@
 
 import unittest
 
-import contextlib
 import numpy as np
 import six
 
@@ -24,8 +23,6 @@ from paddle.fluid import core
 from paddle.fluid import unique_name
 from test_imperative_base import new_program_scope
 from jit_load_rename_var import rename_var_with_generator
-
-import paddle.fluid.transpiler.details.program_utils as pu
 
 LOADED_VAR_SUFFIX = ".load_0"
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
@@ -19,7 +19,7 @@ from paddle.fluid import Embedding, LayerNorm, Linear, Layer
 from paddle.fluid.dygraph import to_variable, guard
 from paddle.fluid.dygraph import TracedLayer
 from test_imperative_base import new_program_scope
-from paddle.fluid.framework import _test_eager_guard, in_dygraph_mode, _in_legacy_dygraph
+from paddle.fluid.framework import _in_legacy_dygraph, _test_eager_guard
 from paddle.fluid import core
 import numpy as np
 import six

--- a/python/paddle/fluid/tests/unittests/test_imperative_triple_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_triple_grad.py
@@ -15,11 +15,10 @@
 import paddle.fluid as fluid
 import paddle
 from paddle.fluid.wrapped_decorator import wrap_decorator
-from paddle.vision.models import resnet50, resnet101
 import unittest
 from unittest import TestCase
 import numpy as np
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph, _in_eager_without_dygraph_check
+from paddle.fluid.framework import _test_eager_guard
 
 
 def _dygraph_guard_(func):

--- a/python/paddle/fluid/tests/unittests/test_index_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_index_add_op.py
@@ -15,10 +15,8 @@
 import unittest
 import paddle
 import numpy as np
-import paddle.fluid.core as core
 from op_test import OpTest
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from paddle.fluid import Program
 
 
 def compute_index_add_ref(axis, x_shape, x_np, add_value_shape, add_value_np,

--- a/python/paddle/fluid/tests/unittests/test_index_select_op.py
+++ b/python/paddle/fluid/tests/unittests/test_index_select_op.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 import numpy as np
-import paddle.fluid.core as core
 from op_test import OpTest
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard

--- a/python/paddle/fluid/tests/unittests/test_infer_no_need_buffer_slots.py
+++ b/python/paddle/fluid/tests/unittests/test_infer_no_need_buffer_slots.py
@@ -16,7 +16,6 @@ import unittest
 
 import paddle.fluid as fluid
 import paddle.fluid.framework as framework
-import paddle.compat as cpt
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/test_inference_api.py
+++ b/python/paddle/fluid/tests/unittests/test_inference_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, shutil
 import unittest
 import paddle
 
@@ -21,7 +20,7 @@ import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid.core import PaddleTensor
 from paddle.fluid.core import PaddleDType
-from paddle.inference import Config, Predictor, create_predictor
+from paddle.inference import Config, create_predictor
 from paddle.inference import get_trt_compile_version, get_trt_runtime_version
 
 

--- a/python/paddle/fluid/tests/unittests/test_inference_model_io.py
+++ b/python/paddle/fluid/tests/unittests/test_inference_model_io.py
@@ -29,7 +29,6 @@ import paddle.fluid.optimizer as optimizer
 from paddle.fluid.compiler import CompiledProgram
 from paddle.fluid.framework import Program, program_guard
 from paddle.fluid.io import save_inference_model, load_inference_model, save_persistables
-from paddle.fluid.transpiler import memory_optimize
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_inner.py
+++ b/python/paddle/fluid/tests/unittests/test_inner.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.static import Program, program_guard
-from paddle.fluid.framework import _test_eager_guard, in_dygraph_mode
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TestMultiplyApi(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -16,8 +16,7 @@ import unittest
 import numpy as np
 
 import paddle
-import paddle.fluid.core as core
-from paddle.fluid.framework import _test_eager_guard, in_dygraph_mode
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TestInplace(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_inplace_abn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace_abn_op.py
@@ -15,12 +15,9 @@
 import unittest
 import numpy as np
 import os
-import six
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid import compiler
-import paddle.fluid.unique_name as unique_name
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/test_inplace_addto_strategy.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace_addto_strategy.py
@@ -16,8 +16,6 @@ import unittest
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
-from paddle.fluid.backward import calc_gradient
 import numpy as np
 
 

--- a/python/paddle/fluid/tests/unittests/test_inplace_and_clear_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace_and_clear_gradient.py
@@ -14,8 +14,7 @@
 
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 import unittest
 
 paddle.disable_static()

--- a/python/paddle/fluid/tests/unittests/test_inplace_auto_generated_apis.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace_auto_generated_apis.py
@@ -15,9 +15,7 @@
 import unittest
 import numpy as np
 
-from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from paddle.static import Program, program_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_inplace_softmax_with_cross_entropy.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace_softmax_with_cross_entropy.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 import paddle.fluid as fluid
-from paddle.fluid import layers
 import numpy as np
 import unittest
 

--- a/python/paddle/fluid/tests/unittests/test_input_spec.py
+++ b/python/paddle/fluid/tests/unittests/test_input_spec.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.static import InputSpec
-from paddle.fluid.framework import core, convert_np_dtype_to_dtype_
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
 from paddle.fluid.dygraph.dygraph_to_static.utils import _compatible_non_tensor_spec
 
 

--- a/python/paddle/fluid/tests/unittests/test_instance_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_instance_norm_op.py
@@ -17,8 +17,6 @@ import numpy as np
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid.op import Operator
-from op_test import OpTest
 from paddle.fluid import Program, program_guard
 from paddle.fluid.dygraph import to_variable
 from paddle.fluid.framework import _test_eager_guard

--- a/python/paddle/fluid/tests/unittests/test_instance_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_instance_norm_op_v2.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from op_test import OpTest, _set_use_system_allocator
-from paddle.fluid.framework import grad_var_name
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard

--- a/python/paddle/fluid/tests/unittests/test_inverse_op.py
+++ b/python/paddle/fluid/tests/unittests/test_inverse_op.py
@@ -179,10 +179,8 @@ class TestInverseSingularAPI(unittest.TestCase):
                                   fetch_list=[result])
             except RuntimeError as ex:
                 print("The mat is singular")
-                pass
             except ValueError as ex:
                 print("The mat is singular")
-                pass
 
     def test_static(self):
         for place in self.places:
@@ -197,10 +195,8 @@ class TestInverseSingularAPI(unittest.TestCase):
                     result = paddle.inverse(input)
                 except RuntimeError as ex:
                     print("The mat is singular")
-                    pass
                 except ValueError as ex:
                     print("The mat is singular")
-                    pass
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_io_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_io_save_load.py
@@ -16,7 +16,7 @@ import unittest
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph
+from paddle.fluid.framework import _test_eager_guard
 import tempfile
 import os
 

--- a/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
+++ b/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import numpy.random as random
-import sys
-import math
 from op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/test_ir_graph.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_graph.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 import six
 from paddle import fluid

--- a/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_ifelse_op.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_ifelse_op.py
@@ -25,9 +25,7 @@ import paddle.fluid.core as core
 
 from paddle.fluid import compiler, Program, program_guard
 from paddle.fluid.executor import Executor
-from paddle.fluid.backward import append_backward
 from paddle.fluid.optimizer import MomentumOptimizer
-from ir_memory_optimize_net_base import TestIrMemOptBase
 
 
 class TestIrMemoryOptimizeIfElseOp(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_pass.py
@@ -17,9 +17,7 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 import numpy as np
 import paddle
-import paddle.dataset.mnist as mnist
 import unittest
-import os
 
 
 def _feed_data_helper():

--- a/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_transformer.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_transformer.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 import os
-import sys
 import unittest
-from timeit import default_timer as timer
-import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
-import paddle.dataset.wmt16 as wmt16
 
 os.environ['FLAGS_eager_delete_tensor_gb'] = "0.0"
 

--- a/python/paddle/fluid/tests/unittests/test_isfinite_op.py
+++ b/python/paddle/fluid/tests/unittests/test_isfinite_op.py
@@ -18,7 +18,6 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from op_test import OpTest
-from paddle.fluid import compiler, Program, program_guard
 
 
 class TestInf(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_jit_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_jit_save_load.py
@@ -24,8 +24,8 @@ from paddle.static import InputSpec
 import paddle.fluid as fluid
 from paddle.fluid.layers.utils import flatten
 from paddle.fluid.dygraph import Linear
-from paddle.fluid.dygraph import declarative, ProgramTranslator
-from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX, INFER_PARAMS_INFO_SUFFIX
+from paddle.fluid.dygraph import declarative
+from paddle.fluid.dygraph.io import INFER_PARAMS_INFO_SUFFIX
 from paddle.fluid import unique_name
 
 BATCH_SIZE = 32


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 F401 unused import 存量 python 代码

- [x] `python/paddle/fluid/tests/unittests/` 下 `test_[f-j]`
    - [x] `python/paddle/fluid/tests/unittests/` 下 `test_f` 开头的文件
    - [x] `python/paddle/fluid/tests/unittests/` 下 `test_g` 开头的文件
    - [x] `python/paddle/fluid/tests/unittests/` 下 `test_h` 开头的文件
    - [x] `python/paddle/fluid/tests/unittests/` 下 `test_i` 开头的文件
    - [x] `python/paddle/fluid/tests/unittests/` 下 `test_j` 开头的文件

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4
- 配置文件更新：#46654
- fixes https://github.com/cattidea/paddle-flake8-project/issues/47