### PR TITLE
[CodeStyle][F401] update flake8 F401 config (unittests/npu,xpu,mlu,ipu)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,11 @@ exclude =
     # A trick to exclude fluid/ but keep fluid/tests/, see more at
     # https://github.com/PaddlePaddle/Paddle/pull/46290#discussion_r976392010
     ./python/paddle/fluid/[!t]**,
-    ./python/paddle/fluid/tra**
+    ./python/paddle/fluid/tra**,
+    # Exclude auto-generated files
+    *_pb2.py,
+    # Exclude third-party libraries
+    ./python/paddle/utils/gast/**
 ignore =
     # E, see https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
     E121,E122,E123,E125,E126,E127,E128,E129,E131,

--- a/.flake8
+++ b/.flake8
@@ -74,11 +74,7 @@ per-file-ignores =
     python/paddle/fluid/tests/custom_runtime/*:F401
     python/paddle/fluid/tests/unittests/ir/*:F401
     python/paddle/fluid/tests/unittests/tokenizer/*:F401
-    python/paddle/fluid/tests/unittests/xpu/*:F401
     python/paddle/fluid/tests/unittests/distribution/*:F401
-    python/paddle/fluid/tests/unittests/mlu/*:F401
-    python/paddle/fluid/tests/unittests/npu/*:F401
-    python/paddle/fluid/tests/unittests/ipu/*:F401
     python/paddle/fluid/tests/unittests/distributed_passes/*:F401
     python/paddle/fluid/tests/unittests/auto_parallel/*:F401
     python/paddle/fluid/tests/unittests/dygraph_to_static/*:F401

--- a/.flake8
+++ b/.flake8
@@ -9,7 +9,11 @@ exclude =
     # Exclude auto-generated files
     *_pb2.py,
     # Exclude third-party libraries
-    ./python/paddle/utils/gast/**
+    ./python/paddle/utils/gast/**,
+    # Exclude files that will be removed in the future, see more at
+    # https://github.com/PaddlePaddle/Paddle/pull/46782#issuecomment-1273033731
+    ./python/paddle/fluid/tests/unittests/npu/**,
+    ./python/paddle/fluid/tests/unittests/mlu/**
 ignore =
     # E, see https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
     E121,E122,E123,E125,E126,E127,E128,E129,E131,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
-# Exclude all third-party libraries globally
+# Exclude all third-party libraries and auto-generated files globally
 exclude: |
     (?x)^(
         patches/.+|
         paddle/fluid/framework/fleet/heter_ps/cudf/.+|
         paddle/fluid/distributed/ps/thirdparty/round_robin.h|
-        python/paddle/utils/gast/.+
+        python/paddle/utils/gast/.+|
+        .+_py2\.py
     )$
 repos:
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,9 @@ exclude: |
         paddle/fluid/framework/fleet/heter_ps/cudf/.+|
         paddle/fluid/distributed/ps/thirdparty/round_robin.h|
         python/paddle/utils/gast/.+|
-        .+_py2\.py
+        .+_py2\.py|
+        python/paddle/fluid/tests/unittests/npu/.+|
+        python/paddle/fluid/tests/unittests/mlu/.+
     )$
 repos:
 -   repo: https://github.com/Lucas-C/pre-commit-hooks.git


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

修复 F401 unused import 存量 python 代码

- ~~`python/paddle/fluid/tests/npu/`~~
- `python/paddle/fluid/tests/xpu/`
- `python/paddle/fluid/tests/ipu/`
- ~~`python/paddle/fluid/tests/mlu/`~~

NPU 及 MLU 的会在之后从主框架移除（见 https://github.com/PaddlePaddle/Paddle/pull/46782#issuecomment-1273033731 ），因此本 PR 同时将这两个目录在 Flake8 和 pre-commit 的全局 exclude 掉

### Related links

- Flake8 tracking issue: #46039
- F401 project: https://github.com/orgs/cattidea/projects/4
- 需先 merge 以下 PR
    - ~~#46782~~
    - #46783
    - ~~#46790~~
    - #46791