### PR TITLE
[CodeStyle][py2][py311] replace deprecated `inspect.getargspec` with `inspect.getfullargspec`

### DIFF
--- a/python/paddle/distributed/auto_parallel/dist_tensor.py
+++ b/python/paddle/distributed/auto_parallel/dist_tensor.py
@@ -306,7 +306,7 @@ class DistributedTensor:
         def _copy_kwargs(serial_tensor):
             kwargs = {}
             no_need_copy_args = ["self", "block", "shape", "name"]
-            arg_spec = inspect.getargspec(Variable.__init__)
+            arg_spec = inspect.getfullargspec(Variable.__init__)
 
             for key in arg_spec.args:
                 # TODO: Check the copied attribute from serial tensor whether valid

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -323,7 +323,7 @@ def _delete_keywords_from(node):
     func_src = astor.to_source(gast.gast_to_ast(node.func))
     import paddle.fluid as fluid
 
-    full_args = eval("inspect.getfullargspec({})".format(func_src))
+    full_args = eval(f"inspect.getfullargspec({func_src})")
     full_args_name = full_args[0]
 
     node.keywords = [k for k in node.keywords if k.arg in full_args_name]
@@ -407,9 +407,7 @@ def update_args_of_func(node, dygraph_node, method_name):
     if method_name == "__init__" or eval(
         "issubclass({}, fluid.dygraph.Layer)".format(class_src)
     ):
-        full_args = eval(
-            "inspect.getfullargspec({}.{})".format(class_src, method_name)
-        )
+        full_args = eval(f"inspect.getfullargspec({class_src}.{method_name})")
         full_args_name = [
             arg_name for arg_name in full_args[0] if arg_name != "self"
         ]

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -96,21 +96,6 @@ FOR_ITER_ZIP_TO_LIST_PREFIX = '__for_loop_iter_zip'
 RE_PYNAME = '[a-zA-Z0-9_]+'
 RE_PYMODULE = r'[a-zA-Z0-9_]+\.'
 
-# FullArgSpec is valid from Python3. Defined a Namedtuple to
-# to make it available in Python2.
-FullArgSpec = collections.namedtuple(
-    'FullArgSpec',
-    [
-        'args',
-        'varargs',
-        'varkw',
-        'defaults',
-        'kwonlyargs',
-        'kwonlydefaults',
-        'annotations',
-    ],
-)
-
 
 def data_layer_not_check(name, shape, dtype='float32', lod_level=0):
     """
@@ -199,27 +184,11 @@ def saw(x):
         return x
 
 
-def getfullargspec(target):
-    if hasattr(inspect, "getfullargspec"):
-        return inspect.getfullargspec(target)
-    else:
-        argspec = inspect.getargspec(target)
-        return FullArgSpec(
-            args=argspec.args,
-            varargs=argspec.varargs,
-            varkw=argspec.keywords,
-            defaults=argspec.defaults,
-            kwonlyargs=[],
-            kwonlydefaults=None,
-            annotations={},
-        )
-
-
 def parse_arg_and_kwargs(function):
     """
     Returns full argument names as list. e.g ['x', 'y', 'z']
     """
-    fullargspec = getfullargspec(function)
+    fullargspec = inspect.getfullargspec(function)
     arg_names = fullargspec.args
     if arg_names and 'self' == arg_names[0]:
         arg_names = fullargspec.args[1:]
@@ -239,7 +208,7 @@ def parse_varargs_name(function):
     """
     Returns varargs name string of function. e.g: 'input' from `foo(x, *input)`
     """
-    fullargspec = getfullargspec(function)
+    fullargspec = inspect.getfullargspec(function)
     varargs = fullargspec.varargs
     return varargs
 
@@ -354,7 +323,7 @@ def _delete_keywords_from(node):
     func_src = astor.to_source(gast.gast_to_ast(node.func))
     import paddle.fluid as fluid
 
-    full_args = eval("inspect.getargspec({})".format(func_src))
+    full_args = eval("inspect.getfullargspec({})".format(func_src))
     full_args_name = full_args[0]
 
     node.keywords = [k for k in node.keywords if k.arg in full_args_name]
@@ -439,7 +408,7 @@ def update_args_of_func(node, dygraph_node, method_name):
         "issubclass({}, fluid.dygraph.Layer)".format(class_src)
     ):
         full_args = eval(
-            "inspect.getargspec({}.{})".format(class_src, method_name)
+            "inspect.getfullargspec({}.{})".format(class_src, method_name)
         )
         full_args_name = [
             arg_name for arg_name in full_args[0] if arg_name != "self"

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12702,7 +12702,7 @@ class PyFuncRegistry:
 
         self._func = func
         # find named args using reflection
-        args = inspect.getargspec(self._func)
+        args = inspect.getfullargspec(self._func)
         if len(args[0]) == 0 and args[1] is None and args[2] is None:
             # Function with no inputs
             self._named_args = None

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -94,10 +94,7 @@ def restore_flatten_list(l, splits):
 
 
 def extract_args(func):
-    if hasattr(inspect, 'getfullargspec'):
-        return inspect.getfullargspec(func)[0]
-    else:
-        return inspect.getargspec(func)[0]
+    return inspect.getfullargspec(func).args
 
 
 def _all_gather(x, nranks, ring_id=0, use_calc_stream=True):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

`inspect.getargspec`[^1] 在 Python 3.0 已经标记为 deprecated 了，并已于 Python 3.11 移除[^2]，因此已有的 `inspect.getargspec` 可能成为支持 Python 3.11 的阻碍

Python 3.0+ 的推荐是使用 `inspect.getfullargspec`[^3] 来替代 `inspect.getargspec`[^1]，为了同时兼容 Python2 和 Python3 目前有一些代码对此做了处理，由于现在 Paddle 已经不再支持 Python2[^4]，因此这些处理可以移除，直接使用 `inspect.getfullargspec` 即可

`inspect.getargspec` 和 `inspect.getfullargspec` 同样以 namedtuple 形式返回函数的参数，只不过后者比前者返回结果多一些，比如 keyword-only 参数和类型注解，前者在传入包含 keyword-only 参数或类型注解的函数时会报错

- `inspect.getargspec`[^1] -> `ArgSpec(args, varargs, keywords, defaults)`
- `inspect.getfullargspec`[^3] -> `FullArgSpec(args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations)`

目前的 `inspect.getargspec` 用例均可使用 `inspect.getfullargspec` 直接替换

[^1]: [inspect — Inspect live objects - inspect.getargspec (Python 3.10 docs)](https://docs.python.org/3.10/library/inspect.html#inspect.getargspec)
[^2]: [What’s New In Python 3.11 - Removed](https://docs.python.org/3/whatsnew/3.11.html#removed)
[^3]: [inspect — Inspect live objects - inspect.getfullargspec (Python 3.10 docs)](https://docs.python.org/3.10/library/inspect.html#inspect.getfullargspec)
[^4]: #46837