### PR TITLE
[cherry-pick] Interpretercore thread not use always_spin (#46687)

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore_util.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore_util.cc
@@ -61,7 +61,7 @@ const std::vector<WorkQueueOptions> ConstructWorkQueueOptions(
   group_options.emplace_back(/*name*/ "DeviceKernelLaunch",
                              /*num_threads*/ device_num_threads,
                              /*allow_spinning*/ true,
-                             /*always_spinning*/ true,
+                             /*always_spinning*/ false,
                              /*track_task*/ false,
                              /*detached*/ true,
                              /*events_waiter*/ waiter);


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
新执行器WorkQueue线程不使用always_spin。V100-40G机器（40个cpu核）对MobileNetV1_bs128_fp32单机8卡动转静模型进行5轮测试，取平均值：
- always_spin=true：5210 images/s
- always_spin=false：5562 images/s
