### PR TITLE
fix vector out of range error

### DIFF
--- a/paddle/phi/kernels/funcs/broadcast_function.h
+++ b/paddle/phi/kernels/funcs/broadcast_function.h
@@ -878,7 +878,7 @@ void BroadcastKernelForDifferentVecSize(
   const auto dims_simplifier =
       BroadcastDimsSimplifier(ins, (*outs)[0]->dims(), axis);
   if (VLOG_IS_ON(4)) {
-    for (size_t i = 0; i < dims_simplifier.in_dims.size(); ++i) {
+    for (size_t i = 0; i < ins.size(); ++i) {
       VLOG(4) << "input i=" << i << ": origin_dims={" << ins[i]->dims()
               << "}, simplied_dims={"
               << phi::make_ddim(dims_simplifier.in_dims[i]) << "}";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix vector out of range error

When ins.size() == 1, the dims_simplifier.in_dims.size() is 2.

in dims_simplifier.h
```
    N = std::max(static_cast<int>(ins.size()), 2);
    in_dims.resize(N);
```