### PR TITLE
[CodeStyle][F401] remove unused imports in python_paddle/inference_device_profiler_text_metric_incubate_quantization_libs_audio_amp_jit.

### DIFF
--- a/python/paddle/device/cuda/streams.py
+++ b/python/paddle/device/cuda/streams.py
@@ -11,6 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from paddle.fluid.core import CUDAStream as Stream
-from paddle.fluid.core import CUDAEvent as Event

--- a/python/paddle/device/cuda/streams.py
+++ b/python/paddle/device/cuda/streams.py
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from paddle.fluid.core import CUDAStream as Stream  # noqa: F401
+from paddle.fluid.core import CUDAEvent as Event  # noqa: F401

--- a/python/paddle/incubate/autograd/functional.py
+++ b/python/paddle/incubate/autograd/functional.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import typing
 
 import paddle

--- a/python/paddle/incubate/autograd/primreg.py
+++ b/python/paddle/incubate/autograd/primreg.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
-
 
 class Registry(object):
     """ A general registry object. """

--- a/python/paddle/incubate/autograd/primrules.py
+++ b/python/paddle/incubate/autograd/primrules.py
@@ -20,15 +20,15 @@ import paddle
 
 from . import primops
 from .primops import (add, broadcast, concat, cos, div, eq, erf, exp,
-                      fill_const, gather, ge, gt, log, matmul, max, mul, ne,
-                      neg, reduce_sum, reshape, scatter_add, select, set_value,
-                      sin, slice_assign, slice_select, split, sqrt, sub, tanh,
+                      fill_const, gather, ge, gt, log, matmul, mul, ne, neg,
+                      reduce_sum, reshape, scatter_add, select, set_value, sin,
+                      slice_assign, slice_select, split, sqrt, sub, tanh,
                       transpose, bernoulli, rsqrt)
 from .primreg import (REGISTER_JVP, REGISTER_ORIG2PRIM, REGISTER_PRIM2ORIG,
                       REGISTER_TRANSPOSE, lookup_fn, lookup_jvp,
                       lookup_orig2prim, lookup_prim2orig, lookup_transpose,
                       op_position_inputs, op_position_output)
-from .utils import INT_DTYPE_2_STRING, get_input_var_list, get_output_var_list
+from .utils import INT_DTYPE_2_STRING, get_output_var_list
 from paddle.fluid.data_feeder import convert_dtype
 from paddle.fluid.framework import convert_np_dtype_to_dtype_
 

--- a/python/paddle/incubate/distributed/models/moe/gate/gshard_gate.py
+++ b/python/paddle/incubate/distributed/models/moe/gate/gshard_gate.py
@@ -22,7 +22,6 @@
 import math
 import paddle
 import paddle.nn.functional as F
-import numpy as np
 from .naive_gate import NaiveGate
 from ..utils import limit_by_capacity
 

--- a/python/paddle/incubate/distributed/models/moe/gate/naive_gate.py
+++ b/python/paddle/incubate/distributed/models/moe/gate/naive_gate.py
@@ -23,7 +23,6 @@ from .base_gate import BaseGate
 
 import paddle
 import paddle.nn as nn
-import paddle.nn.functional as F
 
 
 class NaiveGate(BaseGate):

--- a/python/paddle/incubate/distributed/models/moe/gate/switch_gate.py
+++ b/python/paddle/incubate/distributed/models/moe/gate/switch_gate.py
@@ -21,7 +21,6 @@
 
 import math
 import paddle
-import paddle.nn as nn
 import paddle.nn.functional as F
 from .naive_gate import NaiveGate
 from ..utils import limit_by_capacity

--- a/python/paddle/incubate/distributed/models/moe/grad_clip.py
+++ b/python/paddle/incubate/distributed/models/moe/grad_clip.py
@@ -14,11 +14,8 @@
 
 from paddle.fluid.clip import ClipGradBase, _squared_l2_norm
 from paddle.fluid.dygraph import base as imperative_base
