### PR TITLE
[CodeStyle] remove unused-variable warning in linux

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -153,7 +153,7 @@ if(NOT WIN32)
       -Wno-error=terminate # Warning in PADDLE_ENFORCE
       -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2
       -Wimplicit-fallthrough=0 # Warning in tinyformat.h
-      -Wno-error=maybe-uninitialized # Warning in boost gcc 7.2
+      -Wno-error=maybe-uninitialized # Warning in Paddle-Lite
       ${fsanitize})
 
   if(WITH_IPU)

--- a/paddle/fluid/distributed/CMakeLists.txt
+++ b/paddle/fluid/distributed/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 proto_library(ps_framework_proto SRCS the_one_ps.proto)
 
 set(DISTRIBUTE_COMPILE_FLAGS
-    "-Wno-error=unused-value -Wno-non-virtual-dtor -Wno-error=non-virtual-dtor -Wno-error=delete-non-virtual-dtor -Wno-error=unused-variable -Wno-error=return-type -Wno-error=unused-but-set-variable -Wno-error=unknown-pragmas -Wno-error=parentheses -Wno-error=unused-result"
+    "-Wno-error=unused-value -Wno-non-virtual-dtor -Wno-error=non-virtual-dtor -Wno-error=delete-non-virtual-dtor -Wno-error=return-type -Wno-error=unused-but-set-variable -Wno-error=unknown-pragmas -Wno-error=parentheses -Wno-error=unused-result"
 )
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)

--- a/paddle/fluid/distributed/ps/service/communicator/communicator.cc
+++ b/paddle/fluid/distributed/ps/service/communicator/communicator.cc
@@ -1086,7 +1086,6 @@ void GeoCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
     if (varnames.empty()) {
       VLOG(0) << "ERROR! sparse variables num can not be zero";
     }
-    auto &varname = varnames[0];  // embedding_0.w_0@GRAD
     auto &ids = ctx.remote_sparse_ids;
     if (!ids.empty()) {
       it = send_varname_to_ctx_.erase(it);

--- a/paddle/fluid/distributed/ps/table/common_graph_table.cc
+++ b/paddle/fluid/distributed/ps/table/common_graph_table.cc
@@ -1417,7 +1417,6 @@ int32_t GraphTable::load_edges(const std::string &path,
                                const std::string &edge_type) {
 #ifdef PADDLE_WITH_HETERPS
   if (search_level == 2) total_memory_cost = 0;
-  const uint64_t fixed_load_edges = 1000000;
 #endif
   int idx = 0;
   if (edge_type == "") {

--- a/paddle/fluid/distributed/ps/table/memory_dense_table.cc
+++ b/paddle/fluid/distributed/ps/table/memory_dense_table.cc
@@ -342,7 +342,6 @@ int32_t MemoryDenseTable::Save(const std::string &path,
   std::vector<std::string> result_buffer_param;
   result_buffer_param.reserve(param_dim_);
   auto common = _config.common();
-  int size = static_cast<int>(common.params().size());
   if (_config.common().name() == "summary") {
     for (int x = 0; x < param_dim_; ++x) {
       result_buffer_param.emplace_back(std::to_string(values_[param_idx_][x]));

--- a/paddle/fluid/distributed/ps/table/memory_sparse_table.cc
+++ b/paddle/fluid/distributed/ps/table/memory_sparse_table.cc
@@ -534,7 +534,6 @@ int64_t MemorySparseTable::CacheShuffle(
   int shuffle_node_num = _config.sparse_table_cache_file_num();
   LOG(INFO) << "Table>> shuffle node num is: " << shuffle_node_num;
   // TODO(zhaocaibei123): check shuffle_node_num <= server_node_num
-  size_t file_start_idx = _avg_local_shard_num * _shard_idx;
   int thread_num = _real_local_shard_num < 20 ? _real_local_shard_num : 20;
 
   std::vector<
@@ -638,7 +637,6 @@ int32_t MemorySparseTable::SaveCache(
     return 0;
   }
   int save_param = atoi(param.c_str());  // batch_model:0  xbox:1
-  size_t file_start_idx = _avg_local_shard_num * _shard_idx;
   std::string table_path = paddle::string::format_string(
       "%s/%03d_cache/", path.c_str(), _config.table_id());
   _afs_client.remove(paddle::string::format_string(

--- a/paddle/fluid/distributed/rpc/CMakeLists.txt
+++ b/paddle/fluid/distributed/rpc/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(PADDLE_RPC_SRCS python_rpc_handler.cc rpc_agent.cc)
 set(DISTRIBUTE_COMPILE_FLAGS
-    "-Wno-error=unused-value -Wno-non-virtual-dtor -Wno-error=non-virtual-dtor -Wno-error=delete-non-virtual-dtor -Wno-error=unused-variable -Wno-error=return-type -Wno-error=unused-but-set-variable -Wno-error=unknown-pragmas -Wno-error=parentheses -Wno-error=unused-result"
+    "-Wno-error=unused-value -Wno-non-virtual-dtor -Wno-error=non-virtual-dtor -Wno-error=delete-non-virtual-dtor -Wno-error=return-type -Wno-error=unused-but-set-variable -Wno-error=unknown-pragmas -Wno-error=parentheses -Wno-error=unused-result"
 )
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
remove `unused-variable` warning in Linux.

```bash
cat build_before.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
      6 [-Wterminate]
      4 [-Wunused-variable]
      2 [-Wunknown-pragmas]
```

```bash
cat build_after.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
      6 [-Wterminate]
      2 [-Wunknown-pragmas]
```

- #47143
