### PR TITLE
[CodeStyle][py36-][E722] remove import handling for `collections.abc` in different python versions

### DIFF
--- a/python/paddle/distribution/multinomial.py
+++ b/python/paddle/distribution/multinomial.py
@@ -15,10 +15,7 @@
 import paddle
 from paddle.distribution import categorical, distribution
 
-try:
-    from collections.abc import Iterable
-except:
-    from collections import Iterable
+from collections.abc import Iterable
 
 
 class Multinomial(distribution.Distribution):

--- a/python/paddle/distribution/normal.py
+++ b/python/paddle/distribution/normal.py
@@ -27,10 +27,7 @@ from paddle.fluid.layers import (
     tensor,
 )
 
-try:
-    from collections.abc import Iterable
-except:
-    from collections import Iterable
+from collections.abc import Iterable
 
 
 class Normal(distribution.Distribution):

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -26,10 +26,7 @@ import paddle.fluid
 from .data_feeder import check_type
 import warnings
 
-try:
-    from collections.abc import Sequence
-except:
-    from collections import Sequence
+from collections.abc import Sequence
 
 __all__ = [
     'append_backward',

--- a/python/paddle/fluid/dataloader/collate.py
+++ b/python/paddle/fluid/dataloader/collate.py
@@ -18,10 +18,7 @@ import numpy as np
 from ..framework import _non_static_mode
 from .. import core, layers
 
-try:
-    from collections.abc import Sequence, Mapping
-except:
-    from collections import Sequence, Mapping
+from collections.abc import Sequence, Mapping
 
 
 def default_collate_fn(batch):

--- a/python/paddle/fluid/dataloader/flat.py
+++ b/python/paddle/fluid/dataloader/flat.py
@@ -16,10 +16,8 @@ import paddle
 import numbers
 import numpy as np
 
-try:
-    from collections.abc import Sequence, Mapping
-except:
-    from collections import Sequence, Mapping
+from collections.abc import Sequence, Mapping
+
 
 FIELD_PREFIX = "_paddle_field_"
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/origin_info.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/origin_info.py
@@ -21,10 +21,7 @@ from paddle.fluid.dygraph.dygraph_to_static.utils import unwrap
 from paddle.fluid.dygraph.dygraph_to_static.utils import ORIGI_INFO
 from paddle.fluid.framework import Program
 
-try:
-    from collections.abc import Sequence
-except:
-    from collections import Sequence
+from collections.abc import Sequence
 
 
 class Location:

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -60,6 +60,8 @@ from ..data_feeder import (
 )
 from paddle.utils import deprecated
 from paddle import _C_ops, _legacy_C_ops
+from collections.abc import Iterable
+
 
 __all__ = [
     'fc',
@@ -6808,10 +6810,6 @@ def lod_append(x, level):
             x = fluid.layers.data(name='x', shape=[6, 10], lod_level=1)
             out = fluid.layers.lod_append(x, [1,1,1,1,1,1])
     """
-    try:
-        from collections.abc import Iterable
-    except:
-        from collections import Iterable
     if x is None:
         raise ValueError("Input(x) can't be None.")
     if (not isinstance(level, Iterable)) and (not isinstance(level, Variable)):

--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -32,10 +32,7 @@ from ..framework import _non_static_mode
 from ..param_attr import ParamAttr
 from ..data_feeder import check_variable_and_dtype, check_type, check_dtype
 
-try:
-    from collections.abc import Sequence
-except:
-    from collections import Sequence
+from collections.abc import Sequence
 
 __all__ = [
     'RNNCell',

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -25,10 +25,7 @@ from ..data_feeder import (
 from ..layer_helper import LayerHelper
 from sys import version_info
 
-try:
-    from collections.abc import Sequence
-except:
-    from collections import Sequence
+from collections.abc import Sequence
 
 
 def convert_to_list(value, n, name, dtype=int):

--- a/python/paddle/fluid/tests/unittests/gradient_checker.py
+++ b/python/paddle/fluid/tests/unittests/gradient_checker.py
@@ -22,10 +22,7 @@ import paddle.fluid.core as core
 from paddle.fluid.backward import _append_grad_suffix_, _as_list
 from paddle.fluid.framework import _test_eager_guard
 
-try:
-    from collections.abc import Sequence
-except:
-    from collections import Sequence
+from collections.abc import Sequence
 
 
 def _product(t):

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -49,10 +49,7 @@ from paddle.fluid.dygraph.io import (
 )
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 
-try:
-    from collections.abc import Iterable
-except:
-    from collections import Iterable
+from collections.abc import Iterable
 
 __all__ = []
 

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -30,10 +30,7 @@ from paddle.framework import core
 from paddle.static import default_startup_program
 from paddle.static import program_guard
 
-try:
-    from collections.abc import Sequence
-except:
-    from collections import Sequence
+from collections.abc import Sequence
 
 __all__ = []
 

--- a/python/paddle/vision/transforms/functional_cv2.py
+++ b/python/paddle/vision/transforms/functional_cv2.py
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import math
 import numbers
-import collections
 
 import numpy as np
 
 import paddle
 from paddle.utils import try_import
 
-if sys.version_info < (3, 3):
-    Sequence = collections.Sequence
-    Iterable = collections.Iterable
-else:
-    Sequence = collections.abc.Sequence
-    Iterable = collections.abc.Iterable
+from collections.abc import Sequence, Iterable
 
 __all__ = []
 

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -12,20 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import numbers
-import collections
 from PIL import Image, ImageOps, ImageEnhance
 
 import numpy as np
 import paddle
 
-if sys.version_info < (3, 3):
-    Sequence = collections.Sequence
-    Iterable = collections.Iterable
-else:
-    Sequence = collections.abc.Sequence
-    Iterable = collections.abc.Iterable
+from collections.abc import Sequence, Iterable
 
 try:
     # PIL version >= "9.1.0"

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -13,23 +13,16 @@
 # limitations under the License.
 
 import math
-import sys
 import random
 
 import numpy as np
 import numbers
-import collections
 import traceback
 
 import paddle
 from . import functional as F
 
-if sys.version_info < (3, 3):
-    Sequence = collections.Sequence
-    Iterable = collections.Iterable
-else:
-    Sequence = collections.abc.Sequence
-    Iterable = collections.abc.Iterable
+from collections.abc import Sequence, Iterable
 
 __all__ = []
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

Python collections 模块中原来包含一些抽象基类，自 Python 3.3 移到了 collections.abc 子模块中，但保留别名，也就是 collections 还能 import 这些模块，而 Python 3.10 彻底移除了这些别名[^1]

现在 Paddle 最低支持的 Python 版本为 Python 3.7[^2]，而 Python 3.7+ 都可以从 collections.abc 里直接 import 这些模块，不需要针对 Python 版本进行差异化处理，因此移除这些差异化处理，直接从 collections.abc import

此外，#42242 为了兼容 Python 3.10 的差异化处理是直接 try-except，导致了一些 Flake8[^3] E722 问题[^4]，因此这里顺便消除了一部分 E722 问题～～～

[^1]: [collections — Container datatypes (Python 3.9 docs)](https://docs.python.org/3.9/library/collections.html#module-collections)（Python 3.10+ 文档里已经找不到相关说明了）
[^2]: PaddlePaddle/community#338
[^3]: #46039
[^4]: cattidea/paddle-flake8-project#73