### PR TITLE
[CodeStyle][py2] remove the `next` method for python2 compatibility (PEP 3114)

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -354,10 +354,6 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
 
             self._thread = None
 
-    # python2 compatibility
-    def next(self):
-        return self.__next__()
-
     def _try_shutdown_all(self):
         if not self._shutdown:
             try:
@@ -853,10 +849,6 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         finally:
             if in_profiler_mode():
                 trace_event.end()
-
-    # python2 compatibility
-    def next(self):
-        return self.__next__()
 
     def _on_output_batch(self):
         for _ in range(len(self._places)):

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -152,15 +152,6 @@ class DataLoaderBase(object):
     def __call__(self):
         return self
 
-    def next(self):
-        '''
-        Get the next item in the DataLoader object. This method
-        should not be called by users directly. It is used for
-        implementing iterator protocol of Python 2.x inside
-        PaddlePaddle framework.
-        '''
-        return self.__next__()
-
     def __iter__(self):
         raise NotImplementedError()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

Python2 里迭代器里要求包含 `next` 方法，而在 Python3 中则使用了 `__next__` 方法取代了 `next` 方法[^1]，目前为了兼容 Python2，一些代码添加了 `next` 方法，但只是调用了了一下 `__next__`，现在这个 `next` 方法是没有必要的了

### Related links

- Legacy python2 tracking issue: #46837

[^1]: [PEP 3114 – Renaming `iterator.next()` to `iterator.__next__()`](https://peps.python.org/pep-3114/)