### PR TITLE
add logical_or, logical_xor and logical_and trt converter

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -168,6 +168,9 @@ const std::unordered_map<std::string, nvinfer1::ElementWiseOperation>
         {"pow", nvinfer1::ElementWiseOperation::kPOW},
         {"max", nvinfer1::ElementWiseOperation::kMAX},
         {"floordiv", nvinfer1::ElementWiseOperation::kFLOOR_DIV},
+        {"logical_or", nvinfer1::ElementWiseOperation::kOR},
+        {"logical_xor", nvinfer1::ElementWiseOperation::kXOR},
+        {"logical_and", nvinfer1::ElementWiseOperation::kAND},
 };
 
 class ElementwiseTensorAddOpConverter : public ElementwiseTensorOpConverter {
@@ -211,6 +214,24 @@ class ElementwiseTensorFloorDivOpConverter
   ElementwiseTensorFloorDivOpConverter() { op_type_ = "floordiv"; }
 };
 
+class ElementwiseTensorLogicalOrOpConverter
+    : public ElementwiseTensorOpConverter {
+ public:
+  ElementwiseTensorLogicalOrOpConverter() { op_type_ = "logical_or"; }
+};
+
+class ElementwiseTensorLogicalXorOpConverter
+    : public ElementwiseTensorOpConverter {
+ public:
+  ElementwiseTensorLogicalXorOpConverter() { op_type_ = "logical_xor"; }
+};
+
+class ElementwiseTensorLogicalAndOpConverter
+    : public ElementwiseTensorOpConverter {
+ public:
+  ElementwiseTensorLogicalAndOpConverter() { op_type_ = "logical_and"; }
+};
+
 }  // namespace tensorrt
 }  // namespace inference
 }  // namespace paddle
@@ -248,3 +269,6 @@ REGISTER_TRT_OP_CONVERTER(elementwise_pow_tensor,
                           ElementwiseTensorPowOpConverter);
 REGISTER_TRT_OP_CONVERTER(elementwise_floordiv_tensor,
                           ElementwiseTensorFloorDivOpConverter);
+REGISTER_TRT_OP_CONVERTER(logical_or, ElementwiseTensorLogicalOrOpConverter);
+REGISTER_TRT_OP_CONVERTER(logical_xor, ElementwiseTensorLogicalXorOpConverter);
+REGISTER_TRT_OP_CONVERTER(logical_and, ElementwiseTensorLogicalAndOpConverter);

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1324,6 +1324,19 @@ struct SimpleOpTypeSetTeller : public Teller {
       }
     }
 
