### PR TITLE
 Restore default blacklist in convert_to_mixed_precision

### DIFF
--- a/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
+++ b/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
@@ -114,7 +114,6 @@ class ConvertToMixedPrecisionPass {
     black_list_.insert("assign");
     black_list_.insert("fill_constant");
     black_list_.insert("assign_value");
-    black_list_.insert("set_value");
     black_list_.insert("eye");
     black_list_.insert("fill_any_like");
     black_list_.insert("fill_constant_batch_size_like");

--- a/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
+++ b/paddle/fluid/inference/analysis/passes/convert_to_mixed_precision.cc
@@ -110,7 +110,15 @@ class ConvertToMixedPrecisionPass {
         keep_io_types_(keep_io_types),
         black_list_(black_list),
         place_(paddle::CPUPlace()),
-        executor_(place_) {}
+        executor_(place_) {
+    black_list_.insert("assign");
+    black_list_.insert("fill_constant");
+    black_list_.insert("assign_value");
+    black_list_.insert("set_value");
+    black_list_.insert("eye");
+    black_list_.insert("fill_any_like");
+    black_list_.insert("fill_constant_batch_size_like");
+  }
 
   void Run();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
 Restore default blacklist in convert_to_mixed_precision