### PR TITLE
[Phi]fix TransferLayoutGeneral in phi

### DIFF
--- a/paddle/phi/kernels/transfer_layout_kernel.cc
+++ b/paddle/phi/kernels/transfer_layout_kernel.cc
@@ -55,12 +55,12 @@ void CastDataLayout(const Context& dev_ctx,
 template <typename Context>
 void TransferLayoutGeneral(const Context& dev_ctx,
                            const DenseTensor& x,
+                           DataLayout src_layout,
                            DataLayout dst_layout,
-                           DataLayout from_layout,
                            DenseTensor* out) {
   auto src_dim = x.dims();
 
-  auto axis = GetAxis(from_layout, dst_layout);
+  auto axis = GetAxis(src_layout, dst_layout);
 
   std::vector<int64_t> dst_dim;
   dst_dim.resize(axis.size());
@@ -173,8 +173,11 @@ void TransferLayoutKernel(const Context& dev_ctx,
                                 static_cast<DataLayout>(dst_layout),
                                 out);
 #else
-  TransferLayoutGeneral<Context>(
-      dev_ctx, x, static_cast<DataLayout>(dst_layout), static_cast<DataLayout>(src_layout), out);
+  TransferLayoutGeneral<Context>(dev_ctx,
+                                 x,
+                                 static_cast<DataLayout>(dst_layout),
+                                 static_cast<DataLayout>(src_layout),
+                                 out);
 #endif
 }
 

--- a/paddle/phi/kernels/transfer_layout_kernel.cc
+++ b/paddle/phi/kernels/transfer_layout_kernel.cc
@@ -175,8 +175,8 @@ void TransferLayoutKernel(const Context& dev_ctx,
 #else
   TransferLayoutGeneral<Context>(dev_ctx,
                                  x,
-                                 static_cast<DataLayout>(dst_layout),
                                  static_cast<DataLayout>(src_layout),
+                                 static_cast<DataLayout>(dst_layout),
                                  out);
 #endif
 }

--- a/paddle/phi/kernels/transfer_layout_kernel.cc
+++ b/paddle/phi/kernels/transfer_layout_kernel.cc
@@ -56,10 +56,11 @@ template <typename Context>
 void TransferLayoutGeneral(const Context& dev_ctx,
                            const DenseTensor& x,
                            DataLayout dst_layout,
+                           DataLayout from_layout,
                            DenseTensor* out) {
   auto src_dim = x.dims();
 
-  auto axis = GetAxis(x.layout(), dst_layout);
+  auto axis = GetAxis(from_layout, dst_layout);
 
   std::vector<int64_t> dst_dim;
   dst_dim.resize(axis.size());
@@ -140,7 +141,7 @@ void TransferLayoutMKLDNN(const Context& dev_ctx,
         errors::PreconditionNotMet(
             "No layout transform needed between two oneDNN OPKernels."));
   } else {
-    TransferLayoutGeneral<Context>(dev_ctx, x, dst_layout, out);
+    TransferLayoutGeneral<Context>(dev_ctx, x, dst_layout, src_layout, out);
   }
 }
 #endif
@@ -173,7 +174,7 @@ void TransferLayoutKernel(const Context& dev_ctx,
                                 out);
 #else
   TransferLayoutGeneral<Context>(
-      dev_ctx, x, static_cast<DataLayout>(dst_layout), out);
+      dev_ctx, x, static_cast<DataLayout>(dst_layout), static_cast<DataLayout>(src_layout), out);
 #endif
 }
 

--- a/paddle/phi/kernels/transfer_layout_kernel.cc
+++ b/paddle/phi/kernels/transfer_layout_kernel.cc
@@ -141,7 +141,7 @@ void TransferLayoutMKLDNN(const Context& dev_ctx,
         errors::PreconditionNotMet(
             "No layout transform needed between two oneDNN OPKernels."));
   } else {
-    TransferLayoutGeneral<Context>(dev_ctx, x, dst_layout, src_layout, out);
+    TransferLayoutGeneral<Context>(dev_ctx, x, src_layout, dst_layout, out);
   }
 }
 #endif

--- a/paddle/phi/kernels/transfer_layout_kernel.cc
+++ b/paddle/phi/kernels/transfer_layout_kernel.cc
@@ -60,6 +60,13 @@ void TransferLayoutGeneral(const Context& dev_ctx,
                            DenseTensor* out) {
   auto src_dim = x.dims();
 
+  PADDLE_ENFORCE_EQ(
+      x.layout(),
+      src_layout,
+      phi::errors::InvalidArgument(
+          "Layout obtained from the src_layout attribute of transfer_layout op"
+          "should be equal to the layout of the input tensor"));
+
   auto axis = GetAxis(src_layout, dst_layout);
 
   std::vector<int64_t> dst_dim;

--- a/python/paddle/fluid/tests/unittests/test_transfer_layout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transfer_layout_op.py
@@ -29,7 +29,7 @@ class TestTransferLayoutOpkNCHWTokNHWC(OpTest):
         ipt = np.random.random(size=[2, 3, 10, 10])
         self.inputs = {'X': ipt.astype('float32')}
         self.outputs = {'Out': ipt.transpose([0, 2, 3, 1])}
-        self.attrs = {'src_layout': 0, 'dst_layout': 1}  # kNHWC
+        self.attrs = {'src_layout': 2, 'dst_layout': 1}  # kNHWC
         self.op_type = 'transfer_layout'
 
     def test_check_output(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 对于TransferLayoutGeneral函数，增加一个参数为输入的layout，而不是从输入tensor中读取layout。