### PR TITLE
[CodeStyle] fix pragma-pack warning on macos

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -221,7 +221,8 @@ if(APPLE)
       -Werror=braced-scalar-init
       -Werror=uninitialized
       -Werror=tautological-constant-out-of-range-compare
-      -Werror=literal-conversion)
+      -Werror=literal-conversion
+      -Werror=pragma-pack)
 endif()
 
 if(WITH_HETERPS AND WITH_PSLIB)

--- a/paddle/fluid/operators/math/bloomfilter.h
+++ b/paddle/fluid/operators/math/bloomfilter.h
@@ -26,7 +26,7 @@ namespace paddle {
 namespace operators {
 namespace math {
 
-#pragma pack(4)
+#pragma pack(push, 4)
 struct bloomfilter {
   uint64_t magic_num;
   uint64_t m;
@@ -34,6 +34,8 @@ struct bloomfilter {
   uint64_t count;
   unsigned char bit_vector[1];
 };
+#pragma pack(pop)
+
 int bloomfilter_get(const struct bloomfilter *bloomfilter,
                     const void *key,
                     size_t len);


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
Fix pragma-pack warning on macOS.

```bash
cat before.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
   4 [-Wc++17-extensions]
   2 [-Wexceptions]
   1 [-Wunknown-warning-option]
   1 [-Wreturn-type-c-linkage]
   1 [-Wpragma-pack]
```

```bash
cat after.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
   4 [-Wc++17-extensions]
   2 [-Wexceptions]
   1 [-Wreturn-type-c-linkage]
```
- #47143