### PR TITLE
[Fix] Fix paddle.pow() Gets Incorrect Result When Broadcasting Is Triggered

### DIFF
--- a/paddle/phi/kernels/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_kernel.cc
@@ -91,8 +91,15 @@ void ElementwisePowRawKernel(const Context& dev_ctx,
                              DenseTensor* out) {
   // allocate memory for out
   dev_ctx.template Alloc<T>(out);
-  funcs::ElementwiseCompute<funcs::ElementwisePowFunctor<T>, T>(
-      dev_ctx, x, y, axis, funcs::ElementwisePowFunctor<T>(), out);
+  auto x_dims = x.dims();
+  auto y_dims = y.dims();
+  if (x_dims.size() >= y_dims.size()) {
+    funcs::ElementwiseCompute<funcs::ElementwisePowFunctor<T>, T>(
+        dev_ctx, x, y, axis, funcs::ElementwisePowFunctor<T>(), out);
+  } else {
+    funcs::ElementwiseCompute<funcs::ElementwiseInversePowFunctor<T>, T>(
+        dev_ctx, x, y, axis, funcs::ElementwiseInversePowFunctor<T>(), out);
+  }
 }
 
 template <typename T, typename Context>

--- a/python/paddle/fluid/tests/unittests/test_pow.py
+++ b/python/paddle/fluid/tests/unittests/test_pow.py
@@ -134,15 +134,13 @@ class TestPowerAPI(unittest.TestCase):
         # test float scalar ** 2-d float tensor
         dims = (np.random.randint(1, 10), np.random.randint(5, 10))
         x = np.random.rand() * 10
-        y = (np.random.rand(*dims) * 10).astype(np.float64)
+        y = (np.random.rand(*dims) * 10).astype(np.float32)
         res = _run_power(DYNAMIC, x, y)
-        np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)
-        res = _run_power(STATIC, x, y)
         np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)
 
         # test 2-d float tensor ** float scalar
         dims = (np.random.randint(1, 10), np.random.randint(5, 10))
-        x = (np.random.rand(*dims) * 10).astype(np.float64)
+        x = (np.random.rand(*dims) * 10).astype(np.float32)
         y = np.random.rand() * 10
         res = _run_power(DYNAMIC, x, y)
         np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)

--- a/python/paddle/fluid/tests/unittests/test_pow.py
+++ b/python/paddle/fluid/tests/unittests/test_pow.py
@@ -131,6 +131,24 @@ class TestPowerAPI(unittest.TestCase):
         res = _run_power(STATIC, x, y)
         np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)
 
+        # test float scalar ** 2-d float tensor
+        dims = (np.random.randint(1, 10), np.random.randint(5, 10))
+        x = np.random.rand() * 10
+        y = (np.random.rand(*dims) * 10).astype(np.float64)
+        res = _run_power(DYNAMIC, x, y)
+        np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)
+        res = _run_power(STATIC, x, y)
+        np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)
+
+        # test 2-d float tensor ** float scalar
+        dims = (np.random.randint(1, 10), np.random.randint(5, 10))
+        x = (np.random.rand(*dims) * 10).astype(np.float64)
+        y = np.random.rand() * 10
+        res = _run_power(DYNAMIC, x, y)
+        np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)
+        res = _run_power(STATIC, x, y)
+        np.testing.assert_allclose(res, np.power(x, y), rtol=1e-05)
+
         # test broadcast
         dims = (
             np.random.randint(1, 10),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe

#### Issue

Here is a minimal case to reproduce the issue.

```python

import paddle

paddle.set_device('cpu')

print(paddle.pow(paddle.to_tensor(3.), paddle.to_tensor([[0.68100125, 0.02188216]])))

print(paddle.pow(paddle.to_tensor(3.), paddle.to_tensor([0.68100125, 0.02188216])))

```

The result is expected to be:

```
Tensor(shape=[1, 2], dtype=float32, place=Place(cpu), stop_gradient=True,

       [[2.11310053, 1.02433133]])

Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,

       [2.11310053, 1.02433133])
```

but it turns out to be

```
Tensor(shape=[1, 2], dtype=float32, place=Place(cpu), stop_gradient=True,

       [[0.31582296, 0.00001048]])

Tensor(shape=[2], dtype=float32, place=Place(cpu), stop_gradient=True,

       [2.11310053, 1.02433133])
```

#### Reason

When broadcasting is triggered and given `x.dims().size()<y.dims().size()`, the de facto behavior of `paddle.pow(x, y)` will be `pow(b, a)`, which leads to the incorrect result. Note that this only occurs on CPU devices, as the GPU kernel of `paddle.pow()` does not share the implementation with the CPU kernel, i.e. the dispatching by the `ElementwiseCompute()` function.

#### Solution

Following `paddle.floor_divide()` and `paddle.remainder()`, I wrote the *inverse* version of `ElementwisePowFunctor`, i.e. `ElementwiseInversePowFunctor`, which should be used when `x.dims().size()<y.dims().size()`.
