### PR TITLE
[CodeStyle][F401] remove unused import in unittests/xpu

### DIFF
--- a/python/paddle/fluid/tests/unittests/xpu/test_accuracy_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_accuracy_op_xpu.py
@@ -17,9 +17,6 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 import paddle
 
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_adam_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_adam_op_xpu.py
@@ -17,10 +17,8 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-from op_test import OpTest
 from paddle.fluid import core
 from paddle.fluid.op import Operator
-import paddle.fluid as fluid
 import paddle
 
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_adamw_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_adamw_op_xpu.py
@@ -18,11 +18,8 @@ sys.path.append("..")
 
 import unittest
 import paddle
-import random
 import numpy as np
 import paddle.fluid as fluid
-from functools import partial
-from paddle.framework import core
 
 from op_test_xpu import XPUOpTest
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_arg_max_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_arg_max_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_argsort_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_argsort_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_assign_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_assign_op_xpu.py
@@ -15,15 +15,8 @@
 import sys
 
 sys.path.append("..")
-import op_test
-import numpy as np
 import unittest
 import paddle
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.backward import append_backward
 '''
 class TestAssignOp(op_test.OpTest):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/xpu/test_batch_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_batch_norm_op_xpu.py
@@ -18,14 +18,9 @@ sys.path.append("..")
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from op_test import OpTest
-from scipy.special import expit, erf
 import paddle
 import paddle.fluid as fluid
-import paddle.nn as nn
 import paddle.nn.functional as F
-from paddle.fluid import compiler, Program, program_guard
-from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_bce_loss_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_bce_loss_op_xpu.py
@@ -16,7 +16,6 @@ import sys
 
 sys.path.append("..")
 import paddle
-import paddle.fluid as fluid
 import numpy as np
 import unittest
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_bilinear_interp_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_bilinear_interp_op_xpu.py
@@ -14,16 +14,10 @@
 
 import unittest
 import unittest
-import numpy as np
 import paddle
-import paddle.fluid.core as core
 import sys
 
 sys.path.append("..")
-from op_test_xpu import XPUOpTest
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-import time
 
 paddle.enable_static()
 '''

--- a/python/paddle/fluid/tests/unittests/xpu/test_bilinear_interp_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_bilinear_interp_v2_op_xpu.py
@@ -17,11 +17,9 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from paddle.nn.functional import interpolate
 import paddle
 from op_test_xpu import XPUOpTest
 import unittest
-import paddle.fluid as fluid
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_bmm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_bmm_op_xpu.py
@@ -15,14 +15,9 @@ import sys
 sys.path.append("..")
 
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-import paddle.tensor as tensor
 import unittest
 import numpy as np
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
-from paddle.fluid.framework import Program, program_guard
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_c_embedding_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_c_embedding_op_xpu.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 import unittest
 import sys
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_cast_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_cast_op_xpu.py
@@ -16,12 +16,11 @@ import sys
 
 sys.path.append("..")
 import unittest
-import op_test
 import numpy as np
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 from op_test_xpu import XPUOpTest
 
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_clip_by_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_clip_by_norm_op_xpu.py
@@ -17,11 +17,8 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from op_test_xpu import OpTest, XPUOpTest
+from op_test_xpu import XPUOpTest
 import paddle
-from paddle.fluid import Program, program_guard
 
 
 class TestXPUClipByNormOp(XPUOpTest):

--- a/python/paddle/fluid/tests/unittests/xpu/test_clip_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_clip_op_xpu.py
@@ -17,13 +17,11 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-import paddle.fluid.core as core
 import paddle.fluid as fluid
-from op_test_xpu import OpTest, XPUOpTest
+from op_test_xpu import XPUOpTest
 import paddle
 from paddle.fluid import Program, program_guard
 
-import op_test
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_coalesce_tensor_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_coalesce_tensor_op_xpu.py
@@ -18,7 +18,6 @@ from paddle.fluid import core
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 
 alignment = 256
 import paddle

--- a/python/paddle/fluid/tests/unittests/xpu/test_collective_base_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_collective_base_xpu.py
@@ -152,7 +152,6 @@ def runtime_main(test_class, col_type, sub_type):
     model.run_trainer(args)
 
 
