### PR TITLE
[CustomDevice] turn on WITH_CUSTOM_DEVICE when WITH_PYTHON=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,7 +336,7 @@ endif()
 
 if(LINUX
    AND NOT WITH_CUSTOM_DEVICE
-   AND NOT ON_INFER)
+   AND WITH_PYTHON)
   set(WITH_CUSTOM_DEVICE
       ON
       CACHE BOOL "Enable Custom Device when compiling for Linux" FORCE)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry pick https://github.com/PaddlePaddle/Paddle/pull/47108

原 WITH_CUSTOM_DEVICE 默认打开/关闭的策略随 ON_INFER开关，由于训练和预测共同发包，现在训练包编译时会打开 ON_INFER，导致 WITH_CUSTOM_DEVICE 默认关闭，custom device 功能不可用

WITH_CUSTOM_DEVICE 默认打开/关闭的策略更改为随 WITH_PYTHON 开关