### PR TITLE
Update `ProcessGroupCustom` for `sync_op` compatibility

### DIFF
--- a/paddle/fluid/distributed/collective/ProcessGroupCustom.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupCustom.cc
@@ -299,6 +299,18 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Barrier(
   return task;
 }
 
+const phi::DeviceContext& ProcessGroupCustom::GetDeviceContext(
+    const Place& place) const {
+  const std::string key = GetKeyFromPlace(place);
+  const auto& iter = places_to_ctx_.find(key);
+  PADDLE_ENFORCE_NE(
+      iter,
+      places_to_ctx_.end(),
+      platform::errors::NotFound(
+          "Cannot find the device context in this process group."));
+  return *iter->second[0];
+}
+
 phi::ccl::CCLComm ProcessGroupCustom::CustomCCLComm(const Place& place) const {
   std::vector<Place> places = {place};
   const auto& iter = places_to_customcomm_.find(GetKeyFromPlaces(places));

--- a/paddle/fluid/distributed/collective/ProcessGroupCustom.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupCustom.h
@@ -95,6 +95,21 @@ class ProcessGroupCustom : public ProcessGroup {
 
   phi::ccl::CCLComm CustomCCLComm(const Place& place) const;
 
+  // TODO(sunyilun): methods below will be removed later
+  std::shared_ptr<ProcessGroup::Task> AllGather(
+      std::vector<phi::DenseTensor>& in_tensors,
+      std::vector<phi::DenseTensor>& out_tensors) override;
+
+  std::shared_ptr<ProcessGroup::Task> AllReduce(
+      std::vector<phi::DenseTensor>& in_tensors,
+      std::vector<phi::DenseTensor>& out_tensors,
+      const AllreduceOptions& = AllreduceOptions()) override;
+
+  std::shared_ptr<ProcessGroup::Task> Broadcast(
+      std::vector<phi::DenseTensor>& in_tensors,
+      std::vector<phi::DenseTensor>& out_tensors,
+      const BroadcastOptions& = BroadcastOptions()) override;
+
  protected:
   virtual std::shared_ptr<ProcessGroupCustom::CustomTask> CreateTask(
       std::vector<Place> places,

--- a/paddle/fluid/distributed/collective/ProcessGroupCustom.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupCustom.h
@@ -78,19 +78,17 @@ class ProcessGroupCustom : public ProcessGroup {
       int64_t numel,
       bool sync_op) override;
 
-  std::shared_ptr<ProcessGroup::Task> AllGather(
-      std::vector<phi::DenseTensor>& in_tensors,
-      std::vector<phi::DenseTensor>& out_tensors) override;
-
   std::shared_ptr<ProcessGroup::Task> AllReduce(
-      std::vector<phi::DenseTensor>& in_tensors,
-      std::vector<phi::DenseTensor>& out_tensors,
-      const AllreduceOptions& = AllreduceOptions()) override;
+      phi::DenseTensor* out_tensor,
+      const phi::DenseTensor& in_tensor,
+      const AllreduceOptions& opts,
+      bool sync_op) override;
 
   std::shared_ptr<ProcessGroup::Task> Broadcast(
-      std::vector<phi::DenseTensor>& in_tensors,
-      std::vector<phi::DenseTensor>& out_tensors,
-      const BroadcastOptions& = BroadcastOptions()) override;
+      phi::DenseTensor* out_tensor,
+      const phi::DenseTensor& in_tensor,
+      const BroadcastOptions& opts,
+      bool sync_op) override;
 
   std::shared_ptr<ProcessGroup::Task> Barrier(
       const BarrierOptions& = BarrierOptions()) override;

--- a/paddle/fluid/distributed/collective/ProcessGroupCustom.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupCustom.h
@@ -93,6 +93,8 @@ class ProcessGroupCustom : public ProcessGroup {
   std::shared_ptr<ProcessGroup::Task> Barrier(
       const BarrierOptions& = BarrierOptions()) override;
 
+  const phi::DeviceContext& GetDeviceContext(const Place& place) const override;
+
   phi::ccl::CCLComm CustomCCLComm(const Place& place) const;
 
   // TODO(sunyilun): methods below will be removed later

--- a/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
+++ b/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
@@ -63,11 +63,11 @@ class TestProcessGroupFp32(unittest.TestCase):
 
             sum_result = tensor_x + tensor_y
             if pg.rank() == 0:
-                task = pg.allreduce(tensor_x)
+                task = pg.all_reduce(tensor_x, core.ReduceOp.SUM, sync_op=True)
                 task.wait()
                 # assert np.array_equal(tensor_x, sum_result)
             else:
-                task = pg.allreduce(tensor_y)
+                task = pg.allreduce(tensor_y, core.ReduceOp.SUM, sync_op=True)
                 task.wait()
                 # assert np.array_equal(tensor_y, sum_result)
 
@@ -81,11 +81,11 @@ class TestProcessGroupFp32(unittest.TestCase):
             max_result = paddle.maximum(tensor_x, tensor_y)
 
             if pg.rank() == 0:
-                task = pg.allreduce(tensor_x, core.ReduceOp.MAX)
+                task = pg.all_reduce(tensor_x, core.ReduceOp.MAX, sync_op=True)
                 task.wait()
                 # assert np.array_equal(tensor_x, max_result)
             else:
-                task = pg.allreduce(tensor_y, core.ReduceOp.MAX)
+                task = pg.all_reduce(tensor_y, core.ReduceOp.MAX, sync_op=True)
                 task.wait()
                 # assert np.array_equal(tensor_y, max_result)
 
@@ -101,14 +101,14 @@ class TestProcessGroupFp32(unittest.TestCase):
 
             broadcast_result = paddle.assign(tensor_x)
             if pg.rank() == 0:
-                task = pg.broadcast(tensor_x, 0)
-                task.synchronize()
+                task = pg.broadcast(tensor_x, 0, sync_op=True)
+                task.wait()
                 # paddle.fluid.core._custom_device_synchronize("custom_cpu", -1)
                 assert task.is_completed()
                 # assert np.array_equal(broadcast_result, tensor_x)
             else:
-                task = pg.broadcast(tensor_y, 0)
-                task.synchronize()
+                task = pg.broadcast(tensor_y, 0, sync_op=True)
+                task.wait()
                 # paddle.fluid.core._custom_device_synchronize("custom_cpu", -1)
                 assert task.is_completed()
                 # assert np.array_equal(broadcast_result, tensor_y)
@@ -139,12 +139,12 @@ class TestProcessGroupFp32(unittest.TestCase):
             out = np.random.random(out_shape).astype(self.dtype)
             tensor_out = paddle.to_tensor(out)
             if pg.rank() == 0:
-                task = pg.all_gather(tensor_x, tensor_out)
+                task = pg.all_gather(tensor_out, tensor_x, sync_op=True)
                 task.wait()
                 # paddle.fluid.core._custom_device_synchronize("custom_cpu", -1)
             # rank 1
             else:
-                task = pg.all_gather(tensor_y, tensor_out)
+                task = pg.all_gather(tensor_out, tensor_y, sync_op=True)
                 task.wait()
                 # paddle.fluid.core._custom_device_synchronize("custom_cpu", -1)
             out_1 = paddle.slice(tensor_out, [0], [0], [out_shape[0] // 2])

--- a/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
+++ b/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
@@ -67,7 +67,7 @@ class TestProcessGroupFp32(unittest.TestCase):
                 task.wait()
                 # assert np.array_equal(tensor_x, sum_result)
             else:
-                task = pg.allreduce(tensor_y, core.ReduceOp.SUM, sync_op=True)
+                task = pg.all_reduce(tensor_y, core.ReduceOp.SUM, sync_op=True)
                 task.wait()
                 # assert np.array_equal(tensor_y, sum_result)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
由于`ProcessGroup`接口升级而`ProcessGroupCustom`的接口未完全对齐，套件在自定义硬件上运行时可能出现问题，需要更新 `ProcessGroupCustom`的接口。同时，为了确保兼容性，需要保留旧的通信接口。