### PR TITLE
[Sparse]Fix sparse EmptyLikeKernel and addmm infer_meta

### DIFF
--- a/paddle/phi/api/yaml/sparse_ops.yaml
+++ b/paddle/phi/api/yaml/sparse_ops.yaml
@@ -379,7 +379,8 @@
   args : (Tensor input, Tensor x, Tensor y, float alpha=1.0, float beta=1.0)
   output : Tensor(out)
   infer_meta :
-    func : AddmmInferMeta
+    func : UnchangedInferMeta
+    param : [input]
   kernel :
     func : addmm_csr_dense {dense, sparse_csr, dense -> dense},
            addmm_csr_csr {sparse_csr, sparse_csr, sparse_csr -> sparse_csr},

--- a/paddle/phi/kernels/sparse/empty_kernel.cc
+++ b/paddle/phi/kernels/sparse/empty_kernel.cc
@@ -31,6 +31,7 @@ void EmptyLikeCooKernel(const Context& dev_ctx,
   const DenseTensor& x_values = x.values();
   DenseTensor* out_values = out->mutable_values();
   out_values->Resize(x_values.dims());
+  out->set_meta(x.meta());
   dev_ctx.template Alloc<T>(out_values);
 }
 
@@ -44,6 +45,7 @@ void EmptyLikeCsrKernel(const Context& dev_ctx,
   const DenseTensor& x_values = x.values();
   DenseTensor* out_values = out->mutable_values();
   out_values->Resize(x_values.dims());
+  out->set_meta(x.meta());
   dev_ctx.template Alloc<T>(out_values);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

1. EmptyLikeKernel没有设置输出的meta，当中间变量使用EmptyLike创建SparseTensor的时候，有些地方校验dims会出错
2. 在cuda11.7环境下测试发现dense的addm infermeta不适用sparse，当前kernel内部设置了meta信息，infer_meta暂时使用UnchangedInferMeta。
3. 在cuda11.7下，测试addmm和sparse_attention通过
