### PR TITLE
[CodeStyle] remove boost compiler flags in flags.cmake

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -170,14 +170,7 @@ if(NOT WIN32)
   if(NOT APPLE)
     if((${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER 8.0) OR (WITH_ROCM))
       set(COMMON_FLAGS
-          ${COMMON_FLAGS}
-          -Wno-format-truncation # Warning in boost gcc 8.2
-          -Wno-error=parentheses # Warning in boost gcc 8.2
-          -Wno-error=catch-value # Warning in boost gcc 8.2
-          -Wno-error=nonnull-compare # Warning in boost gcc 8.2
-          -Wno-error=address # Warning in boost gcc 8.2
-          -Wno-ignored-qualifiers # Warning in boost gcc 8.2
-          -Wno-ignored-attributes # Warning in Eigen gcc 8.3
+          ${COMMON_FLAGS} -Wno-ignored-attributes # Warning in Eigen gcc 8.3
           -Wno-parentheses # Warning in Eigen gcc 8.3
       )
     endif()

--- a/paddle/fluid/operators/dgc_op.h
+++ b/paddle/fluid/operators/dgc_op.h
@@ -68,7 +68,7 @@ class DGCOpKernel : public framework::OpKernel<T> {
 
     // nranks
     auto nranks_tensor = ctx.Input<phi::DenseTensor>("nranks");
-    const int nranks = static_cast<const int>(*nranks_tensor->data<float>());
+    const int nranks = static_cast<int>(*nranks_tensor->data<float>());
     PADDLE_ENFORCE_GT(nranks,
                       1,
                       platform::errors::PreconditionNotMet(

--- a/paddle/fluid/operators/mlu/mlu_baseop.cc
+++ b/paddle/fluid/operators/mlu/mlu_baseop.cc
@@ -1610,9 +1610,9 @@ MLURNNDesc::~MLURNNDesc() {
     const float alpha1_float,
     const float alpha2_float,
     const float beta_float) {
-  const int alpha1_int = static_cast<const int>(alpha1_float);
-  const int alpha2_int = static_cast<const int>(alpha2_float);
-  const int beta_int = static_cast<const int>(beta_float);
+  const int alpha1_int = static_cast<int>(alpha1_float);
+  const int alpha2_int = static_cast<int>(alpha2_float);
+  const int beta_int = static_cast<int>(beta_float);
 
   const void* alpha1_ptr = static_cast<const void*>(&alpha1_float);
   const void* alpha2_ptr = static_cast<const void*>(&alpha2_float);

--- a/paddle/fluid/operators/optimizers/dgc_momentum_op.h
+++ b/paddle/fluid/operators/optimizers/dgc_momentum_op.h
@@ -39,7 +39,7 @@ class DGCMomentumKernel : public framework::OpKernel<T> {
 
     // nranks
     auto nranks_tensor = context.Input<phi::DenseTensor>("nranks");
-    const int nranks = static_cast<const int>(*nranks_tensor->data<float>());
+    const int nranks = static_cast<int>(*nranks_tensor->data<float>());
     PADDLE_ENFORCE_GT(
         nranks,
         1,

--- a/paddle/fluid/operators/reduce_ops/logsumexp_op_xpu.cc
+++ b/paddle/fluid/operators/reduce_ops/logsumexp_op_xpu.cc
@@ -33,7 +33,7 @@ class XPULogsumexpKernel : public framework::OpKernel<T> {
 
     const auto& input_dim_size = input->dims().size();
     // The dims has full dim, set the reduce_all is True
-    reduce_all |= (static_cast<const int>(axis.size()) == input_dim_size);
+    reduce_all |= (static_cast<int>(axis.size()) == input_dim_size);
 
     const T* input_data = input->data<T>();
     T* output_data = output->mutable_data<T>(context.GetPlace());

--- a/paddle/phi/kernels/cpu/layer_norm_kernel.cc
+++ b/paddle/phi/kernels/cpu/layer_norm_kernel.cc
@@ -135,7 +135,7 @@ void LayerNormKernel(const Context& dev_ctx,
       scale ? scale->data<T>() : nullptr,
       bias ? bias->data<T>() : nullptr,
       static_cast<int>(left),
-      static_cast<const float>(epsilon),
+      static_cast<float>(epsilon),
       right);
 #endif
 }

--- a/paddle/phi/kernels/impl/logsumexp_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/logsumexp_grad_kernel_impl.h
@@ -61,7 +61,7 @@ void LogsumexpGradKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(in_grad);
 
   const auto input_dim_size = in.dims().size();
-  reduce_all |= (static_cast<const int>(axis.size()) == input_dim_size);
+  reduce_all |= (static_cast<int>(axis.size()) == input_dim_size);
 
   if (reduce_all) {
     auto x = phi::EigenVector<T>::Flatten(in);

--- a/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
+++ b/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
@@ -71,7 +71,7 @@ void LogsumexpKernel(const Context& dev_ctx,
 
   const auto& input_dim_size = x.dims().size();
   // The dims has full dim, set the reduce_all is True
-  reduce_all |= (static_cast<const int>(axis.size()) == input_dim_size);
+  reduce_all |= (static_cast<int>(axis.size()) == input_dim_size);
 
   if (reduce_all) {
     // Flatten and reduce 1-D tensor


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe

remove boost compiler flags in `flags.cmake`.

- #47143
- #47254