### PR TITLE
[CodeStyle][F401] remove unused imports in unittests/mkldnn

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_bf16_mkldnn_op.py
@@ -16,9 +16,9 @@ import six
 import abc
 import unittest
 import numpy as np
-from scipy.special import expit, erf
+from scipy.special import erf
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import OpTestTool, convert_float_to_uint16
 from paddle.fluid.tests.unittests.test_activation_op import TestActivation
 from paddle.fluid.tests.unittests.test_gelu_op import gelu
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
@@ -14,9 +14,9 @@
 
 import unittest
 import numpy as np
-from scipy.special import expit, erf
+from scipy.special import expit
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, convert_float_to_uint16, skip_check_grad_ci
+from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 from paddle.fluid.tests.unittests.test_activation_op import TestActivation, TestRelu, TestTanh, TestSqrt, TestAbs, TestLeakyRelu, TestSwish, TestHardSwish, TestRelu6, TestSigmoid
 from paddle.fluid.tests.unittests.test_gelu_op import gelu
 from mkldnn_op_test import check_if_mkldnn_primitives_exist_in_bwd

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_batch_norm_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_batch_norm_mkldnn_op.py
@@ -15,10 +15,7 @@
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
-from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
-from paddle.fluid.framework import grad_var_name
+from paddle.fluid.tests.unittests.op_test import _set_use_system_allocator
 from paddle.fluid.tests.unittests.test_batch_norm_op import TestBatchNormOpInference, TestBatchNormOpTraining, _reference_training, _reference_grad
 from mkldnn_op_test import check_if_mkldnn_batchnorm_primitives_exist_in_bwd
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_mkldnn_op.py
@@ -15,9 +15,6 @@
 import unittest
 import numpy as np
 import math
-import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
 from paddle.fluid.tests.unittests.op_test import OpTest
 from paddle.fluid.tests.unittests.op_test import skip_check_grad_ci
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_v2_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_bilinear_interp_v2_mkldnn_op.py
@@ -15,9 +15,6 @@
 import unittest
 import numpy as np
 import math
-import paddle
-import paddle.fluid.core as core
-import paddle.fluid as fluid
 from paddle.fluid.tests.unittests.op_test import OpTest
 from paddle.fluid.tests.unittests.op_test import skip_check_grad_ci
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
@@ -17,8 +17,6 @@ import numpy as np
 
 import paddle
 import paddle.fluid.core as core
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_clip_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_clip_mkldnn_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, convert_float_to_uint16
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_concat_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_concat_bf16_mkldnn_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import struct
 
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_concat_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_concat_mkldnn_op.py
@@ -14,10 +14,9 @@
 
 import unittest
 import numpy as np
-import struct
 
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import OpTest
 from paddle import enable_static
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import struct
 
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16, OpTestTool

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 import numpy as np
 
-import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci
 from paddle.fluid.tests.unittests.test_conv2d_op import TestConv2DOp, TestConv2DOp_v2
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -14,10 +14,9 @@
 
 import unittest
 import numpy as np
-import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest
 from paddle import enable_static
-from paddle.fluid.tests.unittests.test_conv2d_transpose_op import conv2dtranspose_forward_naive, TestConv2DTransposeOp
+from paddle.fluid.tests.unittests.test_conv2d_transpose_op import TestConv2DTransposeOp
 
 
 def conv2d_bias_naive(out, bias):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
@@ -14,7 +14,7 @@
 
 import unittest
 import numpy as np
