### PR TITLE
Do not release memory cache after build_op_func_list in interpretercore

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -813,12 +813,6 @@ void BuildOpFuncList(const platform::Place& place,
 
     interpreter::LogDeviceMemoryStats(place);
   }
-
-  // NOTE(Ruibiao): Release memory cache to avoid memory fragments in Allocator.
-  // It reduce about 10% memory usage for V100 8-GPU training of
-  // transformer_base_bs4096_amp_fp16 and transformer_base_bs4096_pure_fp16
-  // model.
-  memory::Release(place);
 }
 
 void LogDeviceMemoryStats(const platform::Place& place) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
PR https://github.com/PaddlePaddle/Paddle/pull/46670 releases memory cache after build_op_func_list to avoid memory fragments in V100 8-GPU training of transformer_base_bs4096_amp_fp16 and transformer_base_bs4096_pure_fp16 models. However, this optimization method is not general that leads to a memory occupancy growth in other models such as A100 single-GPU training of deeplabv3 and SE_ResNeXt50_32x4d_bs32.
This PR tries to revert https://github.com/PaddlePaddle/Paddle/pull/46670. A more general fix-up method that avoid running kernel in build_op_func_list is ongoing. 