### PR TITLE
[Paddle-TRT] fix conv2d

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -281,17 +281,13 @@ struct SimpleOpTypeSetTeller : public Teller {
       }
 #endif
       auto* block = desc.Block();
-      if (block == nullptr) {
-        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
-                   "Developers need to check whether block_desc is passed in "
-                   "the pass.";
-        return false;
-      }
-      auto* filter_var_desc = block->FindVar(desc.Input("Filter")[0]);
-      if (!filter_var_desc->Persistable()) {
-        VLOG(3) << "Trt not support filter is  a intermediate tensor in "
-                   "conv2d op.";
-        return false;
+      if (block) {
+        auto* filter_var_desc = block->FindVar(desc.Input("Filter")[0]);
+        if (!filter_var_desc->Persistable()) {
+          VLOG(3) << "Trt not support filter is  a intermediate tensor in "
+                     "conv2d op.";
+          return false;
+        }
       }
     }
 

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -280,6 +280,19 @@ struct SimpleOpTypeSetTeller : public Teller {
         }
       }
 #endif
+      auto* block = desc.Block();
+      if (block == nullptr) {
+        VLOG(3) << "The block desc is nullptr, we can't continue to analyze. "
+                   "Developers need to check whether block_desc is passed in "
+                   "the pass.";
+        return false;
+      }
+      auto* filter_var_desc = block->FindVar(desc.Input("Filter")[0]);
+      if (!filter_var_desc->Persistable()) {
+        VLOG(3) << "Trt not support filter is  a intermediate tensor in "
+                   "conv2d op.";
+        return false;
+      }
     }
 
     if (op_type == "deformable_conv") {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- Paddle-TRT只支持权重是persistable的tensor，如果经过constant folding之后，权重 tensor仍然不是persistable的，它应该被禁止进入TRT，如图中所示。

<img width="548" alt="image" src="https://user-images.githubusercontent.com/39978853/195866327-05c9b185-e565-4f35-8e48-b7942317a92e.png">


- 事实上，这个修复已经被merge到[release/2.3分支了](https://github.com/PaddlePaddle/Paddle/pull/45023)。
