### PR TITLE
[CodeStyle][F401] update flake8 F401 config (fluid/tests/)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -70,8 +70,6 @@ per-file-ignores =
     python/paddle/tensor/*:F401
     python/paddle/text/*:F401
     python/paddle/metric/*:F401
-    python/paddle/fluid/tests/custom_kernel/*:F401
-    python/paddle/fluid/tests/custom_runtime/*:F401
     python/paddle/fluid/tests/unittests/ir/*:F401
     python/paddle/fluid/tests/unittests/tokenizer/*:F401
     python/paddle/fluid/tests/unittests/xpu/*:F401
@@ -88,8 +86,5 @@ per-file-ignores =
     python/paddle/fluid/tests/unittests/sequence/*:F401
     python/paddle/fluid/tests/unittests/mkldnn/*:F401
     python/paddle/fluid/tests/unittests/rnn/*:F401
-    python/paddle/fluid/tests/book/*:F401
-    python/paddle/fluid/tests/custom_op/*:F401
     python/paddle/fluid/tests/unittests/test_*:F401
-    python/paddle/fluid/tests/test_*:F401
     python/paddle/fluid/tests/*:F401


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 F401 unused import 存量 python 代码

`python/paddle/fluid/tests/` 下，非 `unittests` 下的文件

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4
- 需先 merge 以下 PR
    - #46716
    - #46717