### PR TITLE
Skip some trt unit tests on windows due to precision errors

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_grid_sampler.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_grid_sampler.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from trt_layer_auto_scan_test import TrtLayerAutoScanTest
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest, SkipReasons
 from program_config import TensorConfig, ProgramConfig
 import numpy as np
 import paddle.inference as paddle_infer
 from functools import partial
 from typing import List
 import unittest
+import os
 
 
 class TrtConvertGridSampler(TrtLayerAutoScanTest):
@@ -101,7 +102,19 @@ class TrtConvertGridSampler(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), (1, 3), 1e-5
 
+    def add_skip_trt_case(self):
+
+        def teller1(program_config, predictor_config):
+            if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
+                return True
+            return False
+
+        self.add_skip_case(
+            teller1, SkipReasons.TRT_NOT_SUPPORT,
+            "The output has diff between gpu and trt in Windows.")
+
     def test(self):
+        self.add_skip_case()
         self.run_test()
 
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pad3d.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pad3d.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from trt_layer_auto_scan_test import TrtLayerAutoScanTest
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest, SkipReasons
 from program_config import TensorConfig, ProgramConfig
 import numpy as np
 import paddle.inference as paddle_infer
 from functools import partial
 from typing import List
 import unittest
+import os
 
 
 class TrtConvertPad3d(TrtLayerAutoScanTest):
@@ -97,7 +98,19 @@ class TrtConvertPad3d(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), (1, 2), 1e-5
 
+    def add_skip_trt_case(self):
+
+        def teller1(program_config, predictor_config):
+            if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
+                return True
+            return False
+
+        self.add_skip_case(
+            teller1, SkipReasons.TRT_NOT_SUPPORT,
+            "The output has diff between gpu and trt in Windows.")
+
     def test(self):
+        self.add_skip_case()
         self.run_test()
 
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_scatter_nd_add.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_scatter_nd_add.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from trt_layer_auto_scan_test import TrtLayerAutoScanTest
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest, SkipReasons
 from program_config import TensorConfig, ProgramConfig
 import numpy as np
 import paddle.inference as paddle_infer
 from functools import partial
 from typing import List
 import unittest
+import os
 
 
 class TrtConvertScatterNd(TrtLayerAutoScanTest):
@@ -109,7 +110,19 @@ class TrtConvertScatterNd(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), (1, 4), 1e-5
 
+    def add_skip_trt_case(self):
+
+        def teller1(program_config, predictor_config):
+            if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
+                return True
+            return False
+
+        self.add_skip_case(
+            teller1, SkipReasons.TRT_NOT_SUPPORT,
+            "The output has diff between gpu and trt in Windows.")
+
     def test(self):
+        self.add_skip_case()
         self.run_test()
 
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unfold.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unfold.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from trt_layer_auto_scan_test import TrtLayerAutoScanTest
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest, SkipReasons
 from program_config import TensorConfig, ProgramConfig
 import numpy as np
 import paddle.inference as paddle_infer
 from functools import partial
 from typing import List
 import unittest
+import os
 
 
 class TrtConvertUnfold(TrtLayerAutoScanTest):
@@ -96,7 +97,19 @@ class TrtConvertUnfold(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), (1, 2), 1e-5
 
+    def add_skip_trt_case(self):
+
+        def teller1(program_config, predictor_config):
+            if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
+                return True
+            return False
+
+        self.add_skip_case(
+            teller1, SkipReasons.TRT_NOT_SUPPORT,
+            "The output has diff between gpu and trt in Windows.")
+
     def test(self):
+        self.add_skip_case()
         self.run_test()
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
scatter_nd, grid_sampler, unfold, pad3d这四个 op 的通用 plugin 在windows的CI中偶然地随机挂掉，如下所示
<img width="747" alt="a8079ab4d17faa521b6e3e5656086a77" src="https://user-images.githubusercontent.com/63448337/195749089-2f8bbe97-89e2-4231-a03a-6e0d3d986585.png">

<img width="733" alt="baa361a2e762a859e83daf0e655acf6f" src="https://user-images.githubusercontent.com/63448337/195749102-9e28a780-5035-4d93-bbaa-6808a8e825b6.png">

影响CI的效率，暂停做跳过处理。

