### PR TITLE
[Dy2Static] Remove GradTransformer

### DIFF
--- a/paddle/phi/kernels/impl/einsum_impl.h
+++ b/paddle/phi/kernels/impl/einsum_impl.h
@@ -241,7 +241,7 @@ inline static void InferLabelShape(const std::vector<std::string>& op_labels,
       } else if (labelshape->is_default(c) || (*labelshape)[c] == -1) {
         (*labelshape)[c] = op_dim[dim_ptr];
         dim_ptr++;
-      } else {
+      } else if (op_dim[dim_ptr] != -1) {
         PADDLE_ENFORCE_EQ(
             (*labelshape)[c],
             op_dim[dim_ptr],

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -57,7 +57,7 @@ def declarative_unsupport_argument_warning(func_name, input_names, inputs,
     for name, inp, sup in zip(input_names, inputs, support_values):
         if inp != sup:
             warnings.warn(f"{func_name} has unsupported parameter in jit: " +
-                          + "{name}, jit will discard it")
+                          f"{name}, jit will discard it")
 
 
 def _switch_to_static_graph_(func):

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -447,7 +447,7 @@ def guard(place=None):
                     yield
 
 
-@framework.dygraph_and_dy2static_only
+@framework.non_static_only
 def grad(outputs,
          inputs,
          grad_outputs=None,

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -102,7 +102,7 @@ class DygraphToStaticAst(BaseTransformer):
             PrintTransformer,  # print statement
             CallTransformer,  # transform call recursively
             CastTransformer,  # type casting statement
-            GradTransformer,  # transform paddle.grad to paddle.gradients
+            #GradTransformer,  # transform paddle.grad to paddle.gradients
             DecoratorTransformer,  # transform decorators to function call
         ]
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -513,7 +513,7 @@ def _dygraph_only_(func):
     return __impl__
 
 
-def _dygraph_and_dy2static_only_(func):
+def _non_static_only_(func):
 
     def __impl__(*args, **kwargs):
         from .dygraph.base import in_declarative_mode
@@ -583,7 +583,7 @@ dygraph_not_support = wrap_decorator(_dygraph_not_support_)
 dygraph_only = wrap_decorator(_dygraph_only_)
 static_only = wrap_decorator(_static_only_)
 fake_interface_only = wrap_decorator(_fake_interface_only_)
-dygraph_and_dy2static_only = wrap_decorator(_dygraph_and_dy2static_only_)
+non_static_only = wrap_decorator(_non_static_only_)
 
 
 def _dygraph_tracer():

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -513,6 +513,17 @@ def _dygraph_only_(func):
     return __impl__
 
 
+def _dygraph_and_dy2static_only_(func):
+
+    def __impl__(*args, **kwargs):
+        from .dygraph.base import in_declarative_mode
+        assert _non_static_mode() or in_declarative_mode(
+        ), "We only support '%s()' in dynamic graph mode, please call 'paddle.disable_static()' to enter dynamic graph mode." % func.__name__
+        return func(*args, **kwargs)
+
+    return __impl__
+
+
 def _static_only_(func):
 
     def __impl__(*args, **kwargs):
@@ -572,6 +583,7 @@ dygraph_not_support = wrap_decorator(_dygraph_not_support_)
 dygraph_only = wrap_decorator(_dygraph_only_)
 static_only = wrap_decorator(_static_only_)
 fake_interface_only = wrap_decorator(_fake_interface_only_)
+dygraph_and_dy2static_only = wrap_decorator(_dygraph_and_dy2static_only_)
 
 
 def _dygraph_tracer():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. fix einsum infershape bugs.
2. remove grad_transformer and unify paddle.grad and paddle.static.gradient.
3. add dygraph_and_dy2static_only decorator for dy2static.
