### PR TITLE
Delete old dygraph in OpTest

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -251,8 +251,9 @@ def _test_eager_guard(place=None):
     try:
         yield
     finally:
-        if not already_fallback:
-            _enable_legacy_dygraph()
+        pass
+        # if not already_fallback:
+        #     _enable_legacy_dygraph()
 
 
 global_ipu_index = -1

--- a/python/paddle/fluid/tests/unittests/gradient_checker.py
+++ b/python/paddle/fluid/tests/unittests/gradient_checker.py
@@ -24,7 +24,6 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.executor import Executor
 from paddle.fluid.backward import _append_grad_suffix_, _as_list
-from paddle.fluid.framework import _test_eager_guard
 try:
     from collections.abc import Sequence
 except:
@@ -758,9 +757,7 @@ def double_grad_check_for_dygraph(func,
     x_init = _as_list(x_init)
 
     paddle.disable_static()
-    with _test_eager_guard():
-        eager_double_grad = get_eager_double_grad(func, x_init, y_grads_init,
-                                                  place)
+    eager_double_grad = get_eager_double_grad(func, x_init, y_grads_init, place)
     paddle.enable_static()
 
     static_double_grad = get_static_double_grad(x, y, x_init, y_grads_init,
@@ -927,9 +924,7 @@ def triple_grad_check_for_dygraph(func,
     x_init = _as_list(x_init)
 
     paddle.disable_static()
-    with _test_eager_guard():
-        eager_triple_grad = get_eager_triple_grad(func, x_init, y_grads_init,
-                                                  place)
+    eager_triple_grad = get_eager_triple_grad(func, x_init, y_grads_init, place)
     paddle.enable_static()
 
     static_triple_grad = get_static_triple_grad(x, y, x_init, y_grads_init,

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_mkldnn_op.py
@@ -125,7 +125,7 @@ class TestBilinearInterpMKLDNNOp(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestBilinearInterpOpMKLDNNNHWC(TestBilinearInterpMKLDNNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_v2_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_v2_mkldnn_op.py
@@ -142,7 +142,7 @@ class TestBilinearInterpMKLDNNOp(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestBilinearInterpOpMKLDNNNHWC(TestBilinearInterpMKLDNNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
@@ -44,13 +44,13 @@ class TestCastBF16ToFP32MKLDNNOp(OpTest):
         self.op_type = 'cast'
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         self.check_grad_with_place(
             core.CPUPlace(), ["X"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[self.inputs['X']],
             user_defined_grad_outputs=[self.outputs['Out']])
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_concat_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_concat_int8_mkldnn_op.py
@@ -36,7 +36,7 @@ class TestConcatOp(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 #--------------------test concat s8 in with axis 0--------------------
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
@@ -152,9 +152,7 @@ class TestConv2DInt8Op(TestConv2DOp):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output_with_place(core.CPUPlace(),
-                                     atol=0,
-                                     check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace(), atol=0, check_eager=False)
 
     def test_check_grad(self):
         pass

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
@@ -62,7 +62,7 @@ class TestDeQuantizeOp(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def check_raise_error(self, msg):
         try:

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_bf16_mkldnn_op.py
@@ -49,21 +49,21 @@ class TestElementwiseAddBf16MklDNNOp(OpTest):
     def test_check_grad_normal(self):
         self.check_grad_with_place(core.CPUPlace(), ["X", "Y"],
                                    "Out",
-                                   check_dygraph=False,
+                                   check_eager=False,
                                    user_defined_grads=[self.x, self.x],
                                    user_defined_grad_outputs=[self.x_bf16])
 
     def test_check_grad_ingore_x(self):
         self.check_grad_with_place(core.CPUPlace(), ["Y"],
                                    "Out",
-                                   check_dygraph=False,
+                                   check_eager=False,
                                    user_defined_grads=[self.y],
                                    user_defined_grad_outputs=[self.y_bf16])
 
     def test_check_grad_ingore_y(self):
         self.check_grad_with_place(core.CPUPlace(), ["X"],
                                    "Out",
-                                   check_dygraph=False,
+                                   check_eager=False,
                                    user_defined_grads=[self.x],
                                    user_defined_grad_outputs=[self.x_bf16])
 
@@ -87,7 +87,7 @@ class TestElementwiseAddBroadCastingBf16MklDNNOp(TestElementwiseAddBf16MklDNNOp
         self.check_grad_with_place(
             core.CPUPlace(), ["X", "Y"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[self.x,
                                 self.compute_reduced_gradients(self.x)],
             user_defined_grad_outputs=[self.x_bf16])
@@ -96,7 +96,7 @@ class TestElementwiseAddBroadCastingBf16MklDNNOp(TestElementwiseAddBf16MklDNNOp
         self.check_grad_with_place(
             core.CPUPlace(), ["Y"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[self.compute_reduced_gradients(self.x)],
             user_defined_grad_outputs=[self.x_bf16])
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_mkldnn_op.py
@@ -134,7 +134,7 @@ class TestInt8(TestElementwiseAddOp):
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.init_scales()
-        self.check_output(check_dygraph=(self.use_mkldnn == False))
+        self.check_output(check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_normal(self):
         pass
@@ -172,8 +172,7 @@ class TestInt8Scales(TestInt8):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.init_scales()
         int_atol = 1  # different quantization techniques
-        self.check_output(check_dygraph=(self.use_mkldnn == False),
-                          atol=int_atol)
+        self.check_output(check_eager=(self.use_mkldnn == False), atol=int_atol)
 
 
 class TestUint8Scales(TestInt8Scales):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_mul_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_mul_bf16_mkldnn_op.py
@@ -47,7 +47,7 @@ class TestElementwiseMulBf16MklDNNOp(OpTest):
     def test_check_grad_normal(self):
         self.check_grad_with_place(core.CPUPlace(), ["X", "Y"],
                                    "Out",
-                                   check_dygraph=False,
+                                   check_eager=False,
                                    user_defined_grads=[
                                        np.multiply(self.x, self.y),
                                        np.multiply(self.x, self.x)
@@ -58,7 +58,7 @@ class TestElementwiseMulBf16MklDNNOp(OpTest):
         self.check_grad_with_place(
             core.CPUPlace(), ["Y"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[np.multiply(self.y, self.x)],
             user_defined_grad_outputs=[self.y_bf16])
 
@@ -66,7 +66,7 @@ class TestElementwiseMulBf16MklDNNOp(OpTest):
         self.check_grad_with_place(
             core.CPUPlace(), ["X"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[np.multiply(self.x, self.y)],
             user_defined_grad_outputs=[self.x_bf16])
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_mul_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_mul_mkldnn_op.py
@@ -104,7 +104,7 @@ class TestInt8(ElementwiseMulOp):
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.init_scales()
-        self.check_output(check_dygraph=(self.use_mkldnn == False))
+        self.check_output(check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_normal(self):
         pass
@@ -142,8 +142,7 @@ class TestInt8Scales(TestInt8):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.init_scales()
         int_atol = 1  # different quantization techniques
-        self.check_output(check_dygraph=(self.use_mkldnn == False),
-                          atol=int_atol)
+        self.check_output(check_eager=(self.use_mkldnn == False), atol=int_atol)
 
 
 class TestUint8Scales(TestInt8Scales):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fc_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fc_mkldnn_op.py
@@ -56,7 +56,7 @@ class TestFCMKLDNNOp(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad_normal(self):
         pass

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
@@ -31,7 +31,7 @@ class TestFusionGRUBF16MKLDNNOp(OpTest):
     def test_check_output(self):
         for use_seq in {True, False}:
             self.attrs['use_seq'] = use_seq
-            self.check_output(check_dygraph=False)
+            self.check_output(check_eager=False)
 
     def setUp(self):
         self.op_type = "fusion_gru"

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_int8_mkldnn_op.py
@@ -124,7 +124,7 @@ class TestFusionGRUINT8MKLDNNOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False, atol=self.error_margin)
+        self.check_output(check_eager=False, atol=self.error_margin)
 
 
 class TestFusionGRUINT8MKLDNNOp2(TestFusionGRUINT8MKLDNNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_bf16_mkldnn_op.py
@@ -31,7 +31,7 @@ class TestFusionLSTMBF16ONEDNNOp(OpTest):
     def test_check_output(self):
         for use_seq in {True, False}:
             self.attrs['use_seq'] = use_seq
-            self.check_output(check_dygraph=False,
+            self.check_output(check_eager=False,
                               no_check_set=["Cell"],
                               atol=2e-2)
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_int8_mkldnn_op.py
@@ -129,7 +129,7 @@ class TestFusionLSTMINT8MKLDNNOp(OpTest):
     def test_check_output(self):
         for use_seq in {True, False}:
             self.attrs['use_seq'] = use_seq
-            self.check_output(check_dygraph=False,
+            self.check_output(check_eager=False,
                               no_check_set=["Cell"],
                               atol=self.error_margin)
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_mkldnn_op.py
@@ -25,7 +25,7 @@ class TestFusionLSTMONEDNNOp(TestFusionLSTMOp):
     def test_check_output(self):
         for use_seq in {True, False}:
             self.attrs['use_seq'] = use_seq
-            self.check_output(check_dygraph=False, no_check_set=["Cell"])
+            self.check_output(check_eager=False, no_check_set=["Cell"])
 
 
 class TestFusionLSTMONEDNNOpReverse(TestFusionLSTMONEDNNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
@@ -29,14 +29,14 @@ class TestLRNMKLDNNOp(TestLRNOp):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_output(atol=0.002,
                           no_check_set=['MidOut'],
-                          check_dygraph=False)
+                          check_eager=False)
 
     def test_check_grad_normal(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_grad(['X'],
                         'Out',
                         max_relative_error=0.01,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestLRNMKLDNNOpWithIsTest(TestLRNMKLDNNOp):
@@ -53,7 +53,7 @@ class TestLRNMKLDNNOpWithIsTest(TestLRNMKLDNNOp):
                 self.check_grad(['X'],
                                 'Out',
                                 max_relative_error=0.01,
-                                check_dygraph=False)
+                                check_eager=False)
             except Exception as e:
                 t = \
                 "is_test attribute should be set to False in training phase."

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_bf16_mkldnn_op.py
@@ -65,7 +65,7 @@ class TestMatmulBf16MklDNNOp(OpTest):
         self.check_grad_with_place(
             core.CPUPlace(), ["X", "Y"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[self.dx, self.dy],
             user_defined_grad_outputs=[convert_float_to_uint16(self.dout)])
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_mul_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_mul_int8_mkldnn_op.py
@@ -78,9 +78,7 @@ class TestMKLDNNMulOpS8S8(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output_with_place(core.CPUPlace(),
-                                     atol=0,
-                                     check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace(), atol=0, check_eager=False)
 
 
 '''

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_multi_gru_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_multi_gru_mkldnn_op.py
@@ -163,7 +163,7 @@ class TestMultiGruMkldnnOp(OpTest):
             self.attrs['Shift_data'] = shift_data
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False, atol=self.error_margin)
+        self.check_output(check_eager=False, atol=self.error_margin)
 
 
 class TestMultiGruMkldnnOpNoBias(TestMultiGruMkldnnOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_nearest_interp_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_nearest_interp_mkldnn_op.py
@@ -125,7 +125,7 @@ class TestNearestInterpMKLDNNOp(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestNearestInterpOpMKLDNNNHWC(TestNearestInterpMKLDNNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_nearest_interp_v2_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_nearest_interp_v2_mkldnn_op.py
@@ -146,7 +146,7 @@ class TestNearestInterpV2MKLDNNOp(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestNearestInterpOpV2MKLDNNNHWC(TestNearestInterpV2MKLDNNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_int8_mkldnn_op.py
@@ -45,7 +45,7 @@ class TestPool2DMKLDNNInt8_Op(TestPool2D_Op):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_output_with_place(core.CPUPlace(),
                                      atol=1e-5,
-                                     check_dygraph=False)
+                                     check_eager=False)
 
     def test_check_grad(self):
         pass

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_quantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_quantize_mkldnn_op.py
@@ -61,7 +61,7 @@ class TestQuantizeOp(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def check_raise_error(self, msg):
         try:

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reduce_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reduce_bf16_mkldnn_op.py
@@ -35,7 +35,7 @@ class TestReduceSumDefaultBF16OneDNNOp(OpTest):
         self.attrs = {'use_mkldnn': self.use_mkldnn}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def calculate_grads(self):
         tmp_tensor = np.zeros(self.x_fp32.shape).astype("float32")
@@ -76,7 +76,7 @@ class TestReduceDefaultWithGradBF16OneDNNOp(TestReduceSumDefaultBF16OneDNNOp):
         self.check_grad_with_place(
             core.CPUPlace(), ["X"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[self.grad_X],
             user_defined_grad_outputs=[convert_float_to_uint16(self.grad_Out)])
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
@@ -86,7 +86,7 @@ class TestReQuantizeOp(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.assertTrue(self.input_data_type == 'uint8' or self.shift_in == 0.0,
                         'Input data must be unsigned if it has nonzero shift.')
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def check_raise_error(self, msg):
         try:

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_bf16_op.py
@@ -59,7 +59,7 @@ class TestReshapeBf16Op(OpTest):
     def test_check_grad(self):
         self.check_grad_with_place(core.CPUPlace(), ["X"],
                                    "Out",
-                                   check_dygraph=False,
+                                   check_eager=False,
                                    user_defined_grads=[self.input_data_fp32],
                                    user_defined_grad_outputs=[
                                        self.inputs["X"].reshape(

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_scale_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_scale_bf16_mkldnn_op.py
@@ -51,14 +51,14 @@ class TestScaleOpBF16(OpTest):
         self.dx = (self.out * scale)
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         self.calculate_grads()
         self.check_grad_with_place(
             core.CPUPlace(), ["X"],
             "Out",
-            check_dygraph=False,
+            check_eager=False,
             user_defined_grads=[self.dx],
             user_defined_grad_outputs=[convert_float_to_uint16(self.out)])
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
@@ -31,7 +31,7 @@ class TestScaleOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out')
@@ -54,7 +54,7 @@ class TestScaleOpBiasNotAfterScale(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out')

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_softmax_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_softmax_mkldnn_op.py
@@ -59,9 +59,9 @@ class TestSoftmaxMKLDNNOp(TestSoftmaxOp):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         if self.use_cudnn:
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, check_dygraph=False)
+            self.check_output_with_place(place, check_eager=False)
         else:
-            self.check_output(check_dygraph=False)
+            self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -71,12 +71,12 @@ class TestSoftmaxMKLDNNOp(TestSoftmaxOp):
                 self.check_grad_with_place(place, ["X"],
                                            "Out",
                                            max_relative_error=0.01,
-                                           check_dygraph=False)
+                                           check_eager=False)
         else:
             self.check_grad(["X"],
                             "Out",
                             max_relative_error=0.01,
-                            check_dygraph=False)
+                            check_eager=False)
 
     def init_kernel_type(self):
         self.use_mkldnn = True

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_sum_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_sum_mkldnn_op.py
@@ -38,11 +38,11 @@ class TestSumMKLDNN(TestSumOp):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_grad(['x0'], 'Out', check_dygraph=False)
+        self.check_grad(['x0'], 'Out', check_eager=False)
 
 
 class TestMKLDNNSumInplaceOp(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_int8_mkldnn_op.py
@@ -51,7 +51,7 @@ class TestTransposeOp(OpTest):
         self.check_output_with_place(core.CPUPlace(),
                                      1e-5,
                                      no_check_set=['XShape'],
-                                     check_dygraph=False)
+                                     check_eager=False)
 
     def initTestCase(self):
         self.shape = (2, 3, 4, 5)

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_mkldnn_op.py
@@ -40,11 +40,11 @@ class TestTransposeMKLDNN(TestTransposeOp):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(no_check_set=['XShape'], check_dygraph=False)
+        self.check_output(no_check_set=['XShape'], check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_grad(['X'], 'Out', check_dygraph=False)
+        self.check_grad(['X'], 'Out', check_eager=False)
 
     def initTestCase(self):
         self.shape = (30, 4)

--- a/python/paddle/fluid/tests/unittests/npu/test_one_hot_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_one_hot_op_npu.py
@@ -53,7 +53,7 @@ class TestOneHotOp(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_attr(OpTest):
@@ -81,7 +81,7 @@ class TestOneHotOp_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_default_dtype(OpTest):
@@ -110,7 +110,7 @@ class TestOneHotOp_default_dtype(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_default_dtype_attr(OpTest):
@@ -138,7 +138,7 @@ class TestOneHotOp_default_dtype_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_out_of_range(OpTest):
@@ -162,7 +162,7 @@ class TestOneHotOp_out_of_range(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_dtype_int64(OpTest):
@@ -190,7 +190,7 @@ class TestOneHotOp_dtype_int64(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_one_hot_v2_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_one_hot_v2_op_npu.py
@@ -52,7 +52,7 @@ class TestOneHotOp(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_non_lod(OpTest):
@@ -104,7 +104,7 @@ class TestOneHotOp_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_default_dtype(OpTest):
@@ -132,7 +132,7 @@ class TestOneHotOp_default_dtype(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_default_dtype_attr(OpTest):
@@ -160,7 +160,7 @@ class TestOneHotOp_default_dtype_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_out_of_range(OpTest):
@@ -183,7 +183,7 @@ class TestOneHotOp_out_of_range(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOp_dtype_int64(OpTest):
@@ -206,7 +206,7 @@ class TestOneHotOp_dtype_int64(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output_with_place(paddle.NPUPlace(0), check_dygraph=False)
+        self.check_output_with_place(paddle.NPUPlace(0), check_eager=False)
 
 
 class TestOneHotOpApi(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -647,7 +647,8 @@ class OpTest(unittest.TestCase):
 
                 if if_return_inputs_grad_dict:
                     v.stop_gradient = False
-                    v.retain_grads()
+                    if in_dygraph_mode():
+                        v.retain_grads()
 
                 if has_lod:
                     v.value().get_tensor().set_recursive_sequence_lengths(

--- a/python/paddle/fluid/tests/unittests/op_test_xpu.py
+++ b/python/paddle/fluid/tests/unittests/op_test_xpu.py
@@ -78,21 +78,19 @@ class XPUOpTest(OpTest):
                      atol=0.001,
                      no_check_set=None,
                      equal_nan=False,
-                     check_dygraph=True,
-                     inplace_atol=None,
-                     check_eager=False):
+                     check_eager=True,
+                     inplace_atol=None):
         place = paddle.XPUPlace(0)
         self.check_output_with_place(place, atol, no_check_set, equal_nan,
-                                     check_dygraph, inplace_atol, check_eager)
+                                     check_eager, inplace_atol)
 
     def check_output_with_place(self,
                                 place,
                                 atol=0.001,
                                 no_check_set=None,
                                 equal_nan=False,
-                                check_dygraph=True,
-                                inplace_atol=None,
-                                check_eager=False):
+                                check_eager=True,
+                                inplace_atol=None):
         self.infer_dtype_from_inputs_outputs(self.inputs, self.outputs)
         if self.dtype == np.float64:
             return
@@ -104,7 +102,7 @@ class XPUOpTest(OpTest):
         if self.dtype == np.float16:
             atol = 0.1
         return super().check_output_with_place(place, atol, no_check_set,
-                                               equal_nan, check_dygraph,
+                                               equal_nan, check_eager,
                                                inplace_atol)
 
     def check_grad(self,
@@ -116,15 +114,14 @@ class XPUOpTest(OpTest):
                    max_relative_error=0.005,
                    user_defined_grads=None,
                    user_defined_grad_outputs=None,
-                   check_dygraph=True,
-                   numeric_place=None,
-                   check_eager=False):
+                   check_eager=True,
+                   numeric_place=None):
         place = paddle.XPUPlace(0)
         self.check_grad_with_place(place, inputs_to_check, output_names,
                                    no_grad_set, numeric_grad_delta, in_place,
                                    max_relative_error, user_defined_grads,
-                                   user_defined_grad_outputs, check_dygraph,
-                                   numeric_place, check_eager)
+                                   user_defined_grad_outputs, check_eager,
+                                   numeric_place)
 
     def check_grad_with_place(self,
                               place,
@@ -136,9 +133,8 @@ class XPUOpTest(OpTest):
                               max_relative_error=0.005,
                               user_defined_grads=None,
                               user_defined_grad_outputs=None,
-                              check_dygraph=True,
-                              numeric_place=None,
-                              check_eager=False):
+                              check_eager=True,
+                              numeric_place=None):
         if hasattr(self, 'op_type_need_check_grad'):
             xpu_version = core.get_xpu_device_version(0)
             if is_empty_grad_op_type(xpu_version, self.op_type,
@@ -166,7 +162,7 @@ class XPUOpTest(OpTest):
             return super().check_grad_with_place(
                 place, inputs_to_check, output_names, no_grad_set,
                 numeric_grad_delta, in_place, max_relative_error,
-                user_defined_grads, user_defined_grad_outputs, check_dygraph)
+                user_defined_grads, user_defined_grad_outputs, check_eager)
 
         a1 = self.get_grad_with_place(
             place,
@@ -199,8 +195,7 @@ class XPUOpTest(OpTest):
                             numeric_grad_delta=0.005,
                             in_place=False,
                             max_relative_error=0.005,
-                            user_defined_grad_outputs=None,
-                            check_dygraph=True):
+                            user_defined_grad_outputs=None):
         self.scope = core.Scope()
         op_inputs = self.inputs if hasattr(self, "inputs") else dict()
         op_outputs = self.outputs if hasattr(self, "outputs") else dict()

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_expand.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_expand.py
@@ -74,10 +74,10 @@ class TestSequenceExpand(OpTest):
         self.compute()
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(["X"], "Out", check_eager=False)
 
 
 class TestSequenceExpandCase1(TestSequenceExpand):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_expand_as.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_expand_as.py
@@ -53,10 +53,10 @@ class TestSequenceExpandAs(OpTest):
         self.outputs = {'Out': (out_data, y_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(["X"], "Out", check_eager=False)
 
 
 class TestSequenceExpandAsCase1(TestSequenceExpandAs):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_pad_op.py
@@ -79,10 +79,10 @@ class TestSequencePadOp(OpTest):
         self.compute()
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(["X"], "Out", check_eager=False)
 
 
 class TestSequencePadOp2(TestSequencePadOp):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_pool.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_pool.py
@@ -83,7 +83,7 @@ class TestSeqAvgPool(OpTest):
             self.outputs = {'Out': (out, [lod[0]])}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # Remove MaxIndex after check_grad is refined.
@@ -91,7 +91,7 @@ class TestSeqAvgPool(OpTest):
         if isinstance(out, tuple): out = out[0]
         self.outputs['MaxIndex'] = \
             np.zeros(out.shape).astype('int32')
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(["X"], "Out", check_eager=False)
 
 
 class TestSeqAvgPoolBatch1(TestSeqAvgPool):
@@ -355,7 +355,7 @@ class TestSeqSqrtPool2D(TestSeqAvgPool2D):
         self.check_grad(["X"],
                         "Out",
                         max_relative_error=0.06,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestSeqSqrtPool2DLen0(TestSeqSqrtPool2D):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_reverse.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_reverse.py
@@ -59,10 +59,10 @@ class TestSequenceReverseBase(OpTest):
         return np.reshape(tmp_y, newshape=self.x.shape).astype(self.dtype)
 
     def test_output(self):
-        self.check_output(0, check_dygraph=False)
+        self.check_output(0, check_eager=False)
 
     def test_grad(self):
-        self.check_grad(['X'], 'Y', check_dygraph=False)
+        self.check_grad(['X'], 'Y', check_eager=False)
 
 
 class TestSequenceReserve1(TestSequenceReverseBase):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_scatter_op.py
@@ -50,10 +50,10 @@ class TestSequenceScatterOp(OpTest):
         self.outputs = {'Out': Out_data}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
-        self.check_grad(['Updates'], 'Out', in_place=True, check_dygraph=False)
+        self.check_grad(['Updates'], 'Out', in_place=True, check_eager=False)
 
 
 class TestSequenceScatterOpSeqLen0(TestSequenceScatterOp):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_unpad_op.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_unpad_op.py
@@ -54,10 +54,10 @@ class TestSequenceUnpadOp(OpTest):
         self.compute()
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(["X"], "Out", check_eager=False)
 
 
 class TestSequenceUnpadOp2(TestSequenceUnpadOp):

--- a/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
+++ b/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
@@ -65,13 +65,13 @@ class TestAddPositionEncodingTensorOp(OpTest):
         """
         check the correctness of output
         """
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         """
         check the correctness of grad
         """
-        self.check_grad(['X'], 'Out', check_dygraph=False)
+        self.check_grad(['X'], 'Out', check_eager=False)
 
     def init_input_output(self):
         """
@@ -107,13 +107,13 @@ class TestAddPositionEncodingLoDTensorOp(OpTest):
         """
         check the correctness of output
         """
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         """
         check the correctness of grad
         """
-        self.check_grad(['X'], 'Out', check_dygraph=False)
+        self.check_grad(['X'], 'Out', check_eager=False)
 
     def init_input_output(self):
         """

--- a/python/paddle/fluid/tests/unittests/test_attention_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_attention_lstm_op.py
@@ -151,7 +151,7 @@ class TestAttentionLSTMOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestAttentionOpNonInit(TestAttentionLSTMOp):

--- a/python/paddle/fluid/tests/unittests/test_collect_fpn_proposals_op.py
+++ b/python/paddle/fluid/tests/unittests/test_collect_fpn_proposals_op.py
@@ -98,7 +98,7 @@ class TestCollectFPNProposalstOp(OpTest):
         self.set_data()
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestCollectFPNProposalstOpWithRoisNum(TestCollectFPNProposalstOp):

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -452,7 +452,7 @@ class TestConv2DOp(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_output_with_place(place,
                                      atol=1e-5,
-                                     check_dygraph=(self.use_mkldnn == False))
+                                     check_eager=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         if self.dtype == np.float16 or (hasattr(self, "no_need_check_grad")
@@ -463,7 +463,7 @@ class TestConv2DOp(OpTest):
         self.check_grad_with_place(place, {'Input', 'Filter'},
                                    'Output',
                                    max_relative_error=0.02,
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16 or (hasattr(self, "no_need_check_grad")
@@ -475,7 +475,7 @@ class TestConv2DOp(OpTest):
                                    'Output',
                                    max_relative_error=0.02,
                                    no_grad_set=set(['Filter']),
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_no_input(self):
         if self.dtype == np.float16 or (hasattr(self, "no_need_check_grad")
@@ -486,7 +486,7 @@ class TestConv2DOp(OpTest):
         self.check_grad_with_place(place, ['Filter'],
                                    'Output',
                                    no_grad_set=set(['Input']),
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def init_test_case(self):
         self.pad = [0, 0]
@@ -771,7 +771,7 @@ class TestConv2DOp_v2(OpTest):
         place = core.CUDAPlace(0) if self.has_cuda() else core.CPUPlace()
         self.check_output_with_place(place,
                                      atol=1e-5,
-                                     check_dygraph=(self.use_mkldnn == False))
+                                     check_eager=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -781,7 +781,7 @@ class TestConv2DOp_v2(OpTest):
         self.check_grad_with_place(place, {'Input', 'Filter'},
                                    'Output',
                                    max_relative_error=0.02,
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -792,7 +792,7 @@ class TestConv2DOp_v2(OpTest):
                                    'Output',
                                    max_relative_error=0.02,
                                    no_grad_set=set(['Filter']),
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_no_input(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -802,7 +802,7 @@ class TestConv2DOp_v2(OpTest):
         self.check_grad_with_place(place, ['Filter'],
                                    'Output',
                                    no_grad_set=set(['Input']),
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def init_test_case(self):
         self.pad = [0, 0]

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -164,10 +164,11 @@ class TestConv2DTransposeOp(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         if self.use_cudnn:
             place = core.CUDAPlace(0)
-            self.check_output_with_place(
-                place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
+            self.check_output_with_place(place,
+                                         atol=1e-5,
+                                         check_eager=(self.use_mkldnn == False))
         else:
-            self.check_output(check_dygraph=(self.use_mkldnn == False))
+            self.check_output(check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_no_input(self):
         if self.need_check_grad:
@@ -716,10 +717,11 @@ class TestCUDNN_FP16(TestConv2DTransposeOp):
     def test_check_output(self):
         if self.use_cudnn:
             place = core.CUDAPlace(0)
-            self.check_output_with_place(
-                place, atol=0.02, check_dygraph=(self.use_mkldnn == False))
+            self.check_output_with_place(place,
+                                         atol=0.02,
+                                         check_eager=(self.use_mkldnn == False))
         else:
-            self.check_output(check_dygraph=(self.use_mkldnn == False))
+            self.check_output(check_eager=(self.use_mkldnn == False))
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -300,7 +300,7 @@ class TestConv3DOp(OpTest):
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_output_with_place(place,
                                      atol=1e-5,
-                                     check_dygraph=(self.use_mkldnn == False))
+                                     check_eager=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         if self.dtype == np.float16:
@@ -310,7 +310,7 @@ class TestConv3DOp(OpTest):
         self.check_grad_with_place(place, {'Input', 'Filter'},
                                    'Output',
                                    max_relative_error=0.03,
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
@@ -321,7 +321,7 @@ class TestConv3DOp(OpTest):
                                    'Output',
                                    max_relative_error=0.03,
                                    no_grad_set=set(['Filter']),
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_no_input(self):
         if self.dtype == np.float16:
@@ -332,7 +332,7 @@ class TestConv3DOp(OpTest):
                                    'Output',
                                    max_relative_error=0.03,
                                    no_grad_set=set(['Input']),
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
     def init_test_case(self):
         self.pad = [0, 0, 0]

--- a/python/paddle/fluid/tests/unittests/test_cvm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cvm_op.py
@@ -78,7 +78,7 @@ class TestCVMOpWithLodTensor(OpTest):
         self.outputs = {'Y': (np.array(out), lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         user_grads = np.array(
@@ -89,7 +89,7 @@ class TestCVMOpWithLodTensor(OpTest):
         self.check_grad(['X'],
                         'Y',
                         user_defined_grads=user_grads,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestCVMOpWithOutLodTensor1(OpTest):
@@ -115,7 +115,7 @@ class TestCVMOpWithOutLodTensor1(OpTest):
         self.outputs = {'Y': output}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         numel = self.batch_size * self.item_width
@@ -126,7 +126,7 @@ class TestCVMOpWithOutLodTensor1(OpTest):
         self.check_grad(['X'],
                         'Y',
                         user_defined_grads=user_grads,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestCVMOpWithOutLodTensor2(OpTest):
@@ -152,7 +152,7 @@ class TestCVMOpWithOutLodTensor2(OpTest):
         self.outputs = {'Y': output}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         numel = self.batch_size * self.item_width
@@ -164,7 +164,7 @@ class TestCVMOpWithOutLodTensor2(OpTest):
         self.check_grad(['X'],
                         'Y',
                         user_defined_grads=user_grads,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -42,13 +42,9 @@ class TestElementwiseAddOp(OpTest):
         self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
         self.outputs = {'Out': self.out}
 
-    def check_eager(self):
-        return (self.use_mkldnn == False and self.axis == -1)
-
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=(self.use_mkldnn == False),
-                          check_eager=self.check_eager())
+        self.check_output(check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_normal(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -56,8 +52,7 @@ class TestElementwiseAddOp(OpTest):
             return
         self.check_grad(['X', 'Y'],
                         'Out',
-                        check_dygraph=(self.use_mkldnn == False),
-                        check_eager=self.check_eager())
+                        check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_ingore_x(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -66,8 +61,7 @@ class TestElementwiseAddOp(OpTest):
         self.check_grad(['Y'],
                         'Out',
                         no_grad_set=set("X"),
-                        check_dygraph=(self.use_mkldnn == False),
-                        check_eager=self.check_eager())
+                        check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_ingore_y(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -76,8 +70,7 @@ class TestElementwiseAddOp(OpTest):
         self.check_grad(['X'],
                         'Out',
                         no_grad_set=set('Y'),
-                        check_dygraph=(self.use_mkldnn == False),
-                        check_eager=self.check_eager())
+                        check_eager=(self.use_mkldnn == False))
 
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)
@@ -104,7 +97,7 @@ class TestFP16ElementwiseAddOp(TestElementwiseAddOp):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
                 self.check_output_with_place(
-                    place, atol=1e-3, check_dygraph=(self.use_mkldnn == False))
+                    place, atol=1e-3, check_eager=(self.use_mkldnn == False))
 
 
 @unittest.skipIf(

--- a/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
@@ -53,7 +53,7 @@ class ElementwiseDivOp(OpTest):
         self.grad_y = grad_y
 
     def init_args(self):
-        self.check_dygraph = True
+        self.check_eager = True
         self.place = None
 
     def init_dtype(self):
@@ -105,7 +105,7 @@ class ElementwiseDivOp(OpTest):
                 'no_grad_set': check_option['no_grad'],
                 'user_defined_grads': check_option['val_grad'],
                 'user_defined_grad_outputs': [self.grad_out],
-                'check_dygraph': self.check_dygraph
+                'check_eager': self.check_eager
             }
             if self.place is None:
                 self.check_grad(*check_args, **check_kwargs)
@@ -121,7 +121,7 @@ class TestElementwiseDivOpBF16(ElementwiseDivOp):
 
     def init_args(self):
         # In due to output data type inconsistence of bfloat16 paddle op, we disable the dygraph check.
-        self.check_dygraph = False
+        self.check_eager = False
         self.place = core.CUDAPlace(0)
 
     def init_dtype(self):

--- a/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
@@ -47,27 +47,27 @@ class ElementwiseMulOp(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=(self.use_mkldnn == False))
+        self.check_output(check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_normal(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_grad(['X', 'Y'],
                         'Out',
-                        check_dygraph=(self.use_mkldnn == False))
+                        check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_ingore_x(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_grad(['Y'],
                         'Out',
                         no_grad_set=set("X"),
-                        check_dygraph=(self.use_mkldnn == False))
+                        check_eager=(self.use_mkldnn == False))
 
     def test_check_grad_ingore_y(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_grad(['X'],
                         'Out',
                         no_grad_set=set('Y'),
-                        check_dygraph=(self.use_mkldnn == False))
+                        check_eager=(self.use_mkldnn == False))
 
     def init_input_output(self):
         self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)

--- a/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
@@ -48,7 +48,7 @@ class TestFusedEmbeddingSeqPoolOp(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support lod in dygraph mode
@@ -57,7 +57,7 @@ class TestFusedEmbeddingSeqPoolOp(OpTest):
             self.check_grad(['W'],
                             'Out',
                             no_grad_set=['Ids'],
-                            check_dygraph=False)
+                            check_eager=False)
 
 
 class TestLookupTableOpWithPadding(TestFusedEmbeddingSeqPoolOp):
@@ -84,7 +84,7 @@ class TestLookupTableOpWithPadding(TestFusedEmbeddingSeqPoolOp):
             }
             self.attrs = {'padding_idx': int(padding_idx)}
             # TODO(wangzhongpu): support lod in dygraph mode
-            self.check_output(check_dygraph=False)
+            self.check_output(check_eager=False)
 
     def test_check_grad(self):
         if ver.mkl() == "ON" and 'Linux' in platform.platform():
@@ -95,7 +95,7 @@ class TestLookupTableOpWithPadding(TestFusedEmbeddingSeqPoolOp):
             self.check_grad(['W'],
                             'Out',
                             no_grad_set=['Ids'],
-                            check_dygraph=False)
+                            check_eager=False)
 
 
 class TestFusedEmbeddingSeqPoolApi(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_fused_embedding_fc_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_embedding_fc_lstm_op.py
@@ -139,7 +139,7 @@ class TestFusionLSTMOp(OpTest):
     def test_check_output(self):
         for use_seq in {True, False}:
             self.attrs['use_seq'] = use_seq
-            self.check_output(check_dygraph=False)
+            self.check_output(check_eager=False)
 
 
 class TestFusionLSTMOpInit(TestFusionLSTMOp):

--- a/python/paddle/fluid/tests/unittests/test_fusion_gru_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_gru_op.py
@@ -100,7 +100,7 @@ class TestFusionGRUOp(OpTest):
     def test_check_output(self):
         for use_seq in {True, False}:
             self.attrs['use_seq'] = use_seq
-            self.check_output(check_dygraph=False)
+            self.check_output(check_eager=False)
 
 
 class TestFusionGRUOpNoInitial(TestFusionGRUOp):

--- a/python/paddle/fluid/tests/unittests/test_fusion_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_lstm_op.py
@@ -116,7 +116,7 @@ class TestFusionLSTMOp(OpTest):
     def test_check_output(self):
         for use_seq in {True, False}:
             self.attrs['use_seq'] = use_seq
-            self.check_output(check_dygraph=False)
+            self.check_output(check_eager=False)
 
 
 class TestFusionLSTMOpInit(TestFusionLSTMOp):

--- a/python/paddle/fluid/tests/unittests/test_fusion_seqexpand_concat_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_seqexpand_concat_fc_op.py
@@ -91,7 +91,7 @@ class TestFusionSeqExpandConcatFCOp(OpTest):
         self.attrs = {'fc_activation': self.fc_act}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestFusionSECFCOpNonBias(TestFusionSeqExpandConcatFCOp):

--- a/python/paddle/fluid/tests/unittests/test_gru_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gru_op.py
@@ -162,11 +162,11 @@ class TestGRUOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(atol=1e-8, check_dygraph=False)
+        self.check_output(atol=1e-8, check_eager=False)
 
     def test_check_grad(self):
         self.check_grad(['Input', 'H0', 'Weight', 'Bias'], ['Hidden'],
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestGRUOriginMode(TestGRUOp):
@@ -218,7 +218,7 @@ class TestGRUOpNoInitial(TestGRUOp):
 
     def test_check_grad(self):
         self.check_grad(['Input', 'Weight', 'Bias'], ['Hidden'],
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestGRUOpNoBias(TestGRUOp):
@@ -228,7 +228,7 @@ class TestGRUOpNoBias(TestGRUOp):
 
     def test_check_grad(self):
         self.check_grad(['Input', 'H0', 'Weight'], ['Hidden'],
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestGRUOpReverse(TestGRUOp):

--- a/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
+++ b/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
@@ -23,7 +23,7 @@ from op_test import OpTest
 class TestIOUSimilarityOp(OpTest):
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def setUp(self):
         self.op_type = "iou_similarity"
@@ -69,7 +69,7 @@ class TestIOUSimilarityOp(OpTest):
 class TestIOUSimilarityOpWithLoD(TestIOUSimilarityOp):
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def setUp(self):
         super(TestIOUSimilarityOpWithLoD, self).setUp()
@@ -86,7 +86,7 @@ class TestIOUSimilarityOpWithLoD(TestIOUSimilarityOp):
 class TestIOUSimilarityOpWithBoxNormalized(TestIOUSimilarityOp):
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def setUp(self):
         super(TestIOUSimilarityOpWithBoxNormalized, self).setUp()

--- a/python/paddle/fluid/tests/unittests/test_lod_reset_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lod_reset_op.py
@@ -36,11 +36,11 @@ class TestLodResetOpByAttr(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(["X"], "Out", check_eager=False)
 
 
 class TestLodResetOpByInput(OpTest):
@@ -61,11 +61,11 @@ class TestLodResetOpByInput(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_grad(["X"], "Out", no_grad_set=set("Y"), check_dygraph=False)
+        self.check_grad(["X"], "Out", no_grad_set=set("Y"), check_eager=False)
 
 
 class TestLodResetOpBoth(OpTest):
@@ -86,11 +86,11 @@ class TestLodResetOpBoth(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_grad(["X"], "Out", no_grad_set=set("Y"), check_dygraph=False)
+        self.check_grad(["X"], "Out", no_grad_set=set("Y"), check_eager=False)
 
 
 class TestLodResetOpYIsLoDTensor(OpTest):
@@ -106,11 +106,11 @@ class TestLodResetOpYIsLoDTensor(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_grad(["X"], "Out", no_grad_set=set("Y"), check_dygraph=False)
+        self.check_grad(["X"], "Out", no_grad_set=set("Y"), check_eager=False)
 
 
 class TestLodAppendOpByAttr(OpTest):
@@ -130,11 +130,11 @@ class TestLodAppendOpByAttr(OpTest):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support lod in dygraph mode
-        self.check_grad(["X"], "Out", check_dygraph=False)
+        self.check_grad(["X"], "Out", check_eager=False)
 
 
 class TestLodResetOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
@@ -72,13 +72,13 @@ class TestLookupTableBF16Op(OpTest):
         self.outputs = {'Out': self.out_fp32}
 
     def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace(), check_eager=False)
 
     def test_check_grad(self):
         self.check_grad_with_place(core.CPUPlace(), ['W'],
                                    'Out',
                                    no_grad_set=set('Ids'),
-                                   check_dygraph=False,
+                                   check_eager=False,
                                    max_relative_error=1.5e-2,
                                    user_defined_grads=[self.w_grad_fp32],
                                    user_defined_grad_outputs=[self.out_bf16])
@@ -171,7 +171,7 @@ class TestLookupTableBF16OpWithPadding(TestLookupTableBF16Op):
         padding_idx = np.random.choice(ids, 1)[0]
         self.outputs['Out'][ids == padding_idx] = np.zeros(31)
         self.attrs = {'padding_idx': int(padding_idx)}
-        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace(), check_eager=False)
 
 
 @skip_check_grad_ci(
@@ -188,7 +188,7 @@ class TestLookupTableBF16OpIds4DPadding(TestLookupTableBF16OpIds4D):
         padding_idx = np.random.choice(flatten_idx, 1)[0]
         self.outputs['Out'][np.squeeze(ids == padding_idx)] = np.zeros(31)
         self.attrs = {'padding_idx': int(padding_idx)}
-        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace(), check_eager=False)
 
 
 class TestEmbeddingLayerBF16ConstantInitializer(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_op.py
@@ -275,7 +275,7 @@ class TestLstmOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output(atol=1e-8, check_dygraph=False)
+        self.check_output(atol=1e-8, check_eager=False)
 
     def test_check_grad(self):
         # TODO(qingqing) remove folowing lines after the check_grad is refined.
@@ -285,7 +285,7 @@ class TestLstmOp(OpTest):
             (N, self.D)).astype('float64')
         self.check_grad(['Input', 'Weight', 'Bias'], ['Hidden'],
                         max_relative_error=5e-4,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestLstmOpCase1(TestLstmOp):

--- a/python/paddle/fluid/tests/unittests/test_lstmp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstmp_op.py
@@ -188,7 +188,7 @@ class TestLstmpOp(LstmTest.TestLstmOp):
         }
 
     def test_check_output(self):
-        self.check_output(atol=1e-8, check_dygraph=False)
+        self.check_output(atol=1e-8, check_eager=False)
 
     def test_check_grad(self):
         # TODO(qingqing) remove folowing lines after the check_grad is refined.
@@ -200,7 +200,7 @@ class TestLstmpOp(LstmTest.TestLstmOp):
         self.check_grad(['Input', 'Weight', 'ProjWeight', 'Bias'],
                         ['Projection'],
                         numeric_grad_delta=0.0000005,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestLstmpOpHasInitial(TestLstmpOp):
@@ -218,7 +218,7 @@ class TestLstmpOpHasInitial(TestLstmpOp):
         self.check_grad(['Input', 'Weight', 'ProjWeight', 'Bias', 'H0', 'C0'],
                         ['Projection'],
                         numeric_grad_delta=0.0000005,
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ingore_bias(self):
         N = len(self.lod[0])
@@ -229,7 +229,7 @@ class TestLstmpOpHasInitial(TestLstmpOp):
         self.check_grad(['Input', 'ProjWeight', 'Weight'], ['Projection'],
                         numeric_grad_delta=0.0000005,
                         no_grad_set=set('Bias'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ingore_weight(self):
         N = len(self.lod[0])
@@ -240,7 +240,7 @@ class TestLstmpOpHasInitial(TestLstmpOp):
         self.check_grad(['Input', 'ProjWeight', 'Bias'], ['Projection'],
                         numeric_grad_delta=0.0000005,
                         no_grad_set=set('Weight'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ingore_proj_weight(self):
         N = len(self.lod[0])
@@ -251,7 +251,7 @@ class TestLstmpOpHasInitial(TestLstmpOp):
         self.check_grad(['Input', 'Weight', 'Bias'], ['Projection'],
                         numeric_grad_delta=0.0000005,
                         no_grad_set=set('ProjWeight'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ingore_input(self):
         N = len(self.lod[0])
@@ -262,7 +262,7 @@ class TestLstmpOpHasInitial(TestLstmpOp):
         self.check_grad(['Weight', 'ProjWeight', 'Bias'], ['Projection'],
                         numeric_grad_delta=0.0000005,
                         no_grad_set=set('Input'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ingore_h0(self):
         N = len(self.lod[0])
@@ -274,7 +274,7 @@ class TestLstmpOpHasInitial(TestLstmpOp):
                         ['Projection'],
                         numeric_grad_delta=0.0000005,
                         no_grad_set=set('H0'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ingore_c0(self):
         N = len(self.lod[0])
@@ -286,7 +286,7 @@ class TestLstmpOpHasInitial(TestLstmpOp):
                         ['Projection'],
                         numeric_grad_delta=0.0000005,
                         no_grad_set=set('C0'),
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestLstmpOpRerverse(TestLstmpOp):

--- a/python/paddle/fluid/tests/unittests/test_match_matrix_tensor_op.py
+++ b/python/paddle/fluid/tests/unittests/test_match_matrix_tensor_op.py
@@ -70,10 +70,10 @@ class TestMatchMatrixTensorOp(OpTest):
         self.outputs = {'Out': (out, out_lod), 'Tmp': tmp}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out', check_dygraph=False)
+        self.check_grad(['X', 'Y'], 'Out', check_eager=False)
 
 
 class TestMatchMatrixTensorOpCase1(TestMatchMatrixTensorOp):

--- a/python/paddle/fluid/tests/unittests/test_mean_iou.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_iou.py
@@ -115,10 +115,10 @@ class TestCase1(TestMeanIOUOp):
         self.in_correct_num = 2
         self.in_mean_iou_num = 2
 
-    # NOTE(dev): Skip check_dygraph becuase Python API doesn't expose
+    # NOTE(dev): Skip check_eager becuase Python API doesn't expose
     # in_wrong_num/in_correct_num/in_mean_iou_num argument
     def test_check_output(self):
-        self.check_output(check_dygraph=False, check_eager=False)
+        self.check_output(check_eager=False)
 
 
 class TestMeanIOUOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_nn_functional_hot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_functional_hot_op.py
@@ -45,7 +45,7 @@ class TestOneHotOp(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_attr(OpTest):
@@ -69,7 +69,7 @@ class TestOneHotOp_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_default_dtype(OpTest):
@@ -93,7 +93,7 @@ class TestOneHotOp_default_dtype(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_default_dtype_attr(OpTest):
@@ -117,7 +117,7 @@ class TestOneHotOp_default_dtype_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_exception(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_one_hot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_one_hot_op.py
@@ -45,7 +45,7 @@ class TestOneHotOp(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_attr(OpTest):
@@ -69,7 +69,7 @@ class TestOneHotOp_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_default_dtype(OpTest):
@@ -94,7 +94,7 @@ class TestOneHotOp_default_dtype(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_default_dtype_attr(OpTest):
@@ -118,7 +118,7 @@ class TestOneHotOp_default_dtype_attr(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_out_of_range(OpTest):
@@ -138,7 +138,7 @@ class TestOneHotOp_out_of_range(OpTest):
         self.outputs = {'Out': (out, x_lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
 
 class TestOneHotOp_exception(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -24,12 +24,17 @@ from paddle.fluid import Program, program_guard
 from test_attribute_var import UnittestBase
 
 
+def pad(X, paddings, pad_value):
+    return paddle._C_ops.pad(X, paddings, pad_value)
+
+
 class TestPadOp(OpTest):
 
     def setUp(self):
         self.initTestCase()
         self.dtype = self.get_dtype()
         self.op_type = "pad"
+        self.python_api = pad
         self.inputs = {
             'X': np.random.random(self.shape).astype(self.dtype),
         }

--- a/python/paddle/fluid/tests/unittests/test_pool2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_op.py
@@ -303,10 +303,11 @@ class TestPool2D_Op_Mixin(object):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         if self.has_cudnn():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(
-                place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
+            self.check_output_with_place(place,
+                                         atol=1e-5,
+                                         check_eager=(self.use_mkldnn == False))
         else:
-            self.check_output(check_dygraph=(self.use_mkldnn == False))
+            self.check_output(check_eager=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         if self.dtype == np.float16:
@@ -318,12 +319,12 @@ class TestPool2D_Op_Mixin(object):
                                        set(['X']),
                                        'Out',
                                        max_relative_error=0.07,
-                                       check_dygraph=(self.use_mkldnn == False))
+                                       check_eager=(self.use_mkldnn == False))
         elif self.pool_type != "max":
             self.check_grad(set(['X']),
                             'Out',
                             max_relative_error=0.07,
-                            check_dygraph=(self.use_mkldnn == False))
+                            check_eager=(self.use_mkldnn == False))
 
     def init_data_format(self):
         self.data_format = "NCHW"
@@ -472,7 +473,7 @@ def create_test_cudnn_fp16_class(parent, check_grad=True):
                     self.check_output_with_place(
                         place,
                         atol=1e-3,
-                        check_dygraph=(self.use_mkldnn == False))
+                        check_eager=(self.use_mkldnn == False))
 
         def test_check_grad(self):
             # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -484,7 +485,7 @@ def create_test_cudnn_fp16_class(parent, check_grad=True):
                     set(['X']),
                     'Out',
                     max_relative_error=0.07,
-                    check_dygraph=(self.use_mkldnn == False))
+                    check_eager=(self.use_mkldnn == False))
 
     cls_name = "{0}_{1}".format(parent.__name__, "CUDNNFp16Op")
     TestCUDNNFp16Case.__name__ = cls_name
@@ -509,7 +510,7 @@ def create_test_fp16_class(parent, check_grad=True):
                     self.check_output_with_place(
                         place,
                         atol=1e-3,
-                        check_dygraph=(self.use_mkldnn == False))
+                        check_eager=(self.use_mkldnn == False))
 
         def test_check_grad(self):
             # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -521,7 +522,7 @@ def create_test_fp16_class(parent, check_grad=True):
                     set(['X']),
                     'Out',
                     max_relative_error=0.07,
-                    check_dygraph=(self.use_mkldnn == False))
+                    check_eager=(self.use_mkldnn == False))
 
     cls_name = "{0}_{1}".format(parent.__name__, "Fp16Op")
     TestFp16Case.__name__ = cls_name

--- a/python/paddle/fluid/tests/unittests/test_row_conv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_row_conv_op.py
@@ -60,22 +60,22 @@ class TestRowConvOp1(OpTest):
         self.outputs = {'Out': (out, lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Filter'], 'Out', check_dygraph=False)
+        self.check_grad(['X', 'Filter'], 'Out', check_eager=False)
 
     def test_check_grad_ignore_x(self):
         self.check_grad(['Filter'],
                         'Out',
                         no_grad_set=set('X'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ignore_wt(self):
         self.check_grad(['X'],
                         'Out',
                         no_grad_set=set('Filter'),
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestRowConvOp2(OpTest):
@@ -96,7 +96,7 @@ class TestRowConvOp2(OpTest):
         self.outputs = {'Out': (out, lod)}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     #max_relative_error is increased from 0.05 to 0.06 as for higher
     #dimensional input, the dX on CPU for some values has max_rel_error
@@ -105,21 +105,21 @@ class TestRowConvOp2(OpTest):
         self.check_grad(['X', 'Filter'],
                         'Out',
                         max_relative_error=0.06,
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ignore_x(self):
         self.check_grad(['Filter'],
                         'Out',
                         max_relative_error=0.06,
                         no_grad_set=set('X'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_ignore_wt(self):
         self.check_grad(['X'],
                         'Out',
                         max_relative_error=0.06,
                         no_grad_set=set('Filter'),
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 def row_conv_foward_Tensor(x, wt):
@@ -156,22 +156,22 @@ class TestRowOpWithTensorInput(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad_ignore_x(self):
         self.check_grad(['Filter'],
                         'Out',
                         no_grad_set=set('X'),
-                        check_dygraph=False)
+                        check_eager=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Filter'], 'Out', check_dygraph=False)
+        self.check_grad(['X', 'Filter'], 'Out', check_eager=False)
 
     def test_check_grad_ignore_wt(self):
         self.check_grad(['X'],
                         'Out',
                         no_grad_set=set('Filter'),
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestRowConvLayer(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_sgd_op_bf16.py
+++ b/python/paddle/fluid/tests/unittests/test_sgd_op_bf16.py
@@ -50,7 +50,7 @@ class TestSGDOpBF16(OpTest):
         self.w = 105
 
     def test_check_output(self):
-        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace(), check_eager=False)
 
 
 @unittest.skipIf(not core.supports_bfloat16(),

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -79,10 +79,11 @@ class TestSoftmaxOp(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         if self.use_cudnn:
             place = core.CUDAPlace(0)
-            self.check_output_with_place(
-                place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
+            self.check_output_with_place(place,
+                                         atol=1e-5,
+                                         check_eager=(self.use_mkldnn == False))
         else:
-            self.check_output(check_dygraph=(self.use_mkldnn == False))
+            self.check_output(check_eager=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -93,12 +94,12 @@ class TestSoftmaxOp(OpTest):
                     place, ["X"],
                     "Out",
                     max_relative_error=0.01,
-                    check_dygraph=(self.use_mkldnn == False))
+                    check_eager=(self.use_mkldnn == False))
         else:
             self.check_grad(["X"],
                             "Out",
                             max_relative_error=0.01,
-                            check_dygraph=(self.use_mkldnn == False))
+                            check_eager=(self.use_mkldnn == False))
 
 
 class TestSoftmaxOp2(TestSoftmaxOp):
@@ -347,14 +348,14 @@ class TestSoftmaxBF16Op(OpTest):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         self.check_output_with_place(place,
-                                     check_dygraph=(self.use_mkldnn == False))
+                                     check_eager=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
         self.check_grad_with_place(place, ["X"],
                                    "Out",
                                    numeric_grad_delta=0.05,
-                                   check_dygraph=(self.use_mkldnn == False))
+                                   check_eager=(self.use_mkldnn == False))
 
 
 @unittest.skipIf(

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -184,6 +184,7 @@ class TestTransposeBF16Op(OpTest):
         }
 
     def init_op_type(self):
+        self.python_api = paddle.transpose
         self.op_type = "transpose2"
         self.use_mkldnn = False
 

--- a/python/paddle/fluid/tests/unittests/test_var_conv_2d.py
+++ b/python/paddle/fluid/tests/unittests/test_var_conv_2d.py
@@ -171,13 +171,13 @@ class TestVarConv2DOp(OpTest):
         return col_res, col_res_lod
 
     def test_check_output(self):
-        self.check_output(check_dygraph=False)
+        self.check_output(check_eager=False)
 
     def test_check_grad(self):
         self.check_grad(['X'],
                         'Out',
                         max_relative_error=0.005,
-                        check_dygraph=False)
+                        check_eager=False)
 
 
 class TestVarConv2DOpCase1(TestVarConv2DOp):

--- a/python/paddle/fluid/tests/unittests/test_warpctc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_warpctc_op.py
@@ -255,12 +255,12 @@ class TestWarpCTCOp(OpTest):
             self.check_grad(["Logits"],
                             "Loss",
                             max_relative_error=0.009,
-                            check_dygraph=False)
+                            check_eager=False)
         else:
             self.check_grad(["Logits"],
                             "Loss",
                             max_relative_error=0.007,
-                            check_dygraph=False)
+                            check_eager=False)
 
 
 class TestWarpCTCOpCase1(TestWarpCTCOp):
@@ -362,12 +362,12 @@ class TestWarpCTCOpWithPadding(OpTest):
             self.check_grad(["Logits"],
                             "Loss",
                             max_relative_error=0.009,
-                            check_dygraph=False)
+                            check_eager=False)
         else:
             self.check_grad(["Logits"],
                             "Loss",
                             max_relative_error=0.007,
-                            check_dygraph=False)
+                            check_eager=False)
 
 
 class TestWarpCTCOpWithPaddingCase1(TestWarpCTCOpWithPadding):

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_mul_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_mul_op_xpu.py
@@ -58,7 +58,7 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
                 self.check_grad_with_place(
                     place, ['X', 'Y'],
                     'Out',
-                    check_dygraph=(self.use_mkldnn == False))
+                    check_eager=(self.use_mkldnn == False))
 
         def test_check_grad_ingore_x(self):
             if paddle.is_compiled_with_xpu():
@@ -67,7 +67,7 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
                     place, ['Y'],
                     'Out',
                     no_grad_set=set("X"),
-                    check_dygraph=(self.use_mkldnn == False))
+                    check_eager=(self.use_mkldnn == False))
 
         def test_check_grad_ingore_y(self):
             if paddle.is_compiled_with_xpu():
@@ -76,7 +76,7 @@ class XPUTestElementwiseMulOp(XPUOpTestWrapper):
                     place, ['X'],
                     'Out',
                     no_grad_set=set('Y'),
-                    check_dygraph=(self.use_mkldnn == False))
+                    check_eager=(self.use_mkldnn == False))
 
         def init_input_output(self):
             self.x = np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype)

--- a/python/paddle/fluid/tests/unittests/xpu/test_iou_similarity_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_iou_similarity_op_xpu.py
@@ -87,7 +87,7 @@ class XPUTestIOUSimilarityOp(XPUOpTestWrapper):
     class TestXPUIOUSimilarityOpWithLoD(TestXPUIOUSimilarityOp):
 
         def test_check_output(self):
-            self.check_output_with_place(self.place, check_dygraph=False)
+            self.check_output_with_place(self.place, check_eager=False)
 
         def setUp(self):
             super().setUp()
@@ -106,7 +106,7 @@ class XPUTestIOUSimilarityOp(XPUOpTestWrapper):
     class TestXPUIOUSimilarityOpWithBoxNormalized(TestXPUIOUSimilarityOp):
 
         def test_check_output(self):
-            self.check_output_with_place(self.place, check_dygraph=False)
+            self.check_output_with_place(self.place, check_eager=False)
 
         def setUp(self):
             super().setUp()

--- a/python/paddle/fluid/tests/unittests/xpu/test_one_hot_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_one_hot_op_xpu.py
@@ -68,7 +68,7 @@ class XPUTestOneHotOP(XPUOpTestWrapper):
             self.attrs = {'dtype': int(core.VarDesc.VarType.FP32)}
 
         def test_check_output(self):
-            self.check_output(check_dygraph=False)
+            self.check_output(check_eager=False)
 
         def init_dtype(self):
             self.dtype = self.in_type

--- a/python/paddle/fluid/tests/unittests/xpu/test_range_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_range_xpu.py
@@ -60,7 +60,7 @@ class XPUTestRangeOp(XPUOpTestWrapper):
 
         def test_check_output(self):
             place = paddle.XPUPlace(0)
-            self.check_output_with_place(place, check_dygraph=False)
+            self.check_output_with_place(place, check_eager=False)
 
     class TestRangeOpCase0(TestRangeOp):
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
OpTest删除对老动态图的测试:
1. 删除OpTest基类中的check_dygraph相关逻辑，将check_eager设置为默认为False
2. 删除_test_eager_guard中finally的_enable_legacy_dygraph
3. 将OP单测中所有主动设置check_dygraph的代码改成check_eager