### PR TITLE
[CodeStyle][F401] remove unused imports in python_paddle/io_costmodel_geometric_vision_static.

### DIFF
--- a/python/paddle/geometric/math.py
+++ b/python/paddle/geometric/math.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle.fluid.layer_helper import LayerHelper, _non_static_mode
+from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.data_feeder import check_variable_and_dtype
 from paddle import _C_ops, _legacy_C_ops
 from paddle.fluid.framework import _in_legacy_dygraph, in_dygraph_mode

--- a/python/paddle/geometric/message_passing/send_recv.py
+++ b/python/paddle/geometric/message_passing/send_recv.py
@@ -14,9 +14,9 @@
 
 import numpy as np
 from paddle.fluid.layer_helper import LayerHelper
-from paddle.fluid.framework import _non_static_mode, _in_legacy_dygraph, in_dygraph_mode
+from paddle.fluid.framework import _in_legacy_dygraph, in_dygraph_mode
 from paddle.fluid.framework import Variable
-from paddle.fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype, convert_dtype
+from paddle.fluid.data_feeder import check_dtype, check_type, check_variable_and_dtype
 from paddle import _C_ops, _legacy_C_ops
 
 from .utils import convert_out_size_to_list, get_out_size_tensor_inputs, reshape_lhs_rhs

--- a/python/paddle/geometric/reindex.py
+++ b/python/paddle/geometric/reindex.py
@@ -16,8 +16,7 @@ import paddle
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode, Variable
 from paddle.fluid.data_feeder import check_variable_and_dtype
-from paddle.fluid import core
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 __all__ = []
 

--- a/python/paddle/geometric/sampling/neighbors.py
+++ b/python/paddle/geometric/sampling/neighbors.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode
 from paddle.fluid.data_feeder import check_variable_and_dtype
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 __all__ = []
 

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -33,7 +33,7 @@ from paddle.fluid import (
 )
 from paddle.fluid.io import prepend_feed_ops, append_fetch_ops
 from paddle.fluid.framework import static_only, Parameter
-from paddle.fluid.executor import Executor, global_scope
+from paddle.fluid.executor import global_scope
 from paddle.fluid.log_helper import get_logger
 
 __all__ = []

--- a/python/paddle/vision/datasets/flowers.py
+++ b/python/paddle/vision/datasets/flowers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import io
 import tarfile
 import numpy as np
 from PIL import Image

--- a/python/paddle/vision/datasets/mnist.py
+++ b/python/paddle/vision/datasets/mnist.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import gzip
 import struct
 import numpy as np

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -14,13 +14,11 @@
 
 import numpy as np
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype
-from ..fluid import core, layers
+from ..fluid.data_feeder import check_type, check_variable_and_dtype
 from ..fluid.layers import nn, utils
 from ..nn import Layer, Conv2D, Sequential, ReLU, BatchNorm2D
 from ..fluid.initializer import Normal
 from ..fluid.framework import _non_static_mode, in_dygraph_mode, _in_legacy_dygraph
-from paddle.common_ops_import import *
 from paddle import _C_ops, _legacy_C_ops
 from ..framework import _current_expected_place
 

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import math
 import numbers
-import warnings
-import collections
 
 import numpy as np
 from PIL import Image
-from numpy import sin, cos, tan
 import paddle
 
 from . import functional_pil as F_pil

--- a/python/paddle/vision/transforms/functional_cv2.py
+++ b/python/paddle/vision/transforms/functional_cv2.py
@@ -15,11 +15,9 @@
 import sys
 import math
 import numbers
-import warnings
 import collections
 
 import numpy as np
-from numpy import sin, cos, tan
 
 import paddle
 from paddle.utils import try_import

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 import sys
-import math
 import numbers
-import warnings
 import collections
 from PIL import Image, ImageOps, ImageEnhance
 
 import numpy as np
-from numpy import sin, cos, tan
 import paddle
 
 if sys.version_info < (3, 3):

--- a/python/paddle/vision/transforms/functional_tensor.py
+++ b/python/paddle/vision/transforms/functional_tensor.py
@@ -18,9 +18,6 @@ import numbers
 import paddle
 import paddle.nn.functional as F
 
-import sys
-import collections
-
 __all__ = []
 
 

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -18,13 +18,10 @@ import random
 
 import numpy as np
 import numbers
-import types
 import collections
-import warnings
 import traceback
 
 import paddle
-from paddle.utils import try_import
 from . import functional as F
 
 if sys.version_info < (3, 3):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/io/`、 `python/paddle/cost_model/`、 `python/paddle/geometric/`、 `python/paddle/vision/` 、`python/paddle/static/`、目录 F401 unused import 存量 python 代码

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/io
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/cost_model
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/geometric
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/vision
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/static
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/1
-  配置文件更新: #46756
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/11
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/14
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/16
- fixes https://github.com/cattidea/paddle-flake8-project/issues/20