### PR TITLE
[Dygraph] Support no_sync attr for params in DataParallel

### DIFF
--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -706,7 +706,12 @@ class DataParallel(layers.Layer):
                 if param.trainable:
                     layers_param.append((sublayer, param))
 
-        trainable_parameters = [param for _, param in layers_param]
+        trainable_parameters = list(
+            filter(
+                lambda x: not getattr(x, "no_sync", False),
+                [param for _, param in layers_param],
+            )
+        )
 
         assert len(trainable_parameters) > 0, (
             "This model does not have any parameters to train, and "


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dygraph] Support no_sync attr for params in DataParallel