### PR TITLE
[CodeStyle][F401] remove unused import in unittests/test_[k-o]

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_label_smooth_functional.py
+++ b/python/paddle/fluid/tests/unittests/test_label_smooth_functional.py
@@ -14,10 +14,9 @@
 
 import numpy as np
 import paddle
-from paddle import fluid, nn
+from paddle import fluid
 import paddle.fluid.dygraph as dg
 import paddle.nn.functional as F
-import paddle.fluid.initializer as I
 import unittest
 
 

--- a/python/paddle/fluid/tests/unittests/test_lamb_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lamb_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.op import Operator
 

--- a/python/paddle/fluid/tests/unittests/test_lambv2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lambv2_op.py
@@ -14,9 +14,7 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 from paddle.fluid.dygraph.base import switch_to_static_graph
 import paddle
 import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/test_launch_coverage.py
+++ b/python/paddle/fluid/tests/unittests/test_launch_coverage.py
@@ -12,14 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-import subprocess
-import os
-import time
-import six
-import copy
 import unittest
-import paddle.fluid as fluid
 
 from argparse import ArgumentParser, REMAINDER
 from paddle.distributed.utils.launch_utils import _print_arguments, get_gpus, get_cluster_from_args

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op_v2.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from op_test import OpTest, _set_use_system_allocator
-from paddle.fluid.framework import grad_var_name, _test_eager_guard
+from paddle.fluid.framework import _test_eager_guard
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 import paddle

--- a/python/paddle/fluid/tests/unittests/test_layout_autotune.py
+++ b/python/paddle/fluid/tests/unittests/test_layout_autotune.py
@@ -17,7 +17,6 @@ import json
 import tempfile
 import unittest
 import warnings
-import numpy
 
 import paddle
 import paddle.nn.functional as F

--- a/python/paddle/fluid/tests/unittests/test_lcm.py
+++ b/python/paddle/fluid/tests/unittests/test_lcm.py
@@ -17,8 +17,6 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
-from op_test import OpTest
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
@@ -17,7 +17,6 @@ import math
 import numpy as np
 import unittest
 
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 import paddle.fluid.framework as framework

--- a/python/paddle/fluid/tests/unittests/test_linalg_pinv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_pinv_op.py
@@ -16,11 +16,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import paddle.fluid.core as core
-from op_test import OpTest, skip_check_grad_ci
-from gradient_checker import grad_check
-from decorator_helper import prog_scope
 
 
 class LinalgPinvTestCase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_linear.py
+++ b/python/paddle/fluid/tests/unittests/test_linear.py
@@ -15,12 +15,9 @@
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from op_test import OpTest
 import paddle
-from paddle import fluid, nn
-import paddle.fluid.dygraph as dg
+from paddle import fluid
 import paddle.nn.functional as F
-import paddle.fluid.initializer as I
 
 
 class LinearTestCase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_linspace.py
+++ b/python/paddle/fluid/tests/unittests/test_linspace.py
@@ -17,7 +17,7 @@ import numpy as np
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 from paddle.fluid import core
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_listen_and_serv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_listen_and_serv_op.py
@@ -19,12 +19,9 @@ silentremove("test_list_and_serv_run_empty_optimize_block.flag")
 
 import paddle
 import paddle.fluid as fluid
-import signal
-import subprocess
 import time
 import unittest
 from multiprocessing import Process
-from op_test import OpTest
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_load_op.py
+++ b/python/paddle/fluid/tests/unittests/test_load_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest, randomize_probability
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 import os

--- a/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 import os
 import tempfile
-from op_test import OpTest, randomize_probability
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 import paddle

--- a/python/paddle/fluid/tests/unittests/test_load_vars_shape_check.py
+++ b/python/paddle/fluid/tests/unittests/test_load_vars_shape_check.py
@@ -15,8 +15,6 @@
 import unittest
 import os
 import shutil
-import numpy as np
-import paddle as paddle
 import paddle.fluid as fluid
 from paddle.fluid.executor import Executor
 

--- a/python/paddle/fluid/tests/unittests/test_lod_append_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lod_append_op.py
@@ -15,11 +15,7 @@
 import unittest
 import numpy as np
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
-import paddle.fluid.core as core
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.op import Operator
-from paddle.fluid.backward import append_backward
+from paddle.fluid import Program
 
 
 class TestLoDAppendAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_lod_array_length_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lod_array_length_op.py
