### PR TITLE
[CodeStyle] fix braced-scalar-init warnings on macos

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -214,8 +214,9 @@ if(APPLE)
         CACHE STRING "Build architectures for OSX" FORCE)
   endif()
   # On Mac OS X register class specifier is deprecated and will cause warning error on latest clang 10.0
-  set(COMMON_FLAGS -Wno-deprecated-register -Werror=format
-                   -Werror=inconsistent-missing-override)
+  set(COMMON_FLAGS
+      -Wno-deprecated-register -Werror=format
+      -Werror=inconsistent-missing-override -Werror=braced-scalar-init)
 endif()
 
 if(WITH_HETERPS AND WITH_PSLIB)

--- a/paddle/fluid/eager/tests/task_tests/eager_utils_test.cc
+++ b/paddle/fluid/eager/tests/task_tests/eager_utils_test.cc
@@ -82,7 +82,7 @@ TEST(EagerUtils, AutoGradMeta) {
   CHECK_NOTNULL(grad_node0.get());
 
   EagerUtils::SetHistory(autograd_meta1, test_node);
-  EagerUtils::SetHistory({autograd_meta1}, test_node);
+  EagerUtils::SetHistory(autograd_meta1, test_node);
   std::shared_ptr<GradNodeBase> grad_node1 = EagerUtils::grad_node(et1);
   CHECK_NOTNULL(grad_node1.get());
 

--- a/paddle/fluid/imperative/prepared_operator.h
+++ b/paddle/fluid/imperative/prepared_operator.h
@@ -347,7 +347,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
 
     auto iter = outs.find(output_names[i]);
     if (iter == outs.end()) {
-      kernel_ctx->EmplaceBackOutputWithoutSetRange({nullptr});
+      kernel_ctx->EmplaceBackOutputWithoutSetRange(nullptr);
       kernel_ctx->AssignOutputRange(std::make_pair(start_idx, start_idx + 1),
                                     i);
       continue;
@@ -358,7 +358,7 @@ void BuildDygraphPhiKernelContext(const phi::KernelSignature& kernel_signature,
 
     for (size_t offset = 0; offset < outs_vector.size(); ++offset) {
       if (outs_vector[offset] == nullptr) {
-        kernel_ctx->EmplaceBackOutputWithoutSetRange({nullptr});
+        kernel_ctx->EmplaceBackOutputWithoutSetRange(nullptr);
         continue;
       }
 

--- a/paddle/phi/ops/compat/concat_sig.cc
+++ b/paddle/phi/ops/compat/concat_sig.cc
@@ -26,10 +26,10 @@ KernelSignature ConcatOpArgumentMapping(const ArgumentMappingContext& ctx) {
 KernelSignature ConcatGradOpArgumentMapping(const ArgumentMappingContext& ctx) {
   if (ctx.HasInput("AxisTensor")) {
     return KernelSignature(
-        "concat_grad", {"X", {"Out@GRAD"}}, {"AxisTensor"}, {{"X@GRAD"}});
+        "concat_grad", {"X", "Out@GRAD"}, {"AxisTensor"}, {"X@GRAD"});
   }
   return KernelSignature(
-      "concat_grad", {"X", {"Out@GRAD"}}, {"axis"}, {{"X@GRAD"}});
+      "concat_grad", {"X", "Out@GRAD"}, {"axis"}, {"X@GRAD"});
 }
 
 }  // namespace phi


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe

fix `braced-scalar-init` warnings and add `-Werror` for `braced-scalar-init` warning  on macos
```bash
cat ./before.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr

  26 [-Wnon-c-typedef-for-linkage]
  23 [-Wdeprecated-declarations]
  13 [-Wbraced-scalar-init]
   7 [-Wdangling-gsl]
   4 [-Wc++17-extensions]
   4 [-Walign-mismatch]
   2 [-Wexceptions]
   1 [-Wuninitialized]
   1 [-Wtautological-constant-out-of-range-compare]
   1 [-Wreturn-type-c-linkage]
   1 [-Wpragma-pack]
   1 [-Wliteral-conversion]
```

```bash
cat ./after.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
  26 [-Wnon-c-typedef-for-linkage]
  23 [-Wdeprecated-declarations]
   7 [-Wdangling-gsl]
   4 [-Wc++17-extensions]
   4 [-Walign-mismatch]
   2 [-Wexceptions]
   1 [-Wuninitialized]
   1 [-Wtautological-constant-out-of-range-compare]
   1 [-Wreturn-type-c-linkage]
   1 [-Wpragma-pack]
   1 [-Wliteral-conversion]
```

- #47143
