### PR TITLE
[Eager] fix windows overflow error

### DIFF
--- a/paddle/fluid/pybind/eager_math_op_patch.cc
+++ b/paddle/fluid/pybind/eager_math_op_patch.cc
@@ -178,7 +178,7 @@ static PyObject* tensor__add__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other = CastPyArg2AttrFloat(other_obj, 0);
     }
 
     {
@@ -276,7 +276,7 @@ static PyObject* tensor__sub__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other = CastPyArg2AttrFloat(other_obj, 0);
     }
     {
       eager_gil_scoped_release guard;
@@ -369,7 +369,7 @@ static PyObject* tensor__rsub__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other = CastPyArg2AttrFloat(other_obj, 0);
     }
     {
       eager_gil_scoped_release guard;
@@ -464,7 +464,7 @@ static PyObject* tensor__mul__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other = CastPyArg2AttrFloat(other_obj, 0);
     }
     {
       eager_gil_scoped_release guard;
@@ -560,7 +560,7 @@ static PyObject* tensor__div__method(TensorObject* self,
     if (PyFloat_Check(other_obj)) {
       other = CastPyArg2AttrFloat(other_obj, 0);
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other = CastPyArg2AttrFloat(other_obj, 0);
     }
     if (_supported_int_dtype_.find(self_tensor.dtype()) !=
         _supported_int_dtype_.end()) {
@@ -673,7 +673,7 @@ static PyObject* tensor__rdiv__method(TensorObject* self,
       other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other_float = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     }
     if (_supported_int_dtype_.find(self_tensor.dtype()) !=
@@ -791,7 +791,7 @@ static PyObject* tensor__gt__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other_float = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     }
   }
@@ -876,7 +876,7 @@ static PyObject* tensor__ge__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other_float = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     }
   }
@@ -962,7 +962,7 @@ static PyObject* tensor__mod__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other_float = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     }
   }
@@ -1047,7 +1047,7 @@ static PyObject* tensor__matmul__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other_float = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     }
   }
@@ -1147,7 +1147,7 @@ static PyObject* tensor__lt__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other_float = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     }
   }
@@ -1232,7 +1232,7 @@ static PyObject* tensor__le__method(TensorObject* self,
         self_tensor = cast_ad_func(self_tensor, DataType::FLOAT32);
       }
     } else if (PyCheckInteger(other_obj) || IsNumpyType(other_obj)) {
-      other_float = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));
+      other_float = CastPyArg2AttrFloat(other_obj, 0);
       has_other_float = true;
     }
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
**Bug fixes --- 修复PaddleSeg模型报错问题**


Linux 机器
int, long, long long, sizeof 分别是 4 8 8

Windows 机器
int, long, long long, sizeof 分别是 4 4 8


原代码：
`other = static_cast<float>(CastPyArg2AttrInt(other_obj, 0));`


在 windows 机器下，PyLong_AsLong 接收 8 字节的数据会 overflow
```
int CastPyArg2AttrInt(PyObject* obj, ssize_t arg_pos) {
  if (PyObject_CheckLongOrConvertToLong(&obj)) {
    return static_cast<int>(PyLong_AsLong(obj)); // overflow 发生的地方
  } else {
    PADDLE_THROW(platform::errors::InvalidArgument(
        "argument (position %d) must be "
        "int, but got %s",
        arg_pos + 1,
        (reinterpret_cast<PyTypeObject*>(obj->ob_type))->tp_name));
  }
}
```

现代码：
`other = CastPyArg2AttrFloat(other_obj, 0);`
内部返回 static_cast< float >(PyFloat_AsDouble(obj));  可以避免因接收 8 字节数据导致的 overflow 问题