### PR TITLE
remove all control_vars in IR graph

### DIFF
--- a/paddle/fluid/framework/ir/graph.cc
+++ b/paddle/fluid/framework/ir/graph.cc
@@ -75,7 +75,6 @@ Graph::Graph(const ProgramDesc &program,
     }
   } else {
     auto var_nodes = InitFromProgram(program_, start_op_index, end_op_index);
-    ResolveHazard(var_nodes);
   }
 }
 
@@ -88,7 +87,6 @@ Graph::Graph(const BlockDesc &block,
              const int64_t end_op_index)
     : main_graph_(main_graph) {
   auto var_nodes = InitFromBlock(block, start_op_index, end_op_index);
-  ResolveHazard(var_nodes);
 }
 
 // TODO(levi): delete this interface after when we can convert all

--- a/paddle/fluid/framework/ir/multi_batch_merge_pass.cc
+++ b/paddle/fluid/framework/ir/multi_batch_merge_pass.cc
@@ -331,8 +331,6 @@ void BatchMergePass::ApplyImpl(ir::Graph* graph) const {
       copy_node(node);
     }
   }
-
-  result.ResolveHazard(created);
 }
 
 }  // namespace ir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
### PR changes
Others

### Describe
去掉 IR 中增加 control_var 的逻辑。

本pr主要改动如下：

`改动1：删除 graph::InitFromBlock 函数中容易使人误解的代码和注释`

在 `graph::InitFromBlock` 函数中有这么一段话：
```cpp
PADDLE_ENFORCE_EQ(out_arg_set.count(each_var_name),
                          0,
                          platform::errors::InvalidArgument(
                              "The input Program is invalid. Variable %s occurs"
                              " in output of %s multiple times.",
                              each_var_name,
                              op->Type()));
```
给人的感觉就是如果模型中存在一个变量被多次写入，这个模型就是不合法的，会报错。但是其实不是，仔细阅读这个函数的实现就会发现：这部分只是检测一个Op中不允许出现两个同名输出变量。所以这段检测代码没有作用，而且容易给阅读者带来误解。

`改动2：去掉 Graph::ResolveHazard() 的调用`
本pr未删除该函数，但inference不再使用该函数。
该函数的目的是使得一些同名节点之间保持正确的执行顺序。

<img width="1046" alt="image" src="https://user-images.githubusercontent.com/63448337/195002982-9bc2e9c6-2e57-4e6c-a459-4d73927a9102.png">

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/63448337/195003015-2646f64d-6c14-4898-a85a-7eb6aab7eb2a.png">

<img width="1057" alt="image" src="https://user-images.githubusercontent.com/63448337/195005393-2b13e735-1164-486f-9f40-ea23c70622cb.png">

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/63448337/195003048-2fe12e40-5c86-4f8c-84a3-8f593e1d9c44.png">

这可能是一种保证正确执行顺序的处理方式，但是引入了一些的 contol_var 来保证算子之间的依赖关系，这会使得某些 op 的输入或者输出多一个变量，影响 pass 中的匹配逻辑。

框架中实际并不需要通过这种方式保证执行顺序，而是通过 op 自带的执行顺序来保证（根据创建 op node的顺序，在拓扑排序中做一些改动，可参考[推理时如何保证正确的执行顺序](https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/pKzJfZczuc/EqFijKS5fU/LNKjesZGk_qCD5)）。真是因为框架中有其他方式保证了执行顺序，所以`ir_graph_clean_pass`中去掉`ir_graph_build_pass`中构建 IR 时增加的所有的 control_var 变量。

我猜测是后面的开发人员通过另一种方式保证了执行顺序后，想删掉 control_var b变量，但是没找到这些变量是在哪里创建的，所以特意写了一个 pass 来删除 control_var 变量。因此 该pr顺利合入之后，`ir_graph_clean_pass`可以删除

`其他改动`
修改影响的单测：TEST(GraphTest, WriteAfterRead) ，TEST(GraphTest, WriteAfterWrite)， 删除了增加 control_var 变量的逻辑后，不再需要这两个单测

修改TEST(GraphTest, TestMultiBlock)单测中的模型表示和相关断言。