### PR TITLE
[cherry-pick] Fix inference performance problem caused by selecting cudnn kernel of softmax (#47338)

### DIFF
--- a/paddle/fluid/operators/softmax_op.cc
+++ b/paddle/fluid/operators/softmax_op.cc
@@ -92,6 +92,11 @@ class SoftmaxOpMaker : public framework::OpProtoAndCheckerMaker {
         "Defaults to \"NHWC\". Specify the data format of the output data, "
         "the input will be transformed automatically. ")
         .SetDefault("AnyLayout");
+    AddAttr<bool>(
+        "use_cudnn",
+        "(bool, default false) Only used in cudnn kernel, need install cudnn")
+        .SetDefault(false)
+        .AsExtra();
     AddComment(R"DOC(
 Softmax Operator.
 

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -674,7 +674,7 @@
 - op : softmax
   backward : softmax_grad
   extra :
-    attrs : [bool use_cudnn = false, bool use_mkldnn = false, str mkldnn_data_type = "float32", bool is_test = false]
+    attrs : [bool use_mkldnn = false, str mkldnn_data_type = "float32", bool is_test = false]
 
 - op : softplus
   backward : softplus_grad


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
OpMaker清理导致inference部分模型性能下降，主要原因为softmax算子执行由原先的cudnn kernel变为了普通的gpu kernel，所以导致模型性能下降。

softmax算子在推理阶段没有选到cudnn kernel则是由于use_cudnn参数在保存program时被裁剪，加载program时恢复为默认值false，所以无法选到cudnn kernel，为修复这个问题本PR将softmax算子的extra属性use_cudnn先恢复到OpMaker中暂不清理，后续再进行移除。