### PR TITLE
[CodeStyle][py2][U008] remove unnecessary args in `super()` for some example code

### DIFF
--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -531,7 +531,7 @@ def spawn(func, args=(), nprocs=-1, join=True, daemon=False, **options):
 
             class LinearNet(nn.Layer):
                 def __init__(self):
-                    super(LinearNet, self).__init__()
+                    super().__init__()
                     self._linear1 = nn.Linear(10, 10)
                     self._linear2 = nn.Linear(10, 1)
 

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -1573,7 +1573,7 @@ class TracedLayer(object):
 
                 class ExampleLayer(paddle.nn.Layer):
                     def __init__(self):
-                        super(ExampleLayer, self).__init__()
+                        super().__init__()
                         self._fc = paddle.nn.Linear(3, 10)
 
                     def forward(self, input):
@@ -1591,7 +1591,7 @@ class TracedLayer(object):
                 print(out_static_graph[0].shape) # (2, 10)
 
                 # save the static graph model for inference
-                static_layer.save_inference_model(dirname='./saved_infer_model')
+                static_layer.save_inference_model('./saved_infer_model')
 
         """
         assert isinstance(
@@ -1623,7 +1623,7 @@ class TracedLayer(object):
 
                 class ExampleLayer(paddle.nn.Layer):
                     def __init__(self):
-                        super(ExampleLayer, self).__init__()
+                        super().__init__()
                         self._fc = paddle.nn.Linear(3, 10)
 
                     def forward(self, input):
@@ -1728,7 +1728,7 @@ class TracedLayer(object):
 
                 class ExampleLayer(paddle.nn.Layer):
                     def __init__(self):
-                        super(ExampleLayer, self).__init__()
+                        super().__init__()
                         self._fc = paddle.nn.Linear(3, 10)
 
                     def forward(self, input):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

#47549 遗留的几个示例代码中未解决的

- `paddle.distributed.spawn`：同 #46890
- `paddle.jit.TracedLayer.trace`：[static_layer.save_inference_model](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/jit/TracedLayer_cn.html#save-inference-model-path-feed-none-fetch-none) 使用方法错误，该方法无 `dirname` 参数，应当是误使用了 `paddle.fluid.io.save_inference_model` 的参数，修改后 2.3.2 版本可以运行成功
- `paddle.jit.TracedLayer.set_strategy`
- `paddle.jit.TracedLayer.save_inference_model`

后三个 `paddle.jit.TracedLayer` 上的方法在本地安装 paddle 2.3.2 运行成功，paddle 2.4.0rc0 则都会在 `out_dygraph, static_layer = paddle.jit.TracedLayer.trace(layer, inputs=[in_var])` 处报错，怀疑是 2.4.0 分支（包括 develop）出了问题

### Related links

- Legacy python2 tracking issue: #46837
- #47549