### PR TITLE
fix macos clang warnings of [-Wformat]

### DIFF
--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -157,18 +157,18 @@ static void PrintNanInf(const T* value,
     }
 
     if (count < static_cast<size_t>(print_num)) {
-      printf("numel:%lu index:%lu value:%f\n",
-             static_cast<uint64_t>(numel),
-             static_cast<uint64_t>(i),
+      printf("numel:%zu index:%zu value:%f\n",
+             numel,
+             i,
              static_cast<float>(value[i]));
     }
   }
   printf(
-      "In cpu, there has %lu,%lu,%lu nan,inf,num. "
+      "In cpu, there has %zu,%zu,%zu nan,inf,num. "
       "And in num, min_value is %f, max_value is %f\n",
-      static_cast<uint64_t>(nan_count),
-      static_cast<uint64_t>(inf_count),
-      static_cast<uint64_t>(num_count),
+      nan_count,
+      inf_count,
+      num_count,
       static_cast<double>(min_value),
       static_cast<double>(max_value));
   if (abort) {

--- a/paddle/fluid/operators/math/bloomfilter.h
+++ b/paddle/fluid/operators/math/bloomfilter.h
@@ -20,6 +20,7 @@ limitations under the License. */
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <cinttypes>
 
 namespace paddle {
 namespace operators {
@@ -151,7 +152,7 @@ int bloomfilter_check(struct bloomfilter *filter) {
   if (filter->magic_num == BLOOMFILTER_MAGIC_NUM_NEW) {
     return 1;
   } else {
-    fprintf(stderr, "error magic_num %ld\n", filter->magic_num);
+    fprintf(stderr, "error magic_num, %" PRIu64 "\n", filter->magic_num);
     return 0;
   }
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
fix macos clang warnings of [-Wformat]

```bash
➜ cat make_before.log  | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr 
 757 [-Winconsistent-missing-override]
  31 [-Wformat]
  13 [-Wbraced-scalar-init]
   4 [-Wc++17-extensions]
   2 [-Wexceptions]
   1 [-Wunknown-warning-option]
   1 [-Wuninitialized]
   1 [-Wtautological-constant-out-of-range-compare]
   1 [-Wreturn-type-c-linkage]
   1 [-Wpragma-pack]
   1 [-Wliteral-conversion]

```

```bash
➜ cat make_after.log  | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr 
 757 [-Winconsistent-missing-override]
  13 [-Wbraced-scalar-init]
   4 [-Wc++17-extensions]
   2 [-Wexceptions]
   1 [-Wuninitialized]
   1 [-Wtautological-constant-out-of-range-compare]
   1 [-Wreturn-type-c-linkage]
   1 [-Wpragma-pack]
   1 [-Wliteral-conversion]
   1 [-Wformat]
```

The last one `[-Wformat]` is the title of my git commit log, not the actual warning.
**Compiler Warning tracking issue:**
- #47143