### PR TITLE
[CodeStyle][py2] fix a decode error caused by 47036

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3658,8 +3658,8 @@ class Block(object):
         Rename variable in vars and ops' inputs and outputs
 
         Args:
-            name(bytes): the name that need to be renamed.
-            new_name(bytes): the name that need to rename to.
+            name(str|bytes): the name that need to be renamed.
+            new_name(str|bytes): the name that need to rename to.
 
         Raises:
             ValueError: If this block doesn't have this the giving name,
@@ -3669,8 +3669,9 @@ class Block(object):
         Returns:
             Variable: the Variable with the giving name.
         """
-        name = name.decode()
-        new_name = new_name.decode()
+        name = name.decode() if isinstance(name, bytes) else name
+        new_name = new_name.decode() if isinstance(new_name,
+                                                   bytes) else new_name
 
         if not self.has_var(name):
             raise ValueError("var %s is not in current block" % name)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3669,6 +3669,7 @@ class Block(object):
         Returns:
             Variable: the Variable with the giving name.
         """
+        # Ensure the type of name and new_name is str
         name = name.decode() if isinstance(name, bytes) else name
         new_name = new_name.decode() if isinstance(new_name,
                                                    bytes) else new_name

--- a/python/paddle/fluid/tests/unittests/test_block_rename_var.py
+++ b/python/paddle/fluid/tests/unittests/test_block_rename_var.py
@@ -53,5 +53,4 @@ class TestBlockRenameVarBytes(TestBlockRenameVar):
 
 
 if __name__ == "__main__":
-    paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_block_rename_var.py
+++ b/python/paddle/fluid/tests/unittests/test_block_rename_var.py
@@ -1,0 +1,57 @@
+#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+class TestBlockRenameVar(unittest.TestCase):
+
+    def setUp(self):
+        self.program = paddle.static.Program()
+        self.block = self.program.current_block()
+        self.var = self.block.create_var(name="X",
+                                         shape=[-1, 23, 48],
+                                         dtype='float32')
+        self.op = self.block.append_op(type="abs",
+                                       inputs={"X": [self.var]},
+                                       outputs={"Out": [self.var]})
+        self.new_var_name = self.get_new_var_name()
+
+    def get_new_var_name(self):
+        return "Y"
+
+    def test_rename_var(self):
+        self.block._rename_var(self.var.name, self.new_var_name)
+        new_var_name_str = self.new_var_name if isinstance(
+            self.new_var_name, str) else self.new_var_name.decode()
+        self.assertTrue(new_var_name_str in self.block.vars)
+
+
+class TestBlockRenameVarStrCase2(TestBlockRenameVar):
+
+    def get_new_var_name(self):
+        return "ABC"
+
+
+class TestBlockRenameVarBytes(TestBlockRenameVar):
+
+    def get_new_var_name(self):
+        return b"Y"
+
+
+if __name__ == "__main__":
+    paddle.enable_static()
+    unittest.main()

--- a/tools/static_mode_white_list.py
+++ b/tools/static_mode_white_list.py
@@ -15,6 +15,7 @@
 
 STATIC_MODE_TESTING_LIST = [
     'test_affine_channel_op',
+    'test_block_rename_var',
     'test_transfer_dtype_op',
     'test_transfer_layout_op',
     'test_concat_op',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

详见 #47096，由 #47036 导致，由于主框架内使用方式仅为传递 bytes，未考虑到外部使用了传递 str 的方式，现做出兼容两者的处理，与原有代码行为保持一致

fixes #47096