### PR TITLE
[PHI decoupling] remove "paddle/fluid/framework/gpu_utils.h" in phi

### DIFF
--- a/paddle/phi/kernels/gpu/transpose_kernel.cu
+++ b/paddle/phi/kernels/gpu/transpose_kernel.cu
@@ -16,7 +16,6 @@
 
 #include <vector>
 
-#include "paddle/fluid/framework/gpu_utils.h"
 #include "paddle/fluid/operators/transpose_op.cu.h"
 #include "paddle/fluid/platform/device/gpu/gpu_primitives.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

- #47615 

remove "paddle/fluid/framework/gpu_utils.h" in phi

简单题，直接去除 `#include"paddle/fluid/framework/gpu_utils.h"` 后编译就能过。
