### PR TITLE
Fused QKVBiasAdd and Transpose with Split Q, KV

### DIFF
--- a/paddle/fluid/operators/fused/fmha_ref.h
+++ b/paddle/fluid/operators/fused/fmha_ref.h
@@ -258,6 +258,177 @@ class FMHARef {
         dev_ctx_, *qktv_out_tensor, perm_3, fmha_out_tensor);
   }
 
+  void ComputeForwardForMultiTransformer(const phi::DenseTensor& qkv_input_tensor,
+                                         const phi::DenseTensor* cache_kv_tensor,
+                                         const phi::DenseTensor* src_mask_tensor,
+                                         phi::DenseTensor* q_transpose_out_tensor, 
+                                         phi::DenseTensor* kv_transpose_out_tensor, 
+                                         phi::DenseTensor* cache_kv_out_tensor,
+                                         phi::DenseTensor* qk_out_tensor,
+                                         phi::DenseTensor* src_mask_out_tensor,
+                                         phi::DenseTensor* softmax_out_tensor,
+                                         phi::DenseTensor* dropout_mask_out_tensor,
+                                         phi::DenseTensor* dropout_out_tensor,
+                                         phi::DenseTensor* qktv_out_tensor,
+                                         phi::DenseTensor* fmha_out_tensor) {
+    // input shape: [bs, seq_len, 3, num_head, head_dim]
+    // transpose with perm [2, 0, 3, 1, 4],
+    // output_shape: [3, bs, num_head, seq_len, head_dim]
+    T* qk_out_data = qk_out_tensor->data<T>();
+    T* qktv_out_data = qktv_out_tensor->data<T>();
+    T* softmax_out_data = softmax_out_tensor->data<T>();
+    T* dropout_out_data = dropout_out_tensor->data<T>();
+    T* fmha_out_data = fmha_out_tensor->data<T>();
+
+    auto out_seq_len = seq_len_;
+    if (cache_kv_tensor) {
+      // kv [2, bs, num_head, seq_len, head_dim]
+      phi::funcs::ConcatFunctor<phi::GPUContext, T> concat;
+      // out [2, bs, num_head, cache_seq_len + seq_len, head_dim]
+      concat(dev_ctx_, {*cache_kv_tensor, *kv_transpose_out_tensor}, 3, cache_kv_out_tensor);
+      out_seq_len = cache_kv_out_tensor->dims()[3];
+    }
+
+    int64_t q_size = batch_size_ * seq_len_ * num_head_ * head_dim_;
+    T* q_ptr = q_transpose_out_tensor->data<T>();
+    T* k_ptr = nullptr;
+    T* v_ptr = nullptr;
+
+    if (cache_kv_tensor) {
+      int64_t k_size = cache_kv_out_tensor->numel() / 2;
+      k_ptr = cache_kv_out_tensor->data<T>();
+      v_ptr = k_ptr + k_size;
+    } else {
+      int64_t k_size = q_size;
+      k_ptr = kv_transpose_out_tensor->data<T>();
+      v_ptr = k_ptr + k_size;
+    }
+
+    {
+      // NOTE(wangxi): We scale Q with 1/sqrt(Dh) before QK^T, because for
+      // float16 calculation, INF may appear in QK^T if we do not scale before.
+      float alpha = 1.0 / sqrt(head_dim_);
+      auto functor = phi::funcs::ScaleFunctor<T>(alpha);
+      std::vector<const phi::DenseTensor*> ins = {q_transpose_out_tensor};
+      std::vector<phi::DenseTensor*> outs = {q_transpose_out_tensor};
+      phi::funcs::ElementwiseKernel<T>(dev_ctx_, ins, &outs, functor);
+    }
+
+    // q*k^t, batched_gemm
+    CBLAS_TRANSPOSE transA = CblasNoTrans;
+    CBLAS_TRANSPOSE transB = CblasTrans;
+    auto blas = phi::funcs::GetBlas<phi::GPUContext, T>(dev_ctx_);
+    int gemm_batch_size = batch_size_ * num_head_;
+    int gemm_m = seq_len_;
+    int gemm_n = out_seq_len;
+    int gemm_k = head_dim_;
+    T alpha = static_cast<T>(1.0);
+    T beta = static_cast<T>(0.0);
+    int64_t stride_a = gemm_m * gemm_k;
+    int64_t stride_b = gemm_k * gemm_n;
+    blas.BatchedGEMM(transA,
+                     transB,
+                     gemm_m,
+                     gemm_n,
+                     gemm_k,
+                     alpha,
+                     q_ptr,
+                     k_ptr,
+                     beta,
+                     qk_out_data,
+                     gemm_batch_size,
+                     stride_a,
+                     stride_b);
+    int softmax_axis = -1;
+    if (src_mask_tensor != nullptr) {
+      if (src_mask_out_tensor == nullptr && seq_len_ == out_seq_len) {
+        LaunchFusedSoftmaxMaskKernel<T>(qk_out_data,
+                                        src_mask_tensor->data<T>(),
+                                        softmax_out_data,
+                                        batch_size_,
+                                        num_head_,
+                                        seq_len_,
+                                        dev_ctx_.stream());
+      } else {
+        std::vector<const phi::DenseTensor*> ins;
+        std::vector<phi::DenseTensor*> outs;
+        ins.emplace_back(qk_out_tensor);
+        ins.emplace_back(src_mask_tensor);
+        outs.emplace_back(src_mask_out_tensor);
+        int elewise_add_axis = -1;
+        phi::funcs::BroadcastKernel<phi::ElementwiseType::kBinary, T, T>(
+            dev_ctx_,
+            ins,
+            &outs,
+            elewise_add_axis,
+            phi::funcs::AddFunctor<T>());
+
+        phi::SoftmaxForwardCUDAKernelDriver<T>(
+            dev_ctx_, *src_mask_out_tensor, softmax_axis, softmax_out_tensor);
+      }
+    } else {
+      phi::SoftmaxForwardCUDAKernelDriver<T>(
+          dev_ctx_, *qk_out_tensor, softmax_axis, softmax_out_tensor);
+    }
+
+    transB = CblasNoTrans;
+    gemm_m = seq_len_;
+    gemm_n = head_dim_;
+    gemm_k = out_seq_len;
+    alpha = static_cast<T>(1.0);
+    stride_a = gemm_m * gemm_k;
+    stride_b = gemm_k * gemm_n;
+
+    if (dropout_param_.dropout_prob_) {
+      DropoutFwGPUKernelDriver<T>(
+          static_cast<const phi::GPUContext&>(dev_ctx_),
+          dropout_param_.is_test_,
+          dropout_param_.dropout_prob_,
+          dropout_param_.is_upscale_in_train_,
+          dropout_param_.is_fix_seed_,
+          dropout_param_.seed_val_,
+          static_cast<const phi::DenseTensor&>(*softmax_out_tensor),
+          dropout_param_.seed_,
+          dropout_mask_out_tensor,
+          dropout_out_tensor,
+          false);
+      blas.BatchedGEMM(transA,
+                       transB,
+                       gemm_m,
+                       gemm_n,
+                       gemm_k,
+                       alpha,
+                       dropout_out_data,
+                       v_ptr,
+                       beta,
+                       qktv_out_data,
+                       gemm_batch_size,
+                       stride_a,
+                       stride_b);
+    } else {
+      // softmax_out * v, batched_gemm
+      // output shape: [batch_size, num_heads, seq_len, head_dim]
+      blas.BatchedGEMM(transA,
+                       transB,
+                       gemm_m,
+                       gemm_n,
+                       gemm_k,
+                       alpha,
+                       softmax_out_data,
+                       v_ptr,
+                       beta,
+                       qktv_out_data,
+                       gemm_batch_size,
+                       stride_a,
+                       stride_b);
+    }
+    // transpose: [0, 2, 1, 3]
+    // output shape: [batch_size, seq_len, num_heads, head_dim]
+    std::vector<int> perm_3 = {0, 2, 1, 3};
+    TransposeGPUKernelDriver<T>(
+        dev_ctx_, *qktv_out_tensor, perm_3, fmha_out_tensor);
+  }
+
   void ComputeBackward(const phi::DenseTensor& transpose_2_out_tensor,
                        const phi::DenseTensor* src_mask_tensor,
                        const phi::DenseTensor& softmax_out_tensor,

--- a/paddle/fluid/operators/fused/fmha_ref.h
+++ b/paddle/fluid/operators/fused/fmha_ref.h
@@ -258,20 +258,19 @@ class FMHARef {
         dev_ctx_, *qktv_out_tensor, perm_3, fmha_out_tensor);
   }
 
