### PR TITLE
fix default setting of dygraph PTQ

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/ptq.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/ptq.py
@@ -140,7 +140,7 @@ class ImperativePTQ(object):
         assert isinstance(
             model, paddle.nn.Layer
         ), "The model must be the instance of paddle.nn.Layer."
-        is_postprocess = config.get('postprocess', False)
+        is_postprocess = config.get('postprocess', True)
         config.pop('postprocess', None)
 
         # Convert and save dygraph quantized model


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix default setting of dygraph PTQ.
config.postprocess =False -> True.