### PR TITLE
[Paddle Inference] Add fill_any_like trt converter.

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -2255,6 +2255,7 @@ USE_TRT_CONVERTER(pad);
 USE_TRT_CONVERTER(hard_sigmoid);
 USE_TRT_CONVERTER(hard_swish);
 USE_TRT_CONVERTER(split);
+USE_TRT_CONVERTER(fill_any_like);
 USE_TRT_CONVERTER(prelu);
 USE_TRT_CONVERTER(conv2d_transpose);
 USE_TRT_CONVERTER(leaky_relu);

--- a/paddle/fluid/inference/tensorrt/convert/CMakeLists.txt
+++ b/paddle/fluid/inference/tensorrt/convert/CMakeLists.txt
@@ -25,6 +25,7 @@ list(
   multihead_matmul_op.cc
   multihead_matmul_roformer_op.cc
   shuffle_channel_op.cc
+  fill_any_like_op.cc
   where_op.cc
   swish_op.cc
   silu_op.cc

--- a/paddle/fluid/inference/tensorrt/convert/fill_any_like_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fill_any_like_op.cc
@@ -1,0 +1,92 @@
+/* Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/inference/tensorrt/convert/op_converter.h"
+
+namespace paddle {
+namespace framework {
+class Scope;
+
+namespace proto {
+class OpDesc;
+}  // namespace proto
+}  // namespace framework
+}  // namespace paddle
+
+namespace paddle {
+namespace inference {
+namespace tensorrt {
+
+class FillAnyLikeOpConverter : public OpConverter {
+ public:
+  void operator()(const framework::proto::OpDesc& op,
+                  const framework::Scope& scope,
+                  bool test_mode) override {
+    VLOG(3) << "convert fill_any_like op to tensorrt layer ";
+    framework::OpDesc op_desc(op, nullptr);
+    auto* input = engine_->GetITensor(op_desc.Input("X").front());
+    auto output_name = op_desc.Output("Out").front();
+    auto input_dims = input->getDimensions();
+    auto nbDims_num = input_dims.nbDims;
+    nvinfer1::ITensor* value_tensor;
+
+    const int dtype = PADDLE_GET_CONST(int, op_desc.GetAttr("dtype"));
+    float value = PADDLE_GET_CONST(float, op_desc.GetAttr("value"));
+    if (dtype == 2) {
+      value_tensor = Add1DConstantLayer(static_cast<int32_t>(value),
+                                        output_name + "_value_tensor_");
+    } else {
+      value_tensor = Add1DConstantLayer(value, output_name + "_value_tensor_");
+    }
+    auto shape_tensor = Shape(input);
+    auto* one_rank_tensor = Add1DConstantLayer(
+        std::vector<int32_t>(nbDims_num, 1), output_name + "_one_rank_tensor_");
+    auto input_shape_tensor = one_rank_tensor;
+    auto* shuffle = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *value_tensor);
+    shuffle->setInput(1, *input_shape_tensor);
+
+    std::vector<int32_t> start_vec(nbDims_num, 0);
+    nvinfer1::Dims start;
+    start.nbDims = nbDims_num;
+    for (int32_t i = 0; i < nbDims_num; ++i) {
+      start.d[i] = start_vec[i];
+    }
+    nvinfer1::Dims size;
+    size.nbDims = nbDims_num;
+    nvinfer1::Dims stride;
+    stride.nbDims = nbDims_num;
+
+    auto starts_tensor =
+        Add1DConstantLayer(start_vec, output_name + "_start_tensor_");
+    auto one_tensor = Add1DConstantLayer(1, output_name + "_one_tensor_");
+
+    auto sizes_tensor = Max(input_shape_tensor, shape_tensor);
+    auto input_sub_tensor = Sub(input_shape_tensor, one_tensor);
+    auto strides_tensor = Min(one_tensor, input_sub_tensor);
+
+    auto layer = TRT_ENGINE_ADD_LAYER(
+        engine_, Slice, *shuffle->getOutput(0), start, size, stride);
+    layer->setInput(1, *starts_tensor);
+    layer->setInput(2, *sizes_tensor);
+    layer->setInput(3, *strides_tensor);
+
+    RreplenishLayerAndOutput(layer, "fill_any_like", {output_name}, test_mode);
+  }
+};
+
+}  // namespace tensorrt
+}  // namespace inference
+}  // namespace paddle
+
+REGISTER_TRT_OP_CONVERTER(fill_any_like, FillAnyLikeOpConverter);

--- a/paddle/fluid/inference/tensorrt/convert/fill_any_like_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fill_any_like_op.cc
@@ -43,7 +43,8 @@ class FillAnyLikeOpConverter : public OpConverter {
 
     const int dtype = PADDLE_GET_CONST(int, op_desc.GetAttr("dtype"));
     float value = PADDLE_GET_CONST(float, op_desc.GetAttr("value"));
-    if (dtype == 2) {
+    if ((dtype == 2) ||
+        (dtype == -1 && input->getType() == nvinfer1::DataType::kINT32)) {
       value_tensor = Add1DConstantLayer(static_cast<int32_t>(value),
                                         output_name + "_value_tensor_");
     } else {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1167,9 +1167,19 @@ struct SimpleOpTypeSetTeller : public Teller {
         return false;
       }
       int dtype = PADDLE_GET_CONST(int, desc.GetAttr("dtype"));
-      if (dtype != 2 && dtype != 5) {
+      if (dtype != -1 && dtype != 2 && dtype != 5) {
         VLOG(3) << "the fill_any_like only supports int32 and float32";
         return false;
+      }
+      if (dtype == -1) {
+        auto* block = desc.Block();
+        auto* x_var_desc = block->FindVar(desc.Input("X")[0]);
+        auto input_type = x_var_desc->GetDataType();
+        if (input_type != framework::proto::VarType::INT32 &&
+            input_type != framework::proto::VarType::FP32) {
+          VLOG(3) << "the fill_any_like only supports int32 and float32";
+          return false;
+        }
       }
     }
 

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1161,6 +1161,18 @@ struct SimpleOpTypeSetTeller : public Teller {
       }
     }
 
+    if (op_type == "fill_any_like") {
+      if (!with_dynamic_shape) {
+        VLOG(3) << "the fill_any_like does not support static shape yet";
+        return false;
+      }
+      int dtype = PADDLE_GET_CONST(int, desc.GetAttr("dtype"));
+      if (dtype != 2 && dtype != 5) {
+        VLOG(3) << "the fill_any_like only supports int32 and float32";
+        return false;
+      }
+    }
+
     if (op_type == "slice") {
       if (desc.HasAttr("decrease_axis")) {
         std::vector<int> decrease_axis =
@@ -2290,6 +2302,7 @@ struct SimpleOpTypeSetTeller : public Teller {
       "elementwise_max",
       "equal",
       "dropout",
+      "fill_any_like",
       "prelu",
       "conv2d_transpose",
       "depthwise_conv2d_transpose",
@@ -2415,6 +2428,7 @@ struct SimpleOpTypeSetTeller : public Teller {
       "elementwise_max",
       "equal",
       "dropout",
+      "fill_any_like",
       "prelu",
       "conv2d_transpose",
       "depthwise_conv2d_transpose",

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_any_like.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_any_like.py
@@ -35,7 +35,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
                 self.input_shape = [1, 1, 4, 6]
                 if self.dtype == 0:
                     return np.random.random([1, 1, 4, 6]).astype(np.bool)
-                elif self.dtype == 2:
+                elif self.dtype == 2 or self.dtype == -1:
                     return np.random.random([1, 1, 4, 6]).astype(np.int32)
                 elif self.dtype == 3:
                     return np.random.random([1, 1, 4, 6]).astype(np.int64)
@@ -64,7 +64,7 @@ class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
 
         for dims in [1, 2, 3, 4]:
             for value in [2]:
-                for dtype in [0, 2, 3, 4, 5]:
+                for dtype in [-1, 0, 2, 3, 4, 5]:
                     dics = [
                         {
                             "value": value,

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_any_like.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_any_like.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest
+from program_config import TensorConfig, ProgramConfig
+import numpy as np
+import paddle.inference as paddle_infer
+from functools import partial
+from typing import List, Dict, Any
+import unittest
+
+
+class TrtConvertExpandV2Test(TrtLayerAutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        if self.dtype in [0, 3, 4]:
+            return False
+        if self.dims != 4 and self.dtype != 2:
+            return False
+        return True
+
+    def sample_program_configs(self):
+        def generate_input1(attrs: List[Dict[str, Any]]):
+            if self.dims == 4:
+                self.input_shape = [1, 1, 4, 6]
+                if self.dtype == 0:
+                    return np.random.random([1, 1, 4, 6]).astype(np.bool)
+                elif self.dtype == 2:
+                    return np.random.random([1, 1, 4, 6]).astype(np.int32)
+                elif self.dtype == 3:
+                    return np.random.random([1, 1, 4, 6]).astype(np.int64)
+                elif self.dtype == 4:
+                    return np.random.random([1, 1, 4, 6]).astype(np.float16)
+                else:
+                    return np.random.random([1, 1, 4, 6]).astype(np.float32)
+            elif self.dims == 3:
+                self.input_shape = [1, 8, 6]
+                return np.random.random([1, 8, 6]).astype(np.int32)
+            elif self.dims == 2:
+                self.input_shape = [1, 48]
+                return np.random.random([1, 48]).astype(np.int32)
+            elif self.dims == 1:
+                self.input_shape = [48]
+                return np.random.random([48]).astype(np.int32)
+
+        def generate_weight1(attrs: List[Dict[str, Any]]):
+            return np.array([1, 48]).astype(np.int32)
+
+        def generate_shapeT1_data(attrs: List[Dict[str, Any]]):
+            return np.array([2]).astype(np.int32)
+
+        def generate_shapeT2_data(attrs: List[Dict[str, Any]]):
+            return np.array([24]).astype(np.int32)
+
+        for dims in [1, 2, 3, 4]:
+            for value in [2]:
+                for dtype in [0, 2, 3, 4, 5]:
+                    dics = [
+                        {
+                            "value": value,
+                            "dtype": dtype,
+                        },
+                    ]
+                    self.dims = dims
+                    self.dtype = dtype
+                    dics_intput = [{"X": ["fill_any_like_input"]}]
+
+                    ops_config = [
+                        {
+                            "op_type": "fill_any_like",
+                            "op_inputs": dics_intput[0],
+                            "op_outputs": {"Out": ["fill_any_like_out"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
+                    ops = self.generate_op_config(ops_config)
+                    program_config = ProgramConfig(
+                        ops=ops,
+                        weights={},
+                        inputs={
+                            "fill_any_like_input": TensorConfig(
+                                data_gen=partial(generate_input1, dics)
+                            )
+                        },
+                        outputs=["fill_any_like_out"],
+                    )
+
+                    yield program_config
+
+    def sample_predictor_configs(
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], int):
+        def generate_dynamic_shape(attrs):
+            if self.dims == 4:
+                self.dynamic_shape.min_input_shape = {
+                    "fill_any_like_input": [1, 1, 4, 6]
+                }
+                self.dynamic_shape.max_input_shape = {
+                    "fill_any_like_input": [10, 1, 4, 6]
+                }
+                self.dynamic_shape.opt_input_shape = {
+                    "fill_any_like_input": [1, 1, 4, 6]
+                }
+            elif self.dims == 3:
+                self.dynamic_shape.min_input_shape = {
+                    "fill_any_like_input": [1, 8, 6]
+                }
+                self.dynamic_shape.max_input_shape = {
+                    "fill_any_like_input": [4, 8, 6]
+                }
+                self.dynamic_shape.opt_input_shape = {
+                    "fill_any_like_input": [1, 8, 6]
+                }
+            elif self.dims == 2:
+                self.dynamic_shape.min_input_shape = {
+                    "fill_any_like_input": [1, 48]
+                }
+                self.dynamic_shape.max_input_shape = {
+                    "fill_any_like_input": [4, 48]
+                }
+                self.dynamic_shape.opt_input_shape = {
+                    "fill_any_like_input": [1, 48]
+                }
+            elif self.dims == 1:
+                self.dynamic_shape.min_input_shape = {
+                    "fill_any_like_input": [48]
+                }
+                self.dynamic_shape.max_input_shape = {
+                    "fill_any_like_input": [48]
+                }
+                self.dynamic_shape.opt_input_shape = {
+                    "fill_any_like_input": [48]
+                }
+
+        def clear_dynamic_shape():
+            self.dynamic_shape.min_input_shape = {}
+            self.dynamic_shape.max_input_shape = {}
+            self.dynamic_shape.opt_input_shape = {}
+
+        def generate_trt_nodes_num(attrs, dynamic_shape):
+            if not dynamic_shape:
+                return 0, 3
+            else:
+                return 1, 2
+
+        attrs = [
+            program_config.ops[i].attrs for i in range(len(program_config.ops))
+        ]
+
+        clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False
+        ), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False
+        ), 1e-5
+
+        # for dynamic_shape
+        generate_dynamic_shape(attrs)
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True
+        ), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True
+        ), 1e-5
+
+    def add_skip_trt_case(self):
+        pass
+
+    def test(self):
+        self.add_skip_trt_case()
+        self.run_test()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fill_any_like trt converter only support int32 float32 