### PR TITLE
[cherry-pick] Fix wrong eigen header include in data_type.h (#48157)

### DIFF
--- a/paddle/phi/core/utils/data_type.h
+++ b/paddle/phi/core/utils/data_type.h
@@ -19,8 +19,6 @@ limitations under the License. */
 
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/enforce.h"
-#include "paddle/phi/kernels/funcs/eigen/extensions.h"
-
 namespace phi {
 
 #define _PhiForEachDataTypeHelper_(callback, cpp_type, data_type) \

--- a/paddle/phi/kernels/funcs/eigen/eigen_function.h
+++ b/paddle/phi/kernels/funcs/eigen/eigen_function.h
@@ -18,6 +18,8 @@ limitations under the License. */
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+
+#include "paddle/phi/kernels/funcs/eigen/extensions.h"
 #include "unsupported/Eigen/CXX11/Tensor"
 
 namespace phi {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
`paddle/phi/core/utils/data_type.h`中include了无用的eigen头文件，导致编译时会偶发如下错误：
![68750ad435c53e1920c184ae1f04898a](https://user-images.githubusercontent.com/13048366/202704178-65609614-615d-47b6-802b-c988028af086.png)

PR中对移除了`paddle/phi/core/utils/data_type.h`中的`paddle/phi/kernels/funcs/eigen/extensions.h`头文件引用。
