### PR TITLE
remove postprocess in dygraph ptq export

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/ptq.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/ptq.py
@@ -140,15 +140,11 @@ class ImperativePTQ(object):
         assert isinstance(
             model, paddle.nn.Layer
         ), "The model must be the instance of paddle.nn.Layer."
-        is_postprocess = config.get('postprocess', True)
-        config.pop('postprocess', None)
 
         # Convert and save dygraph quantized model
         self._convert(model)
 
         paddle.jit.save(layer=model, path=path, input_spec=input_spec, **config)
-        if not is_postprocess:
-            return
 
         # Load inference program
         is_dynamic_mode = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Remove `postprocess` parameter in dygraph PTQ export.