-from paddle.fluid import core, layers, framework
+from paddle.fluid import core, layers
 from paddle.distributed import collective
-import six
-import warnings
-import copy
 
 
 class ClipGradForMOEByGlobalNorm(ClipGradBase):

--- a/python/paddle/incubate/distributed/models/moe/moe_layer.py
+++ b/python/paddle/incubate/distributed/models/moe/moe_layer.py
@@ -19,22 +19,14 @@
 #     Copyright 2021, Jiaao He. All rights reserved.
 #   Licensed under the Apache License, Version 2.0 (the "License").
 
-import collections
-import math
-
 import numpy as np
 import paddle
 import paddle.nn as nn
-import paddle.nn.functional as F
 from paddle.distributed.utils.moe_utils import global_scatter, global_gather
-from paddle.distributed import alltoall, all_gather
 
-from paddle.distributed.fleet.meta_parallel import get_rng_state_tracker
-from paddle.distributed import fleet
 from paddle.autograd import PyLayer
 from .gate import NaiveGate, GShardGate, SwitchGate, BaseGate
 from .utils import count_by_gate
-from paddle import fluid
 from paddle.fluid.framework import in_dygraph_mode
 from paddle.incubate.distributed.fleet import recompute_hybrid
 

--- a/python/paddle/incubate/multiprocessing/reductions.py
+++ b/python/paddle/incubate/multiprocessing/reductions.py
@@ -17,13 +17,10 @@ import paddle
 # TODO: check the hooks of tensor
 # TODO: check serializing named tensor
 # TODO: check influence on autograd
-import os
 import sys
 import warnings
-import math
 import copy
 import threading
-import multiprocessing
 from multiprocessing.util import register_after_fork
 from multiprocessing.reduction import ForkingPickler
 

