### PR TITLE
Support NHWC layout in GroupNorm

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
@@ -78,7 +78,7 @@ class TestDygraphGroupNormv2(unittest.TestCase):
 
                     def attr_data_format():
                         out = paddle.nn.GroupNorm(
-                            num_groups=2, num_channels=2, data_format="NHWC"
+                            num_groups=2, num_channels=2, data_format="CNHW"
                         )
 
                     self.assertRaises(ValueError, attr_data_format)

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -377,8 +377,9 @@ class GroupNorm(Layer):
         self._epsilon = epsilon
         self._num_channels = num_channels
         self._num_groups = num_groups
-        if data_format != 'NCHW':
+        if data_format not in ['NCHW', 'NHWC']:
             raise ValueError("unsupported data layout:" + data_format)
+        self._data_format = data_format
 
         param_shape = [self._num_channels]
 
@@ -429,7 +430,7 @@ class GroupNorm(Layer):
                 self.bias,
                 self._epsilon,
                 self._num_groups,
-                "NCHW",
+                self._data_format,
             )
 
             return dygraph_utils._append_activation_in_dygraph(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
GroupNorm OP实现是支持`NHWC`数据格式的，但是在API中却只支持`NCHW`，因此需要统一