### PR TITLE
add cudnn error if compiled cudnn version is incompatible with installed cudnn version

### DIFF
--- a/paddle/phi/backends/gpu/gpu_resources.cc
+++ b/paddle/phi/backends/gpu/gpu_resources.cc
@@ -108,6 +108,20 @@ void InitGpuProperties(Place place,
         << "Please recompile or reinstall Paddle with compatible CUDA "
            "version.";
   }
+
+  auto local_cudnn_version = cudnn_dso_ver / 1000;
+  auto compile_cudnn_version = CUDNN_VERSION / 1000;
+  PADDLE_ENFORCE_EQ(
+      compile_cudnn_version,
+      local_cudnn_version,
+      phi::errors::InvalidArgument(
+          "The installed Paddle is compiled with CUDNN "
+          "%d, but CUDNN version in your machine is %d. "
+          "which will cause serious incompatible bug. "
+          "Please recompile or reinstall Paddle with compatible CUDNN "
+          "version.",
+          compile_cudnn_version,
+          local_cudnn_version));
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

优化cudnn报错逻辑，在用户环境cudnn大版本与安装包的cudnn大版本不一致时，给出明确报错。

测试在cudnn7的环境里安装cudnn8的包：
- 原报错：
![图片](https://user-images.githubusercontent.com/26408901/199906039-43d1aab7-074c-4fcd-8187-82c9e300e4fc.png)

- 现报错：
![图片](https://user-images.githubusercontent.com/26408901/199906453-db7f247d-a327-462d-b332-8a53d865f377.png)


