### PR TITLE
keep run_setup and cmake_gen_and_build same

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3673,7 +3673,9 @@ function run_setup(){
       parallel_number=$3
     fi
     export MAX_JOBS=${parallel_number}
-
+    if [[ "$ENABLE_MAKE_CLEAN" != "OFF" ]]; then
+        export MAKE_CLEAN='ON'
+    fi
     # reset ccache zero stats for collect PR's actual hit rate
 
     ccache -z

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3669,8 +3669,8 @@ function run_setup(){
     else
       parallel_number=8
     fi
-    if [ "$2" != "" ]; then
-      parallel_number=$2
+    if [ "$3" != "" ]; then
+      parallel_number=$3
     fi
     export MAX_JOBS=${parallel_number}
 
@@ -3679,9 +3679,9 @@ function run_setup(){
     ccache -z
     cd ..
     if [ "${PYTHON_EXECUTABLE}" != "" ];then
-        ${PYTHON_EXECUTABLE} setup.py $3;build_error=$?
+        ${PYTHON_EXECUTABLE} setup.py $2;build_error=$?
     else
-        python setup.py $3;build_error=$?
+        python setup.py $2;build_error=$?
     fi
     
     # ci will collect ccache hit rate
@@ -3703,7 +3703,7 @@ function main() {
     init
     case $CMD in
       build_only)
-        run_setup ${PYTHON_ABI:-""} ${parallel_number} bdist_wheel
+        run_setup ${PYTHON_ABI:-""} bdist_wheel ${parallel_number}
         ;;
       build_pr_dev)
         build_pr_and_develop
@@ -3820,7 +3820,7 @@ function main() {
         ;;
       cicheck_coverage)
         check_diff_file_for_coverage
-        run_setup ${PYTHON_ABI:-""} ${parallel_number} install
+        run_setup ${PYTHON_ABI:-""} install ${parallel_number}
         enable_unused_var_check
         parallel_test
         check_coverage
@@ -3907,7 +3907,7 @@ function main() {
         build_mac
         ;;
       cicheck_py37)
-        run_setup ${PYTHON_ABI:-""} ${parallel_number} bdist_wheel
+        run_setup ${PYTHON_ABI:-""} bdist_wheel ${parallel_number} 
         run_linux_cpu_test ${PYTHON_ABI:-""} ${PROC_RUN:-1}
         ;;
       test_cicheck_py37)
@@ -3920,7 +3920,7 @@ function main() {
         parallel_test
         ;;
       build_gpubox)
-        run_setup ${PYTHON_ABI:-""} ${parallel_number} install
+        run_setup ${PYTHON_ABI:-""} install ${parallel_number} 
         ;;
       check_xpu)
         cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3673,9 +3673,6 @@ function run_setup(){
       parallel_number=$3
     fi
     export MAX_JOBS=${parallel_number}
-    if [[ "$ENABLE_MAKE_CLEAN" != "OFF" ]]; then
-        export MAKE_CLEAN='ON'
-    fi
     # reset ccache zero stats for collect PR's actual hit rate
 
     ccache -z

--- a/setup.py
+++ b/setup.py
@@ -703,12 +703,12 @@ def build_steps():
         os.remove(cmake_cache_file_path)
 
     CMAKE_GENERATOR = get_cmake_generator()
-    bool_ninja = (CMAKE_GENERATOR == "Ninja")
+    bool_ninja = CMAKE_GENERATOR == "Ninja"
     build_ninja_file_path = os.path.join(build_path, "build.ninja")
     if os.path.exists(cmake_cache_file_path) and not (
         bool_ninja and not os.path.exists(build_ninja_file_path)
     ):
-        print("Do not need rerun camke,everything is ready,run build now")
+        print("Do not need rerun camke, everything is ready, run build now")
     else:
         cmake_run(build_path)
     # make

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,22 @@ assert (
     CMAKE
 ), 'The "cmake" executable is not found. Please check if Cmake is installed.'
 
+# CMAKE: full path to python library
+if platform.system() == "Windows":
+    cmake_python_library = "{}/libs/python{}.lib".format(
+        sysconfig.get_config_var("prefix"), sysconfig.get_config_var("VERSION")
+    )
+    # Fix virtualenv builds
+    if not os.path.exists(cmake_python_library):
+        cmake_python_library = "{}/libs/python{}.lib".format(
+            sys.base_prefix, sysconfig.get_config_var("VERSION")
+        )
+else:
+    libname = sysconfig.get_config_var("INSTSONAME")
+    libdir = sysconfig.get_config_var('LIBDIR') + (
+        sysconfig.get_config_var("multiarchsubdir") or ""
+    )
+    cmake_python_library = os.path.join(libdir, libname)
 
 TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -565,6 +581,8 @@ def options_process(args, build_options):
                 'PYTHON_INCLUDE_DIR', sysconfig.get_path("include")
             )
         )
