### PR TITLE
[CodeStyle][F821] fix test_exception in test_unpool3d_op and test_unpool_op

### DIFF
--- a/paddle/phi/kernels/gpu/unpool_kernel.cu
+++ b/paddle/phi/kernels/gpu/unpool_kernel.cu
@@ -33,11 +33,23 @@ __global__ void KernelUnpool2dMax(const int nthreads,
                                   T* output_data,
                                   const int output_height,
                                   const int output_width) {
+  int output_feasize = output_height * output_width;
   CUDA_KERNEL_LOOP(linearIndex, nthreads) {
     int c = (linearIndex / input_width / input_height) % channels;
     int n = linearIndex / input_width / input_height / channels;
     output_data += (n * channels + c) * output_height * output_width;
     int maxind = indices_data[linearIndex];
+    PADDLE_ENFORCE_LT(
+        maxind,
+        output_feasize,
+        phi::errors::InvalidArgument(
+            "index should less than output tensor height * output tensor "
+            "width. Expected %ld < %ld, but got "
+            "%ld >= %ld. Please check input value.",
+            maxind,
+            output_feasize,
+            maxind,
+            output_feasize));
     output_data[maxind] = input_data[linearIndex];
   }
 }
@@ -54,12 +66,25 @@ __global__ void KernelUnpool3dMax(const int nthreads,
                                   const int output_depth,
                                   const int output_height,
                                   const int output_width) {
+  int output_feasize = output_depth * output_height * output_width;
   CUDA_KERNEL_LOOP(linearIndex, nthreads) {
     int c = (linearIndex / input_depth / input_width / input_height) % channels;
     int n = linearIndex / input_depth / input_width / input_height / channels;
     output_data +=
         (n * channels + c) * output_depth * output_height * output_width;
     int maxind = indices_data[linearIndex];
+    PADDLE_ENFORCE_LT(
+        maxind,
+        output_feasize,
+        phi::errors::InvalidArgument(
+            "index should less than output tensor depth * output tensor "
+            "height "
+            "* output tensor width. Expected %ld < %ld, but got "
+            "%ld >= %ld. Please check input value.",
+            maxind,
+            output_feasize,
+            maxind,
+            output_feasize));
     output_data[maxind] = input_data[linearIndex];
   }
 }

--- a/paddle/phi/kernels/gpu/unpool_kernel.cu
+++ b/paddle/phi/kernels/gpu/unpool_kernel.cu
@@ -33,23 +33,11 @@ __global__ void KernelUnpool2dMax(const int nthreads,
                                   T* output_data,
                                   const int output_height,
                                   const int output_width) {
-  int output_feasize = output_height * output_width;
   CUDA_KERNEL_LOOP(linearIndex, nthreads) {
     int c = (linearIndex / input_width / input_height) % channels;
     int n = linearIndex / input_width / input_height / channels;
     output_data += (n * channels + c) * output_height * output_width;
     int maxind = indices_data[linearIndex];
-    PADDLE_ENFORCE_LT(
-        maxind,
-        output_feasize,
-        phi::errors::InvalidArgument(
-            "index should less than output tensor height * output tensor "
-            "width. Expected %ld < %ld, but got "
-            "%ld >= %ld. Please check input value.",
-            maxind,
-            output_feasize,
-            maxind,
-            output_feasize));
     output_data[maxind] = input_data[linearIndex];
   }
 }
@@ -66,25 +54,12 @@ __global__ void KernelUnpool3dMax(const int nthreads,
                                   const int output_depth,
                                   const int output_height,
                                   const int output_width) {
-  int output_feasize = output_depth * output_height * output_width;
   CUDA_KERNEL_LOOP(linearIndex, nthreads) {
     int c = (linearIndex / input_depth / input_width / input_height) % channels;
     int n = linearIndex / input_depth / input_width / input_height / channels;
     output_data +=
         (n * channels + c) * output_depth * output_height * output_width;
     int maxind = indices_data[linearIndex];
-    PADDLE_ENFORCE_LT(
-        maxind,
-        output_feasize,
-        phi::errors::InvalidArgument(
-            "index should less than output tensor depth * output tensor "
-            "height "
-            "* output tensor width. Expected %ld < %ld, but got "
-            "%ld >= %ld. Please check input value.",
-            maxind,
-            output_feasize,
-            maxind,
-            output_feasize));
     output_data[maxind] = input_data[linearIndex];
   }
 }

