### PR TITLE
Use an unified FLAGS_check_nan_inf_level to control the result of checking infinite.

### DIFF
--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -70,31 +70,24 @@ PADDLE_DEFINE_EXPORTED_bool(
 
 /**
  * Operator related FLAG
- * Name: FLAGS_abort_on_nan_inf
+ * Name: FLAGS_check_nan_inf_level
  * Since Version: 2.5.0
- * Value Range: bool, default=true
+ * Value Range: int32, default=0
  * Example:
- * Note: Used to debug. Whether abort the process when any operator produce
- * NAN/INF. It only works when FLAGS_check_nan_inf is set.
+ * Note: Used to debug. Setting the check and print level when
+ * FLAGS_check_nan_inf is set.
+ * - 0, abort the process when any operator produce NAN/INF and only print the
+ * information of tensor which holds NAN/INF.
+ * - 1, continue the training or inference process and print the information of
+ * all tensors which holds NAN/INF.
+ * - 2, print the information of float tensors when the max or min value
+ * overflowing float16's limit.
+ * - 3, print the information of all tensors.
  */
-PADDLE_DEFINE_EXPORTED_bool(
-    abort_on_nan_inf,
-    true,
-    "Whether abort the process when any operator produce NAN/INF or not.");
-
-/**
- * Operator related FLAG
- * Name: FLAGS_check_tensor_max_min
- * Since Version: 2.5.0
- * Value Range: bool, default=false
- * Example:
- * Note: Used to debug. Enable to calculate and print the max and min value of
- * each operator's output tensor. It only works when FLAGS_check_nan_inf is set.
- */
-PADDLE_DEFINE_EXPORTED_bool(
-    check_tensor_max_min,
-    false,
-    "Whether to check all the output tensors's min and max value.");
+PADDLE_DEFINE_EXPORTED_int32(
+    check_nan_inf_level,
+    0,
+    "Setting the check and print level when FLAGS_check_nan_inf is set.");
 
 /**
  * Operator related FLAG


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
在https://github.com/PaddlePaddle/Paddle/pull/47095 中，新增了`FLAGS_abort_on_nan_inf`和`FLAGS_check_tensor_max_min`，来控制`FLAGS_check_nan_inf`开启时的行为，便于进行精度排查。实现方式有2个弊端：

1. FLAGS数量太多，需要组合起来使用，配置相对麻烦
2. 无法扩展至更多的精度检查

本PR删除`FLAGS_abort_on_nan_inf`和`FLAGS_check_tensor_max_min`，新增`FLAGS_check_nan_inf_level`来统一控制`FLAGS_check_nan_inf`工具的行为，具体功能如下：

1. `FLAGS_check_nan_inf_level = 0`，只打印存在NAN、Inf的Tensor信息，并在检测到NAN、Inf之后退出进程。为默认配置。
2. `FLAGS_check_nan_inf_level = 1`，只打印存在NAN、Inf的Tensor信息，在检测到NAN、Inf后不会退出进程，而是一直训练，可用于观察不同iter出现NAN、Inf的op_type、位置是否一样。
3. `FLAGS_check_nan_inf_level = 2`，float专用，当Tensor的Max、Min值超出了float16的表示范围时，也会打印。用于amp精度排查。
4. `FLAGS_check_nan_inf_level = 3`，打印全部Tensor的Max、Min等信息。用于进行float、amp训练精度比对。