### PR TITLE
Fix compiler error because of trt.

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -257,7 +257,9 @@ if(WITH_ROCM)
   string(REPLACE "-Werror" "-Wno-error" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 endif()
 
-if(WITH_PSCORE OR WITH_PSLIB)
+if(WITH_PSCORE
+   OR WITH_PSLIB
+   OR WITH_TENSORRT)
   string(REPLACE "-Wnon-virtual-dtor" "-Wno-non-virtual-dtor" CMAKE_CXX_FLAGS
                  ${CMAKE_CXX_FLAGS})
   string(REPLACE "-Wnon-virtual-dtor" "-Wno-non-virtual-dtor" CMAKE_C_FLAGS

--- a/paddle/fluid/inference/tensorrt/plugin/common/bertCommon.h
+++ b/paddle/fluid/inference/tensorrt/plugin/common/bertCommon.h
@@ -82,8 +82,9 @@ inline uint32_t getElementSize(nvinfer1::DataType t) noexcept {
     case nvinfer1::DataType::kBOOL:
     case nvinfer1::DataType::kINT8:
       return 1;
+    default:
+      return 0;
   }
-  return 0;
 }
 
 inline int64_t getWeightsSize(const nvinfer1::Weights& w,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
trt8.5 IAllocator没有默认的虚析构，导致编译报错，修复该问题