### PR TITLE
[CodeStyle][F401] remove unused imports in unittests/distributed_passes,tokenizer,sequence

### DIFF
--- a/python/paddle/fluid/tests/unittests/distributed_passes/auto_parallel_pass_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/auto_parallel_pass_test_base.py
@@ -14,12 +14,8 @@
 
 import paddle
 import os
-import random
 import sys
 import pickle
-import shlex
-import shutil
-import inspect
 import numpy as np
 from collections import OrderedDict
 from dist_pass_test_base import DistPassTestBase

--- a/python/paddle/fluid/tests/unittests/distributed_passes/dist_pass_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/dist_pass_test_base.py
@@ -23,7 +23,7 @@ import inspect
 import numpy as np
 from collections import OrderedDict
 from paddle.distributed.fleet.launch_utils import run_with_coverage
-from paddle.distributed.passes.pass_base import new_pass, PassBase, PassManager
+from paddle.distributed.passes.pass_base import PassBase, PassManager
 
 
 def prepare_python_path_and_return_module(path):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/pass_run_main.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/pass_run_main.py
@@ -17,7 +17,6 @@ import paddle
 import pickle
 import importlib
 import os
-import sys
 from paddle.distributed.fleet.launch_utils import run_with_coverage
 from dist_pass_test_base import prepare_python_path_and_return_module, DistPassTestBase
 

--- a/python/paddle/fluid/tests/unittests/distributed_passes/ps_pass_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/ps_pass_test_base.py
@@ -16,7 +16,8 @@ import os
 import sys
 import shlex
 import unittest
-from paddle.fluid.tests.unittests.distributed_passes.dist_pass_test_base import prepare_python_path_and_return_module
+from paddle.fluid.tests.unittests.distributed_passes.dist_pass_test_base import (  # noqa: F401
+    prepare_python_path_and_return_module, remove_path_if_exists)
 
 
 class PsPassTestBase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/ps_pass_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/ps_pass_test_base.py
@@ -13,18 +13,10 @@
 # limitations under the License.
 
 import os
-import random
 import sys
-import pickle
 import shlex
-import shutil
-import inspect
 import unittest
