### PR TITLE
Revert "[NPU] add more attrs into npu storiages, test=develop"

### DIFF
--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -266,10 +266,6 @@ template const NPUStorageProperties& DenseTensor::storage_properties() const;
 template const OneDNNStorageProperties& DenseTensor::storage_properties() const;
 #endif
 
-bool DenseTensor::storage_properties_initialized() const {
-  return storage_properties_ != nullptr;
-}
-
 void DenseTensor::set_storage_properties(
     std::unique_ptr<StorageProperties>&& storage_properties) {
   storage_properties_ = std::move(storage_properties);

--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -164,10 +164,6 @@ class DenseTensor : public TensorBase,
 
   void* data();
 
-  /// \brief Get whether the storage_properties is inited.
-  /// \return The init status of storage_properties.
-  bool storage_properties_initialized() const;
-
   /// \brief Returns the storage_properties of the tensor.
   /// \return The storage_properties of the tensor.
   template <typename DeviceT>

--- a/paddle/phi/core/storage_properties.h
+++ b/paddle/phi/core/storage_properties.h
@@ -15,7 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include <memory>
-#include "paddle/phi/core/ddim.h"
+
 #include "paddle/phi/core/utils/type_registry.h"
 
 #ifdef PADDLE_WITH_MKLDNN
@@ -42,10 +42,8 @@ struct NPUStorageProperties
   virtual ~NPUStorageProperties() = default;
   static const char* name() { return "NPUStorageProperties"; }
 
-  int64_t origin_format{-1};
-  int64_t storage_format{-1};
-  DDim origin_dims;
-  DDim storage_dims;
+  int64_t storage_format;
+  int64_t storage_layout;
 };
 
 // Add OneDNNStorageProperties firstly for unittest covergae
@@ -76,14 +74,10 @@ static std::unique_ptr<StorageProperties> CopyStorageProperties(
   if (sp) {
     if (NPUStorageProperties::classof(sp.get())) {
       auto result = std::make_unique<NPUStorageProperties>();
-      result->origin_format =
-          static_cast<NPUStorageProperties*>(sp.get())->origin_format;
       result->storage_format =
           static_cast<NPUStorageProperties*>(sp.get())->storage_format;
-      result->origin_dims =
-          static_cast<NPUStorageProperties*>(sp.get())->origin_dims;
-      result->storage_dims =
-          static_cast<NPUStorageProperties*>(sp.get())->storage_dims;
+      result->storage_layout =
+          static_cast<NPUStorageProperties*>(sp.get())->storage_layout;
       return result;
 #ifdef PADDLE_WITH_MKLDNN
     } else if (OneDNNStorageProperties::classof(sp.get())) {

--- a/paddle/phi/tests/core/test_dense_tensor.cc
+++ b/paddle/phi/tests/core/test_dense_tensor.cc
@@ -154,19 +154,13 @@ TEST(dense_tensor, storage_properties) {
   EXPECT_TRUE(caught_exception);
 
   // test custom device storage properties
-  EXPECT_FALSE(tensor.storage_properties_initialized());
   auto npu_properties = std::make_unique<NPUStorageProperties>();
-  npu_properties->origin_format = 0;
-  npu_properties->storage_format = 3;
-  npu_properties->origin_dims = {1, 8, 5, 5};
-  npu_properties->storage_dims = {1, 1, 5, 5, 16};
+  npu_properties->storage_format = 1;
+  npu_properties->storage_layout = 2;
   tensor.set_storage_properties(std::move(npu_properties));
-  EXPECT_TRUE(tensor.storage_properties_initialized());
   auto get_npu_properties = tensor.storage_properties<NPUStorageProperties>();
-  CHECK_EQ(get_npu_properties.origin_format, 0);
-  CHECK_EQ(get_npu_properties.storage_format, 3);
-  CHECK_EQ(get_npu_properties.origin_dims.size(), 4);
-  CHECK_EQ(get_npu_properties.storage_dims.size(), 5);
+  CHECK_EQ(get_npu_properties.storage_format, 1);
+  CHECK_EQ(get_npu_properties.storage_layout, 2);
 
   // test error type storage properties
 #ifdef PADDLE_WITH_MKLDNN
@@ -183,10 +177,8 @@ TEST(dense_tensor, storage_properties) {
   auto cp_tensor = tensor;
   auto get_cp_npu_properties =
       cp_tensor.storage_properties<NPUStorageProperties>();
-  CHECK_EQ(get_cp_npu_properties.origin_format, 0);
-  CHECK_EQ(get_cp_npu_properties.storage_format, 3);
-  CHECK_EQ(get_cp_npu_properties.origin_dims.size(), 4);
-  CHECK_EQ(get_cp_npu_properties.storage_dims.size(), 5);
+  CHECK_EQ(get_cp_npu_properties.storage_format, 1);
+  CHECK_EQ(get_cp_npu_properties.storage_layout, 2);
 }
 
 }  // namespace tests


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

Reverts PaddlePaddle/Paddle#47645

As this PR broken KPS CI, error as following:

https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/7068365/job/20014059

![9efeb9d74415b2ba2a60c249e21eb16b](https://user-images.githubusercontent.com/16605440/200472078-b6af9388-6836-4221-ac71-de5cdc17becb.png)

Possible root cause is the compatibility issue btw Paddle compiler = gcc8.2 and XTDK compiler = clang

cmake target defined here:

https://github.com/PaddlePaddle/Paddle/blob/develop/cmake/xpu_kp.cmake#L191

