### PR TITLE
[CodeStyle][F401][NPU] remove unused imports in unittests/npu

### DIFF
--- a/python/paddle/fluid/tests/unittests/npu/collective_identity_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/collective_identity_op_npu.py
@@ -12,10 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
+import argparse
+import os
+import sys
+import signal
+import time
+from contextlib import closing
+from six import string_types
+import math
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
+import unittest
+from multiprocessing import Process
 import paddle.fluid.layers as layers
+from functools import reduce
 from test_collective_base_npu import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/collective_identity_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/collective_identity_op_npu.py
@@ -12,24 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base_npu import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/process_group_hccl.py
+++ b/python/paddle/fluid/tests/unittests/npu/process_group_hccl.py
@@ -15,12 +15,9 @@
 import unittest
 import random
 import numpy as np
-import os
-import shutil
 
 import paddle
 from paddle.fluid import core
-from datetime import timedelta
 import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.dygraph.parallel import ParallelEnv

--- a/python/paddle/fluid/tests/unittests/npu/process_group_hccl.py
+++ b/python/paddle/fluid/tests/unittests/npu/process_group_hccl.py
@@ -15,9 +15,12 @@
 import unittest
 import random
 import numpy as np
+import os
+import shutil
 
 import paddle
 from paddle.fluid import core
+from datetime import timedelta
 import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.dygraph.parallel import ParallelEnv

--- a/python/paddle/fluid/tests/unittests/npu/sync_batch_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/sync_batch_norm_op_npu.py
@@ -13,13 +13,29 @@
 # limitations under the License.
 
 import numpy as np
+import argparse
+import os
 import sys
 
 sys.path.append("..")
+import signal
+import time
+from contextlib import closing
+from six import string_types
+import math
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.profiler as profiler
+import paddle.fluid.unique_name as nameGen
+from paddle.fluid import core
+import unittest
+from multiprocessing import Process
+import paddle.fluid.layers as layers
+from functools import reduce
 from test_sync_batch_norm_base_npu import TestSyncBatchNormRunnerBase, runtime_main
-from paddle.fluid.tests.unittests.op_test import _set_use_system_allocator
+from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
+
+from paddle.fluid.tests.unittests.test_sync_batch_norm_op import create_or_get_tensor
 
 _set_use_system_allocator(False)
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/sync_batch_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/sync_batch_norm_op_npu.py
@@ -13,29 +13,13 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
 import sys
 
 sys.path.append("..")
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_sync_batch_norm_base_npu import TestSyncBatchNormRunnerBase, runtime_main
-from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
-
-from paddle.fluid.tests.unittests.test_sync_batch_norm_op import create_or_get_tensor
+from paddle.fluid.tests.unittests.op_test import _set_use_system_allocator
 
 _set_use_system_allocator(False)
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_abs_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_abs_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_abs_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_abs_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_adamw_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_adamw_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from test_adam_op import adamw_step
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_adamw_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_adamw_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
 from test_adam_op import adamw_step
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
@@ -17,9 +17,10 @@ import numpy as np
 import sys
 
 sys.path.append("..")
+from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import program_guard
+from paddle.fluid import compiler, Program, program_guard
 from paddle.fluid.contrib.mixed_precision.amp_nn import check_finite_and_unscale
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_amp_check_finite_and_scale_op_npu.py
@@ -17,10 +17,9 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import program_guard
 from paddle.fluid.contrib.mixed_precision.amp_nn import check_finite_and_unscale
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_arg_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_arg_max_op_npu.py
@@ -19,9 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_arg_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_arg_max_op_npu.py
@@ -19,7 +19,9 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 import paddle.fluid.core as core
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_arg_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_arg_min_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_arg_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_arg_min_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_argsort_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_argsort_op_npu.py
@@ -19,6 +19,13 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+
+from paddle.fluid import ParamAttr
+from paddle.fluid.framework import Program, grad_var_name
+from paddle.fluid.executor import Executor
+from paddle.fluid.backward import append_backward
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_argsort_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_argsort_op_npu.py
@@ -19,13 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-
-from paddle.fluid import ParamAttr
-from paddle.fluid.framework import Program, grad_var_name
-from paddle.fluid.executor import Executor
-from paddle.fluid.backward import append_backward
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_assign_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_batch_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_batch_norm_op_npu.py
@@ -20,7 +20,8 @@ sys.path.append("..")
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from op_test import _set_use_system_allocator
+from paddle.fluid.op import Operator
+from op_test import OpTest, _set_use_system_allocator
 from paddle.fluid import Program, program_guard
 
 from test_batch_norm_op import _reference_testing, _cal_mean_variance, _reference_training, _reference_grad