-import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_concat_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_concat_op_xpu.py
@@ -18,10 +18,8 @@ sys.path.append("..")
 import unittest
 import numpy as np
 
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard, core
 import paddle
-from op_test import OpTest, skip_check_grad_ci
+from op_test import skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_conv2d_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_conv2d_op_xpu.py
@@ -19,10 +19,8 @@ import unittest
 import numpy as np
 
 import paddle.fluid.core as core
-import paddle.fluid as fluid
 from op_test_xpu import XPUOpTest
 import paddle
-from paddle.fluid import Program, program_guard
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_conv2d_transpose_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_conv2d_transpose_op_xpu.py
@@ -18,12 +18,9 @@ sys.path.append("..")
 import unittest
 import numpy as np
 
-import paddle.fluid.core as core
-import paddle.fluid as fluid
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 import paddle
-import paddle.nn as nn
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_deformable_conv_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_deformable_conv_op_xpu.py
@@ -22,7 +22,6 @@ import paddle.fluid.core as core
 import paddle.fluid as fluid
 from op_test_xpu import OpTest, XPUOpTest
 import paddle
-from paddle.fluid import Program, program_guard
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_depthwise_conv2d_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_depthwise_conv2d_op_xpu.py
@@ -21,10 +21,6 @@ import numpy as np
 import paddle
 
 paddle.enable_static()
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from op_test_xpu import XPUOpTest
-from paddle.fluid import Program, program_guard
 from test_conv2d_op_xpu import XPUTestConv2DOp, XPUTestConv2DOp_v2
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_device_guard_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_device_guard_xpu.py
@@ -16,9 +16,7 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 
-import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core

--- a/python/paddle/fluid/tests/unittests/xpu/test_dropout_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_dropout_op_xpu.py
@@ -17,9 +17,7 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-import paddle.fluid.core as core
 from paddle import _legacy_C_ops
-from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_add_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_add_op_xpu.py
@@ -21,7 +21,7 @@ from op_test import OpTest, skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 import unittest
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_add_op_xpu_kp.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_add_op_xpu_kp.py
@@ -21,7 +21,7 @@ from op_test import OpTest, skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 import unittest
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_div_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_div_op_xpu.py
@@ -18,8 +18,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from op_test import OpTest, skip_check_grad_ci
+from op_test import skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_floordiv_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_floordiv_op_xpu.py
@@ -17,9 +17,7 @@ sys.path.append("..")
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_max_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_max_op_xpu.py
@@ -16,7 +16,7 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 import paddle
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_min_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_min_op_xpu.py
@@ -16,9 +16,7 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from op_test import skip_check_grad_ci
 import paddle
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_mod_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_mod_op_xpu.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 
 import paddle
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_mul_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_mul_op_xpu.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 import paddle
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_pow_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_pow_op_xpu.py
@@ -17,8 +17,6 @@ sys.path.append("..")
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 from op_test import OpTest, skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_sub_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_sub_op_xpu.py
@@ -17,7 +17,7 @@ import sys
 
 sys.path.append("..")
 import paddle
-from op_test import OpTest, skip_check_grad_ci
+from op_test import skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 import unittest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_empty_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_empty_op_xpu.py
@@ -19,9 +19,7 @@ sys.path.append("..")
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 from op_test_xpu import XPUOpTest
-from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import convert_np_dtype_to_dtype_
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_expand_as_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_expand_as_v2_op_xpu.py
@@ -17,7 +17,6 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 import paddle
 import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/xpu/test_expand_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_expand_v2_op_xpu.py
@@ -17,10 +17,8 @@ import sys
 import numpy as np
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 import paddle
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_fill_any_like_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_fill_any_like_op_xpu.py
@@ -17,13 +17,8 @@ import sys
 sys.path.append("..")
 
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
-import paddle.compat as cpt
 import unittest
 import numpy as np
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_fill_constant_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_fill_constant_op_xpu.py
@@ -17,9 +17,8 @@ import sys
 sys.path.append("..")
 import unittest
 import paddle
