### PR TITLE
[CodeStyle][F401] remove unused imports in unittests/auto_parallel,distribution

### DIFF
--- a/python/paddle/fluid/tests/unittests/auto_parallel/amp_pass_unittest.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/amp_pass_unittest.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import unittest
-import sys
 import random
 import numpy as np
 import paddle
 
 from paddle.distributed.fleet import auto
 from paddle.fluid.dygraph.parallel import ParallelEnv
-from get_gpt_model import generate_model, create_data_holder, FakeDataset
+from get_gpt_model import FakeDataset, generate_model
 
 
 def apply_pass(use_amp=False, level=None):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/auto_parallel_relaunch_model.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/auto_parallel_relaunch_model.py
@@ -12,21 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import time
-import paddle.fluid as fluid
-import copy
-import os
 import numpy as np
-import subprocess
 import paddle
 import paddle.nn as nn
-import paddle.fluid as fluid
 import paddle.static as static
 import paddle.nn.functional as F
 import paddle.utils as utils
-from paddle.fluid import layers
-from paddle.io import IterableDataset, DataLoader
 from paddle.distributed import fleet
 from paddle.distributed.fleet import auto
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/auto_parallel_relaunch_with_gpt_planner.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/auto_parallel_relaunch_with_gpt_planner.py
@@ -19,10 +19,6 @@ import sys
 
 import numpy as np
 
-from paddle.distributed.fleet import auto
-from auto_parallel_relaunch_model import mlp_pretrain_forward
-from auto_parallel_relaunch_model import batch_generator_creator
-
 sys.path.append("..")
 import auto_parallel_gpt_model as modeling
 from auto_parallel_gpt_model import GPTModel, GPTForPretraining, GPTPretrainingCriterion

--- a/python/paddle/fluid/tests/unittests/auto_parallel/clip_grad_by_global_norm.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/clip_grad_by_global_norm.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import unittest
-import sys
 import random
 import numpy as np
 import paddle
 
 from paddle.distributed.fleet import auto
 from paddle.fluid.dygraph.parallel import ParallelEnv
-from get_gpt_model import generate_model, create_data_holder, FakeDataset
+from get_gpt_model import FakeDataset, generate_model
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/converter.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/converter.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import numpy as np
 
 import paddle

--- a/python/paddle/fluid/tests/unittests/auto_parallel/engine_api.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/engine_api.py
@@ -12,26 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import time
 import tempfile
-import copy
 import os
 import numpy as np
-import subprocess
 import paddle
 import paddle.nn as nn
-import paddle.fluid as fluid
-import paddle.static as static
 import paddle.nn.functional as F
-import paddle.utils as utils
-from paddle.fluid import layers
-from paddle.io import Dataset, IterableDataset, DataLoader
+from paddle.io import Dataset
 
 from paddle.distributed.fleet import auto
-from paddle.distributed.auto_parallel.interface import get_collection, CollectionNames
-from paddle.optimizer.lr import CosineAnnealingDecay
-from paddle.fluid.dataloader.collate import default_collate_fn
 
 paddle.enable_static()
 global_process_mesh = auto.ProcessMesh(mesh=[0, 1])

--- a/python/paddle/fluid/tests/unittests/auto_parallel/engine_api_dp.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/engine_api_dp.py
@@ -12,21 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import time
 import tempfile
-import copy
 import os
 import numpy as np
-import subprocess
 import paddle
 import paddle.nn as nn
-import paddle.fluid as fluid
-import paddle.static as static
 import paddle.nn.functional as F
-import paddle.utils as utils
-from paddle.fluid import layers
-from paddle.io import Dataset, DataLoader
+from paddle.io import Dataset
 
 from paddle.distributed.fleet import auto
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/gradient_merge_pass_unittest.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/gradient_merge_pass_unittest.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import unittest
-import sys
 import random
 import numpy as np
 import paddle
 
 from paddle.distributed.fleet import auto
 from paddle.fluid.dygraph.parallel import ParallelEnv
-from get_gpt_model import generate_model, create_data_holder, FakeDataset
+from get_gpt_model import FakeDataset, generate_model
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/high_order_grad.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/high_order_grad.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import random
 import paddle
-import unittest
 import numpy as np
 from paddle.distributed.fleet import auto
 from paddle.incubate.autograd import Hessian

--- a/python/paddle/fluid/tests/unittests/auto_parallel/iterable_dataset.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/iterable_dataset.py
@@ -12,26 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import time
 import tempfile
-import copy
 import os
 import numpy as np
-import subprocess
 import paddle
 import paddle.nn as nn
