### PR TITLE
remove avx check

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -285,8 +285,6 @@ void InitDevices(const std::vector<int> devices) {
 #ifndef PADDLE_WITH_MKLDNN
   platform::SetNumThreads(FLAGS_paddle_num_threads);
 #endif
-
-#endif
 }
 
 #ifndef _WIN32

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -286,50 +286,6 @@ void InitDevices(const std::vector<int> devices) {
   platform::SetNumThreads(FLAGS_paddle_num_threads);
 #endif
 
-#if !defined(_WIN32) && !defined(__APPLE__) && !defined(__OSX__)
-  if (platform::MayIUse(platform::avx)) {
-#ifndef __AVX__
-    LOG(WARNING) << "AVX is available, Please re-compile on local machine";
-#endif
-  }
-
-// Throw some informations when CPU instructions mismatch.
-#define AVX_GUIDE(compiletime, runtime)                                  \
-  PADDLE_THROW(platform::errors::Unavailable(                            \
-      "This version is compiled on higher instruction(" #compiletime     \
-      ") system, you may encounter illegal instruction error running on" \
-      " your local CPU machine. Please reinstall the " #runtime          \
-      " version or compile from source code."))
-
-#ifdef __AVX512F__
-  if (!platform::MayIUse(platform::avx512f)) {
-    if (platform::MayIUse(platform::avx2)) {
-      AVX_GUIDE(AVX512, AVX2);
-    } else if (platform::MayIUse(platform::avx)) {
-      AVX_GUIDE(AVX512, AVX);
-    } else {
-      AVX_GUIDE(AVX512, NonAVX);
-    }
-  }
-#endif
-
-#ifdef __AVX2__
-  if (!platform::MayIUse(platform::avx2)) {
-    if (platform::MayIUse(platform::avx)) {
-      AVX_GUIDE(AVX2, AVX);
-    } else {
-      AVX_GUIDE(AVX2, NonAVX);
-    }
-  }
-#endif
-
-#ifdef __AVX__
-  if (!platform::MayIUse(platform::avx)) {
-    AVX_GUIDE(AVX, NonAVX);
-  }
-#endif
-#undef AVX_GUIDE
-
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
由于以下原因，飞桨放弃对不支持avx指令集的cpu支持：

1. 由于不支持avx指令集的cpu是非常旧的cpu（10年前发布的cpu），目前主流用户使用这种机器的比例非常非常低
2. 同时飞桨框架内部基于avx指令集实现的kernel的数量是非常少的，10个左右，并且大部分属于后面要退场的kernel

该PR优先跳过import paddle阶段的指令检查