-from paddle.fluid import core
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from op_test import convert_float_to_uint16
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_flatten2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_flatten2_op_xpu.py
@@ -18,8 +18,6 @@ import sys
 sys.path.append("..")
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_flatten_contiguous_range_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_flatten_contiguous_range_op_xpu.py
@@ -20,10 +20,8 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 import paddle
-import paddle.fluid as fluid
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_flatten_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_flatten_op_xpu.py
@@ -18,8 +18,6 @@ import sys
 sys.path.append("..")
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_fused_resnet_basic_block_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_fused_resnet_basic_block_op_xpu.py
@@ -22,7 +22,6 @@ import paddle
 import paddle.fluid as fluid
 import paddle.nn as nn
 from paddle.fluid import core
-from paddle import _legacy_C_ops
 from paddle.incubate.xpu.resnet_block import ResNetBasicBlock
 from paddle.fluid.framework import default_main_program
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_gen_bkcl_id_op.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_gen_bkcl_id_op.py
@@ -14,13 +14,11 @@
 
 import unittest
 import os
-import copy
 import sys
 
 sys.path.append("..")
 from launch_function_helper import wait, _find_free_port
-from multiprocessing import Pool, Process
-from threading import Thread
+from multiprocessing import Process
 
 os.environ['GLOG_vmodule'] = str("gen_bkcl_id_op*=10,gen_comm_id*=10")
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_generate_proposals_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_generate_proposals_v2_op_xpu.py
@@ -20,10 +20,8 @@ sys.path.append("..")
 
 import math
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 
-from op_test import OpTest
 import copy
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_grid_sampler_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_grid_sampler_op_xpu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 
 import paddle
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_huber_loss_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_huber_loss_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-import paddle.fluid as fluid
 
 from op_test import OpTest
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_instance_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_instance_norm_op_xpu.py
@@ -16,12 +16,9 @@ import paddle
 import numpy as np
 import sys
 import unittest
-from functools import reduce
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
-from operator import mul
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_iou_similarity_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_iou_similarity_op_xpu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import numpy.random as random
 import sys
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_lamb_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_lamb_op_xpu.py
@@ -18,9 +18,6 @@ sys.path.append("..")
 import unittest
 import numpy as np
 from op_test_xpu import XPUOpTest
-from paddle.fluid import core
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
 import paddle
 
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_layer_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_layer_norm_op_xpu.py
@@ -19,7 +19,6 @@ import unittest
 from functools import reduce
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from operator import mul
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_log_loss_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_log_loss_op_xpu.py
@@ -15,13 +15,10 @@
 import sys
 
 sys.path.append("..")
-import paddle.fluid.core as core
 import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 
 
 def sigmoid_array(x):

--- a/python/paddle/fluid/tests/unittests/xpu/test_log_softmax_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_log_softmax_op_xpu.py
@@ -17,10 +17,8 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 
 import paddle
-import paddle.fluid.core as core
 import paddle.nn.functional as F
 
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_logsumexp_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_logsumexp_op_xpu.py
@@ -18,7 +18,6 @@ import sys
 
 sys.path.append("..")
 import numpy as np
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_masked_select_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_masked_select_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-import paddle.fluid as fluid
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_matmul_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_matmul_op_xpu.py
@@ -15,7 +15,6 @@
 import sys
 
 sys.path.append("..")
-import paddle.fluid.core as core
 import unittest
 import numpy as np
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_matmul_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_matmul_v2_op_xpu.py
@@ -18,12 +18,8 @@ sys.path.append("..")
 import unittest
 import numpy as np
 from op_test_xpu import XPUOpTest
-import paddle.fluid.core as core
 
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.framework as framework
-from paddle.fluid.framework import _test_eager_guard
 
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_mean_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_mean_op_xpu.py
@@ -18,15 +18,12 @@ import sys
 
 sys.path.append("..")
 from op_test_xpu import XPUOpTest
-from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 
 np.random.seed(10)
 
-import op_test
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_merged_momentum_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_merged_momentum_op_xpu.py
@@ -13,16 +13,12 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import sys
 
 sys.path.append("..")
 
 import paddle
-import paddle.fluid.core as core
 
-from op_test import OpTest
-from op_test_xpu import XPUOpTest
 from test_merged_momentum_op_xpu_base import TestMergedMomentumBase
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_momentum_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_momentum_op_xpu.py
@@ -21,7 +21,6 @@ sys.path.append("..")
 import paddle
 import paddle.fluid.core as core
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_mul_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_mul_op_xpu.py
@@ -15,14 +15,12 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid.core as core
 import sys
 
 sys.path.append("..")
 from op_test_xpu import XPUOpTest
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-import time
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_nearest_interp_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_nearest_interp_op_xpu.py
@@ -13,15 +13,10 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
-import paddle.fluid.core as core
 import sys
 
 sys.path.append("..")