+    if 'PYTHON_LIBRARY:FILEPATH' not in build_options.keys():
+        args.append('-D{}={}'.format('PYTHON_LIBRARY', cmake_python_library))
 
 
 def get_cmake_generator():

--- a/setup.py
+++ b/setup.py
@@ -639,7 +639,7 @@ def cmake_run(build_path):
                 key = option_key + ":FILEPATH"
                 print(key)
             elif option_key == 'PYTHON_INCLUDE_DIR':
-                key = key = option_key + ':PATH'
+                key = option_key + ':PATH'
                 print(key)
             else:
                 key = other_options[option_key]
@@ -703,7 +703,7 @@ def build_steps():
         os.remove(cmake_cache_file_path)
 
     CMAKE_GENERATOR = get_cmake_generator()
-    bool_ninja = CMAKE_GENERATOR == "Ninja"
+    bool_ninja = (CMAKE_GENERATOR == "Ninja")
     build_ninja_file_path = os.path.join(build_path, "build.ninja")
     if os.path.exists(cmake_cache_file_path) and not (
         bool_ninja and not os.path.exists(build_ninja_file_path)

--- a/setup.py
+++ b/setup.py
@@ -717,8 +717,8 @@ def build_steps():
             "You have finished running cmake, the program exited,run 'ccmake build' to adjust build options and 'python setup.py install to build'"
         )
         sys.exit()
-    if os.getenv("ENABLE_MAKE_CLEAN") is not None:
-        # os.system('cd %s && make clean' % build_path)
+    if os.getenv("MAKE_CLEAN") == 'ON':
+        os.system('cd %s && make clean' % build_path)
         print("make clean finished")
 
     run_cmake_build(build_path)

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,21 @@ assert (
     CMAKE
 ), 'The "cmake" executable is not found. Please check if Cmake is installed.'
 
+# CMAKE: full path to python library
+if platform.system() == "Windows":
+    cmake_python_library = "{}/libs/python{}.lib".format(
+        sysconfig.get_config_var("prefix"), sysconfig.get_config_var("VERSION")
+    )
+    # Fix virtualenv builds
+    if not os.path.exists(cmake_python_library):
+        cmake_python_library = "{}/libs/python{}.lib".format(
+            sys.base_prefix, sysconfig.get_config_var("VERSION")
+        )
+else:
+    cmake_python_library = "{}/{}".format(
+        sysconfig.get_config_var("LIBDIR"),
+        sysconfig.get_config_var("INSTSONAME"),
+    )
 
 TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -565,6 +580,8 @@ def options_process(args, build_options):
                 'PYTHON_INCLUDE_DIR', sysconfig.get_path("include")
             )
         )
+    if 'PYTHON_LIBRARY:FILEPATH' not in build_options.keys():
+        args.append('-D{}={}'.format('PYTHON_LIBRARY', cmake_python_library))
 
 
 def get_cmake_generator():
@@ -700,10 +717,6 @@ def build_steps():
             "You have finished running cmake, the program exited,run 'ccmake build' to adjust build options and 'python setup.py install to build'"
         )
         sys.exit()
-    if os.getenv("MAKE_CLEAN") == 'ON':
-        os.system('cd %s && make clean' % build_path)
-        print("make clean finished")
-
     run_cmake_build(build_path)
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,21 +50,6 @@ assert (
     CMAKE
 ), 'The "cmake" executable is not found. Please check if Cmake is installed.'
 
