### PR TITLE
params form cpu copy to gpu only once

### DIFF
--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -38,6 +38,8 @@
 			*paddle::ResourceManager*;
 			*paddle::GPUContextResource*;
 			*paddle::CPUContextResource*;
+			*paddle::OpMetaInfoBuilder*;
+			*paddle::CustomOpKernelContext*;
 
 			/* ut needs the following symbol, we need to modify all the ut to hidden such symbols */
 

--- a/paddle/fluid/inference/paddle_inference_custom_device.map
+++ b/paddle/fluid/inference/paddle_inference_custom_device.map
@@ -38,6 +38,8 @@
 			*paddle::ResourceManager*;
 			*paddle::GPUContextResource*;
 			*paddle::CPUContextResource*;
+			*paddle::OpMetaInfoBuilder*;
+			*paddle::CustomOpKernelContext*;
 
 			/* ut needs the following symbol, we need to modify all the ut to hidden such symbols */
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
优化 权重数据拷贝。
当前状态：
权重数据从 CPU 拷贝到 GPU 拷贝了两次：
<img width="597" alt="image" src="https://user-images.githubusercontent.com/63448337/199243793-ab650ce3-2373-46f2-b039-37d71b46e8f9.png">

开始状态 var 中的 tensor 是 cpu tensor
第一次从 将 var 中的 cpu tenosor 拷贝到 另一个临时的 cpu tensor。
然后清理当前 var 中的tensor，再从临时 cpu tensor 考回来，此时 var 中的tensor 变成 GPU tensor

修改后：
<img width="608" alt="image" src="https://user-images.githubusercontent.com/63448337/199243713-54cdc66d-f75f-48ef-991c-de43d39889df.png">

直接将 var 中的 cpu tenosor 拷贝到 另一个 gpu tensor。
然后将 var 重新指向、拥有并管理这个  gpu tensor。
为了使得 var 有重新 指向、拥有并管理一个新的 tensor的能力。给 Variable  增加了Reset 接口。

这样做的好处：
减少拷贝时间； 优化内存占用。