--- a/python/paddle/fluid/tests/unittests/npu/test_batch_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_batch_norm_op_npu.py
@@ -20,8 +20,7 @@ sys.path.append("..")
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid.op import Operator
-from op_test import OpTest, _set_use_system_allocator
+from op_test import _set_use_system_allocator
 from paddle.fluid import Program, program_guard
 
 from test_batch_norm_op import _reference_testing, _cal_mean_variance, _reference_training, _reference_grad

--- a/python/paddle/fluid/tests/unittests/npu/test_bce_loss_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_bce_loss_npu.py
@@ -22,6 +22,7 @@ sys.path.append("..")
 from op_test import OpTest
 
 paddle.enable_static()
+print("trigger npu ut")
 
 
 def test_static_layer(place,

--- a/python/paddle/fluid/tests/unittests/npu/test_bce_loss_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_bce_loss_npu.py
@@ -22,7 +22,6 @@ sys.path.append("..")
 from op_test import OpTest
 
 paddle.enable_static()
-print("trigger npu ut")
 
 
 def test_static_layer(place,

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_decode_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_decode_op_npu.py
@@ -18,8 +18,6 @@ import numpy as np
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid.framework import Program, program_guard
 
 
 class TestBeamSearchDecodeNPUOp(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_decode_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_decode_op_npu.py
@@ -18,6 +18,8 @@ import numpy as np
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
+import paddle.fluid as fluid
+from paddle.fluid.framework import Program, program_guard
 
 
 class TestBeamSearchDecodeNPUOp(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
@@ -19,7 +19,6 @@ sys.path.append("..")
 from op_test import OpTest
 import unittest
 import numpy as np
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_op_npu.py
@@ -19,6 +19,7 @@ sys.path.append("..")
 from op_test import OpTest
 import unittest
 import numpy as np
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_bilinear_interp_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_bilinear_interp_v2_op_npu.py
@@ -18,9 +18,7 @@ import sys
 
 sys.path.append("..")
 from op_test import OpTest
-import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.nn.functional import interpolate
 import paddle
 
 from test_bilinear_interp_v2_op import bilinear_interp_np

--- a/python/paddle/fluid/tests/unittests/npu/test_bilinear_interp_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_bilinear_interp_v2_op_npu.py
@@ -18,7 +18,9 @@ import sys
 
 sys.path.append("..")
 from op_test import OpTest
+import paddle.fluid.core as core
 import paddle.fluid as fluid
+from paddle.nn.functional import interpolate
 import paddle
 
 from test_bilinear_interp_v2_op import bilinear_interp_np

--- a/python/paddle/fluid/tests/unittests/npu/test_box_coder_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_box_coder_op_npu.py
@@ -17,6 +17,7 @@ import numpy as np
 import sys
 
 sys.path.append("..")
+import math
 import paddle
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/npu/test_box_coder_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_box_coder_op_npu.py
@@ -17,7 +17,6 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-import math
 import paddle
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/npu/test_c_embedding_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_c_embedding_op_npu.py
@@ -12,15 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.c_embedding_op_base import TestCEmbeddingCPU, TestCEmbeddingOpBase, TestCEmbeddingOpFP32
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_c_embedding_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_c_embedding_op_npu.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np
 import unittest
 import sys
 
 sys.path.append("..")
+from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.c_embedding_op_base import TestCEmbeddingCPU, TestCEmbeddingOpBase, TestCEmbeddingOpFP32
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_c_identity_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_c_identity_npu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import numpy as np
 import paddle
 import os
 

--- a/python/paddle/fluid/tests/unittests/npu/test_c_identity_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_c_identity_npu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 import os
 

--- a/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
+import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cast_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_clip_by_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_clip_by_norm_op_npu.py
@@ -15,6 +15,8 @@
 import unittest
 import numpy as np
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 import sys
 
 sys.path.append("..")

--- a/python/paddle/fluid/tests/unittests/npu/test_clip_by_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_clip_by_norm_op_npu.py
@@ -15,8 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 import sys
 
 sys.path.append("..")

--- a/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_coalesce_tensor_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
@@ -15,12 +15,9 @@
 import numpy as np
 import unittest
 import time
-import argparse
 import os
 import sys
 import subprocess
-import traceback
-import functools
 import pickle
 from contextlib import closing
 import paddle.fluid as fluid
@@ -129,7 +126,6 @@ def runtime_main(test_class, col_type, sub_type):
     model.run_trainer(args)
 
 
-import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_collective_base_npu.py
@@ -15,9 +15,12 @@
 import numpy as np
 import unittest
 import time
+import argparse
 import os
 import sys
 import subprocess
+import traceback
+import functools
 import pickle
 from contextlib import closing
 import paddle.fluid as fluid
@@ -126,6 +129,7 @@ def runtime_main(test_class, col_type, sub_type):
     model.run_trainer(args)
 
 
+import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_depthwise_conv_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_depthwise_conv_npu.py
@@ -16,11 +16,15 @@ import unittest
 import numpy as np
 
 import paddle
+import paddle.fluid as fluid
 import sys
 
 sys.path.append("..")
 from op_test import OpTest
 from test_conv2d_op import conv2d_forward_naive
+from paddle import ParamAttr
+from paddle.regularizer import L2Decay
+from paddle.nn.initializer import KaimingNormal
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_depthwise_conv_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_depthwise_conv_npu.py
@@ -16,15 +16,11 @@ import unittest
 import numpy as np
 
 import paddle
-import paddle.fluid as fluid
 import sys
 
 sys.path.append("..")
 from op_test import OpTest
 from test_conv2d_op import conv2d_forward_naive
-from paddle import ParamAttr
-from paddle.regularizer import L2Decay
-from paddle.nn.initializer import KaimingNormal
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_npu.py
@@ -18,6 +18,7 @@ import sys
 
 sys.path.append("..")
 import paddle
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv2d_op_npu.py
@@ -18,7 +18,6 @@ import sys
 
 sys.path.append("..")
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/npu/test_conv3d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv3d_op_npu.py
@@ -19,6 +19,7 @@ import sys
 
 sys.path.append("..")
 import paddle
+import paddle.fluid.core as core
 from op_test import OpTest
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/npu/test_conv3d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv3d_op_npu.py
@@ -19,7 +19,6 @@ import sys
 
 sys.path.append("..")
 import paddle
-import paddle.fluid.core as core
 from op_test import OpTest
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/npu/test_conv3d_transpose_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv3d_transpose_op_npu.py
@@ -20,6 +20,8 @@ sys.path.append("..")
 from op_test import OpTest
 
 import paddle
+import paddle.fluid.core as core
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_conv3d_transpose_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_conv3d_transpose_op_npu.py
@@ -20,8 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_crop_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_crop_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
 from test_crop_op import crop
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_crop_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_crop_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 from test_crop_op import crop
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_cumsum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cumsum_op_npu.py
@@ -18,6 +18,7 @@ from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_cumsum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_cumsum_op_npu.py
@@ -18,7 +18,6 @@ from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 
 from paddle.fluid import Program, program_guard
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 import paddle
 from op_test import OpTest, skip_check_grad_ci

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 from paddle.fluid import Program, program_guard
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 import paddle
 from op_test import OpTest, skip_check_grad_ci

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
@@ -20,8 +20,6 @@ sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_min_op_npu.py
@@ -20,6 +20,8 @@ sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
+import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_mul_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_exp_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_exp_op_npu.py
@@ -15,15 +15,9 @@
 import unittest
 
 import numpy as np
-from scipy.special import expit, erf
 
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.nn as nn
-import paddle.nn.functional as F
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 SEED = 2049

--- a/python/paddle/fluid/tests/unittests/npu/test_exp_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_exp_op_npu.py
@@ -15,9 +15,15 @@
 import unittest
 
 import numpy as np
+from scipy.special import expit, erf
 
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 SEED = 2049

--- a/python/paddle/fluid/tests/unittests/npu/test_eye_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_eye_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid import core
 import paddle.fluid.framework as framework
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_eye_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_eye_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 import paddle.fluid.framework as framework
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_any_like_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_any_like_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_any_like_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_any_like_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_constant_batch_size_like_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_constant_batch_size_like_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_constant_batch_size_like_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_constant_batch_size_like_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_fill_constant_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_flags_check_nan_inf_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_flags_check_nan_inf_npu.py
@@ -17,7 +17,6 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.static as static
 import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/npu/test_flags_check_nan_inf_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_flags_check_nan_inf_npu.py
@@ -17,6 +17,7 @@ import numpy as np
 import sys
 
 sys.path.append("..")
+from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.static as static
 import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/npu/test_flatten2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_flatten2_op_npu.py
@@ -18,7 +18,6 @@ import sys
 sys.path.append("..")
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 from op_test import OpTest
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_flatten2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_flatten2_op_npu.py
@@ -18,6 +18,7 @@ import sys
 sys.path.append("..")
 import numpy as np
 import paddle
+import paddle.fluid as fluid
 from op_test import OpTest
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_flatten_contiguous_range_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_flatten_contiguous_range_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_flatten_contiguous_range_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_flatten_contiguous_range_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_float_status_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_float_status_op_npu.py
@@ -17,6 +17,7 @@ import numpy as np
 import sys
 
 sys.path.append("..")
+from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle._legacy_C_ops as ops
 

--- a/python/paddle/fluid/tests/unittests/npu/test_float_status_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_float_status_op_npu.py
@@ -17,7 +17,6 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle._legacy_C_ops as ops
 

--- a/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.framework import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gather_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.framework import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_gaussian_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gaussian_random_op_npu.py
@@ -18,7 +18,9 @@ import numpy as np
 
 sys.path.append("..")
 import paddle
+import paddle.fluid as fluid
 from op_test import OpTest
+from test_gaussian_random_op import TestGaussianRandomOp
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_gaussian_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_gaussian_random_op_npu.py
@@ -18,9 +18,7 @@ import numpy as np
 
 sys.path.append("..")
 import paddle
-import paddle.fluid as fluid
 from op_test import OpTest
-from test_gaussian_random_op import TestGaussianRandomOp
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_group_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_group_norm_op_npu.py
@@ -19,10 +19,8 @@ import sys
 
 sys.path.append("..")
 
-from operator import mul
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_group_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_group_norm_op_npu.py
@@ -19,8 +19,10 @@ import sys
 
 sys.path.append("..")
 
+from operator import mul
 from op_test import OpTest
 import paddle
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_hard_sigmoid_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_hard_sigmoid_op_npu.py
@@ -14,12 +14,10 @@
 
 import numpy as np
 import unittest
-import sys
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.nn.functional as F
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_hard_sigmoid_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_hard_sigmoid_op_npu.py
@@ -14,10 +14,12 @@
 
 import numpy as np
 import unittest
+import sys
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.nn.functional as F
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_hard_swish_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_hard_swish_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 import paddle.nn.functional as F
 
 

--- a/python/paddle/fluid/tests/unittests/npu/test_hard_swish_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_hard_swish_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 import paddle.nn.functional as F
 
 

--- a/python/paddle/fluid/tests/unittests/npu/test_huber_loss_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_huber_loss_op_npu.py
@@ -20,7 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_huber_loss_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_huber_loss_op_npu.py
@@ -20,7 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_increment_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_instance_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_instance_norm_op_npu.py
@@ -17,15 +17,10 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 
 import paddle
 from paddle import fluid
 from paddle.static import Program, program_guard
-from paddle.fluid import core
-from paddle.fluid.op import Operator
-from paddle.fluid.dygraph import to_variable
-from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_instance_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_instance_norm_op_npu.py
@@ -17,10 +17,15 @@ import unittest
 import sys
 
 sys.path.append("..")
+from op_test import OpTest
 
 import paddle
 from paddle import fluid
 from paddle.static import Program, program_guard
+from paddle.fluid import core
+from paddle.fluid.op import Operator
+from paddle.fluid.dygraph import to_variable
+from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_iou_similarity_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_iou_similarity_op_npu.py
@@ -18,6 +18,7 @@ import numpy.random as random
 import sys
 
 sys.path.append("..")
+import math
 import paddle
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/npu/test_iou_similarity_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_iou_similarity_op_npu.py
@@ -18,7 +18,6 @@ import numpy.random as random
 import sys
 
 sys.path.append("..")
-import math
 import paddle
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/npu/test_kldiv_loss_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_kldiv_loss_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from test_kldiv_loss_op import kldiv_loss
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_kldiv_loss_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_kldiv_loss_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 from test_kldiv_loss_op import kldiv_loss
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_label_smooth_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_label_smooth_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_label_smooth_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_label_smooth_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_layer_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_layer_norm_op_npu.py
@@ -17,6 +17,7 @@ import unittest
 import sys
 
 sys.path.append("..")
+from op_test import OpTest
 from functools import reduce
 from operator import mul
 import paddle

--- a/python/paddle/fluid/tests/unittests/npu/test_layer_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_layer_norm_op_npu.py
@@ -17,7 +17,6 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 from functools import reduce
 from operator import mul
 import paddle

--- a/python/paddle/fluid/tests/unittests/npu/test_log_softmax_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_log_softmax_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
 import paddle.nn.functional as F
 
 from test_log_softmax import ref_log_softmax, ref_log_softmax_grad

--- a/python/paddle/fluid/tests/unittests/npu/test_log_softmax_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_log_softmax_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 import paddle.nn.functional as F
 
 from test_log_softmax import ref_log_softmax, ref_log_softmax_grad

--- a/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
@@ -15,10 +15,12 @@
 import sys
 
 sys.path.append("..")
+import op_test
 import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
+from paddle.static import Program, program_guard
 
 SUPPORTED_DTYPES = [bool]
 

--- a/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_logical_op_npu.py
@@ -15,12 +15,10 @@
 import sys
 
 sys.path.append("..")
-import op_test
 import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-from paddle.static import Program, program_guard
 
 SUPPORTED_DTYPES = [bool]
 

--- a/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_lookup_table_v2_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_masked_select_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_masked_select_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_masked_select_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_masked_select_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_matmul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_matmul_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_matmul_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_matmul_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mean_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
@@ -17,9 +17,11 @@ import unittest
 import sys
 
 sys.path.append("..")
+from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+import paddle.fluid.core as core
+from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_memcpy_op_npu.py
@@ -17,11 +17,9 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_meshgrid_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_meshgrid_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
 import paddle
+from paddle.fluid import compiler, Program, program_guard, core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_meshgrid_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_meshgrid_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
 import paddle
-from paddle.fluid import compiler, Program, program_guard, core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_mixed_precision_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mixed_precision_npu.py
@@ -15,9 +15,6 @@
 import unittest
 import sys
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
-from paddle.fluid.contrib.mixed_precision import fp16_utils
 import paddle.nn as nn
 import paddle.static as static
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/npu/test_mixed_precision_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_mixed_precision_npu.py
@@ -15,6 +15,9 @@
 import unittest
 import sys
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
+from paddle.fluid.contrib.mixed_precision import fp16_utils
 import paddle.nn as nn
 import paddle.static as static
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/npu/test_momentum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_momentum_op_npu.py
@@ -21,6 +21,7 @@ from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
+from paddle.fluid.op import Operator
 from test_momentum_op import calculate_momentum_by_numpy
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_momentum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_momentum_op_npu.py
@@ -21,7 +21,6 @@ from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 from test_momentum_op import calculate_momentum_by_numpy
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_multinomial_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_multinomial_op_npu.py
@@ -15,13 +15,11 @@
 import unittest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 import sys
 
 sys.path.append("..")
 from op_test import OpTest
 import numpy as np
-import os
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_multinomial_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_multinomial_op_npu.py
@@ -15,11 +15,13 @@
 import unittest
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid import core
 import sys
 
 sys.path.append("..")
 from op_test import OpTest
 import numpy as np
+import os
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from test_nearest_interp_op import nearest_neighbor_interp_np
 

--- a/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 from test_nearest_interp_op import nearest_neighbor_interp_np
 

--- a/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_v2_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle.fluid.core as core
 import paddle.fluid as fluid
+import paddle.nn as nn
 import paddle
 from paddle.nn.functional import interpolate
 

--- a/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_nearest_interp_v2_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-import paddle.nn as nn
 import paddle
 from paddle.nn.functional import interpolate
 

--- a/python/paddle/fluid/tests/unittests/npu/test_one_hot_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_one_hot_op_npu.py
@@ -20,9 +20,7 @@ sys.path.append("..")
 
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.framework import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_one_hot_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_one_hot_op_npu.py
@@ -20,7 +20,9 @@ sys.path.append("..")
 
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 import paddle.fluid.core as core
+from paddle.fluid.framework import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_one_hot_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_one_hot_v2_op_npu.py
@@ -22,6 +22,7 @@ from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
+from paddle.fluid.framework import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_one_hot_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_one_hot_v2_op_npu.py
@@ -22,7 +22,6 @@ from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.framework import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_pad3d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pad3d_op_npu.py
@@ -21,6 +21,7 @@ import op_test
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard, Executor, default_main_program
 import paddle.fluid as fluid
 
@@ -97,6 +98,7 @@ class TestCase1(TestPad3dNPUOp):
 
     def test_check_grad(self):
         self.__class__.no_need_check_grad = True
+        pass
 
 
 class TestCase2(TestPad3dNPUOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_pad3d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pad3d_op_npu.py
@@ -21,7 +21,6 @@ import op_test
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
-import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard, Executor, default_main_program
 import paddle.fluid as fluid
 
@@ -98,7 +97,6 @@ class TestCase1(TestPad3dNPUOp):
 
     def test_check_grad(self):
         self.__class__.no_need_check_grad = True
-        pass
 
 
 class TestCase2(TestPad3dNPUOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_pad_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pad_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/npu/test_pad_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pad_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/npu/test_pool2d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pool2d_op_npu.py
@@ -20,8 +20,10 @@ sys.path.append("..")
 
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
 from op_test import OpTest
 from test_pool2d_op import pool2D_forward_naive, avg_pool2D_forward_naive, max_pool2D_forward_naive, adaptive_start_index, adaptive_end_index
+from paddle.nn.functional import avg_pool2d, max_pool2d
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_pool2d_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pool2d_op_npu.py
@@ -20,10 +20,8 @@ sys.path.append("..")
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from op_test import OpTest
 from test_pool2d_op import pool2D_forward_naive, avg_pool2D_forward_naive, max_pool2D_forward_naive, adaptive_start_index, adaptive_end_index
-from paddle.nn.functional import avg_pool2d, max_pool2d
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
@@ -15,10 +15,9 @@
 import unittest
 import numpy as np
 import paddle
-import sys
 import math
 
-from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
+from paddle.fluid.tests.unittests.op_test import OpTest
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_prior_box_op_npu.py
@@ -15,9 +15,10 @@
 import unittest
 import numpy as np
 import paddle
+import sys
 import math
 
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_randperm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_randperm_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 from paddle.static import program_guard, Program
 from test_randperm_op import check_randperm_out, error_msg, convert_dtype
 

--- a/python/paddle/fluid/tests/unittests/npu/test_randperm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_randperm_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid.core as core
 from paddle.static import program_guard, Program
 from test_randperm_op import check_randperm_out, error_msg, convert_dtype
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
@@ -17,8 +17,12 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 import paddle
+import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_any_op_npu.py
@@ -17,12 +17,8 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_max_op_npu.py
@@ -17,9 +17,6 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_max_op_npu.py
@@ -17,6 +17,9 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_mean_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_mean_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_mean_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_mean_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_min_op_npu.py
@@ -17,9 +17,6 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_min_op_npu.py
@@ -17,6 +17,9 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
@@ -17,9 +17,6 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_prod_op_npu.py
@@ -17,6 +17,9 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reshape2_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_rmsprop_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_rmsprop_op_npu.py
@@ -16,10 +16,7 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 import numpy as np
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import paddle
 

--- a/python/paddle/fluid/tests/unittests/npu/test_rmsprop_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_rmsprop_op_npu.py
@@ -16,7 +16,10 @@ import unittest
 import sys
 
 sys.path.append("..")
+from op_test import OpTest
 import numpy as np
+import paddle.fluid.core as core
+from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import paddle
 

--- a/python/paddle/fluid/tests/unittests/npu/test_run_program_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_run_program_op_npu.py
@@ -20,12 +20,11 @@ import sys
 
 sys.path.append("..")
 
-from op_test import OpTest
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 import paddle.fluid as fluid
 from paddle import compat as cpt
-from paddle.fluid import core, framework, executor
+from paddle.fluid import core, framework
 from paddle.fluid.layers.utils import _hash_with_id
 from paddle.fluid.framework import _in_eager_mode_
 

--- a/python/paddle/fluid/tests/unittests/npu/test_run_program_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_run_program_op_npu.py
@@ -20,11 +20,12 @@ import sys
 
 sys.path.append("..")
 
+from op_test import OpTest
 import paddle
-from paddle import _legacy_C_ops
+from paddle import _C_ops, _legacy_C_ops
 import paddle.fluid as fluid
 from paddle import compat as cpt
-from paddle.fluid import core, framework
+from paddle.fluid import core, framework, executor
 from paddle.fluid.layers.utils import _hash_with_id
 from paddle.fluid.framework import _in_eager_mode_
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sampling_id_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sampling_id_op_npu.py
@@ -18,10 +18,8 @@ import sys
 
 sys.path.append("..")
 
-from op_test import OpTest, _set_use_system_allocator
-import paddle.fluid.core as core
+from op_test import _set_use_system_allocator
 import paddle.fluid as fluid
-from paddle.fluid.op import Operator
 import paddle
 
 _set_use_system_allocator(False)

--- a/python/paddle/fluid/tests/unittests/npu/test_sampling_id_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sampling_id_op_npu.py
@@ -18,8 +18,10 @@ import sys
 
 sys.path.append("..")
 
-from op_test import _set_use_system_allocator
+from op_test import OpTest, _set_use_system_allocator
+import paddle.fluid.core as core
 import paddle.fluid as fluid
+from paddle.fluid.op import Operator
 import paddle
 
 _set_use_system_allocator(False)

--- a/python/paddle/fluid/tests/unittests/npu/test_save_load_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_save_load_npu.py
@@ -19,6 +19,17 @@ sys.path.append("..")
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
+from paddle.nn import Embedding
+import paddle.fluid.framework as framework
+from paddle.fluid.optimizer import Adam
+from paddle.fluid.dygraph.base import to_variable
+from test_imperative_base import new_program_scope
+from paddle.fluid.executor import global_scope
+import numpy as np
+import six
+import pickle
+import os
+import errno
 from test_static_save_load import *
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_save_load_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_save_load_npu.py
@@ -19,17 +19,6 @@ sys.path.append("..")
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.nn import Embedding
-import paddle.fluid.framework as framework
-from paddle.fluid.optimizer import Adam
-from paddle.fluid.dygraph.base import to_variable
-from test_imperative_base import new_program_scope
-from paddle.fluid.executor import global_scope
-import numpy as np
-import six
-import pickle
-import os
-import errno
 from test_static_save_load import *
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scale_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_scatter_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_seed_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_seed_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_seed_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_seed_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sequence_mask_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sequence_mask_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
 from paddle.fluid.framework import convert_np_dtype_to_dtype_, Program, program_guard
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_sequence_mask_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sequence_mask_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.fluid.framework import convert_np_dtype_to_dtype_, Program, program_guard
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_set_value_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_set_value_op_npu.py
@@ -17,7 +17,10 @@ import unittest
 import sys
 
 sys.path.append("..")
+from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
 
 
 class TestSetValueBase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_set_value_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_set_value_op_npu.py
@@ -17,10 +17,7 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 
 class TestSetValueBase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_shape_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_shard_index_op.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_shard_index_op.py
@@ -14,10 +14,15 @@
 
 import unittest
 import numpy as np
+import math
 import sys
 
 sys.path.append("..")
 from op_test import OpTest
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+import paddle.fluid.framework as framework
+from paddle.fluid.framework import Program, program_guard
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_shard_index_op.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_shard_index_op.py
@@ -14,15 +14,10 @@
 
 import unittest
 import numpy as np
-import math
 import sys
 
 sys.path.append("..")
 from op_test import OpTest
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-import paddle.fluid.framework as framework
-from paddle.fluid.framework import Program, program_guard
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_sigmoid_cross_entropy_with_logits_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sigmoid_cross_entropy_with_logits_op_npu.py
@@ -16,7 +16,10 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest
 from scipy.special import logit
 from scipy.special import expit
+import paddle.fluid.core as core
 import unittest
+from paddle.fluid import compiler, Program, program_guard
+import paddle.fluid as fluid
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_sigmoid_cross_entropy_with_logits_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sigmoid_cross_entropy_with_logits_op_npu.py
@@ -16,10 +16,7 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest
 from scipy.special import logit
 from scipy.special import expit
-import paddle.fluid.core as core
 import unittest
-from paddle.fluid import compiler, Program, program_guard
-import paddle.fluid as fluid
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_sigmoid_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sigmoid_op_npu.py
@@ -14,8 +14,10 @@
 
 import numpy as np
 import unittest
+import sys
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_sigmoid_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sigmoid_op_npu.py
@@ -14,10 +14,8 @@
 
 import numpy as np
 import unittest
-import sys
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_sin_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sin_op_npu.py
@@ -15,15 +15,10 @@
 import unittest
 
 import numpy as np
-from scipy.special import expit, erf
 
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
+from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.nn as nn
-import paddle.nn.functional as F
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sin_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sin_op_npu.py
@@ -15,10 +15,15 @@
 import unittest
 
 import numpy as np
+from scipy.special import expit, erf
 
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16, skip_check_grad_ci
 import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
 import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_softmax_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_split_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_split_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_split_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_split_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_squeeze_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_squeeze_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_squeeze_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_squeeze_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_stack_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_stack_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_stack_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_stack_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_strided_slice_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_strided_slice_op_npu.py
@@ -16,7 +16,7 @@ import sys
 import numpy as np
 
 sys.path.append("..")
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 import unittest
 import paddle.fluid as fluid
 import paddle

--- a/python/paddle/fluid/tests/unittests/npu/test_strided_slice_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_strided_slice_op_npu.py
@@ -16,7 +16,7 @@ import sys
 import numpy as np
 
 sys.path.append("..")
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 import unittest
 import paddle.fluid as fluid
 import paddle

--- a/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_swish_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_swish_op_npu.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append("..")
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
+import paddle.fluid as fluid
 from test_activation_op import ref_swish, expit
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_swish_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_swish_op_npu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 from test_activation_op import ref_swish, expit
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_base_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_base_npu.py
@@ -15,15 +15,12 @@
 import numpy as np
 import unittest
 import time
-import argparse
 import os
 import six
 import sys
 
 sys.path.append("..")
 import subprocess
-import traceback
-import functools
 import pickle
 from contextlib import closing
 import paddle.fluid as fluid
@@ -397,7 +394,6 @@ def runtime_main(test_class, col_type, sub_type):
     model.run_trainer(args)
 
 
-import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_base_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_base_npu.py
@@ -15,12 +15,15 @@
 import numpy as np
 import unittest
 import time
+import argparse
 import os
 import six
 import sys
 
 sys.path.append("..")
 import subprocess
+import traceback
+import functools
 import pickle
 from contextlib import closing
 import paddle.fluid as fluid
@@ -394,6 +397,7 @@ def runtime_main(test_class, col_type, sub_type):
     model.run_trainer(args)
 
 
+import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_baseline.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_baseline.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 import unittest
+import numpy as np
 import paddle
 import os
 import sys
 
 sys.path.append("..")
 
-from paddle.fluid.tests.unittests.op_test import _set_use_system_allocator
+from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
 
 from test_sync_batch_norm_base_npu import TestDistBase
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_baseline.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_baseline.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 import os
 import sys
 
 sys.path.append("..")
 
-from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
+from paddle.fluid.tests.unittests.op_test import _set_use_system_allocator
 
 from test_sync_batch_norm_base_npu import TestDistBase
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_extra.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_extra.py
@@ -15,18 +15,14 @@
 import unittest
 import numpy as np
 import paddle
-import os
 import sys
 
 sys.path.append("..")
 
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 import paddle.nn as nn
 from paddle.fluid import Program, program_guard
-
-from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
 
 # _set_use_system_allocator(False)
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_extra.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sync_batch_norm_op_npu_extra.py
@@ -15,14 +15,18 @@
 import unittest
 import numpy as np
 import paddle
+import os
 import sys
 
 sys.path.append("..")
 
 import paddle
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 import paddle.nn as nn
 from paddle.fluid import Program, program_guard
+
+from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
 
 # _set_use_system_allocator(False)
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_take_along_axis_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_take_along_axis_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.framework import core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_take_along_axis_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_take_along_axis_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.framework import core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_tile_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tile_op_npu.py
@@ -20,6 +20,8 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import core
 
 paddle.enable_static()
 np.random.seed(10)

--- a/python/paddle/fluid/tests/unittests/npu/test_tile_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tile_op_npu.py
@@ -20,8 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid import core
 
 paddle.enable_static()
 np.random.seed(10)

--- a/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
@@ -19,6 +19,8 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
 from test_top_k_v2_op_npu import numpy_topk
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_top_k_op_npu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 from test_top_k_v2_op_npu import numpy_topk
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
@@ -17,9 +17,8 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, _set_use_system_allocator
+from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_transpose_op_npu.py
@@ -17,8 +17,9 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
+from op_test import OpTest, _set_use_system_allocator
 import paddle
+import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
@@ -13,7 +13,7 @@
 
 import unittest
 import numpy as np
-from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
+from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.tensor as tensor

--- a/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
@@ -13,7 +13,7 @@
 
 import unittest
 import numpy as np
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid as fluid
 import paddle.tensor as tensor

--- a/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
@@ -17,12 +17,8 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-from paddle.fluid.executor import Executor
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
@@ -17,8 +17,12 @@ import unittest
 import sys
 
 sys.path.append("..")
+from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid.op import Operator
+from paddle.fluid.executor import Executor
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+import subprocess
 import unittest
 import numpy as np
 
@@ -22,6 +23,9 @@ import paddle
 import paddle.fluid.core as core
 import paddle
 from paddle.fluid.op import Operator
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
+from test_uniform_random_op import TestUniformRandomOp, TestUniformRandomOpSelectedRows
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import sys
-import subprocess
 import unittest
 import numpy as np
 
@@ -23,9 +22,6 @@ import paddle
 import paddle.fluid.core as core
 import paddle
 from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-from test_uniform_random_op import TestUniformRandomOp, TestUniformRandomOpSelectedRows
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_unsqueeze_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_unsqueeze_op_npu.py
@@ -19,9 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_unsqueeze_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_unsqueeze_op_npu.py
@@ -19,6 +19,9 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_min_op_npu.py
@@ -15,10 +15,13 @@
 import unittest
 import numpy as np
 import sys
+import os
 
 sys.path.append("..")
+from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.contrib.mixed_precision.amp_nn as amp_nn
 from test_update_loss_scaling_op_npu import TestUpdateLossScalingOpBad
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_min_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_min_op_npu.py
@@ -15,13 +15,10 @@
 import unittest
 import numpy as np
 import sys
-import os
 
 sys.path.append("..")
-from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.contrib.mixed_precision.amp_nn as amp_nn
 from test_update_loss_scaling_op_npu import TestUpdateLossScalingOpBad
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_where_index_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_where_index_npu.py
@@ -19,7 +19,6 @@ import sys
 
 sys.path.append("..")
 from op_test import OpTest
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/npu/test_where_index_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_where_index_npu.py
@@ -19,6 +19,7 @@ import sys
 
 sys.path.append("..")
 from op_test import OpTest
+from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/npu/test_where_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_where_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program
 from paddle.fluid.backward import append_backward
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_where_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_where_op_npu.py
@@ -20,6 +20,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid import Program
 from paddle.fluid.backward import append_backward
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_while_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_while_op_npu.py
@@ -16,11 +16,9 @@ import unittest
 import paddle
 import paddle.fluid.layers as layers
 from paddle.fluid.executor import Executor
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
 import numpy
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_while_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_while_op_npu.py
@@ -16,9 +16,11 @@ import unittest
 import paddle
 import paddle.fluid.layers as layers
 from paddle.fluid.executor import Executor
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
 import numpy
+from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/fluid/tests/unittests/npu/` 目录 F401 unused import 存量

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/npu/
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/1
-  配置文件更新: #46792
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/33
