### PR TITLE
Add a new instance for process group

### DIFF
--- a/paddle/fluid/distributed/collective/ProcessGroup.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroup.cc
@@ -35,17 +35,6 @@ void ProcessGroup::Task::Synchronize() {}
 
 void ProcessGroup::Task::UpdateWaitChain(const phi::DeviceContext& ctx) {}
 
-ProcessGroup::ProcessGroup(int rank,
-                           int size,
-                           const platform::Place& place,
-                           int gid)
-    : rank_(rank), size_(size), place_(place), gid_(gid) {
-  if (gid != IGNORE_ID) {
-    auto map = ProcessGroupMapFromGid::getInstance();
-    map->insert(gid_, this);
-  }
-}
-
 ProcessGroup::ProcessGroup(int rank, int size, int gid)
     : rank_(rank), size_(size), gid_(gid) {
   if (gid != IGNORE_ID) {
@@ -65,6 +54,11 @@ ProcessGroup::Task::Task(int rank,
                          CommType comm_type,
                          bool sync_op)
     : rank_(rank), comm_type_(comm_type), sync_op_(sync_op) {}
+
+ProcessGroupIdMap& ProcessGroupIdMap::GetInstance() {
+  static ProcessGroupIdMap instance;
+  return instance;
+}
 
 }  //  namespace distributed
 }  //  namespace paddle

--- a/paddle/fluid/distributed/collective/ProcessGroup.h
+++ b/paddle/fluid/distributed/collective/ProcessGroup.h
@@ -82,13 +82,8 @@ class ProcessGroup {
   };
 
  public:
-  explicit ProcessGroup(int rank, int size, int gid);
+  ProcessGroup(int rank, int size, int gid);
   virtual ~ProcessGroup() = default;
-  // TODO(dev): This constructor will be removed later.
-  explicit ProcessGroup(int rank,
-                        int size,
-                        const platform::Place& place,
-                        int gid);
 
   int GetRank() const { return rank_; }
 
@@ -312,12 +307,18 @@ class ProcessGroup {
   }
 
  protected:
-  const int rank_;
-  const int size_;
-  const platform::Place place_;
-  const int gid_;
+  int rank_;
+  int size_;
+  int gid_;
 };
 
+class ProcessGroupIdMap
+    : public std::unordered_map<int, std::shared_ptr<ProcessGroup>> {
+ public:
+  static ProcessGroupIdMap& GetInstance();
+};
+
+// TODO(dev): The following method will be removed soon.
 class ProcessGroupMapFromGid {
  public:
   bool has(int gid) {

--- a/paddle/fluid/distributed/collective/ProcessGroupBKCL.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupBKCL.cc
@@ -531,5 +531,13 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupBKCL::AllGather(
       /*use_calc_stream*/ false);
 }
 
+std::shared_ptr<ProcessGroupBKCL> ProcessGroupBKCL::CreateProcessGroupBKCL(
+    const std::shared_ptr<Store>& store, int rank, int size, int gid) {
+  auto process_group =
+      std::make_shared<ProcessGroupBKCL>(store, rank, size, gid);
+  ProcessGroupIdMap::GetInstance().emplace(gid, process_group);
+  return process_group;
+}
+
 }  //  namespace distributed
 }  //  namespace paddle

--- a/paddle/fluid/distributed/collective/ProcessGroupBKCL.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupBKCL.h
@@ -73,6 +73,9 @@ class ProcessGroupBKCL : public ProcessGroupStream {
                    int size,
                    int gid);
 
+  static std::shared_ptr<ProcessGroupBKCL> CreateProcessGroupBKCL(
+      const std::shared_ptr<Store>& store, int rank, int size, int gid);
+
   std::string GetBackendName() const override {
     return std::string(BKCL_BACKEND_NAME);
   }

--- a/paddle/fluid/distributed/collective/ProcessGroupCustom.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupCustom.cc
@@ -433,5 +433,18 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupCustom::Broadcast(
       CommType::BROADCAST);
 }
 
+std::shared_ptr<ProcessGroupCustom>
+ProcessGroupCustom::CreateProcessGroupCustom(
+    const std::shared_ptr<Store>& store,
+    const std::string& device_type,
+    int rank,
+    int size,
+    int gid) {
+  auto process_group =
+      std::make_shared<ProcessGroupCustom>(store, device_type, rank, size, gid);
+  ProcessGroupIdMap::GetInstance().emplace(gid, process_group);
+  return process_group;
+}
+
 }  //  namespace distributed
 }  //  namespace paddle

--- a/paddle/fluid/distributed/collective/ProcessGroupCustom.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupCustom.h
@@ -69,6 +69,13 @@ class ProcessGroupCustom : public ProcessGroup {
                      int size,
                      int gid);
 
+  static std::shared_ptr<ProcessGroupCustom> CreateProcessGroupCustom(
+      const std::shared_ptr<Store>& store,
+      const std::string& device_type,
+      int rank,
+      int size,
+      int gid);
+
   std::string GetBackendName() const override { return "XCCL_" + device_type_; }
 
   std::shared_ptr<ProcessGroup::Task> AllGather(

--- a/paddle/fluid/distributed/collective/ProcessGroupGloo.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupGloo.cc
@@ -617,5 +617,22 @@ ProcessGroupGloo::createDefaultDevice() {
   return createDeviceForHostname("127.0.0.1");
 }
 
+std::shared_ptr<ProcessGroupGloo> ProcessGroupGloo::CreateProcessGroupGloo(
+    const std::shared_ptr<Store>& store, int rank, int size, int gid) {
+  std::string GLOO_SOCKET_IFNAME_ENV = "GLOO_SOCKET_IFNAME";
+  auto opts = GlooOptions::create();
+  char* ifname = getenv(GLOO_SOCKET_IFNAME_ENV.c_str());
+  if (ifname && strlen(ifname) > 1) {
+    opts->device =
+        ProcessGroupGloo::createDeviceForInterface(std::string(ifname));
+  } else {
+    opts->device = ProcessGroupGloo::createDefaultDevice();
+  }
+  auto process_group =
+      std::make_shared<ProcessGroupGloo>(store, rank, size, gid, opts);
+  ProcessGroupIdMap::GetInstance().emplace(gid, process_group);
+  return process_group;
+}
+
 }  // namespace distributed
 }  // namespace paddle

