### PR TITLE
[CodeStyle][py2] remove future import in docstring

### DIFF
--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -474,8 +474,6 @@ def spawn(func, args=(), nprocs=-1, join=True, daemon=False, **options):
     Examples:
         .. code-block:: python
 
-            from __future__ import print_function
-
             import paddle
             import paddle.nn as nn
             import paddle.optimizer as opt


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

一个在 docstring 里的 future import，但该示例代码无法运行

### Related links

- Legacy python2 tracking issue: #46837
