### PR TITLE
[CodeStyle][F401] remove unused imports in unittests/mlu

### DIFF
--- a/python/paddle/fluid/tests/unittests/mlu/c_comm_init_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/c_comm_init_op_mlu.py
@@ -14,7 +14,6 @@
 
 import unittest
 import os
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.distributed.fleet.base.private_helper_function import wait_server_ready
 import paddle

--- a/python/paddle/fluid/tests/unittests/mlu/collective_allgather_api.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_allgather_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base_mlu import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/collective_allgather_op.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_allgather_op.py
@@ -12,24 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base_mlu import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/collective_allreduce_api.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_allreduce_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base_mlu import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/collective_allreduce_op.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_allreduce_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base_mlu import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/collective_broadcast_api.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_broadcast_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base_mlu import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/collective_broadcast_op.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_broadcast_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base_mlu import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/collective_reduce_api.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_reduce_api.py
@@ -12,25 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_api_base_mlu import TestCollectiveAPIRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/collective_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/mlu/collective_reduce_op.py
@@ -12,25 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
-import argparse
-import os
-import sys
-import signal
-import time
-import socket
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
-import unittest
-from multiprocessing import Process
 import paddle.fluid.layers as layers
-from functools import reduce
 from test_collective_base_mlu import TestCollectiveRunnerBase, runtime_main
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/multi_process_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/multi_process_mlu.py
@@ -15,7 +15,6 @@
 import os
 import sys
 import time
-import paddle.fluid as fluid
 
 
 def train(prefix):

--- a/python/paddle/fluid/tests/unittests/mlu/nproc_process_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/nproc_process_mlu.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import time
 
 
 def train(prefix):

--- a/python/paddle/fluid/tests/unittests/mlu/parallel_dygraph_sync_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/mlu/parallel_dygraph_sync_batch_norm.py
@@ -12,19 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import contextlib
-import unittest
 import numpy as np
-import six
-import pickle
 
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.dygraph as dygraph
-from paddle.fluid import core
-from paddle.fluid.optimizer import SGDOptimizer
-from paddle.nn import Conv2D, Linear, SyncBatchNorm
+from paddle.nn import Conv2D, SyncBatchNorm
 from paddle.fluid.dygraph.base import to_variable
 import sys
 

--- a/python/paddle/fluid/tests/unittests/mlu/sync_batch_norm_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/sync_batch_norm_op_mlu.py
@@ -13,29 +13,13 @@
 # limitations under the License.
 
 import numpy as np
-import argparse
-import os
 import sys
 
 sys.path.append("..")
-import signal
-import time
-from contextlib import closing
-from six import string_types
-import math
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.profiler as profiler
-import paddle.fluid.unique_name as nameGen
-from paddle.fluid import core
-import unittest
-from multiprocessing import Process
-import paddle.fluid.layers as layers
-from functools import reduce
 from test_sync_batch_norm_base_mlu import TestSyncBatchNormRunnerBase, runtime_main
-from op_test import OpTest, _set_use_system_allocator
-
-from test_sync_batch_norm_op import create_or_get_tensor
+from op_test import _set_use_system_allocator
 
 _set_use_system_allocator(False)
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_abs_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_abs_op_mlu.py
@@ -18,11 +18,7 @@ import sys
 
 sys.path.append('..')
 from op_test import OpTest
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 import paddle
-import paddle.nn.functional as F
 
 paddle.enable_static()
 np.random.seed(10)

--- a/python/paddle/fluid/tests/unittests/mlu/test_accuracy_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_accuracy_op_mlu.py
@@ -20,7 +20,7 @@ sys.path.append('..')
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_adam_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_adam_op_mlu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from test_adam_op import adam_step
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_adamw_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_adamw_op_mlu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from test_adam_op import adamw_step
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_arg_max_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_arg_max_op_mlu.py
@@ -19,9 +19,7 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_assign_value_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_assign_value_op_mlu.py
@@ -20,9 +20,7 @@ sys.path.append("..")
 
 import op_test
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.framework as framework
-import paddle.fluid.layers as layers
 
 paddle.enable_static()
 numpy.random.seed(2022)

