### PR TITLE
Remove redundant numpy import in Docs(test=document_fix)

### DIFF
--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -947,7 +947,6 @@ def fused_multi_transformer(
             # required: gpu
             import paddle
             import paddle.incubate.nn.functional as F
-            import numpy as np
 
             # input: [batch_size, seq_len, embed_dim]
             x = paddle.rand(shape=(2, 4, 128), dtype="float32")

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -1171,7 +1171,6 @@ class MaxUnPool1D(Layer):
 
             import paddle
             import paddle.nn.functional as F
-            import numpy as np
 
             data = paddle.rand(shape=[1, 3, 16])
             pool_out, indices = F.max_pool1d(data, kernel_size=2, stride=2, padding=0, return_mask=True)
@@ -1351,7 +1350,6 @@ class MaxUnPool3D(Layer):
 
             import paddle
             import paddle.nn.functional as F
-            import numpy as np
 
             data = paddle.rand(shape=[1, 1, 4, 4, 6])
             pool_out, indices = F.max_pool3d(data, kernel_size=2, stride=2, padding=0, return_mask=True)

--- a/python/paddle/optimizer/adagrad.py
+++ b/python/paddle/optimizer/adagrad.py
@@ -70,7 +70,6 @@ class Adagrad(Optimizer):
         .. code-block:: python
 
             import paddle
-            import numpy as np
 
             inp = paddle.rand(shape=[10, 10])
             linear = paddle.nn.Linear(10, 10)

--- a/python/paddle/regularizer.py
+++ b/python/paddle/regularizer.py
@@ -105,7 +105,6 @@ class L2Decay(fluid.regularizer.L2Decay):
             # Example1: set Regularizer in optimizer
             import paddle
             from paddle.regularizer import L2Decay
-            import numpy as np
             linear = paddle.nn.Linear(10, 10)
             inp = paddle.rand(shape=[10, 10], dtype="float32")
             out = linear(inp)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Docs

### Describe
本次 PR 针对所有 paddle api 文档中出现的以下问题，进行了统一处理：
- 示例代码中存在导入了 numpy 依赖，却没有使用 numpy 任何功能的情况，如：
```python
        """
        Examples:
            .. code-block:: python
                import paddle
                import numpy as np
                original_tensor = paddle.ones([2, 2])
                print("original tensor's dtype is: {}".format(original_tensor.dtype))
                new_tensor = original_tensor.astype('float32')
                print("new tensor's dtype is: {}".format(new_tensor.dtype))
        """
```


