### PR TITLE
[CUDNN] Clean abs cudnn attribute

### DIFF
--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -6,7 +6,7 @@
 - op : abs
   backward : abs_grad
   extra :
-    attrs : [bool use_cudnn = false, bool use_mkldnn = false]
+    attrs : [bool use_mkldnn = false]
 
 - op : acosh
   backward : acosh_grad


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
OPs

### Describe
Clean `abs` `cudnn` attribute

`use_cudnn` is mainly used for kernel selection. However, the `GetExpectedKernelType` function of this op returns plain kernel directly, thus the attribute `use_cudnn` of this op can be deleted safely.

`use_cudnn`属性主要用于 kernel 选择，然而`GetExpectedKernelType`函数并未利用这一属性，因此它可以被直接删除。
