### PR TITLE
Fix collective APIs cannot be recognized when building docs

### DIFF
--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -51,7 +51,7 @@ from .collective import batch_isend_irecv  # noqa: F401
 from .collective import P2POp  # noqa: F401
 from .collective import reduce_scatter  # noqa: F401
 
-from .communication import *  # noqa: F401
+from .communication import stream  # noqa: F401
 
 from .auto_parallel import shard_op  # noqa: F401
 from .auto_parallel import shard_tensor  # noqa: F401
@@ -76,7 +76,7 @@ __all__ = [  # noqa
     "gloo_release", "QueueDataset", "split", "CountFilterEntry",
     "ShowClickEntry", "get_world_size", "get_group", "all_gather",
     "all_gather_object", "InMemoryDataset", "barrier", "all_reduce", "alltoall",
-    "send", "reduce", "recv", "ReduceOp", "wait", "get_rank",
-    "ProbabilityEntry", "ParallelMode", "is_initialized", "isend", "irecv",
-    "reduce_scatter", "rpc"
+    "alltoall_single", "send", "reduce", "recv", "ReduceOp", "wait", "get_rank",
+    "ProbabilityEntry", "ParallelMode", "is_initialized",
+    "destroy_process_group", "isend", "irecv", "reduce_scatter", "rpc", "stream"
 ]

--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -51,7 +51,7 @@ from .collective import batch_isend_irecv  # noqa: F401
 from .collective import P2POp  # noqa: F401
 from .collective import reduce_scatter  # noqa: F401
 
-from .communication import stream  # noqa: F401
+from .communication import *  # noqa: F401
 
 from .auto_parallel import shard_op  # noqa: F401
 from .auto_parallel import shard_tensor  # noqa: F401

--- a/python/paddle/distributed/communication/stream/__init__.py
+++ b/python/paddle/distributed/communication/stream/__init__.py
@@ -18,13 +18,12 @@ from .alltoall import alltoall
 from .alltoall_single import alltoall_single
 from .broadcast import broadcast
 from .reduce import reduce
-from .reduce_scatter import _reduce_scatter_base, reduce_scatter
+from .reduce_scatter import reduce_scatter
 from .recv import recv
 from .scatter import scatter
 from .send import send
 
 __all__ = [
-    "_reduce_scatter_base", "all_gather", "all_reduce", "alltoall",
-    "alltoall_single", "broadcast", "reduce", "reduce_scatter", "recv",
-    "scatter", "send"
+    "all_gather", "all_reduce", "alltoall", "alltoall_single", "broadcast",
+    "reduce", "reduce_scatter", "recv", "scatter", "send"
 ]

--- a/python/paddle/distributed/communication/stream/__init__.py
+++ b/python/paddle/distributed/communication/stream/__init__.py
@@ -24,6 +24,7 @@ from .scatter import scatter
 from .send import send
 
 __all__ = [
-    "_reduce_scatter_base", "all_reduce", "alltoall", "alltoall_single",
-    "broadcast", "reduce", "reduce_scatter", "recv", "scatter", "send"
+    "_reduce_scatter_base", "all_gather", "all_reduce", "alltoall",
+    "alltoall_single", "broadcast", "reduce", "reduce_scatter", "recv",
+    "scatter", "send"
 ]

--- a/python/paddle/fluid/tests/unittests/collective/communication_stream_reduce_scatter_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_stream_reduce_scatter_api_dygraph.py
@@ -17,6 +17,7 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 import test_collective_api_base as test_collective_base
+# from paddle.distributed.communication.stream import _reduce_scatter_base
 
 
 class StreamReduceScatterTestCase():
@@ -77,11 +78,10 @@ class StreamReduceScatterTestCase():
 
         # case 3: test the legacy API
         result_tensor = paddle.empty_like(t1)
-        task = dist.stream._reduce_scatter_base(
-            result_tensor,
-            tensor,
-            sync_op=self._sync_op,
-            use_calc_stream=self._use_calc_stream)
+        task = _reduce_scatter_base(result_tensor,
+                                    tensor,
+                                    sync_op=self._sync_op,
+                                    use_calc_stream=self._use_calc_stream)
         if not self._sync_op:
             task.wait()
         if rank == 0:

--- a/python/paddle/fluid/tests/unittests/collective/communication_stream_reduce_scatter_api_dygraph.py
+++ b/python/paddle/fluid/tests/unittests/collective/communication_stream_reduce_scatter_api_dygraph.py
@@ -17,7 +17,7 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 import test_collective_api_base as test_collective_base
-# from paddle.distributed.communication.stream import _reduce_scatter_base
+from paddle.distributed.communication.stream.reduce_scatter import _reduce_scatter_base
 
 
 class StreamReduceScatterTestCase():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix some APIs in `paddle.distributed` cannot be recognized when building docs.