### PR TITLE
解决imread中文路径读取图片报错问题

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -192,7 +192,7 @@ def load_image(file, is_color=True):
     # Here, use constant 1 and 0
     # 1: COLOR, 0: GRAYSCALE
     flag = 1 if is_color else 0
-    im = cv2.imread(file, flag)
+    im = cv2.imread(file.decode('utf-8'), flag)
     return im
 
 

--- a/python/paddle/dataset/tests/test_image.py
+++ b/python/paddle/dataset/tests/test_image.py
@@ -14,7 +14,7 @@
 
 import unittest
 import numpy as np
-
+import sys
 import paddle.dataset.image as image
 
 __all__ = []
@@ -24,7 +24,8 @@ class Image(unittest.TestCase):
 
     def test_resize_flip_chw(self):
         # resize
-        im = image.load_image('cat.jpg')
+        img_dir = sys.argv[0].replace('test_image.py','cat.jpg')
+        im = image.load_image(img_dir)
         im = image.resize_short(im, 256)
         self.assertEqual(256, min(im.shape[:2]))
         self.assertEqual(3, im.shape[2])


### PR DESCRIPTION
1.解决imread中文路径读取图片报错问题
2.解决测试代码相对路径下attributeError: ‘NoneType’ object has no attribute ‘shape 报错问题

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
