### PR TITLE
[Dy2St][FP16]Enlarge atol from 0.001 to 0.01 for Hopper architecture GPUs

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist_pure_fp16.py
@@ -35,11 +35,12 @@ class TestPureFP16(TestMNIST):
             dygraph_loss = self.train_dygraph()
             static_loss = self.train_static()
             # NOTE: In pure fp16 training, loss is not stable, so we enlarge atol here.
+            # NOTE: Enlarge atol from 0.001 to 0.01 for Hopper architecture GPUs.
             np.testing.assert_allclose(
                 dygraph_loss,
                 static_loss,
                 rtol=1e-05,
-                atol=0.001,
+                atol=0.01,
                 err_msg='dygraph is {}\n static_res is \n{}'.format(
                     dygraph_loss, static_loss))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dy2St][FP16]Enlarge atol from 0.001 to 0.01 for Hopper architecture GPUs