### PR TITLE
[Sparse] Fix indices

### DIFF
--- a/paddle/phi/infermeta/sparse/unary.cc
+++ b/paddle/phi/infermeta/sparse/unary.cc
@@ -20,7 +20,9 @@ namespace phi {
 namespace sparse {
 
 void IndicesInferMeta(const MetaTensor& x, MetaTensor* out) {
-  out->set_dims({-1});
+  // TODO(zhangkaihuo) Currently, we cannot get sparse_dim from tensor. shape[0]
+  // = x.sparse_dim()
+  out->set_dims({4, -1});
   out->set_dtype(DataType::INT32);
   out->set_layout(DataLayout::NCHW);
 }

--- a/paddle/phi/infermeta/sparse/unary.cc
+++ b/paddle/phi/infermeta/sparse/unary.cc
@@ -24,7 +24,7 @@ void IndicesInferMeta(const MetaTensor& x, MetaTensor* out) {
   // correct shape is: shape[0] = x.sparse_dim()
   // In the 3D point cloud model:
   // the input x is 5-D tensor, non_zero_elements is 1-D tensor
-  out->set_dims({x_dims.size() - 1, -1});
+  out->set_dims({x.dims().size() - 1, -1});
   out->set_dtype(DataType::INT32);
   out->set_layout(DataLayout::NCHW);
 }

--- a/paddle/phi/infermeta/sparse/unary.cc
+++ b/paddle/phi/infermeta/sparse/unary.cc
@@ -20,9 +20,11 @@ namespace phi {
 namespace sparse {
 
 void IndicesInferMeta(const MetaTensor& x, MetaTensor* out) {
-  // TODO(zhangkaihuo) Currently, we cannot get sparse_dim from tensor. shape[0]
-  // = x.sparse_dim()
-  out->set_dims({4, -1});
+  // TODO(zhangkaihuo) Currently, we cannot get sparse_dim from tensor.
+  // correct shape is: shape[0] = x.sparse_dim()
+  // In the 3D point cloud model:
+  // the input x is 5-D tensor, non_zero_elements is 1-D tensor
+  out->set_dims({x_dims.size() - 1, -1});
   out->set_dtype(DataType::INT32);
   out->set_layout(DataLayout::NCHW);
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

当前无法从Tensor中获取到SparseTensor的sparse_dim，无法准确推断出indices的shape，所以目前先以3D点云模型为主，输入的SparseTensor的维度是5D的，其中非零元素是一维向量，所以indices是[4, -1]。