### PR TITLE
[PHI decoupling] remove dependency on 2 header files in fluid from phi

### DIFF
--- a/paddle/phi/kernels/cpu/scale_kernel.cc
+++ b/paddle/phi/kernels/cpu/scale_kernel.cc
@@ -21,8 +21,8 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 // See Note [ Why still include the fluid headers? ]
-#include "paddle/fluid/operators/eigen/eigen_function.h"
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 namespace phi {
 
 template <typename T, typename Context>
@@ -43,7 +43,7 @@ void ScaleKernel(const Context& dev_ctx,
   if (x.numel() <= 0 || (!x.IsInitialized())) {
     return;
   }
-  paddle::operators::EigenScale<std::decay_t<decltype(dev)>, T>::Eval(
+  phi::funcs::EigenScale<std::decay_t<decltype(dev)>, T>::Eval(
       dev,
       eigen_out,
       eigen_x,

--- a/paddle/phi/kernels/funcs/reduce_grad_functions.h
+++ b/paddle/phi/kernels/funcs/reduce_grad_functions.h
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include "paddle/fluid/operators/eigen/eigen_function.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/cpu/reduce.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
+#include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 namespace phi {
 
 namespace funcs {

--- a/paddle/phi/kernels/gpu/dot_kernel.cu
+++ b/paddle/phi/kernels/gpu/dot_kernel.cu
@@ -19,8 +19,8 @@
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 // See Note [ Why still include the fluid headers? ]
-#include "paddle/fluid/operators/eigen/eigen_function.h"
 #include "paddle/phi/common/complex.h"
+#include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/gpu/viterbi_decode_kernel.cu
+++ b/paddle/phi/kernels/gpu/viterbi_decode_kernel.cu
@@ -30,7 +30,6 @@ namespace cub = hipcub;
 #include <string>
 #include <vector>
 
-#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"

--- a/paddle/phi/kernels/gpu/viterbi_decode_kernel.cu
+++ b/paddle/phi/kernels/gpu/viterbi_decode_kernel.cu
@@ -30,6 +30,7 @@ namespace cub = hipcub;
 #include <string>
 #include <vector>
 
+#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"

--- a/paddle/phi/kernels/impl/dot_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/dot_grad_kernel_impl.h
@@ -14,11 +14,11 @@ limitations under the License. */
 
 #pragma once
 
-#include "paddle/fluid/operators/eigen/eigen_function.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/complex_kernel.h"
 #include "paddle/phi/kernels/funcs/complex_functors.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
+#include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 
 namespace phi {
 

--- a/paddle/phi/kernels/impl/sign_kernel_impl.h
+++ b/paddle/phi/kernels/impl/sign_kernel_impl.h
@@ -18,7 +18,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 // See Note [ Why still include the fluid headers? ]
-#include "paddle/fluid/operators/eigen/eigen_function.h"
+#include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
 
 namespace phi {
 
@@ -31,7 +31,7 @@ void SignKernel(const Context& dev_ctx,
   auto eigen_x = phi::EigenVector<T>::Flatten(x);
 
   auto& dev = *dev_ctx.eigen_device();
-  paddle::operators::EigenSign<std::decay_t<decltype(dev)>, T>::Eval(
+  phi::funcs::EigenSign<std::decay_t<decltype(dev)>, T>::Eval(
       dev, eigen_out, eigen_x);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
- #47615 

remove dependency on 2 header files in `fluid` from `phi`, including `paddle/fluid/operators/eigen/eigen_function.h` and `paddle/fluid/operators/elementwise/elementwise_op_function.h`.

changes：
1. replace `#include "paddle/fluid/operators/eigen/eigen_function.h"` by `#include "paddle/phi/kernels/funcs/eigen/eigen_function.h"`；replace `paddle::operators::EigenXXX` by `phi::funcs::EigenXXX`.
2. remove `#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"` in a file.

取消移除 `#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"`，该头文件的移除关联了另一个头文件 `paddle/fluid/operators/elementwise/elementwise_op_impl.cu.h`，后续一起处理这两个头文件。