### PR TITLE
fix new executor gc dep bug

### DIFF
--- a/paddle/fluid/framework/new_executor/garbage_collector/CMakeLists.txt
+++ b/paddle/fluid/framework/new_executor/garbage_collector/CMakeLists.txt
@@ -2,4 +2,4 @@ cc_library(
   interpretercore_garbage_collector
   SRCS garbage_collector.cc event_garbage_collector.cc fast_garbage_collector.cc
        no_event_garbage_collector.cc
-  DEPS garbage_collector)
+  DEPS garbage_collector executor_gc_helper)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
fix new executor gc dep bug
使用debug mode编译或者c++17编译都会出现缺少编译依赖的情况，该pr修复该问题