--- a/paddle/fluid/distributed/collective/ProcessGroupGloo.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupGloo.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <future>
+#include <memory>
 #include <mutex>
 
 #include "paddle/fluid/distributed/collective/ProcessGroup.h"
@@ -98,12 +99,17 @@ class ProcessGroupGloo : public ProcessGroup {
     std::shared_ptr<::gloo::transport::Device> device;
   };
 
-  explicit ProcessGroupGloo(
+  ProcessGroupGloo(const std::shared_ptr<paddle::distributed::Store>& store,
+                   int rank,
+                   int world_size,
+                   int gid,
+                   std::shared_ptr<GlooOptions> options);
+
+  static std::shared_ptr<ProcessGroupGloo> CreateProcessGroupGloo(
       const std::shared_ptr<paddle::distributed::Store>& store,
       int rank,
       int world_size,
-      int gid,
-      std::shared_ptr<GlooOptions> options);
+      int gid);
 
   ~ProcessGroupGloo() = default;
 
@@ -192,7 +198,7 @@ class ProcessGroupGloo : public ProcessGroup {
       const std::string& ifname);
   static std::shared_ptr<::gloo::transport::Device> createDefaultDevice();
 
- protected:
+ private:
   uint32_t _tag;
   std::shared_ptr<gloo::rendezvous::Context> _context;
   std::shared_ptr<::gloo::rendezvous::Store> _store;

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
@@ -1417,5 +1417,13 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::Scatter(
       CommType::SCATTER);
 }
 
+std::shared_ptr<ProcessGroupNCCL> ProcessGroupNCCL::CreateProcessGroupNCCL(
+    const std::shared_ptr<Store>& store, int rank, int size, int gid) {
+  auto process_group =
+      std::make_shared<ProcessGroupNCCL>(store, rank, size, gid);
+  ProcessGroupIdMap::GetInstance().emplace(gid, process_group);
+  return process_group;
+}
+
 }  //  namespace distributed
 }  //  namespace paddle

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
@@ -82,6 +82,9 @@ class ProcessGroupNCCL final : public ProcessGroupStream {
   };
 
  public:
+  static std::shared_ptr<ProcessGroupNCCL> CreateProcessGroupNCCL(
+      const std::shared_ptr<Store>& store, int rank, int size, int gid);
+
   ProcessGroupNCCL(const std::shared_ptr<Store>& store,
                    int rank,
                    int size,

--- a/python/paddle/distributed/collective.py
+++ b/python/paddle/distributed/collective.py
@@ -152,15 +152,15 @@ def _new_process_group_impl(
     genv = _get_global_env()
     assert backend in _valid_backend_list, "Unsupported backend: %s." % backend
     if backend == "gloo":
-        pg = core.ProcessGroupGloo(store, rank, world_size, group_id)
+        pg = core.ProcessGroupGloo.create(store, rank, world_size, group_id)
     elif backend == "nccl":
-        pg = core.ProcessGroupNCCL(store, rank, world_size, group_id)
+        pg = core.ProcessGroupNCCL.create(store, rank, world_size, group_id)
     elif backend == "xccl":
-        pg = core.ProcessGroupCustom(
+        pg = core.ProcessGroupCustom.create(
             store, genv.device_type, rank, world_size, group_id
         )
     elif backend == "bkcl":
-        pg = core.ProcessGroupBKCL(store, rank, world_size, group_id)
+        pg = core.ProcessGroupBKCL.create(store, rank, world_size, group_id)
     return pg
 
 

--- a/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
+++ b/python/paddle/fluid/tests/custom_runtime/process_group_xccl.py
@@ -28,7 +28,7 @@ def init_process_group(strategy=None):
     rank = ParallelEnv().local_rank
     is_master = True if rank == 0 else False
     store = paddle.fluid.core.TCPStore("127.0.0.1", 6173, is_master, nranks)
-    pg_group = core.ProcessGroupCustom(
+    pg_group = core.ProcessGroupCustom.create(
         store,
         ParallelEnv().device_type,
         rank,

--- a/python/paddle/fluid/tests/unittests/collective/process_group_gloo.py
+++ b/python/paddle/fluid/tests/unittests/collective/process_group_gloo.py
@@ -42,7 +42,7 @@ class TestProcessGroupFp32(unittest.TestCase):
             store = paddle.fluid.core.TCPStore(
                 "127.0.0.1", 6272, is_master, nranks, 30
             )
-            pg = paddle.fluid.core.ProcessGroupGloo(store, rank, nranks)
+            pg = paddle.fluid.core.ProcessGroupGloo.create(store, rank, nranks)
 
             # test allreduce sum
             # rank 0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
为了动静统一，新增一个C++端的ProcessGroupMap，原来的ProcessGroupMapFromGid直接操作this指针，如果在c++端的op里使用new来构造，相对不安全，同时没有对应对它生命周期的管理机制。