### PR TITLE
[Zero-Dim] support 0D Tensor for reshape/create_parameter

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -1460,11 +1460,6 @@ static phi::DDim ValidateShape(const std::vector<int64_t> shape,
 void InferMetaFromVecValue(const MetaTensor& x,
                            const std::vector<int64_t>& shape,
                            MetaTensor* out) {
-  PADDLE_ENFORCE_EQ(!shape.empty(),
-                    true,
-                    phi::errors::InvalidArgument(
-                        "The parameter 'shape' in ReshapeOp must be set. "
-                        "But received 'shape' is empty."));
   auto x_dims = x.dims();
   auto out_dims = ValidateShape(shape, x_dims);
   out->set_dims(out_dims);
@@ -2833,6 +2828,7 @@ void RepeatInterleaveInferMeta(const MetaTensor& x,
   out->share_lod(x);
   out->set_dtype(x.dtype());
 }
+
 void ReshapeInferMeta(const MetaTensor& x,
                       const IntArray& shape,
                       MetaTensor* out,
@@ -2846,10 +2842,6 @@ void ReshapeInferMeta(const MetaTensor& x,
     out->share_lod(x);
     return;
   }
-  PADDLE_ENFORCE_GT(shape_data.size(),
-                    0,
-                    phi::errors::InvalidArgument(
-                        "The shape's size in ReshapeOp can't be zero."));
   InferMetaFromVecValue(x, shape_data, out);
 }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3257,12 +3257,14 @@ function build_document_preview() {
 # origin name: example
 function exec_samplecode_test() {
     if [ -d "${PADDLE_ROOT}/build/pr_whl" ];then
-        pip install ${PADDLE_ROOT}/build/pr_whl/*.whl
+        pip install ${PADDLE_ROOT}/build/pr_whl/*.whl --force-reinstall
     else
-        pip install ${PADDLE_ROOT}/build/python/dist/*.whl
+        echo "WARNING: PR wheel is not found. Use develop wheel !!!"
+        pip install ${PADDLE_ROOT}/build/python/dist/*.whl  --force-reinstall
     fi
 
-    paddle version
+    python -c "import paddle;print(paddle.__version__);paddle.version.show()"
+
     cd ${PADDLE_ROOT}/tools
     if [ "$1" = "cpu" ] ; then
         python sampcd_processor.py cpu; example_error=$?
@@ -3473,7 +3475,6 @@ function main() {
         ;;
       build_and_check_gpu)
         set +e
-        set +x
         example_info_gpu=""
         example_code_gpu=0
         if [ "${WITH_GPU}" == "ON" ] ; then
@@ -3483,7 +3484,6 @@ function main() {
         example_info=$(exec_samplecode_test cpu)
         example_code=$?
         summary_check_problems $[${example_code_gpu} + ${example_code}] "${example_info_gpu}\n${example_info}"
-        set -x
         assert_api_spec_approvals
         ;;
       check_whl_size)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -6580,10 +6580,6 @@ class Parameter(Variable):
         if dtype is None:
             raise ValueError("The dtype of Parameter should not be None")
 
-        if len(shape) == 0:
-            raise ValueError(
-                "The dimensions of shape for Parameter must be greater than 0")
-
         for each in shape:
             if each < 0:
                 raise ValueError(
@@ -6683,10 +6679,6 @@ class ParamBase(core.VarBase):
             raise ValueError("The shape of Parameter should not be None")
         if dtype is None:
             raise ValueError("The dtype of Parameter should not be None")
-
-        if len(shape) == 0:
-            raise ValueError(
-                "The dimensions of shape for Parameter must be greater than 0")
 
         for each in shape:
             if each < 0:
@@ -6829,10 +6821,6 @@ class EagerParamBase(_core_eager_eagertensor):
             raise ValueError("The shape of Parameter should not be None")
         if dtype is None:
             raise ValueError("The dtype of Parameter should not be None")
-
-        if len(shape) == 0:
-            raise ValueError(
-                "The dimensions of shape for Parameter must be greater than 0")
 
         for each in shape:
             if each < 0:

--- a/python/paddle/fluid/tests/unittests/test_egr_python_api.py
+++ b/python/paddle/fluid/tests/unittests/test_egr_python_api.py
@@ -249,6 +249,9 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         self.assertTrue(egr_tensor12.place._equals(paddle.fluid.CPUPlace()))
         np.testing.assert_array_equal(egr_tensor12.numpy(), x)
 
+        zero_dim_param = EagerParamBase(shape=[], dtype="float32")
+        self.assertEqual(zero_dim_param.shape, [])
+
         with self.assertRaisesRegexp(
                 ValueError, "The shape of Parameter should not be None"):
             eager_param = EagerParamBase(shape=None, dtype="float32")
@@ -256,11 +259,6 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         with self.assertRaisesRegexp(
                 ValueError, "The dtype of Parameter should not be None"):
             eager_param = EagerParamBase(shape=[1, 1], dtype=None)
-
-        with self.assertRaisesRegexp(
-                ValueError,
-                "The dimensions of shape for Parameter must be greater than 0"):
-            eager_param = EagerParamBase(shape=[], dtype="float32")
 
         with self.assertRaisesRegexp(
                 ValueError,

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -16,7 +16,7 @@ import unittest
 import copy
 import paddle
 from paddle.fluid.dygraph import guard
-from paddle.fluid.framework import default_main_program, Variable, _test_eager_guard
+from paddle.fluid.framework import default_main_program, Variable, _test_eager_guard, ParamBase
 import paddle.fluid.core as core
 from paddle.fluid.executor import Executor
 import paddle.fluid.io as io
@@ -48,6 +48,9 @@ class ParameterChecks(unittest.TestCase):
         p = io.get_parameter_value_by_name('fc.w', exe, main_program)
         np.testing.assert_array_equal(p, np.ones(shape) * val)
 
+        zero_dim_param = b.create_parameter(name='x', shape=[], dtype='float32')
+        self.assertEqual(zero_dim_param.shape, ())
+
     def func_parambase(self):
         with guard():
             linear = paddle.nn.Linear(10, 10)
@@ -69,6 +72,9 @@ class ParameterChecks(unittest.TestCase):
 
             pram_copy2 = copy.deepcopy(param, memo)
             self.assertEqual(id(param_copy), id(pram_copy2))
+
+            zero_dim_param = ParamBase(shape=[], dtype='float32')
+            self.assertEqual(zero_dim_param.shape, [])
 
     def test_parambase(self):
         with _test_eager_guard():

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -57,17 +57,17 @@ class TestReshapeOp_ZeroDim1(OpTest):
 class TestReshapeOp_ZeroDim2(OpTest):
 
     def init_data(self):
-        self.ori_shape = (1)
-        self.new_shape = ()
-        self.infered_shape = ()
+        self.ori_shape = ()
+        self.new_shape = (-1)
+        self.infered_shape = (1)
 
 
 class TestReshapeOp_ZeroDim3(OpTest):
 
     def init_data(self):
-        self.ori_shape = ()
-        self.new_shape = (-1)
-        self.infered_shape = (1)
+        self.ori_shape = (1)
+        self.new_shape = ()
+        self.infered_shape = ()
 
 
 class TestReshapeBF16Op(OpTest):
@@ -560,15 +560,23 @@ class TestReshapeAPI_ZeroDim(unittest.TestCase):
 
         out = paddle.reshape(x, [1])
         out.backward()
-        self.assertEqual(out.shape, [1])
         self.assertEqual(x.grad.shape, [])
+        self.assertEqual(out.shape, [1])
         self.assertEqual(out.grad.shape, [1])
 
         out = paddle.reshape(x, [-1, 1])
         out.backward()
-        self.assertEqual(out.shape, [1, 1])
         self.assertEqual(x.grad.shape, [])
+        self.assertEqual(out.shape, [1, 1])
         self.assertEqual(out.grad.shape, [1, 1])
+
+        x = paddle.rand([1])
+        x.stop_gradient = False
+        out = paddle.reshape(x, [])
+        out.backward()
+        self.assertEqual(x.grad.shape, [1])
+        self.assertEqual(out.shape, [])
+        self.assertEqual(out.grad.shape, [])
 
         paddle.enable_static()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
[Zero-Dim] 为`reshape`、`create_parameter` 支持输入0D，属于新增功能，无不兼容影响。

```
paddle.reshape
paddle.static.create_parameter
```