### PR TITLE
Add InferShape for depend OP

### DIFF
--- a/paddle/fluid/operators/controlflow/depend_op.cc
+++ b/paddle/fluid/operators/controlflow/depend_op.cc
@@ -59,6 +59,11 @@ class DependOp : public framework::OperatorBase {
   }
 };
 
+class DependOpShapeInference : public framework::InferShapeBase {
+ public:
+  void operator()(framework::InferShapeContext *ctx) const override {}
+};
+
 class DependOpProtoMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
@@ -97,4 +102,5 @@ REGISTER_OPERATOR(
     paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
     paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>,
     ops::DependOpProtoMaker,
+    ops::DependOpShapeInference,
     ops::DependNoNeedBufferVarsInferer);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe
<!-- Describe what this PR does -->
python端Program中插入depend op会触发infershape的调用，depend OP未注册infershape，在python端使用存在代码适配问题:
![981f4988ba1e04df722846d908b0c518](https://user-images.githubusercontent.com/17673696/201467622-d574ba55-8812-4d52-9f28-5175987a89c2.png)

本PR为depend OP注册infershape