### PR TITLE
Update imread() read image way error

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -192,7 +192,7 @@ def load_image(file, is_color=True):
     # Here, use constant 1 and 0
     # 1: COLOR, 0: GRAYSCALE
     flag = 1 if is_color else 0
-    im = cv2.imread(file, flag)
+    im = cv2.imread(file.encode('utf-8').decode('utf-8'), flag)
     return im
 
 

--- a/python/paddle/dataset/tests/test_image.py
+++ b/python/paddle/dataset/tests/test_image.py
@@ -11,35 +11,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Fliename:
+    test_image.py
+Description:
+    This scipt test image resize,flip and chw.
+"""
 
+import sys
 import unittest
 import numpy as np
-
-import paddle.dataset.image as image
+from paddle.dataset import image
 
 __all__ = []
 
 
 class Image(unittest.TestCase):
+    """
+    This function is test image resize,flip and chw.
+    """
 
     def test_resize_flip_chw(self):
-        # resize
-        im = image.load_image('cat.jpg')
-        im = image.resize_short(im, 256)
-        self.assertEqual(256, min(im.shape[:2]))
-        self.assertEqual(3, im.shape[2])
+        """ resize """
+        imgdir = sys.argv[0].replace('test_image.py', 'cat.jpg')
+        images = image.load_image(imgdir)
+        images = image.resize_short(images, 256)
+        self.assertEqual(256, min(images.shape[:2]))
+        self.assertEqual(3, images.shape[2])
 
         # flip
-        im = image.left_right_flip(im)
-        im2 = np.flip(im, 1)
-        self.assertEqual(im.all(), im2.all())
+        images = image.left_right_flip(images)
+        images2 = np.flip(images, 1)
+        self.assertEqual(images.all(), images2.all())
 
         # to_chw
-        h, w, c = im.shape
-        im = image.to_chw(im)
-        self.assertEqual(c, im.shape[0])
-        self.assertEqual(h, im.shape[1])
-        self.assertEqual(w, im.shape[2])
+        height, width, channel = images.shape
+        images = image.to_chw(images)
+        self.assertEqual(channel, images.shape[0])
+        self.assertEqual(height, images.shape[1])
+        self.assertEqual(width, images.shape[2])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
1.解决imread中文路径读取图片报错问题
2.解决测试代码相对路径下attributeError: ‘NoneType’ object has no attribute ‘shape 报错问题
![image](https://user-images.githubusercontent.com/6836917/195776557-5099f3c5-6671-4fca-9b74-29b3eb4140c4.png)
