### PR TITLE
add Exp_DisableTrtEngineMemorySharing interface

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -657,12 +657,10 @@ void AnalysisConfig::EnableTensorRtEngine(
   use_tensorrt_ = true;
 #ifdef PADDLE_WITH_TENSORRT
   // https://forums.developer.nvidia.com/t/nvinfer1-createexecutioncontextwithoutdevicememory-returns-nullptr/111878/2
-  // when trt version less than 7.2,
-  // createExecutionContextWithoutDeviceMemory() has bug.
-  // so, we cannot enable engine context memory sharing.
-#if IS_TRT_VERSION_GE(7200)
-  trt_engine_memory_sharing_ = true;
-#else
+  // when trt version less than 7.2, the interface
+  // createExecutionContextWithoutDeviceMemory() has bug. so we cannot enable
+  // engine context memory sharing.
+#if IS_TRT_VERSION_LT(7200)
   LOG(WARNING)
       << "TensorRT engine context memory sharing needs version 7.2 and after.";
   trt_engine_memory_sharing_ = false;
@@ -724,6 +722,11 @@ void AnalysisConfig::EnableTensorRtInspector() { trt_use_inspector_ = true; }
 void AnalysisConfig::Exp_DisableTensorRtOPs(
     const std::vector<std::string> &ops) {
   trt_disabled_ops_.insert(trt_disabled_ops_.end(), ops.begin(), ops.end());
+}
+
+void AnalysisConfig::Exp_DisableTrtEngineMemorySharing() {
+  trt_engine_memory_sharing_ = false;
+  Update();
 }
 
 void AnalysisConfig::EnableVarseqlen() { trt_use_varseqlen_ = true; }

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -667,6 +667,12 @@ struct PD_INFER_DECL AnalysisConfig {
   void Exp_DisableTensorRtOPs(const std::vector<std::string>& ops);
 
   ///
+  /// \brief Disable TensorRT engine context memory sharing
+  /// NOTE: just experimental, not an official stable API, easy to be broken.
+  ///
+  void Exp_DisableTrtEngineMemorySharing();
+
+  ///
   /// \brief Replace some TensorRT plugins to TensorRT OSS(
   /// https://github.com/NVIDIA/TensorRT), with which some models's inference
   /// may be more high-performance. Libnvinfer_plugin.so greater than
@@ -1059,7 +1065,7 @@ struct PD_INFER_DECL AnalysisConfig {
 
   // memory reuse related.
   bool enable_memory_optim_{false};
-  bool trt_engine_memory_sharing_{false};
+  bool trt_engine_memory_sharing_{true};
 
   bool use_mkldnn_{false};
   std::unordered_set<std::string> mkldnn_enabled_op_types_;

--- a/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
@@ -81,6 +81,7 @@ TEST(PredictorPool, use_gpu) {
   config.SetModel(model_dir);
   config.EnableTensorRtEngine();
   config.Exp_DisableTensorRtOPs({"fc"});
+  config.Exp_DisableTrtEngineMemorySharing();
   config.EnableTensorRtDLA(0);
   services::PredictorPool pred_pool(config, 1);
 

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -743,6 +743,8 @@ void BindAnalysisConfig(py::module *m) {
       .def("trt_allow_build_at_runtime",
            &AnalysisConfig::trt_allow_build_at_runtime)
       .def("exp_disable_tensorrt_ops", &AnalysisConfig::Exp_DisableTensorRtOPs)
+      .def("exp_disable_trtengine_memory_sharing",
+           &AnalysisConfig::Exp_DisableTrtEngineMemorySharing)
       .def("enable_tensorrt_dla",
            &AnalysisConfig::EnableTensorRtDLA,
            py::arg("dla_core") = 0)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

add Exp_DisableTrtEngineMemorySharing interface

原有的trt engine memory sharing功能是默认开启的，目前为止，个别模型推理会崩溃，是TensorRT内部错误。因此新增这个接口方便特殊情况下用户关闭此功能。