### PR TITLE
[Cherry-pick] remove functions not belong to public-api from __all__

### DIFF
--- a/python/paddle/audio/datasets/esc50.py
+++ b/python/paddle/audio/datasets/esc50.py
@@ -20,7 +20,7 @@ from paddle.utils import download
 from paddle.dataset.common import DATA_HOME
 from .dataset import AudioClassificationDataset
 
-__all__ = ['ESC50']
+__all__ = []
 
 
 class ESC50(AudioClassificationDataset):

--- a/python/paddle/audio/datasets/tess.py
+++ b/python/paddle/audio/datasets/tess.py
@@ -20,7 +20,7 @@ from paddle.utils import download
 from paddle.dataset.common import DATA_HOME
 from .dataset import AudioClassificationDataset
 
-__all__ = ['TESS']
+__all__ = []
 
 
 class TESS(AudioClassificationDataset):

--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -51,7 +51,7 @@ from .collective import batch_isend_irecv  # noqa: F401
 from .collective import P2POp  # noqa: F401
 from .collective import reduce_scatter  # noqa: F401
 
-from .communication import *  # noqa: F401
+from .communication import stream
 
 from .auto_parallel import shard_op  # noqa: F401
 from .auto_parallel import shard_tensor  # noqa: F401
@@ -66,15 +66,43 @@ from paddle.fluid.dygraph.parallel import ParallelEnv  # noqa: F401
 
 from . import cloud_utils  # noqa: F401
 
-from .sharding import *  # noqa: F401
+from .sharding import group_sharded_parallel, save_group_sharded_model
 
 __all__ = [  # noqa
-    "spawn", "launch", "scatter", "broadcast", "ParallelEnv", "new_group",
-    "init_parallel_env", "gloo_init_parallel_env", "gloo_barrier",
-    "gloo_release", "QueueDataset", "split", "CountFilterEntry",
-    "ShowClickEntry", "get_world_size", "get_group", "all_gather",
-    "all_gather_object", "InMemoryDataset", "barrier", "all_reduce", "alltoall",
-    "alltoall_single", "send", "reduce", "recv", "ReduceOp", "wait", "get_rank",
-    "ProbabilityEntry", "ParallelMode", "is_initialized",
-    "destroy_process_group", "isend", "irecv", "reduce_scatter", "stream"
+    "spawn",
+    "launch",
+    "scatter",
+    "broadcast",
+    "ParallelEnv",
+    "new_group",
+    "init_parallel_env",
+    "gloo_init_parallel_env",
+    "gloo_barrier",
+    "gloo_release",
+    "QueueDataset",
+    "split",
+    "CountFilterEntry",
+    "ShowClickEntry",
+    "get_world_size",
+    "get_group",
+    "all_gather",
+    "all_gather_object",
+    "InMemoryDataset",
+    "barrier",
+    "all_reduce",
+    "alltoall",
+    "alltoall_single",
+    "send",
+    "reduce",
+    "recv",
+    "ReduceOp",
+    "wait",
+    "get_rank",
+    "ProbabilityEntry",
+    "ParallelMode",
+    "is_initialized",
+    "destroy_process_group",
+    "isend",
+    "irecv",
+    "reduce_scatter",
 ]

--- a/python/paddle/distributed/communication/__init__.py
+++ b/python/paddle/distributed/communication/__init__.py
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-__all__ = ["stream"]

--- a/python/paddle/geometric/message_passing/__init__.py
+++ b/python/paddle/geometric/message_passing/__init__.py
@@ -16,8 +16,4 @@ from .send_recv import send_u_recv  # noqa: F401
 from .send_recv import send_ue_recv  # noqa: F401
 from .send_recv import send_uv  # noqa: F401
 
-__all__ = [
-    'send_u_recv',
-    'send_ue_recv',
-    'send_uv',
-]
+__all__ = []

--- a/python/paddle/geometric/sampling/__init__.py
+++ b/python/paddle/geometric/sampling/__init__.py
@@ -14,6 +14,4 @@
 
 from .neighbors import sample_neighbors  # noqa: F401
 
-__all__ = [
-    'sample_neighbors',
-]
+__all__ = []

