### PR TITLE
[CodeStyle] remove unused-local-typedefs warning on linux

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -149,7 +149,6 @@ if(NOT WIN32)
       -Wno-unused-parameter
       -Wno-unused-function
       -Wno-error=literal-suffix
-      -Wno-error=unused-local-typedefs
       -Wno-error=ignored-attributes # Warnings in Eigen, gcc 6.3
       -Wno-error=terminate # Warning in PADDLE_ENFORCE
       -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2

--- a/paddle/fluid/operators/collective/c_comm_init_op.cc
+++ b/paddle/fluid/operators/collective/c_comm_init_op.cc
@@ -54,7 +54,6 @@ class CCommInitOp : public framework::OperatorBase {
 // TODO(wangxi): Put this in the unified header file
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
     using UniqueId = ncclUniqueId;
-    using Place = platform::CUDAPlace;
     using CommContext = platform::NCCLCommContext;
 #elif defined(PADDLE_WITH_XPU_BKCL)
     using UniqueId = BKCLUniqueId;

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_mkldnn_op.h
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_mkldnn_op.h
@@ -143,7 +143,6 @@ class EltwiseMKLDNNGradKernel : public ElemwiseGradKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
     ElemwiseGradKernel<T>::Compute(ctx);
-    using Tensor = phi::DenseTensor;
 
     auto& dev_ctx =
         ctx.template device_context<platform::MKLDNNDeviceContext>();

--- a/paddle/phi/kernels/xpu/rnn_kernel.cc
+++ b/paddle/phi/kernels/xpu/rnn_kernel.cc
@@ -39,7 +39,6 @@ void RnnKernel(const Context& dev_ctx,
                DenseTensor* dropout_state,
                std::vector<DenseTensor*> state,
                DenseTensor* reserve) {
-  using XPUTyp = typename XPUTypeTrait<T>::Type;
   if (dropout_state->IsInitialized()) {
     if (dropout_state->numel() != out->numel()) dropout_state->clear();
   }


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
remove `-Wno-error=unused-local-typedefs` warning on linux.

```bash
λ cat build_before.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
      6 [-Wterminate]
      4 [-Wunused-variable]
      4 [-Wunused-local-typedefs]
      2 [-Wunknown-pragmas]
```

```bash
λ cat build_after.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
      6 [-Wterminate]
      4 [-Wunused-variable]
      2 [-Wunknown-pragmas]
```
- #47143
