### PR TITLE
[Dy2static] partial support register hooker

### DIFF
--- a/paddle/fluid/operators/py_func_op.cc
+++ b/paddle/fluid/operators/py_func_op.cc
@@ -84,8 +84,9 @@ static std::vector<paddle::experimental::Tensor> CallPythonFunc(
   }
 
   auto ret = PyObject_CallObject(callable->ptr(), in_args);
-  PADDLE_ENFORCE(ret!=Py_None, platform::errors::Fatal(
-          "The python callable raise exception."));
+  PADDLE_ENFORCE(
+      ret != Py_None,
+      platform::errors::Fatal("The python callable raise exception."));
   VLOG(10) << "after call callable";
   auto ret_num = PyTuple_Size(ret);
   std::vector<paddle::experimental::Tensor> outs(ret_num);
@@ -320,9 +321,12 @@ class PyFuncOp : public framework::OperatorBase {
     VLOG(10) << "Call Python function with id " << callable_id << ": "
              << PythonFuncDebugString(*py_callable);
     auto outputs = CallPythonFunc(py_callable, inputs);
-    PADDLE_ENFORCE_EQ(outputs.size(), out_arg_names.size(), 
-                      platform::errors::InvalidArgument("The return values number is not the same with expected numbers."
-                          "run time error in 'py_func' operator."));
+    PADDLE_ENFORCE_EQ(
+        outputs.size(),
+        out_arg_names.size(),
+        platform::errors::InvalidArgument(
+            "The return values number is not the same with expected numbers."
+            "run time error in 'py_func' operator."));
     for (size_t i = 0; i < out_arg_names.size(); ++i) {
       auto *out_var = scope.FindVar(out_arg_names[i]);
       if (out_var == nullptr) {

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -521,7 +521,7 @@ class PartialProgramLayer:
             if isinstance(out, framework.Variable):
                 targets.append(program.global_block().var(out.name))
 
-        if targets and self._params:
+        if targets and (self._params or self._inputs) :
             backward.gradients(targets=targets, inputs=[])
 
         start_idx = len(main_program.block(0).ops) + 2 * len(

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1707,9 +1707,9 @@ class Variable(metaclass=VariableMetaClass):
 
     def register_hook(self, hook):
         import paddle
+
         def backward_hook_wrapper(d_out):
-            """ call the backward hook in eager mode.
-            """
+            """call the backward hook in eager mode."""
             paddle.disable_static()
             with paddle.no_grad():
                 d_self = hook(d_out)
@@ -1717,14 +1717,20 @@ class Variable(metaclass=VariableMetaClass):
             return d_self
 
         def forward_hook_wrapper(x):
-            """ do nothing but return a new variable.
-            """
+            """do nothing but return a new variable."""
             return x
-        
-        new_var = self.block.create_var(dtype=self.dtype, shape=self.shape) #name=None)
-        new_var = paddle.static.py_func(func=forward_hook_wrapper, x=self,
-            out=new_var, backward_func=backward_hook_wrapper,
-            skip_vars_in_backward_input=[self, new_var])
+
+        new_var = self.block.create_var(
+            dtype=self.dtype, shape=self.shape
+        )  # name=None)
+        new_var = paddle.static.py_func(
+            func=forward_hook_wrapper,
+            x=self,
+            out=new_var,
+            backward_func=backward_hook_wrapper,
+            skip_vars_in_backward_input=[self, new_var],
+        )
+
         return new_var
 
     def __str__(self):

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -14909,7 +14909,7 @@ class PyFuncRegistry(object):
         return self._id
 
     def __call__(self, *args):
-        try: 
+        try:
             if self._named_args is None:
                 func_ret = self._func()
             else:
@@ -14919,9 +14919,12 @@ class PyFuncRegistry(object):
                     kwargs[arg] = args[idx]
                     idx += 1
                 func_ret = self._func(*args[idx:], **kwargs)
-        except Exception as e: 
+        except Exception as e:
             # exception is thrown in hook function.
-            warnings.warn("Exception is thrown in PyFuncOp, return None): {}".format(e))
+            warnings.warn(
+                "Exception is thrown in PyFuncOp, return None): {}".format(e)
+            )
+
             return None
 
         if not isinstance(func_ret, (list, tuple)):

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -14909,15 +14909,20 @@ class PyFuncRegistry(object):
         return self._id
 
     def __call__(self, *args):
-        if self._named_args is None:
-            func_ret = self._func()
-        else:
-            kwargs = dict()
-            idx = 0
-            for arg in self._named_args:
-                kwargs[arg] = args[idx]
-                idx += 1
-            func_ret = self._func(*args[idx:], **kwargs)
+        try: 
+            if self._named_args is None:
+                func_ret = self._func()
+            else:
+                kwargs = dict()
+                idx = 0
+                for arg in self._named_args:
+                    kwargs[arg] = args[idx]
+                    idx += 1
+                func_ret = self._func(*args[idx:], **kwargs)
+        except Exception as e: 
+            # exception is thrown in hook function.
+            warnings.warn("Exception is thrown in PyFuncOp, return None): {}".format(e))
+            return None
 
         if not isinstance(func_ret, (list, tuple)):
             func_ret = (func_ret,)

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -14924,15 +14924,17 @@ class PyFuncRegistry(object):
 
         ret = []
         for each_ret in func_ret:
-            if each_ret is None or isinstance(each_ret, core.LoDTensor):
+            if each_ret is None or isinstance(each_ret, core.eager.Tensor):
                 ret.append(each_ret)
                 continue
 
             if not isinstance(each_ret, np.ndarray):
                 each_ret = np.array(each_ret)
 
-            tensor = core.LoDTensor()
-            tensor.set(each_ret, core.CPUPlace())
+            tensor = paddle.to_tensor()
+            assert isinstance(
+                tensor, core.eager.Tensor
+            ), "tensor must be eager.Tensor, but gets {}".format(type(tensor))
             ret.append(tensor)
 
         return tuple(ret)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Dy2static support register hooker by PyFuncOp. 
1. modify PyFuncOp and support eager tensor.
2. add register_hook for variable by call static.py_func_op and successfully get right grad.

TODO: 
1. 目前动态图和动转静有点不一样，使用一个Transformer处理一下？还是使用额外的方法：
```python
# 动态图
import paddle
def ffff(x):
    def h(g):
        return 3*g
    x.register_hook(h)
    t = 2 * x
    return t

x = paddle.to_tensor([2.0])
x.stop_gradient=False

y = paddle.jit.to_static(ffff)(x)
y.backward()

print(x.grad) # <---  4.0
```

```python
# 动转静
import paddle
def ffff(x):
    def h(g):
        return 3*g
    x = x.register_hook(h)  #<---- 需要使用Transformer修改的地方
    t = 2 * x
    return t

x = paddle.to_tensor([2.0])
x.stop_gradient=False

y = ffff(x)
y.backward()

print(x.grad) # <--- 4.0
```

2. 用户需要保证 x 的 register hook必须保证在 x 使用前调用。例如下面代码会出现错误：（解决方法，lazy模式，register hook负责搜集信息，在动转静结束时刻进行 PyFuncOp 的集中设置。）
```python
y = 2 * x 
x = x.register_hook(lambda dx: 2 * dx)
# 这里 y 对 x 的倒数会有问题。因为 x 使用的是最开始的值。
```

3. 目前的 JIT 方案不支持 remove ，但是 lazy 模式支持 remove（参考2），lazy模式缺点是不太直观。