--- a/python/paddle/fluid/tests/unittests/mlu/test_batch_norm_op_mlu_v2.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_batch_norm_op_mlu_v2.py
@@ -12,17 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, _set_use_system_allocator
-from paddle.fluid.framework import grad_var_name
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 import paddle

--- a/python/paddle/fluid/tests/unittests/mlu/test_bce_with_logits_loss_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_bce_with_logits_loss_mlu.py
@@ -19,7 +19,6 @@ import unittest
 import sys
 
 sys.path.append('..')
-from op_test import OpTest
 from test_bce_with_logits_loss import call_bce_layer, call_bce_functional, test_dygraph, calc_bce_with_logits_loss
 
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_cast_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_cast_op_mlu.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_clip_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_clip_op_mlu.py
@@ -18,10 +18,7 @@ import sys
 sys.path.append("..")
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
 from op_test import OpTest
-from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_allgather.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_allgather.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_allgather_api_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_allgather_api_mlu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_api_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_api_mlu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_max.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_max.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_min.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_min.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_prod.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_prod.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_sum.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_allreduce_sum.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_api_base_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_api_base_mlu.py
@@ -21,7 +21,6 @@ import pickle
 from contextlib import closing
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 
 
 def DataTypeCast(date_type):
@@ -89,7 +88,6 @@ def runtime_main(test_class, col_type):
     model.run_trainer(args)
 
 
-import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_base_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_base_mlu.py
@@ -15,12 +15,9 @@
 import numpy as np
 import unittest
 import time
-import argparse
 import os
 import sys
 import subprocess
-import traceback
-import functools
 import pickle
 from contextlib import closing
 import paddle.fluid as fluid
@@ -153,7 +150,6 @@ def runtime_main(test_class):
     model.run_trainer(args)
 
 
-import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_broadcast.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_broadcast.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_broadcast_api_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_broadcast_api_mlu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_api_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_api_mlu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_api_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_max.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_max.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_min.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_min.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_prod.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_prod.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_sum.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_collective_reduce_sum.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
-import numpy as np
 import paddle
 
 from test_collective_base_mlu import TestDistBase

--- a/python/paddle/fluid/tests/unittests/mlu/test_concat_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_concat_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/mlu/test_conv2d_op_depthwise_conv_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_conv2d_op_depthwise_conv_mlu.py
@@ -21,10 +21,6 @@ sys.path.append("..")
 import paddle
 
 paddle.enable_static()
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from op_test import OpTest
-from paddle.fluid import Program, program_guard
 from test_conv2d_op_mlu import TestConv2DOp, TestConv2DOp_v2, create_test_padding_SAME_class, create_test_padding_VALID_class, create_test_channel_last_class, create_test_fp16_class
 
 #----------------TestDepthwiseConv -----

--- a/python/paddle/fluid/tests/unittests/mlu/test_conv2d_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_conv2d_op_mlu.py
@@ -18,8 +18,6 @@ import sys
 
 sys.path.append("..")
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
 from op_test import OpTest
 
 from test_conv2d_op import conv2d_forward_naive

--- a/python/paddle/fluid/tests/unittests/mlu/test_conv2d_transposed_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_conv2d_transposed_op_mlu.py
@@ -19,7 +19,6 @@ import paddle
 import paddle.nn as nn
 
 paddle.enable_static()
-import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.tests.unittests.op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_cumsum_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_cumsum_op_mlu.py
@@ -16,9 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_deformable_conv_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_deformable_conv_op_mlu.py
@@ -15,8 +15,6 @@
 import paddle
 import unittest
 import numpy as np
