### PR TITLE
[PHI decoupling] remove "paddle/fluid/framework/tensor.h" in phi

### DIFF
--- a/paddle/phi/backends/custom/custom_device_test.cc
+++ b/paddle/phi/backends/custom/custom_device_test.cc
@@ -16,7 +16,6 @@
 
 #include <string>
 
-#include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/framework/variable.h"
 #include "paddle/fluid/imperative/gradient_accumulator.h"

--- a/paddle/phi/kernels/funcs/math_function.h
+++ b/paddle/phi/kernels/funcs/math_function.h
@@ -19,7 +19,6 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/fluid/framework/operator.h"
-#include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/platform/device_context.h"
 #include "paddle/fluid/platform/enforce.h"

--- a/paddle/phi/kernels/funcs/sequence2batch.cc
+++ b/paddle/phi/kernels/funcs/sequence2batch.cc
@@ -22,7 +22,7 @@ class CopyMatrixRowsFunctor<phi::CPUContext, T> {
  public:
   void operator()(const phi::CPUContext& context,
                   const phi::DenseTensor& src,
-                  paddle::framework::Vector<size_t> index_lod,
+                  std::vector<size_t> index_lod,
                   phi::DenseTensor* dst,
                   bool is_src_index) {
     size_t* index = index_lod.data();

--- a/paddle/phi/kernels/funcs/sequence2batch.cu
+++ b/paddle/phi/kernels/funcs/sequence2batch.cu
@@ -43,7 +43,7 @@ class CopyMatrixRowsFunctor<phi::GPUContext, T> {
  public:
   void operator()(const phi::GPUContext& context,
                   const phi::DenseTensor& src,
-                  paddle::framework::Vector<size_t> index_lod,
+                  std::vector<size_t> index_lod,
                   phi::DenseTensor* dst,
                   bool is_src_index) {
     auto src_dims = src.dims();

--- a/paddle/phi/kernels/funcs/sequence2batch.h
+++ b/paddle/phi/kernels/funcs/sequence2batch.h
@@ -16,8 +16,9 @@ limitations under the License. */
 #include <algorithm>
 #include <vector>
 
-#include "paddle/fluid/framework/tensor.h"
+#include "paddle/fluid/framework/mixed_vector.h"
 #include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/kernels/funcs/eigen/common.h"
 
 namespace phi {
@@ -38,7 +39,7 @@ class CopyMatrixRowsFunctor {
   // The indexed rows are based on the input index.
   void operator()(const DeviceContext& context,
                   const phi::DenseTensor& src,
-                  paddle::framework::Vector<size_t> index_lod,
+                  std::vector<size_t> index_lod,
                   phi::DenseTensor* dst,
                   bool is_src_index);
 };

--- a/paddle/phi/kernels/gpu/depthwise_conv.h
+++ b/paddle/phi/kernels/gpu/depthwise_conv.h
@@ -15,8 +15,8 @@ limitations under the License. */
 #pragma once
 #include <vector>
 
-#include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/hostdevice.h"
 
 #ifdef __NVCC__


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

remove "paddle/fluid/framework/tensor.h" in phi

修改:
- 移除或将 `#include "paddle/fluid/framework/tensor.h"` 替换为 `#include "paddle/phi/core/dense_tensor.h"`
- 替换 `paddle/fluid/framework/tensor.h` 中相关依赖项的调用
- `sequence2batch.h` 该文件通过 `paddle/fluid/framework/tensor.h` 依赖了 `paddle/fluid/framework/mixed_vector.h`, 这个也是我们要移除的依赖项，可以后续一起处理，所以我就另外添加了 `#include "paddle/fluid/framework/mixed_vector.h"`。