-  void ComputeForwardForMultiTransformer(
-      const phi::DenseTensor& qkv_input_tensor,
-      const phi::DenseTensor* cache_kv_tensor,
-      const phi::DenseTensor* src_mask_tensor,
-      phi::DenseTensor* q_transpose_out_tensor,
-      phi::DenseTensor* kv_transpose_out_tensor,
-      phi::DenseTensor* cache_kv_out_tensor,
-      phi::DenseTensor* qk_out_tensor,
-      phi::DenseTensor* src_mask_out_tensor,
-      phi::DenseTensor* softmax_out_tensor,
-      phi::DenseTensor* dropout_mask_out_tensor,
-      phi::DenseTensor* dropout_out_tensor,
-      phi::DenseTensor* qktv_out_tensor,
-      phi::DenseTensor* fmha_out_tensor) {
+  void ComputeForwardWithoutTranspose(const phi::DenseTensor& qkv_input_tensor,
+                                      const phi::DenseTensor* cache_kv_tensor,
+                                      const phi::DenseTensor* src_mask_tensor,
+                                      phi::DenseTensor* q_transpose_out_tensor,
+                                      phi::DenseTensor* kv_transpose_out_tensor,
+                                      phi::DenseTensor* cache_kv_out_tensor,
+                                      phi::DenseTensor* qk_out_tensor,
+                                      phi::DenseTensor* src_mask_out_tensor,
+                                      phi::DenseTensor* softmax_out_tensor,
+                                      phi::DenseTensor* dropout_mask_out_tensor,
+                                      phi::DenseTensor* dropout_out_tensor,
+                                      phi::DenseTensor* qktv_out_tensor,
+                                      phi::DenseTensor* fmha_out_tensor) {
     // input shape: [bs, seq_len, 3, num_head, head_dim]
     // transpose with perm [2, 0, 3, 1, 4],
     // output_shape: [3, bs, num_head, seq_len, head_dim]
@@ -294,7 +293,6 @@ class FMHARef {
     }
 
     int64_t q_size = batch_size_ * seq_len_ * num_head_ * head_dim_;
-    // We split q, kv tensor.
     T* q_ptr = q_transpose_out_tensor->data<T>();
     T* k_ptr = nullptr;
     T* v_ptr = nullptr;

--- a/paddle/fluid/operators/fused/fmha_ref.h
+++ b/paddle/fluid/operators/fused/fmha_ref.h
@@ -258,19 +258,20 @@ class FMHARef {
         dev_ctx_, *qktv_out_tensor, perm_3, fmha_out_tensor);
   }
 
-  void ComputeForwardForMultiTransformer(const phi::DenseTensor& qkv_input_tensor,
-                                         const phi::DenseTensor* cache_kv_tensor,
-                                         const phi::DenseTensor* src_mask_tensor,
-                                         phi::DenseTensor* q_transpose_out_tensor, 
-                                         phi::DenseTensor* kv_transpose_out_tensor, 
-                                         phi::DenseTensor* cache_kv_out_tensor,
-                                         phi::DenseTensor* qk_out_tensor,
-                                         phi::DenseTensor* src_mask_out_tensor,
-                                         phi::DenseTensor* softmax_out_tensor,
-                                         phi::DenseTensor* dropout_mask_out_tensor,
-                                         phi::DenseTensor* dropout_out_tensor,
-                                         phi::DenseTensor* qktv_out_tensor,
-                                         phi::DenseTensor* fmha_out_tensor) {
+  void ComputeForwardForMultiTransformer(
+      const phi::DenseTensor& qkv_input_tensor,
+      const phi::DenseTensor* cache_kv_tensor,
+      const phi::DenseTensor* src_mask_tensor,
+      phi::DenseTensor* q_transpose_out_tensor,
+      phi::DenseTensor* kv_transpose_out_tensor,
+      phi::DenseTensor* cache_kv_out_tensor,
+      phi::DenseTensor* qk_out_tensor,
+      phi::DenseTensor* src_mask_out_tensor,
+      phi::DenseTensor* softmax_out_tensor,
+      phi::DenseTensor* dropout_mask_out_tensor,
+      phi::DenseTensor* dropout_out_tensor,
+      phi::DenseTensor* qktv_out_tensor,
+      phi::DenseTensor* fmha_out_tensor) {
     // input shape: [bs, seq_len, 3, num_head, head_dim]
     // transpose with perm [2, 0, 3, 1, 4],
     // output_shape: [3, bs, num_head, seq_len, head_dim]
@@ -285,11 +286,15 @@ class FMHARef {
       // kv [2, bs, num_head, seq_len, head_dim]
       phi::funcs::ConcatFunctor<phi::GPUContext, T> concat;
       // out [2, bs, num_head, cache_seq_len + seq_len, head_dim]
-      concat(dev_ctx_, {*cache_kv_tensor, *kv_transpose_out_tensor}, 3, cache_kv_out_tensor);
+      concat(dev_ctx_,
+             {*cache_kv_tensor, *kv_transpose_out_tensor},
+             3,
+             cache_kv_out_tensor);
       out_seq_len = cache_kv_out_tensor->dims()[3];
     }
 
     int64_t q_size = batch_size_ * seq_len_ * num_head_ * head_dim_;
+    // We split q, kv tensor.
     T* q_ptr = q_transpose_out_tensor->data<T>();
     T* k_ptr = nullptr;
     T* v_ptr = nullptr;

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -59,8 +59,15 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 
     bool compute_bias = qkv_biases.size() > 0 && time_step == nullptr;
     // (transA, transB, compute_bias) = (false, trans_qkvw, false)
-    auto qkv_compute = AttnMatMul<T>(
-        dev_ctx, false, trans_qkvw, bsz_seq, output_size, input_size, false);
+    // Since we fused QKVBias into QKVBiasAddTransposeSplit kernel, here we set
+    // compute_bias as false.
+    auto qkv_compute = AttnMatMul<T>(dev_ctx,
+                                     false,
+                                     trans_qkvw,
+                                     bsz_seq,
+                                     output_size,
+                                     input_size,
+                                     /*compute_bias=*/false);
 
     Tensor qkv_out;
     qkv_out.Resize({{bsz, seq_len, 3, num_head, dim_head}});

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1191,7 +1191,7 @@ __global__ void add_fusedQKV_bias_transpose_split_kernel(
     const int32_t target_batch_id = token_idx / seq_len;
     const int32_t seq_id = token_idx % seq_len;
 
-    // maybe can optimize here. Done
+    // equal to:
     // const int qkv_id  = (linear_index % fused_hidden_size) / hidden_size;
     const int32_t qkv_id = bias_idx / hidden_size;
     const int32_t head_id = (linear_index % hidden_size) / size_per_head;

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1188,7 +1188,7 @@ __global__ void add_fusedQKV_bias_transpose_split_kernel(T* q_buf,
         }
         const int32_t token_idx = linear_index / fused_hidden_size;
         const int32_t target_batch_id = token_idx / seq_len;
-        const int32_t seq_id = token_padded_idx % seq_len;
+        const int32_t seq_id = token_idx % seq_len;
 
         // equal to: 
         // const int qkv_id  = (linear_index % fused_hidden_size) / hidden_size;

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1155,6 +1155,129 @@ void write_cache_kv(const phi::GPUContext &dev_ctx,
       cache_v, v, num_head, dim_head, seq_len, max_seq_len);
 }
 
+template<typename T, int VecSize, bool ComputeBias>
+__global__ void add_fusedQKV_bias_transpose_split_kernel(T* q_buf,
+                                                         T* kv_buf,
+                                                         const T* __restrict QKV,
+                                                         const T* __restrict qkv_bias,
+                                                         const int32_t elem_cnt, 
+                                                         const int32_t batch_size,
+                                                         const int32_t seq_len,
+                                                         const int32_t token_num,
+                                                         const int32_t head_num,
+                                                         const int32_t size_per_head)
+{   
+    const int32_t offset = batch_size * seq_len * head_num * size_per_head; 
+    const int32_t hidden_size = head_num * size_per_head;
+    const int32_t fused_hidden_size = 3 * hidden_size; 
+    int64_t global_thread_idx = blockDim.x * blockIdx.x + threadIdx.x; 
+    using LoadT = phi::AlignedVector<T, VecSize>;
+    LoadT src_vec; 
+    LoadT bias_vec; 
+
+    for (int32_t linear_index = global_thread_idx * VecSize, step = gridDim.x * blockDim.x * VecSize; linear_index < elem_cnt;
+         linear_index += step) {
+        phi::Load<T, VecSize>(&QKV[linear_index], &src_vec); 
+        int32_t bias_idx = linear_index % fused_hidden_size; 
+        if(ComputeBias){
+          phi::Load<T, VecSize>(&qkv_bias[bias_idx], &bias_vec);
+          #pragma unroll
+          for(int32_t unroll_idx = 0; unroll_idx < VecSize; unroll_idx++){
+              src_vec[unroll_idx] += bias_vec[unroll_idx]; 
+          }
+        }
+        const int32_t token_idx = linear_index / fused_hidden_size;
+        const int32_t target_batch_id = token_idx / seq_len;
+        const int32_t seq_id = token_padded_idx % seq_len;
+
+        // equal to: 
+        // const int qkv_id  = (linear_index % fused_hidden_size) / hidden_size;
+        const int32_t qkv_id = bias_idx / hidden_size;
+        const int32_t head_id = (linear_index % hidden_size) / size_per_head;
+        const int32_t size_id = linear_index % size_per_head;
+
+        if(qkv_id == 0){
+          phi::Store<T, VecSize>(src_vec, &q_buf[target_batch_id * head_num * seq_len * size_per_head + head_id * seq_len * size_per_head + seq_id * size_per_head + size_id]); 
+        } else {
+          const int32_t kv_store_offset = (qkv_id - 1) * offset; 
+          phi::Store<T, VecSize>(src_vec, &kv_buf[kv_store_offset + target_batch_id * head_num * seq_len * size_per_head + head_id * seq_len * size_per_head + seq_id * size_per_head + size_id]); 
+        }
+    }
+}
+
+constexpr int kBlockSize = 128;
+constexpr int kNumWaves = 16;
+
+inline cudaError_t GetNumBlocks(int64_t n, int* num_blocks) {
+  int dev;
+  {
+    cudaError_t err = cudaGetDevice(&dev);
+    if (err != cudaSuccess) { return err; }
+  }
+  int sm_count;
+  {
+    cudaError_t err = cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, dev);
+    if (err != cudaSuccess) { return err; }
+  }
+  int max_thread_per_multiprocessor;
+  {
+    cudaError_t err = cudaDeviceGetAttribute(&max_thread_per_multiprocessor, cudaDevAttrMaxThreadsPerMultiProcessor, dev);
+    if (err != cudaSuccess) { return err; }
+  }
+  *num_blocks = std::max<int>(1, std::min<int64_t>((n + kBlockSize - 1) / kBlockSize,
+                                                   sm_count * max_thread_per_multiprocessor / kBlockSize * kNumWaves));
+  return cudaSuccess;
+}
+
+template <typename T>
+void qkv_bias_add_transpose_split(const phi::GPUContext &dev_ctx,
+                            T* q_buf,
+                            T* kv_buf,
+                            const T* qkv,
+                            const T* qkv_bias,
+                            const int batch_size,
+                            const int head_num,
+                            const int seq_len,
+                            const int size_per_head, 
+                            bool compute_bias) {
+  const int32_t token_num = batch_size * seq_len; 
+  const int32_t elem_cnt = token_num * head_num * size_per_head * 3; 
+  constexpr int PackSize = VEC_16B / sizeof(T);
+  PADDLE_ENFORCE_EQ(
+      size_per_head % PackSize,
+      0,
+      platform::errors::PreconditionNotMet(
+          "dim_head=%d must be divisible by vec_size=%d", size_per_head, PackSize));
+  const int32_t pack_num = elem_cnt / PackSize; 
+  const int32_t blocksize = 128; 
+  int32_t grid_size = 1;
+  GetNumBlocks(pack_num, &grid_size); 
+  if(compute_bias){
+    add_fusedQKV_bias_transpose_split_kernel<T, PackSize, true><<<grid_size, blocksize, 0, dev_ctx.stream()>>>(q_buf,
+                                                                                                               kv_buf,
+                                                                                                               qkv,
+                                                                                                               qkv_bias,
+                                                                                                               elem_cnt, 
+                                                                                                               batch_size,
+                                                                                                               seq_len,
+                                                                                                               token_num,
+                                                                                                               head_num,
+                                                                                                               size_per_head);
+  } else {
+    add_fusedQKV_bias_transpose_split_kernel<T, PackSize, false><<<grid_size, blocksize, 0, dev_ctx.stream()>>>(q_buf,
+                                                                                                                kv_buf,
+                                                                                                                qkv,
+                                                                                                                qkv_bias,
+                                                                                                                elem_cnt, 
+                                                                                                                batch_size,
+                                                                                                                seq_len,
+                                                                                                                token_num,
+                                                                                                                head_num,
+                                                                                                                size_per_head);
+  }
+}
+
+
 }  // namespace
 
 }  // namespace operators

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1215,35 +1215,15 @@ __global__ void add_fusedQKV_bias_transpose_split_kernel(
   }
 }
 
