### PR TITLE
[cherry-pick] [PHI] gaussian_random kernel fix accuracy drop (#46747)

### DIFF
--- a/paddle/phi/kernels/onednn/gaussian_random_kernel.cc
+++ b/paddle/phi/kernels/onednn/gaussian_random_kernel.cc
@@ -28,8 +28,13 @@ void GaussianRandomKernel(const Context& ctx,
                           DataType dtype,
                           DenseTensor* out) {
   std::normal_distribution<T> dist(mean, std);
-  auto engine = std::make_shared<std::mt19937_64>();
-  engine->seed(seed);
+  std::shared_ptr<std::mt19937_64> engine;
+  if (seed) {
+    engine = std::make_shared<std::mt19937_64>();
+    engine->seed(seed);
+  } else {
+    engine = ctx.GetGenerator()->GetCPUEngine();
+  }
 
   T* data = ctx.template Alloc<T>(out);
   for (int64_t i = 0; i < out->numel(); ++i) {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
During PHI migration `framework::GetCPURandomEngine()` was removed. In PR https://github.com/PaddlePaddle/Paddle/pull/45481 I didn't add extra seed check to generator, which resulted in accuracy drop in hapi_mnist_bf16_static.py.

This PR adds seed check and restores desired accuracy