-import paddle.fluid as fluid
-import paddle.static as static
 import paddle.nn.functional as F
-import paddle.utils as utils
-from paddle.fluid import layers
-from paddle.io import Dataset, IterableDataset, DataLoader
-from paddle.static import InputSpec
 
 from paddle.distributed.fleet import auto
-from paddle.optimizer.lr import CosineAnnealingDecay
-from paddle.fluid.dataloader.collate import default_collate_fn
 
 paddle.enable_static()
 global_process_mesh = auto.ProcessMesh(mesh=[0, 1])

--- a/python/paddle/fluid/tests/unittests/auto_parallel/optimization_tuner_api.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/optimization_tuner_api.py
@@ -12,21 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import time
-import tempfile
-import copy
-import os
-import numpy as np
-import subprocess
 import paddle
 import paddle.nn as nn
-import paddle.fluid as fluid
-import paddle.static as static
 import paddle.nn.functional as F
-import paddle.utils as utils
-from paddle.fluid import layers
-from paddle.io import Dataset, IterableDataset, DataLoader
 
 from paddle.distributed.fleet import auto
 from engine_api_dp import MyDataset

--- a/python/paddle/fluid/tests/unittests/auto_parallel/recompute_pass_unittest.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/recompute_pass_unittest.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import unittest
-import sys
 import random
 import numpy as np
 import paddle
 
 from paddle.distributed.fleet import auto
 from paddle.fluid.dygraph.parallel import ParallelEnv
-from get_gpt_model import generate_model, create_data_holder, FakeDataset
+from get_gpt_model import FakeDataset, generate_model
 
 
 def apply_pass(use_recompute=False):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/sharding_pass_unittest.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/sharding_pass_unittest.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import unittest
-import sys
 import random
 import numpy as np
 import paddle
 
 from paddle.distributed.fleet import auto
 from paddle.fluid.dygraph.parallel import ParallelEnv
