### PR TITLE
Modified mem_desc() to return reference to Tensor::memory::desc to avoid copying

### DIFF
--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -116,7 +116,7 @@ following codes there.
 #ifdef PADDLE_WITH_MKLDNN
 
 public:
-  dnnl::memory::desc mem_desc() const;
+  const dnnl::memory::desc& mem_desc() const;
 
 inline void set_mem_desc(const dnnl::memory::desc& mem_desc) {
   mem_desc_ = mem_desc;

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -344,7 +344,7 @@ std::vector<DenseTensor> DenseTensor::Chunk(int64_t chunks,
 }
 
 #ifdef PADDLE_WITH_MKLDNN
-dnnl::memory::desc DenseTensor::mem_desc() const { return mem_desc_; }
+const dnnl::memory::desc& DenseTensor::mem_desc() const { return mem_desc_; }
 #endif
 
 // NOTE: For historical reasons, this interface has a special behavior,


### PR DESCRIPTION
### PR types
 Others 

### PR changes
Others 

### Describe
Previously value of memory descriptor was returned from Tensor::mem_desc() . Which could result in unnecessery copying of 400 bytes. So this PR is to make mem_desc() return const reference. This should be safe as tensors live longer than operators where mem_desc() returned value is used.