--- a/python/paddle/incubate/multiprocessing/__init__.py
+++ b/python/paddle/incubate/multiprocessing/__init__.py
@@ -19,8 +19,6 @@ __all__ = []
 
 from multiprocessing import *  # noqa: F403
 
-__all__ += multiprocessing.__all__  # type: ignore[attr-defined]
-
 # Only support linux for now
 # Only support file_system sharing strategy.
 

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -14,17 +14,27 @@
 
 from __future__ import print_function
 import os
-from .layer_function_generator import generate_layer_fn, generate_activation_fn, generate_inplace_fn, add_sample_code
+from .layer_function_generator import (
+    generate_layer_fn,
+    generate_activation_fn,
+    generate_inplace_fn,
+    add_sample_code,
+)
 from ..framework import core
 from ..framework import convert_np_dtype_to_dtype_
 from ..static import Variable
-from ..fluid.data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
+from ..fluid.data_feeder import (
+    convert_dtype,
+    check_variable_and_dtype,
+    check_type,
+    check_dtype,
+)
 from ..fluid.framework import in_dygraph_mode
 from .. import _C_ops, _legacy_C_ops
 
 __deprecated_func_name__ = {
     'tanh_shrink': 'tanhshrink',
-    'logsigmoid': 'log_sigmoid'
+    'logsigmoid': 'log_sigmoid',
 }
 
 __activations_noattr__ = [
@@ -102,7 +112,8 @@ for _OP in set(__inplace_unary_func__):
     globals()[_OP] = _func
 
 add_sample_code(
-    globals()["sigmoid"], r"""
+    globals()["sigmoid"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -114,10 +125,12 @@ Examples:
         print(out)
         # [0.40131234 0.450166   0.52497919 0.57444252]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["silu"], r"""
+    globals()["silu"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -129,10 +142,12 @@ Examples:
         print(out)
         # [ 0.7310586 1.7615942 2.8577224, 3.9280552 ]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["logsigmoid"], r"""
+    globals()["logsigmoid"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -144,10 +159,12 @@ Examples:
         print(out)
         # [-0.91301525 -0.79813887 -0.64439666 -0.55435524]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["exp"], r"""
+    globals()["exp"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -158,10 +175,12 @@ Examples:
         print(out)
         # [0.67032005 0.81873075 1.10517092 1.34985881]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["expm1"], r"""
+    globals()["expm1"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -172,10 +191,12 @@ Examples:
         print(out)
         # [-0.32967997, -0.18126924,  0.10517092,  0.34985882]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["tanh"], r"""
+    globals()["tanh"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -186,10 +207,12 @@ Examples:
         print(out)
         # [-0.37994896 -0.19737532  0.09966799  0.29131261]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["atan"], r"""
+    globals()["atan"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -200,10 +223,12 @@ Examples:
         print(out)
         # [-0.38050638 -0.19739556  0.09966865  0.29145679]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["tanh_shrink"], r"""
+    globals()["tanh_shrink"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -215,10 +240,12 @@ Examples:
         print(out)
         # [-0.020051, -0.00262468, 0.000332005, 0.00868739]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["sqrt"], r"""
+    globals()["sqrt"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -229,10 +256,12 @@ Examples:
         print(out)
         # [0.31622777 0.4472136  0.54772256 0.63245553]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["rsqrt"], r"""
+    globals()["rsqrt"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -243,10 +272,12 @@ Examples:
         print(out)
         # [3.16227766 2.23606798 1.82574186 1.58113883]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["abs"], r"""
+    globals()["abs"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -257,10 +288,12 @@ Examples:
         print(out)
         # [0.4 0.2 0.1 0.3]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["ceil"], r"""
+    globals()["ceil"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -271,10 +304,12 @@ Examples:
         print(out)
         # [-0. -0.  1.  1.]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["floor"], r"""
+    globals()["floor"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -285,10 +320,12 @@ Examples:
         print(out)
         # [-1. -1.  0.  0.]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["cos"], r"""
+    globals()["cos"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -299,10 +336,12 @@ Examples:
         print(out)
         # [0.92106099 0.98006658 0.99500417 0.95533649]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["tan"], r"""
+    globals()["tan"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -313,10 +352,12 @@ Examples:
         print(out)
         # [-0.42279324, -0.20271005, 0.10033467, 0.30933627]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["acos"], r"""
+    globals()["acos"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -327,10 +368,12 @@ Examples:
         print(out)
         # [1.98231317 1.77215425 1.47062891 1.26610367]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["sin"], r"""
+    globals()["sin"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -341,10 +384,12 @@ Examples:
         print(out)
         # [-0.38941834 -0.19866933  0.09983342  0.29552021]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["asin"], r"""
+    globals()["asin"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -355,10 +400,12 @@ Examples:
         print(out)
         # [-0.41151685 -0.20135792  0.10016742  0.30469265]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["cosh"], r"""
+    globals()["cosh"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -369,10 +416,12 @@ Examples:
         print(out)
         # [1.08107237 1.02006676 1.00500417 1.04533851]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["sinh"], r"""
+    globals()["sinh"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -383,10 +432,12 @@ Examples:
         print(out)
         # [-0.41075233 -0.201336    0.10016675  0.30452029]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["asinh"], r"""
+    globals()["asinh"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -397,10 +448,12 @@ Examples:
         print(out)
         # [-0.39003533, -0.19869010,  0.09983408,  0.29567307]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["acosh"], r"""
+    globals()["acosh"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -411,10 +464,12 @@ Examples:
         print(out)
         # [0.        , 1.76274729, 2.06343699, 2.29243159]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["atanh"], r"""
+    globals()["atanh"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -425,10 +480,12 @@ Examples:
         print(out)
         # [-0.42364895, -0.20273256,  0.10033535,  0.30951962]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["round"], r"""
+    globals()["round"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -439,10 +496,12 @@ Examples:
         print(out)
         # [-1. -0.  1.  2.]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["reciprocal"], r"""
+    globals()["reciprocal"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -453,10 +512,12 @@ Examples:
         print(out)
         # [-2.5        -5.         10.          3.33333333]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["square"], r"""
+    globals()["square"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -467,10 +528,12 @@ Examples:
         print(out)
         # [0.16 0.04 0.01 0.09]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["softplus"], r"""
+    globals()["softplus"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -482,10 +545,12 @@ Examples:
         print(out)
         # [0.513015, 0.598139, 0.744397, 0.854355]
 
-""")
+""",
+)
 
 add_sample_code(
-    globals()["softsign"], r"""
+    globals()["softsign"],
+    r"""
 Examples:
     .. code-block:: python
 
@@ -497,7 +562,8 @@ Examples:
         print(out)
         # [-0.285714, -0.166667, 0.0909091, 0.230769]
 
-""")
+""",
+)
 
 _erf_ = generate_layer_fn('erf')
 

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -73,19 +73,12 @@ __inplace_unary_func__ = [
 
 __all__ = []
 
-for _OP in set(__all__):
-    globals()[_OP] = generate_layer_fn(_OP)
-
 # It is a hot fix in some unittest using:
 #   fluid.layers.scale(x=x, scale=10.0, out=out_var)
 # e.g.: test_program_code.py, test_dist_train.py
 globals()['_scale'] = generate_layer_fn('scale')
 
 globals()['_elementwise_div'] = generate_layer_fn('elementwise_div')
-
-__all__ += __activations_noattr__
-__all__ += __unary_func__
-__all__ += __inplace_unary_func__
 
 for _OP in set(__activations_noattr__):
     _new_OP = _OP
@@ -505,8 +498,6 @@ Examples:
         # [-0.285714, -0.166667, 0.0909091, 0.230769]
 
 """)
-
-__all__ += ['erf']
 
 _erf_ = generate_layer_fn('erf')
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Cherry-pick #47502 to version 2.4

For apis of `paddle.distributed`, there are some additional changes since code in 2.4 is kind of different with branch develop:
- remove `paddle.distributed.stream` (a module, not callable)
- remove `from xxx import *`, this may cause some potential problem. For example, the function `all_reduce`(which is expected) is covered by the module `all_reduce` (file `all_reduce.py` in `communication`).