### PR TITLE
[Do Not Review] CUDNN v8 Integration of Convolution Operator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,8 @@ option(WITH_CUSTOM_DEVICE "Compile with custom device support" OFF)
 option(WITH_ARM_BRPC "Supprot Brpc in Arm" OFF)
 option(WITH_FLPS "FL PS mode" OFF)
 option(WITH_RPC "Compile with rpc support" ${WITH_DISTRIBUTE})
+option(WITH_CUDNN_FRONTEND
+       "Compile with CUDNN Frontend API support (experimental)" OFF)
 
 if(WITH_RECORD_BUILDTIME)
   set_property(

--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -248,3 +248,7 @@ endif()
 if(WITH_GPU_GRAPH)
   add_definitions(-DPADDLE_WITH_GPU_GRAPH)
 endif()
+
+if(WITH_CUDNN_FRONTEND)
+  add_definitions(-DPADDLE_WITH_CUDNN_FRONTEND)
+endif()

--- a/cmake/external/cudnn-frontend.cmake
+++ b/cmake/external/cudnn-frontend.cmake
@@ -1,0 +1,68 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(ExternalProject)
+
+set(CUDNN_FRONTEND_CUDNN_MIN_VERSION 8400)
+
+if(NOT WITH_GPU)
+  message(FATAL_ERROR "Can't enable CUDNN Frontend API without CUDA.")
+endif()
+if(CUDNN_VERSION LESS 8400)
+  message(
+    FATAL_ERROR
+      "Minimum CUDNN version is ${CUDNN_FRONTEND_CUDNN_MIN_VERSION}. Current: ${CUDNN_VERSION}"
+  )
+endif()
+
+message(STATUS "Adding cudnn-frontend.")
+
+# Version: v0.7.1
+set(CUDNN_FRONTEND_PREFIX_DIR ${THIRD_PARTY_PATH}/cudnn-frontend)
+set(CUDNN_FRONTEND_SOURCE_DIR
+    ${THIRD_PARTY_PATH}/cudnn-frontend/src/extern_cudnn_frontend/include)
+set(CUDNN_FRONTEND_REPOSITORY https://github.com/NVIDIA/cudnn-frontend.git)
+set(CUDNN_FRONTEND_TAG v0.7.1)
+
+set(CUDNN_FRONTEND_INCLUDE_DIR ${CUDNN_FRONTEND_SOURCE_DIR})
+include_directories(${CUDNN_FRONTEND_INCLUDE_DIR})
+
+ExternalProject_Add(
+  extern_cudnn_frontend
+  ${EXTERNAL_PROJECT_LOG_ARGS} ${SHALLOW_CLONE}
+  GIT_REPOSITORY ${CUDNN_FRONTEND_REPOSITORY}
+  GIT_TAG ${CUDNN_FRONTEND_TAG}
+  PREFIX ${CUDNN_FRONTEND_PREFIX_DIR}
+  UPDATE_COMMAND ""
+  PATCH_COMMAND sed -i s/NULL/nullptr/g
+                ${CUDNN_FRONTEND_SOURCE_DIR}/cudnn_frontend_ExecutionPlan.h
+  COMMAND sed -i s/NULL/nullptr/g
+          ${CUDNN_FRONTEND_SOURCE_DIR}/cudnn_frontend_OperationGraph.h
+  COMMAND sed -i "s/ ::cudnn/ cudnn/g"
+          ${CUDNN_FRONTEND_SOURCE_DIR}/cudnn_frontend_find_plan.h
+  COMMAND sed -i "s/^\\(auto\\)/inline \\1/g"
+          ${CUDNN_FRONTEND_SOURCE_DIR}/cudnn_frontend_get_plan.h
+  COMMAND sed -i "s/, cudnn_frontend::ExecutionPlanCache_v1::compare//"
+          ${CUDNN_FRONTEND_SOURCE_DIR}/cudnn_frontend_ExecutionPlanCache.h
+  COMMAND
+    patch -d ${CUDNN_FRONTEND_SOURCE_DIR} -p2 <
+    ${PADDLE_SOURCE_DIR}/patches/cudnn-frontend/cudnn_frontend_ExecutionPlan_patch_1.patch
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
+  TIMEOUT $ENV{DOWNLOAD_TIMEOUT})
+
+add_library(cudnn-frontend INTERFACE)
+add_dependencies(cudnn-frontend extern_cudnn_frontend)

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -163,6 +163,11 @@ if(NOT WIN32)
     )
   endif()
 
+  if(WITH_CUDNN_FRONTEND)
+    # flags from https://github.com/NVIDIA/cudnn-frontend/blob/v0.7.1/CMakeLists.txt
+    set(COMMON_FLAGS ${COMMON_FLAGS} -Wno-sign-compare -Wno-non-virtual-dtor)
+  endif()
+
   if(WITH_ASCEND_CL AND WITH_ARM_BRPC)
     set(COMMON_FLAGS ${COMMON_FLAGS} -faligned-new)
   endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -505,4 +505,9 @@ if(WITH_CUSPARSELT)
   list(APPEND third_party_deps extern_cusparselt)
 endif()
 
+if(WITH_CUDNN_FRONTEND)
+  include(external/cudnn-frontend) # download cudnn-frontend
+  list(APPEND third_party_deps extern_cudnn_frontend)
+endif()
+
 add_custom_target(third_party ALL DEPENDS ${third_party_deps})

--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -847,6 +847,14 @@ struct SearchAlgorithm : public SearchAlgorithmBase<PerfT> {
 #endif
   }
 };
+#ifdef PADDLE_WITH_CUDNN_FRONTEND
+class WorkspaceHelper {
+ public:
+  static size_t GetWorkspaceSizeLimitBytes() {
+    return CalcWorkspaceLimitInBytes(UseFixedWorkspace());
+  }
+};  // class WorkspaceHelper
+#endif
 
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/platform/device/gpu/CMakeLists.txt
+++ b/paddle/fluid/platform/device/gpu/CMakeLists.txt
@@ -10,6 +10,12 @@ if(WITH_GPU)
     cudnn_desc_test
     SRCS cudnn_desc_test.cc
     DEPS dynload_cuda)
