### PR TITLE
use full directly if device is CPU and in dygraph, for optimizer

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -730,10 +730,22 @@ class Optimizer:
         )
         if device is None:
             device = self._get_device_for_param(param.name)
-        with device_guard(device):
-            self.helper.set_variable_initializer(
-                var, initializer=Constant(value=float(fill_value))
+
+        if in_dygraph_mode() and (
+            device == 'cpu' or isinstance(device, core.CPUPlace)
+        ):
+            _C_ops.full_(
+                var,
+                var.shape,
+                str(float(fill_value)),
+                var.dtype,
+                core.CPUPlace(),
             )
+        else:
+            with device_guard(device):
+                self.helper.set_variable_initializer(
+                    var, initializer=Constant(value=float(fill_value))
+                )
 
         if framework._non_static_mode():
             if len(self._accumulators_holder) > 0:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
optimizer的_add_accumulator，如果device是CPU，且在动态图下，直接使用full初始化var