### PR TITLE
fix paddle.get_default_dtype

### DIFF
--- a/python/paddle/framework/framework.py
+++ b/python/paddle/framework/framework.py
@@ -72,7 +72,7 @@ def get_default_dtype():
     Args:
         None.
     Returns:
-        The default dtype.
+        String, this global dtype only supports float16, float32, float64.
 
     Examples:
         .. code-block:: python


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
Fix paddle.get_default_dtype: Chinese and English return values are inconsistent
<!-- Describe what this PR does -->
