### PR TITLE
[Opt Code] Clean conv_op useless variable

### DIFF
--- a/paddle/fluid/operators/conv_op.h
+++ b/paddle/fluid/operators/conv_op.h
@@ -30,10 +30,6 @@ namespace paddle {
 namespace operators {
 
 using Tensor = phi::DenseTensor;
-constexpr int kConvMKLDNNFP32 = 1;
-constexpr int kConvMKLDNNINT8 = 2;
-constexpr int kConvMKLDNNINT8WS8 = 3;
-constexpr int MaxKeyLength = 256;
 
 // Base convolution operator definations for other conv
 // like operators to reuse the implementation.


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
OPs

### Describe
Clean conv_op useless variable, delete `kConvMKLDNNFP32` and other variables.