### PR TITLE
[Clean fluid] Clean fluid elementwise_max (part2): remove API

### DIFF
--- a/python/paddle/distributed/fleet/metrics/metric.py
+++ b/python/paddle/distributed/fleet/metrics/metric.py
@@ -79,7 +79,7 @@ def max(input, scope=None, util=None):
           input = fluid.layers.cast(some_input, dtype='float32')
           cnt = fluid.layers.reduce_sum(input)
           global_cnt = fluid.layers.create_global_var(persistable=True, dtype='float32', shape=[1], value=0)
-          tmp = fluid.layers.elementwise_max(cnt, global_cnt)
+          tmp = paddle.maximum(cnt, global_cnt)
           fluid.layers.assign(tmp, global_cnt)
 
           # in train.py, after train or infer

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -157,7 +157,6 @@ __all__ = [
     'elementwise_div',
     'elementwise_sub',
     'elementwise_mul',
-    'elementwise_max',
     'elementwise_min',
     'elementwise_pow',
     'elementwise_mod',
@@ -13111,71 +13110,6 @@ def elementwise_mul(x, y, axis=-1, act=None, name=None):
     return _elementwise_op(LayerHelper('elementwise_mul', **locals()))
 
 
-def elementwise_max(x, y, axis=-1, act=None, name=None):
-    """
-        :alias_main: paddle.elementwise_max
-            :alias: paddle.elementwise_max,paddle.tensor.elementwise_max,paddle.tensor.math.elementwise_max
-            :old_api: paddle.fluid.layers.elementwise_max
-
-    Examples:
-
-        .. code-block:: python
-
-            import paddle.fluid as fluid
-            import numpy as np
-            import paddle
-
-            def gen_data():
-                return {
-                    "x": np.array([2, 3, 4]).astype('float32'),
-                    "y": np.array([1, 5, 2]).astype('float32')
-                }
-            paddle.enable_static()
-            x = fluid.data(name="x", shape=[3], dtype='float32')
-            y = fluid.data(name="y", shape=[3], dtype='float32')
-            z = fluid.layers.elementwise_max(x, y)
-
-            place = fluid.CPUPlace()
-            exe = fluid.Executor(place)
-            z_value = exe.run(feed=gen_data(),
-                                fetch_list=[z.name])
-
-            print(z_value) #[2, 5, 4]
-
-
-        .. code-block:: python
-
-            import paddle.fluid as fluid
-            import numpy as np
-            import paddle
-
-            def gen_data():
-                return {
-                    "x": np.ones((2, 3, 4, 5)).astype('float32'),
-                    "y": np.zeros((3, 4)).astype('float32')
-                }
-            paddle.enable_static()
-            x = fluid.data(name="x", shape=[2,3,4,5], dtype='float32')
-            y = fluid.data(name="y", shape=[3,4], dtype='float32')
-            z = fluid.layers.elementwise_max(x, y, axis=1)
-
-            place = fluid.CPUPlace()
-            exe = fluid.Executor(place)
-
-            z_value = exe.run(feed=gen_data(),
-                                fetch_list=[z.name])
-
-            print(z_value)#[[[[1., 1., 1., 1., 1.] .... [1., 1., 1., 1., 1.]]]]
-
-    """
-    if _non_static_mode():
-        return _elementwise_op_in_dygraph(
-            x, y, axis=axis, act=act, op_name='elementwise_max'
-        )
-
-    return _elementwise_op(LayerHelper('elementwise_max', **locals()))
-
-
 def elementwise_min(x, y, axis=-1, act=None, name=None):
     """
         :alias_main: paddle.elementwise_min
@@ -13353,7 +13287,6 @@ for func in [
     elementwise_div,
     elementwise_sub,
     elementwise_mul,
-    elementwise_max,
     elementwise_pow,
     elementwise_min,
     elementwise_mod,

--- a/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_x_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_elemetwise_x_op_ipu.py
@@ -145,7 +145,7 @@ class TestMin(TestMul):
 
 class TestMax(TestMul):
     def set_test_op(self):
-        self.op = paddle.fluid.layers.elementwise_max
+        self.op = paddle.maximum
 
 
 class TestPow(TestMul):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Describe
Clean fluid `elementwise_max` API. 

Function `paddle.fluid.layers.elementwise_max` is deprecated since version 2.x, hence it should be removed.

**Pre PR:** [[Clean fluid] Clean fluid elementwise_max (part1) #47866](https://github.com/PaddlePaddle/Paddle/pull/47866)
