### PR TITLE
Fix ssl symbol not found with distributed on in higher gcc

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -96,7 +96,7 @@ if(NOT APPLE AND NOT WIN32)
   link_libraries(${CMAKE_THREAD_LIBS_INIT})
   if(WITH_PSLIB OR WITH_DISTRIBUTE)
     set(CMAKE_CXX_LINK_EXECUTABLE
-        "${CMAKE_CXX_LINK_EXECUTABLE} -pthread -ldl -lrt -lz -lssl")
+        "${CMAKE_CXX_LINK_EXECUTABLE} -pthread -ldl -lrt -lz -lssl -lcrypto")
   else()
     set(CMAKE_CXX_LINK_EXECUTABLE
         "${CMAKE_CXX_LINK_EXECUTABLE} -pthread -ldl -lrt")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
在高版本gcc（大于8.2）下编译分布式的Paddle，链接时报错：
![7d6254bfd31f269e04e9ad73ae0c6b79](https://user-images.githubusercontent.com/63526175/194810377-863e8b25-9a97-4d60-aaec-20e4f499822b.png)

缺少的符号在crypto中实现，generic.cmake中仅添加ssl，缺少对crypto的依赖。而且generic.cmake中定义的依赖在编译时会放在最后，即使在生成paddle_inference动态链接库时正确的依赖了ssl和crypto，在高版本的gcc下会覆盖，导致因为找不到对应符号链接报错。