### PR TITLE
optimizing a bit tensor_array initialization checking

### DIFF
--- a/paddle/phi/core/tensor_array.cc
+++ b/paddle/phi/core/tensor_array.cc
@@ -23,13 +23,12 @@ TensorArray::TensorArray(const std::vector<DenseTensor>& vec) {
 /// \brief Test whether the tensor's storage in TensorArray is allocated.
 /// return Whether all tensors in TensorArray is allocated.
 bool TensorArray::initialized() const {
-  bool init = true;
   for (auto tensor : tensors_) {
     if (!tensor.IsInitialized()) {
-      init = false;
+      return false;
     }
   }
-  return init;
+  return true;
 }
 
 int64_t TensorArray::numel() const {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Just a tiny change upon tensor_array initialization. We won't need to loop through all tensor_array in the container if the first one by example is uninitialized. We kind of short-circuit the loop.