### PR TITLE
fix mac link python

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -651,5 +651,12 @@ if(WITH_PYTHON)
   target_link_libraries(${SHARD_LIB_NAME} ${os_dependency_modules})
   add_dependencies(${SHARD_LIB_NAME} op_function_generator_cmd)
 
-  target_link_libraries(${SHARD_LIB_NAME} ${PYTHON_LIBRARIES})
+  if(APPLE)
+    string(REGEX REPLACE ".+/(.+)" "\\1" PYTHON_LIBRARY_NAME
+                         ${PYTHON_LIBRARIES})
+    target_link_libraries(${SHARD_LIB_NAME} "-Wl,-rpath,${PYTHON_LIBRARY_NAME}")
+  else()
+    target_link_libraries(${SHARD_LIB_NAME} ${PYTHON_LIBRARIES})
+  endif()
+
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
修改安装包，在mac conda下找不到动态链接库问题