### PR TITLE
fix fp16

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #include <cuda_runtime.h>
 #include <stdio.h>
 
@@ -27,17 +26,6 @@
 #include "paddle/fluid/operators/fused/fused_layernorm_residual_dropout_bias.h"
 #include "paddle/fluid/operators/layer_norm_kernel.cu.h"
 #include "paddle/fluid/operators/math/bert_encoder_functor.h"
-
-#include "paddle/fluid/inference/tensorrt/engine.h"
-#include "paddle/fluid/inference/tensorrt/plugin/trt_plugin.h"
-
-#define STR(x) #x
-#define XSTR(x) STR(x)
-#ifdef __CUDA_ARCH__
-#pragma message ("CUDA_ARCH=" XSTR(__CUDA_ARCH__))
-#else
-#pragma message ("No cuda_arch define")
-#endif
 
 namespace paddle {
 namespace inference {

--- a/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/preln_residual_bias_plugin.cu
@@ -436,9 +436,7 @@ int PrelnResidualBiasPluginDynamic::enqueue(
           rows,
           half_n,
           epsilon);
-    } else 
-#endif
-    {
+    } else {
       paddle::operators::FusedLayernormResidualDropoutBiasFunctor<half,
                                                                   uint8_t,
                                                                   VecSize,
@@ -464,6 +462,32 @@ int PrelnResidualBiasPluginDynamic::enqueue(
           var,
           stream);
     }
+#else
+    paddle::operators::FusedLayernormResidualDropoutBiasFunctor<half,
+                                                                uint8_t,
+                                                                VecSize,
+                                                                float,
+                                                                false>()(
+        rows,
+        cols,
+        seed,
+        dropout_prob,
+        is_upscale_in_train,
+        is_test,
+        increment,
+        epsilon,
+        src,
+        residual,
+        bias,
+        scale,
+        layernorm_bias,
+        mask_data,
+        dst,
+        layernorm_dst,
+        mean,
+        var,
+        stream);
+#endif
 #else
     PADDLE_THROW(platform::errors::Fatal(
         "The Ernie(Bert) tensorRT plugin should be "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix build error for trt plugin preln_resdiual_bias under fp16-no-supported cuda_arch 