+  if(WITH_CUDNN_FRONTEND)
+    nv_test(
+      cudnn_frontend_test
+      SRCS cudnn_frontend_test.cc
+      DEPS dynload_cuda cudnn-frontend)
+  endif()
 elseif(WITH_ROCM)
   add_subdirectory(rocm)
   hip_library(

--- a/paddle/fluid/platform/device/gpu/cuda/CMakeLists.txt
+++ b/paddle/fluid/platform/device/gpu/cuda/CMakeLists.txt
@@ -6,7 +6,12 @@ nv_library(
   cuda_profiler
   SRCS cuda_profiler.cc
   DEPS enforce)
-
+if(WITH_CUDNN_FRONTEND)
+  nv_library(
+    cudnn_frontend
+    SRCS cudnn_frontend.cc
+    DEPS gflags)
+endif()
 nv_test(
   cudnn_helper_test
   SRCS cudnn_helper_test.cc

--- a/paddle/fluid/platform/device/gpu/cuda/cudnn_desc.h
+++ b/paddle/fluid/platform/device/gpu/cuda/cudnn_desc.h
@@ -26,6 +26,9 @@
 #include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/fluid/platform/device/gpu/cuda/cudnn_helper.h"
 #include "paddle/fluid/platform/device_context.h"
+#ifdef PADDLE_WITH_CUDNN_FRONTEND
+#include "paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.h"
+#endif
 
 namespace phi {
 class DenseTensor;

--- a/paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.cc
+++ b/paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#ifdef PADDLE_WITH_CUDNN_FRONTEND
+#include "paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.h"
+#include "paddle/fluid/platform/flags.h"
+
+PADDLE_DEFINE_EXPORTED_bool(cudnn_frontend_enable, false, "");
+PADDLE_DEFINE_EXPORTED_bool(cudnn_frontend_debug, false, "");
+
+#endif  // PADDLE_WITH_CUDNN_FRONTEND

--- a/paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.h
+++ b/paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.h
@@ -1,0 +1,67 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+#include <iostream>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+#include "paddle/fluid/platform/device/gpu/gpu_info.h"
+#include "paddle/phi/backends/dynload/cudnn.h"
+
+DECLARE_bool(cudnn_frontend_enable);
+DECLARE_bool(cudnn_frontend_debug);
+
+// Redirect the CUDNN APIs in the cudnn_frontend namespace to
+// the functions in phi::dynload
+#define CUDNN_FRONTEND_OVERRIDE_SYMBOL(__name) using phi::dynload::__name
+
+#define CUDNN_FRONTEND_APPLY_EACH(__macro) \
+  __macro(cudnnBackendCreateDescriptor);   \
+  __macro(cudnnBackendDestroyDescriptor);  \
+  __macro(cudnnBackendExecute);            \
+  __macro(cudnnBackendFinalize);           \
+  __macro(cudnnBackendGetAttribute);       \
+  __macro(cudnnBackendSetAttribute);       \
+  __macro(cudnnCreateFilterDescriptor);    \
+  __macro(cudnnDestroyFilterDescriptor);   \
+  __macro(cudnnGetStream);                 \
+  __macro(cudnnGetVersion);                \
+  __macro(cudnnReorderFilterAndBias);      \
+  __macro(cudnnSetFilterNdDescriptor);
+
+namespace cudnn_frontend {
+CUDNN_FRONTEND_APPLY_EACH(CUDNN_FRONTEND_OVERRIDE_SYMBOL);
+}  // namespace cudnn_frontend
+
+// clang-format off
+#include <cudnn_frontend.h>                                        // NOLINT
+#include <cudnn_frontend_find_plan.h>                              // NOLINT
+#include <cudnn_frontend_get_plan.h>                               // NOLINT
+// clang-format on
+
+namespace paddle {
+namespace platform {
+inline bool IsCudnnFrontendEnabled() {
+  int cudnn_version = paddle::platform::DnnVersion();
+  bool flag_enabled = FLAGS_cudnn_frontend_enable && (cudnn_version >= 8200);
+  VLOG(3) << "[cudnn_frontend] FLAGS_cudnn_frontend_debug="
+          << FLAGS_cudnn_frontend_debug
+          << "; flag_enabled=" << FLAGS_cudnn_frontend_enable;
+  return flag_enabled;
+}
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/device/gpu/cuda/cudnn_frontend_conv_helper.h
+++ b/paddle/fluid/platform/device/gpu/cuda/cudnn_frontend_conv_helper.h
@@ -1,0 +1,343 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+Copyright (c) 2022 NVIDIA Corporation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <vector>
+
+#include "paddle/fluid/framework/convert_utils.h"
+#include "paddle/fluid/operators/conv_cudnn_helper.h"
+#include "paddle/fluid/platform/device/gpu/cuda/cudnn_desc.h"
+#include "paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
+
+DECLARE_int64(cudnn_exhaustive_search_times);
+
+namespace phi {
+class DenseTensor;
+}  // namespace phi
+
+namespace paddle {
+namespace platform {
+
+class CudnnFrontendPlanCache {
+ public:
+  explicit CudnnFrontendPlanCache(std::string name) : name_(name) {
+    map_.clear();
+    tracker_.clear();
+    search_times_ = FLAGS_cudnn_exhaustive_search_times;
+    saturation_count_ = search_times_ <= 1 ? 1 : search_times_;
+  }
+
+  CudnnFrontendPlanCache(CudnnFrontendPlanCache const&) = delete;
+  void operator=(CudnnFrontendPlanCache const&) = delete;
+
+  inline cudnn_frontend::feature_vector_t MakeKey(
+      const cudnn_frontend::OperationGraph& op_graph, bool use_addto) {
+    auto key = op_graph.getFeatureVector();
+    key.push_back(static_cast<uint64_t>(use_addto));
+    return key;
+  }
+
+  bool FindPlan(const cudnn_frontend::OperationGraph& op_graph,
+                bool use_addto = false) {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto key = op_graph.getFeatureVector();
+    return map_.count(MakeKey(op_graph, use_addto)) > 0;
+  }
+
+  cudnn_frontend::ExecutionPlan GetPlan(
+      const cudnn_frontend::OperationGraph& op_graph,
+      cudnnHandle_t handle,
+      bool use_addto = false) {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto engine_config = map_[MakeKey(op_graph, use_addto)];
+    auto plan = cudnn_frontend::ExecutionPlanBuilder()
+                    .setHandle(handle)
+                    .setEngineConfig(engine_config, op_graph.getTag())
+                    .build();
+    return std::move(plan);
+  }
+
+  void InsertPlan(const cudnn_frontend::OperationGraph& op_graph,
+                  const cudnn_frontend::ExecutionPlan& plan,
+                  bool use_addto = false) {
+    VLOG(4) << "[cudnn_frontend] cache name: " << name_
+            << "; Insert graph tag: " << op_graph.getTag();
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    map_.insert(
+        std::make_pair(MakeKey(op_graph, use_addto), plan.GetEngineConfig()));
+  }
+
+  bool IsStable(const cudnn_frontend::OperationGraph& op_graph,
+                const std::string& tag,
+                bool use_addto = false) {
+    if (saturation_count_ == 1) {
+      return true;
+    }
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    if (map_.count(MakeKey(op_graph, use_addto))) {
+      return false;
+    }
+    int cnt = tracker_[std::make_pair(MakeKey(op_graph, use_addto), tag)] += 1;
+    VLOG(4) << "[cudnn_frontend] SaturationTracker " << name_ << " "
+            << op_graph.getTag() << " " << tag << " " << cnt;
+    return cnt >= saturation_count_;
+  }
+
+  std::string GetName() { return name_; }
+
+ private:
+  std::map<cudnn_frontend::feature_vector_t,
+           cudnn_frontend::ManagedOpaqueDescriptor>
+      map_;
+  int search_times_;
+  std::mutex cache_mutex_;
+  int saturation_count_;
+  std::string name_;
+
+  using SaturationTracker =
+      std::map<std::pair<cudnn_frontend::feature_vector_t, std::string>, int>;
+  SaturationTracker tracker_;
+};  // class CudnnFrontendPlanCache
+
+class CudnnFrontendConvHelper {
+ public:
+  static bool IsNonDeterministic(cudnnBackendDescriptor_t engine_config) {
+    return cudnn_frontend::hasNumericalNote<
+        CUDNN_NUMERICAL_NOTE_NONDETERMINISTIC>(engine_config);
+  }
+  static bool AllowAll(cudnnBackendDescriptor_t engine_config) {
+    (void)engine_config;
+    return false;
+  }
+
+  static uint8_t GetAlignment(const phi::DenseTensor* tensor) {
+    // alignment are in bytes
+    uint8_t alignment = 1;
+    uint64_t address = reinterpret_cast<uint64_t>(tensor->data());
+    while (address % alignment == 0 && alignment < 16) alignment *= 2;
+    return alignment;
+  }
+
+  static std::vector<int64_t> GetInt64Array(const std::vector<int>& in_array) {
+    std::vector<int64_t> out_array(in_array.size());
+    for (int i = 0; i < in_array.size(); i++) {
+      out_array[i] = static_cast<int64_t>(in_array[i]);
+    }
+    return out_array;
+  }
+
+  static void GenerateStrides(const int64_t* dimA,
+                              int64_t* strideA,
+                              int nbDims,
+                              cudnnTensorFormat_t filter_format) {
+    // ref:
+    // https://github.com/NVIDIA/cudnn-frontend/blob/main/samples/helpers.cpp
+    // For INT8x4 and INT8x32 we still compute standard strides here to input
+    // into the cuDNN functions. We will manually scale by resizeFactor in the
+    // cpu ref.
+    if (filter_format == CUDNN_TENSOR_NCHW) {
+      strideA[nbDims - 1] = 1;
+      for (int64_t d = nbDims - 2; d >= 0; d--) {
+        strideA[d] = strideA[d + 1] * dimA[d + 1];
+      }
+    } else {
+      // Here we assume that the format is CUDNN_TENSOR_NHWC
+      strideA[1] = 1;
+      strideA[nbDims - 1] = strideA[1] * dimA[1];
+      for (int64_t d = nbDims - 2; d >= 2; d--) {
+        strideA[d] = strideA[d + 1] * dimA[d + 1];
+      }
+      strideA[0] = strideA[2] * dimA[2];
+    }
+  }
+
+  static cudnn_frontend::Tensor GetTensorDescriptor(
+      const phi::DenseTensor* tensor,
+      int64_t id,
+      cudnnTensorFormat_t layout_format) {
+    auto dims = phi::vectorize<int>(tensor->dims());
+    std::vector<int64_t> transformed_dims;
+    if (layout_format == CUDNN_TENSOR_NHWC) {
+      transformed_dims = GetInt64Array(TransformDimOrder(dims));
+    } else {
+      transformed_dims = GetInt64Array(dims);
+    }
+    std::vector<int64_t> strides(dims.size());
+    GenerateStrides(transformed_dims.data(),
+                    strides.data(),
+                    transformed_dims.size(),
+                    layout_format);
+    return cudnn_frontend::TensorBuilder()
+        .setDim(transformed_dims.size(), transformed_dims.data())
+        .setStrides(strides.size(), strides.data())
+        .setId(id)
+        .setAlignment(GetAlignment(tensor))
+        .setDataType(
+            ToCudnnDataType(framework::TransToProtoVarType(tensor->dtype())))
+        .build();
+  }
+
+  static cudnn_frontend::ConvDesc_v8 GetConvDescriptor(
+      cudnnDataType_t dataType,
+      const std::vector<int>& padding,
+      const std::vector<int>& stride,
+      const std::vector<int>& dilation) {
+    uint64_t conv_dim = stride.size();
+    cudnnDataType_t compute_type =
+        (dataType == CUDNN_DATA_DOUBLE) ? CUDNN_DATA_DOUBLE : CUDNN_DATA_FLOAT;
+    std::vector<int64_t> padding_int64 = GetInt64Array(padding);
+    std::vector<int64_t> stride_int64 = GetInt64Array(stride);
+    std::vector<int64_t> dilation_int64 = GetInt64Array(dilation);
+    return cudnn_frontend::ConvDescBuilder()
+        .setDataType(compute_type)
+        .setMathMode(CUDNN_CROSS_CORRELATION)
+        .setNDims(conv_dim)
+        .setStrides(conv_dim, stride_int64.data())
+        .setPrePadding(conv_dim, padding_int64.data())
+        .setPostPadding(conv_dim, padding_int64.data())
+        .setDilation(conv_dim, dilation_int64.data())
+        .build();
+  }
+
+  template <cudnnBackendDescriptorType_t op_mode>
+  static cudnn_frontend::OperationGraph BuildConvOperationGraph(
+      const phi::DenseTensor* x_tensor,
+      const phi::DenseTensor* y_tensor,
+      const phi::DenseTensor* w_tensor,
+      cudnnTensorFormat_t layout_format,
+      const std::vector<int>& strides,
+      const std::vector<int>& padding_common,
+      const std::vector<int>& dilations,
+      cudnnDataType_t dtype,
+      cudnnHandle_t handle,
+      float alpha,
+      float beta) {
+    auto op = cudnn_frontend::OperationBuilder(op_mode)
+                  .setxDesc(GetTensorDescriptor(x_tensor, 'x', layout_format))
+                  .setyDesc(GetTensorDescriptor(y_tensor, 'y', layout_format))
+                  .setwDesc(GetTensorDescriptor(w_tensor, 'w', layout_format))
+                  .setcDesc(GetConvDescriptor(
+                      dtype, padding_common, strides, dilations))
+                  .setAlpha(alpha)
+                  .setBeta(beta)
+                  .build();
+    std::array<cudnn_frontend::Operation const*, 1> ops = {&op};
+    return cudnn_frontend::OperationGraphBuilder()
+        .setHandle(handle)
+        .setOperationGraph(1, ops.data())
+        .build();
+  }
+
+  static cudnn_frontend::executionPlans_t FindExecutionPlans(
+      cudnn_frontend::OperationGraph* op_graph_pointer,
+      bool exhaustive_search,
+      bool deterministic,
+      void* x_data,
+      void* y_data,
+      void* w_data,
+      cudnnHandle_t handle,
+      phi::DnnWorkspaceHandle* workspace_handle) {
+    auto heurgen_method = [=](cudnn_frontend::OperationGraph& op_graph_)
+        -> cudnn_frontend::EngineConfigList {
+      auto heuristics = cudnn_frontend::EngineHeuristicsBuilder()
+                            .setOperationGraph(op_graph_)
+                            .setHeurMode(CUDNN_HEUR_MODE_INSTANT)
+                            .build();
+      VLOG(4) << "Heuristic has " << heuristics.getEngineConfigCount()
+              << " configurations ";
+
+      auto& engine_configs =
+          heuristics.getEngineConfig(heuristics.getEngineConfigCount());
+      cudnn_frontend::EngineConfigList filtered_configs;
+      cudnn_frontend::filter(engine_configs,
+                             filtered_configs,
+                             deterministic ? IsNonDeterministic : AllowAll);
+      return filtered_configs;
+    };
+
+    auto fallback_method = [=](cudnn_frontend::OperationGraph& op_graph_)
+        -> cudnn_frontend::EngineConfigList {
+      auto fallback = cudnn_frontend::EngineFallbackListBuilder()
+                          .setOperationGraph(op_graph_)
+                          .build();
+      auto& fallback_list = fallback.getFallbackList();
+      cudnn_frontend::EngineConfigList filtered_configs;
+      cudnn_frontend::filter(fallback_list,
+                             filtered_configs,
+                             deterministic ? IsNonDeterministic : AllowAll);
+      return filtered_configs;
+    };
+
+    std::array<cudnn_frontend::GeneratorSource const, 2> sources = {
+        heurgen_method, fallback_method};
+    cudnn_frontend::EngineConfigGenerator generator(sources.size(),
+                                                    sources.data());
+
+    size_t workspace_size_limit =
+        paddle::operators::WorkspaceHelper::GetWorkspaceSizeLimitBytes();
+    auto predicate_function =
+        [=](cudnn_frontend::ExecutionPlan const& plan) -> bool {
+      return plan.getWorkspaceSize() > workspace_size_limit;
+    };
+
+    auto plans =
+        generator.cudnnGetPlan(handle, *op_graph_pointer, predicate_function);
+
+    if (exhaustive_search) {
+      size_t workspace_size_max = 0;
+      std::for_each(
+          plans.begin(), plans.end(), [&](cudnn_frontend::ExecutionPlan& opt) {
+            if (opt.getWorkspaceSize() > workspace_size_max) {
+              workspace_size_max = opt.getWorkspaceSize();
+            }
+          });
+      VLOG(6) << "[cudnn_frontend] Max workspace size: " << workspace_size_max;
+      workspace_handle->RunFunc(
+          [&](void* workspace_ptr) {
+            void* data_ptrs[] = {x_data, y_data, w_data};
+            int64_t uids[] = {'x', 'y', 'w'};
+            auto variant_pack = cudnn_frontend::VariantPackBuilder()
+                                    .setWorkspacePointer(workspace_ptr)
+                                    .setDataPointers(3, data_ptrs)
+                                    .setUids(3, uids)
+                                    .build();
+            plans =
+                generator
+                    .cudnnFindPlan<cudnn_frontend::CudnnFindSamplingTechnique::
+                                       CUDNN_FIND_SAMPLE_MEDIAN_OF_THREE>(
+                        handle,
+                        *op_graph_pointer,
+                        variant_pack,
+                        predicate_function);
+          },
+          workspace_size_max);
+    }
+
+    if (FLAGS_cudnn_frontend_debug) {
+      std::for_each(
+          plans.begin(), plans.end(), [](cudnn_frontend::ExecutionPlan& opt) {
+            VLOG(6) << "Plan tag: " << opt.getTag() << " finished in "
+                    << opt.getExecutionTime() << " ms,"
+                    << " workspace: " << opt.getWorkspaceSize() << " bytes";
+          });
+    }
+    return plans;
+  }
+};  // class CudnnFrontendConvHelper
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/device/gpu/cudnn_frontend_test.cc
+++ b/paddle/fluid/platform/device/gpu/cudnn_frontend_test.cc
@@ -1,0 +1,48 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.h"
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+namespace paddle {
+namespace platform {
+
+TEST(CudnnFrontendTest, TensorCreation) {
+  // Consider creation of a 2d Tensor
+  // n,c,h,w as 4,32,32,32
+  std::cout << "Tensor creation comparison" << std::endl;
+  std::array<int64_t, 4> tensor_dim = {4, 32, 32, 32};
+  std::array<int64_t, 4> tensor_str = {32768, 1024, 32, 1};  // NCHW format
+  cudnnDataType_t data_type = CUDNN_DATA_FLOAT;
+  int64_t alignment = sizeof(float);
+  int64_t id = 0xD0D0CACA;  // Some magic number
+
+  try {
+    auto tensor = cudnn_frontend::TensorBuilder()
+                      .setDim(tensor_dim.size(), tensor_dim.data())
+                      .setStrides(tensor_str.size(), tensor_str.data())
+                      .setId(id)
+                      .setAlignment(alignment)
+                      .setDataType(data_type)
+                      .build();
+  } catch (cudnn_frontend::cudnnException &e) {
+    std::cout << "Exception in tensor creation " << e.what() << std::endl;
+  }
+  std::cout << "Finished tensor creation." << std::endl;
+}
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/phi/backends/dynload/cudnn.cc
+++ b/paddle/phi/backends/dynload/cudnn.cc
@@ -46,6 +46,10 @@ CUDNN_DNN_ROUTINE_EACH_AFTER_R7(DEFINE_WRAP);
 CUDNN_DNN_ROUTINE_EACH_R8(DEFINE_WRAP);
 #endif
 
+#ifdef CUDNN_DNN_ROUTINE_EACH_FRONTEND
+CUDNN_DNN_ROUTINE_EACH_FRONTEND(DEFINE_WRAP);
+#endif
+
 bool HasCUDNN() {
   std::call_once(cudnn_dso_flag,
                  []() { cudnn_dso_handle = GetCUDNNDsoHandle(); });

--- a/paddle/phi/backends/dynload/cudnn.h
+++ b/paddle/phi/backends/dynload/cudnn.h
@@ -194,6 +194,19 @@ CUDNN_DNN_ROUTINE_EACH_AFTER_R7(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
 CUDNN_DNN_ROUTINE_EACH_R8(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
 #endif
 
+#ifdef PADDLE_WITH_CUDNN_FRONTEND
+#define CUDNN_DNN_ROUTINE_EACH_FRONTEND(__macro) \
+  __macro(cudnnBackendCreateDescriptor);         \
+  __macro(cudnnBackendDestroyDescriptor);        \
+  __macro(cudnnBackendExecute);                  \
+  __macro(cudnnBackendFinalize);                 \
+  __macro(cudnnBackendGetAttribute);             \
+  __macro(cudnnBackendSetAttribute);             \
+  __macro(cudnnGetStream);                       \
+  __macro(cudnnReorderFilterAndBias);
+CUDNN_DNN_ROUTINE_EACH_FRONTEND(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
+#endif
+
 }  // namespace dynload
 }  // namespace phi
 

--- a/paddle/phi/kernels/CMakeLists.txt
+++ b/paddle/phi/kernels/CMakeLists.txt
@@ -83,6 +83,9 @@ set(COMMON_KERNEL_DEPS ${COMMON_KERNEL_DEPS} processgroup)
 if(WITH_NCCL OR WITH_RCCL)
   set(COMMON_KERNEL_DEPS ${COMMON_KERNEL_DEPS} processgroup_nccl)
 endif()
+if(WITH_CUDNN_FRONTEND)
+  set(COMMON_KERNEL_DEPS ${COMMON_KERNEL_DEPS} cudnn_frontend)
+endif()
 
 copy_if_different(${kernel_declare_file} ${kernel_declare_file_final})
 

--- a/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
+++ b/paddle/phi/kernels/gpudnn/conv_grad_kernel.cu
@@ -33,8 +33,606 @@
 #include "paddle/phi/kernels/funcs/batch_norm_utils.h"
 #include "paddle/phi/kernels/funcs/padding.h"
 #include "paddle/phi/kernels/impl/conv_cudnn_impl.h"
+#ifdef PADDLE_WITH_CUDNN_FRONTEND
+#include "paddle/fluid/platform/device/gpu/cuda/cudnn_frontend.h"
+#include "paddle/fluid/platform/device/gpu/cuda/cudnn_frontend_conv_helper.h"
+#endif
 
 namespace phi {
+
+#ifdef PADDLE_WITH_CUDNN_FRONTEND
+namespace {
+paddle::platform::CudnnFrontendPlanCache plan_cache_bwd_data(
+    "conv_backward_data");
+paddle::platform::CudnnFrontendPlanCache plan_cache_bwd_filter(
+    "conv_backward_filter");
+}  // namespace
+
+template <typename T>
+void CudnnConvBwdDataV8(DenseTensor* dy_tensor,
+                        DenseTensor* w_tensor,
+                        cudnnHandle_t handle,
+                        DnnWorkspaceHandle* workspace_handle,
+                        const std::vector<int>& strides,
+                        const std::vector<int>& padding_common,
+                        const std::vector<int>& dilations,
+                        cudnnDataType_t dtype,
+                        paddle::platform::DataLayout compute_format,
+                        cudnnTensorFormat_t layout_format,
+                        bool use_addto,
+                        bool exhaustive_search,
+                        bool deterministic,
+                        DenseTensor* dx_tensor) {
+  T* dy_tensor_data = dy_tensor->data<T>();
+  T* w_tensor_data = w_tensor->data<T>();
+  T* dx_tensor_data = dx_tensor->data<T>();
+
+  float alpha = 1.0f;
+  float beta = use_addto ? 1.0f : 0.0f;
+
+  using helper = paddle::platform::CudnnFrontendConvHelper;
+  auto op_graph = helper::BuildConvOperationGraph<
+      CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR>(
+      dx_tensor,
+      dy_tensor,
+      w_tensor,
+      layout_format,
+      strides,
+      padding_common,
+      dilations,
+      dtype,
+      handle,
+      alpha,
+      beta);
+
+  if (plan_cache_bwd_data.FindPlan(op_graph, use_addto)) {
+    auto cached_plan = plan_cache_bwd_data.GetPlan(op_graph, handle, use_addto);
+    auto workspace_size = cached_plan.getWorkspaceSize();
+    VLOG(4) << "Cached execution plan found." << cached_plan.getTag()
+            << "; Require workspace: " << workspace_size;
+    workspace_handle->RunFunc(
+        [&](void* workspace_ptr) {
+          void* data_ptrs[] = {dx_tensor_data, dy_tensor_data, w_tensor_data};
+          int64_t uids[] = {'x', 'y', 'w'};
+          auto variant_pack = cudnn_frontend::VariantPackBuilder()
+                                  .setWorkspacePointer(workspace_ptr)
+                                  .setDataPointers(3, data_ptrs)
+                                  .setUids(3, uids)
+                                  .build();
+          PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnBackendExecute(
+              handle, cached_plan.get_raw_desc(), variant_pack.get_raw_desc()));
+        },
+        workspace_size);
+    return;
+  }
+
+  auto plans = helper::FindExecutionPlans(&op_graph,
+                                          exhaustive_search,
+                                          deterministic,
+                                          dx_tensor_data,
+                                          dy_tensor_data,
+                                          w_tensor_data,
+                                          handle,
+                                          workspace_handle);
+
+  for (auto& plan : plans) {
+    try {
+      int64_t workspace_size = plan.getWorkspaceSize();
+      workspace_handle->RunFunc(
+          [&](void* workspace_ptr) {
+            void* data_ptrs[] = {dx_tensor_data, dy_tensor_data, w_tensor_data};
+            int64_t uids[] = {'x', 'y', 'w'};
+            auto variant_pack = cudnn_frontend::VariantPackBuilder()
+                                    .setWorkspacePointer(workspace_ptr)
+                                    .setDataPointers(3, data_ptrs)
+                                    .setUids(3, uids)
+                                    .build();
+            PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnBackendExecute(
+                handle, plan.get_raw_desc(), variant_pack.get_raw_desc()));
+          },
+          workspace_size);
+      if (!exhaustive_search ||
+          plan_cache_bwd_data.IsStable(op_graph, plan.getTag(), use_addto)) {
+        plan_cache_bwd_data.InsertPlan(op_graph, plan, use_addto);
+      }
+      return;
+    } catch (cudnn_frontend::cudnnException& e) {
+    } catch (phi::enforce::EnforceNotMet& e) {
+    }
+  }
+
+  PADDLE_ENFORCE_EQ(
+      true,
+      false,
+      phi::errors::InvalidArgument("[CUDNN Frontend API] No valid plan could "
+                                   "be found to execute conv backward data."));
+}
+
+template <typename T>
+void CudnnConvBwdFilterV8(DenseTensor* x_tensor,
+                          DenseTensor* dy_tensor,
+                          cudnnHandle_t handle,
+                          DnnWorkspaceHandle* workspace_handle,
+                          const std::vector<int>& strides,
+                          const std::vector<int>& padding_common,
+                          const std::vector<int>& dilations,
+                          cudnnDataType_t dtype,
+                          paddle::platform::DataLayout compute_format,
+                          cudnnTensorFormat_t layout_format,
+                          bool use_addto,
+                          bool exhaustive_search,
+                          bool deterministic,
+                          DenseTensor* dw_tensor) {
+  T* x_tensor_data = x_tensor->data<T>();
+  T* dy_tensor_data = dy_tensor->data<T>();
+  T* dw_tensor_data = dw_tensor->data<T>();
+
+  float alpha = 1.0f;
+  float beta = 0.0f;
+
+  using helper = paddle::platform::CudnnFrontendConvHelper;
+  auto op_graph = helper::BuildConvOperationGraph<
+      CUDNN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_FILTER_DESCRIPTOR>(
+      x_tensor,
+      dy_tensor,
+      dw_tensor,
+      layout_format,
+      strides,
+      padding_common,
+      dilations,
+      dtype,
+      handle,
+      alpha,
+      beta);
+
+  if (plan_cache_bwd_filter.FindPlan(op_graph)) {
+    auto cached_plan = plan_cache_bwd_filter.GetPlan(op_graph, handle);
+    auto workspace_size = cached_plan.getWorkspaceSize();
+    VLOG(4) << "Cached execution plan found." << cached_plan.getTag()
+            << "; Require workspace: " << workspace_size;
+    workspace_handle->RunFunc(
+        [&](void* workspace_ptr) {
+          void* data_ptrs[] = {x_tensor_data, dy_tensor_data, dw_tensor_data};
+          int64_t uids[] = {'x', 'y', 'w'};
+          auto variant_pack = cudnn_frontend::VariantPackBuilder()
+                                  .setWorkspacePointer(workspace_ptr)
+                                  .setDataPointers(3, data_ptrs)
+                                  .setUids(3, uids)
+                                  .build();
+          PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnBackendExecute(
+              handle, cached_plan.get_raw_desc(), variant_pack.get_raw_desc()));
+        },
+        workspace_size);
+    return;
+  }
+
+  auto plans = helper::FindExecutionPlans(&op_graph,
+                                          exhaustive_search,
+                                          deterministic,
+                                          x_tensor_data,
+                                          dy_tensor_data,
+                                          dw_tensor_data,
+                                          handle,
+                                          workspace_handle);
+
+  for (auto& plan : plans) {
+    try {
+      int64_t workspace_size = plan.getWorkspaceSize();
+      workspace_handle->RunFunc(
+          [&](void* workspace_ptr) {
+            void* data_ptrs[] = {x_tensor_data, dy_tensor_data, dw_tensor_data};
+            int64_t uids[] = {'x', 'y', 'w'};
+            auto variant_pack = cudnn_frontend::VariantPackBuilder()
+                                    .setWorkspacePointer(workspace_ptr)
+                                    .setDataPointers(3, data_ptrs)
+                                    .setUids(3, uids)
+                                    .build();
+            PADDLE_ENFORCE_GPU_SUCCESS(phi::dynload::cudnnBackendExecute(
+                handle, plan.get_raw_desc(), variant_pack.get_raw_desc()));
+          },
+          workspace_size);
+      if (!exhaustive_search ||
+          plan_cache_bwd_filter.IsStable(op_graph, plan.getTag())) {
+        plan_cache_bwd_filter.InsertPlan(op_graph, plan);
+      }
+      return;
+    } catch (cudnn_frontend::cudnnException& e) {
+    } catch (phi::enforce::EnforceNotMet& e) {
+    }
+  }
+
+  PADDLE_ENFORCE_EQ(true,
+                    false,
+                    phi::errors::InvalidArgument(
+                        "[CUDNN Frontend API] No valid plan could "
+                        "be found to execute conv backward filter."));
+}
+
+template <typename T, typename Context>
+void ConvCudnnGradKernelImplV8(DenseTensor* transformed_input,
+                               DenseTensor* transformed_filter_channel,
+                               DenseTensor* transformed_output_grad_channel,
+                               DenseTensor* input_grad,
+                               DenseTensor* filter_grad,
+                               const Context& ctx,
+                               const std::vector<int>& strides,
+                               const std::vector<int>& padding_common,
+                               const std::vector<int>& dilations,
+                               cudnnDataType_t dtype,
+                               paddle::platform::DataLayout compute_format,
+                               cudnnTensorFormat_t layout_format,
+                               bool use_addto,
+                               bool exhaustive_search,
+                               bool deterministic,
+                               int groups,
+                               DenseTensor* transformed_input_grad,
+                               DenseTensor* transformed_filter_grad_channel) {
+  PADDLE_ENFORCE_EQ(
+      groups,
+      1,
+      paddle::platform::errors::Unimplemented(
+          "Group concolution using CUDNNv8 API is unsupported for now"));
+
+  cudnnHandle_t handle = const_cast<cudnnHandle_t>(ctx.cudnn_handle());
+  auto workspace_handle = ctx.cudnn_workspace_handle();
+
+  // conv backward data
+  if (input_grad) {
+    CudnnConvBwdDataV8<T>(transformed_output_grad_channel,
+                          transformed_filter_channel,
+                          handle,
+                          &workspace_handle,
+                          strides,
+                          padding_common,
+                          dilations,
+                          dtype,
+                          compute_format,
+                          layout_format,
+                          use_addto,
+                          exhaustive_search,
+                          deterministic,
+                          transformed_input_grad);
+  }
+  // conv backward filter
+  if (filter_grad) {
+    CudnnConvBwdFilterV8<T>(transformed_input,
+                            transformed_output_grad_channel,
+                            handle,
+                            &workspace_handle,
+                            strides,
+                            padding_common,
+                            dilations,
+                            dtype,
+                            compute_format,
+                            layout_format,
+                            use_addto,
+                            exhaustive_search,
+                            deterministic,
+                            transformed_filter_grad_channel);
+  }
+}
+#endif
+
+template <typename T, typename Context>
+void ConvCudnnGradKernelImplV7(DenseTensor* transformed_input,
+                               DenseTensor* transformed_filter_channel,
+                               DenseTensor* transformed_output_grad_channel,
+                               DenseTensor* input_grad,
+                               DenseTensor* filter_grad,
+                               const Context& ctx,
+                               const std::vector<int>& strides,
+                               const std::vector<int>& padding_common,
+                               const std::vector<int>& dilations,
+                               cudnnDataType_t dtype,
+                               paddle::platform::DataLayout compute_format,
+                               paddle::platform::DataLayout layout,
+                               cudnnTensorFormat_t layout_tensor,
+                               bool use_addto,
+                               bool exhaustive_search,
+                               bool deterministic,
+                               int groups,
+                               DenseTensor* transformed_input_grad,
+                               DenseTensor* transformed_filter_grad_channel) {
+  const T* input_data = transformed_input->data<T>();
+  const T* output_grad_data = transformed_output_grad_channel->data<T>();
+  const T* filter_data = transformed_filter_channel->data<T>();
+  T* filter_grad_data = nullptr;
+  T* input_grad_data = nullptr;
+  T* transformed_input_grad_data = nullptr;
+
+  paddle::operators::ConvArgs args1{transformed_input_grad,
+                                    transformed_filter_channel,
+                                    transformed_output_grad_channel,
+                                    strides,
+                                    padding_common,
+                                    dilations,
+                                    dtype,
+                                    groups,
+                                    layout};
+  paddle::operators::ConvArgs args2{transformed_input,
+                                    transformed_filter_grad_channel,
+                                    transformed_output_grad_channel,
+                                    strides,
+                                    padding_common,
+                                    dilations,
+                                    dtype,
+                                    groups,
+                                    layout};
+
+  auto handle = ctx.cudnn_handle();
+  auto workspace_handle = ctx.cudnn_workspace_handle();
+
+  int i_n, i_c, i_d, i_h, i_w;
+  int o_n, o_c, o_d, o_h, o_w;
+  if (compute_format == paddle::platform::DataLayout::kNHWC) {
+    paddle::operators::GetNCDHW(transformed_input->dims(),
+                                paddle::platform::DataLayout::kNHWC,
+                                &i_n,
+                                &i_c,
+                                &i_d,
+                                &i_h,
+                                &i_w);
+    paddle::operators::GetNCDHW(transformed_output_grad_channel->dims(),
+                                paddle::platform::DataLayout::kNHWC,
+                                &o_n,
+                                &o_c,
+                                &o_d,
+                                &o_h,
+                                &o_w);
+  } else {
+    paddle::operators::GetNCDHW(transformed_input->dims(),
+                                paddle::platform::DataLayout::kNCHW,
+                                &i_n,
+                                &i_c,
+                                &i_d,
+                                &i_h,
+                                &i_w);
+    paddle::operators::GetNCDHW(transformed_output_grad_channel->dims(),
+                                paddle::platform::DataLayout::kNCHW,
+                                &o_n,
+                                &o_c,
+                                &o_d,
+                                &o_h,
+                                &o_w);
+  }
+
+  int group_offset_in = i_c / groups * i_h * i_w * i_d;
+  int group_offset_out = o_c / groups * o_h * o_w * o_d;
+  int group_offset_filter = transformed_filter_channel->numel() / groups;
+
+// ------------------- cudnn backward algorithm ---------------------
+#ifdef PADDLE_WITH_HIP
+  paddle::operators::SearchResult<miopenConvBwdDataAlgorithm_t> bwd_result;
+  paddle::operators::SearchResult<miopenConvBwdWeightsAlgorithm_t>
+      filter_result;
+#else
+  paddle::operators::SearchResult<cudnnConvolutionBwdDataAlgo_t> bwd_result;
+  paddle::operators::SearchResult<cudnnConvolutionBwdFilterAlgo_t>
+      filter_result;
+#endif
+  // input data workspace_size
+  size_t workspace_size_d = 0;
+  // weight workspace_size
+  size_t workspace_size_w = 0;
+  int iwo_groups = groups;
+  int c_groups = 1;
+
+#if defined(PADDLE_WITH_HIP) || CUDNN_VERSION_MIN(7, 0, 1)
+  iwo_groups = 1;
+  c_groups = groups;
+  groups = 1;
+#endif
+
+  if (input_grad) {
+    // ------------------- cudnn descriptors ---------------------
+    input_grad_data = input_grad->data<T>();
+    transformed_input_grad_data = transformed_input_grad->data<T>();
+
+    args1.handle = handle;
+    args1.idesc.set(*transformed_input_grad, layout_tensor);
+    args1.wdesc.set(*transformed_filter_channel, layout_tensor, iwo_groups);
+    args1.odesc.set(*transformed_output_grad_channel, layout_tensor);
+    args1.cdesc.set(dtype,
+                    padding_common,
+                    strides,
+                    dilations,
+                    paddle::platform::AllowTF32Cudnn(),
+                    c_groups);
+
+#ifdef PADDLE_WITH_HIP
+    using search1 =
+        paddle::operators::SearchAlgorithm<miopenConvBwdDataAlgorithm_t>;
+    workspace_size_d =
+        std::max(workspace_size_d, search1::GetWorkspaceSize(args1));
+    bwd_result.algo = search1::Find<T>(
+        args1, exhaustive_search, deterministic, workspace_size_d, ctx);
+#else
+    using search1 =
+        paddle::operators::SearchAlgorithm<cudnnConvolutionBwdDataAlgoPerf_t>;
+    bwd_result = search1::Find<T>(ctx, args1, exhaustive_search, deterministic);
+    workspace_size_d = std::max(workspace_size_d, bwd_result.workspace_size);
+#endif
+  }
+
+  if (filter_grad) {
+    // ------------------- cudnn descriptors ---------------------
+    filter_grad_data = transformed_filter_grad_channel->data<T>();
+    args2.handle = handle;
+    args2.idesc.set(*transformed_input, layout_tensor);
+    args2.wdesc.set(
+        *transformed_filter_grad_channel, layout_tensor, iwo_groups);
+    args2.odesc.set(*transformed_output_grad_channel, layout_tensor);
+    args2.cdesc.set(dtype,
+                    padding_common,
+                    strides,
+                    dilations,
+                    paddle::platform::AllowTF32Cudnn(),
+                    c_groups);
+#ifdef PADDLE_WITH_HIP
+    using search2 =
+        paddle::operators::SearchAlgorithm<miopenConvBwdWeightsAlgorithm_t>;
+    workspace_size_w =
+        std::max(workspace_size_w, search2::GetWorkspaceSize(args2));
+    filter_result.algo = search2::Find<T>(
+        args2, exhaustive_search, deterministic, workspace_size_w, ctx);
+#else
+    using search2 =
+        paddle::operators::SearchAlgorithm<cudnnConvolutionBwdFilterAlgoPerf_t>;
+    filter_result =
+        search2::Find<T>(ctx, args2, exhaustive_search, deterministic);
+    VLOG(3) << "filter algo: " << filter_result.algo << ", time "
+            << filter_result.time;
+    workspace_size_w = std::max(workspace_size_w, filter_result.workspace_size);
+#endif
+  }
+
+  // ------------------- cudnn conv backward data ---------------------
+  paddle::operators::ScalingParamType<T> alpha = 1.0f;
+#ifdef PADDLE_WITH_HIP
+  // MIOPEN ONLY support beta to be 0.0f
+  paddle::operators::ScalingParamType<T> beta = 0.0f;
+#else
+  paddle::operators::ScalingParamType<T> beta = use_addto ? 1.0f : 0.0f;
+
+#endif
+  VLOG(4) << "Conv_grad: use_addto = " << use_addto;
+
+  if (input_grad) {
+// When beta is 0, it is unnecessary to reset input_grad.
+// When beta is 1, the output cannot be reset since addt strategy used.
+#ifdef PADDLE_WITH_HIP
+    if (use_addto) {
+      DenseTensor temp_tensor(transformed_input_grad->type());
+      temp_tensor.Resize(transformed_input_grad->dims());
+      T* temp_tensor_data = ctx.template Alloc<T>(&temp_tensor);
+      workspace_handle.RunFunc(
+          [&](void* cudnn_workspace_ptr) {
+            PADDLE_ENFORCE_GPU_SUCCESS(
+                paddle::platform::dynload::miopenConvolutionBackwardData(
+                    handle,
+                    &alpha,
+                    args1.odesc.desc(),
+                    output_grad_data,
+                    args1.wdesc.desc(),
+                    filter_data,
+                    args1.cdesc.desc(),
+                    bwd_result.algo,
+                    &beta,
+                    args1.idesc.desc(),
+                    temp_tensor_data,
+                    cudnn_workspace_ptr,
+                    workspace_size_d));
+          },
+          workspace_size_d);
+      PADDLE_ENFORCE_GPU_SUCCESS(paddle::platform::dynload::miopenOpTensor(
+          handle,
+          miopenTensorOpAdd,
+          &alpha,
+          args1.idesc.desc(),
+          transformed_input_grad_data,
+          &alpha,
+          args1.idesc.desc(),
+          temp_tensor_data,
+          &beta,
+          args1.idesc.desc(),
+          transformed_input_grad_data));
+    } else {
+      workspace_handle.RunFunc(
+          [&](void* cudnn_workspace_ptr) {
+            PADDLE_ENFORCE_GPU_SUCCESS(
+                paddle::platform::dynload::miopenConvolutionBackwardData(
+                    handle,
+                    &alpha,
+                    args1.odesc.desc(),
+                    output_grad_data,
+                    args1.wdesc.desc(),
+                    filter_data,
+                    args1.cdesc.desc(),
+                    bwd_result.algo,
+                    &beta,
+                    args1.idesc.desc(),
+                    transformed_input_grad_data,
+                    cudnn_workspace_ptr,
+                    workspace_size_d));
+          },
+          workspace_size_d);
+    }
+
+#else
+    for (int i = 0; i < groups; i++) {
+      workspace_handle.RunFunc(
+          [&](void* cudnn_workspace_ptr) {
+            PADDLE_ENFORCE_GPU_SUCCESS(
+                paddle::platform::dynload::cudnnConvolutionBackwardData(
+                    handle,
+                    &alpha,
+                    args1.wdesc.desc(),
+                    filter_data + i * group_offset_filter,
+                    args1.odesc.desc(),
+                    output_grad_data + i * group_offset_out,
+                    args1.cdesc.desc(),
+                    bwd_result.algo,
+                    cudnn_workspace_ptr,
+                    workspace_size_d,
+                    &beta,
+                    args1.idesc.desc(),
+                    transformed_input_grad_data + i * group_offset_in));
+          },
+          workspace_size_d);
+    }
+#endif
+  }
+
+  // filter_grad do not use inplace addto.
+  paddle::operators::ScalingParamType<T> beta_filter = 0.0f;
+  // ------------------- cudnn conv backward filter ---------------------
+  if (filter_grad) {
+// Because beta is zero, it is unnecessary to reset filter_grad.
+#ifdef PADDLE_WITH_HIP
+    workspace_handle.RunFunc(
+        [&](void* cudnn_workspace_ptr) {
+          PADDLE_ENFORCE_GPU_SUCCESS(
+              paddle::platform::dynload::miopenConvolutionBackwardWeights(
+                  handle,
+                  &alpha,
+                  args2.odesc.desc(),
+                  output_grad_data,
+                  args2.idesc.desc(),
+                  input_data,
+                  args2.cdesc.desc(),
+                  filter_result.algo,
+                  &beta,
+                  args2.wdesc.desc(),
+                  filter_grad_data,
+                  cudnn_workspace_ptr,
+                  workspace_size_w));
+        },
+        workspace_size_w);
+#else
+    for (int i = 0; i < groups; i++) {
+      workspace_handle.RunFunc(
+          [&](void* cudnn_workspace_ptr) {
+            PADDLE_ENFORCE_GPU_SUCCESS(
+                paddle::platform::dynload::cudnnConvolutionBackwardFilter(
+                    handle,
+                    &alpha,
+                    args2.idesc.desc(),
+                    input_data + i * group_offset_in,
+                    args2.odesc.desc(),
+                    output_grad_data + i * group_offset_out,
+                    args2.cdesc.desc(),
+                    filter_result.algo,
+                    cudnn_workspace_ptr,
+                    workspace_size_w,
+                    &beta_filter,
+                    args2.wdesc.desc(),
+                    filter_grad_data + i * group_offset_filter));
+          },
+          workspace_size_w);
+    }
+#endif
+  }
+}
 
 template <typename T, typename Context>
 void ConvCudnnGradKernel(const Context& ctx,
@@ -243,267 +841,60 @@ void ConvCudnnGradKernel(const Context& ctx,
       }
     }
   }
-
-  const T* input_data = transformed_input.data<T>();
-  const T* output_grad_data = transformed_output_grad_channel.data<T>();
-  const T* filter_data = transformed_filter_channel.data<T>();
-  T* filter_grad_data = nullptr;
-  T* input_grad_data = nullptr;
-  T* transformed_input_grad_data = nullptr;
-
+  // TODO(phlrain): replace paddle::platform::DataLaytout to phi::DataLayout
   paddle::platform::DataLayout layout =
       compute_format == paddle::platform::DataLayout::kNHWC
           ? paddle::platform::DataLayout::kNHWC
           : paddle::platform::DataLayout::kNCHW;
-
-  paddle::operators::ConvArgs args1{&transformed_input_grad,
-                                    &transformed_filter_channel,
-                                    &transformed_output_grad_channel,
-                                    strides,
-                                    padding_common,
-                                    dilations,
-                                    dtype,
-                                    groups,
-                                    layout};
-  paddle::operators::ConvArgs args2{&transformed_input,
-                                    &transformed_filter_grad_channel,
-                                    &transformed_output_grad_channel,
-                                    strides,
-                                    padding_common,
-                                    dilations,
-                                    dtype,
-                                    groups,
-                                    layout};
-
-  auto handle = ctx.cudnn_handle();
-  // TODO(phlrain): replace paddle::platform::DataLaytout to phi::DataLayout
-
   if (transformed_input.dims().size() == 5) {
     layout = compute_format == paddle::platform::DataLayout::kNHWC
                  ? paddle::platform::DataLayout::kNDHWC
                  : paddle::platform::DataLayout::kNCDHW;
   }
   auto layout_tensor = paddle::platform::GetCudnnTensorFormat(layout);
-  auto workspace_handle = ctx.cudnn_workspace_handle();
 
-  int i_n, i_c, i_d, i_h, i_w;
-  int o_n, o_c, o_d, o_h, o_w;
-  if (compute_format == paddle::platform::DataLayout::kNHWC) {
-    paddle::operators::GetNCDHW(transformed_input.dims(),
-                                paddle::platform::DataLayout::kNHWC,
-                                &i_n,
-                                &i_c,
-                                &i_d,
-                                &i_h,
-                                &i_w);
-    paddle::operators::GetNCDHW(transformed_output_grad_channel.dims(),
-                                paddle::platform::DataLayout::kNHWC,
-                                &o_n,
-                                &o_c,
-                                &o_d,
-                                &o_h,
-                                &o_w);
-  } else {
-    paddle::operators::GetNCDHW(transformed_input.dims(),
-                                paddle::platform::DataLayout::kNCHW,
-                                &i_n,
-                                &i_c,
-                                &i_d,
-                                &i_h,
-                                &i_w);
-    paddle::operators::GetNCDHW(transformed_output_grad_channel.dims(),
-                                paddle::platform::DataLayout::kNCHW,
-                                &o_n,
-                                &o_c,
-                                &o_d,
-                                &o_h,
-                                &o_w);
-  }
-
-  int group_offset_in = i_c / groups * i_h * i_w * i_d;
-  int group_offset_out = o_c / groups * o_h * o_w * o_d;
-  int group_offset_filter = transformed_filter_channel.numel() / groups;
-
-// ------------------- cudnn backward algorithm ---------------------
-#ifdef PADDLE_WITH_HIP
-  paddle::operators::SearchResult<miopenConvBwdDataAlgorithm_t> bwd_result;
-  paddle::operators::SearchResult<miopenConvBwdWeightsAlgorithm_t>
-      filter_result;
-#else
-  paddle::operators::SearchResult<cudnnConvolutionBwdDataAlgo_t> bwd_result;
-  paddle::operators::SearchResult<cudnnConvolutionBwdFilterAlgo_t>
-      filter_result;
+#ifdef PADDLE_WITH_CUDNN_FRONTEND
+  if (paddle::platform::IsCudnnFrontendEnabled() && (groups == 1))
+    ConvCudnnGradKernelImplV8<T, Context>(&transformed_input,
+                                          &transformed_filter_channel,
+                                          &transformed_output_grad_channel,
+                                          input_grad,
+                                          filter_grad,
+                                          ctx,
+                                          strides,
+                                          padding_common,
+                                          dilations,
+                                          dtype,
+                                          compute_format,
+                                          layout_tensor,
+                                          use_addto,
+                                          exhaustive_search,
+                                          deterministic,
+                                          groups,
+                                          &transformed_input_grad,
+                                          &transformed_filter_grad_channel);
+  else
 #endif
-  // input data workspace_size
-  size_t workspace_size_d = 0;
-  // weight workspace_size
-  size_t workspace_size_w = 0;
-  int iwo_groups = groups;
-  int c_groups = 1;
-
-#if defined(PADDLE_WITH_HIP) || CUDNN_VERSION_MIN(7, 0, 1)
-  iwo_groups = 1;
-  c_groups = groups;
-  groups = 1;
-#endif
-
+    ConvCudnnGradKernelImplV7<T, Context>(&transformed_input,
+                                          &transformed_filter_channel,
+                                          &transformed_output_grad_channel,
+                                          input_grad,
+                                          filter_grad,
+                                          ctx,
+                                          strides,
+                                          padding_common,
+                                          dilations,
+                                          dtype,
+                                          compute_format,
+                                          layout,
+                                          layout_tensor,
+                                          use_addto,
+                                          exhaustive_search,
+                                          deterministic,
+                                          groups,
+                                          &transformed_input_grad,
+                                          &transformed_filter_grad_channel);
   if (input_grad) {
-    // ------------------- cudnn descriptors ---------------------
-    input_grad_data = input_grad->data<T>();
-    transformed_input_grad_data = transformed_input_grad.data<T>();
-
-    args1.handle = handle;
-    args1.idesc.set(transformed_input_grad, layout_tensor);
-    args1.wdesc.set(transformed_filter_channel, layout_tensor, iwo_groups);
-    args1.odesc.set(transformed_output_grad_channel, layout_tensor);
-    args1.cdesc.set(dtype,
-                    padding_common,
-                    strides,
-                    dilations,
-                    paddle::platform::AllowTF32Cudnn(),
-                    c_groups);
-
-#ifdef PADDLE_WITH_HIP
-    using search1 =
-        paddle::operators::SearchAlgorithm<miopenConvBwdDataAlgorithm_t>;
-    workspace_size_d =
-        std::max(workspace_size_d, search1::GetWorkspaceSize(args1));
-    bwd_result.algo = search1::Find<T>(
-        args1, exhaustive_search, deterministic, workspace_size_d, ctx);
-#else
-    using search1 =
-        paddle::operators::SearchAlgorithm<cudnnConvolutionBwdDataAlgoPerf_t>;
-    bwd_result = search1::Find<T>(ctx, args1, exhaustive_search, deterministic);
-    workspace_size_d = std::max(workspace_size_d, bwd_result.workspace_size);
-#endif
-  }
-
-  if (filter_grad) {
-    // ------------------- cudnn descriptors ---------------------
-    filter_grad_data = transformed_filter_grad_channel.data<T>();
-    args2.handle = handle;
-    args2.idesc.set(transformed_input, layout_tensor);
-    args2.wdesc.set(transformed_filter_grad_channel, layout_tensor, iwo_groups);
-    args2.odesc.set(transformed_output_grad_channel, layout_tensor);
-    args2.cdesc.set(dtype,
-                    padding_common,
-                    strides,
-                    dilations,
-                    paddle::platform::AllowTF32Cudnn(),
-                    c_groups);
-#ifdef PADDLE_WITH_HIP
-    using search2 =
-        paddle::operators::SearchAlgorithm<miopenConvBwdWeightsAlgorithm_t>;
-    workspace_size_w =
-        std::max(workspace_size_w, search2::GetWorkspaceSize(args2));
-    filter_result.algo = search2::Find<T>(
-        args2, exhaustive_search, deterministic, workspace_size_w, ctx);
-#else
-    using search2 =
-        paddle::operators::SearchAlgorithm<cudnnConvolutionBwdFilterAlgoPerf_t>;
-    filter_result =
-        search2::Find<T>(ctx, args2, exhaustive_search, deterministic);
-    VLOG(3) << "filter algo: " << filter_result.algo << ", time "
-            << filter_result.time;
-    workspace_size_w = std::max(workspace_size_w, filter_result.workspace_size);
-#endif
-  }
-
-  // ------------------- cudnn conv backward data ---------------------
-  paddle::operators::ScalingParamType<T> alpha = 1.0f;
-#ifdef PADDLE_WITH_HIP
-  // MIOPEN ONLY support beta to be 0.0f
-  paddle::operators::ScalingParamType<T> beta = 0.0f;
-#else
-  paddle::operators::ScalingParamType<T> beta = use_addto ? 1.0f : 0.0f;
-
-#endif
-  VLOG(4) << "Conv_grad: use_addto = " << use_addto;
-
-  if (input_grad) {
-// When beta is 0, it is unnecessary to reset input_grad.
-// When beta is 1, the output cannot be reset since addt strategy used.
-#ifdef PADDLE_WITH_HIP
-    if (use_addto) {
-      DenseTensor temp_tensor(transformed_input_grad.type());
-      temp_tensor.Resize(transformed_input_grad.dims());
-      T* temp_tensor_data = ctx.template Alloc<T>(&temp_tensor);
-      workspace_handle.RunFunc(
-          [&](void* cudnn_workspace_ptr) {
-            PADDLE_ENFORCE_GPU_SUCCESS(
-                paddle::platform::dynload::miopenConvolutionBackwardData(
-                    handle,
-                    &alpha,
-                    args1.odesc.desc(),
-                    output_grad_data,
-                    args1.wdesc.desc(),
-                    filter_data,
-                    args1.cdesc.desc(),
-                    bwd_result.algo,
-                    &beta,
-                    args1.idesc.desc(),
-                    temp_tensor_data,
-                    cudnn_workspace_ptr,
-                    workspace_size_d));
-          },
-          workspace_size_d);
-      PADDLE_ENFORCE_GPU_SUCCESS(paddle::platform::dynload::miopenOpTensor(
-          handle,
-          miopenTensorOpAdd,
-          &alpha,
-          args1.idesc.desc(),
-          transformed_input_grad_data,
-          &alpha,
-          args1.idesc.desc(),
-          temp_tensor_data,
-          &beta,
-          args1.idesc.desc(),
-          transformed_input_grad_data));
-    } else {
-      workspace_handle.RunFunc(
-          [&](void* cudnn_workspace_ptr) {
-            PADDLE_ENFORCE_GPU_SUCCESS(
-                paddle::platform::dynload::miopenConvolutionBackwardData(
-                    handle,
-                    &alpha,
-                    args1.odesc.desc(),
-                    output_grad_data,
-                    args1.wdesc.desc(),
-                    filter_data,
-                    args1.cdesc.desc(),
-                    bwd_result.algo,
-                    &beta,
-                    args1.idesc.desc(),
-                    transformed_input_grad_data,
-                    cudnn_workspace_ptr,
-                    workspace_size_d));
-          },
-          workspace_size_d);
-    }
-
-#else
-    for (int i = 0; i < groups; i++) {
-      workspace_handle.RunFunc(
-          [&](void* cudnn_workspace_ptr) {
-            PADDLE_ENFORCE_GPU_SUCCESS(
-                paddle::platform::dynload::cudnnConvolutionBackwardData(
-                    handle,
-                    &alpha,
-                    args1.wdesc.desc(),
-                    filter_data + i * group_offset_filter,
-                    args1.odesc.desc(),
-                    output_grad_data + i * group_offset_out,
-                    args1.cdesc.desc(),
-                    bwd_result.algo,
-                    cudnn_workspace_ptr,
-                    workspace_size_d,
-                    &beta,
-                    args1.idesc.desc(),
-                    transformed_input_grad_data + i * group_offset_in));
-          },
-          workspace_size_d);
-    }
-#endif
     if (!is_sys_pad) {
       std::vector<int> starts(transformed_input_channel.dims().size(), 0);
       std::vector<int> axes(transformed_input_channel.dims().size(), 0);
@@ -537,55 +928,7 @@ void ConvCudnnGradKernel(const Context& ctx,
     }
   }
 
-  // filter_grad do not use inplace addto.
-  paddle::operators::ScalingParamType<T> beta_filter = 0.0f;
-  // ------------------- cudnn conv backward filter ---------------------
   if (filter_grad) {
-// Because beta is zero, it is unnecessary to reset filter_grad.
-#ifdef PADDLE_WITH_HIP
-    workspace_handle.RunFunc(
-        [&](void* cudnn_workspace_ptr) {
-          PADDLE_ENFORCE_GPU_SUCCESS(
-              paddle::platform::dynload::miopenConvolutionBackwardWeights(
-                  handle,
-                  &alpha,
-                  args2.odesc.desc(),
-                  output_grad_data,
-                  args2.idesc.desc(),
-                  input_data,
-                  args2.cdesc.desc(),
-                  filter_result.algo,
-                  &beta,
-                  args2.wdesc.desc(),
-                  filter_grad_data,
-                  cudnn_workspace_ptr,
-                  workspace_size_w));
-        },
-        workspace_size_w);
-#else
-    for (int i = 0; i < groups; i++) {
-      workspace_handle.RunFunc(
-          [&](void* cudnn_workspace_ptr) {
-            PADDLE_ENFORCE_GPU_SUCCESS(
-                paddle::platform::dynload::cudnnConvolutionBackwardFilter(
-                    handle,
-                    &alpha,
-                    args2.idesc.desc(),
-                    input_data + i * group_offset_in,
-                    args2.odesc.desc(),
-                    output_grad_data + i * group_offset_out,
-                    args2.cdesc.desc(),
-                    filter_result.algo,
-                    cudnn_workspace_ptr,
-                    workspace_size_w,
-                    &beta_filter,
-                    args2.wdesc.desc(),
-                    filter_grad_data + i * group_offset_filter));
-          },
-          workspace_size_w);
-    }
-#endif
-
     if (compute_format == paddle::platform::DataLayout::kNHWC) {
       TransToChannelFirst<Context, T>(
           ctx, &transformed_filter_grad_channel, filter_grad);

--- a/patches/cudnn-frontend/cudnn_frontend_ExecutionPlan_patch_1.patch
+++ b/patches/cudnn-frontend/cudnn_frontend_ExecutionPlan_patch_1.patch
@@ -1,0 +1,15 @@
+diff --git a/include/cudnn_frontend_ExecutionPlan.h b/include/cudnn_frontend_ExecutionPlan.h
+index 7bed4b4..da1813b 100644
+--- a/include/cudnn_frontend_ExecutionPlan.h
++++ b/include/cudnn_frontend_ExecutionPlan.h
+@@ -167,6 +167,10 @@ class ExecutionPlan_v8 : public BackendDescriptor {
+         return json_string;
+ #endif
+     }
++    
++    ManagedOpaqueDescriptor GetEngineConfig() const {
++        return engine_config;
++    }
+ 
+     ExecutionPlan_v8(ExecutionPlan_v8 const &) = default;
+     ExecutionPlan_v8 &

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_out_scale.py
@@ -123,7 +123,7 @@ class TestImperativeOutSclae(unittest.TestCase):
     def func_out_scale_acc(self):
         seed = 1000
         lr = 0.001
-        loss_decrease_threshold = 2.0
+        loss_decrease_threshold = 1.5
 
         weight_quantize_type = 'abs_max'
         activation_quantize_type = 'moving_average_abs_max'

--- a/python/paddle/fluid/tests/unittests/test_switch_autotune.py
+++ b/python/paddle/fluid/tests/unittests/test_switch_autotune.py
@@ -50,6 +50,8 @@ def static_program(net, data):
     return loss
 
 
+@unittest.skipIf(int(os.getenv('FLAGS_cudnn_frontend_enable', 0)),
+                 "CUDNNv8 does not use phi::autotune")
 class TestAutoTune(unittest.TestCase):
 
     def set_flags(self, enable_autotune):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
We are making a transition from the legacy CUDNNv7 APIs into the latest CUDNN frontend API which is recommended for CUDNNv8 and later. CUDNN frontend API provides easier programming interface along with modern functionalities like autotuning and errata filter(blocks certain engine configs by json files), providing much more flexibility.
As a first step, this merge implements CUDNNv8 APIs for the convolution operator, both forward and backward.

- To build paddle with CUDNNv8 APIs, set the build option `WITH_CUDNN_FRONTEND` to `ON`. Currently, the default value of this option is `OFF`.
- We still use legacy APIs by default. To enable CUDNNv8 APIs at runtime, set the environment variable `FLAGS_cudnn_frontend_enable=1`. To print debug information, set `FLAGS_cudnn_frontend_debug=1`.