### PR TITLE
Add trace mode for interpretercore

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
@@ -40,6 +40,10 @@ class DependencyBuilder {
 
   bool OpHappensBefore(int prior_op_idx, int posterior_op_idx);
 
+  const std::map<int, std::set<int>>& GetOpDownStreamMap() {
+    return op_downstream_map_;
+  }
+
  private:
   void AddDependencyForCoalesceTensorOp();
   void AddDependencyForCommunicationOp();

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -168,7 +168,9 @@ interpreter::CostInfo InterpreterCore::DryRun(
     // For the program that only run once, it is no need to
     // create work_queue, so the async_work_queue_ is created
     // until the second step run.
-    async_work_queue_ = GetWorkQueue();
+    if (!FLAGS_new_executor_trace_run) {
+      async_work_queue_ = GetWorkQueue();
+    }
 
     // lazy initialization of gc, do not create gc is the program only run once
     if (!gc_) {
@@ -205,7 +207,9 @@ paddle::framework::FetchList InterpreterCore::Run(
     // For the program that only run once, it is no need to
     // create work_queue, so the async_work_queue_ is created
     // until the second step run.
-    async_work_queue_ = GetWorkQueue();
+    if (!FLAGS_new_executor_trace_run) {
+      async_work_queue_ = GetWorkQueue();
+    }
 
     // lazy initialization of gc, do not create gc is the program only run once
     if (!gc_) {
@@ -271,7 +275,9 @@ paddle::framework::FetchList InterpreterCore::Run(
     // For the program that only run once, it is no need to
     // create work_queue, so the async_work_queue_ is created
     // until the second step run.
-    async_work_queue_ = GetWorkQueue();
+    if (!FLAGS_new_executor_trace_run) {
+      async_work_queue_ = GetWorkQueue();
+    }
 
     // lazy initialization of gc, do not create gc is the program only run once
     if (!gc_) {
@@ -868,12 +874,6 @@ void InterpreterCore::TraceInstructionList(
 
   if (UNLIKELY(exception_holder_.IsCaught())) {
     VLOG(1) << "Exception caught " << exception_holder_.Type();
-    // Graceful exit when the executor encountered a fatal error.
-    // EOF is not a fatal error.
-    if (exception_holder_.Type() != "EOF") {
-      async_work_queue_->Cancel();
-    }
-    VLOG(4) << "Cancel ok";
     PADDLE_ENFORCE_EQ(
         main_thread_blocker_.Clear(),
         0,

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -1280,6 +1280,8 @@ void InterpreterCore::AnalyseTraceExecuteOrder() {
   VLOG(1) << "Analyze the execution order of Trace scheduling mode.";
   interpreter::ResetAtomicGuard guard(&deps_, &refs_);
 
+  auto op_downstream_map = dependency_builder_.GetOpDownStreamMap();
+
   auto IsReady = [this](size_t next_id) {
     VLOG(4) << "op_id: " << next_id
             << ", remain deps: " << deps_[next_id]->DynamicDep();

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -52,9 +52,6 @@ PADDLE_DEFINE_EXPORTED_bool(new_executor_use_local_scope,
 PADDLE_DEFINE_EXPORTED_bool(control_flow_use_new_executor,
                             false,
                             "Use new executor in control flow op");
-PADDLE_DEFINE_EXPORTED_bool(new_executor_trace_run,
-                            true,
-                            "Enable trace execution for standalone executor.");
 
 DECLARE_bool(check_nan_inf);
 DECLARE_bool(benchmark);

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -202,9 +202,7 @@ paddle::framework::FetchList InterpreterCore::Run(
     // For the program that only run once, it is no need to
     // create work_queue, so the async_work_queue_ is created
     // until the second step run.
-    if (!(FLAGS_new_executor_trace_run && (sync_op_num_ == 0))) {
-      async_work_queue_ = GetWorkQueue();
-    }
+    async_work_queue_ = GetWorkQueue();
 
     // lazy initialization of gc, do not create gc is the program only run once
     if (!gc_) {
@@ -274,9 +272,7 @@ paddle::framework::FetchList InterpreterCore::Run(
     // For the program that only run once, it is no need to
     // create work_queue, so the async_work_queue_ is created
     // until the second step run.
-    if (!(FLAGS_new_executor_trace_run && (sync_op_num_ == 0))) {
-      async_work_queue_ = GetWorkQueue();
-    }
+    async_work_queue_ = GetWorkQueue();
 
     // lazy initialization of gc, do not create gc is the program only run once
     if (!gc_) {

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -209,10 +209,8 @@ paddle::framework::FetchList InterpreterCore::Run(
       gc_ = CreateInterpreterCoreGarbageCollector(place_, vec_instruction_);
     }
 
-    if (FLAGS_new_executor_trace_run) {
-      VLOG(0) << "FLAGS_new_executor_trace_run is: "
-              << FLAGS_new_executor_trace_run;
-      VLOG(0) << "sync_op_num_ is: " << sync_op_num_;
+    if (execution_config_.used_for_jit && (sync_op_num_ == 0)) {
+      VLOG(4) << "Tracing Instruction List";
       TraceInstructionList(vec_instruction_);
     } else {
       ExecuteInstructionList(vec_instruction_);
@@ -279,10 +277,8 @@ paddle::framework::FetchList InterpreterCore::Run(
       gc_ = CreateInterpreterCoreGarbageCollector(place_, vec_instruction_);
     }
 
-    if (FLAGS_new_executor_trace_run) {
-      VLOG(0) << "FLAGS_new_executor_trace_run is: "
-              << FLAGS_new_executor_trace_run;
-      VLOG(0) << "sync_op_num_ is: " << sync_op_num_;
+    if (execution_config_.used_for_jit && (sync_op_num_ == 0)) {
+      VLOG(4) << "Tracing Instruction List";
       TraceInstructionList(vec_instruction_);
     } else {
       ExecuteInstructionList(vec_instruction_);
@@ -821,7 +817,6 @@ void InterpreterCore::RunInstruction(const Instruction& instr_node) {
 
 void InterpreterCore::TraceInstructionList(
     const std::vector<Instruction>& vec_instr) {
-  VLOG(1) << "Tracing Instruction List ...";
   unfinished_op_number_ = vec_instr.size();
   if (unfinished_op_number_ == 0) {
     VLOG(4) << "No op to run, return";
@@ -1273,11 +1268,11 @@ void InterpreterCore::UpdateSyncOpNum() {
     }
   }
   sync_op_num_ = sync_op_num;
-  VLOG(0) << "Update sync op num, sync op num is: " << sync_op_num_;
+  VLOG(4) << "Update sync op num, sync op num is: " << sync_op_num_;
 }
 
 void InterpreterCore::AnalyseTraceExecuteOrder() {
-  VLOG(1) << "Analyze the execution order of Trace scheduling mode.";
+  VLOG(4) << "Analyze the execution order of Trace scheduling mode.";
   interpreter::ResetAtomicGuard guard(&deps_, &refs_);
 
   auto op_downstream_map = dependency_builder_.GetOpDownStreamMap();
@@ -1309,11 +1304,6 @@ void InterpreterCore::AnalyseTraceExecuteOrder() {
         ready_ops.push_back(next_op_id);
       }
     }
-  }
-
-  VLOG(6) << "get trace order: ";
-  for (auto idx : trace_order) {
-    VLOG(1) << idx;
   }
 
   PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -88,6 +88,7 @@ class InterpreterCore {
   void SetFeedVarsInplaceSkip(const std::vector<std::string>& feed_names);
 
   // execution
+  void TraceInstructionList(const std::vector<Instruction>& vec_instr);
   void ExecuteInstructionList(const std::vector<Instruction>& vec_instr);
   void RunInstructionAsync(size_t instr_id);
   void RunInstruction(const Instruction& instr_node);

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -80,6 +80,7 @@ class InterpreterCore {
   void BuildOperatorDependences();
   void BuildAndCacheInstructionCtx(Instruction* instr_node);
   void BuildSkipShareLoDInfo();
+  void UpdateSyncOpNum();
 
   // inplace
   void BuildInplace();
@@ -131,6 +132,8 @@ class InterpreterCore {
   std::vector<VariableMetaInfo> vec_meta_info_;
 
   std::vector<Instruction> vec_instruction_;  // deconstruct before OpFuncNode
+
+  int64_t sync_op_num_{-1};
 
   std::atomic<size_t> unfinished_op_number_{0};
   VariableScope var_scope_;

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -81,6 +81,7 @@ class InterpreterCore {
   void BuildAndCacheInstructionCtx(Instruction* instr_node);
   void BuildSkipShareLoDInfo();
   void UpdateSyncOpNum();
+  void AnalyseTraceExecuteOrder();
 
   // inplace
   void BuildInplace();
@@ -159,6 +160,8 @@ class InterpreterCore {
 
   std::vector<std::shared_ptr<interpreter::OpDepInfo>> deps_;
   std::vector<std::shared_ptr<interpreter::VarRefInfo>> refs_;
+
+  std::vector<size_t> trace_execute_order_;
 };
 
 std::shared_ptr<InterpreterCore> CreateInterpreterCore(

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -93,6 +93,7 @@ class InterpreterCore {
   void TraceInstructionList(const std::vector<Instruction>& vec_instr);
   void ExecuteInstructionList(const std::vector<Instruction>& vec_instr);
   void RunInstructionAsync(size_t instr_id);
+  void RunInstructionOp(const Instruction& instr_node);
   void RunInstruction(const Instruction& instr_node);
   void RunNextInstructions(const Instruction& instr_id,
                            std::deque<size_t>* reserved_next_ops);


### PR DESCRIPTION
### PR types
New features

### PR changes
Others

### Describe
**为新执行器的OP调度添加Trace模式。**
## 1. 背景
在A100训练环境下，存在11个动转静模型的新执行器（Interpretercore）训练性能低于旧执行器（PE），其中：5个模型下降5%-10%，6个模型下降超过10%。

以ResNet152_bs32_fp16单机单卡模型为例，通过timeline分析发现：相比使用PE，当动转静使用interpretercore时，优化器执行阶段的调度耗时会更长。

![图片](https://user-images.githubusercontent.com/82555433/202375417-06890f7a-6fe9-4e45-9656-7501d4cb71a4.png)

对于PE执行器的执行特点及实验现象，分析得到如下结论：
- PE执行过程中cpu切换很少，前向、反向、优化器阶段执行的耗时都是最小的。
- Interpretercore采用多线程调度模式，所有op的调度分发到子线程执行，实验结果表明：前反向用的1个cpu，所以耗时不长，但优化器部分和前反向部分使用不是一个cpu，优化器阶段耗时更长。

根据该实验现象及分析结论，怀疑优化器阶段耗时增加的原因是cpu cahce miss导致，采用perf工具对cache-misses参数进行统计：
- PE：998,753,937，Interpretercore：1,337,549,813

上述分析及实验结论充分证明：**优化器阶段调度耗时增加的原因是执行线程切换导致的。**
## 2. Trace调度模式
### 2.1 Trace调度模式设计
Interpretercore当前的调度才用了多线程调度模式，通过维护一个高性能线程池，将OP的调度分发到线程池维护的各个子线程中，例如上图中，执行器调度阶段，主线程没有任何任务，OP调度的任务分发到了子线程执行。这种调度特点也就导致了前、反向OP的调度与动态图优化器阶段的调度无法在相同线程执行。

此外执行器将所有OP分为2类：KQueueSync、KQueueAsync（kQueueSync表示该算子的所有运行逻辑均为CUDA同步的，而kQueueAsync表示该算子的运行逻辑中存在 CUDA异步操作），kQueueSync和kQueueAsync类型会分别分发到HostThread和DeviceThread线程池中进行调度。当kQueueSync类型OP较多的场景下，这种多线程的调度特点会尽可能的并发执行OP，不因同步问题而阻塞下游OP的调度。

但是，**当一个模型均为KQueueAsync类型OP的时候，所有OP都会分发到DeviceThread进行执行，多线程的调度也就不存在任何收益，还会因为线程切换带来额外开销，因此在该情况下，直接在主线程调度所有的OP会更好**，这种调度模式也就是Trace模式。

**Trace模式**：执行器会按照预先提供的OP顺序在主线程直接调度OP，而不再分发到线程池。（这里OP的顺序可能是Program中描述的OP顺序，也可是经过调度分析及优化后的OP顺序，本PR针对kQueueSync存在的场景采用广度遍历的方法对Program中描述的OP顺序进行了调度优化，后面会对此进行介绍）。

**基于上述分析结论，本PR将在动转静场景下，当模型OP均为KQueueAsync类型时，默认采用Trace调度逻辑**。

### 2.2 基于广度遍历的调度优化
当模型内存在KQueueSync类型OP时，采用广度遍历的方式会比深度遍历更好，如下图所示的示例，深度优先遍历会比广度优先遍历性能差：如果B在C之前调度，B可能会一直阻塞着以等待A执行结束，但其实这段时间是可以先执行C的。因此采用广度优先遍历的方案性能会更好

![图片](https://user-images.githubusercontent.com/82555433/202379272-ab16f4aa-79d3-429d-9181-0882a9b77d8a.png)
### 2.3 性能测试：
![图片](https://user-images.githubusercontent.com/82555433/202378654-fc0258ab-9e11-4dad-8244-12ddc28ffecf.png)




