### PR TITLE
Move dropout removing pass at the beginning of the INT8 process

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -390,9 +390,9 @@ void CpuPassStrategy::EnableMkldnnInt8() {
 #ifdef PADDLE_WITH_MKLDNN
   if (!use_mkldnn_int8_) {
     passes_.clear();
+    passes_.push_back("simplify_with_basic_ops_pass");
     passes_.push_back("quant_dequant_mkldnn_pass");
     passes_.push_back("mkldnn_placement_pass");
-    passes_.push_back("simplify_with_basic_ops_pass");
     passes_.push_back("constant_folding_pass");
     passes_.push_back("squeeze2_transpose2_onednn_fuse_pass");
     passes_.push_back("layer_norm_fuse_pass");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
It turn out that pass `simplify_with_basic_ops_pass` that is removing dropout was placed after `quant_dequant_mkldnn_pass`. 
So if the dropout was before some quantizable operator, the scale to it [tensor_name, scale] was lost because the tensor_name was changing. The simplest solution is to move this pass before quant_dequant_mkldnn_pass. 

It improves U2++ int8 model: 
- in encoder model before only 61 fc was quantized and right now 85 fc is quantized. 
- in decoder model before only 39 was quantized and right now 44 fc is quantized. 
This should give us almost a 12% performance improvement
I am still checking whether it will affect other models.