### PR TITLE
Refine shape op lanch method for standalone executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -321,6 +321,9 @@ OpFuncType AnalyseOpFuncType(const OpFuncNode& op_func_node,
     return OpFuncType::kQueueSync;
   }
 
+  if (op->Type() == "shape") {
+    return OpFuncType::kQueueSync;
+  }
   return OpFuncType::kQueueAsync;
 }
 

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -321,9 +321,6 @@ OpFuncType AnalyseOpFuncType(const OpFuncNode& op_func_node,
     return OpFuncType::kQueueSync;
   }
 
-  if (op->Type() == "shape") {
-    return OpFuncType::kQueueSync;
-  }
   return OpFuncType::kQueueAsync;
 }
 

--- a/paddle/fluid/framework/new_executor/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.cc
@@ -90,6 +90,13 @@ std::vector<size_t> StreamAnalyzer::GetNeedEventVarIds(
     return false;
   };
 
+  auto is_shape_op = [](std::string op_name) {
+    if (op_name == "shape") {
+      return true;
+    }
+    return false;
+  };
+
   bool is_memcpy =
       interpreter::IsMemcpyOp(cur_instr) || interpreter::IsMemcpyOp(next_instr);
 
@@ -97,7 +104,7 @@ std::vector<size_t> StreamAnalyzer::GetNeedEventVarIds(
   for (auto& item : next_instr.Inputs()) {
     for (auto var_id : item.second) {
       if (unique_var_ids.count(var_id) > 0) {
-        if (is_memcpy) {
+        if (is_memcpy || is_shape_op(next_instr.OpBase()->Type())) {
           if (next_instr.NoDataTransformVars().count(var_id)) {
             VLOG(4) << "Skip inserting event at variable " << item.first
                     << " of operator " << next_instr.OpBase()->Type()
@@ -239,6 +246,11 @@ platform::DeviceContext* StreamAnalyzer::ParseDeviceContext(
  */
 bool StreamAnalyzer::IsDirectRun(Instruction& cur_instr,
                                  const Instruction& next_instr) {
+  if ((cur_instr.KernelType() == OpFuncType::kQueueSync) &&
+      (next_instr.KernelType() == OpFuncType::kQueueSync)) {
+    return true;
+  }
+
   if (cur_instr.KernelType() == next_instr.KernelType() &&
       (&cur_instr.DeviceContext() == &next_instr.DeviceContext())) {
     return true;

--- a/paddle/fluid/framework/new_executor/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.cc
@@ -90,13 +90,6 @@ std::vector<size_t> StreamAnalyzer::GetNeedEventVarIds(
     return false;
   };
 
-  auto is_shape_op = [](std::string op_name) {
-    if (op_name == "shape") {
-      return true;
-    }
-    return false;
-  };
-
   bool is_memcpy =
       interpreter::IsMemcpyOp(cur_instr) || interpreter::IsMemcpyOp(next_instr);
 
@@ -104,7 +97,7 @@ std::vector<size_t> StreamAnalyzer::GetNeedEventVarIds(
   for (auto& item : next_instr.Inputs()) {
     for (auto var_id : item.second) {
       if (unique_var_ids.count(var_id) > 0) {
-        if (is_memcpy || is_shape_op(next_instr.OpBase()->Type())) {
+        if (is_memcpy) {
           if (next_instr.NoDataTransformVars().count(var_id)) {
             VLOG(4) << "Skip inserting event at variable " << item.first
                     << " of operator " << next_instr.OpBase()->Type()
@@ -246,10 +239,6 @@ platform::DeviceContext* StreamAnalyzer::ParseDeviceContext(
  */
 bool StreamAnalyzer::IsDirectRun(Instruction& cur_instr,
                                  const Instruction& next_instr) {
-  if ((cur_instr.KernelType() == OpFuncType::kQueueSync) && (next_instr.KernelType() == OpFuncType::kQueueSync)) {
-    return true;
-  }
-
   if (cur_instr.KernelType() == next_instr.KernelType() &&
       (&cur_instr.DeviceContext() == &next_instr.DeviceContext())) {
     return true;

--- a/paddle/fluid/framework/new_executor/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/stream_analyzer.cc
@@ -90,6 +90,13 @@ std::vector<size_t> StreamAnalyzer::GetNeedEventVarIds(
     return false;
   };
 
+  auto is_shape_op = [](std::string op_name) {
+    if (op_name == "shape") {
+      return true;
+    }
+    return false;
+  };
+
   bool is_memcpy =
       interpreter::IsMemcpyOp(cur_instr) || interpreter::IsMemcpyOp(next_instr);
 
@@ -97,7 +104,7 @@ std::vector<size_t> StreamAnalyzer::GetNeedEventVarIds(
   for (auto& item : next_instr.Inputs()) {
     for (auto var_id : item.second) {
       if (unique_var_ids.count(var_id) > 0) {
-        if (is_memcpy) {
+        if (is_memcpy || is_shape_op(next_instr.OpBase()->Type())) {
           if (next_instr.NoDataTransformVars().count(var_id)) {
             VLOG(4) << "Skip inserting event at variable " << item.first
                     << " of operator " << next_instr.OpBase()->Type()
@@ -239,6 +246,10 @@ platform::DeviceContext* StreamAnalyzer::ParseDeviceContext(
  */
 bool StreamAnalyzer::IsDirectRun(Instruction& cur_instr,
                                  const Instruction& next_instr) {
+  if ((cur_instr.KernelType() == OpFuncType::kQueueSync) && (next_instr.KernelType() == OpFuncType::kQueueSync)) {
+    return true;
+  }
+
   if (cur_instr.KernelType() == next_instr.KernelType() &&
       (&cur_instr.DeviceContext() == &next_instr.DeviceContext())) {
     return true;

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2553,6 +2553,13 @@ void OperatorWithKernel::ParseInputDataType(
       }
     }
     if (t != nullptr) {
+      PADDLE_ENFORCE_EQ(t->IsInitialized(),
+                        true,
+                        platform::errors::InvalidArgument(
+                            "The %s Op's Input Variable `%s` "
+                            "contains uninitialized phi::DenseTensor.",
+                            Type(),
+                            name));
       *data_type = paddle::framework::TransToProtoVarType(t->dtype());
     }
   }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2553,13 +2553,6 @@ void OperatorWithKernel::ParseInputDataType(
       }
     }
     if (t != nullptr) {
-      PADDLE_ENFORCE_EQ(t->IsInitialized(),
-                        true,
-                        platform::errors::InvalidArgument(
-                            "The %s Op's Input Variable `%s` "
-                            "contains uninitialized phi::DenseTensor.",
-                            Type(),
-                            name));
       *data_type = paddle::framework::TransToProtoVarType(t->dtype());
     }
   }

--- a/paddle/fluid/framework/operator_test.cc
+++ b/paddle/fluid/framework/operator_test.cc
@@ -429,61 +429,6 @@ REGISTER_OP_CPU_KERNEL(
     indicate_other_data_type_test,
     paddle::framework::EmptyTestKernel<phi::CPUContext, int>);
 
-TEST(IndicateVarDataTypeTest, lodtensor) {
-  paddle::framework::InitDevices();
-  paddle::framework::proto::OpDesc op_desc;
-  op_desc.set_type("indicate_lod_tensor_data_type_test");
-  BuildVar("phi::DenseTensor", {"lodtensor_1"}, op_desc.add_inputs());
-
-  paddle::platform::CPUPlace cpu_place;
-  paddle::framework::Scope scope;
-
-  auto op = paddle::framework::OpRegistry::CreateOp(op_desc);
-  auto* var = scope.Var("lodtensor_1");
-  var->GetMutable<phi::DenseTensor>();
-
-  bool caught = false;
-  try {
-    op->Run(scope, cpu_place);
-  } catch (paddle::platform::EnforceNotMet& err) {
-    caught = true;
-    std::string ex_msg = err.what();
-    EXPECT_TRUE(
-        ex_msg.find(
-            "The indicate_lod_tensor_data_type_test Op's Input Variable "
-            "`phi::DenseTensor` contains uninitialized phi::DenseTensor.") !=
-        std::string::npos);
-  }
-  ASSERT_TRUE(caught);
-}
-
-TEST(IndicateVarDataTypeTest, selectedrows) {
-  paddle::framework::InitDevices();
-  paddle::framework::proto::OpDesc op_desc;
-  op_desc.set_type("indicate_selected_rows_data_type_test");
-  BuildVar("SelectedRows", {"selected_rows_1"}, op_desc.add_inputs());
-
-  paddle::platform::CPUPlace cpu_place;
-  paddle::framework::Scope scope;
-
-  auto op = paddle::framework::OpRegistry::CreateOp(op_desc);
-  auto* var = scope.Var("selected_rows_1");
-  var->GetMutable<phi::SelectedRows>();
-
-  bool caught = false;
-  try {
-    op->Run(scope, cpu_place);
-  } catch (paddle::platform::EnforceNotMet& err) {
-    caught = true;
-    std::string ex_msg = err.what();
-    EXPECT_TRUE(
-        ex_msg.find("The indicate_selected_rows_data_type_test Op's "
-                    "Input Variable `SelectedRows` contains uninitialized "
-                    "phi::DenseTensor.") != std::string::npos);
-  }
-  ASSERT_TRUE(caught);
-}
-
 TEST(IndicateVarDataTypeTest, other) {
   paddle::framework::InitDevices();
   paddle::framework::proto::OpDesc op_desc;

--- a/paddle/fluid/operators/shape_op.cc
+++ b/paddle/fluid/operators/shape_op.cc
@@ -60,6 +60,8 @@ Return the shape of the input.
   }
 };
 
+DECLARE_NO_NEED_BUFFER_VARS_INFERER(ShapeNoNeedBufferVarsInferer, "Input");
+
 }  // namespace operators
 }  // namespace paddle
 
@@ -76,4 +78,5 @@ REGISTER_OPERATOR(
     ops::ShapeOpMaker,
     paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
     paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>,
+    ops::ShapeNoNeedBufferVarsInferer,
     ShapeInferShapeFunctor);

--- a/paddle/fluid/operators/shape_op.cc
+++ b/paddle/fluid/operators/shape_op.cc
@@ -34,6 +34,8 @@ class ShapeOp : public framework::OperatorWithKernel {
     const phi::DenseTensor *t = nullptr;
     if (ctx.InputVar("Input")->IsType<phi::DenseTensor>()) {
       t = &ctx.InputVar("Input")->Get<phi::DenseTensor>();
+    } else if (ctx.InputVar("Input")->IsType<phi::SelectedRows>()) {
+      t = &(ctx.InputVar("Input")->Get<phi::SelectedRows>().value());
     }
     if (t != nullptr) {
       input_data_type = paddle::framework::TransToProtoVarType(t->dtype());
@@ -43,7 +45,8 @@ class ShapeOp : public framework::OperatorWithKernel {
                       platform::errors::InvalidArgument(
                           "The Input Variable(Input) of (shape) Operator used "
                           "to determine kernel "
-                          "data type is empty or not phi::DenseTensor."));
+                          "data type is empty or not phi::DenseTensor or "
+                          "phi::SelectedRows."));
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 

--- a/paddle/fluid/operators/shape_op.cc
+++ b/paddle/fluid/operators/shape_op.cc
@@ -60,8 +60,6 @@ Return the shape of the input.
   }
 };
 
-DECLARE_NO_NEED_BUFFER_VARS_INFERER(ShapeNoNeedBufferVarsInferer, "Input");
-
 }  // namespace operators
 }  // namespace paddle
 
@@ -78,5 +76,4 @@ REGISTER_OPERATOR(
     ops::ShapeOpMaker,
     paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
     paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>,
-    ops::ShapeNoNeedBufferVarsInferer,
     ShapeInferShapeFunctor);

--- a/paddle/fluid/operators/shape_op.cc
+++ b/paddle/fluid/operators/shape_op.cc
@@ -28,25 +28,8 @@ class ShapeOp : public framework::OperatorWithKernel {
 
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
-    framework::proto::VarType::Type dafault_data_type =
-        static_cast<framework::proto::VarType::Type>(-1);
-    framework::proto::VarType::Type input_data_type = dafault_data_type;
-    const phi::DenseTensor *t = nullptr;
-    if (ctx.InputVar("Input")->IsType<phi::DenseTensor>()) {
-      t = &ctx.InputVar("Input")->Get<phi::DenseTensor>();
-    } else if (ctx.InputVar("Input")->IsType<phi::SelectedRows>()) {
-      t = &(ctx.InputVar("Input")->Get<phi::SelectedRows>().value());
-    }
-    if (t != nullptr) {
-      input_data_type = paddle::framework::TransToProtoVarType(t->dtype());
-    }
-    PADDLE_ENFORCE_NE(input_data_type,
-                      dafault_data_type,
-                      platform::errors::InvalidArgument(
-                          "The Input Variable(Input) of (shape) Operator used "
-                          "to determine kernel "
-                          "data type is empty or not phi::DenseTensor or "
-                          "phi::SelectedRows."));
+    auto input_data_type =
+        framework::OperatorWithKernel::IndicateVarDataType(ctx, "Input");
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 

--- a/paddle/fluid/operators/shape_op.cc
+++ b/paddle/fluid/operators/shape_op.cc
@@ -28,8 +28,22 @@ class ShapeOp : public framework::OperatorWithKernel {
 
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
-    auto input_data_type =
-        framework::OperatorWithKernel::IndicateVarDataType(ctx, "Input");
+    framework::proto::VarType::Type dafault_data_type =
+        static_cast<framework::proto::VarType::Type>(-1);
+    framework::proto::VarType::Type input_data_type = dafault_data_type;
+    const phi::DenseTensor *t = nullptr;
+    if (ctx.InputVar("Input")->IsType<phi::DenseTensor>()) {
+      t = &ctx.InputVar("Input")->Get<phi::DenseTensor>();
+    }
+    if (t != nullptr) {
+      input_data_type = paddle::framework::TransToProtoVarType(t->dtype());
+    }
+    PADDLE_ENFORCE_NE(input_data_type,
+                      dafault_data_type,
+                      platform::errors::InvalidArgument(
+                          "The Input Variable(Input) of (shape) Operator used "
+                          "to determine kernel "
+                          "data type is empty or not phi::DenseTensor."));
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
优化shape op在新执行器的调度方法：
gpu 的shape op不需要拉起cuda kernel且不需要上游op的tensor，因此可以直接在host线程拉起，以免阻塞shape下游op的调度
- 优化前：shape在device thread拉起，与conv的kernel lanch存在一个同步
![图片](https://user-images.githubusercontent.com/82555433/201056240-4122ac80-b6dd-48e7-b1e9-7faa76caa343.png)
- 优化后：shape在host线程拉起，无需同conv kernel同步
![图片](https://user-images.githubusercontent.com/82555433/201056641-267bad6b-fc92-453a-9de8-fc704a4528b2.png)


