### PR TITLE
repair log bugs that keeps printing warnings

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -476,7 +476,7 @@ class PostTrainingQuantization(object):
 
         self._reset_activation_persistable()
 
-        if self._algo is 'min_max':
+        if self._algo == 'min_max':
             self._save_input_threhold()
         else:
             self._update_program()


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
Others

### Describe
精准测试日志打印中出现大量以下警告日志，影响从日志筛选内容，是由于python版本的问题，次PR修复此问题。


<img width="1328" alt="6dd42e8ec515be57dadb1e3b8b86dbc2" src="https://user-images.githubusercontent.com/62429225/198814101-fa0c3e13-1934-434f-9fdb-676b9aec775e.png">

<img width="817" alt="93d6250dcbac2c5a5b65e53753a9a9d7" src="https://user-images.githubusercontent.com/62429225/198814167-61b5e0d0-dc10-4749-b70f-600a50bc3ee0.png">


