### PR TITLE
remove functions not belong to public-api from __all__

### DIFF
--- a/python/paddle/audio/datasets/esc50.py
+++ b/python/paddle/audio/datasets/esc50.py
@@ -20,7 +20,7 @@ from paddle.utils import download
 from paddle.dataset.common import DATA_HOME
 from .dataset import AudioClassificationDataset
 
-__all__ = ['ESC50']
+__all__ = []
 
 
 class ESC50(AudioClassificationDataset):

--- a/python/paddle/audio/datasets/tess.py
+++ b/python/paddle/audio/datasets/tess.py
@@ -20,7 +20,7 @@ from paddle.utils import download
 from paddle.dataset.common import DATA_HOME
 from .dataset import AudioClassificationDataset
 
-__all__ = ['TESS']
+__all__ = []
 
 
 class TESS(AudioClassificationDataset):

--- a/python/paddle/distributed/communication/__init__.py
+++ b/python/paddle/distributed/communication/__init__.py
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-__all__ = ["stream"]

--- a/python/paddle/geometric/message_passing/__init__.py
+++ b/python/paddle/geometric/message_passing/__init__.py
@@ -16,8 +16,4 @@ from .send_recv import send_u_recv  # noqa: F401
 from .send_recv import send_ue_recv  # noqa: F401
 from .send_recv import send_uv  # noqa: F401
 
-__all__ = [
-    'send_u_recv',
-    'send_ue_recv',
-    'send_uv',
-]
+__all__ = []

--- a/python/paddle/geometric/sampling/__init__.py
+++ b/python/paddle/geometric/sampling/__init__.py
@@ -14,6 +14,4 @@
 
 from .neighbors import sample_neighbors  # noqa: F401
 
-__all__ = [
-    'sample_neighbors',
-]
+__all__ = []

--- a/python/paddle/incubate/multiprocessing/__init__.py
+++ b/python/paddle/incubate/multiprocessing/__init__.py
@@ -19,8 +19,6 @@ __all__ = []
 
 from multiprocessing import *  # noqa: F403
 
-__all__ += multiprocessing.__all__  # type: ignore[attr-defined]
-
 # Only support linux for now
 # Only support file_system sharing strategy.
 

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -62,19 +62,12 @@ __inplace_unary_func__ = [
 
 __all__ = []
 
-for _OP in set(__all__):
-    globals()[_OP] = generate_layer_fn(_OP)
-
 # It is a hot fix in some unittest using:
 #   fluid.layers.scale(x=x, scale=10.0, out=out_var)
 # e.g.: test_program_code.py, test_dist_train.py
 globals()['_scale'] = generate_layer_fn('scale')
 
 globals()['_elementwise_div'] = generate_layer_fn('elementwise_div')
-
-__all__ += __activations_noattr__
-__all__ += __unary_func__
-__all__ += __inplace_unary_func__
 
 for _OP in set(__activations_noattr__):
     _new_OP = _OP
@@ -823,8 +816,6 @@ def tan(x, name=None):
     helper.append_op(type='tan', inputs={"X": x}, outputs={"Out": out})
     return out
 
-
-__all__ += ['erf']
 
 _erf_ = generate_layer_fn('erf')
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
From version 2.0，the public APIs will be add to `__all__` in each module. So the **definition of public api** in Paddle is the Class / function in `__all__`  (exclude modules belongs to `fluid`), and each of them should be maintained continuously. However, there are some unexpected functions are wrongly regarded as public apis, which we do not recommend  to use them by the path.  This PR is to remove them. 

**Note: the definition of these functions are not be removed, so the developers can still use these functions.**

The following will be removed from the public api：
```
paddle.tensor.ops.*    (should be used by paddle.xxx or paddle.Tensor.xxx)
paddle.audio.datasets,esc50.ESC50 (there is already paddle.audio.datasets.ESC50)
paddle.audio.datasets,tess.TESS (there is already paddle.audio.datasets.TESS)
paddle.distributed.commuication.stream (stream.py is a module, only callable function or Class can be API)
paddle.geometric.message_passing.* (should be used by paddle.geometric.xxx)
paddle.geometric.sampling.* (should be used by paddle.geometric.xxx)
paddle.incubate.multiprocessing.* (muiltiprocessing is a other python packages, not a function provided by Paddle)
```