### PR TITLE
Optimize the implementation of the argsort operator.

### DIFF
--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -65,7 +65,7 @@ struct SegmentOffsetIter {
 };
 
 template <typename T>
-static __global__ void FillIndex(T* indices, T num_rows, T num_cols) {
+static __global__ void FillIndex(T *indices, T num_rows, T num_cols) {
   int col_id = threadIdx.x;
   int row_id = blockIdx.x;
 
@@ -76,13 +76,285 @@ static __global__ void FillIndex(T* indices, T num_rows, T num_cols) {
   }
 }
 
+// this is defined for CUDA LOOP
+#define CUDA_KERNEL_LOOP_TYPE(i, n, index_type)               \
+  int64_t _i_n_d_e_x = blockIdx.x * blockDim.x + threadIdx.x; \
+  for (index_type i = _i_n_d_e_x; _i_n_d_e_x < (n);           \
+       _i_n_d_e_x += blockDim.x * gridDim.x, i = _i_n_d_e_x)
+#define CUDA_KERNEL_LOOP(i, n) CUDA_KERNEL_LOOP_TYPE(i, n, int)
+
+static __global__ void Fill_index_and_segment_kernel(int2 *data,
+                                                     int numel,
+                                                     int nsort) {
+  CUDA_KERNEL_LOOP(idx, numel) {
+    auto segment = static_cast<int>(idx / nsort);
+    auto sort = static_cast<int>(idx % nsort);
+    data[idx] = int2{segment, sort};
+  }
+}
+
+#define CUB_WRAPPER(func, ctx, ...)                                            \
+  do {                                                                         \
+    size_t temp_storage_bytes = 0;                                             \
+    gpuError_t err;                                                            \
+    err = func(nullptr, temp_storage_bytes, __VA_ARGS__);                      \
+    PADDLE_ENFORCE_GPU_SUCCESS(err);                                           \
+    DenseTensor temp_storage;                                                  \
+    int64_t temp_size = temp_storage_bytes;                                    \
+    temp_storage.Resize({temp_size});                                          \
+    ctx.template Alloc<uint8_t>(&temp_storage);                                \
+    err = func(temp_storage.data<uint8_t>(), temp_storage_bytes, __VA_ARGS__); \
+    PADDLE_ENFORCE_GPU_SUCCESS(err);                                           \
+  } while (false)
+
+constexpr int CUDA_NUM_THREADS = 1024;
+
+inline int GET_BLOCKS(const int64_t N,
+                      const int64_t max_threads_per_block = CUDA_NUM_THREADS) {
+  constexpr int64_t max_int = std::numeric_limits<int>::max();
+
+  // Round up division for positive number that cannot cause integer overflow
+  auto block_num = (N - 1) / max_threads_per_block + 1;
+
+  return static_cast<int>(block_num);
+}
+
+template <typename key_t, typename value_type>
+static void radix_sort_pairs_impl(const key_t *keys_in,
+                                  key_t *keys_out,
+                                  const value_type *values_in,
+                                  value_type *values_out,
+                                  int64_t n,
+                                  bool descending,
+                                  int64_t begin_bit,
+                                  int64_t end_bit,
+                                  const phi::GPUContext &ctx) {
+  if (keys_out == nullptr) {
+    DenseTensor key_out_owner;
+    int64_t key_out_owner_size = n;
+    key_out_owner.Resize({key_out_owner_size});
+    ctx.template Alloc<key_t>(&key_out_owner);
+    keys_out = key_out_owner.data<key_t>();
+  }
+
+  if (descending) {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortPairsDescending,
+                ctx,
+                keys_in,
+                keys_out,
+                values_in,
+                values_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  } else {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortPairs,
+                ctx,
+                keys_in,
+                keys_out,
+                values_in,
+                values_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  }
+}
+
+template <typename key_t, typename value_t>
+static void radix_sort_pairs(const phi::GPUContext &ctx,
+                             const key_t *keys_in,
+                             key_t *keys_out,
+                             const value_t *values_in,
+                             value_t *values_out,
+                             int64_t n,
+                             bool descending = false,
+                             int64_t begin_bit = 0,
+                             int64_t end_bit = sizeof(key_t) * 8) {
+  radix_sort_pairs_impl(keys_in,
+                        keys_out,
+                        values_in,
+                        values_out,
+                        n,
+                        descending,
+                        begin_bit,
+                        end_bit,
+                        ctx);
+}
+
+template <typename key_t>
+static void radix_sort_keys(const key_t *keys_in,
+                            key_t *keys_out,
+                            int64_t n,
+                            bool descending,
+                            int64_t begin_bit,
+                            int64_t end_bit,
+                            const phi::GPUContext &ctx) {
+  if (descending) {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortKeysDescending,
+                ctx,
+                keys_in,
+                keys_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  } else {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortKeys,
+                ctx,
+                keys_in,
+                keys_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  }
+}
+
+template <typename scalar_t>
+static __global__ void sort_postprocess_kernel(const scalar_t *in,
+                                               scalar_t *out,
+                                               int64_t *index,
+                                               const int2 *i_s_ptr,
+                                               int nsegments,
+                                               int nsort) {
+  CUDA_KERNEL_LOOP(i, nsegments * nsort) {
+    int segment = i / nsort;  // segment_id
+    int j = i % nsort;
+
+    int offset = segment * nsort;
+    const scalar_t *in_ = in + offset;
+    scalar_t *out_ = out + offset;
+    int64_t *index_ = index + offset;
+    const int2 *i_s_ptr_ = i_s_ptr + offset;
+
+    int idx = i_s_ptr_[j].y;
+    index_[j] = idx;
+    out_[j] = in_[idx];
+  }
+}
+
+template <typename scalar_t>
+inline void segmented_sort_pairs_by_full_sort(const int64_t nsegments,
+                                              const int64_t nsort,
+                                              const int64_t n,
+                                              const bool descending,
+                                              const scalar_t *const self_ptr,
+                                              scalar_t *const values_ptr,
+                                              int64_t *const indices_ptr,
+                                              const phi::GPUContext &ctx) {
+  int64_t segment_bits = std::max<int64_t>(
+      1L, static_cast<int64_t>(std::ceil(std::log2(nsegments))));
+
+  const auto numel = nsort * nsegments;
+
+  DenseTensor indices_and_segment;
+  int64_t indices_and_segment_size = numel;
+  indices_and_segment.Resize({indices_and_segment_size * 2});
+  ctx.template Alloc<int64_t>(&indices_and_segment);
+  auto i_s_ptr_base = indices_and_segment.data<int64_t>();
+  auto i_s_ptr = reinterpret_cast<int2 *>(i_s_ptr_base);
+
+  dim3 block = CUDA_NUM_THREADS;
+  dim3 grid = GET_BLOCKS(numel);
+  auto cu_stream = ctx.stream();
+
+  Fill_index_and_segment_kernel<<<grid, block, 0, cu_stream>>>(
+      i_s_ptr, numel, nsort);
+
+  DenseTensor indices_and_segment2;
+  int64_t indices_and_segment2_size = numel;
+  indices_and_segment2.Resize({indices_and_segment2_size * 2});
+  ctx.template Alloc<int64_t>(&indices_and_segment2);
+  auto i_s_ptr2_base = indices_and_segment2.data<int64_t>();
+  auto i_s_ptr2 = reinterpret_cast<int2 *>(i_s_ptr2_base);
+
+  radix_sort_pairs<scalar_t, int2>(
+      ctx, self_ptr, nullptr, i_s_ptr, i_s_ptr2, n, descending);
+
+  radix_sort_keys<int64_t>(reinterpret_cast<int64_t *>(i_s_ptr2),
+                           reinterpret_cast<int64_t *>(i_s_ptr),
+                           n,
+                           false,
+                           0,
+                           segment_bits,
+                           ctx);
+
+  sort_postprocess_kernel<<<(n + 511) / 512, 512, 0, cu_stream>>>(
+      self_ptr, values_ptr, indices_ptr, i_s_ptr, nsegments, nsort);
+}
+
+// Sort by flag descending, True: descending. False: Ascending.
+// Default is false.
+// The method is called when # of the rows of the input is less than or equal to
+// 32
+template <typename T, typename IndType>
+void ArgFullSortForTinyRows(const phi::GPUContext &ctx,
+                            const DenseTensor *input,
+                            DenseTensor *output,
+                            DenseTensor *indices,
+                            const IndType num_rows,
+                            const IndType num_cols,
+                            const bool descending) {
+  auto cu_stream = ctx.stream();
+  DenseTensor input_indices;
+  const std::vector<IndType> dims = {num_rows, num_cols};
+  auto dim = phi::make_ddim(dims);
+  input_indices.Resize(dim);
+  ctx.template Alloc<IndType>(&input_indices);
+  size_t temp_storage_bytes = -1;
+
+  int block_size = 1024;
+  int maxGridDimX = ctx.GetCUDAMaxGridDimSize()[0];
+  int grid_size = num_rows < maxGridDimX ? num_rows : maxGridDimX;
+  IndType numel = num_rows * num_cols;
+  if (numel == 0) {
+    return;
+  }
+
+  IndType numel_or_intmax =
+      std::min(numel, static_cast<int64_t>(std::numeric_limits<int>::max()));
+  IndType nsort = num_cols;
+  IndType nbatch = (numel_or_intmax / nsort) * nsort;
+
+  T *sorted_out_ptr;
+  IndType *sorted_indices_ptr;
+  const T *inp = input->data<T>();
+  T *out = ctx.template Alloc<T>(output);
+  IndType *ind = ctx.template Alloc<IndType>(indices);
+  sorted_out_ptr = out;
+  sorted_indices_ptr = ind;
+
+  int64_t remaining = numel;
+
+  while (remaining > 0) {
+    int64_t n = std::min(remaining, nbatch);
+    IndType nsegments = n / nsort;
+
+    segmented_sort_pairs_by_full_sort(nsegments,
+                                      nsort,
+                                      n,
+                                      descending,
+                                      inp,
+                                      sorted_out_ptr,
+                                      sorted_indices_ptr,
+                                      ctx);
+
+    remaining -= n;
+    inp += n;
+    sorted_out_ptr += n;
+    sorted_indices_ptr += n;
+  }
+}
+
 // Sort by flag descending, True: descending. False: Ascending.
 // Default is false.
 template <typename T, typename IndType>
-void ArgFullSort(const phi::GPUContext& ctx,
-                 const DenseTensor* input,
-                 DenseTensor* output,
-                 DenseTensor* indices,
+void ArgFullSort(const phi::GPUContext &ctx,
+                 const DenseTensor *input,
+                 DenseTensor *output,
+                 DenseTensor *indices,
                  const IndType num_rows,
                  const IndType num_cols,
                  const bool descending) {
@@ -115,11 +387,11 @@ void ArgFullSort(const phi::GPUContext& ctx,
   FillIndex<<<grid_size, block_size, 0, cu_stream>>>(
       input_indices.data<IndType>(), num_rows, num_cols);
 
-  T* sorted_out_ptr;
-  IndType* sorted_indices_ptr;
-  const T* inp = input->data<T>();
-  T* out = ctx.template Alloc<T>(output);
-  IndType* ind = ctx.template Alloc<IndType>(indices);
+  T *sorted_out_ptr;
+  IndType *sorted_indices_ptr;
+  const T *inp = input->data<T>();
+  T *out = ctx.template Alloc<T>(output);
+  IndType *ind = ctx.template Alloc<IndType>(indices);
   sorted_out_ptr = out;
   sorted_indices_ptr = ind;
 
@@ -133,96 +405,49 @@ void ArgFullSort(const phi::GPUContext& ctx,
 
   gpuError_t err;
   if (descending) {
-    err = cub::DeviceSegmentedRadixSort::SortPairsDescending(
-        nullptr,
-        temp_storage_bytes,
-        inp,
-        sorted_out_ptr,
-        input_indices.data<IndType>(),
-        sorted_indices_ptr,
-        num_cols * num_rows,
-        num_rows,
-        segment_offsets_t,
-        segment_offsets_t + 1,
-        0,
-        sizeof(T) * 8,
-        cu_stream);
+    CUB_WRAPPER(cub::DeviceSegmentedRadixSort::SortPairsDescending,
+                ctx,
+                inp,
+                sorted_out_ptr,
+                input_indices.data<IndType>(),
+                sorted_indices_ptr,
+                num_cols * num_rows,
+                num_rows,
+                segment_offsets_t,
+                segment_offsets_t + 1,
+                0,
+                sizeof(T) * 8,
+                ctx.stream());
   } else {
-    err =
-        cub::DeviceSegmentedRadixSort::SortPairs(nullptr,
-                                                 temp_storage_bytes,
-                                                 inp,
-                                                 sorted_out_ptr,
-                                                 input_indices.data<IndType>(),
-                                                 sorted_indices_ptr,
-                                                 num_cols * num_rows,
-                                                 num_rows,
-                                                 segment_offsets_t,
-                                                 segment_offsets_t + 1,
-                                                 0,
-                                                 sizeof(T) * 8,
-                                                 cu_stream);
+    CUB_WRAPPER(cub::DeviceSegmentedRadixSort::SortPairs,
+                ctx,
+                inp,
+                sorted_out_ptr,
+                input_indices.data<IndType>(),
+                sorted_indices_ptr,
+                num_cols * num_rows,
+                num_rows,
+                segment_offsets_t,
+                segment_offsets_t + 1,
+                0,
+                sizeof(T) * 8,
+                ctx.stream());
   }
-  PADDLE_ENFORCE_GPU_SUCCESS(err);
-
-  DenseTensor temp_storage;
-  int64_t temp_size = temp_storage_bytes;
-  temp_storage.Resize({temp_size});
-  ctx.template Alloc<uint8_t>(&temp_storage);
-
-  if (descending) {
-    err = cub::DeviceSegmentedRadixSort::SortPairsDescending(
-        temp_storage.data<uint8_t>(),
-        temp_storage_bytes,
-        inp,
-        sorted_out_ptr,
-        input_indices.data<IndType>(),
-        sorted_indices_ptr,
-        num_cols * num_rows,
-        num_rows,
-        segment_offsets_t,
-        segment_offsets_t + 1,
-        0,
-        sizeof(T) * 8,
-        cu_stream);
-  } else {
-    err =
-        cub::DeviceSegmentedRadixSort::SortPairs(temp_storage.data<uint8_t>(),
-                                                 temp_storage_bytes,
-                                                 inp,
-                                                 sorted_out_ptr,
-                                                 input_indices.data<IndType>(),
-                                                 sorted_indices_ptr,
-                                                 num_cols * num_rows,
-                                                 num_rows,
-                                                 segment_offsets_t,
-                                                 segment_offsets_t + 1,
-                                                 0,
-                                                 sizeof(T) * 8,
-                                                 cu_stream);
-  }
-
-  PADDLE_ENFORCE_GPU_SUCCESS(err);
 }
 
 template <typename T, typename Context>
-void ArgsortKernel(const Context& dev_ctx,
-                   const DenseTensor& input,
+void ArgsortKernel(const Context &dev_ctx,
+                   const DenseTensor &input,
                    int axis,
                    bool descending,
-                   DenseTensor* output,
-                   DenseTensor* indices) {
-  auto in_dims = input.dims();
-  axis = (axis < 0) ? (in_dims.size() + axis) : axis;
-  const T* in_data = input.data<T>();
+                   DenseTensor *output,
+                   DenseTensor *indices) {
   auto size = input.numel();
-  T* out_data = dev_ctx.template Alloc<T>(output);
-  int64_t* ids_data = dev_ctx.template Alloc<int64_t>(indices);
+  auto in_dims = input.dims();
+  T *out_data = dev_ctx.template Alloc<T>(output);
+  int64_t *ids_data = dev_ctx.template Alloc<int64_t>(indices);
+  const T *in_data = input.data<T>();
 
-  // Use thrust for parallel acceleration when the input size is equal to the
-  // length of the ‘axis’ dimension.
-  // Compared to the following 'Special case for full sort', ascending sort is
-  // 34 times faster and descending sort is 31 times faster.
   if (size == in_dims[axis]) {
     thrust::sequence(thrust::device, ids_data, ids_data + size);
     thrust::copy(thrust::device, in_data, in_data + size, out_data);
@@ -234,20 +459,28 @@ void ArgsortKernel(const Context& dev_ctx,
     return;
   }
 
-  // Special case for full sort, speedup ~190x.
   if (axis == -1 || axis + 1 == in_dims.size()) {
     const int64_t input_height =
         phi::product(phi::slice_ddim(in_dims, 0, in_dims.size() - 1));
     const int64_t input_width = in_dims[in_dims.size() - 1];
-    ArgFullSort<T, int64_t>(dev_ctx,
-                            &input,
-                            output,
-                            indices,
-                            input_height,
-                            input_width,
-                            descending);
+    if (input_height <= 32) {
+      ArgFullSortForTinyRows<T, int64_t>(dev_ctx,
+                                         &input,
+                                         output,
+                                         indices,
+                                         input_height,
+                                         input_width,
+                                         descending);
+    } else {
+      ArgFullSort<T, int64_t>(dev_ctx,
+                              &input,
+                              output,
+                              indices,
+                              input_height,
+                              input_width,
+                              descending);
+    }
   } else {
-    // if not full sort, do transpose first
     std::vector<int> trans;
     for (int i = 0; i < axis; i++) {
       trans.push_back(i);
@@ -264,8 +497,7 @@ void ArgsortKernel(const Context& dev_ctx,
 
     DenseTensor trans_inp;
     trans_inp.Resize(trans_dims);
-    T* trans_inp_data = dev_ctx.template Alloc<T>(&trans_inp);
-    // Do transpose
+    T *trans_inp_data = dev_ctx.template Alloc<T>(&trans_inp);
     TransposeKernel<T, Context>(dev_ctx, input, trans, &trans_inp);
 
     const int64_t input_height =
@@ -277,21 +509,29 @@ void ArgsortKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(&tmp_out);
 
     DenseTensor tmp_indices;
-    // temp indices for sorting
     tmp_indices.Resize(trans_dims);
     dev_ctx.template Alloc<int64_t>(&tmp_indices);
     dev_ctx.template Alloc<int64_t>(indices);
 
-    ArgFullSort<T, int64_t>(dev_ctx,
-                            &trans_inp,
-                            &tmp_out,
-                            &tmp_indices,
-                            input_height,
-                            input_width,
-                            descending);
+    if (input_height <= 32) {
+      ArgFullSortForTinyRows<T, int64_t>(dev_ctx,
+                                         &input,
+                                         output,
+                                         indices,
+                                         input_height,
+                                         input_width,
+                                         descending);
+    } else {
+      ArgFullSort<T, int64_t>(dev_ctx,
+                              &trans_inp,
+                              &tmp_out,
+                              &tmp_indices,
+                              input_height,
+                              input_width,
+                              descending);
+    }
 
     TransposeKernel<int64_t, Context>(dev_ctx, tmp_indices, trans, indices);
-    // transpose back
     TransposeKernel<T, Context>(dev_ctx, tmp_out, trans, output);
     return;
   }

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -429,7 +430,7 @@ void ArgsortKernel(const Context &dev_ctx,
   auto size = input.numel();
   T *out_data = dev_ctx.template Alloc<T>(output);
   int64_t *ids_data = dev_ctx.template Alloc<int64_t>(indices);
-  
+
   // Use thrust for parallel acceleration when the input size is equal to the
   // length of the ‘axis’ dimension.
   // Compared to the following 'Special case for full sort', ascending sort is

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -200,14 +200,14 @@ static __global__ void SortPostprocessKernel(const T *in,
 }
 
 template <typename T>
-inline void SegmentedSortPairsByFullSort(
-    const phi::GPUContext &ctx,
-    const T *const self_ptr,
-    T *const values_ptr,
-    int64_t *const indices_ptr const int64_t nsegments,
-    const int64_t nsort,
-    const int64_t n,
-    const bool descending) {
+inline void SegmentedSortPairsByFullSort(const phi::GPUContext &ctx,
+                                         const T *const self_ptr,
+                                         T *const values_ptr,
+                                         int64_t *const indices_ptr,
+                                         const int64_t nsegments,
+                                         const int64_t nsort,
+                                         const int64_t n,
+                                         const bool descending) {
   int64_t segment_bits = std::max<int64_t>(
       1L, static_cast<int64_t>(std::ceil(std::log2(nsegments))));
 

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -268,7 +268,7 @@ inline void SegmentedSortPairsByFullSort(const int64_t nsegments,
                          segment_bits,
                          ctx);
 
-  SortPostprocessKernel<<<(n + 511) / 512, 512, 0, cu_stream>>>(
+  SortPostprocessKernel<<<grid, block, 0, cu_stream>>>(
       self_ptr, values_ptr, indices_ptr, i_s_ptr, nsegments, nsort);
 }
 
@@ -375,7 +375,9 @@ void ArgFullSort(const phi::GPUContext &ctx,
   sorted_out_ptr = out;
   sorted_indices_ptr = ind;
 
+  // create iter for counting input
   cub::CountingInputIterator<IndexType> counting_iter(0);
+  // segment_offset is used for move to next row
   cub::TransformInputIterator<IndexType,
                               SegmentOffsetIter,
                               cub::CountingInputIterator<IndexType>>

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -247,7 +247,7 @@ inline void SegmentedSortPairsByFullSort(const phi::GPUContext &ctx,
                          segment_bits);
 
   SortPostprocessKernel<<<grid, block, 0, cu_stream>>>(
-      self_ptr, i_s_ptr, indices_ptr, values_ptr, nsegments, nsort);
+      self_ptr, i_s_ptr, values_ptr, indices_ptr, nsegments, nsort);
 }
 
 // The method is called when # of the rows of the input is less than or equal to

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -64,8 +64,12 @@ struct SegmentOffsetIter {
   int num_cols_;
 };
 
+// using phi::paddle::platform::PADDLE_CUDA_NUM_THREADS;
+
+#define PADDLE_CUDA_NUM_THREADS 1024
+
 template <typename T>
-static __global__ void FillIndex(T* indices, T num_rows, T num_cols) {
+static __global__ void FillIndex(T *indices, T num_rows, T num_cols) {
   int col_id = threadIdx.x;
   int row_id = blockIdx.x;
 
@@ -76,13 +80,269 @@ static __global__ void FillIndex(T* indices, T num_rows, T num_cols) {
   }
 }
 
-// Sort by flag descending, True: descending. False: Ascending.
-// Default is false.
+static __global__ void FillIndexAndSegmentKernel(int2 *data,
+                                                 int numel,
+                                                 int nsort) {
+  CUDA_KERNEL_LOOP(idx, numel) {
+    auto segment = static_cast<int>(idx / nsort);
+    auto sort = static_cast<int>(idx % nsort);
+    data[idx] = int2{segment, sort};
+  }
+}
+
+#define CUB_WRAPPER(func, ctx, ...)                                            \
+  do {                                                                         \
+    size_t temp_storage_bytes = 0;                                             \
+    gpuError_t err;                                                            \
+    err = func(nullptr, temp_storage_bytes, __VA_ARGS__);                      \
+    PADDLE_ENFORCE_GPU_SUCCESS(err);                                           \
+    DenseTensor temp_storage;                                                  \
+    int64_t temp_size = temp_storage_bytes;                                    \
+    temp_storage.Resize({temp_size});                                          \
+    ctx.template Alloc<uint8_t>(&temp_storage);                                \
+    err = func(temp_storage.data<uint8_t>(), temp_storage_bytes, __VA_ARGS__); \
+    PADDLE_ENFORCE_GPU_SUCCESS(err);                                           \
+  } while (false)
+
+inline int GET_BLOCKS(
+    const int64_t N,
+    const int64_t max_threads_per_block = PADDLE_CUDA_NUM_THREADS) {
+  // Round up division for positive number that cannot cause integer overflow
+  auto block_num = (N - 1) / max_threads_per_block + 1;
+
+  return static_cast<int>(block_num);
+}
+
+template <typename key_t, typename value_type>
+static void RadixSortPairsImpl(const key_t *keys_in,
+                               key_t *keys_out,
+                               const value_type *values_in,
+                               value_type *values_out,
+                               int64_t n,
+                               bool descending,
+                               int64_t begin_bit,
+                               int64_t end_bit,
+                               const phi::GPUContext &ctx) {
+  if (keys_out == nullptr) {
+    DenseTensor key_out_owner;
+    int64_t key_out_owner_size = n;
+    key_out_owner.Resize({key_out_owner_size});
+    ctx.template Alloc<key_t>(&key_out_owner);
+    keys_out = key_out_owner.data<key_t>();
+  }
+
+  if (descending) {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortPairsDescending,
+                ctx,
+                keys_in,
+                keys_out,
+                values_in,
+                values_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  } else {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortPairs,
+                ctx,
+                keys_in,
+                keys_out,
+                values_in,
+                values_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  }
+}
+
+template <typename key_t, typename value_t>
+static void RadixSortPairs(const phi::GPUContext &ctx,
+                           const key_t *keys_in,
+                           key_t *keys_out,
+                           const value_t *values_in,
+                           value_t *values_out,
+                           int64_t n,
+                           bool descending = false,
+                           int64_t begin_bit = 0,
+                           int64_t end_bit = sizeof(key_t) * 8) {
+  RadixSortPairsImpl(keys_in,
+                     keys_out,
+                     values_in,
+                     values_out,
+                     n,
+                     descending,
+                     begin_bit,
+                     end_bit,
+                     ctx);
+}
+
+template <typename key_t>
+static void RadixSortKeys(const key_t *keys_in,
+                          key_t *keys_out,
+                          int64_t n,
+                          bool descending,
+                          int64_t begin_bit,
+                          int64_t end_bit,
+                          const phi::GPUContext &ctx) {
+  if (descending) {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortKeysDescending,
+                ctx,
+                keys_in,
+                keys_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  } else {
+    CUB_WRAPPER(cub::DeviceRadixSort::SortKeys,
+                ctx,
+                keys_in,
+                keys_out,
+                n,
+                begin_bit,
+                end_bit,
+                ctx.stream());
+  }
+}
+
+template <typename scalar_t>
+static __global__ void SortPostprocessKernel(const scalar_t *in,
+                                             scalar_t *out,
+                                             int64_t *index,
+                                             const int2 *i_s_ptr,
+                                             int nsegments,
+                                             int nsort) {
+  CUDA_KERNEL_LOOP(i, nsegments * nsort) {
+    int segment = i / nsort;  // segment_id
+    int j = i % nsort;
+
+    int offset = segment * nsort;
+    const scalar_t *in_ = in + offset;
+    scalar_t *out_ = out + offset;
+    int64_t *index_ = index + offset;
+    const int2 *i_s_ptr_ = i_s_ptr + offset;
+
+    int idx = i_s_ptr_[j].y;
+    index_[j] = idx;
+    out_[j] = in_[idx];
+  }
+}
+
+template <typename scalar_t>
+inline void SegmentedSortPairsByFullSort(const int64_t nsegments,
+                                         const int64_t nsort,
+                                         const int64_t n,
+                                         const bool descending,
+                                         const scalar_t *const self_ptr,
+                                         scalar_t *const values_ptr,
+                                         int64_t *const indices_ptr,
+                                         const phi::GPUContext &ctx) {
+  int64_t segment_bits = std::max<int64_t>(
+      1L, static_cast<int64_t>(std::ceil(std::log2(nsegments))));
+
+  const auto numel = nsort * nsegments;
+
+  DenseTensor indices_and_segment;
+  int64_t indices_and_segment_size = numel;
+  indices_and_segment.Resize({indices_and_segment_size * 2});
+  ctx.template Alloc<int64_t>(&indices_and_segment);
+  auto i_s_ptr_base = indices_and_segment.data<int64_t>();
+  auto i_s_ptr = reinterpret_cast<int2 *>(i_s_ptr_base);
+
+  dim3 block = PADDLE_CUDA_NUM_THREADS;
+  dim3 grid = GET_BLOCKS(numel);
+  auto cu_stream = ctx.stream();
+
+  FillIndexAndSegmentKernel<<<grid, block, 0, cu_stream>>>(
+      i_s_ptr, numel, nsort);
+
+  // Fill_index_and_segment(i_s_ptr, numel, nsort);
+  DenseTensor indices_and_segment2;
+  int64_t indices_and_segment2_size = numel;
+  indices_and_segment2.Resize({indices_and_segment2_size * 2});
+  ctx.template Alloc<int64_t>(&indices_and_segment2);
+  auto i_s_ptr2_base = indices_and_segment2.data<int64_t>();
+  auto i_s_ptr2 = reinterpret_cast<int2 *>(i_s_ptr2_base);
+
+  RadixSortPairs<scalar_t, int2>(
+      ctx, self_ptr, nullptr, i_s_ptr, i_s_ptr2, n, descending);
+
+  RadixSortKeys<int64_t>(reinterpret_cast<int64_t *>(i_s_ptr2),
+                         reinterpret_cast<int64_t *>(i_s_ptr),
+                         n,
+                         false,
+                         0,
+                         segment_bits,
+                         ctx);
+
+  SortPostprocessKernel<<<(n + 511) / 512, 512, 0, cu_stream>>>(
+      self_ptr, values_ptr, indices_ptr, i_s_ptr, nsegments, nsort);
+}
+
+// The method is called when # of the rows of the input is less than or equal to
+// 32
 template <typename T, typename IndType>
-void ArgFullSort(const phi::GPUContext& ctx,
-                 const DenseTensor* input,
-                 DenseTensor* output,
-                 DenseTensor* indices,
+void ArgFullSortForTinyRows(const phi::GPUContext &ctx,
+                            const DenseTensor *input,
+                            DenseTensor *output,
+                            DenseTensor *indices,
+                            const IndType num_rows,
+                            const IndType num_cols,
+                            const bool descending) {
+  auto gpu_stream = ctx.stream();
+  DenseTensor input_indices;
+  const std::vector<IndType> dims = {num_rows, num_cols};
+  auto dim = phi::make_ddim(dims);
+  input_indices.Resize(dim);
+  ctx.template Alloc<IndType>(&input_indices);
+  size_t temp_storage_bytes = -1;
+
+  IndType numel = num_rows * num_cols;
+  if (numel == 0) {
+    return;
+  }
+
+  IndType numel_or_intmax =
+      std::min(numel, static_cast<int64_t>(std::numeric_limits<int>::max()));
+  IndType nsort = num_cols;
+  IndType nbatch = (numel_or_intmax / nsort) * nsort;
+
+  T *sorted_out_ptr;
+  IndType *sorted_indices_ptr;
+  const T *inp = input->data<T>();
+  T *out = ctx.template Alloc<T>(output);
+  IndType *ind = ctx.template Alloc<IndType>(indices);
+  sorted_out_ptr = out;
+  sorted_indices_ptr = ind;
+
+  int64_t remaining = numel;
+
+  while (remaining > 0) {
+    int64_t n = std::min(remaining, nbatch);
+    IndType nsegments = n / nsort;
+
+    SegmentedSortPairsByFullSort(nsegments,
+                                 nsort,
+                                 n,
+                                 descending,
+                                 inp,
+                                 sorted_out_ptr,
+                                 sorted_indices_ptr,
+                                 ctx);
+
+    remaining -= n;
+    inp += n;
+    sorted_out_ptr += n;
+    sorted_indices_ptr += n;
+  }
+}
+
+template <typename T, typename IndType>
+void ArgFullSort(const phi::GPUContext &ctx,
+                 const DenseTensor *input,
+                 DenseTensor *output,
+                 DenseTensor *indices,
                  const IndType num_rows,
                  const IndType num_cols,
                  const bool descending) {
@@ -115,17 +375,15 @@ void ArgFullSort(const phi::GPUContext& ctx,
   FillIndex<<<grid_size, block_size, 0, cu_stream>>>(
       input_indices.data<IndType>(), num_rows, num_cols);
 
-  T* sorted_out_ptr;
-  IndType* sorted_indices_ptr;
-  const T* inp = input->data<T>();
-  T* out = ctx.template Alloc<T>(output);
-  IndType* ind = ctx.template Alloc<IndType>(indices);
+  T *sorted_out_ptr;
+  IndType *sorted_indices_ptr;
+  const T *inp = input->data<T>();
+  T *out = ctx.template Alloc<T>(output);
+  IndType *ind = ctx.template Alloc<IndType>(indices);
   sorted_out_ptr = out;
   sorted_indices_ptr = ind;
 
-  // create iter for counting input
   cub::CountingInputIterator<IndType> counting_iter(0);
-  // segment_offset is used for move to next row
   cub::TransformInputIterator<IndType,
                               SegmentOffsetIter,
                               cub::CountingInputIterator<IndType>>
@@ -133,96 +391,52 @@ void ArgFullSort(const phi::GPUContext& ctx,
 
   gpuError_t err;
   if (descending) {
-    err = cub::DeviceSegmentedRadixSort::SortPairsDescending(
-        nullptr,
-        temp_storage_bytes,
-        inp,
-        sorted_out_ptr,
-        input_indices.data<IndType>(),
-        sorted_indices_ptr,
-        num_cols * num_rows,
-        num_rows,
-        segment_offsets_t,
-        segment_offsets_t + 1,
-        0,
-        sizeof(T) * 8,
-        cu_stream);
+    CUB_WRAPPER(cub::DeviceSegmentedRadixSort::SortPairsDescending,
+                ctx,
+                inp,
+                sorted_out_ptr,
+                input_indices.data<IndType>(),
+                sorted_indices_ptr,
+                num_cols * num_rows,
+                num_rows,
+                segment_offsets_t,
+                segment_offsets_t + 1,
+                0,
+                sizeof(T) * 8,
+                ctx.stream());
   } else {
-    err =
-        cub::DeviceSegmentedRadixSort::SortPairs(nullptr,
-                                                 temp_storage_bytes,
-                                                 inp,
-                                                 sorted_out_ptr,
-                                                 input_indices.data<IndType>(),
-                                                 sorted_indices_ptr,
-                                                 num_cols * num_rows,
-                                                 num_rows,
-                                                 segment_offsets_t,
-                                                 segment_offsets_t + 1,
-                                                 0,
-                                                 sizeof(T) * 8,
-                                                 cu_stream);
+    CUB_WRAPPER(cub::DeviceSegmentedRadixSort::SortPairs,
+                ctx,
+                inp,
+                sorted_out_ptr,
+                input_indices.data<IndType>(),
+                sorted_indices_ptr,
+                num_cols * num_rows,
+                num_rows,
+                segment_offsets_t,
+                segment_offsets_t + 1,
+                0,
+                sizeof(T) * 8,
+                ctx.stream());
   }
-  PADDLE_ENFORCE_GPU_SUCCESS(err);
-
-  DenseTensor temp_storage;
-  int64_t temp_size = temp_storage_bytes;
-  temp_storage.Resize({temp_size});
-  ctx.template Alloc<uint8_t>(&temp_storage);
-
-  if (descending) {
-    err = cub::DeviceSegmentedRadixSort::SortPairsDescending(
-        temp_storage.data<uint8_t>(),
-        temp_storage_bytes,
-        inp,
-        sorted_out_ptr,
-        input_indices.data<IndType>(),
-        sorted_indices_ptr,
-        num_cols * num_rows,
-        num_rows,
-        segment_offsets_t,
-        segment_offsets_t + 1,
-        0,
-        sizeof(T) * 8,
-        cu_stream);
-  } else {
-    err =
-        cub::DeviceSegmentedRadixSort::SortPairs(temp_storage.data<uint8_t>(),
-                                                 temp_storage_bytes,
-                                                 inp,
-                                                 sorted_out_ptr,
-                                                 input_indices.data<IndType>(),
-                                                 sorted_indices_ptr,
-                                                 num_cols * num_rows,
-                                                 num_rows,
-                                                 segment_offsets_t,
-                                                 segment_offsets_t + 1,
-                                                 0,
-                                                 sizeof(T) * 8,
-                                                 cu_stream);
-  }
-
-  PADDLE_ENFORCE_GPU_SUCCESS(err);
 }
 
 template <typename T, typename Context>
-void ArgsortKernel(const Context& dev_ctx,
-                   const DenseTensor& input,
+void ArgsortKernel(const Context &dev_ctx,
+                   const DenseTensor &input,
                    int axis,
                    bool descending,
-                   DenseTensor* output,
-                   DenseTensor* indices) {
+                   DenseTensor *output,
+                   DenseTensor *indices) {
+  auto size = input.numel();
   auto in_dims = input.dims();
   axis = (axis < 0) ? (in_dims.size() + axis) : axis;
-  const T* in_data = input.data<T>();
-  auto size = input.numel();
-  T* out_data = dev_ctx.template Alloc<T>(output);
-  int64_t* ids_data = dev_ctx.template Alloc<int64_t>(indices);
+
+  T *out_data = dev_ctx.template Alloc<T>(output);
+  int64_t *ids_data = dev_ctx.template Alloc<int64_t>(indices);
+  const T *in_data = input.data<T>();
 
   // Use thrust for parallel acceleration when the input size is equal to the
-  // length of the ‘axis’ dimension.
-  // Compared to the following 'Special case for full sort', ascending sort is
-  // 34 times faster and descending sort is 31 times faster.
   if (size == in_dims[axis]) {
     thrust::sequence(thrust::device, ids_data, ids_data + size);
     thrust::copy(thrust::device, in_data, in_data + size, out_data);
@@ -234,20 +448,28 @@ void ArgsortKernel(const Context& dev_ctx,
     return;
   }
 
-  // Special case for full sort, speedup ~190x.
   if (axis == -1 || axis + 1 == in_dims.size()) {
     const int64_t input_height =
         phi::product(phi::slice_ddim(in_dims, 0, in_dims.size() - 1));
     const int64_t input_width = in_dims[in_dims.size() - 1];
-    ArgFullSort<T, int64_t>(dev_ctx,
-                            &input,
-                            output,
-                            indices,
-                            input_height,
-                            input_width,
-                            descending);
+    if (input_height <= 32) {
+      ArgFullSortForTinyRows<T, int64_t>(dev_ctx,
+                                         &input,
+                                         output,
+                                         indices,
+                                         input_height,
+                                         input_width,
+                                         descending);
+    } else {
+      ArgFullSort<T, int64_t>(dev_ctx,
+                              &input,
+                              output,
+                              indices,
+                              input_height,
+                              input_width,
+                              descending);
+    }
   } else {
-    // if not full sort, do transpose first
     std::vector<int> trans;
     for (int i = 0; i < axis; i++) {
       trans.push_back(i);
@@ -264,8 +486,7 @@ void ArgsortKernel(const Context& dev_ctx,
 
     DenseTensor trans_inp;
     trans_inp.Resize(trans_dims);
-    T* trans_inp_data = dev_ctx.template Alloc<T>(&trans_inp);
-    // Do transpose
+    T *trans_inp_data = dev_ctx.template Alloc<T>(&trans_inp);
     TransposeKernel<T, Context>(dev_ctx, input, trans, &trans_inp);
 
     const int64_t input_height =
@@ -277,18 +498,27 @@ void ArgsortKernel(const Context& dev_ctx,
     dev_ctx.template Alloc<T>(&tmp_out);
 
     DenseTensor tmp_indices;
-    // temp indices for sorting
     tmp_indices.Resize(trans_dims);
     dev_ctx.template Alloc<int64_t>(&tmp_indices);
     dev_ctx.template Alloc<int64_t>(indices);
 
-    ArgFullSort<T, int64_t>(dev_ctx,
-                            &trans_inp,
-                            &tmp_out,
-                            &tmp_indices,
-                            input_height,
-                            input_width,
-                            descending);
+    if (input_height <= 32) {
+      ArgFullSortForTinyRows<T, int64_t>(dev_ctx,
+                                         &trans_inp,
+                                         &tmp_out,
+                                         &tmp_indices,
+                                         input_height,
+                                         input_width,
+                                         descending);
+    } else {
+      ArgFullSort<T, int64_t>(dev_ctx,
+                              &trans_inp,
+                              &tmp_out,
+                              &tmp_indices,
+                              input_height,
+                              input_width,
+                              descending);
+    }
 
     TransposeKernel<int64_t, Context>(dev_ctx, tmp_indices, trans, indices);
     // transpose back

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -177,9 +177,9 @@ static void RadixSortKeys(const phi::GPUContext &ctx,
 
 template <typename T>
 static __global__ void SortPostprocessKernel(const T *in,
+                                             const int2 *i_s_ptr,
                                              T *out,
                                              int64_t *index,
-                                             const int2 *i_s_ptr,
                                              int nsegments,
                                              int nsort) {
   CUDA_KERNEL_LOOP(i, nsegments * nsort) {
@@ -247,7 +247,7 @@ inline void SegmentedSortPairsByFullSort(const phi::GPUContext &ctx,
                          segment_bits);
 
   SortPostprocessKernel<<<grid, block, 0, cu_stream>>>(
-      self_ptr, values_ptr, indices_ptr, i_s_ptr, nsegments, nsort);
+      self_ptr, i_s_ptr, indices_ptr, values_ptr, nsegments, nsort);
 }
 
 // The method is called when # of the rows of the input is less than or equal to

--- a/paddle/phi/kernels/gpu/argsort_kernel.cu
+++ b/paddle/phi/kernels/gpu/argsort_kernel.cu
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -106,14 +107,14 @@ static __global__ void FillIndexAndSegmentKernel(int2 *data,
 
 template <typename KT, typename VT>
 static void RadixSortPairs(const phi::GPUContext &ctx,
-                               const KT *keys_in,
-                               const VT *values_in,
-                               KT *keys_out,
-                               VT *values_out,
-                               int64_t n,
-                               bool descending = false,
-                               int64_t begin_bit = 0,
-                               int64_t end_bit = sizeof(KT) * 8) {
+                           const KT *keys_in,
+                           const VT *values_in,
+                           KT *keys_out,
+                           VT *values_out,
+                           int64_t n,
+                           bool descending = false,
+                           int64_t begin_bit = 0,
+                           int64_t end_bit = sizeof(KT) * 8) {
   if (keys_out == nullptr) {
     DenseTensor key_out_owner;
     key_out_owner.Resize({n});
@@ -199,14 +200,14 @@ static __global__ void SortPostprocessKernel(const T *in,
 }
 
 template <typename T>
-inline void SegmentedSortPairsByFullSort(const phi::GPUContext &ctx,
-                                         const T *const self_ptr,
-                                         T *const values_ptr,
-                                         int64_t *const indices_ptr
-                                         const int64_t nsegments,
-                                         const int64_t nsort,
-                                         const int64_t n,
-                                         const bool descending) {
+inline void SegmentedSortPairsByFullSort(
+    const phi::GPUContext &ctx,
+    const T *const self_ptr,
+    T *const values_ptr,
+    int64_t *const indices_ptr const int64_t nsegments,
+    const int64_t nsort,
+    const int64_t n,
+    const bool descending) {
   int64_t segment_bits = std::max<int64_t>(
       1L, static_cast<int64_t>(std::ceil(std::log2(nsegments))));
 
@@ -250,7 +251,8 @@ inline void SegmentedSortPairsByFullSort(const phi::GPUContext &ctx,
       self_ptr, values_ptr, indices_ptr, i_s_ptr, nsegments, nsort);
 }
 
-// The method is called when # of the rows of the input is less than or equal to 4
+// The method is called when # of the rows of the input is less than or equal to
+// 4
 template <typename T, typename IndexType>
 void ArgFullSortForTinyRows(const phi::GPUContext &ctx,
                             const DenseTensor *input,

--- a/python/paddle/fluid/tests/unittests/test_argsort_op.py
+++ b/python/paddle/fluid/tests/unittests/test_argsort_op.py
@@ -437,7 +437,7 @@ class TestArgsortImperative(unittest.TestCase):
             self.place = core.CPUPlace()
 
     def test_api(self):
-        paddle.enable_static(self.place)
+        paddle.disable_static(self.place)
         var_x = paddle.to_tensor(self.input_data)
         out = paddle.argsort(var_x, axis=self.axis)
         expect = np.argsort(self.input_data, axis=self.axis)
@@ -481,7 +481,7 @@ class TestArgsortWithInputNaN(unittest.TestCase):
             self.place = core.CPUPlace()
 
     def test_api(self):
-        paddle.enable_static(self.place)
+        paddle.disable_static(self.place)
         var_x = paddle.to_tensor(self.input_data)
         out = paddle.argsort(var_x, axis=self.axis)
         self.assertEqual((out.numpy() == np.array([0, 3, 2, 1])).all(), True)

--- a/python/paddle/fluid/tests/unittests/test_argsort_op.py
+++ b/python/paddle/fluid/tests/unittests/test_argsort_op.py
@@ -437,7 +437,7 @@ class TestArgsortImperative(unittest.TestCase):
             self.place = core.CPUPlace()
 
     def test_api(self):
-        paddle.disable_static(self.place)
+        paddle.enable_static(self.place)
         var_x = paddle.to_tensor(self.input_data)
         out = paddle.argsort(var_x, axis=self.axis)
         expect = np.argsort(self.input_data, axis=self.axis)
@@ -481,7 +481,7 @@ class TestArgsortWithInputNaN(unittest.TestCase):
             self.place = core.CPUPlace()
 
     def test_api(self):
-        paddle.disable_static(self.place)
+        paddle.enable_static(self.place)
         var_x = paddle.to_tensor(self.input_data)
         out = paddle.argsort(var_x, axis=self.axis)
         self.assertEqual((out.numpy() == np.array([0, 3, 2, 1])).all(), True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Optimize the implementation of argsort operator. The performance is better than Pytorch.  
Given on the input size of [4, 68992], which is slower than Pytorch initially, the performance of optimized argsort kernel can achieve 3.3x speedup, which is ~1.5x the performance of Pytorch. 
Reorganize the code of argsort operator to reduce the code redundancy.  
This optimal codes are called when the number of rows of input tensor is less.  
When the number of input tensor is large, the original implementation is called. (The performance is also better than Pytorch)  

| case | pytorch | paddle (before optimization) | diff | paddle (after optimization) | diff | speedup |
|------|--------|-----|------|------|------|-------|
|x(Variable)-dtype: float32, shape: [1L, 68892L]  axis(int):-1 | 0.17 | 0.23 | lower than(35.3%) | 0.20| lower than(17.6%)| 1.15|
|x(Variable)-dtype: float32, shape: [2L, 68892L]  axis(int):-1|0.25|0.91|lower than(2.64)|0.28|lower than(12%)|3.25|
|x(Variable)-dtype: float32, shape: [4L, 68892L]  axis(int):-1|0.42|0.97|lower than(1.31)|0.29|greater than(31.0%)|3.34|
|x(Variable)-dtype: float32, shape: [8L, 68892L]  axis(int):-1|0.71|1.03|lower than(45.1%)|0.39|greater than(45.1%)|2.64|
|x(Variable)-dtype: float32, shape: [16L, 68892L]  axis(int):-1|1.21|1.07|greater than(11.6%)|1.04|greater than(14.0%)|1.03|
|x(Variable)-dtype: float32, shape: [32L, 68892L]  axis(int):-1|2.23|1.31|greater than(41.3%)|1.11|greater than(50.2%)|1.18|