-from get_gpt_model import generate_model, create_data_holder, FakeDataset
+from get_gpt_model import FakeDataset, generate_model
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_auto_parallel_relaunch.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_auto_parallel_relaunch.py
@@ -17,9 +17,7 @@ import unittest
 import os
 import sys
 import json
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 cluster_json = """
 {

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_base_cost.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_base_cost.py
@@ -27,11 +27,7 @@ from paddle.distributed.auto_parallel.completion import Completer
 from paddle.distributed.auto_parallel.dist_context import DistributedContext
 from paddle.distributed import fleet
 from paddle.distributed.auto_parallel.parallelizer import AutoParallelizer
-from paddle.distributed.auto_parallel.partitioner import Partitioner
-from paddle.distributed.auto_parallel.reshard import Resharder
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 from paddle.distributed.auto_parallel.cluster import Cluster
-from paddle.distributed.auto_parallel.cost import CommContext
 from paddle.distributed.auto_parallel.cost.base_cost import build_comp_desc_from_dist_op
 from paddle.distributed.auto_parallel.cost.base_cost import build_comm_desc_from_dist_op
 from paddle.distributed.auto_parallel.cost.base_cost import build_comm_costs_from_descs

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_cluster.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_cluster.py
@@ -17,7 +17,6 @@ import unittest
 import os
 import json
 
-import paddle
 from paddle.distributed.auto_parallel.cluster import Cluster
 from paddle.distributed.auto_parallel.cluster import get_default_cluster
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_comp_cost.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_comp_cost.py
@@ -16,7 +16,6 @@ import unittest
 import os
 import json
 
-import paddle
 from paddle.distributed.auto_parallel.cluster import Cluster
 from paddle.distributed.auto_parallel.cost.comp_op_cost import AssignOpCost
 from paddle.distributed.auto_parallel.cost.comp_op_cost import AssignValueOpCost
@@ -51,7 +50,6 @@ from paddle.distributed.auto_parallel.cost.comp_op_cost import LogOpCost
 from paddle.distributed.auto_parallel.cost.comp_op_cost import LookupTableV2OpCost
 from paddle.distributed.auto_parallel.cost.comp_op_cost import LookupTableV2GradOpCost
 from paddle.distributed.auto_parallel.cost.comp_op_cost import MatmulOpCost
-from paddle.distributed.auto_parallel.cost.comp_op_cost import MatmulGradOpCost
 from paddle.distributed.auto_parallel.cost.comp_op_cost import MatmulV2OpCost
 from paddle.distributed.auto_parallel.cost.comp_op_cost import MatmulV2GradOpCost
 from paddle.distributed.auto_parallel.cost.comp_op_cost import MemcpyOpCost

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_converter.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_converter.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 from paddle.distributed.auto_parallel.converter import Converter
 
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_attr_v2.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_attr_v2.py
@@ -14,8 +14,6 @@
 
 import unittest
 import paddle
-import numpy as np
-import paddle.nn as nn
 import paddle.static as static
 from paddle.fluid.core import TensorDistAttr
 from paddle.fluid.core import OperatorDistAttr

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_context.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_context.py
@@ -13,21 +13,17 @@
 # limitations under the License.
 
 import unittest
-import os
-import json
 import copy
 
 import paddle
 import numpy as np
 import paddle.nn as nn
-import paddle.utils as utils
 import paddle.static as static
 import paddle.nn.functional as F
 
 from paddle.distributed import fleet
 from paddle.distributed.fleet import auto
 from paddle.distributed.auto_parallel.dist_context import DistributedContext
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_embedding.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_embedding.py
@@ -16,9 +16,6 @@ import unittest
 import paddle
 from paddle.distributed.fleet import auto
 
-from paddle.fluid import program_guard
-from paddle.fluid.backward import append_backward
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 from test_dist_pnorm import parallelizer
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_matmul.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_matmul.py
@@ -18,7 +18,6 @@ from paddle.distributed.fleet import auto
 
 from paddle.fluid import program_guard
 from paddle.fluid.backward import append_backward
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_op_cost.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_op_cost.py
@@ -29,7 +29,6 @@ paddle.enable_static()
 
 def parallelizer(program_func, rank):
     from paddle.distributed.auto_parallel.completion import Completer
-    from paddle.distributed.auto_parallel.partitioner import Partitioner
     from paddle.distributed.auto_parallel.dist_context import DistributedContext
 
     main_program, startup_program, loss = program_func()

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_pnorm.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_pnorm.py
@@ -18,7 +18,6 @@ from paddle.distributed.fleet import auto
 
 from paddle.fluid import program_guard
 from paddle.fluid.backward import append_backward
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_reshape.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_reshape.py
@@ -16,10 +16,6 @@ import unittest
 import paddle
 from paddle.distributed.fleet import auto
 
-from paddle.fluid import program_guard
-from paddle.fluid.backward import append_backward
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
-
 paddle.enable_static()
 
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_slice.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_slice.py
@@ -15,7 +15,6 @@
 import unittest
 import paddle
 from paddle.distributed.fleet import auto
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_split.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_dist_split.py
@@ -16,9 +16,6 @@ import unittest
 import paddle
 from paddle.distributed.fleet import auto
 
-from paddle.fluid import program_guard
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
-
 paddle.enable_static()
 
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_engine_api.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_engine_api.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestEngineAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_engine_api_dp.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_engine_api_dp.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestEngineAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_high_order_grad.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_high_order_grad.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestHighOrderGrad(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_interface.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_interface.py
@@ -14,15 +14,12 @@
 
 import unittest
 import paddle
-import paddle.fluid as fluid
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.static as static
-import paddle.distributed as dist
 from paddle.distributed.fleet import auto
 from paddle.distributed.auto_parallel.dist_context import get_default_distributed_context
 from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_iterable_dataset.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_iterable_dataset.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestEngineAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_lr_grad_clip.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_lr_grad_clip.py
@@ -14,18 +14,8 @@
 
 import unittest
 
-import os
-import numpy as np
-
 import paddle
-import paddle.nn as nn
-import paddle.nn.functional as F
 from paddle.distributed.fleet import auto
-import paddle.distributed.fleet as fleet
-
-from paddle.io import Dataset
-from paddle.static import InputSpec
-from paddle.fluid.framework import _non_static_mode
 
 from test_to_static import MLPLayer, MyDataset
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_new_cost_model.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_new_cost_model.py
@@ -25,7 +25,7 @@ from paddle.distributed.auto_parallel.cost.base_cost import build_comp_desc_str_
 from paddle.distributed.auto_parallel.cost.base_cost import calc_time_by_modeling
 from paddle.distributed.auto_parallel.cluster import Cluster
 from paddle.distributed.auto_parallel.cost import CommContext
-from test_cluster import cluster_json, multi_cluster_json
+from test_cluster import cluster_json
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_optimization_tuner_api.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_optimization_tuner_api.py
@@ -18,7 +18,6 @@ import os
 import sys
 import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestOptimizationTunerAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_amp.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_amp.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestAMPPass(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_grad_clip.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_grad_clip.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestGradientClip(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_gradient_merge.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_gradient_merge.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestGradientMergePass(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_quantization.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_quantization.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 
 import unittest
-import sys
-import random
-import numpy as np
 import paddle
 
 from paddle.distributed.fleet import auto
-from get_gpt_model import generate_model, create_data_holder, FakeDataset
+from get_gpt_model import FakeDataset, generate_model
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_recompute.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_recompute.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestRecomputePass(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_sharding.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_pass_sharding.py
@@ -16,9 +16,7 @@ import tempfile
 import unittest
 import os
 import sys
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestShardingPass(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_prim_dist_op.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_prim_dist_op.py
@@ -16,15 +16,13 @@ import unittest
 import paddle
 from paddle.distributed.fleet import auto
 
-from paddle.fluid import program_guard
-from paddle.incubate.autograd import prim2orig, enable_prim, prim_enabled
+from paddle.incubate.autograd import enable_prim
 from paddle.fluid.layer_helper import LayerHelper
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 from paddle.distributed.fleet import auto
 from paddle.distributed.auto_parallel.completion import Completer
 from paddle.distributed.auto_parallel.partitioner import Partitioner
 from paddle.distributed.auto_parallel.utils import set_var_dist_attr
-from paddle.distributed.auto_parallel.dist_context import DistributedContext, get_default_distributed_context, set_default_distributed_context
+from paddle.distributed.auto_parallel.dist_context import DistributedContext, get_default_distributed_context
 
 paddle.enable_static()
 enable_prim()

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_process_mesh.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_process_mesh.py
@@ -15,14 +15,11 @@
 import unittest
 import numpy as np
 import paddle
-import paddle.fluid as fluid
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.static as static
-from paddle.distributed.fleet import auto
 from paddle.distributed.auto_parallel.process_mesh import ProcessMesh
 from paddle.distributed.auto_parallel.dist_context import get_default_distributed_context
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_relaunch_with_gpt_planner.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_relaunch_with_gpt_planner.py
@@ -17,9 +17,7 @@ import unittest
 import os
 import sys
 import json
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestPlannerReLaunch(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_relaunch_with_planner.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_relaunch_with_planner.py
@@ -17,9 +17,7 @@ import unittest
 import os
 import sys
 import json
-import shutil
 import subprocess
-from paddle.distributed.fleet.launch_utils import run_with_coverage
 
 
 class TestPlannerReLaunch(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_strategy.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_strategy.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 # import yaml
 import unittest
 from paddle.distributed.fleet import auto

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_to_static.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_to_static.py
@@ -14,14 +14,12 @@
 
 import unittest
 
-import os
 import numpy as np
 
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.distributed.fleet import auto
-import paddle.distributed.fleet as fleet
 
 from paddle import LazyGuard
 from paddle.io import Dataset

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_while_op_completion.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_while_op_completion.py
@@ -16,19 +16,13 @@ import unittest
 import paddle
 import numpy as np
 import paddle.nn as nn
-import paddle.utils as utils
 import paddle.static as static
 import paddle.nn.functional as F
 from paddle.distributed.fleet import auto
 
 from paddle.distributed import fleet
 from paddle.distributed.auto_parallel.completion import Completer
-from paddle.distributed.auto_parallel.partitioner import Partitioner
-from paddle.distributed.auto_parallel.utils import make_data_unshard
-from paddle.distributed.auto_parallel.dist_attribute import OperatorDistributedAttribute, TensorDistributedAttribute
-from paddle.distributed.auto_parallel.dist_context import DistributedContext, get_default_distributed_context
-from paddle.distributed.auto_parallel.operators import find_compatible_distributed_operator_impls
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
+from paddle.distributed.auto_parallel.dist_context import DistributedContext
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/auto_parallel/test_while_op_partition.py
+++ b/python/paddle/fluid/tests/unittests/auto_parallel/test_while_op_partition.py
@@ -16,7 +16,6 @@ import unittest
 import paddle
 import numpy as np
 import paddle.nn as nn
-import paddle.utils as utils
 import paddle.fluid as fluid
 import paddle.static as static
 import paddle.nn.functional as F
@@ -26,10 +25,7 @@ from paddle.distributed import fleet
 from paddle.distributed.auto_parallel.completion import Completer
 from paddle.distributed.auto_parallel.partitioner import Partitioner
 from paddle.distributed.auto_parallel.utils import make_data_unshard
-from paddle.distributed.auto_parallel.dist_attribute import OperatorDistributedAttribute, TensorDistributedAttribute
-from paddle.distributed.auto_parallel.dist_context import DistributedContext, get_default_distributed_context
-from paddle.distributed.auto_parallel.operators import find_compatible_distributed_operator_impls
-from paddle.distributed.auto_parallel.utils import print_program_with_dist_attr
+from paddle.distributed.auto_parallel.dist_context import get_default_distributed_context
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_dirichlet_op.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_dirichlet_op.py
@@ -12,21 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 import sys
-import unittest
 
 import numpy as np
 import paddle
-import paddle.fluid.core as core
-import paddle.fluid.dygraph as dg
-import paddle.static as static
 import scipy.stats
-from numpy.random import random as rand
 
 sys.path.append("../")
 from op_test import OpTest
-from paddle.fluid import Program, program_guard
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import unittest
 
 import numpy as np
 import paddle
-from paddle import fluid
 from paddle.distribution import *
 from paddle.fluid import layers
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta.py
@@ -18,7 +18,6 @@ import numpy as np
 import paddle
 import scipy.stats
 
-import config
 from config import ATOL, DEVICES, RTOL
 from parameterize import TEST_CASE_NAME, parameterize_cls, place, xrand
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_beta_static.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numbers
 import unittest
 
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_categorical.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_categorical.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import unittest
 
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_constraint.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_constraint.py
@@ -18,7 +18,6 @@ import numpy as np
 import paddle
 from paddle.distribution import constraint
 
-import config
 import parameterize as param
 
 np.random.seed(2022)

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet.py
@@ -18,7 +18,6 @@ import numpy as np
 import paddle
 import scipy.stats
 
-import config
 from config import ATOL, DEVICES, RTOL
 import parameterize as param
 

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_dirichlet_static.py
@@ -19,7 +19,7 @@ import paddle
 import scipy.stats
 
 from config import ATOL, DEVICES, RTOL
-from parameterize import TEST_CASE_NAME, parameterize_cls, place, xrand
+from parameterize import TEST_CASE_NAME, parameterize_cls, place
 
 np.random.seed(2022)
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily.py
@@ -16,7 +16,6 @@ import unittest
 
 import numpy as np
 import paddle
-import scipy.stats
 
 import config
 import mock_data as mock

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_expfamily_static.py
@@ -16,7 +16,6 @@ import unittest
 
 import numpy as np
 import paddle
-import scipy.stats
 
 import config
 import mock_data as mock

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numbers
 import unittest
 
 import numpy as np
 import paddle
-import scipy.stats
 
 import config
 import parameterize as param

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_independent_static.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numbers
 import unittest
 
 import numpy as np
 import paddle
-import scipy.stats
 
 import config
 import parameterize as param

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy as np
 import paddle
-from paddle.distribution import constraint, transform, variable
+from paddle.distribution import transform, variable
 
 import config
 import parameterize as param

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_transform_static.py
@@ -16,7 +16,7 @@ import unittest
 
 import numpy as np
 import paddle
-from paddle.distribution import transform, variable, constraint
+from paddle.distribution import transform, variable
 
 import config
 import parameterize as param

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_transformed_distribution.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_transformed_distribution.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numbers
 import unittest
 
 import numpy as np
 import paddle
-import scipy.stats
 
 import config
 import parameterize as param

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_transformed_distribution_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_transformed_distribution_static.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numbers
 import unittest
 
 import numpy as np
 import paddle
-import scipy.stats
 
 import config
 import parameterize as param

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_uniform.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_uniform.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import unittest
 
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/distribution/test_distribution_variable.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_distribution_variable.py
@@ -14,12 +14,10 @@
 
 import unittest
 
-import numpy as np
 import paddle
 from paddle.distribution import variable
 from paddle.distribution import constraint
 
-import config
 import parameterize as param
 
 paddle.seed(2022)

--- a/python/paddle/fluid/tests/unittests/distribution/test_kl.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_kl.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numbers
 import unittest
 
 import numpy as np

--- a/python/paddle/fluid/tests/unittests/distribution/test_kl_static.py
+++ b/python/paddle/fluid/tests/unittests/distribution/test_kl_static.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numbers
 import unittest
 
 import numpy as np


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->

### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes

<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe

<!-- Describe what this PR does -->

修复 `python/paddle/fluid/tests/unittests/auto_parallel/` 和 `python/paddle/fluid/tests/unittests/distribution/` 目录 F401 (unused import) 存量

```bash
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/auto_parallel/
autoflake --in-place --remove-all-unused-imports --ignore-pass-after-docstring --exclude=__init__.py --recursive ./python/paddle/fluid/tests/unittests/distribution/
```

### Related links

-  Flake8 tracking issue: #46039
-  F401 project: https://github.com/orgs/cattidea/projects/4/views/7
-  配置文件更新: #46916
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/31
-  fixes https://github.com/cattidea/paddle-flake8-project/issues/35
