### PR TITLE
[Bug-Fix]Fix bugs when run RnnGradInferMeta

### DIFF
--- a/paddle/fluid/framework/infershape_utils.cc
+++ b/paddle/fluid/framework/infershape_utils.cc
@@ -489,9 +489,18 @@ std::vector<phi::MetaTensor*> CompatInferMetaContext::MutableOutputBetween(
     size_t start, size_t end) {
   std::vector<phi::MetaTensor*> result;
   result.reserve(end - start);
+  bool has_meta_tensor = false;
+
   for (size_t i = start; i < end; ++i) {
     auto& out = compat_outputs_.at(i);
     result.emplace_back(out.initialized() ? &out : nullptr);
+    if (!has_meta_tensor && out.initialized()) {
+      has_meta_tensor = true;
+    }
+  }
+
+  if (!has_meta_tensor) {
+    result.clear();
   }
   return result;
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
迁移了rnn算子后，出现了在旧动态图上rnn反向算子调用InferMeta报如下断言错误，本PR修复了这个问题。
<img width="878" alt="image" src="https://user-images.githubusercontent.com/29249150/195339531-183a84a7-b79f-4772-a506-faf01e995dd6.png">
