### PR TITLE
[Del Old Dygraph] disable _in_legacy_dygraph

### DIFF
--- a/python/paddle/fluid/dygraph/tracer.py
+++ b/python/paddle/fluid/dygraph/tracer.py
@@ -298,7 +298,7 @@ class Tracer(core.Tracer):
                  attrs,
                  stop_gradient=False,
                  inplace_map=None):
-        if not framework._in_legacy_dygraph():
+        if not framework._in_legacy_dygraph2():
             # inputs : {"sum": [tensor], ...}
             # outputs : {"sum": [tensor], ...}
             if type in name_mapping.keys():

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -234,7 +234,7 @@ def in_dygraph_mode():
 
 
 def _in_legacy_dygraph():
-    return (not _in_eager_mode_) and (_dygraph_tracer_ is not None)
+    return False
 
 
 def _non_static_mode():

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -237,6 +237,10 @@ def _in_legacy_dygraph():
     return False
 
 
+def _in_legacy_dygraph2():
+    return (not _in_eager_mode_) and (_dygraph_tracer_ is not None)
+
+
 def _non_static_mode():
     return _dygraph_tracer_ is not None
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -255,8 +255,9 @@ def _test_eager_guard(place=None):
     try:
         yield
     finally:
-        if not already_fallback:
-            _enable_legacy_dygraph()
+        pass
+        # if not already_fallback:
+        #     _enable_legacy_dygraph()
 
 
 global_ipu_index = -1

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -30,7 +30,7 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid.framework import _dygraph_tracer
 import paddle.fluid.core as core
-from paddle.fluid.framework import _in_legacy_dygraph, _enable_legacy_dygraph, _in_eager_without_dygraph_check, _disable_legacy_dygraph
+from paddle.fluid.framework import _in_legacy_dygraph2, _enable_legacy_dygraph, _in_eager_without_dygraph_check, _disable_legacy_dygraph
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.backward import append_backward
 from paddle.fluid.op import Operator
@@ -653,7 +653,7 @@ class OpTest(unittest.TestCase):
 
                 if if_return_inputs_grad_dict:
                     v.stop_gradient = False
-                    if not _in_legacy_dygraph():
+                    if not _in_legacy_dygraph2():
                         v.retain_grads()
 
                 if has_lod:
@@ -2180,7 +2180,7 @@ class OpTest(unittest.TestCase):
                 for no_grad_val in no_grad_set:
                     del (inputs[no_grad_val])
 
-                if not _in_legacy_dygraph():
+                if not _in_legacy_dygraph2():
                     core.eager.run_backward(fluid.layers.utils.flatten(outputs),
                                             grad_outputs, False)
                     grad_inputs = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
1. 将_in_legacy_dygraph永久返回False，以测试会挂多少单测
2. 删除_test_eager_guard中finally的_enable_legacy_dygraph