-from op_test_xpu import XPUOpTest
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 '''

--- a/python/paddle/fluid/tests/unittests/xpu/test_nearest_interp_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_nearest_interp_v2_op_xpu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 
 import paddle
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_one_hot_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_one_hot_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 import paddle
 import paddle.fluid.core as core
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_p_norm_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_p_norm_op_xpu.py
@@ -16,12 +16,9 @@ import paddle
 import numpy as np
 import sys
 import unittest
-from functools import reduce
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
-from operator import mul
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_pool2d_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_pool2d_op_xpu.py
@@ -18,10 +18,7 @@ sys.path.append("..")
 import unittest
 import numpy as np
 
-import paddle.fluid.core as core
 from op_test_xpu import XPUOpTest
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 from test_pool2d_op import adaptive_start_index, adaptive_end_index
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 import paddle

--- a/python/paddle/fluid/tests/unittests/xpu/test_pow2_decay_with_linear_warmup_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_pow2_decay_with_linear_warmup_op_xpu.py
@@ -21,8 +21,6 @@ import sys
 
 sys.path.append("..")
 
-from op_test import OpTest
-from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import record_op_test
 
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_all_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_all_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_amax_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_amax_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_amin_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_amin_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_any_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_any_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_max_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_max_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_min_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_min_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_prod_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_prod_op_xpu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 
 import paddle
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_reduce_sum_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_reduce_sum_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_refactor_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_refactor_op_xpu.py
@@ -19,12 +19,9 @@ import sys
 sys.path.append("..")
 
 import paddle
-import paddle.fluid as fluid
 from paddle.fluid import core
-from paddle.fluid import compiler, Program, program_guard
 
-import op_test
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_rmsprop_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_rmsprop_op_xpu.py
@@ -21,7 +21,6 @@ sys.path.append("..")
 import paddle
 import paddle.fluid.core as core
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_rnn_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_rnn_op_xpu.py
@@ -15,18 +15,14 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-import math
 import paddle.fluid.core as core
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import random
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 
 sys.path.append("../rnn")
-from rnn_numpy import SimpleRNN, LSTM, GRU
+from rnn_numpy import LSTM
 from convert import get_params_for_net
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_sampling_id_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_sampling_id_op_xpu.py
@@ -18,10 +18,7 @@ import sys
 
 sys.path.append("..")
 
-from op_test import OpTest
-import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid.op import Operator
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_scale_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_scale_op_xpu.py
@@ -19,12 +19,8 @@ import sys
 sys.path.append("..")
 
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
-import op_test
-from op_test import OpTest, skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_sequence_unpad_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_sequence_unpad_op_xpu.py
@@ -23,9 +23,7 @@ import paddle
 import paddle.fluid as fluid
 import unittest
 import numpy as np
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
-from paddle.fluid.framework import Program, program_guard
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_sgd_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_sgd_op_xpu.py
@@ -15,14 +15,10 @@
 import unittest
 import numpy as np
 import sys
-import os
 
 sys.path.append("..")
-from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper

--- a/python/paddle/fluid/tests/unittests/xpu/test_sigmoid_cross_entropy_with_logits_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_sigmoid_cross_entropy_with_logits_op_xpu.py
@@ -17,14 +17,9 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test_xpu import OpTest, XPUOpTest
+from op_test_xpu import XPUOpTest
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
-from paddle.fluid import compiler, Program, program_guard, core
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 from scipy.special import logit

--- a/python/paddle/fluid/tests/unittests/xpu/test_sign_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_sign_op_xpu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 
 import paddle
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_slice_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_slice_op_xpu.py
@@ -18,7 +18,6 @@ import sys
 import unittest
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_softmax_with_cross_entropy_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_softmax_with_cross_entropy_op_xpu.py
@@ -18,7 +18,6 @@ sys.path.append("..")
 
 from test_softmax_op import stable_softmax
 from op_test_xpu import XPUOpTest
-import paddle.fluid.core as core
 import paddle
 
 import unittest

--- a/python/paddle/fluid/tests/unittests/xpu/test_split_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_split_op_xpu.py
@@ -17,12 +17,8 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-import paddle.fluid.core as core
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_squeeze2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_squeeze2_op_xpu.py
@@ -19,7 +19,6 @@ sys.path.append("..")
 
 import numpy as np
 
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 import paddle

--- a/python/paddle/fluid/tests/unittests/xpu/test_squeeze_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_squeeze_op_xpu.py
@@ -22,7 +22,6 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_stack_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_stack_op_xpu.py
@@ -17,12 +17,9 @@ import sys
 sys.path.append("..")
 import unittest
 import numpy as np
-import paddle.fluid.core as core
-from op_test import OpTest, skip_check_grad_ci
+from op_test import skip_check_grad_ci
 from op_test_xpu import XPUOpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_sum_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_sum_op_xpu.py
@@ -21,12 +21,6 @@ from op_test_xpu import XPUOpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-from paddle.fluid.tests.unittests.op_test import (OpTest,
-                                                  convert_float_to_uint16,
-                                                  convert_uint16_to_float)
-from paddle import _C_ops, _legacy_C_ops
-import op_test
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_tile_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_tile_op_xpu.py
@@ -17,12 +17,9 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid import core
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_top_k_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_top_k_op_xpu.py
@@ -18,7 +18,6 @@ import sys
 
 sys.path.append("..")
 import paddle
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_top_k_v2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_top_k_v2_op_xpu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test_xpu import XPUOpTest
 import paddle
-import paddle.fluid.core as core
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_transpose_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_transpose_op_xpu.py
@@ -17,11 +17,8 @@ import numpy as np
 import sys
 
 sys.path.append("..")
-from op_test_xpu import OpTest, XPUOpTest
+from op_test_xpu import XPUOpTest
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 
 
 class TestXPUTransposeOp(XPUOpTest):

--- a/python/paddle/fluid/tests/unittests/xpu/test_tril_triu_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_tril_triu_op_xpu.py
@@ -15,14 +15,11 @@ import sys
 sys.path.append("..")
 
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 import paddle.tensor as tensor
 import unittest
 import numpy as np
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
-from paddle.fluid.framework import Program, program_guard
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_uniform_random_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_uniform_random_op_xpu.py
@@ -15,15 +15,9 @@
 import sys
 
 sys.path.append("..")
-import subprocess
 import unittest
 import numpy as np
-from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 from test_uniform_random_op import TestUniformRandomOp, TestUniformRandomOpSelectedRows
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/xpu/test_unsqueeze2_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_unsqueeze2_op_xpu.py
@@ -20,8 +20,6 @@ sys.path.append("..")
 import numpy as np
 
 import paddle
-import paddle.fluid as fluid
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_unsqueeze_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_unsqueeze_op_xpu.py
@@ -20,8 +20,6 @@ sys.path.append("..")
 import numpy as np
 
 import paddle
-import paddle.fluid as fluid
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 from xpu.get_test_cover_info import create_test_class, get_xpu_op_support_types, XPUOpTestWrapper
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_update_loss_scaling_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_update_loss_scaling_op_xpu.py
@@ -17,7 +17,6 @@ import sys
 
 sys.path.append("..")
 import numpy as np
-from op_test import OpTest
 from op_test_xpu import XPUOpTest
 import paddle
 import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/xpu/test_where_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_where_op_xpu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program
 from paddle.fluid.backward import append_backward
 
 from op_test_xpu import XPUOpTest

--- a/python/paddle/fluid/tests/unittests/xpu/test_while_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_while_op_xpu.py
@@ -16,11 +16,9 @@ import unittest
 import paddle
 import paddle.fluid.layers as layers
 from paddle.fluid.executor import Executor
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
 import numpy
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_xpu_place.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_xpu_place.py
@@ -15,7 +15,6 @@
 import unittest
 import os
 import paddle
-import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid import core
 import paddle.static as static


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/fluid/tests/unittests/npu/` 目录 F401（unused import）存量

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/xpu/
```

参考 https://github.com/PaddlePaddle/Paddle/pull/44988#issuecomment-1216060762 加了 `test=kunlun` 以触发相关流水线

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/1
-  配置文件更新: #46792
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/30