-# CMAKE: full path to python library
-if platform.system() == "Windows":
-    cmake_python_library = "{}/libs/python{}.lib".format(
-        sysconfig.get_config_var("prefix"), sysconfig.get_config_var("VERSION")
-    )
-    # Fix virtualenv builds
-    if not os.path.exists(cmake_python_library):
-        cmake_python_library = "{}/libs/python{}.lib".format(
-            sys.base_prefix, sysconfig.get_config_var("VERSION")
-        )
-else:
-    cmake_python_library = "{}/{}".format(
-        sysconfig.get_config_var("LIBDIR"),
-        sysconfig.get_config_var("INSTSONAME"),
-    )
 
 TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -580,8 +565,6 @@ def options_process(args, build_options):
                 'PYTHON_INCLUDE_DIR', sysconfig.get_path("include")
             )
         )
-    if 'PYTHON_LIBRARY:FILEPATH' not in build_options.keys():
-        args.append('-D{}={}'.format('PYTHON_LIBRARY', cmake_python_library))
 
 
 def get_cmake_generator():

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,16 @@ if platform.system() == "Windows":
             sys.base_prefix, sysconfig.get_config_var("VERSION")
         )
 else:
-    libname = sysconfig.get_config_var("INSTSONAME")
-    libdir = sysconfig.get_config_var('LIBDIR') + (
-        sysconfig.get_config_var("multiarchsubdir") or ""
+    cmake_python_library = "{}/{}".format(
+        sysconfig.get_config_var("LIBDIR"),
+        sysconfig.get_config_var("INSTSONAME"),
     )
-    cmake_python_library = os.path.join(libdir, libname)
+    if not os.path.exists(cmake_python_library):
+        libname = sysconfig.get_config_var("INSTSONAME")
+        libdir = sysconfig.get_config_var('LIBDIR') + (
+            sysconfig.get_config_var("multiarchsubdir") or ""
+        )
+        cmake_python_library = os.path.join(libdir, libname)
 
 TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -1341,7 +1346,7 @@ def main():
         env_dict_path = TOP_DIR + '/' + build_dir + '/python'
     else:
         env_dict_path = TOP_DIR + "/build/python/"
-    sys.path.append(env_dict_path)
+    sys.path.insert(1, env_dict_path)
     from env_dict import env_dict as env_dict
 
     global env_dict

--- a/setup.py
+++ b/setup.py
@@ -717,6 +717,10 @@ def build_steps():
             "You have finished running cmake, the program exited,run 'ccmake build' to adjust build options and 'python setup.py install to build'"
         )
         sys.exit()
+    if os.getenv("ENABLE_MAKE_CLEAN") is not None:
+        # os.system('cd %s && make clean' % build_path)
+        print("make clean finished")
+
     run_cmake_build(build_path)
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ import platform
 import re
 import shutil
 import subprocess
-import sysconfig
 import sys
+import sysconfig
 from contextlib import contextmanager
 from distutils.spawn import find_executable
 from subprocess import CalledProcessError
@@ -50,20 +50,21 @@ assert (
     CMAKE
 ), 'The "cmake" executable is not found. Please check if Cmake is installed.'
 
-#CMAKE: full path to python library
-if (platform.system() == "Windows"):
+# CMAKE: full path to python library
+if platform.system() == "Windows":
     cmake_python_library = "{}/libs/python{}.lib".format(
-        sysconfig.get_config_var("prefix"),
-        sysconfig.get_config_var("VERSION"))
+        sysconfig.get_config_var("prefix"), sysconfig.get_config_var("VERSION")
+    )
     # Fix virtualenv builds
     if not os.path.exists(cmake_python_library):
         cmake_python_library = "{}/libs/python{}.lib".format(
-            sys.base_prefix,
-            sysconfig.get_config_var("VERSION"))
+            sys.base_prefix, sysconfig.get_config_var("VERSION")
+        )
 else:
     cmake_python_library = "{}/{}".format(
         sysconfig.get_config_var("LIBDIR"),
-        sysconfig.get_config_var("INSTSONAME"))
+        sysconfig.get_config_var("INSTSONAME"),
+    )
 
 TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -571,14 +572,17 @@ def options_process(args, build_options):
     for key, value in sorted(build_options.items()):
         if value is not None:
             args.append("-D{}={}".format(key, value))
