### PR TITLE
Fix cannot import `paddle.distributed` in python 3.6 on release/2.4

### DIFF
--- a/python/paddle/distributed/communication/stream/recv.py
+++ b/python/paddle/distributed/communication/stream/recv.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.distributed.collective as collective
 import paddle.fluid.framework as framework
+from paddle.distributed import collective
 
 
 def _recv_in_dygraph(tensor, src, group, sync_op, use_calc_stream):

--- a/python/paddle/distributed/communication/stream/reduce_scatter.py
+++ b/python/paddle/distributed/communication/stream/reduce_scatter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import paddle
-import paddle.distributed as dist
 import paddle.fluid.framework as framework
 from paddle.distributed.communication.group import _get_global_group
 from paddle.distributed.communication.reduce import _get_reduce_op, ReduceOp

--- a/python/paddle/distributed/communication/stream/scatter.py
+++ b/python/paddle/distributed/communication/stream/scatter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import paddle
-import paddle.distributed as dist
 import paddle.fluid.framework as framework
 from paddle.distributed import collective
 
@@ -44,7 +43,7 @@ def _scatter_tensor_in_dygraph(out_tensor, in_tensor, src, group, sync_op,
         raise RuntimeError("Src rank out of group.")
 
     nranks = group.nranks
-    rank = dist.get_rank()
+    rank = paddle.distributed.get_rank()
     if rank == src_rank:
         _check_tensor_shape(out_tensor, in_tensor.shape, nranks)
 

--- a/python/paddle/distributed/communication/stream/scatter.py
+++ b/python/paddle/distributed/communication/stream/scatter.py
@@ -68,7 +68,7 @@ def _scatter_in_dygraph(tensor, tensor_list, src, group, sync_op,
         raise RuntimeError("Src rank out of group.")
 
     nranks = group.nranks
-    rank = dist.get_rank()
+    rank = paddle.distributed.get_rank()
     if rank == src_rank:
         if len(tensor_list) == 0:
             raise RuntimeError(

--- a/python/paddle/distributed/communication/stream/send.py
+++ b/python/paddle/distributed/communication/stream/send.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.distributed.collective as collective
 import paddle.fluid.framework as framework
+from paddle.distributed import collective
 
 
 def _send_in_dygraph(tensor, dst, group, sync_op, use_calc_stream):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix cannot import `paddle.distributed` in python 3.6 on release/2.4.