### PR TITLE
Adjust mkldnn_placement_pass to check library type and data type

### DIFF
--- a/paddle/fluid/framework/ir/cudnn_placement_pass.h
+++ b/paddle/fluid/framework/ir/cudnn_placement_pass.h
@@ -29,9 +29,6 @@ namespace ir {
 class CUDNNPlacementPass : public PlacementPassBase {
  protected:
   bool IsSupport(const Node* op) const override;
-  bool IsDefaultOpTypes(const std::string& op_type) const override {
-    return true;
-  };
 
  private:
   const std::string GetPlacementName() const override { return "cuDNN"; }

--- a/paddle/fluid/framework/ir/cudnn_placement_pass.h
+++ b/paddle/fluid/framework/ir/cudnn_placement_pass.h
@@ -27,6 +27,12 @@ namespace ir {
  * Specifies which operators should use cuDNN.
  */
 class CUDNNPlacementPass : public PlacementPassBase {
+ protected:
+  bool IsSupport(const Node* op) const override;
+  bool IsDefaultOpTypes(const std::string& op_type) const override {
+    return true;
+  };
+
  private:
   const std::string GetPlacementName() const override { return "cuDNN"; }
 

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
@@ -158,11 +158,6 @@ void CPUQuantizeSquashPass::DequantQuantSquash(
         PADDLE_GET_CONST(float, quant_op->Op()->GetAttr("Scale"));
     float dequant_shift = dequant_op->Op()->GetAttrIfExists<float>("Shift");
     float quant_shift = quant_op->Op()->GetAttrIfExists<float>("Shift");
-    if (quant_op->Op()->GetAttrIfExists<bool>("is_negative_input") !=
-        dequant_op->Op()->GetAttrIfExists<bool>("is_negative_input")) {
-      return;
-    }
-
     PADDLE_ENFORCE_NE(
         nodes_keep_counter->find(dequant_out),
         nodes_keep_counter->end(),
@@ -174,13 +169,14 @@ void CPUQuantizeSquashPass::DequantQuantSquash(
     if (dequant_scale == quant_scale && dequant_shift == quant_shift) {
       // squash dequantize-quantize to nothing
       auto quant_out_var_name = quant_out->Name();
-      for (auto input_name : next_op_desc->InputNames()) {
-        auto& input_names = next_op_desc->MutableInputs()->at(input_name);
+      auto next_op_inputs = next_op_desc->InputNames();
+      for (const auto& name : next_op_inputs) {
+        auto input_names = next_op_desc->Input(name);
         std::replace(input_names.begin(),
                      input_names.end(),
                      quant_out_var_name,
                      dequant_in->Name());
-        next_op_desc->SetInput(input_name, input_names);
+        next_op_desc->SetInput(name, input_names);
       }
 
       if (keep_dequant)

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_fc_rnn_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_fc_rnn_fuse_pass_tester.cc
@@ -23,6 +23,20 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
+void RegisterOpKernels() {
+  auto& all_kernels = OperatorWithKernel::AllOpKernels();
+  platform::CPUPlace place = platform::CPUPlace();
+  OpKernelType mkldnn_kernel_type = OpKernelType(proto::VarType::FP32,
+                                                 place,
+                                                 DataLayout::kAnyLayout,
+                                                 LibraryType::kMKLDNN);
+
+  auto fake_kernel_func = [](const ExecutionContext&) -> void {};
+
+  all_kernels["mul"][mkldnn_kernel_type] = fake_kernel_func;
+  all_kernels["elementwise_add"][mkldnn_kernel_type] = fake_kernel_func;
+}
+
 void TestFcRNNFusePass(const std::string& pass_name,
                        std::string activation = "tanh",
                        std::string gate_activation = "sigmoid",
@@ -40,6 +54,7 @@ void TestFcRNNFusePass(const std::string& pass_name,
       "__param_scope__",
       (pass_name == "fc_gru_fuse_pass" ? fc_gru_test::CreateParamScope()
                                        : fc_lstm_test::CreateParamScope()));
+  RegisterOpKernels();
   graph.reset(mkldnn_placement_pass_->Apply(graph.release()));
 
   auto check_num_mkldnn_nodes = [&](const std::unique_ptr<ir::Graph>& graph) {

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
@@ -20,6 +20,7 @@ namespace framework {
 namespace ir {
 
 bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
+  std::cout << "MkldnnPlacementPass" << std::endl;
   auto& all_kernels = OperatorWithKernel::AllOpKernels();
   auto op_type = op->Op()->Type();
 
@@ -34,12 +35,15 @@ bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
 
   auto it = all_kernels.find(op_type);
   if (it != all_kernels.end()) {
+    std::cout << "Kernel type founded" << std::endl;
     for (auto& kernel_pair : it->second) {
       if (platform::is_cpu_place(kernel_pair.first.place_) &&
           (kernel_pair.first.library_type_ == LibraryType::kMKLDNN)) {
+        std::cout << "Mkldnn backend" << std::endl;
         if (op->inputs.size() > 0 && op->inputs[0]->IsVar() &&
             kernel_pair.first.data_type_ == op->inputs[0]->Var()->GetDataType())
           return true;
+        return true;
       }
     }
   }
@@ -48,11 +52,14 @@ bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
       phi::TransToPhiKernelName(op_type));
 
   for (auto& kernel_pair : phi_kernels) {
+    std::cout << "PHI kernel type founded" << std::endl;
     if (kernel_pair.first.backend() == phi::Backend::ONEDNN) {
+      std::cout << "Onednn backend" << std::endl;
       if (op->inputs.size() > 0 && op->inputs[0]->IsVar() &&
           kernel_pair.first.dtype() == framework::TransToPhiDataType(
                                            op->inputs[0]->Var()->GetDataType()))
         return true;
+      return true;
     }
   }
   return false;

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
@@ -64,5 +64,5 @@ bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
 
 REGISTER_PASS(mkldnn_placement_pass, paddle::framework::ir::MKLDNNPlacementPass)
     .RequirePassAttr("mkldnn_enabled_op_types")
-    .DefaultPassAttr("mkldnn_excluded_op_types",
+    .DefaultPassAttr("mkldnn_excluded_ops",
                      new std::unordered_set<std::string>());

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
@@ -20,7 +20,6 @@ namespace framework {
 namespace ir {
 
 bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
-  std::cout << "MkldnnPlacementPass" << std::endl;
   auto& all_kernels = OperatorWithKernel::AllOpKernels();
   auto op_type = op->Op()->Type();
 
@@ -35,11 +34,9 @@ bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
 
   auto it = all_kernels.find(op_type);
   if (it != all_kernels.end()) {
-    std::cout << "Kernel type founded" << std::endl;
     for (auto& kernel_pair : it->second) {
       if (platform::is_cpu_place(kernel_pair.first.place_) &&
           (kernel_pair.first.library_type_ == LibraryType::kMKLDNN)) {
-        std::cout << "Mkldnn backend" << std::endl;
         if (op->inputs.size() > 0 && op->inputs[0]->IsVar() &&
             kernel_pair.first.data_type_ == op->inputs[0]->Var()->GetDataType())
           return true;
@@ -52,9 +49,7 @@ bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
       phi::TransToPhiKernelName(op_type));
 
   for (auto& kernel_pair : phi_kernels) {
-    std::cout << "PHI kernel type founded" << std::endl;
     if (kernel_pair.first.backend() == phi::Backend::ONEDNN) {
-      std::cout << "Onednn backend" << std::endl;
       if (op->inputs.size() > 0 && op->inputs[0]->IsVar() &&
           kernel_pair.first.dtype() == framework::TransToPhiDataType(
                                            op->inputs[0]->Var()->GetDataType()))

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
@@ -13,6 +13,72 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.h"
+#include "paddle/fluid/framework/operator.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
+  auto& all_kernels = OperatorWithKernel::AllOpKernels();
+  auto op_type = op->Op()->Type();
+
+  // This ops have use_mkldnn attr, but not support for now.
+  const std::vector<std::string> op_types = {
+      "trilinear_interp", "bicubic_interp", "linear_interp"};
+  bool is_not_supported_type =
+      std::find(op_types.begin(), op_types.end(), op_type) != op_types.end();
+  if (is_not_supported_type) {
+    return false;
+  }
+
+  auto data_type = op->inputs[0]->Var()->GetDataType();
+  auto it = all_kernels.find(op_type);
+  if (it != all_kernels.end()) {
+    for (auto& kernel_pair : it->second) {
+      if (platform::is_cpu_place(kernel_pair.first.place_) &&
+          (kernel_pair.first.library_type_ == LibraryType::kMKLDNN) &&
+          kernel_pair.first.data_type_ == data_type) {
+        return true;
+      }
+    }
+  }
+
+  auto phi_kernels = phi::KernelFactory::Instance().SelectKernelMap(
+      phi::TransToPhiKernelName(op_type));
+
+  for (auto& kernel_pair : phi_kernels) {
+    if ((kernel_pair.first.backend() == phi::Backend::ONEDNN) &&
+        (kernel_pair.first.dtype() ==
+         framework::TransToPhiDataType(data_type))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool MKLDNNPlacementPass::IsDefaultOpTypes(const std::string& op_type) const {
+  // For interpolate ops, there's a little difference between Paddle and
+  // MKLDNN.
+  // If run MKLDNN interpolate ops, manual set AnalysisConfig and apply
+  // the corresponding pass.
+  const std::vector<std::string> not_default_op_types = {"bilinear_interp",
+                                                         "nearest_interp",
+                                                         "trilinear_interp",
+                                                         "bicubic_interp",
+                                                         "linear_interp",
+                                                         "bilinear_interp_v2",
+                                                         "linear_interp_v2"};
+  bool is_interpolate_op = std::find(not_default_op_types.begin(),
+                                     not_default_op_types.end(),
+                                     op_type) != not_default_op_types.end();
+  return !is_interpolate_op;
+}
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle
 
 REGISTER_PASS(mkldnn_placement_pass, paddle::framework::ir::MKLDNNPlacementPass)
     .RequirePassAttr("mkldnn_enabled_op_types");

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.cc
@@ -20,18 +20,16 @@ namespace framework {
 namespace ir {
 
 bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
-  auto& all_kernels = OperatorWithKernel::AllOpKernels();
   auto op_type = op->Op()->Type();
-
-  // This ops have use_mkldnn attr, but not support for now.
-  const std::vector<std::string> op_types = {
-      "trilinear_interp", "bicubic_interp", "linear_interp"};
-  bool is_not_supported_type =
-      std::find(op_types.begin(), op_types.end(), op_type) != op_types.end();
-  if (is_not_supported_type) {
+  const auto excluded_op_types_list = GetExcludedOpTypesList();
+  if (!excluded_op_types_list.empty() &&
+      std::find(excluded_op_types_list.begin(),
+                excluded_op_types_list.end(),
+                op_type) != excluded_op_types_list.end()) {
     return false;
   }
 
+  auto& all_kernels = OperatorWithKernel::AllOpKernels();
   auto it = all_kernels.find(op_type);
   if (it != all_kernels.end()) {
     for (auto& kernel_pair : it->second) {
@@ -60,27 +58,11 @@ bool MKLDNNPlacementPass::IsSupport(const Node* op) const {
   return false;
 }
 
-bool MKLDNNPlacementPass::IsDefaultOpTypes(const std::string& op_type) const {
-  // For interpolate ops, there's a little difference between Paddle and
-  // MKLDNN.
-  // If run MKLDNN interpolate ops, manual set AnalysisConfig and apply
-  // the corresponding pass.
-  const std::vector<std::string> not_default_op_types = {"bilinear_interp",
-                                                         "nearest_interp",
-                                                         "trilinear_interp",
-                                                         "bicubic_interp",
-                                                         "linear_interp",
-                                                         "bilinear_interp_v2",
-                                                         "linear_interp_v2"};
-  bool is_interpolate_op = std::find(not_default_op_types.begin(),
-                                     not_default_op_types.end(),
-                                     op_type) != not_default_op_types.end();
-  return !is_interpolate_op;
-}
-
 }  // namespace ir
 }  // namespace framework
 }  // namespace paddle
 
 REGISTER_PASS(mkldnn_placement_pass, paddle::framework::ir::MKLDNNPlacementPass)
-    .RequirePassAttr("mkldnn_enabled_op_types");
+    .RequirePassAttr("mkldnn_enabled_op_types")
+    .DefaultPassAttr("mkldnn_excluded_op_types",
+                     new std::unordered_set<std::string>());

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.h
@@ -27,6 +27,10 @@ namespace ir {
  * Specifies which operators should use MKLDNN.
  */
 class MKLDNNPlacementPass : public PlacementPassBase {
+ protected:
+  bool IsSupport(const Node* op) const override;
+  bool IsDefaultOpTypes(const std::string& op_type) const override;
+
  private:
   const std::string GetPlacementName() const override { return "MKLDNN"; }
 

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.h
@@ -29,7 +29,6 @@ namespace ir {
 class MKLDNNPlacementPass : public PlacementPassBase {
  protected:
   bool IsSupport(const Node* op) const override;
-  bool IsDefaultOpTypes(const std::string& op_type) const override;
 
  private:
   const std::string GetPlacementName() const override { return "MKLDNN"; }
@@ -38,6 +37,10 @@ class MKLDNNPlacementPass : public PlacementPassBase {
 
   const std::unordered_set<std::string> GetOpTypesList() const override {
     return Get<std::unordered_set<std::string>>("mkldnn_enabled_op_types");
+  }
+
+  const std::unordered_set<std::string> GetExcludedOpTypesList() const {
+    return Get<std::unordered_set<std::string>>("mkldnn_excluded_op_types");
   }
 };
 

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass.h
@@ -40,7 +40,7 @@ class MKLDNNPlacementPass : public PlacementPassBase {
   }
 
   const std::unordered_set<std::string> GetExcludedOpTypesList() const {
-    return Get<std::unordered_set<std::string>>("mkldnn_excluded_op_types");
+    return Get<std::unordered_set<std::string>>("mkldnn_excluded_ops");
   }
 };
 

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass_tester.cc
@@ -149,10 +149,9 @@ class PlacementPassTest {
   }
 
  public:
-  void MainTest(
-      std::initializer_list<std::string> mkldnn_enabled_op_types,
-      unsigned expected_use_mkldnn_true_count,
-      std::initializer_list<std::string> mkldnn_excluded_op_types = {}) {
+  void MainTest(std::initializer_list<std::string> mkldnn_enabled_op_types,
+                unsigned expected_use_mkldnn_true_count,
+                std::initializer_list<std::string> mkldnn_excluded_ops = {}) {
     auto prog = BuildProgramDesc();
     RegisterOpKernel();
     std::unique_ptr<ir::Graph> graph(new ir::Graph(prog));
@@ -161,8 +160,8 @@ class PlacementPassTest {
 
     pass->Set("mkldnn_enabled_op_types",
               new std::unordered_set<std::string>(mkldnn_enabled_op_types));
-    pass->Set("mkldnn_excluded_op_types",
-              new std::unordered_set<std::string>(mkldnn_excluded_op_types));
+    pass->Set("mkldnn_excluded_ops",
+              new std::unordered_set<std::string>(mkldnn_excluded_ops));
 
     graph.reset(pass->Apply(graph.release()));
 

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass_tester.cc
@@ -80,6 +80,7 @@ class PlacementPassTest {
                                              "l"})) {
       auto* var = prog.MutableBlock(0)->Var(v);
       var->SetType(proto::VarType::SELECTED_ROWS);
+      var->SetDataType(framework::proto::VarType::FP32);
       if (v == "weights" || v == "bias") {
         var->SetPersistable(true);
       }
@@ -162,8 +163,8 @@ class PlacementPassTest {
 };
 
 TEST(MKLDNNPlacementPass, enable_conv_relu) {
-  // 1 conv (1 conv is always true) + 2 relu (1 relu is always true) + 0 pool
-  PlacementPassTest().MainTest({"conv2d", "relu"}, 3);
+  // 2 conv (1 conv is always true) + 2 relu (1 relu is always true) + 0 pool
+  PlacementPassTest().MainTest({"conv2d", "relu"}, 4);
 }
 
 TEST(MKLDNNPlacementPass, enable_relu_pool) {
@@ -172,8 +173,9 @@ TEST(MKLDNNPlacementPass, enable_relu_pool) {
 }
 
 TEST(MKLDNNPlacementPass, enable_all) {
-  // 1 conv (1 conv is always true) + 2 relu (1 relu is always true) + 1 pool
-  PlacementPassTest().MainTest({}, 4);
+  // 2 conv (1 conv is always true) + 2 relu (1 relu is always true) + 1 pool +
+  // 1 concat
+  PlacementPassTest().MainTest({}, 6);
 }
 
 TEST(MKLDNNPlacementPass, placement_name) {

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_placement_pass_tester.cc
@@ -149,8 +149,10 @@ class PlacementPassTest {
   }
 
  public:
-  void MainTest(std::initializer_list<std::string> mkldnn_enabled_op_types,
-                unsigned expected_use_mkldnn_true_count) {
+  void MainTest(
+      std::initializer_list<std::string> mkldnn_enabled_op_types,
+      unsigned expected_use_mkldnn_true_count,
+      std::initializer_list<std::string> mkldnn_excluded_op_types = {}) {
     auto prog = BuildProgramDesc();
     RegisterOpKernel();
     std::unique_ptr<ir::Graph> graph(new ir::Graph(prog));
@@ -159,6 +161,8 @@ class PlacementPassTest {
 
     pass->Set("mkldnn_enabled_op_types",
               new std::unordered_set<std::string>(mkldnn_enabled_op_types));
+    pass->Set("mkldnn_excluded_op_types",
+              new std::unordered_set<std::string>(mkldnn_excluded_op_types));
 
     graph.reset(pass->Apply(graph.release()));
 
@@ -198,6 +202,12 @@ TEST(MKLDNNPlacementPass, enable_all) {
   // 2 conv (1 conv is always true) + 2 relu (1 relu is always true) + 1 pool +
   // 1 concat
   PlacementPassTest().MainTest({}, 6);
+}
+
+TEST(MKLDNNPlacementPass, enable_all_excluded_conv) {
+  // 1 conv (1 conv is always true) + 2 relu (1 relu is always true) + 1 pool +
+  // 1 concat
+  PlacementPassTest().MainTest({}, 5, {"conv2d"});
 }
 
 TEST(MKLDNNPlacementPass, placement_name) {

--- a/paddle/fluid/framework/ir/placement_pass_base.cc
+++ b/paddle/fluid/framework/ir/placement_pass_base.cc
@@ -32,8 +32,7 @@ void PlacementPassBase::ApplyImpl(ir::Graph* graph) const {
   for (const Node* n : graph->Nodes()) {
     if (n->IsOp()) {
       auto* op = n->Op();
-      if ((op->HasAttr(attr_name) || op->HasProtoAttr(attr_name)) &&
-          IsSupport(op->Type())) {
+      if (IsSupport(n)) {
         if (op_types_list.empty() && IsDefaultOpTypes(op->Type())) {
           op->SetAttr(attr_name, true);
         } else if (std::find(op_types_list.begin(),
@@ -44,53 +43,6 @@ void PlacementPassBase::ApplyImpl(ir::Graph* graph) const {
       }
     }
   }
-}
-
-bool PlacementPassBase::IsSupport(const std::string& op_type) const {
-  if (GetAttrName() == "use_cudnn") {
-    auto& all_kernels = OperatorWithKernel::AllOpKernels();
-    auto it = all_kernels.find(op_type);
-    if (it == all_kernels.end()) {
-      // All control operators don't have kernel.
-      return false;
-    }
-    for (auto& kernel_pair : it->second) {
-      if (platform::is_gpu_place(kernel_pair.first.place_) &&
-          (kernel_pair.first.library_type_ == LibraryType::kCUDNN)) {
-        return true;
-      }
-    }
-  } else if (GetAttrName() == "use_mkldnn") {
-    // This ops have use_mkldnn attr, but not support for now.
-    const std::vector<std::string> op_types = {
-        "trilinear_interp", "bicubic_interp", "linear_interp"};
-    return std::find(op_types.begin(), op_types.end(), op_type) ==
-           op_types.end();
-  }
-  return false;
-}
-
-bool PlacementPassBase::IsDefaultOpTypes(const std::string& op_type) const {
-  if (GetAttrName() == "use_cudnn") {
-    return true;
-  } else if (GetAttrName() == "use_mkldnn") {
-    // For interpolate ops, there's a little difference between Paddle and
-    // MKLDNN.
-    // If run MKLDNN interpolate ops, manual set AnalysisConfig and apply
-    // the corresponding pass.
-    const std::vector<std::string> not_default_op_types = {"bilinear_interp",
-                                                           "nearest_interp",
-                                                           "trilinear_interp",
-                                                           "bicubic_interp",
-                                                           "linear_interp",
-                                                           "bilinear_interp_v2",
-                                                           "linear_interp_v2"};
-    bool is_interpolate_op = std::find(not_default_op_types.begin(),
-                                       not_default_op_types.end(),
-                                       op_type) != not_default_op_types.end();
-    return !is_interpolate_op;
-  }
-  return false;
 }
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/placement_pass_base.cc
+++ b/paddle/fluid/framework/ir/placement_pass_base.cc
@@ -24,7 +24,6 @@ namespace ir {
 
 void PlacementPassBase::ApplyImpl(ir::Graph* graph) const {
   VLOG(3) << "Applies " << GetPlacementName() << " placement strategy.";
-  std::cout << "PlacementPassBase ApplyImpl" << std::endl;
   std::string attr_name = GetAttrName();
   const auto& op_types_list = GetOpTypesList();
   if (!graph->Has(attr_name)) {
@@ -34,11 +33,9 @@ void PlacementPassBase::ApplyImpl(ir::Graph* graph) const {
     if (n->IsOp()) {
       auto* op = n->Op();
       if (IsSupport(n)) {
-        if (op_types_list.empty() && IsDefaultOpTypes(op->Type())) {
-          op->SetAttr(attr_name, true);
-        } else if (std::find(op_types_list.begin(),
-                             op_types_list.end(),
-                             n->Name()) != op_types_list.end()) {
+        if (op_types_list.empty() ||
+            std::find(op_types_list.begin(), op_types_list.end(), n->Name()) !=
+                op_types_list.end()) {
           op->SetAttr(attr_name, true);
         }
       }

--- a/paddle/fluid/framework/ir/placement_pass_base.cc
+++ b/paddle/fluid/framework/ir/placement_pass_base.cc
@@ -24,6 +24,7 @@ namespace ir {
 
 void PlacementPassBase::ApplyImpl(ir::Graph* graph) const {
   VLOG(3) << "Applies " << GetPlacementName() << " placement strategy.";
+  std::cout << "PlacementPassBase ApplyImpl" << std::endl;
   std::string attr_name = GetAttrName();
   const auto& op_types_list = GetOpTypesList();
   if (!graph->Has(attr_name)) {

--- a/paddle/fluid/framework/ir/placement_pass_base.h
+++ b/paddle/fluid/framework/ir/placement_pass_base.h
@@ -36,7 +36,6 @@ class PlacementPassBase : public Pass {
   virtual const std::string GetAttrName() const = 0;
   virtual const std::unordered_set<std::string> GetOpTypesList() const = 0;
   virtual bool IsSupport(const Node* op) const = 0;
-  virtual bool IsDefaultOpTypes(const std::string& op_type) const = 0;
 
 #if PADDLE_WITH_TESTING
   friend class PlacementPassTest;

--- a/paddle/fluid/framework/ir/placement_pass_base.h
+++ b/paddle/fluid/framework/ir/placement_pass_base.h
@@ -35,10 +35,8 @@ class PlacementPassBase : public Pass {
   virtual const std::string GetPlacementName() const = 0;
   virtual const std::string GetAttrName() const = 0;
   virtual const std::unordered_set<std::string> GetOpTypesList() const = 0;
-
- private:
-  bool IsSupport(const std::string& op_type) const;
-  bool IsDefaultOpTypes(const std::string& op_type) const;
+  virtual bool IsSupport(const Node* op) const = 0;
+  virtual bool IsDefaultOpTypes(const std::string& op_type) const = 0;
 
 #if PADDLE_WITH_TESTING
   friend class PlacementPassTest;

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -175,6 +175,12 @@ struct Argument {
   DECL_ARGUMENT_FIELD(mkldnn_enabled_op_types,
                       MKLDNNEnabledOpTypes,
                       std::unordered_set<std::string>);
+
+  // Pass a set of operation types to disable their mkldnn kernel
+  DECL_ARGUMENT_FIELD(mkldnn_excluded_op_types,
+                      MKLDNNExcludedOpTypes,
+                      std::unordered_set<std::string>);
+
   // The cache capacity of different input shapes for mkldnn.
   DECL_ARGUMENT_FIELD(mkldnn_cache_capacity, MkldnnCacheCapacity, int);
 

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -177,8 +177,8 @@ struct Argument {
                       std::unordered_set<std::string>);
 
   // Pass a set of operation types to disable their mkldnn kernel
-  DECL_ARGUMENT_FIELD(mkldnn_excluded_op_types,
-                      MKLDNNExcludedOpTypes,
+  DECL_ARGUMENT_FIELD(mkldnn_excluded_ops,
+                      MKLDNNExcludedOps,
                       std::unordered_set<std::string>);
 
   // The cache capacity of different input shapes for mkldnn.

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -121,6 +121,9 @@ void IRPassManager::CreatePasses(Argument *argument,
       pass->Set("mkldnn_enabled_op_types",
                 new std::unordered_set<std::string>(
                     argument->mkldnn_enabled_op_types()));
+      pass->Set("mkldnn_excluded_op_types",
+                new std::unordered_set<std::string>(
+                    argument->mkldnn_excluded_op_types()));
     } else if (pass_name == "cudnn_placement_pass") {
       pass->Set("cudnn_enabled_op_types",
                 new std::unordered_set<std::string>());

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -121,9 +121,9 @@ void IRPassManager::CreatePasses(Argument *argument,
       pass->Set("mkldnn_enabled_op_types",
                 new std::unordered_set<std::string>(
                     argument->mkldnn_enabled_op_types()));
-      pass->Set("mkldnn_excluded_op_types",
-                new std::unordered_set<std::string>(
-                    argument->mkldnn_excluded_op_types()));
+      pass->Set(
+          "mkldnn_excluded_ops",
+          new std::unordered_set<std::string>(argument->mkldnn_excluded_ops()));
     } else if (pass_name == "cudnn_placement_pass") {
       pass->Set("cudnn_enabled_op_types",
                 new std::unordered_set<std::string>());

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -448,7 +448,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   // MKLDNN related.
   CP_MEMBER(use_mkldnn_);
   CP_MEMBER(mkldnn_enabled_op_types_);
-  CP_MEMBER(mkldnn_excluded_op_types_);
+  CP_MEMBER(mkldnn_excluded_ops_);
   CP_MEMBER(mkldnn_cache_capacity_);
   // Bfloat16 related.
   CP_MEMBER(use_mkldnn_bfloat16_);

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -448,6 +448,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   // MKLDNN related.
   CP_MEMBER(use_mkldnn_);
   CP_MEMBER(mkldnn_enabled_op_types_);
+  CP_MEMBER(mkldnn_excluded_op_types_);
   CP_MEMBER(mkldnn_cache_capacity_);
   // Bfloat16 related.
   CP_MEMBER(use_mkldnn_bfloat16_);

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1218,6 +1218,7 @@ void AnalysisPredictor::PrepareArgument() {
   if (config_.use_mkldnn_) {
     LOG(INFO) << "MKLDNN is enabled";
     argument_->SetMKLDNNEnabledOpTypes(config_.mkldnn_enabled_op_types_);
+    argument_->SetMKLDNNExcludedOpTypes(config_.mkldnn_excluded_op_types_);
   }
 
   if (config_.use_cinn_compiler_) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1218,7 +1218,7 @@ void AnalysisPredictor::PrepareArgument() {
   if (config_.use_mkldnn_) {
     LOG(INFO) << "MKLDNN is enabled";
     argument_->SetMKLDNNEnabledOpTypes(config_.mkldnn_enabled_op_types_);
-    argument_->SetMKLDNNExcludedOpTypes(config_.mkldnn_excluded_op_types_);
+    argument_->SetMKLDNNExcludedOps(config_.mkldnn_excluded_ops_);
   }
 
   if (config_.use_cinn_compiler_) {

--- a/paddle/fluid/inference/api/analysis_predictor_tester.cc
+++ b/paddle/fluid/inference/api/analysis_predictor_tester.cc
@@ -383,11 +383,11 @@ TEST(AnalysisPredictor, mkldnn_fc_passes_gpu_pass_strategy) {
 #endif
 
 #ifdef PADDLE_WITH_MKLDNN
-TEST(AnalysisPredictor, mkldnn_excluded_op_types) {
+TEST(AnalysisPredictor, mkldnn_excluded_ops) {
   AnalysisConfig config;
   config.EnableMKLDNN();
-  config.SetMKLDNNExcludedOp({"conv2d", "pool2d"});
-  ASSERT_EQ(config.mkldnn_excluded_op_types().size(), (size_t)2);
+  config.SetMKLDNNExcludedOps({"conv2d", "pool2d"});
+  ASSERT_EQ(config.mkldnn_excluded_ops().size(), (size_t)2);
 }
 #endif
 

--- a/paddle/fluid/inference/api/analysis_predictor_tester.cc
+++ b/paddle/fluid/inference/api/analysis_predictor_tester.cc
@@ -382,6 +382,15 @@ TEST(AnalysisPredictor, mkldnn_fc_passes_gpu_pass_strategy) {
 }
 #endif
 
+#ifdef PADDLE_WITH_MKLDNN
+TEST(AnalysisPredictor, mkldnn_excluded_op_types) {
+  AnalysisConfig config;
+  config.EnableMKLDNN();
+  config.SetMKLDNNExcludedOp({"conv2d", "pool2d"});
+  ASSERT_EQ(config.mkldnn_excluded_op_types().size(), (size_t)2);
+}
+#endif
+
 #ifdef PADDLE_WITH_XPU
 TEST(AnalysisPredictor, set_xpu_device_id) {
   AnalysisConfig config;

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -833,6 +833,20 @@ struct PD_INFER_DECL AnalysisConfig {
     mkldnn_enabled_op_types_ = op_list;
   }
 
+  /// \brief Specify the operator type list excluded from MKLDNN acceleration.
+  ///
+  /// \param op_list The operator type list.
+  ///
+  void SetMKLDNNExcludedOp(std::unordered_set<std::string> op_list) {
+    mkldnn_excluded_op_types_ = op_list;
+  }
+
+  /// \brief Return list of operators excluded from MKLDNN acceleration.
+  ///
+  std::unordered_set<std::string> mkldnn_excluded_op_types() const {
+    return mkldnn_excluded_op_types_;
+  }
+
   ///
   /// \brief Turn on MKLDNN quantization.
   ///
@@ -1137,6 +1151,7 @@ struct PD_INFER_DECL AnalysisConfig {
 
   bool use_mkldnn_{false};
   std::unordered_set<std::string> mkldnn_enabled_op_types_;
+  std::unordered_set<std::string> mkldnn_excluded_op_types_;
 
   bool model_from_memory_{false};
 

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -837,14 +837,14 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   /// \param op_list The operator type list.
   ///
-  void SetMKLDNNExcludedOp(std::unordered_set<std::string> op_list) {
-    mkldnn_excluded_op_types_ = op_list;
+  void SetMKLDNNExcludedOps(std::unordered_set<std::string> op_list) {
+    mkldnn_excluded_ops_ = op_list;
   }
 
   /// \brief Return list of operators excluded from MKLDNN acceleration.
   ///
-  std::unordered_set<std::string> mkldnn_excluded_op_types() const {
-    return mkldnn_excluded_op_types_;
+  std::unordered_set<std::string> mkldnn_excluded_ops() const {
+    return mkldnn_excluded_ops_;
   }
 
   ///
@@ -1151,7 +1151,7 @@ struct PD_INFER_DECL AnalysisConfig {
 
   bool use_mkldnn_{false};
   std::unordered_set<std::string> mkldnn_enabled_op_types_;
-  std::unordered_set<std::string> mkldnn_excluded_op_types_;
+  std::unordered_set<std::string> mkldnn_excluded_ops_;
 
   bool model_from_memory_{false};
 

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -868,7 +868,7 @@ void BindAnalysisConfig(py::module *m) {
            )DOC")
 #endif
       .def("set_mkldnn_op", &AnalysisConfig::SetMKLDNNOp)
-      .def("set_mkldnn_excluded_op", &AnalysisConfig::SetMKLDNNExcludedOp)
+      .def("set_mkldnn_excluded_ops", &AnalysisConfig::SetMKLDNNExcludedOps)
       .def("set_model_buffer", &AnalysisConfig::SetModelBuffer)
       .def("model_from_memory", &AnalysisConfig::model_from_memory)
       .def("delete_pass",

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -868,6 +868,7 @@ void BindAnalysisConfig(py::module *m) {
            )DOC")
 #endif
       .def("set_mkldnn_op", &AnalysisConfig::SetMKLDNNOp)
+      .def("set_mkldnn_excluded_op", &AnalysisConfig::SetMKLDNNExcludedOp)
       .def("set_model_buffer", &AnalysisConfig::SetModelBuffer)
       .def("model_from_memory", &AnalysisConfig::model_from_memory)
       .def("delete_pass",

--- a/python/paddle/fluid/tests/unittests/test_eager_deletion_delete_vars.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_deletion_delete_vars.py
@@ -89,6 +89,14 @@ class TestExecutor(unittest.TestCase):
                     with fluid.unique_name.guard():
                         self.pe_main()
 
+    def test_executor_mkldnn(self):
+        self.place = fluid.CPUPlace()
+        fluid.set_flags({'FLAGS_use_mkldnn': True})
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            with fluid.scope_guard(fluid.Scope()):
+                with fluid.unique_name.guard():
+                    self.executor_main()
+
     def prepare_feed(self, image, label, dev_cnt=1):
         batch_size = 32 * dev_cnt
         image_shape = (batch_size,) + tuple(image.shape[1:])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
Previously in mkldnn_placement_pass use_mkldnn was only set based on whether there is a `use_mkldnn` attribute. I changed it to check if there is an OneDNN kernel registered with the appropriate datatype and only, in this case, `use_mkldnn` is set to True.   

In addition, I added an option to exclude some operators from using MKLDNN `SetMKLDNNExcludedOps`, this can be very useful in some cases for not very well known models.