### PR TITLE
[CodeStyle] fix three types of compiler warnings on macOS

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -215,8 +215,13 @@ if(APPLE)
   endif()
   # On Mac OS X register class specifier is deprecated and will cause warning error on latest clang 10.0
   set(COMMON_FLAGS
-      -Wno-deprecated-register -Werror=format
-      -Werror=inconsistent-missing-override -Werror=braced-scalar-init)
+      -Wno-deprecated-register
+      -Werror=format
+      -Werror=inconsistent-missing-override
+      -Werror=braced-scalar-init
+      -Werror=uninitialized
+      -Werror=tautological-constant-out-of-range-compare
+      -Werror=literal-conversion)
 endif()
 
 if(WITH_HETERPS AND WITH_PSLIB)

--- a/paddle/fluid/framework/new_executor/workqueue/nonblocking_threadpool.h
+++ b/paddle/fluid/framework/new_executor/workqueue/nonblocking_threadpool.h
@@ -37,7 +37,7 @@ class ThreadPoolTempl {
       : env_(env),
         allow_spinning_(allow_spinning),
         always_spinning_(always_spinning),
-        global_steal_partition_(EncodePartition(0, num_threads_)),
+        global_steal_partition_(EncodePartition(0, num_threads)),
         blocked_(0),
         num_tasks_(0),
         done_(false),

--- a/paddle/fluid/imperative/partial_grad_engine.cc
+++ b/paddle/fluid/imperative/partial_grad_engine.cc
@@ -328,7 +328,8 @@ static void FillConstantLike(const VariableWrapper &ref_var,
   // grad mission
   // we can't get data_type_ directly. We need to check if we can only use
   // default data_type for now.
-  if (ref_var.ForwardDataType() != -1) {
+  if (ref_var.ForwardDataType() !=
+      static_cast<framework::proto::VarType::Type>(-1)) {
     dst_tensor->mutable_data(
         place, framework::TransToPhiDataType(ref_var.ForwardDataType()));
   } else {

--- a/paddle/fluid/operators/interpolate_op.h
+++ b/paddle/fluid/operators/interpolate_op.h
@@ -502,7 +502,7 @@ HOSTDEVICE inline T cubic_convolution2(T x, T A) {
 
 template <typename T>
 HOSTDEVICE inline void get_cubic_upsample_coefficients(T coeffs[4], T t) {
-  T A = -0.75;
+  T A = static_cast<T>(-0.75);
 
   T x1 = t;
   coeffs[0] = cubic_convolution2<T>(x1 + 1.0, A);

--- a/paddle/phi/kernels/cpu/lstsq_kernel.cc
+++ b/paddle/phi/kernels/cpu/lstsq_kernel.cc
@@ -128,7 +128,7 @@ void LstsqKernel(const Context& dev_ctx,
 
   // run once the driver, first to get the optimal workspace size
   int lwork = -1;
-  T wkopt;
+  T wkopt = 0.0;
   ValueType rwkopt;
   int iwkopt = 0;
 


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
Fix uninitialized, tautological-constant-out-of-range-compare and literal-conversion warning on macOS.

```bash
cat before.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
   4 [-Wc++17-extensions]
   3 [-Wunknown-warning-option]
   2 [-Wexceptions]
   1 [-Wuninitialized]
   1 [-Wtautological-constant-out-of-range-compare]
   1 [-Wreturn-type-c-linkage]
   1 [-Wpragma-pack]
   1 [-Wliteral-conversion]
```

```bash
cat after.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
   4 [-Wc++17-extensions]
   2 [-Wexceptions]
   1 [-Wreturn-type-c-linkage]
   1 [-Wpragma-pack]
```

 **Compiler Warning tracking:**
- #47143