### PR TITLE
[Zero-Dim] temporarily revert create_scalar due to API input 0D is not fully supported

### DIFF
--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -99,7 +99,8 @@ def monkey_patch_variable():
         return var
 
     def create_scalar(block, value, dtype):
-        return create_tensor(block, value, dtype, shape=[])
+        # TODO(zhouwei): will change to [] which is 0-D Tensor
+        return create_tensor(block, value, dtype, shape=[1])
 
     def create_tensor_with_batchsize(ref_var, value, dtype):
         assert isinstance(ref_var, Variable)

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -350,7 +350,7 @@ class TestBinaryAPI(unittest.TestCase):
 
         paddle.enable_static()
 
-    def test_static_unary(self):
+    def test_static_binary(self):
         paddle.enable_static()
         for api in binary_api_list + binary_api_list_without_grad:
             main_prog = fluid.Program()
@@ -377,15 +377,19 @@ class TestBinaryAPI(unittest.TestCase):
                 # Test runtime shape
                 self.assertEqual(out_np.shape, ())
 
+                # TODO(zhouwei): will open when create_scalar is []
                 # 2) x is 0D , y is scalar
+                '''
                 x = paddle.rand([])
                 y = 0.5
                 x.stop_gradient = False
+                print(api)
                 if isinstance(api, dict):
                     out = getattr(paddle.static.Variable, api['cls_method'])(
                         x, y
                     )
                     self.assertEqual(out.shape, ())
+                '''
 
         for api in binary_int_api_list_without_grad:
             main_prog = fluid.Program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

由于目前API还未完全支持输入0D，暂时先revert关闭这个功能，避免0D过早的流入到网络，引发模型报错。报错截图举例（表示expand不能输入0D，陆续有其他API报错）：

![ca2f71f7335d7b4e08982668bdade1fb](https://user-images.githubusercontent.com/52485244/202191193-8355890d-37ef-451b-a527-4dbb64fed267.png)

待API**完全支持输入0D**后，再打开这个功能，此时将是安全的。