### PR TITLE
【Cherry-pick PR47743】change cudnn error to cuda error if compiled cuda version is incompatible with installed cuda version

### DIFF
--- a/paddle/phi/backends/gpu/gpu_resources.cc
+++ b/paddle/phi/backends/gpu/gpu_resources.cc
@@ -97,7 +97,7 @@ void InitGpuProperties(Place place,
       (*driver_version / 1000) * 10 + (*driver_version % 100) / 10;
   auto compile_cuda_version =
       (CUDA_VERSION / 1000) * 10 + (CUDA_VERSION % 100) / 10;
-#if (defined _LINUX)
+#if defined(__linux__)
   PADDLE_ENFORCE_EQ(
       local_cuda_version / 10,
       compile_cuda_version / 10,

--- a/paddle/phi/backends/gpu/gpu_resources.cc
+++ b/paddle/phi/backends/gpu/gpu_resources.cc
@@ -99,16 +99,19 @@ void InitGpuProperties(Place place,
       (CUDA_VERSION / 1000) * 10 + (CUDA_VERSION % 100) / 10;
 #if defined(__linux__)
   PADDLE_ENFORCE_EQ(
-      local_cuda_version / 10,
-      compile_cuda_version / 10,
+      (*runtime_version / 1000 == CUDA_VERSION / 1000) ||
+          (cudnn_dso_ver / 1000 == CUDNN_VERSION / 1000),
+      true,
       phi::errors::InvalidArgument(
-          "The installed Paddle is compiled with CUDA %d,"
-          "but CUDA version in your machine is %d. "
+          "The installed Paddle is compiled with CUDA%d/cuDNN%d,"
+          "but CUDA/cuDNN version in your machine is CUDA%d/cuDNN%d. "
           "which will cause serious incompatible bug. "
-          "Please recompile or reinstall Paddle with compatible CUDA "
+          "Please recompile or reinstall Paddle with compatible CUDA/cuDNN "
           "version.",
-          compile_cuda_version / 10,
-          local_cuda_version / 10));
+          CUDA_VERSION / 1000,
+          CUDNN_VERSION / 1000,
+          *runtime_version / 1000,
+          cudnn_dso_ver / 1000));
 #endif
   if (local_cuda_version < compile_cuda_version) {
     LOG_FIRST_N(WARNING, 1)

--- a/paddle/phi/backends/gpu/gpu_resources.cc
+++ b/paddle/phi/backends/gpu/gpu_resources.cc
@@ -99,18 +99,18 @@ void InitGpuProperties(Place place,
       (CUDA_VERSION / 1000) * 10 + (CUDA_VERSION % 100) / 10;
 #if defined(__linux__)
   PADDLE_ENFORCE_EQ(
-      (*runtime_version / 1000 == CUDA_VERSION / 1000) ||
-          (cudnn_dso_ver / 1000 == CUDNN_VERSION / 1000),
-      true,
+      (local_cuda_version / 10 < compile_cuda_version / 10) &&
+          (cudnn_dso_ver / 1000 < CUDNN_VERSION / 1000),
+      false,
       phi::errors::InvalidArgument(
           "The installed Paddle is compiled with CUDA%d/cuDNN%d,"
           "but CUDA/cuDNN version in your machine is CUDA%d/cuDNN%d. "
           "which will cause serious incompatible bug. "
           "Please recompile or reinstall Paddle with compatible CUDA/cuDNN "
           "version.",
-          CUDA_VERSION / 1000,
+          compile_cuda_version / 10,
           CUDNN_VERSION / 1000,
-          *runtime_version / 1000,
+          local_cuda_version / 10,
           cudnn_dso_ver / 1000));
 #endif
   if (local_cuda_version < compile_cuda_version) {

--- a/paddle/phi/backends/gpu/gpu_resources.cc
+++ b/paddle/phi/backends/gpu/gpu_resources.cc
@@ -97,6 +97,19 @@ void InitGpuProperties(Place place,
       (*driver_version / 1000) * 10 + (*driver_version % 100) / 10;
   auto compile_cuda_version =
       (CUDA_VERSION / 1000) * 10 + (CUDA_VERSION % 100) / 10;
+#if (defined _LINUX)
+  PADDLE_ENFORCE_EQ(
+      local_cuda_version / 10,
+      compile_cuda_version / 10,
+      phi::errors::InvalidArgument(
+          "The installed Paddle is compiled with CUDA %d,"
+          "but CUDA version in your machine is %d. "
+          "which will cause serious incompatible bug. "
+          "Please recompile or reinstall Paddle with compatible CUDA "
+          "version.",
+          compile_cuda_version / 10,
+          local_cuda_version / 10));
+#endif
   if (local_cuda_version < compile_cuda_version) {
     LOG_FIRST_N(WARNING, 1)
         << "WARNING: device: " << static_cast<int>(place.device)
@@ -108,20 +121,6 @@ void InitGpuProperties(Place place,
         << "Please recompile or reinstall Paddle with compatible CUDA "
            "version.";
   }
-
-  auto local_cudnn_version = cudnn_dso_ver / 1000;
-  auto compile_cudnn_version = CUDNN_VERSION / 1000;
-  PADDLE_ENFORCE_EQ(
-      compile_cudnn_version,
-      local_cudnn_version,
-      phi::errors::InvalidArgument(
-          "The installed Paddle is compiled with CUDNN "
-          "%d, but CUDNN version in your machine is %d. "
-          "which will cause serious incompatible bug. "
-          "Please recompile or reinstall Paddle with compatible CUDNN "
-          "version.",
-          compile_cudnn_version,
-          local_cudnn_version));
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Cherry-pick PR https://github.com/PaddlePaddle/Paddle/pull/47743 。

目前已经明确会报错的场景是：linux系统下，cuda11.2/cudnn8环境下编译的whl包，在用户cuda10.2/cudnn7的环境中使用时run_check会报错。

因此，限制报错的条件为： `用户环境中的cuda大版本` < `whl包编译的cuda大版本`  并且  `用户环境中的cudnn大版本` < `whl包编译的cudnn大版本` 时，会报错。