--- a/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
@@ -230,6 +230,12 @@ class TestUnpool3DOpException(unittest.TestCase):
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
+        # Test start
+        place = paddle.to_tensor([1]).place
+        print(
+            f"==> core.is_compiled_with_cuda: {core.is_compiled_with_cuda()}, place: {place}"
+        )
+        # Test end
         if not core.is_compiled_with_cuda():
             self.assertRaisesRegex(
                 ValueError,

--- a/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
@@ -180,34 +180,34 @@ class TestUnpool3DOpOutput(TestUnpool3DOp):
 class TestUnpool3DOpException(unittest.TestCase):
     def test_exception(self):
         def indices_size_error():
-            data = paddle.randint(shape=[1, 1, 3, 3, 3])
+            data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(0, 36), shape=[1, 1, 3, 3, 4]
-            )
-            MaxUnPool3D = F.maxunpool3d(data, indices, kernel_size=2, stride=2)
+            ).astype("int32")
+            MaxUnPool3D = F.max_unpool3d(data, indices, kernel_size=2, stride=2)
 
         def indices_value_error():
-            data = paddle.randint(shape=[1, 1, 3, 3, 3])
+            data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
-                paddle.arange(4, 40), shape=[1, 1, 3, 3, 3]
-            )
-            MaxUnPool3D = F.maxunpool3d(data, indices, kernel_size=2, stride=2)
+                paddle.arange(195, 222), shape=[1, 1, 3, 3, 3]
+            ).astype("int32")
+            MaxUnPool3D = F.max_unpool3d(data, indices, kernel_size=2, stride=2)
 
         def data_format_error():
-            data = paddle.randint(shape=[1, 1, 3, 3, 3])
+            data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(0, 27), shape=[1, 1, 3, 3, 3]
-            )
-            MaxUnPool3D = F.maxunpool3d(
+            ).astype("int32")
+            MaxUnPool3D = F.max_unpool3d(
                 data, indices, kernel_size=2, stride=2, data_format="NDHWC"
             )
 
         def data_outputsize_error():
-            data = paddle.randint(shape=[1, 1, 3, 3, 3])
+            data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(0, 27), shape=[1, 1, 3, 3, 3]
-            )
-            MaxUnPool3D = F.maxunpool3d(
+            ).astype("int32")
+            MaxUnPool3D = F.max_unpool3d(
                 data,
                 indices,
                 kernel_size=2,
@@ -216,19 +216,35 @@ class TestUnpool3DOpException(unittest.TestCase):
             )
 
         def data_outputsize_error2():
-            data = paddle.randint(shape=[1, 1, 3, 3, 3])
+            data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(0, 27), shape=[1, 1, 3, 3, 3]
             )
