### PR TITLE
Fix A10 inference test : trt_quant_int8_yolov3_r50_test

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -1261,7 +1261,7 @@ cc_test(
 
 if(WITH_GPU AND TENSORRT_FOUND)
   set_tests_properties(trt_resnext_test PROPERTIES TIMEOUT 300)
-  set_tests_properties(trt_quant_int8_yolov3_r50_test PROPERTIES TIMEOUT 300)
+  set_tests_properties(trt_quant_int8_yolov3_r50_test PROPERTIES TIMEOUT 400)
   set_tests_properties(trt_resnet50_test PROPERTIES TIMEOUT 300)
   set_tests_properties(trt_cascade_rcnn_test PROPERTIES TIMEOUT 300)
   set_tests_properties(test_trt_dynamic_shape_ernie_ser_deser PROPERTIES TIMEOUT


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix A10 inference test : trt_quant_int8_yolov3_r50_test by modifying timeout limitation