### PR TITLE
[BugFix]Fix set_attr modify underly type

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -6100,7 +6100,7 @@ class Program(object):
             for j in range(block.op_size()):
                 op = block.op(j)
                 if op.has_attr('is_test'):
-                    op._set_attr('is_test', True)
+                    op._set_bool_attr('is_test', True)
                 if op.type() == "batch_norm":
                     # Remove the output ReserveSpace of batch_norm if exists.
                     op.remove_output("ReserveSpace")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

修复了当保存的模型包含一些反向算子时（如batch_norm_grad），在 _inference_optimize 函数修改 `is_test` 属性会导致其 attr_type 错误地由 `BOOL` 变成 `INT`，会导致预测执行时报错。

Pybind11 在似乎会将 Python端的True以 Int的形式传递给 C++ 后端。但我看了OpDesc::SetAttr 是包含这部分处理逻辑的，但前向算子是生效的，反向算子似乎没有按照预期生效，为了统一解决，这里修改为显式地调用`_set_bool_attr`:
```cpp
// OpDesc::SetAttr函数实现

  // In order to set bool attr properly
  if (attr_type == proto::AttrType::INT) {
    if (HasProtoAttr(name) &&
        GetProtoAttr(name).type() == proto::AttrType::BOOLEAN) {
      attrs_ptr->operator[](name) = static_cast<bool>(PADDLE_GET_CONST(int, v));
      need_update_ = true;
      return;
    }
```