### PR TITLE
Apply new precise_test_map to Coverage_ci

### DIFF
--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -306,7 +306,7 @@ class PRChecker:
         file_ut_map = None
 
         ret = self.__urlretrieve(
-            'https://paddle-docker-tar.bj.bcebos.com/tmp_test/ut_file_map.json',
+            'https://paddle-docker-tar.bj.bcebos.com/precision_test_map_store/ut_file_map.json',
             'ut_file_map.json',
         )
         if not ret:
@@ -362,7 +362,7 @@ class PRChecker:
         if len(file_list) == 0:
             ut_list.append('filterfiles_placeholder')
             ret = self.__urlretrieve(
-                'https://paddle-docker-tar.bj.bcebos.com/tmp_test/prec_delta',
+                'https://paddle-docker-tar.bj.bcebos.com/precision_test_map_store/prec_delta',
                 'prec_delta',
             )
             if ret:
@@ -474,7 +474,7 @@ class PRChecker:
             else:
                 if ut_list:
                     ret = self.__urlretrieve(
-                        'https://paddle-docker-tar.bj.bcebos.com/tmp_test/prec_delta',
+                        'https://paddle-docker-tar.bj.bcebos.com/precision_test_map_store/prec_delta',
                         'prec_delta',
                     )
                     if ret:


### PR DESCRIPTION
### PR types
 Others 

### PR changes
 Others 

### Describe
将新的精准测试map应用到Coverage流水线，主要受益如下：
1 精准测试map范围扩大，新增了615个文件
2 每一个文件对应的单测文件减少，跑单测的数量减少，触发精准测试的时候coverage速度更快