### PR TITLE
Fix A10 inference test : trt_resnet50_test

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -1262,7 +1262,7 @@ cc_test(
 if(WITH_GPU AND TENSORRT_FOUND)
   set_tests_properties(trt_resnext_test PROPERTIES TIMEOUT 300)
   set_tests_properties(trt_quant_int8_yolov3_r50_test PROPERTIES TIMEOUT 300)
-  set_tests_properties(trt_resnet50_test PROPERTIES TIMEOUT 300)
+  set_tests_properties(trt_resnet50_test PROPERTIES TIMEOUT 500)
   set_tests_properties(trt_cascade_rcnn_test PROPERTIES TIMEOUT 300)
   set_tests_properties(test_trt_dynamic_shape_ernie_ser_deser PROPERTIES TIMEOUT
                                                                          300)

--- a/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
@@ -22,6 +22,7 @@ namespace paddle {
 namespace inference {
 
 TEST(resnet50, compare_continuous_input) {
+  setenv("NVIDIA_TF32_OVERRIDE", "0", 1);
   std::string model_dir = FLAGS_infer_model + "/resnet50";
   compare_continuous_input(model_dir, /* use_tensorrt */ true);
 }

--- a/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
@@ -22,7 +22,9 @@ namespace paddle {
 namespace inference {
 
 TEST(resnet50, compare_continuous_input) {
+#if !defined(_WIN32)
   setenv("NVIDIA_TF32_OVERRIDE", "0", 1);
+#endif
   std::string model_dir = FLAGS_infer_model + "/resnet50";
   compare_continuous_input(model_dir, /* use_tensorrt */ true);
 }

--- a/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
@@ -22,11 +22,9 @@ namespace paddle {
 namespace inference {
 
 TEST(resnet50, compare_continuous_input) {
-  
 #if !defined(_WIN32) 
   setenv("NVIDIA_TF32_OVERRIDE", "0", 1);
 #endif
-
   std::string model_dir = FLAGS_infer_model + "/resnet50";
   compare_continuous_input(model_dir, /* use_tensorrt */ true);
 }

--- a/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
@@ -22,9 +22,11 @@ namespace paddle {
 namespace inference {
 
 TEST(resnet50, compare_continuous_input) {
-#if !defined(_WIN32)
+  
+#if !defined(_WIN32) 
   setenv("NVIDIA_TF32_OVERRIDE", "0", 1);
 #endif
+
   std::string model_dir = FLAGS_infer_model + "/resnet50";
   compare_continuous_input(model_dir, /* use_tensorrt */ true);
 }

--- a/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_resnet50_test.cc
@@ -22,11 +22,9 @@ namespace paddle {
 namespace inference {
 
 TEST(resnet50, compare_continuous_input) {
-  
-#if !defined(_WIN32) 
+#if !defined(_WIN32)
   setenv("NVIDIA_TF32_OVERRIDE", "0", 1);
 #endif
-
   std::string model_dir = FLAGS_infer_model + "/resnet50";
   compare_continuous_input(model_dir, /* use_tensorrt */ true);
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix A10 inference test : trt_resnet50_test by add env: NVIDIA_TF32_OVERRIDE=0