### PR TITLE
[CodeStyle][F401] remove unused imports in python_paddle/proto_onnx_optimizer_hapi_autograd_framework.

### DIFF
--- a/python/paddle/autograd/backward_mode.py
+++ b/python/paddle/autograd/backward_mode.py
@@ -14,7 +14,6 @@
 
 from paddle.fluid import core
 from paddle.fluid import framework
-from paddle.fluid.backward import gradients_with_optimizer
 import paddle
 
 __all__ = []

--- a/python/paddle/autograd/backward_mode.py
+++ b/python/paddle/autograd/backward_mode.py
@@ -14,6 +14,7 @@
 
 from paddle.fluid import core
 from paddle.fluid import framework
+from paddle.fluid.backward import gradients_with_optimizer  # noqa: F401
 import paddle
 
 __all__ = []

--- a/python/paddle/fluid/tests/unittests/test_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_backward.py
@@ -359,8 +359,6 @@ class TestGradientsWithOptimizer(unittest.TestCase):
             opt = paddle.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
 
             forward_list = [o.type for o in main.current_block().ops]
-            optimize_ops, pram_grads = paddle.autograd.backward_mode.gradients_with_optimizer(
-                main, opt)
 
             optimized_list = [o.type for o in main.current_block().ops]
 

--- a/python/paddle/fluid/tests/unittests/test_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_backward.py
@@ -359,6 +359,8 @@ class TestGradientsWithOptimizer(unittest.TestCase):
             opt = paddle.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
 
             forward_list = [o.type for o in main.current_block().ops]
+            optimize_ops, pram_grads = paddle.autograd.backward_mode.gradients_with_optimizer(
+                main, opt)
 
             optimized_list = [o.type for o in main.current_block().ops]
 

--- a/python/paddle/framework/framework.py
+++ b/python/paddle/framework/framework.py
@@ -14,7 +14,6 @@
 
 # TODO: define framework api
 from paddle.fluid.layer_helper_base import LayerHelperBase
-from paddle.fluid.data_feeder import convert_dtype
 from paddle.fluid.framework import _dygraph_tracer
 import numpy as np
 from contextlib import contextmanager

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -31,7 +31,7 @@ from paddle.fluid.io import _open_file_buffer, _is_file_path, _is_memory_buffer
 from paddle.fluid.framework import Variable, _varbase_creator, _dygraph_tracer, _non_static_mode, ParamBase, EagerParamBase, _current_expected_place, Program
 from paddle.fluid.dygraph.jit import _SaveLoadConfig
 from paddle.fluid.dygraph.io import _construct_program_holders, _construct_params_and_buffers
-from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX, INFER_PARAMS_INFO_SUFFIX
+from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 try:
     from collections.abc import Iterable
 except:

--- a/python/paddle/hapi/hub.py
+++ b/python/paddle/hapi/hub.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import re
 import sys
 import shutil
 import zipfile

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -25,7 +25,7 @@ import contextlib
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.framework import _non_static_mode, in_dygraph_mode
+from paddle.fluid.framework import _non_static_mode
 from paddle.fluid.framework import Variable
 from paddle.fluid.framework import _get_paddle_place
 from paddle.fluid.framework import _current_expected_place as _get_device

--- a/python/paddle/hapi/static_flops.py
+++ b/python/paddle/hapi/static_flops.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import numpy as np
-import paddle
 from collections import OrderedDict
-from paddle.static import Program, program_guard, Variable
+from paddle.static import Program, Variable
 
 __all__ = []
 

--- a/python/paddle/optimizer/adadelta.py
+++ b/python/paddle/optimizer/adadelta.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 from .optimizer import Optimizer
-from ..fluid import core
 from ..fluid import framework
-from ..fluid.framework import Variable, name_scope
 from ..framework import in_dygraph_mode
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from ..fluid.dygraph import no_grad
 
 __all__ = []

--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from .optimizer import Optimizer
-from ..fluid import core
 from ..fluid import framework
-from ..fluid.framework import Variable
 
 __all__ = []
 

--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -15,15 +15,13 @@
 from .optimizer import Optimizer
 from ..fluid import core
 from ..fluid import framework
