### PR TITLE
[Inference] modify CollectShapeRangeInfo function

### DIFF
--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -65,8 +65,10 @@ void NaiveExecutor::Run() {
 #ifdef PADDLE_WITH_INFERENCE_NVTX
     platform::CudaNvtxRangePop();
 #endif
-    if (hookfunc_) {
-      hookfunc_(op.get());
+    if (hookfunc_.size()) {
+      for (auto &func : hookfunc_) {
+        func(op.get());
+      }
     }
   }
 #ifdef PADDLE_WITH_INFERENCE_NVTX
@@ -146,7 +148,7 @@ phi::DenseTensor *NaiveExecutor::FindTensor(const std::string &name) {
 }
 
 void NaiveExecutor::RegisterOutputHook(const HookFunc &hookfunc) {
-  hookfunc_ = hookfunc;
+  hookfunc_.push_back(hookfunc);
 }
 
 NaiveExecutor::~NaiveExecutor() {

--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -65,10 +65,8 @@ void NaiveExecutor::Run() {
 #ifdef PADDLE_WITH_INFERENCE_NVTX
     platform::CudaNvtxRangePop();
 #endif
-    if (hookfunc_.size()) {
-      for (auto &func : hookfunc_) {
-        func(op.get());
-      }
+    for (auto &func : hookfunc_) {
+      func(op.get());
     }
   }
 #ifdef PADDLE_WITH_INFERENCE_NVTX

--- a/paddle/fluid/framework/naive_executor.h
+++ b/paddle/fluid/framework/naive_executor.h
@@ -82,7 +82,7 @@ class NaiveExecutor {
   std::vector<std::unique_ptr<OperatorBase>> ops_;
   Scope* scope_{nullptr};
 
-  HookFunc hookfunc_{nullptr};
+  std::vector<HookFunc> hookfunc_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -258,7 +258,11 @@ void UpdateOpDescsByReuse(
         }
       }
 
+      std::vector<std::string> output_var_names;
       for (auto argument : node->Op()->Outputs()) {
+        std::copy(argument.second.begin(),
+                  argument.second.end(),
+                  std::back_inserter(output_var_names));
         for (const auto& x : argument.second) {
           auto name = x;
           if (reuse_table.count(x) && reuse_table.at(x) != x) {
@@ -268,6 +272,7 @@ void UpdateOpDescsByReuse(
           VLOG(4) << node->Name() << " output " << x << " -> " << name;
         }
       }
+      node->Op()->SetAttr("OutputVarNames", std::move(output_var_names));
 
       // modify the graph
       for (auto out_node : node->outputs) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -2215,12 +2215,6 @@ void AnalysisPredictor::SaveOptimModel(const std::string &dir) {
 }
 
 void AnalysisPredictor::RegisterOutputHook(const Exp_OutputHookFunc &hookfunc) {
-  if (config_.enable_memory_optim()) {
-    LOG(WARNING) << "If you want to run output hook function, you should "
-                    "use config.EnableMemoryOptim(false) to turn off memory "
-                    "reuse!";
-    return;
-  }
   static std::once_flag register_hook_flag;
   std::call_once(register_hook_flag, [this] {
     executor_->RegisterOutputHook([this](framework::OperatorBase *op) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1706,12 +1706,12 @@ bool AnalysisPredictor::ZeroCopyRun() {
   }
 #endif
 
-  executor_->Run();
-  inference::DisplayMemoryInfo(place_, "after run");
-
   if (config_.shape_range_info_collected()) {
     CollectShapeRangeInfo();
   }
+
+  executor_->Run();
+  inference::DisplayMemoryInfo(place_, "after run");
 
   // Fix TensorArray reuse not cleaned bug.
   tensor_array_batch_cleaner_.CollectTensorArrays(sub_scope_);
@@ -1782,46 +1782,74 @@ void AnalysisPredictor::CollectShapeRangeInfo() {
 #endif
   }
 
-  std::vector<std::string> var_names = sub_scope_->LocalVarNames();
-  for (const auto &name : var_names) {
-    auto *var = sub_scope_->GetVar(name);
-    if (!var->IsType<phi::DenseTensor>()) {
+  auto input_names = GetInputNames();
+  for (auto &input_name : input_names) {
+    auto *var = sub_scope_->FindVar(input_name);
+    if (!var || !var->IsType<phi::DenseTensor>()) {
       continue;
     }
-    auto tensor = var->Get<phi::DenseTensor>();
-    framework::DDim dim = tensor.dims();
+    auto dense_tensor = var->Get<phi::DenseTensor>();
+    framework::DDim dim = dense_tensor.dims();
     std::vector<int32_t> shape(dim.size());
-    for (size_t i = 0; i < shape.size(); ++i) shape[i] = dim[i];
-    shape_info_[name].emplace_back(shape);
-
-    // We need collect value range for shape tensor for Paddle-TRT's use.
-    // To be noticed, this method to identify all shape tensors is based on
-    // assumption that all shape tensors in the model have numbers <= 7.
-    // This is a simple method to identify all shape tensors with some
-    // mistakes, but it doesn't matter.
-    auto is_shape_tensor = tensor.numel() <= 7 && tensor.numel() >= 1;
-    if (tensor.dtype() == paddle::experimental::DataType::INT32 &&
-        is_shape_tensor) {
-      std::vector<int> int32_host(tensor.numel());
-      if (tensor.place() == platform::CPUPlace()) {
-        paddle::memory::Copy(platform::CPUPlace(),
-                             int32_host.data(),
-                             platform::CPUPlace(),
-                             tensor.data<int>(),
-                             tensor.numel() * sizeof(int));
-      } else if (tensor.place() == platform::CUDAPlace()) {
-#if defined(PADDLE_WITH_CUDA)
-        paddle::memory::Copy(platform::CPUPlace(),
-                             int32_host.data(),
-                             platform::CUDAPlace(),
-                             tensor.data<int>(),
-                             tensor.numel() * sizeof(int),
-                             nullptr);
-#endif
-      }
-      shape_tensor_value_[name].emplace_back(int32_host);
+    for (size_t i = 0; i < shape.size(); ++i) {
+      shape[i] = dim[i];
     }
+    this->shape_info_[input_name].emplace_back(shape);
   }
+
+  executor_->RegisterOutputHook([this](framework::OperatorBase *op) {
+    auto output_var_names =
+        op->Attr<std::vector<std::string>>("OutputVarNames");
+    int output_var_names_index = 0;
+    for (auto &output : op->Outputs()) {
+      for (size_t i = 0; i < output.second.size(); ++i) {
+        auto &var_name = output.second[i];
+        auto *var = sub_scope_->FindVar(var_name);
+        if (!var || !var->IsType<phi::DenseTensor>()) {
+          continue;
+        }
+        auto dense_tensor = var->Get<phi::DenseTensor>();
+        framework::DDim dim = dense_tensor.dims();
+        std::vector<int32_t> shape(dim.size());
+        for (size_t i = 0; i < shape.size(); ++i) {
+          shape[i] = dim[i];
+        }
+        this->shape_info_[output_var_names[output_var_names_index]]
+            .emplace_back(shape);
+
+        // We need collect value range for shape tensor for Paddle-TRT's use.
+        // To be noticed, this method to identify all shape tensors is based on
+        // assumption that all shape tensors in the model have numbers <= 7.
+        // This is a simple method to identify all shape tensors with some
+        // mistakes, but it doesn't matter.
+        auto is_shape_tensor =
+            dense_tensor.numel() <= 7 && dense_tensor.numel() >= 1;
+        if (dense_tensor.dtype() == paddle::experimental::DataType::INT32 &&
+            is_shape_tensor) {
+          std::vector<int> int32_host(dense_tensor.numel());
+          if (dense_tensor.place() == platform::CPUPlace()) {
+            paddle::memory::Copy(platform::CPUPlace(),
+                                 int32_host.data(),
+                                 platform::CPUPlace(),
+                                 dense_tensor.data<int>(),
+                                 dense_tensor.numel() * sizeof(int));
+          } else if (dense_tensor.place() == platform::CUDAPlace()) {
+#if defined(PADDLE_WITH_CUDA)
+            paddle::memory::Copy(platform::CPUPlace(),
+                                 int32_host.data(),
+                                 platform::CUDAPlace(),
+                                 dense_tensor.data<int>(),
+                                 dense_tensor.numel() * sizeof(int),
+                                 nullptr);
+#endif
+          }
+          this->shape_tensor_value_[output_var_names[output_var_names_index]]
+              .emplace_back(int32_host);
+        }
+        output_var_names_index++;
+      }
+    }
+  });
 }
 
 void AnalysisPredictor::StatisticShapeRangeInfo() {
@@ -2196,6 +2224,9 @@ void AnalysisPredictor::RegisterOutputHook(const Exp_OutputHookFunc &hookfunc) {
   static std::once_flag register_hook_flag;
   std::call_once(register_hook_flag, [this] {
     executor_->RegisterOutputHook([this](framework::OperatorBase *op) {
+      auto output_var_names =
+          op->Attr<std::vector<std::string>>("OutputVarNames");
+      int output_var_names_index = 0;
       for (auto &output : op->Outputs()) {
         for (auto &var_name : output.second) {
           auto *var = this->sub_scope_->FindVar(var_name);
@@ -2204,7 +2235,9 @@ void AnalysisPredictor::RegisterOutputHook(const Exp_OutputHookFunc &hookfunc) {
           if (!dense_tensor.initialized()) continue;
           auto tensor = this->GetOutputTensor(var_name);
           for (auto &hookfunc : this->hookfuncs_) {
-            hookfunc(op->Type(), var_name, *tensor);
+            hookfunc(op->Type(),
+                     output_var_names[output_var_names_index++],
+                     *tensor);
           }
         }
       }

--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -102,7 +102,7 @@ class AnalysisPredictor : public PaddlePredictor {
   explicit AnalysisPredictor(const AnalysisConfig &config) : config_(config) {
     if (config_.shape_range_info_collected()) {
       config_.SwitchIrOptim(false);
-      config_.EnableMemoryOptim(false);
+      config_.EnableMemoryOptim(true);
     }
     predictor_id_ = inference::GetUniqueId();
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
**背景：**
MemoryOptimizePass 会复用 VarName，例如若 Var B 复用了 Var A，经过 MemoryOptimizePass 后，graph 中只有 Var A 没有 VarB。CollectShapeRangeInfo 无法正确收集到 Var A 和 Var B 的信息，因此在以往的处理中，CollectShape 时，会关掉 MemoryOptimizePass。对显存或内存需求高的模型，会因无法复用，爆显存或内存。
**工作：**
修改 CollectShapeRangeInfo 功能，使得 CollectShapeRangeInfo 可以和 MemoryOptimizePass  共同使用
**基本原理：**
1. 在 MemoryOptimPass 中，记录每个 Op 的输出 VarName 的变化，记录在 op 的属性中
2. 在每个 op run 结束后，遍历 op 的输出 var，根据记录的映射关系恢复回原来的名字

使用时，会关闭除了 MemoryOptimPass 之外的所有优化。