+    if (op_type == "logical_or" || op_type == "logical_xor" ||
+        op_type == "logical_and") {
+      if (!with_dynamic_shape) {
+        VLOG(3)
+            << "static shape mode is not supported for TRT logical_or, "
+               "logical_xor and logical_than.\n"
+               "You can use the config.SetTRTDynamicShapeInfo(...) interface"
+               " to set the shape information to run the dynamic shape "
+               "mode.";
+        return false;
+      }
+    }
+
     if (op_type == "stack") {
       if (!with_dynamic_shape) {
         VLOG(3)
@@ -2327,6 +2340,9 @@ struct SimpleOpTypeSetTeller : public Teller {
       "elementwise_min",
       "elementwise_max",
       "elementwise_floordiv",
+      "logical_or",
+      "logical_xor",
+      "logical_and",
       "equal",
       "dropout",
       "fill_any_like",
@@ -2454,6 +2470,9 @@ struct SimpleOpTypeSetTeller : public Teller {
       "elementwise_min",
       "elementwise_max",
       "elementwise_floordiv",
+      "logical_or",
+      "logical_xor",
+      "logical_and",
       "equal",
       "dropout",
       "fill_any_like",

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1326,11 +1326,17 @@ struct SimpleOpTypeSetTeller : public Teller {
 
     if (op_type == "logical_or" || op_type == "logical_xor" ||
         op_type == "logical_and") {
+#if !IS_TRT_VERSION_GE(8400)
+      VLOG(3) << "logical_or, logical_xor and logical_and is not supported "
+                 "when TensorRT < 8.0";
+      return false;
+#else
       if (!with_dynamic_shape) {
         VLOG(3) << "static shape mode is not supported for TRT logical_or, "
                    "logical_xor and logical_than.\n";
         return false;
       }
+#endif
     }
 
     if (op_type == "stack") {

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -1327,12 +1327,8 @@ struct SimpleOpTypeSetTeller : public Teller {
     if (op_type == "logical_or" || op_type == "logical_xor" ||
         op_type == "logical_and") {
       if (!with_dynamic_shape) {
-        VLOG(3)
-            << "static shape mode is not supported for TRT logical_or, "
-               "logical_xor and logical_than.\n"
-               "You can use the config.SetTRTDynamicShapeInfo(...) interface"
-               " to set the shape information to run the dynamic shape "
-               "mode.";
+        VLOG(3) << "static shape mode is not supported for TRT logical_or, "
+                   "logical_xor and logical_than.\n";
         return false;
       }
     }

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logical.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logical.py
@@ -100,12 +100,21 @@ class TrtConvertElementwiseTest_one_input_special_case0(TrtLayerAutoScanTest):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [1, 32, 16, 32],
+                    "cast_output_data1": [1, 32, 16, 32],
+                    "cast_output_data3": [1, 32, 16, 32],
+                    "cast_output_data0": [1, 32, 16, 32],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [1, 32, 16, 32],
+                    "cast_output_data1": [1, 32, 16, 32],
+                    "cast_output_data3": [1, 32, 16, 32],
+                    "cast_output_data0": [1, 32, 16, 32],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [1, 32, 16, 32],
+                    "cast_output_data1": [1, 32, 16, 32],
+                    "cast_output_data3": [1, 32, 16, 32],
+                    "cast_output_data0": [1, 32, 16, 32],
                 }
 
         def clear_dynamic_shape():

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logical.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logical.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest
+from program_config import TensorConfig, ProgramConfig
+import unittest
+import numpy as np
+import paddle.inference as paddle_infer
+from functools import partial
+from typing import List
+
+
+# This is the special test case with weight including batch dimension
+# I don't want to mess up the code written by others, so I wrote a class specifically
+class TrtConvertElementwiseTest_one_input_special_case0(TrtLayerAutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self):
+        def generate_input(shape):
+            return np.random.random(shape).astype(np.float32)
+
+        def generate_weight():
+            return np.random.random([1, 32, 16, 32]).astype(np.float32)
+
+        for batch in [1]:
+            for shape in [[batch, 32, 16, 32]]:
+                for op_type in ["logical_and", "logical_or", "logical_xor"]:
+                    for axis in [-1]:
+                        self.dims = len(shape)
+                        dics = [
+                            {"axis": axis},
+                            {"in_dtype": 5, "out_dtype": 0},
+                            {"in_dtype": 0, "out_dtype": 5},
+                        ]
+                        ops_config = [
+                            {
+                                "op_type": "cast",
+                                "op_inputs": {"X": ["input_data"]},
+                                "op_outputs": {"Out": ["cast_output_data1"]},
+                                "op_attrs": dics[1],
+                            },
+                            {
+                                "op_type": "cast",
+                                "op_inputs": {"X": ["input_data"]},
+                                "op_outputs": {"Out": ["cast_output_data3"]},
+                                "op_attrs": dics[1],
+                            },
+                            {
+                                "op_type": op_type,
+                                "op_inputs": {
+                                    "X": ["cast_output_data1"],
+                                    "Y": ["cast_output_data3"],
+                                },
+                                "op_outputs": {"Out": ["cast_output_data0"]},
+                                "op_attrs": dics[0],
+                            },
+                            {
+                                "op_type": "cast",
+                                "op_inputs": {"X": ["cast_output_data0"]},
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[2],
+                            },
+                        ]
+                        ops = self.generate_op_config(ops_config)
+
+                        program_config = ProgramConfig(
+                            ops=ops,
+                            weights={
+                                "weight": TensorConfig(
+                                    data_gen=partial(generate_weight)
+                                )
+                            },
+                            inputs={
+                                "input_data": TensorConfig(
+                                    data_gen=partial(generate_input, shape)
+                                ),
+                            },
+                            outputs=["output_data"],
+                        )
+
+                        yield program_config
+
+    def sample_predictor_configs(
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
+        def generate_dynamic_shape(attrs):
+            # The input.dims[1] must be equal to the weight's length.
+            if self.dims == 4:
+                self.dynamic_shape.min_input_shape = {
+                    "input_data": [1, 32, 16, 32],
+                    "cast_output_data1": [1, 32, 16, 32],
+                    "cast_output_data3": [1, 32, 16, 32],
+                    "cast_output_data0": [1, 32, 16, 32],
+                }
+                self.dynamic_shape.max_input_shape = {
+                    "input_data": [1, 32, 16, 32],
+                    "cast_output_data1": [1, 32, 16, 32],
+                    "cast_output_data3": [1, 32, 16, 32],
+                    "cast_output_data0": [1, 32, 16, 32],
+                }
+                self.dynamic_shape.opt_input_shape = {
+                    "input_data": [1, 32, 16, 32],
+                    "cast_output_data1": [1, 32, 16, 32],
+                    "cast_output_data3": [1, 32, 16, 32],
+                    "cast_output_data0": [1, 32, 16, 32],
+                }
+
+        def clear_dynamic_shape():
+            self.dynamic_shape.max_input_shape = {}
+            self.dynamic_shape.min_input_shape = {}
+            self.dynamic_shape.opt_input_shape = {}
+
+        def generate_trt_nodes_num(attrs, dynamic_shape):
+            if not dynamic_shape:
+                return 0, 6
+            return 1, 2
+
+        attrs = [
+            program_config.ops[i].attrs for i in range(len(program_config.ops))
+        ]
+
+        # for static_shape
+        clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False
+        ), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False
+        ), (1e-3, 1e-3)
+
+        # for dynamic_shape
+        generate_dynamic_shape(attrs)
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True
+        ), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True
+        ), (1e-3, 1e-3)
+
+    def add_skip_trt_case(self):
+        pass
+
+    def test(self):
+        self.add_skip_trt_case()
+        self.run_test()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logical.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logical.py
@@ -100,21 +100,12 @@ class TrtConvertElementwiseTest_one_input_special_case0(TrtLayerAutoScanTest):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [1, 32, 16, 32],
-                    "cast_output_data1": [1, 32, 16, 32],
-                    "cast_output_data3": [1, 32, 16, 32],
-                    "cast_output_data0": [1, 32, 16, 32],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [1, 32, 16, 32],
-                    "cast_output_data1": [1, 32, 16, 32],
-                    "cast_output_data3": [1, 32, 16, 32],
-                    "cast_output_data0": [1, 32, 16, 32],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [1, 32, 16, 32],
-                    "cast_output_data1": [1, 32, 16, 32],
-                    "cast_output_data3": [1, 32, 16, 32],
-                    "cast_output_data0": [1, 32, 16, 32],
                 }
 
         def clear_dynamic_shape():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. add logical_or, logical_xor and logical_and trt converter.
2. 三个op的输入输出都为bool，通过cast将其他类型转为bool.