### PR TITLE
Fix for bias caching and scales computation optimization for oneDNN FC

### DIFF
--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -164,17 +164,16 @@ class FCMKLDNNHandler
                             ? 1.0f
                             : ctx.Attr<float>("Scale_out");
     const size_t weight_scales_num = scale_weights_data.size();
-    std::vector<float> output_shift_scale(weight_scales_num);
 
-    for (size_t i = 0; i < weight_scales_num; i++) {
+    for (size_t i = 0; i < weight_scales_num; ++i) {
       if (scale_weights_data[i] == 0.0)
-        output_shift_scale[i] = inner_scale;
+        scale_weights_data[i] = inner_scale;
       else
-        output_shift_scale[i] =
+        scale_weights_data[i] =
             inner_scale / (scale_in_data * scale_weights_data[i]);
     }
 
-    return make_tuple(output_shift_scale, scale);
+    return make_tuple(scale_weights_data, scale);
   }
 
   // Computing MKL-DNN's scaling mask which determines along which dimension
@@ -257,6 +256,7 @@ class FCMKLDNNHandler
             this->fwd_pd_->bias_desc(),
             to_void_cast<float>(bias_data),
             attrs);
+        this->dev_ctx_.SetBlob(bias_key, memory_p);
       }
       return memory_p;
     }


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
OPs

### Describe
Fix for bias caching and scales computation optimization for oneDNN FC. Previously bias was not properly stored in cache and computing output scales was creating an unnecessary vector.  
