### PR TITLE
[Dy2Stat]Polish @to_static temporary file directory to speed up transformation

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -19,7 +19,7 @@ import copy
 import collections
 from paddle.utils import gast
 import inspect
-import os
+import os, sys
 import shutil
 import six
 import tempfile
@@ -83,7 +83,6 @@ dygraph_class_to_static_api = {
     "PolynomialDecay": "polynomial_decay",
 }
 
-TEMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Temp")
 DEL_TEMP_DIR = True  # A flag to avoid atexit.register more than once
 FOR_ITER_INDEX_PREFIX = '__for_loop_var_index'
 FOR_ITER_TUPLE_PREFIX = '__for_loop_iter_tuple'
@@ -549,6 +548,22 @@ def create_assign_node(name, node):
     return targets, assign_node
 
 
+def get_temp_dir():
+    """
+    Return @to_static temp directory.
+    """
+    dir_name = "paddle/to_static_tmp"
+    temp_dir = os.path.join(os.path.expanduser('~/.cache'), dir_name)
+    is_windows = sys.platform.startswith('win')
+    if is_windows:
+        temp_dir = os.path.normpath(temp_dir)
+
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir)
+
+    return temp_dir
+
+
 def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
     """
     Transform modified AST of decorated function into python callable object.
@@ -560,15 +575,23 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
         if os.path.exists(dir_path):
             shutil.rmtree(dir_path)
 
-    if not os.path.exists(TEMP_DIR):
-        os.mkdir(TEMP_DIR)
+    def func_prefix(func):
+        pre_fix = func.__name__
+        if hasattr(func, '__self__'):
+            try:
+                pre_fix = func.__self__.__class__.__name__ + '_' + func.__name__
+            except:
+                pass
+        return pre_fix
+
     source = ast_to_source_code(ast_root)
     source = _inject_import_statements() + source
-
+    temp_dir = get_temp_dir()
     f = tempfile.NamedTemporaryFile(mode='w',
+                                    prefix=func_prefix(),
                                     suffix='.py',
                                     delete=False,
-                                    dir=TEMP_DIR,
+                                    dir=temp_dir,
                                     encoding='utf-8')
     with f:
         module_name = os.path.basename(f.name[:-3])
@@ -577,11 +600,11 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
     global DEL_TEMP_DIR
     if delete_on_exit and DEL_TEMP_DIR:
         # Clear temporary files in TEMP_DIR while exitting Python process
-        atexit.register(remove_if_exit, dir_path=TEMP_DIR)
+        atexit.register(remove_if_exit, dir_path=temp_dir)
         DEL_TEMP_DIR = False
 
-    module = SourceFileLoader(module_name, f.name).load_module()
     func_name = dyfunc.__name__
+    module = SourceFileLoader(module_name, f.name).load_module()
     # The 'forward' or 'another_forward' of 'TranslatedLayer' cannot be obtained
     # through 'func_name'. So set the special function name '__i_m_p_l__'.
     if hasattr(module, '__i_m_p_l__'):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -588,7 +588,7 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
     source = _inject_import_statements() + source
     temp_dir = get_temp_dir()
     f = tempfile.NamedTemporaryFile(mode='w',
-                                    prefix=func_prefix(),
+                                    prefix=func_prefix(func),
                                     suffix='.py',
                                     delete=False,
                                     dir=temp_dir,

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -588,7 +588,7 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
     source = _inject_import_statements() + source
     temp_dir = get_temp_dir()
     f = tempfile.NamedTemporaryFile(mode='w',
-                                    prefix=func_prefix(func),
+                                    prefix=func_prefix(dyfunc),
                                     suffix='.py',
                                     delete=False,
                                     dir=temp_dir,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### What's New?

+ 独立了@to_static 的temp 目录
+ 指定了 temp文件的前缀为类似 resnet_forward_xxx.py，便于调试

在 windows Python39 环境下发现 PaddleSeg 某个模型转写特别慢，经过分析发现：发现99.9%的时间都耗费在 ast_to_func函数中的 `module = SourceFileLoader(module_name, f.name).load_module()` 代码行。
![image](https://user-images.githubusercontent.com/9301846/196376483-a24f89aa-7df4-421f-939a-ade7be247fa1.png)


经定位是因为windows下会默认把 temp文件写到 `C:\Users\Administrator.DESKTOP-xxxxx\AppData\Local\Temp`目录，在读取这个目录文件时存在一定的额外开销，可能原因：

* 此目录是公共目录，可能会被多个进程读取，有锁？
* 发现开发机器上 Temp下非常多文件，读取时可能会影响性能。

修复方案：在 `NamedTemporaryFileAPI` 里可以指定 dir 参数，换成其他空目录后，导出就非常快了：
![image](https://user-images.githubusercontent.com/9301846/196376513-ae9087ac-4f84-40c7-be7c-66f6dcf5e8ad.png)
