### PR TITLE
[inference][trt] reshape do not support ShapeTesnor Input using dynamic shape mode

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1744,16 +1744,16 @@ struct SimpleOpTypeSetTeller : public Teller {
     }
 
     if (op_type == "reshape" || op_type == "reshape2") {
-      if (with_dynamic_shape) {
-        return true;
-      }
       if (!desc.HasAttr("shape")) {
         return false;
       }
-      // Paddle-TRT does not support the input tensors: Shape and ShapeTensor
+      // Static shape mode does not support the input tensors: Shape and
+      // ShapeTensor.
+      // Dynamic shape mode does not support the input tensor:
+      // ShapeTensor
       auto reshape_inputs = desc.Inputs();
       if (reshape_inputs.find("Shape") != reshape_inputs.end()) {
-        if (desc.Input("Shape").size() >= 1) {
+        if (!with_dynamic_shape && desc.Input("Shape").size() >= 1) {
           return false;
         }
       }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- reshape do not support ShapeTesnor Input using dynamic shape mode
<img width="710" alt="image" src="https://user-images.githubusercontent.com/1312389/194757223-e5dfd8b8-1902-462a-8cfe-f27e917001bf.png">