-from paddle.fluid.tests.unittests.test_conv3d_op import TestConv3DOp, TestCase1, TestWithGroup1, TestWithGroup2, TestWith1x1, TestWithInput1x1Filter1x1, TestConv3DOp_2
+from paddle.fluid.tests.unittests.test_conv3d_op import TestCase1, TestConv3DOp, TestWith1x1, TestWithGroup1, TestWithGroup2, TestWithInput1x1Filter1x1
 
 
 class TestMKLDNN(TestConv3DOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_expand_v2_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_expand_v2_mkldnn_op.py
@@ -15,8 +15,7 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard, core
+from paddle.fluid import core
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, convert_float_to_uint16
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
@@ -14,11 +14,10 @@
 
 import unittest
 import numpy as np
-import struct
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 from paddle.fluid.tests.unittests.test_fusion_gru_op import fusion_gru
-from paddle.fluid.tests.unittests.test_fusion_lstm_op import fc, ACTIVATION
+from paddle.fluid.tests.unittests.test_fusion_lstm_op import ACTIVATION
 
 
 @unittest.skipIf(not core.supports_bfloat16(),

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_int8_mkldnn_op.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest
 from paddle.fluid.tests.unittests.test_fusion_gru_op import fusion_gru
-from paddle.fluid.tests.unittests.test_fusion_lstm_op import fc, ACTIVATION
+from paddle.fluid.tests.unittests.test_fusion_lstm_op import ACTIVATION
 
 
 class TestFusionGRUINT8MKLDNNOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_mkldnn_op.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 from paddle.fluid.tests.unittests.test_fusion_gru_op import TestFusionGRUOp
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_bf16_mkldnn_op.py
@@ -14,11 +14,9 @@
 
 import unittest
 import numpy as np
-import struct
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16, convert_uint16_to_float
-from paddle.fluid.tests.unittests.test_fusion_lstm_op import TestFusionLSTMOp, fc, ACTIVATION, fusion_lstm
-from paddle.fluid.tests.unittests.test_fusion_gru_op import fusion_gru
+from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
+from paddle.fluid.tests.unittests.test_fusion_lstm_op import ACTIVATION, fusion_lstm
 
 
 @unittest.skipIf(not core.supports_bfloat16(),

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_int8_mkldnn_op.py
@@ -15,7 +15,7 @@
 import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest
-from paddle.fluid.tests.unittests.test_fusion_lstm_op import fc, ACTIVATION, fusion_lstm
+from paddle.fluid.tests.unittests.test_fusion_lstm_op import ACTIVATION, fusion_lstm
 
 
 class TestFusionLSTMINT8MKLDNNOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_lstm_mkldnn_op.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 from paddle.fluid.tests.unittests.test_fusion_lstm_op import TestFusionLSTMOp
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_layer_norm_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_layer_norm_bf16_mkldnn_op.py
@@ -24,7 +24,7 @@ from functools import reduce
 
 from paddle.fluid.tests.unittests.mkldnn.test_layer_norm_mkldnn_op import TestLayerNormMKLDNNOp
 from paddle.fluid.tests.unittests.mkldnn.test_layer_norm_mkldnn_op import _reference_layer_norm_naive
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import convert_float_to_uint16
 from paddle.fluid.tests.unittests.op_test import _set_use_system_allocator
 
 np.random.random(123)

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 from paddle.fluid.tests.unittests.test_lrn_op import TestLRNOp
-import paddle.fluid as fluid
 
 
 class TestLRNMKLDNNOp(TestLRNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_bf16_mkldnn_op.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import unittest
-import os
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 from paddle import enable_static
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_v2_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_v2_mkldnn_op.py
@@ -13,14 +13,11 @@
 # limitations under the License.
 
 import unittest
-from functools import reduce
 import numpy as np
 
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, convert_float_to_uint16
 import paddle.fluid.core as core
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.framework as framework
 from paddle.fluid.tests.unittests.mkldnn.test_matmul_mkldnn_op import (
     TestMatMulOpTransposeReshapeEmptyFloat,
     TestMatMulOpTransposeReshapeBasicFloat,

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_mul_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_mul_mkldnn_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-from numpy.matrixlib import defmatrix
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16, OpTestTool

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_multi_gru_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_multi_gru_mkldnn_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest
 from paddle.fluid.tests.unittests.test_fusion_gru_op import fusion_gru, ACTIVATION
-from paddle.fluid.dygraph.base import disable_dygraph
 
 
 def multi_gru(

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_onnx_format_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_onnx_format_quantization_mobilenetv1.py
@@ -16,12 +16,10 @@ import os
 import time
 import sys
 import random
-import math
 import functools
-import contextlib
 import tempfile
 import numpy as np
-from PIL import Image, ImageEnhance
+from PIL import Image
 import paddle
 import paddle.fluid as fluid
 from paddle.dataset.common import download
@@ -158,7 +156,6 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
     def tearDown(self):
         self.root_path.cleanup()
-        pass
 
     def cache_unzipping(self, target_folder, zip_path):
         if not os.path.exists(target_folder):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_int8_mkldnn_op.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest
-from paddle.fluid.tests.unittests.test_pool2d_op import TestPool2D_Op, avg_pool2D_forward_naive, max_pool2D_forward_naive
+from paddle.fluid.tests.unittests.test_pool2d_op import TestPool2D_Op, max_pool2D_forward_naive
 
 
 class TestPool2DMKLDNNInt8_Op(TestPool2D_Op):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reduce_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reduce_bf16_mkldnn_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTestTool, OpTest, skip_check_grad_ci, convert_float_to_uint16
 import paddle.fluid.core as core
-import paddle.fluid as fluid
 import paddle
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reduce_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reduce_mkldnn_op.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, skip_check_grad_ci
-import paddle.fluid as fluid
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_bf16_op.py
@@ -14,7 +14,6 @@
 
 import unittest
 import numpy as np
-import struct
 
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_scale_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_scale_bf16_mkldnn_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest
 import paddle
-import paddle.fluid as fluid
 
 
 class TestScaleOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_shape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_shape_mkldnn_op.py
@@ -17,7 +17,6 @@ import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 @OpTestTool.skip_if_not_cpu_bf16()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_shuffle_channel_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_shuffle_channel_mkldnn_op.py
@@ -16,7 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_slice_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_slice_mkldnn_op.py
@@ -16,8 +16,6 @@ import unittest
 import numpy as np
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, convert_float_to_uint16
-import paddle.fluid as fluid
-import paddle.fluid.layers as layers
 import paddle
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_softplus_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_softplus_mkldnn_op.py
@@ -16,9 +16,6 @@ import unittest
 import numpy as np
 from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, convert_float_to_uint16
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
-from paddle.fluid.framework import _current_expected_place
 
 
 def ref_softplus(x, beta, threshold):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_split_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_split_bf16_mkldnn_op.py
@@ -15,8 +15,7 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard, core
+from paddle.fluid import core
 from paddle.fluid.tests.unittests.op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_split_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_split_mkldnn_op.py
@@ -15,8 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard, core
 from paddle.fluid.tests.unittests.op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_stack_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_stack_mkldnn_op.py
@@ -14,9 +14,8 @@
 
 import unittest
 import numpy as np
-from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool, skip_check_grad_ci
+from paddle.fluid.tests.unittests.op_test import OpTest, OpTestTool
 import paddle
-import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_sum_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_sum_bf16_mkldnn_op.py
@@ -15,10 +15,9 @@
 import unittest
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.test_sum_op import TestSumOp
-from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import convert_float_to_uint16
 from paddle import enable_static
 import numpy as np
-import paddle.fluid.op as fluid_op
 
 
 @unittest.skipIf(not core.supports_bfloat16(),

--- a/python/paddle/fluid/tests/unittests/test_cuda_random_seed.py
+++ b/python/paddle/fluid/tests/unittests/test_cuda_random_seed.py
@@ -16,7 +16,6 @@
 import os
 import unittest
 
-import time  # temp for debug
 import paddle.fluid as fluid
 import numpy as np
 import paddle

--- a/python/paddle/fluid/tests/unittests/test_dataset.py
+++ b/python/paddle/fluid/tests/unittests/test_dataset.py
@@ -18,7 +18,6 @@ including create, config, run, etc.
 
 import paddle
 import paddle.fluid as fluid
-import paddle.compat as cpt
 import paddle.fluid.core as core
 import os
 import tempfile

--- a/python/paddle/fluid/tests/unittests/test_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_exception.py
@@ -17,7 +17,6 @@ import unittest
 
 import paddle
 import paddle.fluid as fluid
-import paddle.compat as cpt
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/test_fs_interface.py
+++ b/python/paddle/fluid/tests/unittests/test_fs_interface.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-import sys
 import inspect
 
 from paddle.distributed.fleet.utils.fs import FS

--- a/python/paddle/fluid/tests/unittests/test_generator.py
+++ b/python/paddle/fluid/tests/unittests/test_generator.py
@@ -16,7 +16,6 @@
 import unittest
 import paddle
 import paddle.fluid.generator as generator
-import time  # temp for debug
 
 
 class TestGenerator(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exception.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid import core
-import paddle.compat as cpt
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exit_func.py
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import signal
 import unittest
 import multiprocessing
 import time
 
-import paddle.compat as cpt
 from paddle.fluid.framework import _test_eager_guard
 
 import queue

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_process.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_process.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 import multiprocessing
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/test_imperative_double_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_double_grad.py
@@ -19,7 +19,6 @@ from paddle.vision.models import resnet50, resnet101
 import unittest
 from unittest import TestCase
 import numpy as np
-import paddle.compat as cpt
 from paddle.fluid.framework import _test_eager_guard
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
@@ -19,7 +19,6 @@ import unittest
 import multiprocessing
 import time
 
-import paddle.compat as cpt
 from paddle.fluid import core
 from paddle.fluid.framework import _test_eager_guard
 

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -17,7 +17,6 @@ import numpy as np
 from op_test import OpTest, skip_check_grad_ci, check_out_dtype
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
-import paddle.compat as cpt
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 import paddle.nn.functional as F

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
@@ -19,7 +19,6 @@ import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.op import Operator
-import paddle.compat as cpt
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/test_operator_desc.py
+++ b/python/paddle/fluid/tests/unittests/test_operator_desc.py
@@ -15,7 +15,6 @@
 import unittest
 
 import paddle.fluid.core as core
-import paddle.compat as cpt
 
 from paddle.fluid.framework import Program, default_startup_program
 

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -20,7 +20,6 @@ import paddle.fluid as fluid
 import paddle.fluid.framework as framework
 import paddle.fluid.optimizer as optimizer
 import paddle.fluid.core as core
-import paddle.compat as cpt
 import numpy as np
 from paddle.fluid.backward import append_backward
 from paddle.fluid.framework import Program, program_guard, convert_np_dtype_to_dtype_

--- a/python/paddle/fluid/tests/unittests/test_prune.py
+++ b/python/paddle/fluid/tests/unittests/test_prune.py
@@ -17,7 +17,6 @@ import unittest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.framework as framework
-import paddle.compat as cpt
 import numpy as np
 import os
 import contextlib

--- a/python/paddle/fluid/tests/unittests/test_random_seed.py
+++ b/python/paddle/fluid/tests/unittests/test_random_seed.py
@@ -16,7 +16,6 @@
 import unittest
 import paddle.fluid.generator as generator
 
-import time  # temp for debug
 import paddle.fluid as fluid
 import numpy as np
 import paddle

--- a/python/paddle/fluid/tests/unittests/test_zeros_op.py
+++ b/python/paddle/fluid/tests/unittests/test_zeros_op.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.compat as cpt
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 from paddle.fluid.framework import _test_eager_guard


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/fluid/tests/unittests/mkldnn/` 目录 F401 (unused import) 存量以及一部分其他目录的增量

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/mkldnn/
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/7
-  配置文件更新: #46916
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/41
