### PR TITLE
Get three grad lists in CPP to avoid gpu idle time

### DIFF
--- a/paddle/fluid/pybind/eager_utils.cc
+++ b/paddle/fluid/pybind/eager_utils.cc
@@ -720,6 +720,17 @@ PyObject* ToPyObject(const std::vector<paddle::experimental::Tensor>& value,
   return result;
 }
 
+PyObject* ToPyObject(
+    const std::vector<std::vector<paddle::experimental::Tensor>>& value) {
+  PyObject* result = PyList_New((Py_ssize_t)value.size());
+
+  for (size_t i = 0; i < value.size(); i++) {
+    PyList_SET_ITEM(result, static_cast<Py_ssize_t>(i), ToPyObject(value[i]));
+  }
+
+  return result;
+}
+
 PyObject* ToPyObject(const platform::Place& value) {
   auto obj = ::pybind11::cast(value);
   obj.inc_ref();

--- a/paddle/fluid/pybind/eager_utils.h
+++ b/paddle/fluid/pybind/eager_utils.h
@@ -103,6 +103,8 @@ PyObject* ToPyObject(const std::vector<double>& value);
 PyObject* ToPyObject(const std::vector<std::vector<size_t>>& value);
 PyObject* ToPyObject(const std::vector<paddle::experimental::Tensor>& value,
                      bool return_py_none_if_not_initialize = false);
+PyObject* ToPyObject(
+    const std::vector<std::vector<paddle::experimental::Tensor>>& value);
 PyObject* ToPyObject(const platform::Place& value);
 PyObject* ToPyObject(const phi::DenseTensor* value);
 PyObject* ToPyObject(const phi::SelectedRows* value);

--- a/python/paddle/fluid/dygraph/amp/loss_scaler.py
+++ b/python/paddle/fluid/dygraph/amp/loss_scaler.py
@@ -297,26 +297,11 @@ class AmpScaler(object):
                         else:
                             param_grads_fp32.append(param._grad_ivar())
         else:
-            param_grads = [
-                param._grad_ivar()
-                for param in optimizer._parameter_list
-                if param._grad_ivar() is not None
-            ]
-            param_grads_fp16 = [
-                param
-                for param in param_grads
-                if param.dtype == core.VarDesc.VarType.FP16
-            ]
-            param_grads_bf16 = [
-                param
-                for param in param_grads
-                if param.dtype == core.VarDesc.VarType.BF16
-            ]
-            param_grads_fp32 = [
-                param
-                for param in param_grads
-                if param.dtype == core.VarDesc.VarType.FP32
-            ]
+            (
+                param_grads_fp16,
+                param_grads_bf16,
+                param_grads_fp32,
+            ) = core.eager.get_grads_lists(optimizer._parameter_list)
         if core.is_compiled_with_npu():
             float_status = _legacy_C_ops.alloc_float_status()
             _legacy_C_ops.clear_float_status(float_status, float_status)

--- a/python/paddle/fluid/dygraph/amp/loss_scaler.py
+++ b/python/paddle/fluid/dygraph/amp/loss_scaler.py
@@ -26,6 +26,7 @@ import numpy as np
 from paddle import _C_ops, _legacy_C_ops
 from collections import defaultdict
 from enum import Enum
+from paddle.fluid import in_dygraph_mode
 
 __all__ = ['AmpScaler', 'OptimizerState']
 
@@ -297,11 +298,33 @@ class AmpScaler(object):
                         else:
                             param_grads_fp32.append(param._grad_ivar())
         else:
-            (
-                param_grads_fp16,
-                param_grads_bf16,
-                param_grads_fp32,
-            ) = core.eager.get_grads_lists(optimizer._parameter_list)
+            if in_dygraph_mode():
+                (
+                    param_grads_fp16,
+                    param_grads_bf16,
+                    param_grads_fp32,
+                ) = core.eager.get_grads_lists(optimizer._parameter_list)
+            else:
+                param_grads = [
+                    param._grad_ivar()
+                    for param in optimizer._parameter_list
+                    if param._grad_ivar() is not None
+                ]
+                param_grads_fp16 = [
+                    param
+                    for param in param_grads
+                    if param.dtype == core.VarDesc.VarType.FP16
+                ]
+                param_grads_bf16 = [
+                    param
+                    for param in param_grads
+                    if param.dtype == core.VarDesc.VarType.BF16
+                ]
+                param_grads_fp32 = [
+                    param
+                    for param in param_grads
+                    if param.dtype == core.VarDesc.VarType.FP32
+                ]
         if core.is_compiled_with_npu():
             float_status = _legacy_C_ops.alloc_float_status()
             _legacy_C_ops.clear_float_status(float_status, float_status)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. unscaler中的for每次循环都会多个调用c++的函数，此PR将for循环整体放到c++端，只需要调用一次c++的逻辑。减少了python和c++的交互时间，减少gpu的等待时间

在transformer_base_fp16模型上
- 优化前
![image](https://user-images.githubusercontent.com/23097963/200216264-cd01d75c-66cf-4c8a-bbfc-c6f90a550ca7.png)
- 优化后
![image](https://user-images.githubusercontent.com/23097963/200216296-41193555-9cee-4f48-8096-42a5197e175f.png)

2. 保留了原来的代码逻辑作为老动态图的分支。
