### PR TITLE
Fix for conv_bias_mkldnn_pass

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1707,7 +1707,6 @@ PDNode *patterns::ConvBias::operator()(
   // Filter
   auto *conv_weight_var = pattern->NewNode(conv_weight_repr())
                               ->AsInput()
-                              ->assert_is_persistable_var()
                               ->assert_is_op_input(conv_type, "Filter");
   // intermediate variable, will be removed in the IR after fuse.
   auto *conv_out_var = pattern->NewNode(conv_out_repr())


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix for conv_bias_mkldnn_pass. Because of enforcing persistency of conv_weights this pattern was not being properly detected in U2++ model. Basically the persistency of conv weights has nothing to do to the fused bias, so it was clearly just a bug