### PR TITLE
[typo]  correct typo errors in python\paddle\vision\datasets\cifar.py

### DIFF
--- a/python/paddle/nn/functional/activation.py
+++ b/python/paddle/nn/functional/activation.py
@@ -1056,9 +1056,9 @@ def softmax(x, axis=-1, dtype=None, name=None):
 
     Parameters:
         x (Tensor): The input Tensor with data type float32, float64.
-        axis (int, optional): The axis along which to perform log_softmax
+        axis (int, optional): The axis along which to perform softmax
             calculations. It should be in range [-D, D), where D is the
-            dimensions of ``x`` . If ``axis`` < 0, it works the same way as
+            rank of ``x`` . If ``axis`` < 0, it works the same way as
             :math:`axis + D` . Default is -1.
         dtype (str, optional): The data type of the output tensor, can be float32, float64.
         name (str, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.

--- a/python/paddle/vision/datasets/cifar.py
+++ b/python/paddle/vision/datasets/cifar.py
@@ -109,8 +109,8 @@ class Cifar10(Dataset):
                  transform=None,
                  download=True,
                  backend=None):
-        assert mode.lower() in ['train', 'test', 'train', 'test'], \
-            "mode should be 'train10', 'test10', 'train100' or 'test100', but got {}".format(mode)
+        assert mode.lower() in ['train', 'test'], \
+            "mode.lower() should be 'train' or 'test', but got {}".format(mode)
         self.mode = mode.lower()
 
         if backend is None:

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -300,7 +300,7 @@ class ToTensor(BaseTransform):
 
     Converts a PIL.Image or numpy.ndarray (H x W x C) to a paddle.Tensor of shape (C x H x W).
 
-    If input is a grayscale image (H x W), it will be converted to a image of shape (H x W x 1).
+    If input is a grayscale image (H x W), it will be converted to an image of shape (H x W x 1).
     And the shape of output tensor will be (1 x H x W).
 
     If you want to keep the shape of output tensor as (H x W x C), you can set data_format = ``HWC`` .


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
correct typo errors