### PR TITLE
[cherry-pick] fix ScaleKernel configuration error where input numel is 0

### DIFF
--- a/paddle/phi/kernels/cpu/scale_kernel.cc
+++ b/paddle/phi/kernels/cpu/scale_kernel.cc
@@ -40,6 +40,9 @@ void ScaleKernel(const Context& dev_ctx,
   // TODO(chenweihang): now the eigen function here need the dtype of scale,
   // eigen_x, bias should be same, so here need cast for two scalar arg,
   // maybe we declare that the type of scale and bias is T?
+  if (x.numel() <= 0 || (!x.IsInitialized())) {
+    return;
+  }
   paddle::operators::EigenScale<std::decay_t<decltype(dev)>, T>::Eval(
       dev,
       eigen_out,

--- a/paddle/phi/kernels/gpu/scale_kernel.cu
+++ b/paddle/phi/kernels/gpu/scale_kernel.cu
@@ -53,6 +53,9 @@ void ScaleKernel(const Context& dev_ctx,
   inputs.emplace_back(&x);
   outputs.emplace_back(out);
   dev_ctx.template Alloc<T>(out);
+  if (x.numel() <= 0 || (!x.IsInitialized())) {
+    return;
+  }
   phi::funcs::ElementwiseKernel<T>(
       dev_ctx,
       inputs,

--- a/python/paddle/fluid/tests/unittests/test_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scale_op.py
@@ -321,5 +321,19 @@ class TestScaleTripleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+class TestScaleOpZeroNumelVariable(unittest.TestCase):
+    def test_check_zero_numel_cpu(self):
+        paddle.set_device('cpu')
+        data = paddle.ones([0, 1])
+        out = paddle.scale(data, 2)
+        self.assertEqual(out, data)
+
+        if paddle.is_compiled_with_cuda():
+            paddle.set_device('gpu')
+            data = paddle.ones([0, 1])
+            out = paddle.scale(data, 2)
+            self.assertEqual(out, data)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe

cherry-pick https://github.com/PaddlePaddle/Paddle/pull/47111

when input `x` of `paddle.scale` is a zero-shape tensor,  scale kernel cause a error when run with cuda-memcheck :

```
import paddle
data = paddle.ones([0, 1]) 
out = paddle.scale(data, 2)
```

```
========= CUDA-MEMCHECK
========= Program hit cudaErrorInvalidConfiguration (error 9) due to "invalid configuration argument" on CUDA API call to cudaLaunchKernel.
=========     Saved host backtrace up to driver entry point at error
=========     Host Frame:/usr/lib/x86_64-linux-gnu/libcuda.so.1 [0x3c43a3]
=========     Host Frame:/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/fluid/libpaddle.so [0xc3658d5]
=========     Host Frame:/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/fluid/libpaddle.so (_ZN3phi5funcs27LaunchElementwiseCudaKernelIfNS_12ScaleFunctorIfEELi1ELi1ELi4EEEvRKNS_10GPUContextERKSt6vectorIPKNS_11DenseTensorESaISA_EEPS7_IPS8_SaISF_EET0_ + 0x1ee) [0x922c78e]
=========     Host Frame:/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/fluid/libpaddle.so (_ZN3phi5funcs17ElementwiseKernelIfNS_12ScaleFunctorIfEELi1EEEvRKNS_10GPUContextERKSt6vectorIPKNS_11DenseTensorESaISA_EEPS7_IPS8_SaISF_EET0_ + 0xf8) [0x9230868]
=========     Host Frame:/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/fluid/libpaddle.so (_ZN3phi11ScaleKernelIfNS_10GPUContextEEEvRKT0_RKNS_11DenseTensorERKN6paddle12experimental10ScalarBaseIS5_EEfbPS5_ + 0x11f) [0x9230e9f]
=========     Host Frame:/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/fluid/libpaddle.so (_ZN6paddle12experimental5scaleERKNS0_6TensorERKNS0_10ScalarBaseIS1_EEfb + 0x443) [0x874d323]
=========     Host Frame:/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/fluid/libpaddle.so (_Z13scale_ad_funcRKN6paddle12experimental6TensorENS0_10ScalarBaseIS1_EEfb + 0x823) [0x4b43373]
=========     Host Frame:/usr/local/python3.7.0/lib/python3.7/site-packages/paddle/fluid/libpaddle.so [0x3f5f76a]
=========     Host Frame:/usr/local/python3.7.0/lib/libpython3.7m.so.1.0 (_PyMethodDef_RawFastCallKeywords + 0x2eb) [0x937fb]
=========     Host Frame:/usr/local/python3.7.0/lib/libpython3.7m.so.1.0 (_PyCFunction_FastCallKeywords + 0x25) [0x938a5]
=========     Host Frame:/usr/local/python3.7.0/lib/libpython3.7m.so.1.0 (_PyEval_EvalFrameDefault + 0x77d8) [0x70068]
=========     Host Frame:/usr/local/python3.7.0/lib/libpython3.7m.so.1.0 (_PyEval_EvalCodeWithName + 0x9a2) [0x16ad32

```
So we add a zero-shape judgement for input and then skip the kernel,  then the test code run normally:
```
========= ERROR SUMMARY: 0 errors
```