### PR TITLE
[Inference] [Don't Merge] Add infer shape cache.

### DIFF
--- a/paddle/fluid/framework/ir/runtime_context_cache_pass.cc
+++ b/paddle/fluid/framework/ir/runtime_context_cache_pass.cc
@@ -22,9 +22,12 @@ namespace ir {
 
 void RuntimeContextCachePass::ApplyImpl(ir::Graph* graph) const {
   VLOG(3) << "Applies Runtime Context Cache strategy.";
+
+  auto infershape_cache = Get<bool>("infershape_cache");
   for (const Node* n : graph->Nodes()) {
     if (n->IsOp() && n->Op()) {
       n->Op()->SetAttr(kEnableCacheRuntimeContext, true);
+      if (infershape_cache) n->Op()->SetAttr("@ENABLE_INFERSHAPE_CACHE@", true);
     }
   }
 }

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -169,6 +169,8 @@ struct Argument {
   // whether to mute all logs in inference.
   DECL_ARGUMENT_FIELD(disable_logs, DisableLogs, bool);
 
+  DECL_ARGUMENT_FIELD(infershape_cache, InferShapeCache, bool);
+
   // Pass a set of op types to enable its mkldnn kernel
   DECL_ARGUMENT_FIELD(mkldnn_enabled_op_types,
                       MKLDNNEnabledOpTypes,

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -65,6 +65,7 @@ void IRPassManager::CreatePasses(Argument *argument,
     pass->Set("tensorrt_transformer_maskid",
               new std::string(argument->tensorrt_transformer_maskid()));
     pass->Set("disable_logs", new bool(argument->disable_logs()));
+    pass->Set("infershape_cache", new bool(argument->infershape_cache()));
     auto precision_mode = argument->tensorrt_precision_mode();
     bool enable_int8 = precision_mode == AnalysisConfig::Precision::kInt8;
     pass->Set("enable_int8", new bool(enable_int8));

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -362,6 +362,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(prog_file_);
   CP_MEMBER(params_file_);
 
+  CP_MEMBER(infershape_cahce_);
   CP_MEMBER(use_fc_padding_);
   // GPU related.
   CP_MEMBER(use_gpu_);
@@ -957,7 +958,7 @@ std::string AnalysisConfig::SerializeInfoCache() {
   ss << model_dir_;
   ss << prog_file_;
   ss << params_file_;
-
+  ss << infershape_cahce_;
   ss << use_gpu_;
   ss << use_external_stream_;
   ss << exec_stream_;
@@ -1266,6 +1267,8 @@ std::string AnalysisConfig::Summary() {
 
   return os.PrintTable();
 }
+
+void AnalysisConfig::EnableInferShapeCache(bool x) { infershape_cahce_ = x; }
 
 LiteNNAdapterConfig &LiteNNAdapterConfig::SetDeviceNames(
     const std::vector<std::string> &names) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <memory>
 #include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -1051,6 +1052,7 @@ bool AnalysisPredictor::GetFetch(std::vector<PaddleTensor> *outputs,
 void AnalysisPredictor::PrepareArgument() {
   argument_.SetUseGPU(config_.use_gpu());
   argument_.SetUseFcPadding(config_.use_fc_padding());
+  argument_.SetInferShapeCache(config_.infershape_cahce_);
   argument_.SetGPUDeviceId(config_.gpu_device_id());
   argument_.SetEnableAnalysisOptim(config_.enable_ir_optim_);
   argument_.SetEnableMemoryOptim(config_.enable_memory_optim());
@@ -1366,6 +1368,17 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
       } else {
         process_level_allocator_enabled = true;
       }
+
+      // support set flags from enviorment.
+      const platform::ExportedFlagInfoMap &env_map =
+          platform::GetExportedFlagInfoMap();
+      std::ostringstream os;
+      os << "--tryfromenv=";
+      for (auto &pair : env_map) {
+        os << pair.second.name << ",";
+      }
+      auto tryfromenv_str = os.str();
+      gflags.push_back(os.str().substr(0, tryfromenv_str.size() - 1));
 
       if (framework::InitGflags(gflags)) {
         VLOG(3) << "The following gpu analysis configurations only take effect "

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -949,6 +949,8 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   std::string Summary();
 
+  void EnableInferShapeCache(bool x);
+
   LiteNNAdapterConfig& NNAdapter() { return nnadapter_config_; }
 
   void SetDistConfig(const DistConfig& dist_config) {
@@ -976,6 +978,9 @@ struct PD_INFER_DECL AnalysisConfig {
   std::string model_dir_;
   mutable std::string prog_file_;
   mutable std::string params_file_;
+
+  // General optimization.
+  bool infershape_cahce_;
 
   // Mixed precision.
   std::unordered_set<std::string> mixed_black_list_;

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -138,7 +138,7 @@ const std::vector<std::string> kTRTSubgraphPasses({
       "conv_elementwise_add2_act_fuse_pass",  //
 #endif
 #endif
-      "transpose_flatten_concat_fuse_pass",
+      "transpose_flatten_concat_fuse_pass", "runtime_context_cache_pass",
 });
 
 const std::vector<std::string> kDlnneSubgraphPasses({
@@ -187,6 +187,7 @@ const std::vector<std::string> kTrtLowerPrecisionPasses{
     "trt_map_matmul_to_mul_pass",
     "fc_fuse_pass",
     "tensorrt_subgraph_pass",
+    "runtime_context_cache_pass",
 };
 
 GpuPassStrategy::GpuPassStrategy() : PassStrategy({}) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
针对phi算子的`InferShape`过程进行cache.

收益：代码分析，跳过phi算子InferShape过程，性能收益在100-700ns之间，但由于会引入当前shape和上一轮shape比较（约200ns），性能收益最大约500ns每op，实际测试由于缺失phi fusion算子无法看出效果。
缺陷：与显/内存复用冲突，无法同时使用；

代码不合入，仅保留参考；