### PR TITLE
[CodeStyle][F401] remove unused import in unittests/test_[u-z]

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_unbind_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unbind_op.py
@@ -18,7 +18,7 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 import paddle.fluid as fluid
 import paddle.tensor as tensor
-from paddle.fluid import compiler, Program, program_guard, core
+from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_unfold_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unfold_op.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import numpy as np
 import unittest
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_bf16_op.py
@@ -14,12 +14,11 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest, convert_uint16_to_float, convert_float_to_uint16
+from op_test import OpTest, convert_uint16_to_float
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 from paddle.fluid.tests.unittests.test_uniform_random_op import output_hist, output_hist_diag
 
 

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import os
-import subprocess
 import unittest
 import numpy as np
 from op_test import OpTest

--- a/python/paddle/fluid/tests/unittests/test_unique.py
+++ b/python/paddle/fluid/tests/unittests/test_unique.py
@@ -18,7 +18,6 @@ from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_unique_consecutive_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unique_consecutive_op.py
@@ -19,7 +19,6 @@ import paddle.fluid.core as core
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.framework as framework
 
 
 def reference_unique_consecutive(X, return_inverse=False, return_counts=False):

--- a/python/paddle/fluid/tests/unittests/test_unique_with_counts.py
+++ b/python/paddle/fluid/tests/unittests/test_unique_with_counts.py
@@ -17,7 +17,6 @@ import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 
 
 class TestUniqueWithCountsOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_unpool1d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool1d_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
 import paddle
 import paddle.nn.functional as F
 

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -288,7 +288,6 @@ class TestUnpoolOpAPI_dy3(unittest.TestCase):
 
     def test_case(self):
         import paddle
-        import paddle.nn.functional as F
         import paddle.fluid.core as core
         import paddle.fluid as fluid
         import numpy as np

--- a/python/paddle/fluid/tests/unittests/test_var_info.py
+++ b/python/paddle/fluid/tests/unittests/test_var_info.py
@@ -18,8 +18,6 @@ including create, config, run, etc.
 
 import paddle.fluid as fluid
 import numpy as np
-import os
-import shutil
 import unittest
 
 

--- a/python/paddle/fluid/tests/unittests/test_variable.py
+++ b/python/paddle/fluid/tests/unittests/test_variable.py
@@ -16,10 +16,9 @@ import unittest
 from functools import reduce
 
 import paddle
-from paddle.fluid.framework import default_main_program, Program, convert_np_dtype_to_dtype_, _non_static_mode
+from paddle.fluid.framework import Program, convert_np_dtype_to_dtype_, default_main_program
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import paddle.fluid.core as core
 import numpy as np
 

--- a/python/paddle/fluid/tests/unittests/test_view_op_reuse_allocation.py
+++ b/python/paddle/fluid/tests/unittests/test_view_op_reuse_allocation.py
@@ -16,9 +16,8 @@ import unittest
 
 import numpy as np
 
-from op_test import OpTest
 import paddle
-from paddle.fluid.framework import _test_eager_guard, in_dygraph_mode
+from paddle.fluid.framework import _test_eager_guard
 
 
 # NOTE(pangyoki): Tensor View Strategy.

--- a/python/paddle/fluid/tests/unittests/test_where_op.py
+++ b/python/paddle/fluid/tests/unittests/test_where_op.py
@@ -16,11 +16,8 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
-import paddle.fluid.core as core
 from op_test import OpTest
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.op import Operator
+from paddle.fluid import Program, program_guard
 from paddle.fluid.backward import append_backward
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -19,8 +19,6 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import paddle.fluid.layers as layers
-import paddle.fluid.framework as framework
-from paddle.fluid.executor import Executor
 from paddle.fluid.framework import Program, program_guard
 from paddle.fluid.backward import append_backward
 

--- a/python/paddle/fluid/tests/unittests/test_while_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_op.py
@@ -20,7 +20,6 @@ import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
 import numpy
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_yolo_box_op.py
+++ b/python/paddle/fluid/tests/unittests/test_yolo_box_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-from paddle.fluid import core
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_zeros_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_zeros_like_op.py
@@ -17,7 +17,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle import zeros_like
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid import core, Program, program_guard
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.framework import convert_np_dtype_to_dtype_

--- a/python/paddle/fluid/tests/unittests/test_zeros_op.py
+++ b/python/paddle/fluid/tests/unittests/test_zeros_op.py
@@ -14,13 +14,10 @@
 
 import unittest
 import numpy as np
-from op_test import OpTest
 import paddle
 import paddle.compat as cpt
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 F401 unused import 存量 python 代码

- [x] `python/paddle/fluid/tests/unittests/` 下 `test_[u-z]`

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4
- 配置文件更新：#46654
- fixes https://github.com/cattidea/paddle-flake8-project/issues/50