-import numpy as np
-from collections import OrderedDict
-from paddle.distributed.ps.utils.public import logger
-from paddle.fluid.tests.unittests.distributed_passes.dist_pass_test_base import prepare_python_path_and_return_module, remove_path_if_exists
-import paddle.distributed.fleet as fleet
+from paddle.fluid.tests.unittests.distributed_passes.dist_pass_test_base import prepare_python_path_and_return_module
 
 
 class PsPassTestBase(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_amp_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_amp_pass.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import random
 import numpy as np
 

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_data_parallel_optimization_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_data_parallel_optimization_pass.py
@@ -18,16 +18,12 @@ import numpy as np
 
 import unittest
 import paddle
-import paddle.nn as nn
 import paddle.distributed.fleet as fleet
-from paddle.distributed.fleet import auto
 from paddle.distributed.auto_parallel.dist_context import get_default_distributed_context
-from paddle.distributed.passes import new_pass, PassManager, PassContext
+from paddle.distributed.passes import PassContext, new_pass
 from auto_parallel_pass_test_base import AutoPallelPassTestBase
 
 sys.path.append("..")
-import auto_parallel_gpt_model as modeling
-from auto_parallel_gpt_model import GPTModel, GPTForPretraining, GPTPretrainingCriterion
 
 
 class TestDataParallelPassWithScale1(AutoPallelPassTestBase):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_fp16_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_fp16_pass.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import random
 import numpy as np
 

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_gradient_merge_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_gradient_merge_pass.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import unittest
 import random
 import numpy as np
-import os
-import shutil
 import logging
 
 import paddle

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_recompute_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_recompute_pass.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import random
 import numpy as np
 
 import unittest
 import paddle
-import paddle.nn as nn
 import paddle.distributed.fleet as fleet
-from paddle.distributed.fleet import auto
-from paddle.distributed.passes import new_pass, PassManager
 from auto_parallel_pass_test_base import AutoPallelPassTestBase
 
 

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_sharding_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_auto_parallel_sharding_pass.py
@@ -18,15 +18,10 @@ import numpy as np
 
 import unittest
 import paddle
-import paddle.nn as nn
 import paddle.distributed.fleet as fleet
-from paddle.distributed.fleet import auto
-from paddle.distributed.passes import new_pass, PassManager
 from auto_parallel_pass_test_base import AutoPallelPassTestBase
 
 sys.path.append("..")
-import auto_parallel_gpt_model as modeling
-from auto_parallel_gpt_model import GPTModel, GPTForPretraining, GPTPretrainingCriterion
 
 
 class TestShardingPass(AutoPallelPassTestBase):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_server_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_server_pass.py
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
-import numpy as np
-import paddle
 from ps_pass_test_base import *
-from paddle.fluid.tests.unittests.ps.ps_dnn_trainer import DnnTrainer
 
 
 class TestPsServerPass(PsPassTestBase):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_server_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_server_pass.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from ps_pass_test_base import *
+from ps_pass_test_base import PsPassTestBase
 
 
 class TestPsServerPass(PsPassTestBase):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_trainer_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_trainer_pass.py
@@ -12,14 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
-import numpy as np
 
-import paddle
 from ps_pass_test_base import *
 from paddle.distributed.ps.utils.public import logger, ps_log_root_dir
-from paddle.fluid.tests.unittests.ps.ps_dnn_trainer import DnnTrainer
 
 
 class TestPsTrainerPass(PsPassTestBase):

--- a/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_trainer_pass.py
+++ b/python/paddle/fluid/tests/unittests/distributed_passes/test_ps_trainer_pass.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from ps_pass_test_base import *
+from ps_pass_test_base import remove_path_if_exists, PsPassTestBase
 from paddle.distributed.ps.utils.public import logger, ps_log_root_dir
 
 

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_first_step.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_first_step.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import paddle.fluid as fluid
-from paddle.fluid.framework import convert_np_dtype_to_dtype_, Program, program_guard
-import paddle.fluid.core as core
+from paddle.fluid.framework import Program, program_guard
 import numpy as np
-import copy
 import unittest
 import sys
 
 sys.path.append("../")
-from op_test import OpTest
 
 
 class TestSequenceFirstStepOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_last_step.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_last_step.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import paddle.fluid as fluid
-from paddle.fluid.framework import convert_np_dtype_to_dtype_, Program, program_guard
-import paddle.fluid.core as core
+from paddle.fluid.framework import Program, program_guard
 import numpy as np
-import copy
 import unittest
 import sys
 
 sys.path.append("../")
-from op_test import OpTest
 
 
 class TestSequenceLastStepOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_mask.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_mask.py
@@ -14,9 +14,7 @@
 
 import paddle.fluid as fluid
 from paddle.fluid.framework import convert_np_dtype_to_dtype_, Program, program_guard
-import paddle.fluid.core as core
 import numpy as np
-import copy
 import unittest
 import sys
 

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_reshape.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_reshape.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import math
 import sys
 
 sys.path.append("../")

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_reverse.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_reverse.py
@@ -14,7 +14,6 @@
 
 import unittest
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 import numpy as np
 import sys
 

--- a/python/paddle/fluid/tests/unittests/tokenizer/bert_tokenizer.py
+++ b/python/paddle/fluid/tests/unittests/tokenizer/bert_tokenizer.py
@@ -13,11 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
-import io
-import json
 import os
-import six
 import unicodedata
 
 from tokenizer_utils import PretrainedTokenizer

--- a/python/paddle/fluid/tests/unittests/tokenizer/tokenizer_utils.py
+++ b/python/paddle/fluid/tests/unittests/tokenizer/tokenizer_utils.py
@@ -20,7 +20,7 @@ import json
 import os
 import unicodedata
 from shutil import copyfile
-from typing import Iterable, Iterator, Optional, List, Any, Callable, Union
+from typing import Optional
 
 from paddle.dataset.common import DATA_HOME
 from paddle.utils.download import get_path_from_url


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/fluid/tests/unittests/distributed_passes/` `python/paddle/fluid/tests/unittests/tokenizer/` `python/paddle/fluid/tests/unittests/sequence/` 目录 F401 unused import 存量 python 代码

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/distributed_passes/
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/tokenizer/
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/sequence/
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/7
-  配置文件更新: #46794
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/40
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/29
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/34