@@ -19,7 +19,7 @@ import paddle.fluid.layers as layers
 from paddle.fluid.executor import Executor
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 import numpy
 
 

--- a/python/paddle/fluid/tests/unittests/test_logcumsumexp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logcumsumexp_op.py
@@ -19,8 +19,6 @@ import numpy as np
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import _test_eager_guard
 from op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/test_logical_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logical_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import op_test
 import unittest
 import numpy as np
 import paddle

--- a/python/paddle/fluid/tests/unittests/test_lookahead.py
+++ b/python/paddle/fluid/tests/unittests/test_lookahead.py
@@ -14,13 +14,10 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
-from paddle.fluid import core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import paddle
 import paddle.nn as nn
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph
+from paddle.fluid.framework import _test_eager_guard
 
 LOOKAHEAD_K = 5
 LOOKAHEAD_ALPHA = 0.2

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_dequant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_dequant_op.py
@@ -14,12 +14,7 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-import paddle.compat as cpt
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from op_test import OpTest
 import struct
 
 

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
@@ -15,8 +15,7 @@
 import unittest
 import numpy as np
 import paddle
-from paddle.fluid.tests.unittests.op_test import (skip_check_grad_ci,
-                                                  convert_uint16_to_float)
+from paddle.fluid.tests.unittests.op_test import convert_uint16_to_float
 from paddle.fluid.tests.unittests.test_lookup_table_bf16_op import (
     _lookup, TestLookupTableBF16Op, TestLookupTableBF16OpIds4D,
     TestLookupTableBF16OpWIsSelectedRows,

--- a/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import math
 import numpy as np
 import unittest
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
-import paddle.fluid.framework as framework
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/test_lrn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lrn_op.py
@@ -18,7 +18,7 @@ import numpy as np
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from op_test import OpTest
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 
 class TestLRNOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_op.py
@@ -14,7 +14,7 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 from paddle import fluid
 from paddle.fluid.layers import lstm as LSTM
 from paddle.fluid.layers import fill_constant

--- a/python/paddle/fluid/tests/unittests/test_lu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lu_op.py
@@ -18,7 +18,6 @@ import itertools
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import paddle.fluid.core as core
 import scipy
 import scipy.linalg

--- a/python/paddle/fluid/tests/unittests/test_lu_unpack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lu_unpack_op.py
@@ -18,7 +18,6 @@ import itertools
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import paddle.fluid.core as core
 import scipy
 import scipy.linalg

--- a/python/paddle/fluid/tests/unittests/test_manual_seed.py
+++ b/python/paddle/fluid/tests/unittests/test_manual_seed.py
@@ -16,8 +16,6 @@ import unittest
 
 import paddle
 import paddle.fluid as fluid
-from paddle.framework import seed
-from paddle.fluid.framework import Program, default_main_program, default_startup_program
 import numpy as np
 
 

--- a/python/paddle/fluid/tests/unittests/test_margin_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_margin_cross_entropy_op.py
@@ -15,10 +15,7 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import math
-import random
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/test_marker_op.py
+++ b/python/paddle/fluid/tests/unittests/test_marker_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-import numpy as np
 from op_test import OpTest
 from paddle.distributed.fleet.meta_optimizers.common import OpRole
 

--- a/python/paddle/fluid/tests/unittests/test_masked_select_op.py
+++ b/python/paddle/fluid/tests/unittests/test_masked_select_op.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.fluid as fluid
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
@@ -17,7 +17,7 @@ import paddle
 import paddle.fluid as fluid
 import numpy as np
 import inspect
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TestMathOpPatchesVarBase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.fluid.core as core
 import unittest
 import numpy as np
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_matmul_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_v2_op.py
@@ -20,7 +20,6 @@ import paddle.fluid.core as core
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.framework as framework
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_matrix_power_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matrix_power_op.py
@@ -359,10 +359,8 @@ class TestMatrixPowerSingularAPI(unittest.TestCase):
                                   fetch_list=[result])
             except RuntimeError as ex:
                 print("The mat is singular")
-                pass
             except ValueError as ex:
                 print("The mat is singular")
-                pass
 
     def test_static(self):
         paddle.enable_static()
