### PR TITLE
optimize setup.py under conda virtual environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1417,25 +1417,16 @@ Please run 'pip install -r python/requirements.txt' to make sure you have all th
         )  # Specify the dependencies to install
 
     python_dependcies_module = []
-    for dependency in build_dependencies:
-        if '>=' in dependency:
-            python_dependcies_module.append(
-                dependency.partition('>=')[0].replace('-', '').replace('_', '')
-            )
-        elif '==' in dependency:
-            python_dependcies_module.append(
-                dependency.partition('==')[0].replace('-', '').replace('_', '')
-            )
-        else:
-            python_dependcies_module.append(
-                dependency.replace('-', '').replace('_', '')
-            )
+    installed_packages = []
 
+    for dependency in build_dependencies:
+        python_dependcies_module.append(
+            re.sub("_|-", '', re.sub(r"==.*|>=.*|<=.*", '', dependency))
+        )
     reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
-    installed_packages = [
-        r.decode().split('==')[0].replace('-', '').replace('_', '')
-        for r in reqs.split()
-    ]
+
+    for r in reqs.split():
+        installed_packages.append(re.sub("_|-", '', r.decode().split('==')[0]))
 
     for dependency in python_dependcies_module:
         if dependency not in installed_packages:

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,11 @@ TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 
 IS_WINDOWS = os.name == 'nt'
 
+missing_modules = '''
+Missing build dependency: {dependency}
+Please run 'pip install -r python/requirements.txt' to make sure you have all the dependencies installed.
+'''.strip()
+
 
 def filter_setup_args(input_args):
     cmake_and_build = True
@@ -1405,9 +1410,30 @@ def get_setup_parameters():
     )
 
 
+def check_build_dependency():
+    python_dependcies_module = [
+        'requests',
+        'numpy',
+        'protobuf',
+        'Pillow',
+        'decorator',
+        'astor',
+        'paddle-bfloat',
+        'opt-einsum',
+    ]
+    reqs = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze'])
+    installed_packages = [r.decode().split('==')[0] for r in reqs.split()]
+    for dependency in python_dependcies_module:
+        if dependency not in installed_packages:
+            raise RuntimeError(missing_modules.format(dependency=dependency))
+
+
 def main():
     # Parse the command line and check arguments before we proceed with building steps and setup
     parse_input_command(filter_args_list)
+
+    # check build dependency
+    check_build_dependency()
 
     # Execute the build process,cmake and make
     if cmake_and_build:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others

### Describe
<!-- Describe what this PR does -->
优化setup.py
当我们通过conda 创建一个新的空的环境时候，setup.py不会检查依赖，直接编译，会在cmake阶段报错缺少依赖，现在在cmake之前进行判断，并提示用户安装依赖，如缺少protobuf，则会提示，如图
![image](https://user-images.githubusercontent.com/62429225/217772444-42ea80e5-3215-44d1-a740-2549d53ce14a.png)
