### PR TITLE
[paddle][trt]memory set change from setMaxWorkspaceSize to setMemoryPoolLimit since trt 8.3+

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -150,8 +150,12 @@ void TensorRTEngine::FreezeNetwork() {
                               "Call InitNetwork first to initialize network."));
   // build engine.
   infer_builder_->setMaxBatchSize(max_batch_);
+#if IS_TRT_VERSION_GE(8300)
+  infer_builder_config_->setMemoryPoolLimit(
+      nvinfer1::MemoryPoolType::kWORKSPACE, max_workspace_);
+#else
   infer_builder_config_->setMaxWorkspaceSize(max_workspace_);
-
+#endif
   bool enable_fp16 = (precision_ == AnalysisConfig::Precision::kHalf);
   if (enable_fp16) {
     bool support_fp16 = infer_builder_->platformHasFastFp16();

--- a/paddle/fluid/inference/tensorrt/test_tensorrt.cc
+++ b/paddle/fluid/inference/tensorrt/test_tensorrt.cc
@@ -95,7 +95,11 @@ nvinfer1::IHostMemory* CreateNetwork() {
   network->markOutput(*output);
   // Build the engine.
   builder->setMaxBatchSize(1);
+#if IS_TRT_VERSION_GE(8300)
+  config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 1 << 10);
+#else
   config->setMaxWorkspaceSize(1 << 10);
+#endif
   auto engine = builder->buildEngineWithConfig(*network, *config);
   EXPECT_NE(engine, nullptr);
   // Serialize the engine to create a model, then close.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- use setMemoryPoolLimit instead of setMaxWorkspaceSize since trt 8.3+

> setMaxWorkspaceSize is deprecated in TensorRT 8.3. Superseded by [IBuilderConfig::setMemoryPoolLimit()](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder_config.html#a0a88a9b43bbe47c839ba65de9b40779f) with [MemoryPoolType::kWORKSPACE]

refer to [link](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder_config.html#a8209999988ab480c60c8a905dfd2654d)