### PR TITLE
[Dy2St]Fix Regex DeprecationWarning in PY3

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -92,7 +92,7 @@ FOR_ITER_VAR_NAME_PREFIX = '__for_loop_iter_var'
 FOR_ITER_ZIP_TO_LIST_PREFIX = '__for_loop_iter_zip'
 
 RE_PYNAME = '[a-zA-Z0-9_]+'
-RE_PYMODULE = '[a-zA-Z0-9_]+\.'
+RE_PYMODULE = r'[a-zA-Z0-9_]+\.'
 
 # FullArgSpec is valid from Python3. Defined a Namedtuple to
 # to make it available in Python2.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dy2St]Fix Regex DeprecationWarning in PY3，like this:

```bash
/workspace/env3.7/lib/python3.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/utils.py:97: DeprecationWarning: invalid escape sequence \.
  RE_PYMODULE = '[a-zA-Z0-9_]+\.'
```