### PR TITLE
[Paddle-TRT] Support engine sharing memory of multiple predictors

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -104,7 +104,11 @@ class AnalysisPredictor : public PaddlePredictor {
       config_.SwitchIrOptim(false);
       config_.EnableMemoryOptim(false);
     }
-    predictor_id_ = inference::GetUniqueId();
+    if (config_.trt_engine_memory_sharing_ == 2) {
+      predictor_id_ = -1;
+    } else {
+      predictor_id_ = inference::GetUniqueId();
+    }
   }
   ///
   /// \brief Destroy the Analysis Predictor object

--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -104,8 +104,9 @@ class AnalysisPredictor : public PaddlePredictor {
       config_.SwitchIrOptim(false);
       config_.EnableMemoryOptim(false);
     }
-    if (config_.trt_engine_memory_sharing_ == 2) {
-      predictor_id_ = -1;
+    auto trt_identifier = config_.trt_engine_memory_sharing_identifier_;
+    if (trt_identifier > 0) {
+      predictor_id_ = -trt_identifier;
     } else {
       predictor_id_ = inference::GetUniqueId();
     }

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -551,10 +551,6 @@ struct PD_INFER_DECL AnalysisConfig {
   /// \param use_static Serialize optimization information to disk for reusing.
   /// \param use_calib_mode Use TRT int8 calibration(post training
   /// quantization).
-  /// \param engine_memory_sharing The level to control TensorRT engine memory
-  /// sharing in predictors. 0 is disable, 1 is enable, 2 is enable for multi
-  /// predictors. NOTE: when value is equal to 2, the multi predictors should be
-  /// executed serially.
   ///
   ///
   void EnableTensorRtEngine(int64_t workspace_size = 1 << 30,
@@ -562,14 +558,27 @@ struct PD_INFER_DECL AnalysisConfig {
                             int min_subgraph_size = 3,
                             Precision precision = Precision::kFloat32,
                             bool use_static = false,
-                            bool use_calib_mode = true,
-                            int engine_memory_sharing = 1);
+                            bool use_calib_mode = true);
   ///
   /// \brief A boolean state telling whether the TensorRT engine is used.
   ///
   /// \return bool Whether the TensorRT engine is used.
   ///
   bool tensorrt_engine_enabled() const { return use_tensorrt_; }
+  ///
+  /// \brief Turn on the TensorRT memory optimization.
+  ///
+  /// \param engine_memory_sharing Whether to enable TensorRT memory
+  /// optimization.
+  /// \param sharing_identifier This parameter can be set if TensorRT memory
+  /// optimization is enabled, and the value must be greater than 0. If you have
+  /// multiple predictors that want to share memory, you can specify a
+  /// same value for these predictors. NOTE: The predictors specified with the
+  /// same value must be guaranteed to be executed serially, otherwise undefined
+  /// behavior will occur.
+  ///
+  void EnableTensorRTMemoryOptim(bool engine_memory_sharing = true,
+                                 int sharing_identifier = 0);
   ///
   /// \brief A boolean state telling whether the tensorrt engine memory sharing
   /// is activated.
@@ -1070,7 +1079,8 @@ struct PD_INFER_DECL AnalysisConfig {
 
   // memory reuse related.
   bool enable_memory_optim_{false};
-  int trt_engine_memory_sharing_{1};
+  bool trt_engine_memory_sharing_{false};
+  int trt_engine_memory_sharing_identifier_{0};
 
   bool use_mkldnn_{false};
   std::unordered_set<std::string> mkldnn_enabled_op_types_;

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -551,6 +551,10 @@ struct PD_INFER_DECL AnalysisConfig {
   /// \param use_static Serialize optimization information to disk for reusing.
   /// \param use_calib_mode Use TRT int8 calibration(post training
   /// quantization).
+  /// \param engine_memory_sharing The level to control TensorRT engine memory
+  /// sharing in predictors. 0 is disable, 1 is enable, 2 is enable for multi
+  /// predictors. NOTE: when value is equal to 2, the multi predictors should be
+  /// executed serially.
   ///
   ///
   void EnableTensorRtEngine(int64_t workspace_size = 1 << 30,

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -558,7 +558,8 @@ struct PD_INFER_DECL AnalysisConfig {
                             int min_subgraph_size = 3,
                             Precision precision = Precision::kFloat32,
                             bool use_static = false,
-                            bool use_calib_mode = true);
+                            bool use_calib_mode = true,
+                            int engine_memory_sharing = 1);
   ///
   /// \brief A boolean state telling whether the TensorRT engine is used.
   ///
@@ -1065,7 +1066,7 @@ struct PD_INFER_DECL AnalysisConfig {
 
   // memory reuse related.
   bool enable_memory_optim_{false};
-  bool trt_engine_memory_sharing_{false};
+  int trt_engine_memory_sharing_{1};
 
   bool use_mkldnn_{false};
   std::unordered_set<std::string> mkldnn_enabled_op_types_;

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -32,6 +32,7 @@
 
 #include "paddle/fluid/inference/api/analysis_predictor.h"
 #include "paddle/fluid/inference/api/helper.h"
+#include "paddle/fluid/inference/api/paddle_analysis_config.h"
 #include "paddle/fluid/inference/api/paddle_infer_contrib.h"
 #include "paddle/fluid/inference/api/paddle_inference_api.h"
 #include "paddle/fluid/inference/api/paddle_pass_builder.h"
@@ -725,8 +726,11 @@ void BindAnalysisConfig(py::module *m) {
            py::arg("min_subgraph_size") = 3,
            py::arg("precision_mode") = AnalysisConfig::Precision::kFloat32,
            py::arg("use_static") = false,
-           py::arg("use_calib_mode") = true,
-           py::arg("engine_memory_sharing") = 1)
+           py::arg("use_calib_mode") = true)
+      .def("enable_tensorrt_memory_optim",
+           &AnalysisConfig::EnableTensorRTMemoryOptim,
+           py::arg("engine_memory_sharing") = true,
+           py::arg("sharing_identifier") = 0)
       .def("tensorrt_precision_mode", &AnalysisConfig::tensorrt_precision_mode)
       .def("set_trt_dynamic_shape_info",
            &AnalysisConfig::SetTRTDynamicShapeInfo,

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -725,7 +725,8 @@ void BindAnalysisConfig(py::module *m) {
            py::arg("min_subgraph_size") = 3,
            py::arg("precision_mode") = AnalysisConfig::Precision::kFloat32,
            py::arg("use_static") = false,
-           py::arg("use_calib_mode") = true)
+           py::arg("use_calib_mode") = true,
+           py::arg("engine_memory_sharing") = 1)
       .def("tensorrt_precision_mode", &AnalysisConfig::tensorrt_precision_mode)
       .def("set_trt_dynamic_shape_info",
            &AnalysisConfig::SetTRTDynamicShapeInfo,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

**Related PR:** [PR1链接](https://github.com/PaddlePaddle/Paddle/pull/45468)、[PR2链接](https://github.com/PaddlePaddle/Paddle/pull/45842)

在上述PR实现的基础上，由于每个engine所需的显存块是与predicotr id绑定的，如若两个predictor共用同一块显存的话，只需要将这两个predictor的id设置为相同即可。此时，这两个predictor就相当于同一predictor的两个不同trt子图。

实现方案：

新增enable_tensorrt_memory_optim（Python）和EnableTensorRTMemoryOptim（C++）接口。

```cpp
  ///
  /// \brief Turn on the TensorRT memory optimization.
  ///
  /// \param engine_memory_sharing Whether to enable TensorRT memory
  /// optimization.
  /// \param sharing_identifier This parameter can be set if TensorRT memory
  /// optimization is enabled, and the value must be greater than 0. If you have
  /// multiple predictors that want to share memory, you can specify a
  /// same value for these predictors. NOTE: The predictors specified with the
  /// same value must be guaranteed to be executed serially, otherwise undefined
  /// behavior will occur.
  ///
  void EnableTensorRTMemoryOptim(bool engine_memory_sharing = true,
                                 int sharing_identifier = 0);
```

- engine_memory_sharing参数来控制显存共享是否开启。
- sharing_identifier参数来标识参与显存共享的predictor（指定相同此参数值的predictors必须保证串行执行！）。