### PR TITLE
[Dy2St]Remove usless cast operation to speed up FP16 training

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -598,16 +598,6 @@ class PartialProgramLayer:
                         == paddle.float16):
                     in_vars[i] = var.astype('float16')
                     in_vars[i].name = name
-                if (self.forward_program.global_block().has_var(name)
-                        and self.forward_program.global_block().var(name).dtype
-                        == paddle.float16):
-                    in_vars[i] = var.astype('float16')
-                    in_vars[i].name = name
-                if (self.backward_program.global_block().has_var(name)
-                        and self.backward_program.global_block().var(name).dtype
-                        == paddle.float16):
-                    in_vars[i] = var.astype('float16')
-                    in_vars[i].name = name
 
     @property
     def program(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dy2St]Remove usless cast operation to speed up FP16 training