-            MaxUnPool3D = F.maxunpool3d(
+            MaxUnPool3D = F.max_unpool3d(
                 data, indices, kernel_size=2, stride=2, output_size=[10, 10, 10]
             )
 
-        self.assertRaises(ValueError, indices_size_error)
-        self.assertRaises(ValueError, indices_value_error)
-        self.assertRaises(ValueError, data_format_error)
-        self.assertRaises(ValueError, data_outputsize_error)
-        self.assertRaises(ValueError, data_outputsize_error2)
+        self.assertRaisesRegex(
+            ValueError,
+            r"\(InvalidArgument\) The dimensions of Input\(X\) must.+",
+            indices_size_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"\(InvalidArgument\) index should less than output.+",
+            indices_value_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"Attr\(data_format\) should be 'NCDHW'.+",
+            data_format_error,
+        )
+        self.assertRaisesRegex(
+            ValueError, r"invalid output_size.+", data_outputsize_error
+        )
+        self.assertRaisesRegex(
+            ValueError, r"invalid output_size.+", data_outputsize_error2
+        )
 
 
 class TestUnpool3DOpAPI_dygraph(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
@@ -179,6 +179,12 @@ class TestUnpool3DOpOutput(TestUnpool3DOp):
 
 
 class TestUnpool3DOpException(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def tearDown(self):
+        paddle.enable_static()
+
     def test_exception(self):
         def indices_size_error():
             data = paddle.rand(shape=[1, 1, 3, 3, 3])
@@ -230,12 +236,6 @@ class TestUnpool3DOpException(unittest.TestCase):
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
-        # Test start
-        place = paddle.to_tensor([1]).place
-        print(
-            f"==> core.is_compiled_with_cuda: {core.is_compiled_with_cuda()}, place: {place}"
-        )
-        # Test end
         if not core.is_compiled_with_cuda():
             self.assertRaisesRegex(
                 ValueError,

--- a/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
@@ -17,6 +17,7 @@ import numpy as np
 from op_test import OpTest
 import paddle
 import paddle.nn.functional as F
+from paddle.fluid import core
 
 paddle.enable_static()
 paddle.seed(2022)
@@ -229,11 +230,12 @@ class TestUnpool3DOpException(unittest.TestCase):
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
-        self.assertRaisesRegex(
-            ValueError,
-            r"index should less than output",
-            indices_value_error,
-        )
+        if not core.is_compiled_with_cuda():
+            self.assertRaisesRegex(
+                ValueError,
+                r"index should less than output",
+                indices_value_error,
+            )
         self.assertRaisesRegex(
             ValueError,
             r"Attr\(data_format\) should be 'NCDHW'",

--- a/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
@@ -226,24 +226,24 @@ class TestUnpool3DOpException(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            r"\(InvalidArgument\) The dimensions of Input\(X\) must.+",
+            r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
         self.assertRaisesRegex(
             ValueError,
-            r"\(InvalidArgument\) index should less than output.+",
+            r"index should less than output",
             indices_value_error,
         )
         self.assertRaisesRegex(
             ValueError,
-            r"Attr\(data_format\) should be 'NCDHW'.+",
+            r"Attr\(data_format\) should be 'NCDHW'",
             data_format_error,
         )
         self.assertRaisesRegex(
-            ValueError, r"invalid output_size.+", data_outputsize_error
+            ValueError, r"invalid output_size", data_outputsize_error
         )
         self.assertRaisesRegex(
-            ValueError, r"invalid output_size.+", data_outputsize_error2
+            ValueError, r"invalid output_size", data_outputsize_error2
         )
 
 

--- a/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
@@ -184,21 +184,21 @@ class TestUnpool3DOpException(unittest.TestCase):
             indices = paddle.reshape(
                 paddle.arange(0, 36), shape=[1, 1, 3, 3, 4]
             ).astype("int32")
-            MaxUnPool3D = F.max_unpool3d(data, indices, kernel_size=2, stride=2)
+            F.max_unpool3d(data, indices, kernel_size=2, stride=2)
 
         def indices_value_error():
             data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(195, 222), shape=[1, 1, 3, 3, 3]
             ).astype("int32")
-            MaxUnPool3D = F.max_unpool3d(data, indices, kernel_size=2, stride=2)
+            F.max_unpool3d(data, indices, kernel_size=2, stride=2)
 
         def data_format_error():
             data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(0, 27), shape=[1, 1, 3, 3, 3]
             ).astype("int32")
-            MaxUnPool3D = F.max_unpool3d(
+            F.max_unpool3d(
                 data, indices, kernel_size=2, stride=2, data_format="NDHWC"
             )
 
@@ -207,7 +207,7 @@ class TestUnpool3DOpException(unittest.TestCase):
             indices = paddle.reshape(
                 paddle.arange(0, 27), shape=[1, 1, 3, 3, 3]
             ).astype("int32")
-            MaxUnPool3D = F.max_unpool3d(
+            F.max_unpool3d(
                 data,
                 indices,
                 kernel_size=2,
@@ -220,7 +220,7 @@ class TestUnpool3DOpException(unittest.TestCase):
             indices = paddle.reshape(
                 paddle.arange(0, 27), shape=[1, 1, 3, 3, 3]
             )
-            MaxUnPool3D = F.max_unpool3d(
+            F.max_unpool3d(
                 data, indices, kernel_size=2, stride=2, output_size=[10, 10, 10]
             )
 

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -178,6 +178,12 @@ class TestUnpoolOpOutput(TestUnpoolOp):
 
 
 class TestUnpoolOpException(unittest.TestCase):
+    def setUp(self):
+        paddle.disable_static()
+
+    def tearDown(self):
+        paddle.enable_static()
+
     def test_exception(self):
         def indices_size_error():
             data = paddle.rand(shape=[1, 1, 3, 3])
@@ -225,12 +231,6 @@ class TestUnpoolOpException(unittest.TestCase):
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
-        # Test start
-        place = paddle.to_tensor([1]).place
-        print(
-            f"==> core.is_compiled_with_cuda: {core.is_compiled_with_cuda()}, place: {place}"
-        )
-        # Test end
         if not core.is_compiled_with_cuda():
             self.assertRaisesRegex(
                 ValueError,

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -184,21 +184,21 @@ class TestUnpoolOpException(unittest.TestCase):
             indices = paddle.reshape(
                 paddle.arange(0, 12), shape=[1, 1, 3, 4]
             ).astype("int32")
-            MaxPool2D = F.max_unpool2d(data, indices, kernel_size=2, stride=2)
+            F.max_unpool2d(data, indices, kernel_size=2, stride=2)
 
         def indices_value_error():
             data = paddle.rand(shape=[1, 1, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(31, 40), shape=[1, 1, 3, 3]
             ).astype("int32")
-            MaxPool2D = F.max_unpool2d(data, indices, kernel_size=2, stride=2)
+            F.max_unpool2d(data, indices, kernel_size=2, stride=2)
 
         def data_format_error():
             data = paddle.rand(shape=[1, 1, 3, 3])
             indices = paddle.reshape(
                 paddle.arange(0, 9), shape=[1, 1, 3, 3]
             ).astype("int32")
-            MaxPool2D = F.max_unpool2d(
+            F.max_unpool2d(
                 data, indices, kernel_size=2, stride=2, data_format="NHWC"
             )
 
@@ -207,7 +207,7 @@ class TestUnpoolOpException(unittest.TestCase):
             indices = paddle.reshape(
                 paddle.arange(0, 9), shape=[1, 1, 3, 3]
             ).astype("int32")
-            MaxPool2D = F.max_unpool2d(
+            F.max_unpool2d(
                 data, indices, kernel_size=2, stride=2, output_size=[5, 6, 7, 8]
             )
 
@@ -216,7 +216,7 @@ class TestUnpoolOpException(unittest.TestCase):
             indices = paddle.reshape(
                 paddle.arange(0, 9), shape=[1, 1, 3, 3]
             ).astype("int32")
-            MaxPool2D = F.max_unpool2d(
+            F.max_unpool2d(
                 data, indices, kernel_size=2, stride=2, output_size=[100, 100]
             )
 

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -18,7 +18,7 @@ import numpy as np
 from op_test import OpTest
 import paddle
 import paddle.nn.functional as F
-from paddle.fluid import Program, program_guard
+from paddle.fluid import Program, program_guard, core
 
 from test_attribute_var import UnittestBase
 
@@ -225,11 +225,12 @@ class TestUnpoolOpException(unittest.TestCase):
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
-        self.assertRaisesRegex(
-            ValueError,
-            r"index should less than output",
-            indices_value_error,
-        )
+        if not core.is_compiled_with_cuda():
+            self.assertRaisesRegex(
+                ValueError,
+                r"index should less than output",
+                indices_value_error,
+            )
         self.assertRaisesRegex(
             ValueError,
             r"Attr\(data_format\) should be 'NCHW'",

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -222,24 +222,24 @@ class TestUnpoolOpException(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError,
-            r"\(InvalidArgument\) The dimensions of Input\(X\) must.+",
+            r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
         self.assertRaisesRegex(
             ValueError,
-            r"\(InvalidArgument\) index should less than output.+",
+            r"index should less than output",
             indices_value_error,
         )
         self.assertRaisesRegex(
             ValueError,
-            r"Attr\(data_format\) should be 'NCHW'.+",
+            r"Attr\(data_format\) should be 'NCHW'",
             data_format_error,
         )
         self.assertRaisesRegex(
-            ValueError, r"invalid output_size.+", data_outputsize_error
+            ValueError, r"invalid output_size", data_outputsize_error
         )
         self.assertRaisesRegex(
-            ValueError, r"invalid output_size.+", data_outputsize_error2
+            ValueError, r"invalid output_size", data_outputsize_error2
         )
 
 

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -180,41 +180,67 @@ class TestUnpoolOpOutput(TestUnpoolOp):
 class TestUnpoolOpException(unittest.TestCase):
     def test_exception(self):
         def indices_size_error():
-            data = paddle.randint(shape=[1, 1, 3, 3])
-            indices = paddle.reshape(paddle.arange(0, 12), shape[1, 1, 3, 4])
-            MaxPool2D = F.maxunpool2d(data, indices, kernel_size=2, stride=2)
+            data = paddle.rand(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 12), shape=[1, 1, 3, 4]
+            ).astype("int32")
+            MaxPool2D = F.max_unpool2d(data, indices, kernel_size=2, stride=2)
 
         def indices_value_error():
-            data = paddle.randint(shape=[1, 1, 3, 3])
-            indices = paddle.reshape(paddle.arange(4, 40), shape[1, 1, 3, 4])
-            MaxPool2D = F.maxunpool2d(data, indices, kernel_size=2, stride=2)
+            data = paddle.rand(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(31, 40), shape=[1, 1, 3, 3]
+            ).astype("int32")
+            MaxPool2D = F.max_unpool2d(data, indices, kernel_size=2, stride=2)
 
         def data_format_error():
-            data = paddle.randint(shape=[1, 1, 3, 3])
-            indices = paddle.reshape(paddle.arange(4, 40), shape[1, 1, 3, 4])
-            MaxPool2D = F.maxunpool2d(
+            data = paddle.rand(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 9), shape=[1, 1, 3, 3]
+            ).astype("int32")
+            MaxPool2D = F.max_unpool2d(
                 data, indices, kernel_size=2, stride=2, data_format="NHWC"
             )
 
         def data_outputsize_error():
-            data = paddle.randint(shape=[1, 1, 3, 3])
-            indices = paddle.reshape(paddle.arange(4, 40), shape[1, 1, 3, 4])
-            MaxPool2D = F.maxunpool2d(
+            data = paddle.rand(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 9), shape=[1, 1, 3, 3]
+            ).astype("int32")
+            MaxPool2D = F.max_unpool2d(
                 data, indices, kernel_size=2, stride=2, output_size=[5, 6, 7, 8]
             )
 
         def data_outputsize_error2():
-            data = paddle.randint(shape=[1, 1, 3, 3])
-            indices = paddle.reshape(paddle.arange(4, 40), shape[1, 1, 3, 4])
-            MaxPool2D = F.maxunpool2d(
+            data = paddle.rand(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 9), shape=[1, 1, 3, 3]
+            ).astype("int32")
+            MaxPool2D = F.max_unpool2d(
                 data, indices, kernel_size=2, stride=2, output_size=[100, 100]
             )
 
-        self.assertRaises(ValueError, indices_size_error)
-        self.assertRaises(ValueError, indices_value_error)
-        self.assertRaises(ValueError, data_format_error)
-        self.assertRaises(ValueError, data_outputsize_error)
-        self.assertRaises(ValueError, data_outputsize_error2)
+        self.assertRaisesRegex(
+            ValueError,
+            r"\(InvalidArgument\) The dimensions of Input\(X\) must.+",
+            indices_size_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"\(InvalidArgument\) index should less than output.+",
+            indices_value_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"Attr\(data_format\) should be 'NCHW'.+",
+            data_format_error,
+        )
+        self.assertRaisesRegex(
+            ValueError, r"invalid output_size.+", data_outputsize_error
+        )
+        self.assertRaisesRegex(
+            ValueError, r"invalid output_size.+", data_outputsize_error2
+        )
 
 
 class TestUnpoolOpAPI_dy(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -225,6 +225,12 @@ class TestUnpoolOpException(unittest.TestCase):
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
         )
+        # Test start
+        place = paddle.to_tensor([1]).place
+        print(
+            f"==> core.is_compiled_with_cuda: {core.is_compiled_with_cuda()}, place: {place}"
+        )
+        # Test end
         if not core.is_compiled_with_cuda():
             self.assertRaisesRegex(
                 ValueError,

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -179,9 +179,6 @@ class TestUnpoolOpOutput(TestUnpoolOp):
 
 class TestUnpoolOpException(unittest.TestCase):
     def test_exception(self):
-        import paddle.nn.functional as F
-        import paddle
-
         def indices_size_error():
             data = paddle.randint(shape=[1, 1, 3, 3])
             indices = paddle.reshape(paddle.arange(0, 12), shape[1, 1, 3, 4])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

在查看 F821 已有问题时发现的，修复了一下这两个单测，算是顺带修复了几个 F821 问题（75 个 -> 70 个，修复了 5 个，剩余很多，需要之后慢慢修）

这两个单测 assertRaises ValueError 都是 `paddle.randint(shape=[1, 1, 3, 3, 3])` 报的（randint 需要传入 low、high），而不是需要测试的 API/OP（`F.max_unpool2d`）报的（名字都写成 `F.maxunpool2d` 了，肯定不是他报的……），因此将其余部分改对（除此之外错误还有不少……），使 ValueError 确实在需要测试的 API 报错

为了确保这一点，使用 assertRaisesRegex 代替了 assertRaises，这样能对 Error 的 message 有一个约束，可以确保是需要的那个错误

### Related links

-  Flake8 tracking issue: #46039
- cattidea/paddle-flake8-project#79