-    if ('PYTHON_EXECUTABLE:FILEPATH' not in build_options.keys()):
-        args.append("-D{}={}".format('PYTHON_EXECUTABLE',sys.executable))
-    if ('PYTHON_INCLUDE_DIR:PATH' not in build_options.keys()):
-        args.append('-D{}={}'.format('PYTHON_INCLUDE_DIR',sysconfig.get_path("include")))
-    if ('PYTHON_LIBRARY:FILEPATH' not in build_options.keys()):
-        args.append('-D{}={}'.format('PYTHON_LIBRARY',cmake_python_library))
-        
-        
+    if 'PYTHON_EXECUTABLE:FILEPATH' not in build_options.keys():
+        args.append("-D{}={}".format('PYTHON_EXECUTABLE', sys.executable))
+    if 'PYTHON_INCLUDE_DIR:PATH' not in build_options.keys():
+        args.append(
+            '-D{}={}'.format(
+                'PYTHON_INCLUDE_DIR', sysconfig.get_path("include")
+            )
+        )
+    if 'PYTHON_LIBRARY:FILEPATH' not in build_options.keys():
+        args.append('-D{}={}'.format('PYTHON_LIBRARY', cmake_python_library))
+
 
 def get_cmake_generator():
     if os.getenv("CMAKE_GENERATOR"):
@@ -698,11 +702,13 @@ def build_steps():
     # if rerun_cmake is True,remove CMakeCache.txt and rerun camke
     if os.path.isfile(cmake_cache_file_path) and rerun_cmake is True:
         os.remove(cmake_cache_file_path)
-        
+
     CMAKE_GENERATOR = get_cmake_generator()
-    bool_ninja = (CMAKE_GENERATOR == "Ninja")
+    bool_ninja = CMAKE_GENERATOR == "Ninja"
     build_ninja_file_path = os.path.join(build_path, "build.ninja")
-    if os.path.exists(cmake_cache_file_path) and not (bool_ninja and not os.path.exists(build_ninja_file_path)):
+    if os.path.exists(cmake_cache_file_path) and not (
+        bool_ninja and not os.path.exists(build_ninja_file_path)
+    ):
         print("Do not need rerun camke,everything is ready,run build now")
     else:
         cmake_run(build_path)

--- a/setup.py
+++ b/setup.py
@@ -601,15 +601,15 @@ def cmake_run(build_path):
         {
             option: option
             for option in (
-                # "PYTHON_LIBRARY",
+                "PYTHON_LIBRARY",
                 "INFERENCE_DEMO_INSTALL_DIR",
                 "ON_INFER",
-                # "PYTHON_EXECUTABLE",
+                "PYTHON_EXECUTABLE",
                 "TENSORRT_ROOT",
                 "CUDA_ARCH_NAME",
                 "CUDA_ARCH_BIN",
-                # "PYTHON_INCLUDE_DIR",
-                # "PYTHON_LIBRARIES",
+                "PYTHON_INCLUDE_DIR",
+                "PYTHON_LIBRARIES",
                 "PY_VERSION",
                 "CUB_PATH",
                 "NEW_RELEASE_PYPI",

--- a/setup.py
+++ b/setup.py
@@ -589,7 +589,6 @@ def get_cmake_generator():
         cmake_generator = os.getenv("CMAKE_GENERATOR")
     else:
         cmake_generator = "Unix Makefiles"
-
     return cmake_generator
 
 


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
此PR主要做了2件事情：
1 修改run_setup脚本，保持run_setup脚本和cmake_gen_and_build一致；
2 修复setup.py存在的一些问题,之前在当前环境和export PY_VERSION不同时，打包时会报错，编译和打包版本不一致，现在可以在不同python环境下打包，如当前环境为python2.7，可执行python3.67/3.8/3.9 setup.py install/develop/bdist_wheel 均可成功。
3 修复了当设置不同编译目录的时候，出现No module named 'env_dict'的问题