### PR TITLE
[BUG]Fix expand_as_v2 bug while X and Y with different dtype

### DIFF
--- a/paddle/fluid/operators/expand_as_v2_op.cc
+++ b/paddle/fluid/operators/expand_as_v2_op.cc
@@ -24,6 +24,13 @@ namespace operators {
 class ExpandAsV2Op : public framework::OperatorWithKernel {
  public:
   using framework::OperatorWithKernel::OperatorWithKernel;
+
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const {
+    return framework::OpKernelType(
+        OperatorWithKernel::IndicateVarDataType(ctx, "X"),
+        ctx.device_context());
+  }
 };
 
 class ExpandAsV2OpMaker : public framework::OpProtoAndCheckerMaker {

--- a/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
@@ -82,6 +82,7 @@ class TestExpandAsOpRank4(TestExpandAsBasic):
 
 
 class TestExpandAsOpRank5(TestExpandAsBasic):
+    no_need_check_grad = True
 
     def setUp(self):
         self.op_type = "expand_as_v2"
@@ -93,6 +94,9 @@ class TestExpandAsOpRank5(TestExpandAsBasic):
         bcast_dims = [4, 6, 1, 1]
         output = np.tile(self.inputs['X'], bcast_dims)
         self.outputs = {'Out': output}
+
+    def test_check_grad(self):
+        pass
 
 
 class TestExpandAsV2Error(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
@@ -81,6 +81,20 @@ class TestExpandAsOpRank4(TestExpandAsBasic):
         self.outputs = {'Out': output}
 
 
+class TestExpandAsOpRank5(TestExpandAsBasic):
+
+    def setUp(self):
+        self.op_type = "expand_as_v2"
+        self.python_api = paddle.expand_as
+        x = np.random.rand(1, 1, 7, 16).astype("int64")
+        target_tensor = np.random.rand(4, 6, 7, 16).astype("float64")
+        self.inputs = {'X': x, "Y": target_tensor}
+        self.attrs = {'target_shape': target_tensor.shape}
+        bcast_dims = [4, 6, 1, 1]
+        output = np.tile(self.inputs['X'], bcast_dims)
+        self.outputs = {'Out': output}
+
+
 class TestExpandAsV2Error(unittest.TestCase):
 
     def test_errors(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
[BUG]Fix expand_as_v2 bug while X and Y with different dtype