-from ..fluid.framework import Variable, _in_legacy_dygraph, in_dygraph_mode
+from ..fluid.framework import Variable, in_dygraph_mode
 from ..fluid import layers
 from ..fluid import unique_name
 from ..fluid.layer_helper import LayerHelper
 import warnings
 from ..fluid.dygraph import base as imperative_base
 from collections import defaultdict
-import numpy as np
-import time
 
 import paddle
 from paddle import _C_ops, _legacy_C_ops

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 from .optimizer import Optimizer
-from ..fluid import core
 from ..fluid import framework
-from ..fluid.framework import Variable, name_scope
+from ..fluid.framework import name_scope
 from paddle import _C_ops, _legacy_C_ops
 from ..fluid.dygraph import no_grad
 

--- a/python/paddle/optimizer/lamb.py
+++ b/python/paddle/optimizer/lamb.py
@@ -21,7 +21,6 @@ from ..fluid import unique_name
 from ..fluid.layer_helper import LayerHelper
 from paddle import _C_ops, _legacy_C_ops
 from paddle.fluid.executor import global_scope
-import paddle
 
 __all__ = []
 

--- a/python/paddle/optimizer/momentum.py
+++ b/python/paddle/optimizer/momentum.py
@@ -17,11 +17,9 @@ import warnings
 from .optimizer import Optimizer
 from ..fluid import core
 from ..fluid import framework
-from ..fluid.framework import Variable, name_scope
 from ..fluid.layer_helper import LayerHelper
 from ..fluid import unique_name
 from ..fluid import layers
-import paddle.fluid as fluid
 from paddle.fluid.regularizer import L2DecayRegularizer
 from paddle import _C_ops, _legacy_C_ops
 import paddle

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -13,32 +13,23 @@
 # limitations under the License.
 
 import numpy as np
-import six
 import logging
 from collections import defaultdict
 
 import paddle
-from paddle.fluid.distribute_lookup_table import find_distributed_lookup_table
-from paddle.fluid.framework import Program, Variable, name_scope, default_main_program, default_startup_program, device_guard
+from paddle.fluid.framework import Variable, default_main_program, device_guard, name_scope
 
 from ..fluid import framework
 from ..fluid import layers
 from ..fluid import unique_name
-from ..fluid.backward import append_backward, _some_in_set_, _append_grad_suffix_, _get_no_grad_set_name
-from ..fluid.clip import GradientClipBase, GradientClipByNorm, error_clip_callback, append_gradient_clip_ops
+from ..fluid.backward import _get_no_grad_set_name, append_backward
+from ..fluid.clip import GradientClipBase, append_gradient_clip_ops, error_clip_callback
 from ..fluid.framework import program_guard, Parameter
 from ..fluid.initializer import Constant
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.layers import ops
 from ..fluid.dygraph import base as imperative_base
-from ..fluid.dygraph import no_grad
 from paddle.fluid import core
-from paddle.fluid.layers import tensor
-from functools import reduce
-from ..fluid.wrapped_decorator import signature_safe_contextmanager
-from .. import compat as cpt
 from .lr import LRScheduler
-import copy
 from paddle import _C_ops, _legacy_C_ops
 from paddle.fluid.framework import _in_legacy_dygraph, _in_eager_without_dygraph_check, _current_expected_place, in_dygraph_mode
 

--- a/python/paddle/optimizer/rmsprop.py
+++ b/python/paddle/optimizer/rmsprop.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 from .optimizer import Optimizer
-from ..fluid import core
 from ..fluid import framework
-from ..fluid.framework import Variable
 
 __all__ = []
 

--- a/python/paddle/optimizer/sgd.py
+++ b/python/paddle/optimizer/sgd.py
@@ -15,7 +15,6 @@
 from .optimizer import Optimizer
 from ..fluid import core
 from ..fluid import framework
-from ..fluid.framework import Variable, name_scope
 from ..fluid.dygraph import no_grad
 from paddle import _C_ops, _legacy_C_ops
 import warnings


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/proto/`、 `python/paddle/onnx/`、 `python/paddle/optimizer`、 `python/paddle/hapi/` 、`python/paddle/autograd/`、`python/paddle/framework/`目录 F401 unused import 存量 python 代码

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/proto
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/onnx
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/optimizer
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/hapi
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/autograd
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/framework
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/1
-  配置文件更新: #46756
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/8
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/9