--- a/python/paddle/incubate/nn/functional/fused_matmul_bias.py
+++ b/python/paddle/incubate/nn/functional/fused_matmul_bias.py
@@ -15,7 +15,7 @@
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode
 from paddle.tensor.linalg import matmul
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 
 def fused_matmul_bias(x,

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -15,8 +15,8 @@
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode, default_main_program
 from paddle.fluid.data_feeder import check_variable_and_dtype, check_dtype
-from paddle.fluid import core, dygraph_utils
-from paddle import _C_ops, _legacy_C_ops
+from paddle.fluid import core
+from paddle import _legacy_C_ops
 
 __all__ = []
 

--- a/python/paddle/incubate/nn/layer/fused_transformer.py
+++ b/python/paddle/incubate/nn/layer/fused_transformer.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from paddle.nn import functional as F
 from paddle.incubate.nn import functional as incubate_f
 from paddle.nn import Layer
-from paddle.framework import ParamAttr
 import paddle
 from paddle.nn.layer.transformer import _convert_attention_mask, _convert_param_attr_to_list
 from paddle.nn.initializer import Constant

--- a/python/paddle/incubate/operators/graph_khop_sampler.py
+++ b/python/paddle/incubate/operators/graph_khop_sampler.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode
 from paddle.fluid.data_feeder import check_variable_and_dtype
-from paddle.fluid import core
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 
 def graph_khop_sampler(row,

--- a/python/paddle/incubate/operators/graph_reindex.py
+++ b/python/paddle/incubate/operators/graph_reindex.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode
 from paddle.fluid.data_feeder import check_variable_and_dtype
-from paddle.fluid import core
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 import paddle.utils.deprecated as deprecated
 
 

--- a/python/paddle/incubate/operators/graph_sample_neighbors.py
+++ b/python/paddle/incubate/operators/graph_sample_neighbors.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode
 from paddle.fluid.data_feeder import check_variable_and_dtype
-from paddle.fluid import core
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 import paddle.utils.deprecated as deprecated
 
 

--- a/python/paddle/incubate/operators/graph_send_recv.py
+++ b/python/paddle/incubate/operators/graph_send_recv.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 from paddle.fluid.layer_helper import LayerHelper
-from paddle.fluid.framework import _non_static_mode, _in_legacy_dygraph, in_dygraph_mode
+from paddle.fluid.framework import _in_legacy_dygraph, in_dygraph_mode
 from paddle.fluid.framework import Variable
 from paddle.fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype, convert_dtype
 from paddle.fluid.layers.tensor import cast

--- a/python/paddle/incubate/operators/resnet_unit.py
+++ b/python/paddle/incubate/operators/resnet_unit.py
@@ -12,28 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-import collections
-import itertools
-import six
-import math
-import sys
-import warnings
-from functools import partial, reduce
-
 import numpy as np
-import paddle
 import paddle.fluid as fluid
-from paddle import framework
-from paddle.device import get_device, get_cudnn_version
 from paddle.nn import initializer as I
-from paddle.nn import Layer, LayerList
+from paddle.nn import Layer
 from paddle.fluid.layers import utils
 from paddle.fluid.layer_helper import LayerHelper
-from paddle.fluid.layers.utils import map_structure, flatten, pack_sequence_as
-from paddle.fluid.data_feeder import convert_dtype
 from paddle.fluid.param_attr import ParamAttr
-from paddle import _C_ops, _legacy_C_ops
 
 
 def resnet_unit(x, filter_x, scale_x, bias_x, mean_x, var_x, z, filter_z,

--- a/python/paddle/incubate/operators/softmax_mask_fuse.py
+++ b/python/paddle/incubate/operators/softmax_mask_fuse.py
@@ -14,8 +14,7 @@
 
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode
-from paddle.fluid import core
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 
 def softmax_mask_fuse(x, mask, name=None):

--- a/python/paddle/incubate/operators/softmax_mask_fuse_upper_triangle.py
+++ b/python/paddle/incubate/operators/softmax_mask_fuse_upper_triangle.py
@@ -14,8 +14,7 @@
 
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.framework import _non_static_mode
-from paddle.fluid import core
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 
 def softmax_mask_fuse_upper_triangle(x):

--- a/python/paddle/incubate/optimizer/distributed_fused_lamb.py
+++ b/python/paddle/incubate/optimizer/distributed_fused_lamb.py
@@ -17,14 +17,11 @@ import paddle
 from paddle.fluid import framework, core, layers, unique_name
 from paddle.fluid.framework import Variable
 from paddle.fluid.clip import ClipGradByGlobalNorm
-from paddle.fluid.initializer import Constant
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.optimizer import Optimizer
-from paddle.distributed.collective import new_group
 from paddle.fluid.executor import global_scope
 from paddle.fluid.framework import name_scope
 from paddle.fluid import core, unique_name
-import numpy as np
 
 
 def init_communicator(block, rank, ranks, ring_id):

--- a/python/paddle/incubate/optimizer/functional/utils.py
+++ b/python/paddle/incubate/optimizer/functional/utils.py
@@ -14,7 +14,7 @@
 
 import paddle
 from paddle.fluid.framework import Variable
-from paddle.fluid.data_feeder import check_type, check_dtype
+from paddle.fluid.data_feeder import check_type
 
 
 def check_input_type(input, name, op_name):

--- a/python/paddle/incubate/optimizer/lookahead.py
+++ b/python/paddle/incubate/optimizer/lookahead.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 from paddle.optimizer import Optimizer
-from paddle.fluid import core, framework, layers, unique_name
-from paddle.fluid.framework import Program, Variable, name_scope, default_main_program, default_startup_program, device_guard
+from paddle.fluid import framework, layers, unique_name
+from paddle.fluid.framework import Variable
 from paddle.fluid.layer_helper import LayerHelper
 import paddle
-import numpy as np
 from paddle.fluid.dygraph import base as imperative_base
 
 __all__ = []

--- a/python/paddle/incubate/optimizer/modelaverage.py
+++ b/python/paddle/incubate/optimizer/modelaverage.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 from paddle.optimizer import Optimizer
-from paddle.fluid import core, framework, layers
-from paddle.fluid.framework import Program, Variable
+from paddle.fluid import framework, layers
+from paddle.fluid.framework import Program
 from paddle.fluid.layer_helper import LayerHelper
 import paddle
-import numpy as np
 from paddle.fluid.dygraph import base as imperative_base
 from paddle.fluid.wrapped_decorator import signature_safe_contextmanager
 from paddle import _C_ops, _legacy_C_ops

--- a/python/paddle/incubate/passes/fuse_resnet_unit_pass.py
+++ b/python/paddle/incubate/passes/fuse_resnet_unit_pass.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 import paddle.fluid.ir as ir
 
 

--- a/python/paddle/incubate/sparse/binary.py
+++ b/python/paddle/incubate/sparse/binary.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid.framework import dygraph_only, core
 from paddle import in_dynamic_mode
 from paddle.fluid.layer_helper import LayerHelper

--- a/python/paddle/incubate/sparse/creation.py
+++ b/python/paddle/incubate/sparse/creation.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid.framework import core, dygraph_only
 from paddle.fluid.framework import _current_expected_place, _get_paddle_place
 from paddle.tensor import to_tensor, max
-from paddle.fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype, convert_dtype
+from paddle.fluid.data_feeder import convert_dtype
 from paddle import in_dynamic_mode
 from paddle.fluid.layer_helper import LayerHelper
 

--- a/python/paddle/incubate/sparse/multiary.py
+++ b/python/paddle/incubate/sparse/multiary.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid.framework import dygraph_only
 
 __all__ = []

--- a/python/paddle/incubate/sparse/nn/functional/activation.py
+++ b/python/paddle/incubate/sparse/nn/functional/activation.py
@@ -14,7 +14,7 @@
 
 __all__ = []
 
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid.framework import dygraph_only
 from paddle import in_dynamic_mode
 from paddle.fluid.layer_helper import LayerHelper

--- a/python/paddle/incubate/sparse/nn/functional/conv.py
+++ b/python/paddle/incubate/sparse/nn/functional/conv.py
@@ -14,10 +14,8 @@
 
 __all__ = []
 
-from paddle import _C_ops, _legacy_C_ops, in_dynamic_mode
+from paddle import _C_ops, in_dynamic_mode
 from paddle.fluid.layers.utils import convert_to_list
-from paddle.fluid.layers.nn import elementwise_add
-from ...creation import sparse_coo_tensor
 from ...binary import add
 from paddle.nn.functional.conv import _update_padding_nd
 from paddle.fluid.layer_helper import LayerHelper

--- a/python/paddle/incubate/sparse/nn/functional/pooling.py
+++ b/python/paddle/incubate/sparse/nn/functional/pooling.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from paddle.fluid.layers import utils
-from paddle import _C_ops, _legacy_C_ops, in_dynamic_mode
+from paddle import _C_ops, in_dynamic_mode
 from paddle.nn.functional.pooling import _update_padding_nd
 
 __all__ = []

--- a/python/paddle/incubate/sparse/nn/functional/transformer.py
+++ b/python/paddle/incubate/sparse/nn/functional/transformer.py
@@ -14,7 +14,7 @@
 
 __all__ = []
 
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid.framework import dygraph_only
 
 

--- a/python/paddle/incubate/sparse/unary.py
+++ b/python/paddle/incubate/sparse/unary.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid.framework import dygraph_only, core, convert_np_dtype_to_dtype_
 
 __all__ = []

--- a/python/paddle/incubate/xpu/resnet_block.py
+++ b/python/paddle/incubate/xpu/resnet_block.py
@@ -12,26 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-import collections
-import itertools
-import six
-import math
-import sys
-import warnings
-from functools import partial, reduce
-
 import numpy as np
-import paddle
 import paddle.fluid as fluid
-from paddle import framework
 from paddle.nn import initializer as I
-from paddle.nn import Layer, LayerList
+from paddle.nn import Layer
 from paddle.fluid.layers import utils
 from paddle.fluid.layer_helper import LayerHelper
-from paddle.fluid.data_feeder import convert_dtype
 from paddle.fluid.param_attr import ParamAttr
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 __all__ = ['resnet_basic_block', 'ResNetBasicBlock']
 

--- a/python/paddle/metric/metrics.py
+++ b/python/paddle/metric/metrics.py
@@ -18,9 +18,9 @@ import numpy as np
 
 from ..fluid.data_feeder import check_variable_and_dtype
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.framework import core, _varbase_creator, _non_static_mode, _in_legacy_dygraph
+from ..fluid.framework import _non_static_mode, _varbase_creator
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 __all__ = []
 

--- a/python/paddle/profiler/profiler.py
+++ b/python/paddle/profiler/profiler.py
@@ -22,8 +22,8 @@ import importlib
 import json
 
 import paddle
-from paddle.fluid.core import (_Profiler, _ProfilerResult, ProfilerOptions,
-                               TracerEventType, enable_memory_recorder,
+from paddle.fluid.core import (_Profiler, ProfilerOptions, TracerEventType,
+                               enable_memory_recorder,
                                enable_input_shape_recorder,
                                disable_memory_recorder,
                                disable_input_shape_recorder)

--- a/python/paddle/profiler/statistic_helper.py
+++ b/python/paddle/profiler/statistic_helper.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import collections
 
 
 def sum_ranges(ranges):

--- a/python/paddle/profiler/timer.py
+++ b/python/paddle/profiler/timer.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import timeit
-import logging
 from collections import OrderedDict
 
 

--- a/python/paddle/text/datasets/conll05.py
+++ b/python/paddle/text/datasets/conll05.py
@@ -15,8 +15,6 @@
 import gzip
 import tarfile
 import numpy as np
-import six
-from six.moves import cPickle as pickle
 
 from paddle.io import Dataset
 import paddle.compat as cpt

--- a/python/paddle/text/datasets/movielens.py
+++ b/python/paddle/text/datasets/movielens.py
@@ -15,11 +15,7 @@
 import numpy as np
 import zipfile
 import re
-import random
-import functools
-import six
 
-import paddle
 from paddle.io import Dataset
 import paddle.compat as cpt
 from paddle.dataset.common import _check_exists_and_download

--- a/python/paddle/text/datasets/wmt14.py
+++ b/python/paddle/text/datasets/wmt14.py
@@ -14,7 +14,6 @@
 
 import tarfile
 import numpy as np
-import gzip
 import six
 
 from paddle.io import Dataset

--- a/python/paddle/text/viterbi_decode.py
+++ b/python/paddle/text/viterbi_decode.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from ..nn import Layer
-from ..fluid.framework import core, _non_static_mode, in_dygraph_mode
+from ..fluid.framework import _non_static_mode, in_dygraph_mode
 from ..fluid.layer_helper import LayerHelper
 from ..fluid.data_feeder import check_variable_and_dtype, check_type
 from paddle import _C_ops, _legacy_C_ops


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/inference/`、 `python/paddle/device/`、 `python/paddle/profiler/`、 `python/paddle/text/` 、`python/paddle/metric/`、 `python/paddle/incubate/`、 `python/paddle/quantization/`、 `python/paddle/libs/` 、`python/paddle/audio/`、 `python/paddle/amp/` 、`python/paddle/jit/`目录 F401 unused import 存量 python 代码

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/inference
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/device
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/profiler
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/text
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/metric
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/incubate
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/quantization
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/libs
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/audio
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/amp
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/jit
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/1
-  配置文件更新: #46763
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/21
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/23
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/18
- fixes https://github.com/cattidea/paddle-flake8-project/issues/17
- fixes https://github.com/cattidea/paddle-flake8-project/issues/19