### PR TITLE
Add missing scale parameter for fused_allreduce_gradients_with_group

### DIFF
--- a/python/paddle/distributed/fleet/utils/hybrid_parallel_util.py
+++ b/python/paddle/distributed/fleet/utils/hybrid_parallel_util.py
@@ -193,7 +193,7 @@ def fused_allreduce_gradients_with_group(
         else _apply_collective_grads
     )
     with framework.no_grad():
-        apply_func(parameter_list, group, bucket_size)
+        apply_func(parameter_list, group, bucket_size, scale)
 
 
 def fused_allreduce_gradients(parameter_list, hcg):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
Add missing `scale` parameter passing for `fused_allreduce_gradients_with_group`.