### PR TITLE
xpu.cmake: use baidu-kunlun-product. update to 1116.

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -10,18 +10,9 @@ set(XPU_RT_LIB_NAME "libxpurt.so")
 if(NOT DEFINED XPU_BASE_URL)
   set(XPU_BASE_URL_WITHOUT_DATE
       "https://baidu-kunlun-product.su.bcebos.com/KL-SDK/klsdk-dev")
-  set(XPU_BASE_URL "${XPU_BASE_URL_WITHOUT_DATE}/20221110")
+  set(XPU_BASE_URL "${XPU_BASE_URL_WITHOUT_DATE}/20221116")
 else()
   set(XPU_BASE_URL "${XPU_BASE_URL}")
-endif()
-
-# ubuntu and centos: use output by XDNN API team
-if(NOT DEFINED XPU_XDNN_BASE_URL)
-  set(XPU_XDNN_BASE_URL_WITHOUT_DATE
-      "https://klx-sdk-release-public.su.bcebos.com/xdnn/dev")
-  set(XPU_XDNN_BASE_URL "${XPU_XDNN_BASE_URL_WITHOUT_DATE}/20221109")
-else()
-  set(XPU_XDNN_BASE_URL "${XPU_XDNN_BASE_URL}")
 endif()
 
 set(XPU_XCCL_BASE_URL
@@ -31,52 +22,33 @@ if(WITH_AARCH64)
   set(XPU_XRE_DIR_NAME "xre-kylin_aarch64")
   set(XPU_XDNN_DIR_NAME "xdnn-kylin_aarch64")
   set(XPU_XCCL_DIR_NAME "xccl-kylin_aarch64")
-  set(XPU_XDNN_URL
-      "${XPU_XDNN_BASE_URL}/${XPU_XDNN_DIR_NAME}.tar.gz"
-      CACHE STRING "" FORCE)
 elseif(WITH_SUNWAY)
   set(XPU_XRE_DIR_NAME "xre-deepin_sw6_64")
   set(XPU_XDNN_DIR_NAME "xdnn-deepin_sw6_64")
   set(XPU_XCCL_DIR_NAME "xccl-deepin_sw6_64")
-  set(XPU_XDNN_URL
-      "${XPU_BASE_URL}/${XPU_XDNN_DIR_NAME}.tar.gz"
-      CACHE STRING "" FORCE)
 elseif(WITH_BDCENTOS)
   set(XPU_XRE_DIR_NAME "xre-bdcentos_x86_64")
   set(XPU_XDNN_DIR_NAME "xdnn-bdcentos_x86_64")
   set(XPU_XCCL_DIR_NAME "xccl-bdcentos_x86_64")
-  # ubuntu and centos: use output by XDNN API team
-  set(XPU_XDNN_URL
-      "${XPU_XDNN_BASE_URL}/${XPU_XDNN_DIR_NAME}.tar.gz"
-      CACHE STRING "" FORCE)
 elseif(WITH_UBUNTU)
   set(XPU_XRE_DIR_NAME "xre-ubuntu_x86_64")
   set(XPU_XDNN_DIR_NAME "xdnn-ubuntu_x86_64")
   set(XPU_XCCL_DIR_NAME "xccl-ubuntu_x86_64")
-  # ubuntu and centos: use output by XDNN API team
-  set(XPU_XDNN_URL
-      "${XPU_XDNN_BASE_URL}/${XPU_XDNN_DIR_NAME}.tar.gz"
-      CACHE STRING "" FORCE)
 elseif(WITH_CENTOS)
   set(XPU_XRE_DIR_NAME "xre-centos7_x86_64")
-  set(XPU_XDNN_DIR_NAME "xdnn-bdcentos_x86_64")
+  set(XPU_XDNN_DIR_NAME "xdnn-centos7_x86_64")
   set(XPU_XCCL_DIR_NAME "xccl-bdcentos_x86_64")
-  # ubuntu and centos: use output by XDNN API team
-  set(XPU_XDNN_URL
-      "${XPU_XDNN_BASE_URL}/${XPU_XDNN_DIR_NAME}.tar.gz"
-      CACHE STRING "" FORCE)
 else()
   set(XPU_XRE_DIR_NAME "xre-ubuntu_x86_64")
   set(XPU_XDNN_DIR_NAME "xdnn-ubuntu_x86_64")
   set(XPU_XCCL_DIR_NAME "xccl-ubuntu_x86_64")
-  # default: use output by XDNN API team
-  set(XPU_XDNN_URL
-      "${XPU_XDNN_BASE_URL}/${XPU_XDNN_DIR_NAME}.tar.gz"
-      CACHE STRING "" FORCE)
 endif()
 
 set(XPU_XRE_URL
     "${XPU_BASE_URL}/${XPU_XRE_DIR_NAME}.tar.gz"
+    CACHE STRING "" FORCE)
+set(XPU_XDNN_URL
+    "${XPU_BASE_URL}/${XPU_XDNN_DIR_NAME}.tar.gz"
     CACHE STRING "" FORCE)
 set(XPU_XCCL_URL
     "${XPU_XCCL_BASE_URL}/${XPU_XCCL_DIR_NAME}.tar.gz"


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
在2022年4月的时候，由于XPU的某个流水线产出不稳定，所以替换了一下XDNN的依赖，见 https://github.com/PaddlePaddle/Paddle/pull/41685 。
近期流水线稳定了，所以改回来，即，XRE和XDNN都从baidu-kunlun-product里面拿。