-import paddle.fluid.core as core
-import paddle.fluid as fluid
 
 import sys
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_add_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_add_op_mlu.py
@@ -21,7 +21,7 @@ import sys
 sys.path.append('..')
 from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_div_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_div_op_mlu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid.core import ops
 
 paddle.enable_static()
 SEED = 2022

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_min_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_min_op_mlu.py
@@ -20,8 +20,6 @@ sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2022

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_mul_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_mul_op_mlu.py
@@ -17,9 +17,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid import Program, compiler, program_guard
-from paddle.fluid.op import Operator
+from paddle.fluid import Program, program_guard
 
 import sys
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_pow_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_pow_op_mlu.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.fluid as fluid
 import paddle
 
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_sub_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_sub_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest, skip_check_grad_ci
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_exp_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_exp_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/mlu/test_expand_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_expand_v2_op_mlu.py
@@ -19,9 +19,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 import paddle
-from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_fill_constant_batch_size_like_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_fill_constant_batch_size_like_op_mlu.py
@@ -17,12 +17,9 @@ import sys
 sys.path.append("..")
 import paddle
 import paddle.fluid.core as core
-from paddle.static import program_guard, Program
-import paddle.compat as cpt
 import unittest
 import numpy as np
 from op_test import OpTest
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_fill_constant_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_fill_constant_op_mlu.py
@@ -17,14 +17,14 @@ import numpy as np
 import sys
 
 sys.path.append('..')
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest
 
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import numpy as np
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_flatten_contigous_range_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_flatten_contigous_range_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_flatten_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_flatten_op_mlu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_gather_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_gather_op_mlu.py
@@ -17,11 +17,9 @@ import numpy as np
 import sys
 
 sys.path.append('..')
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.framework import core
-from paddle.fluid.dygraph.base import switch_to_static_graph
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_gaussian_random_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_gaussian_random_op_mlu.py
@@ -15,10 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-from paddle.fluid.executor import Executor
 import sys
 
 sys.path.append('..')

--- a/python/paddle/fluid/tests/unittests/mlu/test_grid_sampler_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_grid_sampler_op_mlu.py
@@ -15,7 +15,6 @@
 import paddle
 import unittest
 import numpy as np
-import paddle.fluid.core as core
 import sys
 
 sys.path.append('..')

--- a/python/paddle/fluid/tests/unittests/mlu/test_hard_swish_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_hard_swish_op_mlu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import paddle.nn.functional as F
-import paddle.fluid as fluid
 import paddle
 import sys
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_huber_loss_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_huber_loss_op_mlu.py
@@ -22,7 +22,7 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_iou_similarity_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_iou_similarity_op_mlu.py
@@ -18,7 +18,6 @@ import numpy.random as random
 import sys
 
 sys.path.append("..")
-import math
 import paddle
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_label_smooth_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_label_smooth_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 SEED = 2022
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_log_softmax_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_log_softmax_op_mlu.py
@@ -14,9 +14,8 @@
 
 import unittest
 import numpy as np
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 import paddle.nn.functional as F
 
 np.random.seed(10)

--- a/python/paddle/fluid/tests/unittests/mlu/test_logical_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_logical_op_mlu.py
@@ -15,7 +15,6 @@
 import sys
 
 sys.path.append('..')
-import op_test
 import unittest
 import numpy as np
 import paddle

--- a/python/paddle/fluid/tests/unittests/mlu/test_lookup_table_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_lookup_table_v2_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2022

--- a/python/paddle/fluid/tests/unittests/mlu/test_masked_select_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_masked_select_op_mlu.py
@@ -18,7 +18,6 @@ import sys
 sys.path.append("..")
 import numpy as np
 from op_test import OpTest, skip_check_grad_ci
-import paddle.fluid as fluid
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_matmul_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_matmul_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2022

--- a/python/paddle/fluid/tests/unittests/mlu/test_mean_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_mean_op_mlu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/mlu/test_meshgrid_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_meshgrid_op_mlu.py
@@ -17,11 +17,9 @@ import numpy as np
 import sys
 
 sys.path.append('..')
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 import paddle.fluid as fluid
 import paddle
-from paddle.fluid import compiler, Program, program_guard, core
-from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_momentum_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_momentum_op_mlu.py
@@ -14,8 +14,6 @@
 
 import unittest
 import numpy as np
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import sys
 
 sys.path.append('..')

