### PR TITLE
[CodeStyle][F401] remove unused imports in fluid/tests/custom_*

### DIFF
--- a/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_setup.py
+++ b/python/paddle/fluid/tests/custom_kernel/custom_kernel_dot_setup.py
@@ -15,7 +15,6 @@
 import os
 import site
 from paddle.fluid import core
-from distutils.sysconfig import get_python_lib
 from distutils.core import setup, Extension
 from setuptools.command.build_ext import build_ext
 

--- a/python/paddle/fluid/tests/custom_kernel/test_custom_kernel_dot.py
+++ b/python/paddle/fluid/tests/custom_kernel/test_custom_kernel_dot.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import site
 import unittest
 import numpy as np
 

--- a/python/paddle/fluid/tests/custom_op/custom_relu_setup.py
+++ b/python/paddle/fluid/tests/custom_op/custom_relu_setup.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from utils import paddle_includes, extra_compile_args, IS_MAC
 from paddle.utils.cpp_extension import CUDAExtension, setup, CppExtension
 

--- a/python/paddle/fluid/tests/custom_op/test_check_abi.py
+++ b/python/paddle/fluid/tests/custom_op/test_check_abi.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import paddle
 import os
 import warnings
 

--- a/python/paddle/fluid/tests/custom_op/test_custom_relu_op_jit.py
+++ b/python/paddle/fluid/tests/custom_op/test_custom_relu_op_jit.py
@@ -18,7 +18,7 @@ import paddle
 import numpy as np
 from paddle.utils.cpp_extension import load, get_build_directory
 from paddle.utils.cpp_extension.extension_utils import run_cmd
-from utils import paddle_includes, extra_cc_args, extra_nvcc_args, IS_WINDOWS, IS_MAC
+from utils import IS_MAC, extra_cc_args, extra_nvcc_args, paddle_includes
 from test_custom_relu_op_setup import custom_relu_dynamic, custom_relu_static
 from paddle.fluid.framework import _test_eager_guard
 # Because Windows don't use docker, the shared lib already exists in the

--- a/python/paddle/fluid/tests/custom_op/test_custom_relu_op_setup.py
+++ b/python/paddle/fluid/tests/custom_op/test_custom_relu_op_setup.py
@@ -18,8 +18,6 @@ import site
 import unittest
 import paddle
 import paddle.static as static
-import tempfile
-import subprocess
 import numpy as np
 from paddle.vision.transforms import Compose, Normalize
 from paddle.utils.cpp_extension.extension_utils import run_cmd

--- a/python/paddle/fluid/tests/custom_op/test_custom_tanh_double_grad.py
+++ b/python/paddle/fluid/tests/custom_op/test_custom_tanh_double_grad.py
@@ -18,7 +18,6 @@ import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-import paddle.static as static
 from paddle.utils.cpp_extension import load, get_build_directory
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 from utils import paddle_includes, extra_cc_args, extra_nvcc_args

--- a/python/paddle/fluid/tests/custom_op/test_multi_out_jit.py
+++ b/python/paddle/fluid/tests/custom_op/test_multi_out_jit.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import subprocess
 import unittest
 import numpy as np
 

--- a/python/paddle/fluid/tests/custom_op/utils.py
+++ b/python/paddle/fluid/tests/custom_op/utils.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import six
 from distutils.sysconfig import get_python_lib
 from paddle.utils.cpp_extension.extension_utils import IS_WINDOWS
 

--- a/python/paddle/fluid/tests/custom_runtime/custom_device_multi_process_collective.py
+++ b/python/paddle/fluid/tests/custom_runtime/custom_device_multi_process_collective.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import time
 
 
 def train(prefix):

--- a/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
+++ b/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
@@ -15,12 +15,9 @@
 import unittest
 import random
 import numpy as np
-import os
-import shutil
 
 import paddle
 from paddle.fluid import core
-from datetime import timedelta
 import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.dygraph.parallel import ParallelEnv

--- a/python/paddle/fluid/tests/custom_runtime/test_collective_process_group_xccl.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_collective_process_group_xccl.py
@@ -14,7 +14,6 @@
 
 import unittest
 import os
-import sys
 import copy
 import subprocess
 import time
@@ -27,7 +26,7 @@ def start_local_trainers(cluster,
                          training_script_args,
                          eager_mode=True,
                          log_dir=None):
-    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+    from paddle.distributed.utils.launch_utils import TrainerProc
 
     current_env = copy.copy(os.environ.copy())
     #paddle broadcast ncclUniqueId use socket, and