-constexpr int kBlockSize = 128;
-constexpr int kNumWaves = 16;
-
 inline cudaError_t GetNumBlocks(int64_t n, int *num_blocks) {
-  int dev;
-  {
-    cudaError_t err = cudaGetDevice(&dev);
-    if (err != cudaSuccess) {
-      return err;
-    }
-  }
-  int sm_count;
-  {
-    cudaError_t err =
-        cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, dev);
-    if (err != cudaSuccess) {
-      return err;
-    }
-  }
-  int max_thread_per_multiprocessor;
-  {
-    cudaError_t err =
-        cudaDeviceGetAttribute(&max_thread_per_multiprocessor,
-                               cudaDevAttrMaxThreadsPerMultiProcessor,
-                               dev);
-    if (err != cudaSuccess) {
-      return err;
-    }
-  }
+  constexpr int kBlockSize = 128;
+  constexpr int kNumWaves = 16;
+
+  const int device_id = paddle::platform::GetCurrentDeviceId();
+  const int sm_count = paddle::platform::GetGPUMultiProcessors(device_id);
+  const int max_thread_per_multiprocessor =
+      paddle::platform::GetGPUMultiProcessors(device_id);
+
   *num_blocks =
       std::max<int>(1,
                     std::min<int64_t>((n + kBlockSize - 1) / kBlockSize,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization
### PR changes
OPs
### Describe
In MultiTransformer OP，we fuse QKVBiasAdd and reshape + transpose + split operations into single kernel. 