--- a/python/paddle/fluid/tests/unittests/mlu/test_nearest_interp_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_nearest_interp_v2_op_mlu.py
@@ -18,11 +18,8 @@ import sys
 
 sys.path.append('..')
 from op_test import OpTest
-import paddle.fluid.core as core
 import paddle.fluid as fluid
-import paddle.nn as nn
 import paddle
-from paddle.nn.functional import interpolate
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_one_hot_v2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_one_hot_v2_op_mlu.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import math
 import sys
 
 sys.path.append('..')
@@ -22,8 +21,7 @@ from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-import paddle.fluid.framework as framework
-from paddle.fluid.framework import Program, program_guard, _test_eager_guard
+from paddle.fluid.framework import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_prior_box_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_prior_box_op_mlu.py
@@ -20,7 +20,6 @@ import sys
 sys.path.append('..')
 import numpy as np
 from op_test import OpTest
-import paddle.fluid as fluid
 import paddle
 import math
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_randperm_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_randperm_op_mlu.py
@@ -21,7 +21,6 @@ from op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 from paddle.static import program_guard, Program
-import os
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_reciprocal_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_reciprocal_op_mlu.py
@@ -17,7 +17,7 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_reduce_max_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_reduce_max_op_mlu.py
@@ -17,9 +17,6 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_reduce_mean_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_reduce_mean_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_reduce_min_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_reduce_min_op_mlu.py
@@ -17,9 +17,6 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_reduce_prod_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_reduce_prod_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_reshape2_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_reshape2_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2022

--- a/python/paddle/fluid/tests/unittests/mlu/test_rnn_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_rnn_op_mlu.py
@@ -14,11 +14,7 @@
 
 import unittest
 import numpy as np
-import math
-import paddle.fluid.core as core
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import random
 import sys
 
@@ -26,7 +22,7 @@ sys.path.append('..')
 from op_test import OpTest
 
 sys.path.append("../rnn")
-from rnn_numpy import SimpleRNN, LSTM, GRU
+from rnn_numpy import LSTM
 from convert import get_params_for_net
 
 random.seed(2)

--- a/python/paddle/fluid/tests/unittests/mlu/test_scatter_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_scatter_op_mlu.py
@@ -21,7 +21,6 @@ import os
 import paddle
 import paddle.fluid as fluid
 from op_test import OpTest
-import paddle.fluid.core as core
 from paddle.fluid.dygraph.base import switch_to_static_graph
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_set_value_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_set_value_op_mlu.py
@@ -17,10 +17,7 @@ import unittest
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import core
 
 
 class TestSetValueBase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/mlu/test_sigmoid_cross_entropy_with_logits_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_sigmoid_cross_entropy_with_logits_op_mlu.py
@@ -19,10 +19,7 @@ sys.path.append('..')
 from op_test import OpTest
 from scipy.special import logit
 from scipy.special import expit
-import paddle.fluid.core as core
 import unittest
-from paddle.fluid import compiler, Program, program_guard
-import paddle.fluid as fluid
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_sigmoid_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_sigmoid_op_mlu.py
@@ -14,10 +14,8 @@
 
 import numpy as np
 import unittest
-import sys
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/mlu/test_slice_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_slice_op_mlu.py
@@ -14,13 +14,11 @@
 
 import unittest
 import numpy as np
-import paddle.fluid.core as core
 import sys
 
 sys.path.append('..')
 from op_test import OpTest
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_softmax_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_softmax_op_mlu.py
@@ -18,9 +18,6 @@ import sys
 
 sys.path.append('..')
 from op_test import OpTest
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 import paddle
 import paddle.nn.functional as F
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_split_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_split_op_mlu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/mlu/test_sqrt_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_sqrt_op_mlu.py
@@ -18,11 +18,7 @@ import sys
 
 sys.path.append('..')
 from op_test import OpTest
-import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 import paddle
-import paddle.nn.functional as F
 
 paddle.enable_static()
 np.random.seed(10)

