### PR TITLE
[Tools]Add autoflake pre-commit hook to remove unused-imports/var

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,4 +116,9 @@ repos:
     rev: v1.7.7
     hooks:
     -   id: autoflake
-        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
+        args:
+            - --in-place
+            - --remove-all-unused-imports
+            - --ignore-pass-after-docstring
+            - --ignore-init-module-imports
+            - --exclude=python/paddle/fluid/[!t]**,python/paddle/fluid/tra**

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,3 +111,9 @@ repos:
     hooks:
     -   id: cmakelint
         args: [--config=./tools/codestyle/.cmakelintrc]
+
+-   repo: https://github.com/PyCQA/autoflake
+    rev: v1.7.7
+    hooks:
+    -   id: autoflake
+        args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### What's new?

I found a great tool: [autoflake](https://github.com/PyCQA/autoflake), it has two import features for Paddle development:

+ Remove unused-imports
<img width="1523" alt="image" src="https://user-images.githubusercontent.com/9301846/198584357-60c35d3e-275e-4051-bd3a-e68a61034dc8.png">

+ Remove unused-variables

<img width="1446" alt="image" src="https://user-images.githubusercontent.com/9301846/198584499-a50c6f63-4dea-44e3-8199-61c0edb5e7fe.png">
