### PR TITLE
[Fix Typo] Fix typo errors

### DIFF
--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -780,13 +780,13 @@ class MatMulOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::vector<int>>(
         "fused_reshape_Out",
         R"DOC(When MKLDNN MatMul_transpose_reshape fuse activated, "
-              "it's a shape atribute of fused reshape for `Out` output.)DOC")
+              "it's a shape attribute of fused reshape for `Out` output.)DOC")
         .SetDefault({})
         .AsExtra();
     AddAttr<std::vector<int>>(
         "fused_transpose_Out",
         R"DOC(When MKLDNN MatMul_transpose_reshape fuse activated, "
-              "it's a axis atribute of fused transpose for `Out` output.)DOC")
+              "it's a axis attribute of fused transpose for `Out` output.)DOC")
         .SetDefault({})
         .AsExtra();
     AddAttr<bool>(

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -538,7 +538,7 @@ def add(x, y, name=None):
     For case 2:
 
     1. Broadcast $Y$ to match the shape of $X$, where axis is the start dimension index for broadcasting $Y$ onto $X$.
-    2. If $axis$ is -1 (default), $axis$=rank($X$)−rank($Y$).
+    2. If $axis$ is -1 (default), $axis$=rank($X$)-rank($Y$).
     3. The trailing dimensions of size 1 for $Y$ will be ignored for the consideration of subsequence, such as shape($Y$) = (2, 1) => (2).
 
         For example:
@@ -558,7 +558,7 @@ def add(x, y, name=None):
         name (string, optional): For details, please refer to :ref:`api_guide_Name`. Generally, no setting is required. Default: None.
 
     Returns:
-        N-D Tensor. A location into which the result is stored. It’s dimension equals with x.
+        N-D Tensor. A location into which the result is stored. It's dimension equals with x.
 
     Examples:
 


### PR DESCRIPTION
### PR types
Others

### PR changes
Docs

### Describe
Fix typo errors

The error message of math.py: 
- `The character U+2212 "−" could be confused with the character U+002d "-", which is more common in source code.`
- ```The character U+2019 "’" could be confused with the character U+0060 "`", which is more common in source code.```