### PR TITLE
Fix test_fused_dropout_act_bias failure on H100

### DIFF
--- a/paddle/fluid/operators/fused/fused_dropout_act_bias.h
+++ b/paddle/fluid/operators/fused/fused_dropout_act_bias.h
@@ -256,17 +256,19 @@ template <typename T,
           int BlockSizeX,
           int BlockSizeY,
           int VecSize,
-          typename Functor>
-__global__ void FusedDropoutActBiasGrad(Functor act_grad,
-                                        const T *dout,
-                                        const MaskType *mask,
-                                        const T *src,
-                                        const T *bias,
-                                        const T factor,
-                                        const int64_t rows,
-                                        const int64_t cols,
-                                        T *dx,
-                                        T *dbias) {
+          typename Functor,
+          int THREADS_PER_CTA = BlockSizeX *BlockSizeY>
+__global__ __launch_bounds__(THREADS_PER_CTA) void FusedDropoutActBiasGrad(
+    Functor act_grad,
+    const T *dout,
+    const MaskType *mask,
+    const T *src,
+    const T *bias,
+    const T factor,
+    const int64_t rows,
+    const int64_t cols,
+    T *dx,
+    T *dbias) {
   int64_t col_id = blockIdx.x * blockDim.x + threadIdx.x;
 
   using LoadT = phi::AlignedVector<T, VecSize>;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
`test_fused_dropout_act_bias` UT can pass on A100 but failed on H100. Adding `__launch_bounds__(THREADS_PER_CTA)` to `FusedDropoutActBiasGrad` kernel can solve the bug.
I have already reported this bug internally. I guess the `nvcc` compiler doesn't allocate resources properly for Hopper. This bug may also occur in H800. Thus, I file this PR.

Compute-sanitizer error message:
```
========= COMPUTE-SANITIZER
========= Program hit cudaErrorLaunchOutOfResources (error 701) due to "too many resources requested for launch" on CUDA API call to cudaLaunchKernel.
=========     Saved host backtrace up to driver entry point at error
=========     Host Frame: [0x454676]
=========                in /lib/x86_64-linux-gnu/libcuda.so.1
=========     Host Frame:cudaLaunchKernel [0x6d4a8]
=========                in /test-hopper/./test.out
=========     Host Frame:cudaError cudaLaunchKernel<char>(char const*, dim3, dim3, void**, unsigned long, CUstream_st*) [0xb777]
=========                in /test-hopper/./test.out
=========     Host Frame:__device_stub__Z23FusedDropoutActBiasGradIdEv15GeluGradFunctorIT_EPKS1_PKhS4_S4_S1_llPS1_S7_(GeluGradFunctor<double>&, double const*, unsigned char const*, double const*, double const*, double, long, long, double*, double*) [0xb5ad]  
=========                in /test-hopper/./test.out
=========     Host Frame:void __wrapper__device_stub_FusedDropoutActBiasGrad<double>(GeluGradFunctor<double>&, double const*&, unsigned char const*&, double const*&, double const*&, double const&, long const&, long const&, double*&, double*&) [0xb64c]        
=========                in /test-hopper/./test.out
=========     Host Frame:void FusedDropoutActBiasGrad<double>(GeluGradFunctor<double>, double const*, unsigned char const*, double const*, double const*, double, long, long, double*, double*) [0xb849]
```