### PR TITLE
Fix send for old dygraph mode by passing use_calc_stream to the send api

### DIFF
--- a/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
+++ b/python/paddle/distributed/fleet/meta_parallel/pp_utils/p2p_communication.py
@@ -199,7 +199,8 @@ def send_partial(tensor,
         dst_rank = _hcg._get_p2p_next_rank(
         ) if dst == 1 else _hcg._get_p2p_prev_rank()
         if _in_legacy_dygraph():
-            send_op = paddle.distributed.send
+            send_op = lambda x, dst, group: \
+                    paddle.distributed.send(x, dst, group, use_calc_stream)
         elif in_dygraph_mode():
             send_op = paddle.distributed.isend
         return send_op(tensor.detach(), dst=dst_rank, group=group)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
When using old drgraph mode and pipeline parallel, send is synchronized , which makesthe process hanging.
We fix it by passing an option use_calc_stream determined by users.