--- a/python/paddle/fluid/tests/unittests/mlu/test_squared_l2_norm_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_squared_l2_norm_op_mlu.py
@@ -20,7 +20,7 @@ import sys
 sys.path.append('..')
 from op_test import OpTest
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _legacy_C_ops
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_squeeze_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_squeeze_op_mlu.py
@@ -20,10 +20,7 @@ sys.path.append("..")
 import numpy as np
 
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 from op_test import OpTest, convert_float_to_uint16
-import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_sum_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_sum_op_mlu.py
@@ -19,8 +19,6 @@ import sys
 sys.path.append("..")
 from op_test import OpTest
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
 
 paddle.enable_static()
 SEED = 2021

--- a/python/paddle/fluid/tests/unittests/mlu/test_sync_batch_norm_base_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_sync_batch_norm_base_mlu.py
@@ -15,15 +15,12 @@
 import numpy as np
 import unittest
 import time
-import argparse
 import os
 import six
 import sys
 
 sys.path.append("..")
 import subprocess
-import traceback
-import functools
 import pickle
 from contextlib import closing
 import paddle.fluid as fluid
@@ -392,7 +389,6 @@ def runtime_main(test_class, col_type, sub_type):
     model.run_trainer(args)
 
 
-import paddle.compat as cpt
 import socket
 from contextlib import closing
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_sync_batch_norm_op_mlu_baseline.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_sync_batch_norm_op_mlu_baseline.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 import paddle
-import os
 import sys
 
 sys.path.append("..")
-from op_test import OpTest, _set_use_system_allocator
+from op_test import _set_use_system_allocator
 
 from test_sync_batch_norm_base_mlu import TestDistBase
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_sync_batch_norm_op_mlu_extra.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_sync_batch_norm_op_mlu_extra.py
@@ -18,9 +18,7 @@ for both FP32 and FP16 input.
 
 import unittest
 import numpy as np
-import os
 import sys
-import six
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
@@ -28,8 +26,6 @@ import paddle.nn as nn
 from paddle.fluid import Program, program_guard
 
 sys.path.append("..")
-from op_test import OpTest, _set_use_system_allocator
-from test_dist_base import TestDistBase
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_tile_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_tile_op_mlu.py
@@ -20,7 +20,7 @@ import numpy as np
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_top_k_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_top_k_op_mlu.py
@@ -19,7 +19,6 @@ import sys
 sys.path.append('..')
 from op_test import OpTest
 import paddle
-import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_transpose_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_transpose_op_mlu.py
@@ -17,11 +17,10 @@ import numpy as np
 import sys
 
 sys.path.append('..')
-from op_test import OpTest, convert_float_to_uint16
+from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-import paddle.fluid.core as core
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_truncated_gaussian_random_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_truncated_gaussian_random_op_mlu.py
@@ -21,8 +21,6 @@ import paddle.fluid.core as core
 import sys
 
 sys.path.append("..")
-from op_test import OpTest
-from paddle.fluid.op import Operator
 from paddle.fluid.executor import Executor
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_uniform_random_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_uniform_random_op_mlu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import sys
-import subprocess
 import unittest
 import numpy as np
 
@@ -23,9 +22,6 @@ import paddle
 import paddle.fluid.core as core
 import paddle
 from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
-from test_uniform_random_op import TestUniformRandomOp, TestUniformRandomOpSelectedRows
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_where_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_where_op_mlu.py
@@ -19,13 +19,9 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
-import paddle.fluid.core as core
 from op_test import OpTest
-from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.op import Operator
+from paddle.fluid import Program, program_guard
 from paddle.fluid.backward import append_backward
-from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_yolo_box_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_yolo_box_op_mlu.py
@@ -20,11 +20,6 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle
-from paddle.fluid import core
-import paddle.fluid as fluid
-from paddle.fluid.op import Operator
-from paddle.fluid.executor import Executor
-from paddle.fluid.framework import _test_eager_guard
 
 paddle.enable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/fluid/tests/unittests/mlu/` 目录 F401(unused import) 存量

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/mlu/
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/7
-  配置文件更新: #46792
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/32
