### PR TITLE
[Inference]add lacked method predictor::GetInputTensorShape

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -2344,6 +2344,10 @@ std::map<std::string, DataType> Predictor::GetInputTypes() {
   return predictor_->GetInputTypes();
 }
 
+std::map<std::string, std::vector<int64_t>> Predictor::GetInputTensorShape() {
+  return predictor_->GetInputTensorShape();
+}
+
 std::unique_ptr<Tensor> Predictor::GetInputHandle(const std::string &name) {
   return predictor_->GetInputTensor(name);
 }

--- a/paddle/fluid/inference/api/paddle_inference_api.h
+++ b/paddle/fluid/inference/api/paddle_inference_api.h
@@ -100,6 +100,13 @@ class PD_INFER_DECL Predictor {
   std::map<std::string, DataType> GetInputTypes();
 
   ///
+  /// \brief Get all input names and their corresponding shape
+  ///
+  /// \return the map of input names and shape
+  ///
+  std::map<std::string, std::vector<int64_t>> GetInputTensorShape();
+
+  ///
   /// \brief Get the input names
   ///
   /// \return input names


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
添加PaddleInference中， predictor遗漏的方法std::map<std::string, int64_t> Predictor::GetInputTensorShape()
可以获取模型所有输入层所需的尺寸大小。
GetInputTensorShape  在PaddlePredictor类中作为虚函数存在。
**ISSUE:**
https://github.com/PaddlePaddle/Paddle/issues/47494