### PR TITLE
export all symbols for phi_function_api

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -118,6 +118,12 @@ if(WITH_ONNXRUNTIME)
       ${CMAKE_CURRENT_SOURCE_DIR}/api/onnxruntime_predictor.cc)
 endif()
 
+#export all symbols for paddle/phi/api/include/api.h on paddle_inference_shared, only for UNIX
+if(UNIX)
+  set(SHARED_INFERENCE_DEPS ${SHARED_INFERENCE_DEPS}
+                            $<TARGET_OBJECTS:phi_function_api>)
+endif()
+
 # Create shared inference library
 cc_library(
   paddle_inference_shared SHARED


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
export all symbols for phi_function_api on paddle_inference_shared

修复libpaddle_inference.so 没有导出phi_function_api的问题
在调用libpaddle_inference.so  使用phi算子C++接口
例如, 
undefined reference to `paddle::experimental::add(paddle::experimental::Tensor const&, paddle::experimental::Tensor const&)
导致https://github.com/PaddlePaddle/Paddle/issues/47162 出现symbol丢失

原因: 
GCC在链接不使用的静态库API接口，会导致符号丢弃。
CMake TARGET_OBJECTS 可以使静态库优先导出符号