### PR TITLE
[Clean Fluid API]Remove API: remove dice_loss from paddle.fluid.layers

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -112,7 +112,6 @@ __all__ = [
     'label_smooth',
     'roi_pool',
     'roi_align',
-    'dice_loss',
     'image_resize',
     'image_resize_short',
     'resize_linear',
@@ -7450,53 +7449,6 @@ def roi_align(
         },
     )
     return align_out
-
-
-def dice_loss(input, label, epsilon=0.00001, name=None):
-    r"""
-
-    Dice loss for comparing the similarity between the input predictions and the label.
-    This implementation is for binary classification, where the input is sigmoid
-    predictions of each pixel, usually used for segmentation task. The dice loss can
-    be defined as the following equation:
-
-    .. math::
-
-        dice\_loss &= 1 - \frac{2 * intersection\_area}{total\_area} \\
-                  &= \frac{(total\_area - intersection\_area) - intersection\_area}{total\_area} \\
-                  &= \frac{(union\_area - intersection\_area)}{total\_area}
-
-
-    Parameters:
-        input (Tensor): Tensor, rank>=2, shape is :math:`[N_1, N_2, ..., N_k, D]`, where :math:`N_1` is
-                          the batch_size, :math:`D` is the number of categories. It is usually the output
-                          predictions of sigmoid activation. The data type can be float32 or float64.
-        label (Tensor): Tensor, the groud truth with the same rank as input, shape is :math:`[N_1, N_2, ..., N_k, 1]`.
-                          where :math:`N_1` is the batch_size. The data type can be int32 or int64.
-        epsilon (float): The epsilon will be added to the numerator and denominator.
-                         If both input and label are empty, it makes sure dice is 1.
-                         Default: 0.00001
-        name(str, optional): The default value is None.
-                             Normally there is no need for user to set this property.
-                             For more information, please refer to :ref:`api_guide_Name`
-
-    Returns:
-        Tensor, which shape is [1], data type is the same as `input` .
-
-    Example:
-        .. code-block:: python
-
-            import paddle
-            import paddle.nn.functional as F
-
-            x = paddle.randn((3,224,224,2))
-            label = paddle.randint(high=2, shape=(3,224,224,1))
-            predictions = F.softmax(x)
-            loss = F.dice_loss(input=predictions, label=label)
-    """
-    return paddle.nn.functional.dice_loss(
-        input, label, epsilon=epsilon, name=name
-    )
 
 
 def image_resize(

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -4453,38 +4453,6 @@ class TestBook(LayerTest):
         np.testing.assert_array_equal(static_res, dy_eager_res_value)
         np.testing.assert_array_equal(static_res, dy_res_value)
 
-    def test_dice_loss(self):
-        num_classes = 4
-        eps = 1e-6
-        input_np = np.random.rand(2, 3, num_classes).astype('float32')
-        label_np = np.random.randint(0, num_classes, [2, 3, 1], dtype=np.int64)
-
-        with self.static_graph():
-            input_ = layers.data(
-                name="input", shape=[None, 3, num_classes], dtype="float32"
-            )
-            label_ = layers.data(
-                name="label", shape=[None, 3, 1], dtype="int64"
-            )
-            output = layers.dice_loss(input_, label_, eps)
-            static_res = self.get_static_graph_result(
-                feed={'input': input_np, 'label': label_np}, fetch_list=[output]
-            )[0]
-
-        with self.dynamic_graph():
-            with _test_eager_guard():
-                input_ = base.to_variable(input_np)
-                label_ = base.to_variable(label_np)
-                dy_eager_res = layers.dice_loss(input_, label_, eps)
-                dy_eager_res_value = dy_eager_res.numpy()
-
-            input_ = base.to_variable(input_np)
-            label_ = base.to_variable(label_np)
-            dy_res = layers.dice_loss(input_, label_, eps)
-            dy_res_value = dy_res.numpy()
-        np.testing.assert_array_equal(static_res, dy_res_value)
-        np.testing.assert_array_equal(static_res, dy_eager_res_value)
-
     def test_roi_perspective_transform(self):
         # TODO(minqiyang): dygraph do not support lod now
         with self.static_graph():

--- a/python/paddle/fluid/tests/unittests/test_nn_dice_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_dice_loss.py
@@ -13,50 +13,9 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
-import paddle
-import paddle.fluid.layers.nn as nn
 
 num_classes = 4
 eps = 1e-6
-
-
-class TestDiceLossValue(unittest.TestCase):
-    def test_dice_loss(self):
-        input_ = paddle.rand([2, 3, num_classes])
-        label_ = paddle.randint(0, num_classes, [2, 3, 1], dtype=paddle.int64)
-
-        input_np, label_np = input_.numpy(), label_.numpy()
-        eye_np = np.eye(num_classes)
-        label_np = np.float32(eye_np[np.squeeze(label_np)])
-        input_np = np.reshape(input_np, [2, -1])
-        label_np = np.reshape(label_np, [2, -1])
-        intersection_np = np.sum(input_np * label_np, axis=-1)
-        union_np = input_np.sum(-1) + label_np.sum(-1)
-        dice_np = np.mean(1 - 2 * intersection_np / (union_np + eps))
-        dice_paddle = nn.dice_loss(input_, label_, eps)
-        np.testing.assert_allclose(dice_np, dice_paddle.numpy(), rtol=1e-05)
-
-
-class TestDiceLossInvalidInput(unittest.TestCase):
-    def test_error(self):
-        def test_invalid_dtype():
-            input_ = paddle.rand([2, 3, num_classes], dtype=paddle.float32)
-            label_ = paddle.randint(
-                0, num_classes, [2, 3, 1], dtype=paddle.int64
-            )
-            nn.dice_loss(input_, label_.astype(paddle.float32))
-
-        self.assertRaises(AssertionError, test_invalid_dtype)
-
-        def test_zero_shape_input():
-            input_ = paddle.rand([0, 3, num_classes], dtype=paddle.float32)
-            label_ = paddle.randint(
-                0, num_classes, [0, 3, 1], dtype=paddle.int64
-            )
-            nn.dice_loss(input_, label_)
-
-        self.assertRaises(AssertionError, test_zero_shape_input)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Remove API: dice_loss 
remove dice_loss which is not used in paddle 2.0