### PR TITLE
fix amax/amin/max/min write overflow

### DIFF
--- a/paddle/phi/kernels/funcs/reduce_functor.h
+++ b/paddle/phi/kernels/funcs/reduce_functor.h
@@ -177,7 +177,8 @@ struct MaxOrMinGradFunctor {
     auto zeros = dx->constant(0);
     // If there are multiple minimum or maximum elements, the subgradient of
     // each is the set [0, 1], and we pass gradient to all of them here.
-    dx->device(place) = dy->broadcast(dim) * equals.select(ones, zeros);
+    dx->device(place) = dy->broadcast(dim).reshape(x->dimensions()) *
+                        equals.select(ones, zeros);
   }
 };
 
@@ -259,7 +260,8 @@ struct AMaxOrAMinGradFunctor {
       auto equal_number = mask.sum()
                               .reshape(Eigen::array<int, 1>({1}))
                               .broadcast(Eigen::array<int, 1>({size}));
-      dx->device(place) = dy->broadcast(dim) * mask / equal_number;
+      dx->device(place) =
+          dy->broadcast(dim).reshape(x->dimensions()) * mask / equal_number;
       return;
     }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
export FLAGS_use_system_allocator=1, 问题来源于 https://github.com/PaddlePaddle/Paddle/pull/47125

amax最小复现代码：
```
import paddle
import numpy as np
x_np = np.array([[0.2, 0.3, 0.9, 0.9], [0.1, 0.1, 0.6, 0.7]])
x = paddle.to_tensor(x_np, dtype="float32", stop_gradient=False)
out = paddle.amax(x, axis=None, keepdim=False) # 报错(前向没问题，反向触发错误)
grad_tensor = paddle.ones_like(x)
paddle.autograd.backward([out], [grad_tensor], True) 
```
max最小复现代码：
```
import paddle
import numpy as np
x_np = np.array([[0.2, 0.3, 0.9, 0.9], [0.1, 0.1, 0.6, 0.7]])
x = paddle.to_tensor(x_np, dtype="float32", stop_gradient=False)
out = paddle.max(x, axis=None, keepdim=False) # 报错(前向没问题，反向触发错误)
# out = paddle.max(x, axis=[0], keepdim=False) # 不报错
grad_tensor = paddle.ones_like(x)
paddle.autograd.backward([out], [grad_tensor], True) 
```
#### 定位说明
@veyron95 定位到的情况是：
- amax出错：`Paddle/paddle/phi/kernels/funcs/reduce_functor.h` 中 `AMaxOrAMinGradFunctor` 内部一个计算发现了写越界：`dx->device(place) = dy->broadcast(dim) * mask / equal_number;` 
- max出错：`Paddle/paddle/phi/kernels/funcs/reduce_functor.h`中 `MaxOrMinGradFunctor` 内部一个计算发现了写越界：`dx->device(place) = (dy->broadcast(dim) * equals.select(ones, zeros));`
- 两者左边 dx dim 原本是（2，4），右边结果打出来有64个数值。右边结果写入左边，写越界了。导致在后续内存释放的时候导致异常。
- 原先未报错的原因：原先默认`FLAGS_use_system_allocator=0`，内存管理使用的是 BestFitAllocator, 会申请一大块内存供 tensor 使用，即使在实际使用中写越界，由于越界的部分没人使用，也不会有什么太大的问题。

@luotao1 定位到的情况是：
- 静态图没问题，老动态图也没问题，只有新动态图有问题。把`python/paddle/fluid/tests/unittests/test_max_min_amax_amin_op.py` 115行  `def test_dygraph(self):` 注释就可以过
- 只有`axis=None`的情况下，会出错。也就是 `TestMaxMinAmaxAminAPI2` 和 `TestMaxMinAmaxAminAPI6`会出错。

> 两者左边 dx dim 原本是（2，4），右边结果打出来有64个数值

依次打印右边的变量，`dy->broadcast(dim)`是64数值，需要做一下reshape