### PR TITLE
[phi] remove <fluid/eager/api/utils/global_utils.h> from phi

### DIFF
--- a/paddle/phi/api/yaml/generator/backward_api_gen.py
+++ b/paddle/phi/api/yaml/generator/backward_api_gen.py
@@ -285,7 +285,6 @@ def source_include(header_file_path):
 #include "paddle/phi/infermeta/backward.h"
 #include "paddle/phi/infermeta/unary.h"
 
-#include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/platform/profiler/event_tracing.h"
 #include "paddle/fluid/platform/profiler/supplement_tracing.h"
 


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
remove `<fluid/eager/api/utils/global_utils.h>` from `phi`

- #47615
