### PR TITLE
Close popen pipe after used

### DIFF
--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -73,7 +73,9 @@ def avx_supported():
     has_avx = False
     if sysstr == 'linux':
         try:
-            has_avx = os.popen('cat /proc/cpuinfo | grep -i avx').read() != ''
+            pipe = os.popen('cat /proc/cpuinfo | grep -i avx')
+            has_avx = pipe.read() != ''
+            pipe.close()
         except Exception as e:
             sys.stderr.write(
                 'Can not get the AVX flag from /proc/cpuinfo.\n'
@@ -82,10 +84,9 @@ def avx_supported():
         return has_avx
     elif sysstr == 'darwin':
         try:
-            has_avx = (
-                os.popen('sysctl machdep.cpu.features | grep -i avx').read()
-                != ''
-            )
+            pipe = os.popen('sysctl machdep.cpu.features | grep -i avx')
+            has_avx = pipe.read() != ''
+            pipe.close()
         except Exception as e:
             sys.stderr.write(
                 'Can not get the AVX flag from machdep.cpu.features.\n'


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->
The `popen` should be closed after used, otherwise, it will cause error on some of the OS.