### PR TITLE
Fix bug of zero_allocator in HostAlloc

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -427,6 +427,10 @@ void AnalysisPredictor::InitDeviceContexts() {
               memory::allocation::AllocatorFacade::Instance()
                   .GetZeroAllocator(place_)
                   .get());
+          gpu_context->SetHostZeroAllocator(
+              memory::allocation::AllocatorFacade::Instance()
+                  .GetZeroAllocator(platform::CPUPlace())
+                  .get());
           gpu_context->SetGenerator(
               framework::DefaultCUDAGenerator(place_.GetDeviceId()).get());
           gpu_context->SetHostGenerator(framework::DefaultCPUGenerator().get());

--- a/paddle/fluid/inference/tensorrt/test_engine.cc
+++ b/paddle/fluid/inference/tensorrt/test_engine.cc
@@ -38,6 +38,10 @@ class TensorRTEngineTest : public ::testing::Test {
         paddle::memory::allocation::AllocatorFacade::Instance()
             .GetZeroAllocator(platform::CUDAPlace(0))
             .get());
+    ctx_->SetHostZeroAllocator(
+        paddle::memory::allocation::AllocatorFacade::Instance()
+            .GetZeroAllocator(paddle::platform::CPUPlace())
+            .get());
     ctx_->SetPinnedAllocator(
         paddle::memory::allocation::AllocatorFacade::Instance()
             .GetAllocator(paddle::platform::CUDAPinnedPlace())

--- a/paddle/fluid/memory/malloc_test.cu
+++ b/paddle/fluid/memory/malloc_test.cu
@@ -183,6 +183,10 @@ TEST(Malloc, GPUContextMultiThreadMultiStream) {
         paddle::memory::allocation::AllocatorFacade::Instance()
             .GetZeroAllocator(place)
             .get());
+    ctx->SetHostZeroAllocator(
+        paddle::memory::allocation::AllocatorFacade::Instance()
+            .GetZeroAllocator(paddle::platform::CPUPlace())
+            .get());
     ctx->SetPinnedAllocator(
         paddle::memory::allocation::AllocatorFacade::Instance()
             .GetAllocator(paddle::platform::CUDAPinnedPlace())

--- a/paddle/fluid/platform/collective_helper.cc
+++ b/paddle/fluid/platform/collective_helper.cc
@@ -221,6 +221,10 @@ NCCLComm* NCCLCommContext::AssignNCCLComm(
       paddle::memory::allocation::AllocatorFacade::Instance()
           .GetZeroAllocator(CUDAPlace(dev_id))
           .get());
+  dev_ctx->SetHostZeroAllocator(
+      paddle::memory::allocation::AllocatorFacade::Instance()
+          .GetZeroAllocator(paddle::platform::CPUPlace())
+          .get());
   dev_ctx->SetPinnedAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
           .GetAllocator(paddle::platform::CUDAPinnedPlace())
@@ -363,6 +367,10 @@ BKCLComm* BKCLCommContext::AssignBKCLComm(
   dev_ctx->SetZeroAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
           .GetZeroAllocator(XPUPlace(dev_id))
+          .get());
+  dev_ctx->SetHostZeroAllocator(
+      paddle::memory::allocation::AllocatorFacade::Instance()
+          .GetZeroAllocator(paddle::platform::CPUPlace())
           .get());
 
   BKCLCommImpl* c = new BKCLCommImpl;

--- a/paddle/fluid/platform/device/gpu/nccl_helper.h
+++ b/paddle/fluid/platform/device/gpu/nccl_helper.h
@@ -136,6 +136,10 @@ struct NCCLContext {
         paddle::memory::allocation::AllocatorFacade::Instance()
             .GetZeroAllocator(CUDAPlace(dev_id))
             .get());
+    ctx_->SetHostZeroAllocator(
+        paddle::memory::allocation::AllocatorFacade::Instance()
+            .GetZeroAllocator(paddle::platform::CPUPlace())
+            .get());
     ctx_->SetPinnedAllocator(
         paddle::memory::allocation::AllocatorFacade::Instance()
             .GetAllocator(paddle::platform::CUDAPinnedPlace())

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -183,6 +183,9 @@ std::unique_ptr<DeviceContext> CreateDeviceContext(
   dev_ctx->SetZeroAllocator(memory::allocation::AllocatorFacade::Instance()
                                 .GetZeroAllocator(p)
                                 .get());
+  dev_ctx->SetHostZeroAllocator(memory::allocation::AllocatorFacade::Instance()
+                                    .GetZeroAllocator(platform::CPUPlace())
+                                    .get());
   return PtrType(dev_ctx);
 }
 

--- a/paddle/fluid/platform/device_context_test.cu
+++ b/paddle/fluid/platform/device_context_test.cu
@@ -17,6 +17,7 @@ limitations under the License. */
 #include "gtest/gtest.h"
 #include "paddle/fluid/memory/allocation/allocator_facade.h"
 #include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/core/dense_tensor.h"
 
 TEST(Device, Init) {
   using paddle::platform::CUDAPlace;
@@ -107,7 +108,7 @@ TEST(Device, HostZeroAllocator) {
   phi::GPUContext* device_context = new phi::GPUContext(CUDAPlace(0));
   device_context->SetAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
-          .GetAllocator(CUDAPlace(i), device_context->stream())
+          .GetAllocator(CUDAPlace(0), device_context->stream())
           .get());
   device_context->SetHostAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
@@ -115,7 +116,7 @@ TEST(Device, HostZeroAllocator) {
           .get());
   device_context->SetZeroAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
-          .GetZeroAllocator(CUDAPlace(i))
+          .GetZeroAllocator(CUDAPlace(0))
           .get());
   device_context->SetHostZeroAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
@@ -132,7 +133,7 @@ TEST(Device, HostZeroAllocator) {
   device_context->HostAlloc<float>(&tensor);
   ASSERT_EQ(tensor.place().GetType(), phi::AllocationType::CPU);
   ASSERT_EQ(tensor.numel(), 0);
-  ASSERT_EQ(tensor.dtype, phi::DataType::FLOAT32);
+  ASSERT_EQ(tensor.dtype(), phi::DataType::FLOAT32);
 }
 
 TEST(Device, DeviceContextPool) {

--- a/paddle/fluid/platform/device_context_test.cu
+++ b/paddle/fluid/platform/device_context_test.cu
@@ -103,11 +103,8 @@ TEST(Device, GPUContext) {
 
 TEST(Device, HostZeroAllocator) {
   using paddle::platform::CUDAPlace;
-  using phi::GPUContext;
 
-  phi::GPUContext gpu_context(CUDAPlace(0));
-  auto device_context =
-      std::make_unique<phi::GPUContext>(std::move(gpu_context));
+  auto device_context = std::make_unique<phi::GPUContext>(CUDAPlace(0));
   device_context->SetAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
           .GetAllocator(CUDAPlace(0), device_context->stream())
@@ -136,6 +133,11 @@ TEST(Device, HostZeroAllocator) {
   ASSERT_EQ(tensor.place().GetType(), phi::AllocationType::CPU);
   ASSERT_EQ(tensor.numel(), 0);
   ASSERT_EQ(tensor.dtype(), phi::DataType::FLOAT32);
+
+  phi::GPUContext gpu_context(CUDAPlace(0));
+  gpu_context.SetHostZeroAllocator(&device_context->GetHostZeroAllocator());
+  gpu_context.HostAlloc<float>(&tensor);
+  ASSERT_EQ(tensor.place().GetType(), phi::AllocationType::CPU);
 }
 
 TEST(Device, DeviceContextPool) {

--- a/paddle/fluid/platform/device_context_test.cu
+++ b/paddle/fluid/platform/device_context_test.cu
@@ -105,7 +105,9 @@ TEST(Device, HostZeroAllocator) {
   using paddle::platform::CUDAPlace;
   using phi::GPUContext;
 
-  phi::GPUContext* device_context = new phi::GPUContext(CUDAPlace(0));
+  phi::GPUContext gpu_context(CUDAPlace(0));
+  auto device_context =
+      std::make_unique<phi::GPUContext>(std::move(gpu_context));
   device_context->SetAllocator(
       paddle::memory::allocation::AllocatorFacade::Instance()
           .GetAllocator(CUDAPlace(0), device_context->stream())

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1325,6 +1325,10 @@ All parameter, weight, gradient are variables in Paddle.
                         paddle::memory::allocation::AllocatorFacade::Instance()
                             .GetZeroAllocator(place)
                             .get());
+                    context->SetHostZeroAllocator(
+                        paddle::memory::allocation::AllocatorFacade::Instance()
+                            .GetZeroAllocator(paddle::platform::CPUPlace())
+                            .get());
                     return context;
                   })
       .def_static(
@@ -1348,6 +1352,10 @@ All parameter, weight, gradient are variables in Paddle.
       context->SetZeroAllocator(
         paddle::memory::allocation::AllocatorFacade::Instance()
           .GetZeroAllocator(place)
+          .get());
+      context->SetHostZeroAllocator(
+        paddle::memory::allocation::AllocatorFacade::Instance()
+          .GetZeroAllocator(paddle::platform::CPUPlace())
           .get());
       return context;
 #endif
@@ -1409,6 +1417,10 @@ All parameter, weight, gradient are variables in Paddle.
       context->SetZeroAllocator(
         paddle::memory::allocation::AllocatorFacade::Instance()
         .GetZeroAllocator(place)
+        .get());
+      context->SetHostZeroAllocator(
+        paddle::memory::allocation::AllocatorFacade::Instance()
+        .GetZeroAllocator(paddle::platform::CPUPlace())
         .get());
       context->SetPinnedAllocator(
         paddle::memory::allocation::AllocatorFacade::Instance()

--- a/paddle/phi/core/device_context.h
+++ b/paddle/phi/core/device_context.h
@@ -83,6 +83,13 @@ class PADDLE_API DeviceContext {
   void SetZeroAllocator(const Allocator*);
 
   /**
+   * @brief Set the zero-size host Allocator object.
+   *
+   * @param allocator
+   */
+  void SetHostZeroAllocator(const Allocator*);
+
+  /**
    * @brief Set the zero-size Allocator object.
    *
    * @param allocator
@@ -104,6 +111,8 @@ class PADDLE_API DeviceContext {
   const Allocator& GetHostAllocator() const;
 
   const Allocator& GetZeroAllocator() const;
+
+  const Allocator& GetHostZeroAllocator() const;
 
   const Allocator& GetPinnedAllocator() const;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
问题描述：
<img width="583" alt="image" src="https://user-images.githubusercontent.com/13048366/202451689-8cc85241-04d3-4055-a855-53d08f9e05eb.png">
在使用`DeviceContext`的`HostAlloc`成员函数分配主机内存时，如果需要分配的内存为0会使用`zero_allocator_`，但在使用异构设备的场景下`zero_allocator_`被分配为异构设备的allocator，此时使用`zero_allocator_`分配得到的为非主机内存，与HostAlloc函数定义的行为不符。


修改方式：
为`DeviceContext`新增`host_zero_allocator_`成员变量，在`HostAlloc`内直接使用`host_zero_allocator_`分配size为0的主机内存。
