### PR TITLE
[PHI decoupling] remove "paddle/fluid/platform/complex.h" in phi

### DIFF
--- a/paddle/phi/backends/dynload/lapack.h
+++ b/paddle/phi/backends/dynload/lapack.h
@@ -17,7 +17,6 @@ limitations under the License. */
 #include <complex>
 #include <mutex>
 
-#include "paddle/fluid/platform/complex.h"
 #include "paddle/phi/backends/dynload/dynamic_loader.h"
 #include "paddle/phi/backends/dynload/port.h"
 

--- a/paddle/phi/kernels/cpu/concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/concat_kernel.cc
@@ -15,7 +15,7 @@
 #include "paddle/phi/kernels/concat_kernel.h"
 
 #include "paddle/fluid/operators/strided_memcpy.h"
-#include "paddle/fluid/platform/complex.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/scalar.h"

--- a/paddle/phi/kernels/cpu/concat_kernel.cc
+++ b/paddle/phi/kernels/cpu/concat_kernel.cc
@@ -15,9 +15,9 @@
 #include "paddle/phi/kernels/concat_kernel.h"
 
 #include "paddle/fluid/operators/strided_memcpy.h"
-#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/gpu/concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/concat_kernel.cu
@@ -15,7 +15,7 @@
 #include "paddle/phi/kernels/concat_kernel.h"
 
 #include "paddle/fluid/operators/strided_memcpy.h"
-#include "paddle/fluid/platform/complex.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/scalar.h"

--- a/paddle/phi/kernels/gpu/concat_kernel.cu
+++ b/paddle/phi/kernels/gpu/concat_kernel.cu
@@ -15,9 +15,9 @@
 #include "paddle/phi/kernels/concat_kernel.h"
 
 #include "paddle/fluid/operators/strided_memcpy.h"
-#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/bfloat16.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"

--- a/paddle/phi/kernels/gpu/pad_kernel.cu
+++ b/paddle/phi/kernels/gpu/pad_kernel.cu
@@ -14,8 +14,8 @@
 
 #include "paddle/phi/kernels/pad_kernel.h"
 
-#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/pad_kernel_impl.h"
 

--- a/paddle/phi/kernels/gpu/pad_kernel.cu
+++ b/paddle/phi/kernels/gpu/pad_kernel.cu
@@ -14,7 +14,7 @@
 
 #include "paddle/phi/kernels/pad_kernel.h"
 
-#include "paddle/fluid/platform/complex.h"
+#include "paddle/phi/common/complex.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/pad_kernel_impl.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
- #47615 

remove "paddle/fluid/platform/complex.h" in phi.

changes: replace `#include "paddle/fluid/platform/complex.h"` by `#include "paddle/phi/common/complex.h"`
