### PR TITLE
Fix for missing oneDNN reorders in profiling

### DIFF
--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_mkldnn_op.h
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_mkldnn_op.h
@@ -60,10 +60,6 @@ inline void AddSubNonBroadcast(platform::ReorderMKLDNNHandler* reorder_handler,
   reorder_attr.set_output_scales(0, scales);
   auto reorder_p =
       reorder_handler->AcquireReorder(dst_memory, src_memory, reorder_attr);
-  platform::RecordEvent record_reorder("int_reorder",
-                                       platform::TracerEventType::UserDefined,
-                                       2,
-                                       platform::EventRole::kUniqueOp);
 
   reorder_p->execute(platform::MKLDNNDeviceContext::tls().get_stream(),
                      *src_memory,

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -292,7 +292,7 @@ class ConvTransposeMKLDNNHandlerT
         platform::RecordEvent record_reorder(
             "int_reorder",
             platform::TracerEventType::UserDefined,
-            2,
+            1,
             platform::EventRole::kUniqueOp);
         reorder_p->execute(
             astream,
@@ -318,7 +318,7 @@ class ConvTransposeMKLDNNHandlerT
         platform::RecordEvent record_reorder(
             "int_reorder",
             platform::TracerEventType::UserDefined,
-            2,
+            1,
             platform::EventRole::kUniqueOp);
         reorder_p->execute(
             astream,

--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -211,10 +211,17 @@ class FCMKLDNNHandler
         *user_memory_p, *target_memory_p, attrs);
 
     auto& astream = platform::MKLDNNDeviceContext::tls().get_stream();
-    reorder_p->execute(
-        astream,
-        {{DNNL_ARG_FROM, *user_memory_p}, {DNNL_ARG_TO, *target_memory_p}});
-    astream.wait();
+    {
+      platform::RecordEvent record_reorder(
+          "int_reorder",
+          platform::TracerEventType::UserDefined,
+          1,
+          platform::EventRole::kUniqueOp);
+      reorder_p->execute(
+          astream,
+          {{DNNL_ARG_FROM, *user_memory_p}, {DNNL_ARG_TO, *target_memory_p}});
+      astream.wait();
+    }
 
     return target_memory_p;
   }

--- a/paddle/phi/backends/onednn/onednn_reuse.h
+++ b/paddle/phi/backends/onednn/onednn_reuse.h
@@ -380,7 +380,7 @@ class OneDNNHandlerT {
     paddle::platform::RecordEvent record_reorder(
         "int_reorder",
         paddle::platform::TracerEventType::UserDefined,
-        2,
+        1,
         paddle::platform::EventRole::kUniqueOp);
     reorder_p->execute(
         astream,
@@ -433,7 +433,7 @@ class OneDNNHandlerT {
         paddle::platform::RecordEvent record_reorder(
             "int_reorder",
             paddle::platform::TracerEventType::UserDefined,
-            2,
+            1,
             paddle::platform::EventRole::kUniqueOp);
         reorder_p->execute(
             astream,
@@ -459,7 +459,7 @@ class OneDNNHandlerT {
         paddle::platform::RecordEvent record_reorder(
             "int_reorder",
             paddle::platform::TracerEventType::UserDefined,
-            2,
+            1,
             paddle::platform::EventRole::kUniqueOp);
         reorder_p->execute(
             astream,
@@ -647,7 +647,7 @@ class OneDNNHandlerNoCachingT {
     paddle::platform::RecordEvent record_reorder(
         "int_reorder",
         paddle::platform::TracerEventType::UserDefined,
-        2,
+        1,
         paddle::platform::EventRole::kUniqueOp);
     reorder_p->execute(
         astream,
@@ -678,7 +678,7 @@ class OneDNNHandlerNoCachingT {
       paddle::platform::RecordEvent record_reorder(
           "int_reorder",
           paddle::platform::TracerEventType::UserDefined,
-          2,
+          1,
           paddle::platform::EventRole::kUniqueOp);
       reorder_p->execute(
           astream,

--- a/paddle/phi/kernels/onednn/conv_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/conv_grad_kernel.cc
@@ -143,7 +143,7 @@ void ConvGradKernel(const Context& dev_ctx,
               paddle::platform::RecordEvent record_reorder(
                   "int_reorder",
                   paddle::platform::TracerEventType::UserDefined,
-                  2,
+                  1,
                   paddle::platform::EventRole::kUniqueOp);
               reorder_p->execute(
                   astream, *diff_weights_memory_p, *reorder_dst_memory_p);


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix for missing oneDNN reorders in profiling