@@ -83,7 +82,7 @@ def start_local_trainers(cluster,
 
 
 def get_cluster_from_args(selected_gpus):
-    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+    from paddle.distributed.utils.launch_utils import find_free_ports, get_cluster
 
     cluster_node_ips = '127.0.0.1'
     node_ip = '127.0.0.1'
@@ -107,7 +106,7 @@ def get_cluster_from_args(selected_gpus):
 class TestMultipleCustomCPU(unittest.TestCase):
 
     def run_mnist_2custom_cpu(self, target_file_name, eager_mode=True):
-        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+        from paddle.distributed.utils.launch_utils import watch_local_trainers
 
         selected_devices = [0, 1]
         cluster = None
@@ -160,7 +159,7 @@ class TestProcessGroup(TestMultipleCustomCPU):
         self.temp_dir.cleanup()
 
     def test_process_group_xccl(self):
-        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+        pass
 
         self.run_mnist_2custom_cpu('process_group_xccl.py')
 

--- a/python/paddle/fluid/tests/custom_runtime/test_collective_process_group_xccl.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_collective_process_group_xccl.py
@@ -14,6 +14,7 @@
 
 import unittest
 import os
+import sys
 import copy
 import subprocess
 import time
@@ -26,7 +27,7 @@ def start_local_trainers(cluster,
                          training_script_args,
                          eager_mode=True,
                          log_dir=None):
-    from paddle.distributed.utils.launch_utils import TrainerProc
+    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
 
     current_env = copy.copy(os.environ.copy())
     #paddle broadcast ncclUniqueId use socket, and
@@ -82,7 +83,7 @@ def start_local_trainers(cluster,
 
 
 def get_cluster_from_args(selected_gpus):
-    from paddle.distributed.utils.launch_utils import find_free_ports, get_cluster
+    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
 
     cluster_node_ips = '127.0.0.1'
     node_ip = '127.0.0.1'
@@ -106,7 +107,7 @@ def get_cluster_from_args(selected_gpus):
 class TestMultipleCustomCPU(unittest.TestCase):
 
     def run_mnist_2custom_cpu(self, target_file_name, eager_mode=True):
-        from paddle.distributed.utils.launch_utils import watch_local_trainers
+        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
 
         selected_devices = [0, 1]
         cluster = None
@@ -159,7 +160,7 @@ class TestProcessGroup(TestMultipleCustomCPU):
         self.temp_dir.cleanup()
 
     def test_process_group_xccl(self):
-        pass
+        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
 
         self.run_mnist_2custom_cpu('process_group_xccl.py')
 

--- a/python/paddle/fluid/tests/custom_runtime/test_collective_process_group_xccl.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_collective_process_group_xccl.py
@@ -14,7 +14,6 @@
 
 import unittest
 import os
-import sys
 import copy
 import subprocess
 import time
@@ -27,7 +26,7 @@ def start_local_trainers(cluster,
                          training_script_args,
                          eager_mode=True,
                          log_dir=None):
-    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc  # noqa: F401
 
     current_env = copy.copy(os.environ.copy())
     #paddle broadcast ncclUniqueId use socket, and
@@ -83,7 +82,7 @@ def start_local_trainers(cluster,
 
 
 def get_cluster_from_args(selected_gpus):
-    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+    from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc  # noqa: F401
 
     cluster_node_ips = '127.0.0.1'
     node_ip = '127.0.0.1'
@@ -107,7 +106,7 @@ def get_cluster_from_args(selected_gpus):
 class TestMultipleCustomCPU(unittest.TestCase):
 
     def run_mnist_2custom_cpu(self, target_file_name, eager_mode=True):
-        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc  # noqa: F401
 
         selected_devices = [0, 1]
         cluster = None
@@ -160,7 +159,7 @@ class TestProcessGroup(TestMultipleCustomCPU):
         self.temp_dir.cleanup()
 
     def test_process_group_xccl(self):
-        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc
+        from paddle.distributed.utils.launch_utils import find_free_ports, watch_local_trainers, get_cluster, TrainerProc  # noqa: F401
 
         self.run_mnist_2custom_cpu('process_group_xccl.py')
 

--- a/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_plugin.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_plugin.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import site
 import unittest
 import numpy as np
 import tempfile

--- a/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_profiler_plugin.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_profiler_plugin.py
@@ -14,9 +14,7 @@
 
 import os
 import sys
-import site
 import unittest
-import numpy as np
 import tempfile
 
 

--- a/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_to_static.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_to_static.py
@@ -24,7 +24,6 @@ BATCH_SIZE = 1024
 
 
 def train_func_base(epoch_id, train_loader, model, cost, optimizer):
-    pass
 
     total_step = len(train_loader)
     epoch_start = time.time()

--- a/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_to_static.py
+++ b/python/paddle/fluid/tests/custom_runtime/test_custom_cpu_to_static.py
@@ -24,7 +24,7 @@ BATCH_SIZE = 1024
 
 
 def train_func_base(epoch_id, train_loader, model, cost, optimizer):
-    import paddle
+    pass
 
     total_step = len(train_loader)
     epoch_start = time.time()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 F401 unused import 存量 python 代码

- [x] `python/paddle/fluid/tests/custom_runtime/`
- [x] `python/paddle/fluid/tests/custom_op/`
- [x] `python/paddle/fluid/tests/custom_kernel/`

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive python/paddle/fluid/tests/custom_runtime/
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive python/paddle/fluid/tests/custom_op/
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive python/paddle/fluid/tests/custom_kernel/
```

`python/paddle/fluid/tests/custom_runtime/test_collective_process_group_xccl.py` 添加了 noqa 以避免删除部分 import

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4
- 配置文件更新：#46718
- fixes https://github.com/cattidea/paddle-flake8-project/issues/24
- fixes https://github.com/cattidea/paddle-flake8-project/issues/44
