### PR TITLE
Fix set_value failure when source tensor is fp16 Dtype

### DIFF
--- a/paddle/fluid/operators/set_value_op.cc
+++ b/paddle/fluid/operators/set_value_op.cc
@@ -104,7 +104,8 @@ class SetValueMaker : public framework::OpProtoAndCheckerMaker {
                  framework::proto::VarType::INT32,
                  framework::proto::VarType::INT64,
                  framework::proto::VarType::FP32,
-                 framework::proto::VarType::FP64})
+                 framework::proto::VarType::FP64,
+                 framework::proto::VarType::FP16})
         .SetDefault(framework::proto::VarType::FP32);
     AddAttr<std::vector<int64_t>>(
         "axes", "(list<int64_t>) Axes that `starts` and `ends` apply to.");
@@ -134,6 +135,8 @@ class SetValueMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::vector<int64_t>>("int64_values", "Store the int64 values.")
         .SetDefault({});
     AddAttr<std::vector<double>>("fp64_values", "Store the float64 values.")
+        .SetDefault({});
+    AddAttr<std::vector<float>>("fp16_values", "Store the float16 values.")
         .SetDefault({});
 
     AddAttr<std::vector<int64_t>>("shape", "(vector<int64_t>) Shape of values.")

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1217,7 +1217,14 @@ static PyObject* tensor_method__setitem_eager_tensor(TensorObject* self,
         } else if (self->tensor.dtype() ==
                    paddle::experimental::DataType::BOOL) {
           attrs["bool_values"] = std::vector<int>{value_obj_tmp.cast<bool>()};
+        } else if (self->tensor.dtype() ==
+                   paddle::experimental::DataType::FLOAT16) {
+          std::cout << "yes here is fp16 branch" << std::endl;
+          attrs["fp16_values"] =
+              std::vector<float>{value_obj_tmp.cast<float>()};
         } else {
+          std::cout << "the type of this tensor is: " << self->tensor.dtype()
+                    << std::endl;
           PADDLE_THROW(platform::errors::InvalidArgument(
               "When assign a value to a paddle.Tensor, "
               "the data type of the paddle.Tensor must be bool, "

--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1219,16 +1219,13 @@ static PyObject* tensor_method__setitem_eager_tensor(TensorObject* self,
           attrs["bool_values"] = std::vector<int>{value_obj_tmp.cast<bool>()};
         } else if (self->tensor.dtype() ==
                    paddle::experimental::DataType::FLOAT16) {
-          std::cout << "yes here is fp16 branch" << std::endl;
           attrs["fp16_values"] =
               std::vector<float>{value_obj_tmp.cast<float>()};
         } else {
-          std::cout << "the type of this tensor is: " << self->tensor.dtype()
-                    << std::endl;
           PADDLE_THROW(platform::errors::InvalidArgument(
               "When assign a value to a paddle.Tensor, "
               "the data type of the paddle.Tensor must be bool, "
-              "float32, int32 or int64, "
+              "float32, int32, int64 or float16, "
               "please check the type of tensor."));
         }
         attrs["shape"] = std::vector<int64_t>{1};

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -964,11 +964,15 @@ void BindImperative(py::module *m_ptr) {
                              framework::proto::VarType::BOOL) {
                     attrs["bool_values"] =
                         std::vector<int>{value_obj.cast<bool>()};
+                  } else if (self->DataType() ==
+                             framework::proto::VarType::FP16) {
+                    attrs["fp16_values"] =
+                        std::vector<float>{value_obj.cast<float>()};
                   } else {
                     PADDLE_THROW(platform::errors::InvalidArgument(
                         "When assign a value to a paddle.Tensor, "
                         "the data type of the paddle.Tensor must be bool, "
-                        "float32, int32 or int64, "
+                        "float32, int32, int64 or float16, "
                         "please check the type of tensor."));
                   }
                   attrs["shape"] = std::vector<int64_t>{1};

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -98,6 +98,7 @@ void FlipKernel(const Context& dev_ctx,
   const size_t total_dims = x.dims().size();
   switch (total_dims) {
     case 1:
+<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -123,6 +124,33 @@ void FlipKernel(const Context& dev_ctx,
       break;
     case 9:
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
+=======
+      launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
+      break;
+    case 2:
+      launch_flip_cuda_kernel<T, Context, 2>(dev_ctx, x, axis, out);
+      break;
+    case 3:
+      launch_flip_cuda_kernel<T, Context, 3>(dev_ctx, x, axis, out);
+      break;
+    case 4:
+      launch_flip_cuda_kernel<T, Context, 4>(dev_ctx, x, axis, out);
+      break;
+    case 5:
+      launch_flip_cuda_kernel<T, Context, 5>(dev_ctx, x, axis, out);
+      break;
+    case 6:
+      launch_flip_cuda_kernel<T, Context, 6>(dev_ctx, x, axis, out);
+      break;
+    case 7:
+      launch_flip_cuda_kernel<T, Context, 7>(dev_ctx, x, axis, out);
+      break;
+    case 8:
+      launch_flip_cuda_kernel<T, Context, 8>(dev_ctx, x, axis, out);
+      break;
+    case 9:
+      launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
+>>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -58,8 +58,17 @@ void LaunchFlipCudaKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const std::vector<int>& axis,
                           DenseTensor* out) {
+<<<<<<< HEAD
 
   std::vector<int> flip_dims_v = axis;
+=======
+  auto* in_data = x.data<T>();
+  auto* out_data = dev_ctx.template Alloc<T>(out);
+
+  auto x_dims = x.dims();
+  const int total_dims = x_dims.size();
+  const int64_t numel = x.numel();
+>>>>>>> fix extra flip_dims_v
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   auto x_stride = phi::stride(x_dims);
 
@@ -98,8 +107,6 @@ void FlipKernel(const Context& dev_ctx,
   const size_t total_dims = x.dims().size();
   switch (total_dims) {
     case 1:
-<<<<<<< HEAD
-<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -125,40 +132,6 @@ void FlipKernel(const Context& dev_ctx,
       break;
     case 9:
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
-=======
-      launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
-=======
-      LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
->>>>>>> fix function name
-      break;
-    case 2:
-      LaunchFlipCudaKernel<T, Context, 2>(dev_ctx, x, axis, out);
-      break;
-    case 3:
-      LaunchFlipCudaKernel<T, Context, 3>(dev_ctx, x, axis, out);
-      break;
-    case 4:
-      LaunchFlipCudaKernel<T, Context, 4>(dev_ctx, x, axis, out);
-      break;
-    case 5:
-      LaunchFlipCudaKernel<T, Context, 5>(dev_ctx, x, axis, out);
-      break;
-    case 6:
-      LaunchFlipCudaKernel<T, Context, 6>(dev_ctx, x, axis, out);
-      break;
-    case 7:
-      LaunchFlipCudaKernel<T, Context, 7>(dev_ctx, x, axis, out);
-      break;
-    case 8:
-      LaunchFlipCudaKernel<T, Context, 8>(dev_ctx, x, axis, out);
-      break;
-    case 9:
-<<<<<<< HEAD
-      launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
->>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
-=======
-      LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
->>>>>>> fix function name
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -99,6 +99,7 @@ void FlipKernel(const Context& dev_ctx,
   switch (total_dims) {
     case 1:
 <<<<<<< HEAD
+<<<<<<< HEAD
       LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
       break;
     case 2:
@@ -126,31 +127,38 @@ void FlipKernel(const Context& dev_ctx,
       LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
 =======
       launch_flip_cuda_kernel<T, Context, 1>(dev_ctx, x, axis, out);
+=======
+      LaunchFlipCudaKernel<T, Context, 1>(dev_ctx, x, axis, out);
+>>>>>>> fix function name
       break;
     case 2:
-      launch_flip_cuda_kernel<T, Context, 2>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 2>(dev_ctx, x, axis, out);
       break;
     case 3:
-      launch_flip_cuda_kernel<T, Context, 3>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 3>(dev_ctx, x, axis, out);
       break;
     case 4:
-      launch_flip_cuda_kernel<T, Context, 4>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 4>(dev_ctx, x, axis, out);
       break;
     case 5:
-      launch_flip_cuda_kernel<T, Context, 5>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 5>(dev_ctx, x, axis, out);
       break;
     case 6:
-      launch_flip_cuda_kernel<T, Context, 6>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 6>(dev_ctx, x, axis, out);
       break;
     case 7:
-      launch_flip_cuda_kernel<T, Context, 7>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 7>(dev_ctx, x, axis, out);
       break;
     case 8:
-      launch_flip_cuda_kernel<T, Context, 8>(dev_ctx, x, axis, out);
+      LaunchFlipCudaKernel<T, Context, 8>(dev_ctx, x, axis, out);
       break;
     case 9:
+<<<<<<< HEAD
       launch_flip_cuda_kernel<T, Context, 9>(dev_ctx, x, axis, out);
 >>>>>>> Optimize flip kernel by eliminating H2D data transfer, test=develop
+=======
+      LaunchFlipCudaKernel<T, Context, 9>(dev_ctx, x, axis, out);
+>>>>>>> fix function name
       break;
     default:
       PADDLE_THROW(phi::errors::InvalidArgument(

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -58,12 +58,8 @@ void LaunchFlipCudaKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const std::vector<int>& axis,
                           DenseTensor* out) {
-  auto* in_data = x.data<T>();
-  auto* out_data = dev_ctx.template Alloc<T>(out);
 
-  auto x_dims = x.dims();
-  const int total_dims = x_dims.size();
-  const int64_t numel = x.numel();
+  std::vector<int> flip_dims_v = axis;
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   auto x_stride = phi::stride(x_dims);
 

--- a/paddle/phi/kernels/gpu/flip_kernel.cu
+++ b/paddle/phi/kernels/gpu/flip_kernel.cu
@@ -58,17 +58,12 @@ void LaunchFlipCudaKernel(const Context& dev_ctx,
                           const DenseTensor& x,
                           const std::vector<int>& axis,
                           DenseTensor* out) {
-<<<<<<< HEAD
-
-  std::vector<int> flip_dims_v = axis;
-=======
   auto* in_data = x.data<T>();
   auto* out_data = dev_ctx.template Alloc<T>(out);
 
   auto x_dims = x.dims();
   const int total_dims = x_dims.size();
   const int64_t numel = x.numel();
->>>>>>> fix extra flip_dims_v
   auto config = phi::backends::gpu::GetGpuLaunchConfig1D(dev_ctx, numel);
   auto x_stride = phi::stride(x_dims);
 

--- a/paddle/phi/ops/compat/set_value_sig.cc
+++ b/paddle/phi/ops/compat/set_value_sig.cc
@@ -724,6 +724,19 @@ KernelSignature SetValueOpArgumentMapping(const ArgumentMappingContext& ctx) {
                                     "shape",
                                     "bool_values"},
                                    {"Out"});
+          } else if (ctx.HasAttr("fp16_values")) {
+            // NOTE(LiuYang):Here any_cast doesn't support fp16 values.
+            return KernelSignature("set_value",
+                                   {"Input"},
+                                   {"starts",
+                                    "ends",
+                                    "steps",
+                                    "axes",
+                                    "decrease_axes",
+                                    "none_axes",
+                                    "shape",
+                                    "fp16_values"},
+                                   {"Out"});
           }
         }
       }

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -574,6 +574,28 @@ create_test_value_int64(TestSetValueItemSlice3)
 create_test_value_int64(TestSetValueItemSlice4)
 
 
+def create_test_value_fp16(parent):
+
+    class TestValueInt(parent):
+
+        def set_value(self):
+            self.value = 3.7
+
+        def set_dtype(self):
+            self.dtype = "float16"
+
+    cls_name = "{0}_{1}".format(parent.__name__, "Valuefp16")
+    TestValueInt.__name__ = cls_name
+    globals()[cls_name] = TestValueInt
+
+
+create_test_value_fp16(TestSetValueItemInt)
+create_test_value_fp16(TestSetValueItemSlice)
+create_test_value_fp16(TestSetValueItemSlice2)
+create_test_value_fp16(TestSetValueItemSlice3)
+create_test_value_fp16(TestSetValueItemSlice4)
+
+
 def create_test_value_fp32(parent):
 
     class TestValueInt(parent):
@@ -1013,7 +1035,6 @@ class TestError(TestSetValueBase):
         paddle.enable_static()
         with paddle.static.program_guard(self.program):
             self._value_type_error()
-            self._dtype_error()
             self._step_error()
             self._bool_list_error()
             self._bool_tensor_error()

--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -730,10 +730,13 @@ def _setitem_impl_(var, item, value):
         elif dtype == core.VarDesc.VarType.INT64:
             value_name = "int64_values"
             values = [int(v) for v in value.flat]
+        elif dtype == core.VarDesc.VarType.FP16:
+            value_name = "fp16_values"
+            values = [float(v) for v in value.flat]
         else:
             raise TypeError(
                 "When assign a numpy.ndarray, integer or float to a paddle.Tensor, "
-                "the data type of the paddle.Tensor must be bool, float32, int32 or int64, but "
+                "the data type of the paddle.Tensor must be bool, float32, int32, int64 or float16, but "
                 "received %s." % convert_dtype(dtype))
         attrs[value_name] = values
         attrs["shape"] = shape


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix set_value failure when source tensor is fp16 Dtype and destiny value is a number
