### PR TITLE
Mapping from dist to single

### DIFF
--- a/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
@@ -145,7 +145,7 @@ class VocabParallelEmbedding(Layer):
 
         self.weight.is_distributed = True if self.is_mp else False
         if self.weight.is_distributed:
-            setattr(self.weight, "split_aixs", 0)
+            setattr(self.weight, "split_axis", 0)
 
     def forward(self, x):
         if self.is_mp:
@@ -279,7 +279,7 @@ class ColumnParallelLinear(Layer):
         self.weight.is_distributed = True if self.is_mp else False
 
         if self.weight.is_distributed:
-            setattr(self.weight, "split_aixs", 1)
+            setattr(self.weight, "split_axis", 1)
 
         if has_bias:
             # initialize bias to zero like Megatron

--- a/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_layers.py
@@ -144,6 +144,8 @@ class VocabParallelEmbedding(Layer):
             )
 
         self.weight.is_distributed = True if self.is_mp else False
+        if self.weight.is_distributed:
+            setattr(self.weight, "split_aixs", 0)
 
     def forward(self, x):
         if self.is_mp:
@@ -276,6 +278,9 @@ class ColumnParallelLinear(Layer):
 
         self.weight.is_distributed = True if self.is_mp else False
 
+        if self.weight.is_distributed:
+            setattr(self.weight, "split_aixs", 1)
+
         if has_bias:
             # initialize bias to zero like Megatron
             self.bias = self.create_parameter(
@@ -285,6 +290,8 @@ class ColumnParallelLinear(Layer):
                 is_bias=True,
             )
             self.bias.is_distributed = True if self.is_mp else False
+            if self.bias.is_distributed:
+                setattr(self.bias, "split_axis", 0)
         else:
             self.bias = None
 
@@ -437,6 +444,8 @@ class RowParallelLinear(Layer):
             )
 
         self.weight.is_distributed = True if self.is_mp else False
+        if self.weight.is_distributed:
+            setattr(self.weight, "split_axis", 0)
 
         if has_bias:
             self.bias = self.create_parameter(

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -69,6 +69,9 @@ def _scope_dist2single(dist_scope):
         "vocab_parallel_embedding": "embedding",
         "parallel_cross_entropy": "cross_entropy",
     }
+    assert (
+        dist_scope != "parallel_cross_entropy"
+    ), f"Not execpted param name: parallel_cross_entropy"
     if dist_scope in mapping:
         return mapping[dist_scope]
     return dist_scope

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -67,11 +67,10 @@ def _scope_dist2single(dist_scope):
         "row_parallel_linear": "linear",
         "column_parallel_linear": "linear",
         "vocab_parallel_embedding": "embedding",
-        "parallel_cross_entropy": "cross_entropy",
+        # "parallel_cross_entropy": "cross_entropy", while mp_layer has parallel_cross_entropy,
+        # but there is no parameters so the mapping of parallel_cross_entropy is not neccessary.
     }
-    assert (
-        dist_scope != "parallel_cross_entropy"
-    ), f"Not execpted param name: parallel_cross_entropy"
+
     if dist_scope in mapping:
         return mapping[dist_scope]
     return dist_scope

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -62,6 +62,18 @@ _first_cap_re = re.compile('(.)([A-Z][a-z]+)')
 _all_cap_re = re.compile('([a-z])([A-Z])')
 
 
+def _scope_dist2single(dist_scope):
+    mapping = {
+        "row_parallel_linear": "linear",
+        "column_parallel_linear": "linear",
+        "vocab_parallel_embedding": "embedding",
+        "parallel_cross_entropy": "cross_entropy",
+    }
+    if dist_scope in mapping:
+        return mapping[dist_scope]
+    return dist_scope
+
+
 def _convert_camel_to_snake(name):
     s1 = _first_cap_re.sub(r'\1_\2', name)
     return _all_cap_re.sub(r'\1_\2', s1).lower()
@@ -137,6 +149,7 @@ class Layer(object):
         self.training = True
         if name_scope is None:
             name_scope = _convert_camel_to_snake(self.__class__.__name__)
+            name_scope = _scope_dist2single(name_scope)
         self._full_name = unique_name.generate(name_scope)
         self._helper = LayerObjectHelper(self._full_name)
         self._built = False

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -70,10 +70,7 @@ def _scope_dist2single(dist_scope):
         # "parallel_cross_entropy": "cross_entropy", while mp_layer has parallel_cross_entropy,
         # but there is no parameters so the mapping of parallel_cross_entropy is not neccessary.
     }
-
-    if dist_scope in mapping:
-        return mapping[dist_scope]
-    return dist_scope
+    return mapping.get(dist_scope, dist_scope)
 
 
 def _convert_camel_to_snake(name):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. Add an attribute 'split_axis' to implicate the splitting way of a distributed parameter
2. mapping distributed name scope to s single-card name scope for following distributed layer:
- (1)row_parallel_linear : linear
- (2)column_parallel_linear : linear
- (3)vocab_parallel_embedding : linear