### PR TITLE
skip ReplaceAllReduceOp in GraphtoBlock when nccl_ctxs_ is nullptr

### DIFF
--- a/paddle/fluid/framework/details/nccl_op_handle.h
+++ b/paddle/fluid/framework/details/nccl_op_handle.h
@@ -81,6 +81,10 @@ class NCCLOpHandleBase : public OpHandleBase {
                       0,
                       platform::errors::Unimplemented(
                           "Not supported use_hierarchical_allreduce_ now"));
+    PADDLE_ENFORCE_NOT_NULL(
+        nccl_ctxs_,
+        platform::errors::NotFound("Can't get flat %d nccl contexts.",
+                                   run_order_));
     auto flat_nccl_ctxs = nccl_ctxs_->GetFlatCtx(run_order_);
     int dev_id = places_[0].device;
     auto& nccl_ctx = flat_nccl_ctxs->at(dev_id);

--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -648,7 +648,8 @@ static void GetGraphOpDesc(const std::vector<Node *> &nodes,
       ops->emplace_back();
       auto &desc = ops->back();
       ReplaceScaleLossGradOp(*n, &desc);
-    } else if (n->Name() == "allreduce" || n->Name() == "fused_all_reduce") {
+    } else if ((n->Name() == "allreduce" || n->Name() == "fused_all_reduce") &&
+               n->IsWrappedBy<details::NCCLOpHandleBase>()) {
       VLOG(4) << "convert op node " << n->Name() << " to desc c_allreduce_sum";
       ReplaceAllReduceOp(*n, block, ops);
       VLOG(4) << n->ToString();

--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -648,11 +648,13 @@ static void GetGraphOpDesc(const std::vector<Node *> &nodes,
       ops->emplace_back();
       auto &desc = ops->back();
       ReplaceScaleLossGradOp(*n, &desc);
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
     } else if ((n->Name() == "allreduce" || n->Name() == "fused_all_reduce") &&
                n->IsWrappedBy<details::NCCLOpHandleBase>()) {
       VLOG(4) << "convert op node " << n->Name() << " to desc c_allreduce_sum";
       ReplaceAllReduceOp(*n, block, ops);
       VLOG(4) << n->ToString();
+#endif
     } else if (n->Op()) {
       VLOG(4) << "convert op node to desc " << n->Op()->Type();
       if (is_fused_opt(n)) {

--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -650,7 +650,8 @@ static void GetGraphOpDesc(const std::vector<Node *> &nodes,
       ReplaceScaleLossGradOp(*n, &desc);
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
     } else if ((n->Name() == "allreduce" || n->Name() == "fused_all_reduce") &&
-               n->IsWrappedBy<details::NCCLOpHandleBase>()) {
+               dynamic_cast<details::NCCLOpHandleBase *>(
+                   &(n->Wrapper<details::OpHandleBase>())) != nullptr) {
       VLOG(4) << "convert op node " << n->Name() << " to desc c_allreduce_sum";
       ReplaceAllReduceOp(*n, block, ops);
       VLOG(4) << n->ToString();

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1567,15 +1567,6 @@ class Executor(object):
                 compiled_program = program if isinstance(
                     program, compiler.CompiledProgram) else program._graph
 
-                # delete this code after supporting distribution
-                if compiled_program._build_strategy is not None and (
-                        compiled_program._build_strategy.is_distribution
-                        or compiled_program._build_strategy.num_trainers > 1):
-                    warnings.warn(
-                        "Standalone executor is not used for distribution",
-                        UserWarning)
-                    return use_standalone_executor_for_distribution
-
                 # Unsupported case 1: data parallel
                 if compiled_program._is_data_parallel and len(
                         compiled_program._get_places(

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_graph_executor.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_graph_executor.py
@@ -29,7 +29,8 @@ class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
             "PADDLE_TRAINERS_NUM": "2",
             "PADDLE_TRAINER_ENDPOINTS": "127.0.0.1:36001,127.0.0.1:36002",
             "http_proxy": "",
-            "https_proxy": ""
+            "https_proxy": "",
+            "FLAGS_CONVERT_GRAPH_TO_PROGRAM": "1"
         }
 
         node_b = {
@@ -38,7 +39,8 @@ class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
             "PADDLE_TRAINERS_NUM": "2",
             "PADDLE_TRAINER_ENDPOINTS": "127.0.0.1:36001,127.0.0.1:36002",
             "http_proxy": "",
-            "https_proxy": ""
+            "https_proxy": "",
+            "FLAGS_CONVERT_GRAPH_TO_PROGRAM": "1"
         }
 
         def node_func():

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -1477,8 +1477,7 @@ class TestDistBase(unittest.TestCase):
             "FLAGS_rpc_disable_reuse_port": "1",
             "http_proxy": "",
             "NCCL_P2P_DISABLE": "1",
-            "NCCL_SHM_DISABLE": "1",
-            "FLAGS_CONVERT_GRAPH_TO_PROGRAM": "1"
+            "NCCL_SHM_DISABLE": "1"
         }
 
         if check_error_log:

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -1477,7 +1477,8 @@ class TestDistBase(unittest.TestCase):
             "FLAGS_rpc_disable_reuse_port": "1",
             "http_proxy": "",
             "NCCL_P2P_DISABLE": "1",
-            "NCCL_SHM_DISABLE": "1"
+            "NCCL_SHM_DISABLE": "1",
+            "FLAGS_CONVERT_GRAPH_TO_PROGRAM": "1"
         }
 
         if check_error_log:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

#### 问题1：nccl_ctxs_为空

新执行器中，将is_distribution打开时，单测test_fleet_graph_executor和test_fleet_graph_executor_meta_optimizer失败。原因如下：
GraphToBlock中，将allreduce转化为c_allreduce_sum op时，需要使用nccl，但是单测test_fleet_graph_executor单测跑在CPU上（多进程形式），nccl_ctxs为空，导致使用`NCCLOpHandleBase`的`GetComm`方法报错。
但是CPU上的allreduce方法本来就有问题，多进程形式执行没有真正allreduce，可能需要使用gloo方法（参考c_allreduce_sum op的CPU kernel）。所以这里直接跳过了CPU上的allreduce。

#### 问题2：本来就需要执行allreduce op，无需转化成c_allreduce_sum op
单测test_dist_allreduce_op失败，GraphToBlock时本来就需要向block中插入allreduce op。
判断NCCLAllReduceOpHandle为nullptr时，不需要转化为c_allreduce_sum op。