@@ -379,10 +377,8 @@ class TestMatrixPowerSingularAPI(unittest.TestCase):
                     result = paddle.linalg.matrix_power(input, -2)
                 except RuntimeError as ex:
                     print("The mat is singular")
-                    pass
                 except ValueError as ex:
                     print("The mat is singular")
-                    pass
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_matrix_rank_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matrix_rank_op.py
@@ -16,13 +16,10 @@ import unittest
 
 import numpy as np
 
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.nn as nn
-import paddle.nn.functional as F
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 SEED = 2049

--- a/python/paddle/fluid/tests/unittests/test_max_min_amax_amin_op.py
+++ b/python/paddle/fluid/tests/unittests/test_max_min_amax_amin_op.py
@@ -17,8 +17,6 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
-from op_test import OpTest
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_max_op.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
-import tempfile
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci, check_out_dtype
+from op_test import check_out_dtype
 import paddle
 from paddle.fluid.framework import _test_eager_guard
 import paddle.fluid.core as core
-import paddle.inference as paddle_infer
 from test_sum_op import TestReduceOPTensorAxisBase
 
 

--- a/python/paddle/fluid/tests/unittests/test_mean_iou.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_iou.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
-import paddle
 
 
 def compute_mean_iou(predictions, labels, num_classes, in_wrongs, in_corrects,

--- a/python/paddle/fluid/tests/unittests/test_mean_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_op.py
@@ -19,7 +19,6 @@ import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-from paddle.fluid.framework import _test_eager_guard
 from test_sum_op import TestReduceOPTensorAxisBase
 import gradient_checker
 from decorator_helper import prog_scope

--- a/python/paddle/fluid/tests/unittests/test_memcpy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_memcpy_op.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import op_test
 import numpy as np
 import unittest
 import paddle
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.backward import append_backward
+from paddle.fluid import Program, program_guard
 
 
 class TestMemcpy_FillConstant(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_meshgrid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_meshgrid_op.py
@@ -14,10 +14,9 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 import paddle.fluid as fluid
 import paddle
-from paddle.fluid import compiler, Program, program_guard, core
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_min_op.py
+++ b/python/paddle/fluid/tests/unittests/test_min_op.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
-import tempfile
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci, check_out_dtype
+from op_test import check_out_dtype
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
-import paddle.inference as paddle_infer
 from test_sum_op import TestReduceOPTensorAxisBase
 
 

--- a/python/paddle/fluid/tests/unittests/test_mine_hard_examples_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mine_hard_examples_op.py
@@ -14,8 +14,6 @@
 
 import unittest
 import numpy as np
-import sys
-import math
 from op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
+++ b/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 import paddle.fluid.core as core
-import math
-import os
-import sys
 import unittest
 
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/test_modelaverage.py
+++ b/python/paddle/fluid/tests/unittests/test_modelaverage.py
@@ -14,9 +14,6 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
-from paddle.fluid import core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import paddle
 import paddle.nn as nn

--- a/python/paddle/fluid/tests/unittests/test_monitor.py
+++ b/python/paddle/fluid/tests/unittests/test_monitor.py
@@ -21,7 +21,6 @@ paddle.enable_static()
 
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-import numpy as np
 import os
 import unittest
 import tempfile

--- a/python/paddle/fluid/tests/unittests/test_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mul_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import paddle
 import paddle.fluid.core as core
 import sys
 

--- a/python/paddle/fluid/tests/unittests/test_multi_dot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_multi_dot_op.py
@@ -14,7 +14,7 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 from numpy.linalg import multi_dot
 from op_test import OpTest
 import paddle

--- a/python/paddle/fluid/tests/unittests/test_multinomial_op.py
+++ b/python/paddle/fluid/tests/unittests/test_multinomial_op.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 from op_test import OpTest
 import numpy as np
 import os

--- a/python/paddle/fluid/tests/unittests/test_multiply.py
+++ b/python/paddle/fluid/tests/unittests/test_multiply.py
@@ -19,7 +19,7 @@ import numpy as np
 import paddle
 import paddle.tensor as tensor
 from paddle.static import Program, program_guard
-from paddle.fluid.framework import _test_eager_guard, in_dygraph_mode
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TestMultiplyApi(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dataset.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dataset.py
@@ -18,8 +18,8 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.io import Dataset, IterableDataset, TensorDataset, \
-        ComposeDataset, ChainDataset, DataLoader, random_split, Subset
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph
+        ComposeDataset, ChainDataset, DataLoader
+from paddle.fluid.framework import _test_eager_guard
 
 IMAGE_SIZE = 32
 

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import six
 import time
 import unittest
-import multiprocessing
 import numpy as np
 
 import paddle.fluid as fluid
-from paddle.io import Dataset, BatchSampler, DataLoader
+from paddle.io import DataLoader
 from paddle.fluid.dygraph.nn import Linear
-from paddle.fluid.dygraph.base import to_variable
 
 from test_multiprocess_dataloader_static import RandomDataset, RandomBatchedDataset, prepare_places
 from test_multiprocess_dataloader_static import EPOCH_NUM, BATCH_SIZE, IMAGE_SIZE, SAMPLE_NUM, CLASS_NUM

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
-import six
-import time
 import unittest
 import multiprocessing
 import numpy as np
@@ -23,8 +19,6 @@ import numpy as np
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.io import Dataset, IterableDataset, BatchSampler, DataLoader
-from paddle.fluid.dygraph.nn import Linear
-from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.dataloader.dataloader_iter import _worker_loop
 
 

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import six
 import time
 import unittest
-import multiprocessing
 import numpy as np
 
 import paddle.fluid as fluid
-from paddle.io import Dataset, BatchSampler, DataLoader
+from paddle.io import DataLoader
 from paddle.fluid.dygraph.nn import Linear
-from paddle.fluid.dygraph.base import to_variable
 
 from test_multiprocess_dataloader_iterable_dataset_static import RandomDataset, RandomBatchedDataset, prepare_places
 from test_multiprocess_dataloader_iterable_dataset_static import EPOCH_NUM, BATCH_SIZE, IMAGE_SIZE, SAMPLE_NUM, CLASS_NUM

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_split.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_split.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 
 import paddle.fluid as fluid
-from paddle.io import IterableDataset, BatchSampler, DataLoader, get_worker_info
+from paddle.io import DataLoader, IterableDataset, get_worker_info
 
 
 class RangeIterableDatasetSplit(IterableDataset):

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_static.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_static.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import six
 import time
 import unittest
-import multiprocessing
 import numpy as np
 
 import paddle.fluid as fluid
-from paddle.io import IterableDataset, BatchSampler, DataLoader, get_worker_info
+from paddle.io import DataLoader, IterableDataset
 
 EPOCH_NUM = 2
 BATCH_SIZE = 8

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
@@ -12,17 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 import six
 import time
 import unittest
-import multiprocessing
 import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-from paddle.io import Dataset, BatchSampler, DataLoader
+from paddle.io import DataLoader, Dataset
 
 EPOCH_NUM = 3
 BATCH_SIZE = 8

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_reader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_reader_exception.py
@@ -17,8 +17,6 @@ import paddle.fluid as fluid
 from paddle.reader import multiprocess_reader
 import unittest
 import numpy as np
-import six
-import sys
 
 
 class ReaderException(Exception):

--- a/python/paddle/fluid/tests/unittests/test_mv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mv_op.py
@@ -15,9 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.layers as layers
-import paddle.fluid.core as core
 from paddle.static import program_guard, Program
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/test_nanmean_api.py
+++ b/python/paddle/fluid/tests/unittests/test_nanmean_api.py
@@ -15,9 +15,7 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 np.random.seed(10)
 

--- a/python/paddle/fluid/tests/unittests/test_nansum_api.py
+++ b/python/paddle/fluid/tests/unittests/test_nansum_api.py
@@ -16,8 +16,6 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 
 class API_Test_Nansum(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_v2_op.py
@@ -17,7 +17,6 @@ import numpy as np
 from op_test import OpTest
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-import paddle.nn as nn
 import paddle
 from paddle.nn.functional import interpolate
 

--- a/python/paddle/fluid/tests/unittests/test_network_with_dtype.py
+++ b/python/paddle/fluid/tests/unittests/test_network_with_dtype.py
@@ -14,11 +14,9 @@
 
 import unittest
 
-import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.executor import Executor
 
 BATCH_SIZE = 20
 

--- a/python/paddle/fluid/tests/unittests/test_nn_functional_embedding_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_functional_embedding_dygraph.py
@@ -15,7 +15,6 @@
 import unittest
 
 import paddle
-import paddle.nn as nn
 import numpy as np
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_nn_functional_hot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_functional_hot_op.py
@@ -14,13 +14,11 @@
 
 import unittest
 import numpy as np
-import math
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import paddle.nn.functional as functional
-import paddle.fluid.framework as framework
 from paddle.fluid.framework import Program, program_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_nn_matmul_v2_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_matmul_v2_grad.py
@@ -17,7 +17,6 @@ import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import paddle.fluid.core as core
 import gradient_checker
 from decorator_helper import prog_scope

--- a/python/paddle/fluid/tests/unittests/test_nn_sigmoid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_sigmoid_op.py
@@ -16,8 +16,6 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid.core as core
-from op_test import OpTest
-from scipy.special import expit, erf
 import paddle
 import paddle.fluid as fluid
 import paddle.nn as nn

--- a/python/paddle/fluid/tests/unittests/test_nonzero_api.py
+++ b/python/paddle/fluid/tests/unittests/test_nonzero_api.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard

--- a/python/paddle/fluid/tests/unittests/test_normalize.py
+++ b/python/paddle/fluid/tests/unittests/test_normalize.py
@@ -16,7 +16,6 @@ import unittest
 import paddle
 import paddle.nn.functional as F
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 import numpy as np
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_number_count_op.py
+++ b/python/paddle/fluid/tests/unittests/test_number_count_op.py
@@ -17,10 +17,6 @@ import numpy as np
 import unittest
 import paddle
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.backward import append_backward
 from paddle.distributed.models.moe import utils
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_numel_op.py
+++ b/python/paddle/fluid/tests/unittests/test_numel_op.py
@@ -15,10 +15,7 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-import functools
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/test_one_hot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_one_hot_op.py
@@ -14,12 +14,10 @@
 
 import unittest
 import numpy as np
-import math
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-import paddle.fluid.framework as framework
 from paddle.fluid.framework import Program, program_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_one_hot_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_one_hot_v2_op.py
@@ -14,12 +14,10 @@
 
 import unittest
 import numpy as np
-import math
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-import paddle.fluid.framework as framework
 from paddle.fluid.framework import Program, program_guard, _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_ones_like.py
+++ b/python/paddle/fluid/tests/unittests/test_ones_like.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle import ones_like
 from paddle.fluid import core, Program, program_guard
 from paddle.fluid.framework import convert_np_dtype_to_dtype_

--- a/python/paddle/fluid/tests/unittests/test_ones_op.py
+++ b/python/paddle/fluid/tests/unittests/test_ones_op.py
@@ -14,11 +14,8 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
 
 import paddle
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import numpy as np
 

--- a/python/paddle/fluid/tests/unittests/test_onnx_export.py
+++ b/python/paddle/fluid/tests/unittests/test_onnx_export.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import pickle
 import unittest
 import numpy as np
 import paddle
-from paddle.static import InputSpec
 
-from paddle.fluid.framework import in_dygraph_mode, _test_eager_guard
+from paddle.fluid.framework import _test_eager_guard
 
 
 class LinearNet(paddle.nn.Layer):

--- a/python/paddle/fluid/tests/unittests/test_op_function_generator.py
+++ b/python/paddle/fluid/tests/unittests/test_op_function_generator.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import unittest
-from paddle.fluid.framework import default_main_program, Program, convert_np_dtype_to_dtype_, _non_static_mode, in_dygraph_mode
+from paddle.fluid.framework import in_dygraph_mode
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
-import paddle.fluid.core as core
 from paddle.fluid.dygraph.jit import TracedLayer
 import numpy as np
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 
 class TestTracedLayer(fluid.dygraph.Layer):

--- a/python/paddle/fluid/tests/unittests/test_outer.py
+++ b/python/paddle/fluid/tests/unittests/test_outer.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.static import Program, program_guard
-from paddle.fluid.framework import _test_eager_guard, in_dygraph_mode
+from paddle.fluid.framework import _test_eager_guard
 
 
 class TestMultiplyApi(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 F401 unused import 存量 python 代码

- [x] `python/paddle/fluid/tests/unittests/` 下 `test_[k-o]`

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4
- 配置文件更新：#46654
- fixes https://github.com/cattidea/paddle-flake8-project/issues/48