### PR TITLE
Cherrypick NV fixes to release/2.4

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -123,6 +123,7 @@ message BuildStrategy {
   optional bool allow_cuda_graph_capture = 14 [ default = false ];
   optional int32 reduce_strategy = 15 [ default = 0 ];
   optional bool fuse_gemm_epilogue = 16 [ default = false ];
+  optional string debug_graphviz_path = 17;
 }
 
 message ExecutionStrategy {

--- a/paddle/fluid/operators/fused/cudnn_norm_conv.cu.h
+++ b/paddle/fluid/operators/fused/cudnn_norm_conv.cu.h
@@ -45,6 +45,14 @@ struct NormConvolutionArgs {
            int stride,
            int dilation,
            int group) {
+    PADDLE_ENFORCE_LT(
+        ctx.GetComputeCapability(),
+        90,
+        phi::errors::PreconditionNotMet(
+            "Expect compute compatiblity to be less than 90, but got %d. "
+            "CUDNN FusedOps is no longer available on H100 and later "
+            "devices.",
+            ctx.GetComputeCapability()));
     PADDLE_ENFORCE_EQ(
         input_shape.size(),
         4U,

--- a/paddle/fluid/operators/fused/cudnn_norm_conv_test.cc
+++ b/paddle/fluid/operators/fused/cudnn_norm_conv_test.cc
@@ -442,7 +442,7 @@ TEST(CudnnNormConvFp16, K1S1) {
   phi::GPUContext *ctx = static_cast<phi::GPUContext *>(
       platform::DeviceContextPool::Instance().Get(platform::CUDAPlace(0)));
 
-  if (ctx->GetComputeCapability() < 70) {
+  if (ctx->GetComputeCapability() < 70 || ctx->GetComputeCapability() >= 90) {
     ASSERT_THROW(test.CheckForward(1e-3, true),
                  paddle::platform::EnforceNotMet);
     ASSERT_THROW(test.CheckBackward(1e-3, true),
@@ -472,7 +472,7 @@ TEST(CudnnNormConvFp16, K3S1) {
   phi::GPUContext *ctx = static_cast<phi::GPUContext *>(
       platform::DeviceContextPool::Instance().Get(platform::CUDAPlace(0)));
 
-  if (ctx->GetComputeCapability() < 70) {
+  if (ctx->GetComputeCapability() < 70 || ctx->GetComputeCapability() >= 90) {
     ASSERT_THROW(test.CheckForward(1e-3, true),
                  paddle::platform::EnforceNotMet);
     ASSERT_THROW(test.CheckBackward(1e-3, true),
@@ -502,7 +502,7 @@ TEST(CudnnNormConvFp16, K1S1O4) {
   phi::GPUContext *ctx = static_cast<phi::GPUContext *>(
       platform::DeviceContextPool::Instance().Get(platform::CUDAPlace(0)));
 
-  if (ctx->GetComputeCapability() < 70) {
+  if (ctx->GetComputeCapability() < 70 || ctx->GetComputeCapability() >= 90) {
     ASSERT_THROW(test.CheckForward(1e-3, true),
                  paddle::platform::EnforceNotMet);
     ASSERT_THROW(test.CheckBackward(1e-3, true),
@@ -532,7 +532,7 @@ TEST(CudnnNormConvFp16, K1S2O4) {
   phi::GPUContext *ctx = static_cast<phi::GPUContext *>(
       platform::DeviceContextPool::Instance().Get(platform::CUDAPlace(0)));
 
-  if (ctx->GetComputeCapability() <= 70) {
+  if (ctx->GetComputeCapability() <= 70 || ctx->GetComputeCapability() >= 90) {
     ASSERT_THROW(test.CheckForward(1e-3, true),
                  paddle::platform::EnforceNotMet);
     ASSERT_THROW(test.CheckBackward(1e-3), paddle::platform::EnforceNotMet);

--- a/paddle/fluid/operators/fused/fused_dropout_act_bias.h
+++ b/paddle/fluid/operators/fused/fused_dropout_act_bias.h
@@ -256,17 +256,19 @@ template <typename T,
           int BlockSizeX,
           int BlockSizeY,
           int VecSize,
-          typename Functor>
-__global__ void FusedDropoutActBiasGrad(Functor act_grad,
-                                        const T *dout,
-                                        const MaskType *mask,
-                                        const T *src,
-                                        const T *bias,
-                                        const T factor,
-                                        const int64_t rows,
-                                        const int64_t cols,
-                                        T *dx,
-                                        T *dbias) {
+          typename Functor,
+          int THREADS_PER_CTA = BlockSizeX *BlockSizeY>
+__global__ __launch_bounds__(THREADS_PER_CTA) void FusedDropoutActBiasGrad(
+    Functor act_grad,
+    const T *dout,
+    const MaskType *mask,
+    const T *src,
+    const T *bias,
+    const T factor,
+    const int64_t rows,
+    const int64_t cols,
+    T *dx,
+    T *dbias) {
   int64_t col_id = blockIdx.x * blockDim.x + threadIdx.x;
 
   using LoadT = phi::AlignedVector<T, VecSize>;

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -74,7 +74,9 @@ def avx_supported():
     has_avx = False
     if sysstr == 'linux':
         try:
-            has_avx = os.popen('cat /proc/cpuinfo | grep -i avx').read() != ''
+            pipe = os.popen('cat /proc/cpuinfo | grep -i avx')
+            has_avx = pipe.read() != ''
+            pipe.close()
         except Exception as e:
             sys.stderr.write('Can not get the AVX flag from /proc/cpuinfo.\n'
                              'The original error is: %s\n' %
@@ -82,8 +84,9 @@ def avx_supported():
         return has_avx
     elif sysstr == 'darwin':
         try:
-            has_avx = os.popen(
-                'sysctl machdep.cpu.features | grep -i avx').read() != ''
+            pipe = os.popen('sysctl machdep.cpu.features | grep -i avx')
+            has_avx = pipe.read() != ''
+            pipe.close()
         except Exception as e:
             sys.stderr.write(
                 'Can not get the AVX flag from machdep.cpu.features.\n'

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -35,9 +35,9 @@ try:
     if os.name == 'nt':
         third_lib_path = current_path + os.sep + '..' + os.sep + 'libs'
         # Will load shared library from 'path' on windows
-        os.environ[
-            'path'] = current_path + ';' + third_lib_path + ';' + os.environ[
-                'path']
+        os.environ['path'] = (
+            current_path + ';' + third_lib_path + ';' + os.environ['path']
+        )
         sys.path.insert(0, third_lib_path)
         # Note: from python3.8, PATH will not take effect
         # https://github.com/python/cpython/pull/12302
@@ -47,20 +47,24 @@ try:
 
 except ImportError as e:
     from .. import compat as cpt
+
     if os.name == 'nt':
         executable_path = os.path.abspath(os.path.dirname(sys.executable))
         raise ImportError(
             """NOTE: You may need to run \"set PATH=%s;%%PATH%%\"
         if you encounters \"DLL load failed\" errors. If you have python
         installed in other directory, replace \"%s\" with your own
-        directory. The original error is: \n %s""" %
-            (executable_path, executable_path, cpt.get_exception_message(e)))
+        directory. The original error is: \n %s"""
+            % (executable_path, executable_path, cpt.get_exception_message(e))
+        )
     else:
         raise ImportError(
             """NOTE: You may need to run \"export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH\"
         if you encounters \"libmkldnn.so not found\" errors. If you have python
         installed in other directory, replace \"/usr/local/lib\" with your own
-        directory. The original error is: \n""" + cpt.get_exception_message(e))
+        directory. The original error is: \n"""
+            + cpt.get_exception_message(e)
+        )
 except Exception as e:
     raise e
 
@@ -70,6 +74,7 @@ def avx_supported():
     Whether current system(Linux, MacOS, Windows) is supported with AVX.
     """
     from .. import compat as cpt
+
     sysstr = platform.system().lower()
     has_avx = False
     if sysstr == 'linux':
@@ -78,9 +83,10 @@ def avx_supported():
             has_avx = pipe.read() != ''
             pipe.close()
         except Exception as e:
-            sys.stderr.write('Can not get the AVX flag from /proc/cpuinfo.\n'
-                             'The original error is: %s\n' %
-                             cpt.get_exception_message(e))
+            sys.stderr.write(
+                'Can not get the AVX flag from /proc/cpuinfo.\n'
+                'The original error is: %s\n' % cpt.get_exception_message(e)
+            )
         return has_avx
     elif sysstr == 'darwin':
         try:
@@ -90,19 +96,23 @@ def avx_supported():
         except Exception as e:
             sys.stderr.write(
                 'Can not get the AVX flag from machdep.cpu.features.\n'
-                'The original error is: %s\n' % cpt.get_exception_message(e))
+                'The original error is: %s\n' % cpt.get_exception_message(e)
+            )
         if not has_avx:
             import subprocess
+
             pipe = subprocess.Popen(
                 'sysctl machdep.cpu.leaf7_features | grep -i avx',
                 shell=True,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                stderr=subprocess.PIPE,
+            )
             _ = pipe.communicate()
             has_avx = True if pipe.returncode == 0 else False
         return has_avx
     elif sysstr == 'windows':
         import ctypes
+
         ONE_PAGE = ctypes.c_size_t(0x1000)
 
         def asm_func(code_str, restype=ctypes.c_uint32, argtypes=()):
@@ -112,24 +122,31 @@ def avx_supported():
             pfnVirtualAlloc.restype = ctypes.c_void_p
             MEM_COMMIT = ctypes.c_ulong(0x1000)
             PAGE_READWRITE = ctypes.c_ulong(0x4)
-            address = pfnVirtualAlloc(None, ONE_PAGE, MEM_COMMIT,
-                                      PAGE_READWRITE)
+            address = pfnVirtualAlloc(
+                None, ONE_PAGE, MEM_COMMIT, PAGE_READWRITE
+            )
             if not address:
                 raise Exception("Failed to VirtualAlloc")
 
             # Copy the code into the memory segment
-            memmove = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p,
-                                       ctypes.c_void_p,
-                                       ctypes.c_size_t)(ctypes._memmove_addr)
+            memmove = ctypes.CFUNCTYPE(
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_size_t,
+            )(ctypes._memmove_addr)
             if memmove(address, code_str, len(code_str)) < 0:
                 raise Exception("Failed to memmove")
 
             # Enable execute permissions
             PAGE_EXECUTE = ctypes.c_ulong(0x10)
             pfnVirtualProtect = ctypes.windll.kernel32.VirtualProtect
-            res = pfnVirtualProtect(ctypes.c_void_p(address),
-                                    ONE_PAGE, PAGE_EXECUTE,
-                                    ctypes.byref(ctypes.c_ulong(0)))
+            res = pfnVirtualProtect(
+                ctypes.c_void_p(address),
+                ONE_PAGE,
+                PAGE_EXECUTE,
+                ctypes.byref(ctypes.c_ulong(0)),
+            )
             if not res:
                 raise Exception("Failed VirtualProtect")
 
@@ -138,7 +155,8 @@ def avx_supported():
             pfnGetCurrentProcess.restype = ctypes.c_void_p
             prochandle = ctypes.c_void_p(pfnGetCurrentProcess())
             res = ctypes.windll.kernel32.FlushInstructionCache(
-                prochandle, ctypes.c_void_p(address), ONE_PAGE)
+                prochandle, ctypes.c_void_p(address), ONE_PAGE
+            )
             if not res:
                 raise Exception("Failed FlushInstructionCache")
 
@@ -156,12 +174,14 @@ def avx_supported():
             # Convert the code_str into a function that returns uint
             func, address = asm_func(code_str)
             retval = func()
-            ctypes.windll.kernel32.VirtualFree(ctypes.c_void_p(address),
-                                               ctypes.c_size_t(0), ONE_PAGE)
+            ctypes.windll.kernel32.VirtualFree(
+                ctypes.c_void_p(address), ctypes.c_size_t(0), ONE_PAGE
+            )
         except Exception as e:
-            sys.stderr.write('Failed getting the AVX flag on Windows.\n'
-                             'The original error is: %s\n' %
-                             cpt.get_exception_message(e))
+            sys.stderr.write(
+                'Failed getting the AVX flag on Windows.\n'
+                'The original error is: %s\n' % cpt.get_exception_message(e)
+            )
         return (retval & (1 << avx_bit)) > 0
     else:
         sys.stderr.write('Do not get AVX flag on %s\n' % sysstr)
@@ -170,10 +190,10 @@ def avx_supported():
 
 def run_shell_command(cmd):
     import subprocess
-    out, err = subprocess.Popen(cmd,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                shell=True).communicate()
+
+    out, err = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    ).communicate()
     if err:
         return None
     else:
@@ -182,8 +202,9 @@ def run_shell_command(cmd):
 
 def get_dso_path(core_so, dso_name):
     if core_so and dso_name:
-        return run_shell_command("ldd %s|grep %s|awk '{print $3}'" %
-                                 (core_so, dso_name))
+        return run_shell_command(
+            "ldd %s|grep %s|awk '{print $3}'" % (core_so, dso_name)
+        )
     else:
         return None
 
@@ -192,6 +213,7 @@ def load_dso(dso_absolute_path):
     if dso_absolute_path:
         try:
             from ctypes import cdll
+
             cdll.LoadLibrary(dso_absolute_path)
         except:
             warnings.warn("Load {} failed".format(dso_absolute_path))
@@ -250,12 +272,14 @@ if platform.system().lower() == 'linux':
 
 try:
     from . import libpaddle
+
     if avx_supported() and not libpaddle.is_compiled_with_avx():
         sys.stderr.write(
             "Hint: Your machine support AVX, but the installed paddlepaddle doesn't have avx core. "
             "Hence, no-avx core with worse preformance will be imported.\nIf you like, you could "
             "reinstall paddlepaddle by 'python -m pip install --force-reinstall paddlepaddle-gpu[==version]' "
-            "to get better performance.\n")
+            "to get better performance.\n"
+        )
 
     # assign tensor alias
     libpaddle.LoDTensor = libpaddle.Tensor
@@ -286,6 +310,7 @@ try:
     from .libpaddle import _Profiler, _ProfilerResult, _RecordEvent
     from .libpaddle import _set_current_stream
     from .libpaddle import _get_phi_kernel_name
+
     if sys.platform != 'win32':
         from .libpaddle import _set_process_pids
         from .libpaddle import _erase_process_pids
@@ -298,12 +323,18 @@ try:
 except Exception as e:
     if has_paddle_dy_lib:
         sys.stderr.write(
-            'Error: Can not import paddle core while this file exists: ' +
-            current_path + os.sep + 'libpaddle.' + dy_lib_suffix + '\n')
+            'Error: Can not import paddle core while this file exists: '
+            + current_path
+            + os.sep
+            + 'libpaddle.'
+            + dy_lib_suffix
+            + '\n'
+        )
     if not avx_supported() and libpaddle.is_compiled_with_avx():
         sys.stderr.write(
             "Error: Your machine doesn't support AVX, but the installed PaddlePaddle is avx core, "
-            "you should reinstall paddlepaddle with no-avx core.\n")
+            "you should reinstall paddlepaddle with no-avx core.\n"
+        )
     raise e
 
 
@@ -320,22 +351,26 @@ def set_paddle_custom_device_lib_path(lib_path):
 
 # set paddle lib path
 def set_paddle_lib_path():
-    site_dirs = site.getsitepackages() if hasattr(
-        site,
-        'getsitepackages') else [x for x in sys.path if 'site-packages' in x]
+    site_dirs = (
+        site.getsitepackages()
+        if hasattr(site, 'getsitepackages')
+        else [x for x in sys.path if 'site-packages' in x]
+    )
     for site_dir in site_dirs:
         lib_dir = os.path.sep.join([site_dir, 'paddle', 'libs'])
         if os.path.exists(lib_dir):
             _set_paddle_lib_path(lib_dir)
             set_paddle_custom_device_lib_path(
-                os.path.sep.join([lib_dir, '..', '..', 'paddle-plugins']))
+                os.path.sep.join([lib_dir, '..', '..', 'paddle-plugins'])
+            )
             return
     if hasattr(site, 'USER_SITE'):
         lib_dir = os.path.sep.join([site.USER_SITE, 'paddle', 'libs'])
         if os.path.exists(lib_dir):
             _set_paddle_lib_path(lib_dir)
             set_paddle_custom_device_lib_path(
-                os.path.sep.join([lib_dir, '..', '..', 'paddle-plugins']))
+                os.path.sep.join([lib_dir, '..', '..', 'paddle-plugins'])
+            )
 
 
 set_paddle_lib_path()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_activation.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_activation.py
@@ -134,7 +134,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -143,7 +143,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_activation.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_activation.py
@@ -22,12 +22,10 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertActivationTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(dims, batch, attrs: List[Dict[str, Any]]):
             if dims == 1:
                 return np.random.random([32]).astype(np.float32)
@@ -41,11 +39,19 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         for dims in [1, 2, 3, 4]:
             for batch in [1, 4]:
                 for op_type in [
-                        "relu", "sigmoid", "tanh", "relu6", "elu", "selu",
-                        "softsign", "stanh", "thresholded_relu", "softplus"
+                    "relu",
+                    "sigmoid",
+                    "tanh",
+                    "relu6",
+                    "elu",
+                    "selu",
+                    "softsign",
+                    "stanh",
+                    "thresholded_relu",
+                    "softplus",
                 ]:
                     # few samples to reduce time
-                    #for beta in [-0.2, 0.5, 0.67, 3]:
+                    # for beta in [-0.2, 0.5, 0.67, 3]:
                     #    for alpha in [-0.2, 0.5, 0.67, 3]:
                     for beta in [0.67]:
                         for alpha in [0.67]:
@@ -62,33 +68,34 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
                             if op_type == "softplus":
                                 dics = [{"beta": beta}]
 
-                            ops_config = [{
-                                "op_type": op_type,
-                                "op_inputs": {
-                                    "X": ["input_data"]
-                                },
-                                "op_outputs": {
-                                    "Out": ["output_data"]
-                                },
-                                "op_attrs": dics[0]
-                            }]
+                            ops_config = [
+                                {
+                                    "op_type": op_type,
+                                    "op_inputs": {"X": ["input_data"]},
+                                    "op_outputs": {"Out": ["output_data"]},
+                                    "op_attrs": dics[0],
+                                }
+                            ]
                             ops = self.generate_op_config(ops_config)
 
                             program_config = ProgramConfig(
                                 ops=ops,
                                 weights={},
                                 inputs={
-                                    "input_data":
-                                    TensorConfig(data_gen=partial(
-                                        generate_input1, dims, batch, dics))
+                                    "input_data": TensorConfig(
+                                        data_gen=partial(
+                                            generate_input1, dims, batch, dics
+                                        )
+                                    )
                                 },
-                                outputs=["output_data"])
+                                outputs=["output_data"],
+                            )
 
                             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}
@@ -131,19 +138,23 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_anchor_generator.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_anchor_generator.py
@@ -103,7 +103,7 @@ class TrtConvertAnchorGeneratorTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -112,7 +112,7 @@ class TrtConvertAnchorGeneratorTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_anchor_generator.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_anchor_generator.py
@@ -22,60 +22,66 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertAnchorGeneratorTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(batch, attrs: List[Dict[str, Any]]):
             return np.random.random([batch, 3, 64, 64]).astype(np.float32)
 
         for batch in [1, 2, 4]:
             for anchor_sizes in [[64.0, 128.0, 256.0, 512.0]]:
                 for aspect_ratios in [[0.5, 1, 2], [0.4, 1.2, 3]]:
-                    for variances in [[1.0, 1.0, 1.0, 1.0],
-                                      [0.5, 1.0, 0.5, 1.0]]:
+                    for variances in [
+                        [1.0, 1.0, 1.0, 1.0],
+                        [0.5, 1.0, 0.5, 1.0],
+                    ]:
                         for stride in [[16.0, 16.0], [16.0, 32.0]]:
                             for offset in [0.5, 0.8]:
-                                dics = [{
-                                    "anchor_sizes": anchor_sizes,
-                                    "aspect_ratios": aspect_ratios,
-                                    "variances": variances,
-                                    "stride": stride,
-                                    "offset": offset
-                                }]
+                                dics = [
+                                    {
+                                        "anchor_sizes": anchor_sizes,
+                                        "aspect_ratios": aspect_ratios,
+                                        "variances": variances,
+                                        "stride": stride,
+                                        "offset": offset,
+                                    }
+                                ]
 
-                                ops_config = [{
-                                    "op_type": "anchor_generator",
-                                    "op_inputs": {
-                                        "Input": ["input_data"]
-                                    },
-                                    "op_outputs": {
-                                        "Anchors": ["output_anchors"],
-                                        "Variances": ["output_variances"]
-                                    },
-                                    "op_attrs": dics[0]
-                                }]
+                                ops_config = [
+                                    {
+                                        "op_type": "anchor_generator",
+                                        "op_inputs": {"Input": ["input_data"]},
+                                        "op_outputs": {
+                                            "Anchors": ["output_anchors"],
+                                            "Variances": ["output_variances"],
+                                        },
+                                        "op_attrs": dics[0],
+                                    }
+                                ]
                                 ops = self.generate_op_config(ops_config)
 
                                 program_config = ProgramConfig(
                                     ops=ops,
                                     weights={},
                                     inputs={
-                                        "input_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input1, batch, dics))
+                                        "input_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input1, batch, dics
+                                            )
+                                        )
                                     },
                                     outputs=[
-                                        "output_anchors", "output_variances"
-                                    ])
+                                        "output_anchors",
+                                        "output_variances",
+                                    ],
+                                )
 
                                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}
@@ -100,19 +106,23 @@ class TrtConvertAnchorGeneratorTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_arg_max.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_arg_max.py
@@ -120,7 +120,7 @@ class TrtConvertArgMaxTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -129,7 +129,7 @@ class TrtConvertArgMaxTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_arg_max.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_arg_max.py
@@ -22,7 +22,6 @@ from typing import List
 
 
 class TrtConvertArgMaxTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         input_shape = program_config.inputs["arg_max_input"].shape
         axis = program_config.ops[0].attrs["axis"]
@@ -33,7 +32,6 @@ class TrtConvertArgMaxTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input(rank, batch):
             dims = [batch]
             for i in range(rank - 1):
@@ -48,36 +46,37 @@ class TrtConvertArgMaxTest(TrtLayerAutoScanTest):
                         self.rank = rank
                         flatten = False
                         dtype = 2
-                        ops_config = [{
-                            "op_type": "arg_max",
-                            "op_inputs": {
-                                "X": ["arg_max_input"]
-                            },
-                            "op_outputs": {
-                                "Out": ["arg_max_out"]
-                            },
-                            "op_attrs": {
-                                "axis": axis,
-                                "keepdims": keepdims,
-                                "flatten": flatten,
-                                "dtype": dtype
+                        ops_config = [
+                            {
+                                "op_type": "arg_max",
+                                "op_inputs": {"X": ["arg_max_input"]},
+                                "op_outputs": {"Out": ["arg_max_out"]},
+                                "op_attrs": {
+                                    "axis": axis,
+                                    "keepdims": keepdims,
+                                    "flatten": flatten,
+                                    "dtype": dtype,
+                                },
                             }
-                        }]
+                        ]
                         ops = self.generate_op_config(ops_config)
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={},
                             inputs={
-                                "arg_max_input":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, rank, batch))
+                                "arg_max_input": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, rank, batch
+                                    )
+                                )
                             },
-                            outputs=["arg_max_out"])
+                            outputs=["arg_max_out"],
+                        )
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.rank == 3:
                 self.dynamic_shape.min_input_shape = {
@@ -117,19 +116,23 @@ class TrtConvertArgMaxTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_bmm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_bmm.py
@@ -23,9 +23,7 @@ import os
 
 
 class TrtConvertBmmTest_dynamic(TrtLayerAutoScanTest):
-
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -33,48 +31,47 @@ class TrtConvertBmmTest_dynamic(TrtLayerAutoScanTest):
             input1_shape = [batch, 350, 75]
             input2_shape = [batch, 75, 25]
             dics = [{}]
-            ops_config = [{
-                "op_type": "bmm",
-                "op_inputs": {
-                    "X": ["input1_data"],
-                    "Y": ["input2_data"]
-                },
-                "op_outputs": {
-                    "Out": ["output_data"]
-                },
-                "op_attrs": dics[0]
-            }]
+            ops_config = [
+                {
+                    "op_type": "bmm",
+                    "op_inputs": {"X": ["input1_data"], "Y": ["input2_data"]},
+                    "op_outputs": {"Out": ["output_data"]},
+                    "op_attrs": dics[0],
+                }
+            ]
             ops = self.generate_op_config(ops_config)
 
             program_config = ProgramConfig(
                 ops=ops,
                 weights={},
                 inputs={
-                    "input1_data":
-                    TensorConfig(
-                        data_gen=partial(generate_input, input1_shape)),
-                    "input2_data":
-                    TensorConfig(data_gen=partial(generate_input, input2_shape))
+                    "input1_data": TensorConfig(
+                        data_gen=partial(generate_input, input1_shape)
+                    ),
+                    "input2_data": TensorConfig(
+                        data_gen=partial(generate_input, input2_shape)
+                    ),
                 },
-                outputs=["output_data"])
+                outputs=["output_data"],
+            )
 
             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input1_data": [10, 350, 75],
-                "input2_data": [10, 75, 25]
+                "input2_data": [10, 75, 25],
             }
             self.dynamic_shape.max_input_shape = {
                 "input1_data": [100, 350, 75],
-                "input2_data": [100, 75, 25]
+                "input2_data": [100, 75, 25],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input1_data": [15, 350, 75],
-                "input2_data": [15, 75, 25]
+                "input2_data": [15, 75, 25],
             }
 
         def clear_dynamic_shape():
@@ -95,25 +92,29 @@ class TrtConvertBmmTest_dynamic(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # The output has little diff between gpu and trt in CI-Windows-Inference
         tol_fp32 = 1e-4
         tol_half = 1e-4
-        if (os.name == 'nt'):
+        if os.name == 'nt':
             tol_fp32 = 1e-2
             tol_half = 1e-2
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), tol_fp32
+            attrs, True
+        ), tol_fp32
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), tol_half
+            attrs, True
+        ), tol_half
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_bmm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_bmm.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from trt_layer_auto_scan_test import TrtLayerAutoScanTest, SkipReasons
+from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 from program_config import TensorConfig, ProgramConfig
 import numpy as np
 import paddle.inference as paddle_infer
 from functools import partial
-from typing import Optional, List, Callable, Dict, Any, Set
+from typing import List
 import unittest
 import os
 
@@ -98,7 +98,7 @@ class TrtConvertBmmTest_dynamic(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # The output has little diff between gpu and trt in CI-Windows-Inference
         tol_fp32 = 1e-4

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_clip.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_clip.py
@@ -22,12 +22,10 @@ import unittest
 
 
 class TrtConvertClipTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(dims, batch, attrs: List[Dict[str, Any]]):
             if dims == 1:
                 return np.ones([32]).astype(np.float32)
@@ -46,52 +44,52 @@ class TrtConvertClipTest(TrtLayerAutoScanTest):
 
         for dims in [1, 2, 3, 4]:
             for batch in [1, 4]:
-                for op_inputs in [{
-                        "X": ["input_data"]
-                }, {
-                        "X": ["input_data"],
-                        "Min": ["Min_"],
-                        "Max": ["Max_"]
-                }]:
+                for op_inputs in [
+                    {"X": ["input_data"]},
+                    {"X": ["input_data"], "Min": ["Min_"], "Max": ["Max_"]},
+                ]:
                     self.input_num = len(op_inputs)
                     self.dims = dims
-                    dics = [{
-                        "min": np.random.uniform(1, 10),
-                        "max": np.random.uniform(10, 20)
-                    }, {
-                        "op_inputs": op_inputs
-                    }]
-                    ops_config = [{
-                        "op_type": "clip",
-                        "op_inputs": op_inputs,
-                        "op_outputs": {
-                            "Out": ["output_data"]
+                    dics = [
+                        {
+                            "min": np.random.uniform(1, 10),
+                            "max": np.random.uniform(10, 20),
                         },
-                        "op_attrs": dics[0]
-                    }]
+                        {"op_inputs": op_inputs},
+                    ]
+                    ops_config = [
+                        {
+                            "op_type": "clip",
+                            "op_inputs": op_inputs,
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={
-                            "Min_":
-                            TensorConfig(
-                                data_gen=partial(generate_weight1, dics)),
-                            "Max_":
-                            TensorConfig(
-                                data_gen=partial(generate_weight2, dics))
+                            "Min_": TensorConfig(
+                                data_gen=partial(generate_weight1, dics)
+                            ),
+                            "Max_": TensorConfig(
+                                data_gen=partial(generate_weight2, dics)
+                            ),
                         },
                         inputs={
-                            "input_data":
-                            TensorConfig(data_gen=partial(
-                                generate_input1, dims, batch, dics))
+                            "input_data": TensorConfig(
+                                data_gen=partial(
+                                    generate_input1, dims, batch, dics
+                                )
+                            )
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(self, program_config):
-
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}
@@ -135,19 +133,23 @@ class TrtConvertClipTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_clip.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_clip.py
@@ -138,7 +138,7 @@ class TrtConvertClipTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -147,7 +147,7 @@ class TrtConvertClipTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_concat.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_concat.py
@@ -299,7 +299,7 @@ class TrtConvertConcatTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -308,7 +308,7 @@ class TrtConvertConcatTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_concat.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_concat.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertConcatTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -31,14 +30,13 @@ class TrtConvertConcatTest(TrtLayerAutoScanTest):
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
-        #The input dimension should be less than or equal to the set axis.
+        # The input dimension should be less than or equal to the set axis.
         if len(inputs['concat_input1'].shape) <= attrs[0]['axis']:
             return False
 
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]], batch):
             if self.dims == 4:
                 return np.ones([batch, 3, 24, 24]).astype(np.float32)
@@ -79,58 +77,83 @@ class TrtConvertConcatTest(TrtLayerAutoScanTest):
                         self.num_input = num_input
                         self.dims = dims
                         dics = [{"axis": axis}, {}]
-                        dics_intput = [{
-                            "X":
-                            ["concat_input1", "concat_input2", "concat_input3"],
-                            "AxisTensor": ["AxisTensor"],
-                        }, {
-                            "X":
-                            ["concat_input1", "concat_input2", "concat_input3"]
-                        }]
-                        dics_inputs = [{
-                            "concat_input1":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, dics, batch)),
-                            "concat_input2":
-                            TensorConfig(
-                                data_gen=partial(generate_input2, dics, batch)),
-                            "concat_input3":
-                            TensorConfig(
-                                data_gen=partial(generate_input3, dics, batch)),
-                            "AxisTensor":
-                            TensorConfig(
-                                data_gen=partial(generate_weight1, dics))
-                        }, {
-                            "concat_input1":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, dics, batch)),
-                            "concat_input2":
-                            TensorConfig(
-                                data_gen=partial(generate_input2, dics, batch)),
-                            "concat_input3":
-                            TensorConfig(
-                                data_gen=partial(generate_input3, dics, batch))
-                        }]
-                        ops_config = [{
-                            "op_type": "concat",
-                            "op_inputs": dics_intput[num_input],
-                            "op_outputs": {
-                                "Out": ["concat_output"]
+                        dics_intput = [
+                            {
+                                "X": [
+                                    "concat_input1",
+                                    "concat_input2",
+                                    "concat_input3",
+                                ],
+                                "AxisTensor": ["AxisTensor"],
                             },
-                            "op_attrs": dics[0]
-                        }]
+                            {
+                                "X": [
+                                    "concat_input1",
+                                    "concat_input2",
+                                    "concat_input3",
+                                ]
+                            },
+                        ]
+                        dics_inputs = [
+                            {
+                                "concat_input1": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input1, dics, batch
+                                    )
+                                ),
+                                "concat_input2": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input2, dics, batch
+                                    )
+                                ),
+                                "concat_input3": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input3, dics, batch
+                                    )
+                                ),
+                                "AxisTensor": TensorConfig(
+                                    data_gen=partial(generate_weight1, dics)
+                                ),
+                            },
+                            {
+                                "concat_input1": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input1, dics, batch
+                                    )
+                                ),
+                                "concat_input2": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input2, dics, batch
+                                    )
+                                ),
+                                "concat_input3": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input3, dics, batch
+                                    )
+                                ),
+                            },
+                        ]
+                        ops_config = [
+                            {
+                                "op_type": "concat",
+                                "op_inputs": dics_intput[num_input],
+                                "op_outputs": {"Out": ["concat_output"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={},
                             inputs=dics_inputs[num_input],
-                            outputs=["concat_output"])
+                            outputs=["concat_output"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.num_input == 0:
                 if self.dims == 4:
@@ -138,76 +161,76 @@ class TrtConvertConcatTest(TrtLayerAutoScanTest):
                         "concat_input1": [1, 3, 24, 24],
                         "concat_input2": [1, 3, 24, 24],
                         "concat_input3": [1, 3, 24, 24],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [4, 3, 48, 48],
                         "concat_input2": [4, 3, 48, 48],
                         "concat_input3": [4, 3, 48, 48],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [1, 3, 24, 24],
                         "concat_input2": [1, 3, 24, 24],
                         "concat_input3": [1, 3, 24, 24],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                 elif self.dims == 3:
                     self.dynamic_shape.min_input_shape = {
                         "concat_input1": [1, 3, 24],
                         "concat_input2": [1, 3, 24],
                         "concat_input3": [1, 3, 24],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [4, 12, 48],
                         "concat_input2": [4, 12, 48],
                         "concat_input3": [4, 12, 48],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [1, 3, 24],
                         "concat_input2": [1, 3, 24],
                         "concat_input3": [1, 3, 24],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                 elif self.dims == 2:
                     self.dynamic_shape.min_input_shape = {
                         "concat_input1": [1, 24],
                         "concat_input2": [1, 24],
                         "concat_input3": [1, 24],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [4, 48],
                         "concat_input2": [4, 48],
                         "concat_input3": [4, 48],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [1, 24],
                         "concat_input2": [1, 24],
                         "concat_input3": [1, 24],
-                        "AxisTensor": [1]
+                        "AxisTensor": [1],
                     }
                 elif self.dims == 1:
                     self.dynamic_shape.min_input_shape = {
                         "concat_input1": [24],
                         "concat_input2": [24],
                         "concat_input3": [24],
-                        "AxisTensor": [0]
+                        "AxisTensor": [0],
                     }
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [48],
                         "concat_input2": [48],
                         "concat_input3": [48],
-                        "AxisTensor": [0]
+                        "AxisTensor": [0],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [24],
                         "concat_input2": [24],
                         "concat_input3": [24],
-                        "AxisTensor": [0]
+                        "AxisTensor": [0],
                     }
             elif self.num_input == 1:
                 if self.dims == 4:
@@ -219,60 +242,60 @@ class TrtConvertConcatTest(TrtLayerAutoScanTest):
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [4, 3, 48, 48],
                         "concat_input2": [4, 3, 48, 48],
-                        "concat_input3": [4, 3, 48, 48]
+                        "concat_input3": [4, 3, 48, 48],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [1, 3, 24, 24],
                         "concat_input2": [1, 3, 24, 24],
-                        "concat_input3": [1, 3, 24, 24]
+                        "concat_input3": [1, 3, 24, 24],
                     }
                 elif self.dims == 3:
                     self.dynamic_shape.min_input_shape = {
                         "concat_input1": [1, 3, 24],
                         "concat_input2": [1, 3, 24],
-                        "concat_input3": [1, 3, 24]
+                        "concat_input3": [1, 3, 24],
                     }
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [4, 12, 48],
                         "concat_input2": [4, 12, 48],
-                        "concat_input3": [4, 12, 48]
+                        "concat_input3": [4, 12, 48],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [1, 3, 24],
                         "concat_input2": [1, 3, 24],
-                        "concat_input3": [1, 3, 24]
+                        "concat_input3": [1, 3, 24],
                     }
                 elif self.dims == 2:
                     self.dynamic_shape.min_input_shape = {
                         "concat_input1": [1, 24],
                         "concat_input2": [1, 24],
-                        "concat_input3": [1, 24]
+                        "concat_input3": [1, 24],
                     }
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [4, 48],
                         "concat_input2": [4, 48],
-                        "concat_input3": [4, 48]
+                        "concat_input3": [4, 48],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [1, 24],
                         "concat_input2": [1, 24],
-                        "concat_input3": [1, 24]
+                        "concat_input3": [1, 24],
                     }
                 elif self.dims == 1:
                     self.dynamic_shape.min_input_shape = {
                         "concat_input1": [24],
                         "concat_input2": [24],
-                        "concat_input3": [24]
+                        "concat_input3": [24],
                     }
                     self.dynamic_shape.max_input_shape = {
                         "concat_input1": [48],
                         "concat_input2": [48],
-                        "concat_input3": [48]
+                        "concat_input3": [48],
                     }
                     self.dynamic_shape.opt_input_shape = {
                         "concat_input1": [24],
                         "concat_input2": [24],
-                        "concat_input3": [24]
+                        "concat_input3": [24],
                     }
 
         def clear_dynamic_shape():
@@ -296,29 +319,33 @@ class TrtConvertConcatTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(program_config.inputs) == 4:
                 return True
             return False
 
-        self.add_skip_case(teller1, SkipReasons.TRT_NOT_SUPPORT,
-                           "INPUT AxisTensor NOT SUPPORT")
+        self.add_skip_case(
+            teller1, SkipReasons.TRT_NOT_SUPPORT, "INPUT AxisTensor NOT SUPPORT"
+        )
 
     def test(self):
         self.add_skip_trt_case()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv2d_transpose.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv2d_transpose.py
@@ -181,7 +181,7 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-3)
+            attrs, False), (1e-3, 1e-3)
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, False), (1e-5, 1e-5)
@@ -193,7 +193,7 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-3)
+            attrs, True), (1e-3, 1e-3)
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, True), (1e-5, 1e-5)

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv2d_transpose.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv2d_transpose.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -30,8 +29,10 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        if inputs['input_data'].shape[
-                1] != weights['conv2d_weight'].shape[1] * attrs[0]['groups']:
+        if (
+            inputs['input_data'].shape[1]
+            != weights['conv2d_weight'].shape[1] * attrs[0]['groups']
+        ):
             return False
 
         if inputs['input_data'].shape[1] != weights['conv2d_weight'].shape[0]:
@@ -54,12 +55,13 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
 
         def generate_weight1(num_channels, attrs: List[Dict[str, Any]]):
             if attrs[0]['groups'] == 1:
-                return np.random.random([num_channels, num_channels, 3,
-                                         3]).astype(np.float32)
+                return np.random.random(
+                    [num_channels, num_channels, 3, 3]
+                ).astype(np.float32)
             else:
                 return np.random.random(
-                    [num_channels, int(num_channels / 2), 3,
-                     3]).astype(np.float32)
+                    [num_channels, int(num_channels / 2), 3, 3]
+                ).astype(np.float32)
 
         for num_channels in [2, 4, 6]:
             for batch in [1, 4]:
@@ -67,99 +69,113 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
                     for paddings in [[0, 3], [1, 2, 3, 4]]:
                         for groups in [2]:
                             for padding_algorithm in [
-                                    'EXPLICIT', 'SAME', 'VALID'
+                                'EXPLICIT',
+                                'SAME',
+                                'VALID',
                             ]:
                                 for dilations in [[2, 2], [1, 2]]:
                                     for data_format in ['NCHW']:
 
                                         self.num_channels = num_channels
-                                        dics = [{
-                                            "data_fromat": data_format,
-                                            "dilations": dilations,
-                                            "padding_algorithm":
-                                            padding_algorithm,
-                                            "groups": groups,
-                                            "paddings": paddings,
-                                            "strides": strides,
-                                            "data_format": data_format,
-                                            "output_size": [],
-                                            "output_padding": []
-                                        }]
+                                        dics = [
+                                            {
+                                                "data_fromat": data_format,
+                                                "dilations": dilations,
+                                                "padding_algorithm": padding_algorithm,
+                                                "groups": groups,
+                                                "paddings": paddings,
+                                                "strides": strides,
+                                                "data_format": data_format,
+                                                "output_size": [],
+                                                "output_padding": [],
+                                            }
+                                        ]
 
-                                        ops_config = [{
-                                            "op_type": "conv2d_transpose",
-                                            "op_inputs": {
-                                                "Input": ["input_data"],
-                                                "Filter": ["conv2d_weight"]
-                                            },
-                                            "op_outputs": {
-                                                "Output": ["output_data"]
-                                            },
-                                            "op_attrs": dics[0]
-                                        }]
+                                        ops_config = [
+                                            {
+                                                "op_type": "conv2d_transpose",
+                                                "op_inputs": {
+                                                    "Input": ["input_data"],
+                                                    "Filter": ["conv2d_weight"],
+                                                },
+                                                "op_outputs": {
+                                                    "Output": ["output_data"]
+                                                },
+                                                "op_attrs": dics[0],
+                                            }
+                                        ]
                                         ops = self.generate_op_config(
-                                            ops_config)
+                                            ops_config
+                                        )
 
                                         program_config = ProgramConfig(
                                             ops=ops,
                                             weights={
-                                                "conv2d_weight":
-                                                TensorConfig(data_gen=partial(
-                                                    generate_weight1,
-                                                    num_channels, dics))
+                                                "conv2d_weight": TensorConfig(
+                                                    data_gen=partial(
+                                                        generate_weight1,
+                                                        num_channels,
+                                                        dics,
+                                                    )
+                                                )
                                             },
                                             inputs={
-                                                "input_data":
-                                                TensorConfig(data_gen=partial(
-                                                    generate_input1, batch,
-                                                    num_channels, dics))
+                                                "input_data": TensorConfig(
+                                                    data_gen=partial(
+                                                        generate_input1,
+                                                        batch,
+                                                        num_channels,
+                                                        dics,
+                                                    )
+                                                )
                                             },
-                                            outputs=["output_data"])
+                                            outputs=["output_data"],
+                                        )
 
                                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.num_channels == 2:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [1, 2, 32, 32],
-                    "output_data": [1, 24, 32, 32]
+                    "output_data": [1, 24, 32, 32],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [4, 2, 64, 64],
-                    "output_data": [4, 24, 64, 64]
+                    "output_data": [4, 24, 64, 64],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [1, 2, 64, 64],
-                    "output_data": [1, 24, 64, 64]
+                    "output_data": [1, 24, 64, 64],
                 }
             elif self.num_channels == 4:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [1, 4, 32, 32],
-                    "output_data": [1, 24, 32, 32]
+                    "output_data": [1, 24, 32, 32],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [4, 4, 64, 64],
-                    "output_data": [4, 24, 64, 64]
+                    "output_data": [4, 24, 64, 64],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [1, 4, 64, 64],
-                    "output_data": [1, 24, 64, 64]
+                    "output_data": [1, 24, 64, 64],
                 }
             else:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [1, 6, 32, 32],
-                    "output_data": [1, 24, 32, 32]
+                    "output_data": [1, 24, 32, 32],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [4, 6, 64, 64],
-                    "output_data": [4, 24, 64, 64]
+                    "output_data": [4, 24, 64, 64],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [1, 6, 64, 64],
-                    "output_data": [1, 24, 64, 64]
+                    "output_data": [1, 24, 64, 64],
                 }
 
         def clear_dynamic_shape():
@@ -178,10 +194,12 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, False), (1e-5, 1e-5)
@@ -190,24 +208,26 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
         # self.trt_param.precision = paddle_infer.PrecisionType.Int8
         # yield self.create_inference_config(), generate_trt_nodes_num(
         #     attrs, True), (1e-5, 1e-5)
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if self.trt_param.precision == paddle_infer.PrecisionType.Int8:
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_IMPLEMENTED,
-            "When precisionType is int8 without relu op, output is different between Trt and Paddle."
+            teller1,
+            SkipReasons.TRT_NOT_IMPLEMENTED,
+            "When precisionType is int8 without relu op, output is different between Trt and Paddle.",
         )
 
     def test(self):
@@ -221,7 +241,6 @@ class TrtConvertConv2dTransposeTest(TrtLayerAutoScanTest):
 
 # Special case
 class TrtConvertConv2dTransposeTest2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         ver = paddle_infer.get_trt_compile_version()
         if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 7000:
@@ -241,49 +260,52 @@ class TrtConvertConv2dTransposeTest2(TrtLayerAutoScanTest):
         batch = 1
 
         self.num_channels = num_channels
-        dics = [{
-            "data_fromat": 'NCHW',
-            "dilations": [1, 1],
-            "padding_algorithm": 'EXPLICIT',
-            "groups": 1,
-            "paddings": [1, 1],
-            "strides": [2, 2],
-            "output_padding": [1, 1],
-            "output_size": [],
-        }]
+        dics = [
+            {
+                "data_fromat": 'NCHW',
+                "dilations": [1, 1],
+                "padding_algorithm": 'EXPLICIT',
+                "groups": 1,
+                "paddings": [1, 1],
+                "strides": [2, 2],
+                "output_padding": [1, 1],
+                "output_size": [],
+            }
+        ]
 
-        ops_config = [{
-            "op_type": "conv2d_transpose",
-            "op_inputs": {
-                "Input": ["input_data"],
-                "Filter": ["conv2d_weight"]
-            },
-            "op_outputs": {
-                "Output": ["output_data"]
-            },
-            "op_attrs": dics[0]
-        }]
+        ops_config = [
+            {
+                "op_type": "conv2d_transpose",
+                "op_inputs": {
+                    "Input": ["input_data"],
+                    "Filter": ["conv2d_weight"],
+                },
+                "op_outputs": {"Output": ["output_data"]},
+                "op_attrs": dics[0],
+            }
+        ]
         ops = self.generate_op_config(ops_config)
 
         program_config = ProgramConfig(
             ops=ops,
             weights={
-                "conv2d_weight":
-                TensorConfig(
-                    data_gen=partial(generate_weight1, num_channels, dics))
+                "conv2d_weight": TensorConfig(
+                    data_gen=partial(generate_weight1, num_channels, dics)
+                )
             },
             inputs={
-                "input_data":
-                TensorConfig(data_gen=partial(generate_input1, batch,
-                                              num_channels, dics))
+                "input_data": TensorConfig(
+                    data_gen=partial(generate_input1, batch, num_channels, dics)
+                )
             },
-            outputs=["output_data"])
+            outputs=["output_data"],
+        )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 128, 20, 30],
@@ -311,19 +333,23 @@ class TrtConvertConv2dTransposeTest2(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-4
+            attrs, False
+        ), 1e-4
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e0, 1e-3)
+            attrs, False
+        ), (1e0, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-4
+            attrs, True
+        ), 1e-4
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e0, 1e-3)
+            attrs, True
+        ), (1e0, 1e-3)
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_dropout.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_dropout.py
@@ -131,7 +131,7 @@ class TrtConvertDropoutTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -140,7 +140,7 @@ class TrtConvertDropoutTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_dropout.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_dropout.py
@@ -22,12 +22,10 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertDropoutTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(dims, batch, attrs: List[Dict[str, Any]]):
             if dims == 1:
                 return np.ones([64]).astype(np.float32)
@@ -42,47 +40,57 @@ class TrtConvertDropoutTest(TrtLayerAutoScanTest):
             for batch in [1, 2, 4]:
                 for fix_seed in [False, True]:
                     for dropout_implementation in [
-                            "downgrade_in_infer", "upscale_in_train"
+                        "downgrade_in_infer",
+                        "upscale_in_train",
                     ]:
                         for dropout_prob in [np.random.random()]:
                             for seed in [0, 64, 128, 512]:
                                 self.dims = dims
-                                dics = [{
-                                    "fix_seed": fix_seed,
-                                    "dropout_implementation":
-                                    dropout_implementation,
-                                    "dropout_prob": dropout_prob,
-                                    "seed": seed,
-                                    "is_test": True
-                                }]
+                                dics = [
+                                    {
+                                        "fix_seed": fix_seed,
+                                        "dropout_implementation": dropout_implementation,
+                                        "dropout_prob": dropout_prob,
+                                        "seed": seed,
+                                        "is_test": True,
+                                    }
+                                ]
 
-                                ops_config = [{
-                                    "op_type": "dropout",
-                                    "op_inputs": {
-                                        "X": ["input_data"],
-                                    },
-                                    "op_outputs": {
-                                        "Out": ["dropout_output_data"]
-                                    },
-                                    "op_attrs": dics[0]
-                                }]
+                                ops_config = [
+                                    {
+                                        "op_type": "dropout",
+                                        "op_inputs": {
+                                            "X": ["input_data"],
+                                        },
+                                        "op_outputs": {
+                                            "Out": ["dropout_output_data"]
+                                        },
+                                        "op_attrs": dics[0],
+                                    }
+                                ]
                                 ops = self.generate_op_config(ops_config)
 
                                 program_config = ProgramConfig(
                                     ops=ops,
                                     weights={},
                                     inputs={
-                                        "input_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input1, dims, batch, dics))
+                                        "input_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input1,
+                                                dims,
+                                                batch,
+                                                dics,
+                                            )
+                                        )
                                     },
-                                    outputs=["dropout_output_data"])
+                                    outputs=["dropout_output_data"],
+                                )
 
                                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}
@@ -128,19 +136,23 @@ class TrtConvertDropoutTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_elementwise.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_elementwise.py
@@ -358,7 +358,7 @@ class TrtConvertElementwiseTest_two_input_without_broadcast(
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
-        for shape in [[4], [4, 32], [2, 64, 32], [1, 8, 16, 32]]:
+        for shape in [[4], [4, 32], [2, 32, 16], [1, 8, 16, 32]]:
             for op_type in [
                     "elementwise_add", "elementwise_mul", "elementwise_sub",
                     "elementwise_div", "elementwise_pow", "elementwise_min",
@@ -435,8 +435,8 @@ class TrtConvertElementwiseTest_two_input_without_broadcast(
                     "input_data2": [128, 128, 256]
                 }
                 self.dynamic_shape.opt_input_shape = {
-                    "input_data1": [2, 64, 64],
-                    "input_data2": [2, 64, 64]
+                    "input_data1": [2, 32, 16],
+                    "input_data2": [2, 32, 16]
                 }
             elif self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_elementwise.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_elementwise.py
@@ -24,12 +24,10 @@ from typing import Optional, List, Callable, Dict, Any, Set
 # This is the special test case with weight including batch dimension
 # I don't want to mess up the code written by others, so I wrote a class specifically
 class TrtConvertElementwiseTest_one_input_special_case0(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -39,44 +37,50 @@ class TrtConvertElementwiseTest_one_input_special_case0(TrtLayerAutoScanTest):
         for batch in [1, 4]:
             for shape in [[batch, 32, 16, 32]]:
                 for op_type in [
-                        "elementwise_add", "elementwise_mul", "elementwise_sub",
-                        "elementwise_div", "elementwise_pow", "elementwise_min",
-                        "elementwise_max"
+                    "elementwise_add",
+                    "elementwise_mul",
+                    "elementwise_sub",
+                    "elementwise_div",
+                    "elementwise_pow",
+                    "elementwise_min",
+                    "elementwise_max",
                 ]:
                     for axis in [-1]:
                         self.dims = len(shape)
                         dics = [{"axis": axis}]
-                        ops_config = [{
-                            "op_type": op_type,
-                            "op_inputs": {
-                                "X": ["input_data"],
-                                "Y": ["weight"]
-                            },
-                            "op_outputs": {
-                                "Out": ["output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        ops_config = [
+                            {
+                                "op_type": op_type,
+                                "op_inputs": {
+                                    "X": ["input_data"],
+                                    "Y": ["weight"],
+                                },
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={
-                                "weight":
-                                TensorConfig(data_gen=partial(generate_weight))
+                                "weight": TensorConfig(
+                                    data_gen=partial(generate_weight)
+                                )
                             },
                             inputs={
-                                "input_data":
-                                TensorConfig(
-                                    data_gen=partial(generate_input, shape)),
+                                "input_data": TensorConfig(
+                                    data_gen=partial(generate_input, shape)
+                                ),
                             },
-                            outputs=["output_data"])
+                            outputs=["output_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 4:
@@ -106,19 +110,23 @@ class TrtConvertElementwiseTest_one_input_special_case0(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
         pass
@@ -130,12 +138,10 @@ class TrtConvertElementwiseTest_one_input_special_case0(TrtLayerAutoScanTest):
 
 # This is the special test case
 class TrtConvertElementwiseTest_one_input_special_case1(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -144,44 +150,47 @@ class TrtConvertElementwiseTest_one_input_special_case1(TrtLayerAutoScanTest):
 
         for shape in [[32]]:
             for op_type in [
-                    "elementwise_add", "elementwise_mul", "elementwise_sub",
-                    "elementwise_div", "elementwise_pow", "elementwise_min",
-                    "elementwise_max"
+                "elementwise_add",
+                "elementwise_mul",
+                "elementwise_sub",
+                "elementwise_div",
+                "elementwise_pow",
+                "elementwise_min",
+                "elementwise_max",
             ]:
                 for axis in [-1]:
                     self.dims = len(shape)
                     dics = [{"axis": axis}]
-                    ops_config = [{
-                        "op_type": op_type,
-                        "op_inputs": {
-                            "X": ["input_data"],
-                            "Y": ["weight"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": op_type,
+                            "op_inputs": {"X": ["input_data"], "Y": ["weight"]},
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={
-                            "weight":
-                            TensorConfig(data_gen=partial(generate_weight))
+                            "weight": TensorConfig(
+                                data_gen=partial(generate_weight)
+                            )
                         },
                         inputs={
-                            "input_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, shape)),
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input, shape)
+                            ),
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [32]}
             self.dynamic_shape.max_input_shape = {"input_data": [64]}
@@ -205,19 +214,23 @@ class TrtConvertElementwiseTest_one_input_special_case1(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
         pass
@@ -228,12 +241,10 @@ class TrtConvertElementwiseTest_one_input_special_case1(TrtLayerAutoScanTest):
 
 
 class TrtConvertElementwiseTest_one_input(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -241,47 +252,57 @@ class TrtConvertElementwiseTest_one_input(TrtLayerAutoScanTest):
             return np.random.randn(32).astype(np.float32)
 
         for batch in [1, 4]:
-            for shape in [[32], [batch, 32], [batch, 32, 32],
-                          [batch, 32, 16, 32]]:
+            for shape in [
+                [32],
+                [batch, 32],
+                [batch, 32, 32],
+                [batch, 32, 16, 32],
+            ]:
                 for op_type in [
-                        "elementwise_add", "elementwise_mul", "elementwise_sub",
-                        "elementwise_div", "elementwise_pow", "elementwise_min",
-                        "elementwise_max"
+                    "elementwise_add",
+                    "elementwise_mul",
+                    "elementwise_sub",
+                    "elementwise_div",
+                    "elementwise_pow",
+                    "elementwise_min",
+                    "elementwise_max",
                 ]:
                     for axis in [-1 if len(shape) == 1 else 1]:
                         self.dims = len(shape)
                         dics = [{"axis": axis}]
-                        ops_config = [{
-                            "op_type": op_type,
-                            "op_inputs": {
-                                "X": ["input_data"],
-                                "Y": ["weight"]
-                            },
-                            "op_outputs": {
-                                "Out": ["output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        ops_config = [
+                            {
+                                "op_type": op_type,
+                                "op_inputs": {
+                                    "X": ["input_data"],
+                                    "Y": ["weight"],
+                                },
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={
-                                "weight":
-                                TensorConfig(data_gen=partial(generate_weight))
+                                "weight": TensorConfig(
+                                    data_gen=partial(generate_weight)
+                                )
                             },
                             inputs={
-                                "input_data":
-                                TensorConfig(
-                                    data_gen=partial(generate_input, shape)),
+                                "input_data": TensorConfig(
+                                    data_gen=partial(generate_input, shape)
+                                ),
                             },
-                            outputs=["output_data"])
+                            outputs=["output_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 1:
@@ -325,19 +346,23 @@ class TrtConvertElementwiseTest_one_input(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
         pass
@@ -348,108 +373,112 @@ class TrtConvertElementwiseTest_one_input(TrtLayerAutoScanTest):
 
 
 class TrtConvertElementwiseTest_two_input_without_broadcast(
-        TrtLayerAutoScanTest):
-
+    TrtLayerAutoScanTest
+):
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
         for shape in [[4], [4, 32], [2, 32, 16], [1, 8, 16, 32]]:
             for op_type in [
-                    "elementwise_add", "elementwise_mul", "elementwise_sub",
-                    "elementwise_div", "elementwise_pow", "elementwise_min",
-                    "elementwise_max"
+                "elementwise_add",
+                "elementwise_mul",
+                "elementwise_sub",
+                "elementwise_div",
+                "elementwise_pow",
+                "elementwise_min",
+                "elementwise_max",
             ]:
                 for axis in [0, -1]:
                     self.dims = len(shape)
                     dics = [{"axis": axis}]
-                    ops_config = [{
-                        "op_type": op_type,
-                        "op_inputs": {
-                            "X": ["input_data1"],
-                            "Y": ["input_data2"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": op_type,
+                            "op_inputs": {
+                                "X": ["input_data1"],
+                                "Y": ["input_data2"],
+                            },
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data1":
-                            TensorConfig(
-                                data_gen=partial(generate_input, shape)),
-                            "input_data2":
-                            TensorConfig(
-                                data_gen=partial(generate_input, shape))
+                            "input_data1": TensorConfig(
+                                data_gen=partial(generate_input, shape)
+                            ),
+                            "input_data2": TensorConfig(
+                                data_gen=partial(generate_input, shape)
+                            ),
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
                     "input_data1": [1],
-                    "input_data2": [1]
+                    "input_data2": [1],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data1": [128],
-                    "input_data2": [128]
+                    "input_data2": [128],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data1": [32],
-                    "input_data2": [32]
+                    "input_data2": [32],
                 }
             elif self.dims == 2:
                 self.dynamic_shape.min_input_shape = {
                     "input_data1": [1, 4],
-                    "input_data2": [1, 4]
+                    "input_data2": [1, 4],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data1": [128, 256],
-                    "input_data2": [128, 256]
+                    "input_data2": [128, 256],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data1": [32, 64],
-                    "input_data2": [32, 64]
+                    "input_data2": [32, 64],
                 }
             elif self.dims == 3:
                 self.dynamic_shape.min_input_shape = {
                     "input_data1": [1, 4, 4],
-                    "input_data2": [1, 4, 4]
+                    "input_data2": [1, 4, 4],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data1": [128, 128, 256],
-                    "input_data2": [128, 128, 256]
+                    "input_data2": [128, 128, 256],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data1": [2, 32, 16],
-                    "input_data2": [2, 32, 16]
+                    "input_data2": [2, 32, 16],
                 }
             elif self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
                     "input_data1": [1, 4, 4, 4],
-                    "input_data2": [1, 4, 4, 4]
+                    "input_data2": [1, 4, 4, 4],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data1": [8, 128, 64, 128],
-                    "input_data2": [8, 128, 64, 128]
+                    "input_data2": [8, 128, 64, 128],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data1": [2, 64, 32, 32],
-                    "input_data2": [2, 64, 32, 32]
+                    "input_data2": [2, 64, 32, 32],
                 }
 
         def clear_dynamic_shape():
@@ -470,10 +499,12 @@ class TrtConvertElementwiseTest_two_input_without_broadcast(
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -491,7 +522,6 @@ class TrtConvertElementwiseTest_two_input_without_broadcast(
 
 
 class TrtConvertElementwiseTest_two_input_with_broadcast(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         if len(inputs['input_data1'].shape) != len(inputs['input_data2'].shape):
@@ -500,7 +530,6 @@ class TrtConvertElementwiseTest_two_input_with_broadcast(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -512,8 +541,12 @@ class TrtConvertElementwiseTest_two_input_with_broadcast(TrtLayerAutoScanTest):
         input2_shape5_list = [[32], [2, 1, 32], [4, 1, 1, 32]]
         input2_shape6_list = [[1, 32], [1, 32], [1, 1, 1, 32]]
         input2_shape_list = [
-            input2_shape1_list, input2_shape2_list, input2_shape3_list,
-            input2_shape4_list, input2_shape5_list, input2_shape6_list
+            input2_shape1_list,
+            input2_shape2_list,
+            input2_shape3_list,
+            input2_shape4_list,
+            input2_shape5_list,
+            input2_shape6_list,
         ]
         axis1_list = [[-1], [1, -1], [1, -1]]
         axis2_list = [[-1], [0], [0]]
@@ -522,8 +555,12 @@ class TrtConvertElementwiseTest_two_input_with_broadcast(TrtLayerAutoScanTest):
         axis5_list = [[-1, 1], [-1, 0], [-1, 0]]
         axis6_list = [[-1, 0], [-1, 1], [-1, 0]]
         axis_list = [
-            axis1_list, axis2_list, axis3_list, axis4_list, axis5_list,
-            axis6_list
+            axis1_list,
+            axis2_list,
+            axis3_list,
+            axis4_list,
+            axis5_list,
+            axis6_list,
         ]
 
         for i in range(3):
@@ -531,66 +568,75 @@ class TrtConvertElementwiseTest_two_input_with_broadcast(TrtLayerAutoScanTest):
             for j in range(6):
                 input2_shape = input2_shape_list[j][i]
                 for op_type in [
-                        "elementwise_add",
-                        "elementwise_mul",
-                        "elementwise_sub",
-                        "elementwise_div",
-                        "elementwise_pow",
-                        "elementwise_min",
-                        "elementwise_max",
+                    "elementwise_add",
+                    "elementwise_mul",
+                    "elementwise_sub",
+                    "elementwise_div",
+                    "elementwise_pow",
+                    "elementwise_min",
+                    "elementwise_max",
                 ]:
                     for axis in axis_list[j][i]:
                         self.shape1 = input1_shape
                         self.shape2 = input2_shape
                         dics = [{"axis": axis}]
-                        ops_config = [{
-                            "op_type": op_type,
-                            "op_inputs": {
-                                "X": ["input_data1"],
-                                "Y": ["input_data2"]
-                            },
-                            "op_outputs": {
-                                "Out": ["output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        ops_config = [
+                            {
+                                "op_type": op_type,
+                                "op_inputs": {
+                                    "X": ["input_data1"],
+                                    "Y": ["input_data2"],
+                                },
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={},
                             inputs={
-                                "input_data1":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, input1_shape)),
-                                "input_data2":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, input2_shape))
+                                "input_data1": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, input1_shape
+                                    )
+                                ),
+                                "input_data2": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, input2_shape
+                                    )
+                                ),
                             },
-                            outputs=["output_data"])
+                            outputs=["output_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
-            max_shape = [[128], [128, 128], [128, 128, 128],
-                         [128, 128, 128, 128]]
+            max_shape = [
+                [128],
+                [128, 128],
+                [128, 128, 128],
+                [128, 128, 128, 128],
+            ]
             min_shape = [[1], [1, 1], [1, 1, 1], [1, 1, 1, 1]]
             opt_shape = [[32], [32, 32], [32, 32, 32], [32, 32, 32, 32]]
 
             self.dynamic_shape.min_input_shape = {
                 "input_data1": min_shape[len(self.shape1) - 1],
-                "input_data2": min_shape[len(self.shape2) - 1]
+                "input_data2": min_shape[len(self.shape2) - 1],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data1": max_shape[len(self.shape1) - 1],
-                "input_data2": max_shape[len(self.shape2) - 1]
+                "input_data2": max_shape[len(self.shape2) - 1],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data1": opt_shape[len(self.shape1) - 1],
-                "input_data2": opt_shape[len(self.shape2) - 1]
+                "input_data2": opt_shape[len(self.shape2) - 1],
             }
 
         def clear_dynamic_shape():
@@ -626,12 +672,10 @@ class TrtConvertElementwiseTest_two_input_with_broadcast(TrtLayerAutoScanTest):
 
 
 class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -640,52 +684,58 @@ class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
             return np.random.rand(32).astype(np.float32)
 
         for batch in [1, 2, 4]:
-            for shape in [[32], [batch, 32], [batch, 32, 32],
-                          [batch, 32, 16, 32]]:
+            for shape in [
+                [32],
+                [batch, 32],
+                [batch, 32, 32],
+                [batch, 32, 16, 32],
+            ]:
                 for op_type in [
-                        "elementwise_add",
-                        "elementwise_mul",
-                        "elementwise_sub",
-                        "elementwise_div",
-                        "elementwise_pow",
-                        "elementwise_min",
-                        "elementwise_max",
+                    "elementwise_add",
+                    "elementwise_mul",
+                    "elementwise_sub",
+                    "elementwise_div",
+                    "elementwise_pow",
+                    "elementwise_min",
+                    "elementwise_max",
                 ]:
                     self.op_type = op_type
                     for axis in [-1 if len(shape) == 1 else 1]:
                         self.dims = len(shape)
                         dics = [{"axis": axis}]
-                        ops_config = [{
-                            "op_type": op_type,
-                            "op_inputs": {
-                                "X": ["weight"],
-                                "Y": ["input_data"]
-                            },
-                            "op_outputs": {
-                                "Out": ["output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        ops_config = [
+                            {
+                                "op_type": op_type,
+                                "op_inputs": {
+                                    "X": ["weight"],
+                                    "Y": ["input_data"],
+                                },
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={
-                                "weight":
-                                TensorConfig(data_gen=partial(generate_weight))
+                                "weight": TensorConfig(
+                                    data_gen=partial(generate_weight)
+                                )
                             },
                             inputs={
-                                "input_data":
-                                TensorConfig(
-                                    data_gen=partial(generate_input, shape)),
+                                "input_data": TensorConfig(
+                                    data_gen=partial(generate_input, shape)
+                                ),
                             },
-                            outputs=["output_data"])
+                            outputs=["output_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 1:

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_equal.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_equal.py
@@ -147,7 +147,7 @@ class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -156,7 +156,7 @@ class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_equal.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_equal.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
@@ -35,7 +34,6 @@ class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -44,86 +42,84 @@ class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
                 for axis in [-1 if len(shape) == 1 else 1]:
                     self.dims = len(shape)
                     dics = [{"axis": axis}, {"in_dtype": 0, "out_dtype": 5}]
-                    ops_config = [{
-                        "op_type": "equal",
-                        "op_inputs": {
-                            "X": ["input_data1"],
-                            "Y": ["input_data2"]
+                    ops_config = [
+                        {
+                            "op_type": "equal",
+                            "op_inputs": {
+                                "X": ["input_data1"],
+                                "Y": ["input_data2"],
+                            },
+                            "op_outputs": {"Out": ["compare_output_data"]},
+                            "op_attrs": dics[0],
                         },
-                        "op_outputs": {
-                            "Out": ["compare_output_data"]
+                        {
+                            "op_type": "cast",
+                            "op_inputs": {"X": ["compare_output_data"]},
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[1],
                         },
-                        "op_attrs": dics[0]
-                    }, {
-                        "op_type": "cast",
-                        "op_inputs": {
-                            "X": ["compare_output_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[1]
-                    }]
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data1":
-                            TensorConfig(
-                                data_gen=partial(generate_input, shape)),
-                            "input_data2":
-                            TensorConfig(
-                                data_gen=partial(generate_input, shape))
+                            "input_data1": TensorConfig(
+                                data_gen=partial(generate_input, shape)
+                            ),
+                            "input_data2": TensorConfig(
+                                data_gen=partial(generate_input, shape)
+                            ),
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             # The input.dims[1] must be equal to the weight's length.
             if self.dims == 2:
                 self.dynamic_shape.min_input_shape = {
                     "input_data1": [1, 1],
-                    "input_data2": [1, 1]
+                    "input_data2": [1, 1],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data1": [4, 1],
-                    "input_data2": [4, 1]
+                    "input_data2": [4, 1],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data1": [2, 1],
-                    "input_data2": [2, 1]
+                    "input_data2": [2, 1],
                 }
             elif self.dims == 3:
                 self.dynamic_shape.min_input_shape = {
                     "input_data1": [1, 1, 4],
-                    "input_data2": [1, 1, 4]
+                    "input_data2": [1, 1, 4],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data1": [4, 1, 256],
-                    "input_data2": [1, 1, 256]
+                    "input_data2": [1, 1, 256],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data1": [2, 1, 16],
-                    "input_data2": [2, 1, 16]
+                    "input_data2": [2, 1, 16],
                 }
             elif self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
                     "input_data1": [1, 1, 4, 4],
-                    "input_data2": [1, 1, 4, 4]
+                    "input_data2": [1, 1, 4, 4],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data1": [4, 1, 128, 256],
-                    "input_data2": [4, 1, 128, 256]
+                    "input_data2": [4, 1, 128, 256],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data1": [2, 1, 32, 16],
-                    "input_data2": [2, 1, 32, 16]
+                    "input_data2": [2, 1, 32, 16],
                 }
 
         def clear_dynamic_shape():
@@ -144,19 +140,23 @@ class TrtConvertElementwiseTest_one_input_corner_case(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fc.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fc.py
@@ -23,10 +23,9 @@ import os
 
 
 class TrtConvertFcTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         # The output has diff between gpu and trt in CI windows
-        if (os.name == 'nt'):
+        if os.name == 'nt':
             return False
         return True
 
@@ -34,12 +33,14 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
         self.trt_param.workspace_size = 1073741824
 
         def generate_input1(batch, attrs: List[Dict[str, Any]]):
-            return np.random.random([batch, 3, 64, (int)(attrs[0]["m"] / 2),
-                                     2]).astype(np.float32)
+            return np.random.random(
+                [batch, 3, 64, (int)(attrs[0]["m"] / 2), 2]
+            ).astype(np.float32)
 
         def generate_w(batch, attrs: List[Dict[str, Any]]):
-            return np.random.random([attrs[0]["m"],
-                                     attrs[0]["n"]]).astype(np.float32)
+            return np.random.random([attrs[0]["m"], attrs[0]["n"]]).astype(
+                np.float32
+            )
 
         def generate_bias(batch, attrs: List[Dict[str, Any]]):
             return np.random.random([attrs[0]["n"]]).astype(np.float32)
@@ -53,7 +54,7 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
                         "m": m,
                         "n": n,
                     },
-                    {}
+                    {},
                 ]
 
                 ops_config = [
@@ -62,12 +63,10 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
                         "op_inputs": {
                             "Input": ["input_data"],
                             "W": ["w_data"],
-                            "Bias": ["bias_data"]
+                            "Bias": ["bias_data"],
                         },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
+                        "op_outputs": {"Out": ["output_data"]},
+                        "op_attrs": dics[0],
                     },
                 ]
 
@@ -76,24 +75,26 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={
-                        "w_data":
-                        TensorConfig(data_gen=partial(generate_w, batch, dics)),
-                        "bias_data":
-                        TensorConfig(
-                            data_gen=partial(generate_bias, batch, dics))
+                        "w_data": TensorConfig(
+                            data_gen=partial(generate_w, batch, dics)
+                        ),
+                        "bias_data": TensorConfig(
+                            data_gen=partial(generate_bias, batch, dics)
+                        ),
                     },
                     inputs={
-                        "input_data":
-                        TensorConfig(
-                            data_gen=partial(generate_input1, batch, dics)),
+                        "input_data": TensorConfig(
+                            data_gen=partial(generate_input1, batch, dics)
+                        ),
                     },
-                    outputs=["output_data"])
+                    outputs=["output_data"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 3, 32, 16, 2],
@@ -121,19 +122,23 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
         # clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()
@@ -143,10 +148,9 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
 
 
 class TrtConvertFcTest2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         # The output has diff between gpu and trt in CI windows
-        if (os.name == 'nt'):
+        if os.name == 'nt':
             return False
         return True
 
@@ -157,8 +161,9 @@ class TrtConvertFcTest2(TrtLayerAutoScanTest):
             return np.random.random([batch, 3, 64, 14]).astype(np.float32)
 
         def generate_w(batch, attrs: List[Dict[str, Any]]):
-            return np.random.random([attrs[0]["m"],
-                                     attrs[0]["n"]]).astype(np.float32)
+            return np.random.random([attrs[0]["m"], attrs[0]["n"]]).astype(
+                np.float32
+            )
 
         def generate_bias(batch, attrs: List[Dict[str, Any]]):
             return np.random.random([attrs[0]["n"]]).astype(np.float32)
@@ -172,7 +177,7 @@ class TrtConvertFcTest2(TrtLayerAutoScanTest):
                         "m": m,
                         "n": n,
                     },
-                    {}
+                    {},
                 ]
 
                 ops_config = [
@@ -181,12 +186,10 @@ class TrtConvertFcTest2(TrtLayerAutoScanTest):
                         "op_inputs": {
                             "Input": ["input_data"],
                             "W": ["w_data"],
-                            "Bias": ["bias_data"]
+                            "Bias": ["bias_data"],
                         },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
+                        "op_outputs": {"Out": ["output_data"]},
+                        "op_attrs": dics[0],
                     },
                 ]
 
@@ -195,24 +198,26 @@ class TrtConvertFcTest2(TrtLayerAutoScanTest):
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={
-                        "w_data":
-                        TensorConfig(data_gen=partial(generate_w, batch, dics)),
-                        "bias_data":
-                        TensorConfig(
-                            data_gen=partial(generate_bias, batch, dics))
+                        "w_data": TensorConfig(
+                            data_gen=partial(generate_w, batch, dics)
+                        ),
+                        "bias_data": TensorConfig(
+                            data_gen=partial(generate_bias, batch, dics)
+                        ),
                     },
                     inputs={
-                        "input_data":
-                        TensorConfig(
-                            data_gen=partial(generate_input1, batch, dics)),
+                        "input_data": TensorConfig(
+                            data_gen=partial(generate_input1, batch, dics)
+                        ),
                     },
-                    outputs=["output_data"])
+                    outputs=["output_data"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 3, 32, 14],
@@ -277,7 +282,7 @@ class TrtConvertFcTest3(TrtLayerAutoScanTest):
                         "m": m,
                         "n": n,
                     },
-                    {}
+                    {},
                 ]
 
                 ops_config = [
@@ -286,12 +291,10 @@ class TrtConvertFcTest3(TrtLayerAutoScanTest):
                         "op_inputs": {
                             "Input": ["input_data"],
                             "W": ["w_data"],
-                            "Bias": ["bias_data"]
+                            "Bias": ["bias_data"],
                         },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
+                        "op_outputs": {"Out": ["output_data"]},
+                        "op_attrs": dics[0],
                     },
                 ]
 
@@ -300,24 +303,26 @@ class TrtConvertFcTest3(TrtLayerAutoScanTest):
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={
-                        "w_data":
-                        TensorConfig(data_gen=partial(generate_w, batch, dics)),
-                        "bias_data":
-                        TensorConfig(
-                            data_gen=partial(generate_bias, batch, dics))
+                        "w_data": TensorConfig(
+                            data_gen=partial(generate_w, batch, dics)
+                        ),
+                        "bias_data": TensorConfig(
+                            data_gen=partial(generate_bias, batch, dics)
+                        ),
                     },
                     inputs={
-                        "input_data":
-                        TensorConfig(
-                            data_gen=partial(generate_input1, batch, dics)),
+                        "input_data": TensorConfig(
+                            data_gen=partial(generate_input1, batch, dics)
+                        ),
                     },
-                    outputs=["output_data"])
+                    outputs=["output_data"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 14, 1, 2],

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fc.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fc.py
@@ -124,7 +124,7 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -133,7 +133,7 @@ class TrtConvertFcTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()
@@ -234,14 +234,14 @@ class TrtConvertFcTest2(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), (1e-5, 1e-5)
+        yield self.create_inference_config(), (1, 2), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), (1e-5, 1e-5)
+        yield self.create_inference_config(), (1, 2), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()
@@ -339,16 +339,16 @@ class TrtConvertFcTest3(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), (1e-5, 1e-5)
+        yield self.create_inference_config(), (1, 2), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), (1e-5, 1e-5)
+        yield self.create_inference_config(), (1, 2), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
-        yield self.create_inference_config(), (1, 2), (1e-5, 1e-5)
+        yield self.create_inference_config(), (1, 2), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_constant.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_constant.py
@@ -134,7 +134,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_constant.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_fill_constant.py
@@ -22,12 +22,10 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertSplitTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_value_data(attrs: List[Dict[str, Any]]):
             return np.array([1]).astype(np.int32)
 
@@ -47,21 +45,28 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                             str_value = str_value
                         else:
                             str_value = ""
-                        dics = [{
-                            "str_value": str_value,
-                            "value": value,
-                            "shape": shape,
-                            "dtype": dtype
-                        }, {
-                            "axis": -1
-                        }]
-                        dics_intput = [{
-                            "ValueTensor": ["value_data"]
-                        }, {
-                            "ShapeTensor": ["shape_data"],
-                        }, {
-                            "ShapeTensorList": ["shapeT1_data", "shapeT2_data"],
-                        }, {}]
+                        dics = [
+                            {
+                                "str_value": str_value,
+                                "value": value,
+                                "shape": shape,
+                                "dtype": dtype,
+                            },
+                            {"axis": -1},
+                        ]
+                        dics_intput = [
+                            {"ValueTensor": ["value_data"]},
+                            {
+                                "ShapeTensor": ["shape_data"],
+                            },
+                            {
+                                "ShapeTensorList": [
+                                    "shapeT1_data",
+                                    "shapeT2_data",
+                                ],
+                            },
+                            {},
+                        ]
                         ops_config = [
                             {
                                 "op_type": "fill_constant",
@@ -69,7 +74,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                                 "op_outputs": {
                                     "Out": ["out_data"],
                                 },
-                                "op_attrs": dics[0]
+                                "op_attrs": dics[0],
                             },
                         ]
 
@@ -81,26 +86,31 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                             ops=ops,
                             weights={},
                             inputs={
-                                "value_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_value_data, dics)),
-                                "shape_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_shape_data, dics)),
-                                "shapeT1_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_shapelist_data, dics)),
-                                "shapeT2_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_shapelist_data, dics)),
+                                "value_data": TensorConfig(
+                                    data_gen=partial(generate_value_data, dics)
+                                ),
+                                "shape_data": TensorConfig(
+                                    data_gen=partial(generate_shape_data, dics)
+                                ),
+                                "shapeT1_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_shapelist_data, dics
+                                    )
+                                ),
+                                "shapeT2_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_shapelist_data, dics
+                                    )
+                                ),
                             },
-                            outputs=["out_data"])
+                            outputs=["out_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.input_shape = [1, 1]
             max_shape = list(self.input_shape)
@@ -118,7 +128,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if (self.num_input < 3):
+            if self.num_input < 3:
                 return 0, 6
             return 1, 5
 
@@ -131,10 +141,12 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_flatten.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_flatten.py
@@ -31,7 +31,7 @@ class TrtConvertFlattenTest_dim_2(TrtLayerAutoScanTest):
         def generate_input(batch):
             return np.random.random([batch, 32]).astype(np.float32)
 
-        for batch in [1, 2, 4]:
+        for batch in [1, 4]:
             for axis in [0, 1]:
                 for type in ["flatten", "flatten2"]:
                     if type == "flatten":
@@ -128,7 +128,7 @@ class TrtConvertFlattenTest_dim_3(TrtLayerAutoScanTest):
         def generate_input(batch):
             return np.random.random([batch, 32, 64]).astype(np.float32)
 
-        for batch in [1, 2, 4]:
+        for batch in [1, 4]:
             for axis in [0, 1, 2]:
                 for type in ["flatten", "flatten2"]:
                     if type == "flatten":
@@ -166,8 +166,8 @@ class TrtConvertFlattenTest_dim_3(TrtLayerAutoScanTest):
 
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 8, 8]}
-            self.dynamic_shape.max_input_shape = {"input_data": [4, 64, 768]}
-            self.dynamic_shape.opt_input_shape = {"input_data": [2, 32, 256]}
+            self.dynamic_shape.max_input_shape = {"input_data": [4, 32, 64]}
+            self.dynamic_shape.opt_input_shape = {"input_data": [2, 32, 64]}
 
         def clear_dynamic_shape():
             self.dynamic_shape.max_input_shape = {}
@@ -226,7 +226,7 @@ class TrtConvertFlattenTest_dim_4(TrtLayerAutoScanTest):
         def generate_input(batch):
             return np.random.random([batch, 8, 8, 8]).astype(np.float32)
 
-        for batch in [1, 2, 4]:
+        for batch in [1, 4]:
             for axis in [0, 1, 2, 3]:
                 for type in ["flatten", "flatten2"]:
                     if type == "flatten":
@@ -264,7 +264,7 @@ class TrtConvertFlattenTest_dim_4(TrtLayerAutoScanTest):
 
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 4, 4, 4]}
-            self.dynamic_shape.max_input_shape = {"input_data": [4, 32, 64, 64]}
+            self.dynamic_shape.max_input_shape = {"input_data": [4, 32, 32, 32]}
             self.dynamic_shape.opt_input_shape = {"input_data": [2, 16, 16, 8]}
 
         def clear_dynamic_shape():
@@ -294,6 +294,7 @@ class TrtConvertFlattenTest_dim_4(TrtLayerAutoScanTest):
 
         # for static_shape
         clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
@@ -323,7 +324,7 @@ class TrtConvertFlattenTest_dim_5(TrtLayerAutoScanTest):
         def generate_input(batch):
             return np.random.random([batch, 8, 8, 8]).astype(np.float32)
 
-        for batch in [1, 2, 4]:
+        for batch in [1, 4]:
             for axis in [0, 1, 2, 3, 4]:
                 for type in ["flatten", "flatten2"]:
                     if type == "flatten":
@@ -361,7 +362,7 @@ class TrtConvertFlattenTest_dim_5(TrtLayerAutoScanTest):
 
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 4, 4, 4]}
-            self.dynamic_shape.max_input_shape = {"input_data": [4, 32, 64, 64]}
+            self.dynamic_shape.max_input_shape = {"input_data": [4, 16, 16, 8]}
             self.dynamic_shape.opt_input_shape = {"input_data": [2, 16, 16, 8]}
 
         def clear_dynamic_shape():
@@ -391,6 +392,7 @@ class TrtConvertFlattenTest_dim_5(TrtLayerAutoScanTest):
 
         # for static_shape
         clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_flatten.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_flatten.py
@@ -22,12 +22,10 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertFlattenTest_dim_2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(batch):
             return np.random.random([batch, 32]).astype(np.float32)
 
@@ -39,34 +37,35 @@ class TrtConvertFlattenTest_dim_2(TrtLayerAutoScanTest):
                     else:
                         op_outputs = {
                             "Out": ["output_data"],
-                            "XShape": ["xshape_data"]
+                            "XShape": ["xshape_data"],
                         }
                     dics = [{"axis": axis}]
-                    ops_config = [{
-                        "op_type": "flatten",
-                        "op_inputs": {
-                            "X": ["input_data"]
-                        },
-                        "op_outputs": op_outputs,
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "flatten",
+                            "op_inputs": {"X": ["input_data"]},
+                            "op_outputs": op_outputs,
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, batch))
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input, batch)
+                            )
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 8]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 64]}
@@ -100,31 +99,33 @@ class TrtConvertFlattenTest_dim_2(TrtLayerAutoScanTest):
         # for static_shape
         clear_dynamic_shape()
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()
 
 
 class TrtConvertFlattenTest_dim_3(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(batch):
             return np.random.random([batch, 32, 64]).astype(np.float32)
 
@@ -136,34 +137,35 @@ class TrtConvertFlattenTest_dim_3(TrtLayerAutoScanTest):
                     else:
                         op_outputs = {
                             "Out": ["output_data"],
-                            "XShape": ["xshape_data"]
+                            "XShape": ["xshape_data"],
                         }
                     dics = [{"axis": axis}]
-                    ops_config = [{
-                        "op_type": "flatten",
-                        "op_inputs": {
-                            "X": ["input_data"]
-                        },
-                        "op_outputs": op_outputs,
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "flatten",
+                            "op_inputs": {"X": ["input_data"]},
+                            "op_outputs": op_outputs,
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, batch))
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input, batch)
+                            )
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 8, 8]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 32, 64]}
@@ -198,31 +200,33 @@ class TrtConvertFlattenTest_dim_3(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()
 
 
 class TrtConvertFlattenTest_dim_4(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(batch):
             return np.random.random([batch, 8, 8, 8]).astype(np.float32)
 
@@ -234,34 +238,35 @@ class TrtConvertFlattenTest_dim_4(TrtLayerAutoScanTest):
                     else:
                         op_outputs = {
                             "Out": ["output_data"],
-                            "XShape": ["xshape_data"]
+                            "XShape": ["xshape_data"],
                         }
                     dics = [{"axis": axis}]
-                    ops_config = [{
-                        "op_type": "flatten",
-                        "op_inputs": {
-                            "X": ["input_data"]
-                        },
-                        "op_outputs": op_outputs,
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "flatten",
+                            "op_inputs": {"X": ["input_data"]},
+                            "op_outputs": op_outputs,
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, batch))
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input, batch)
+                            )
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 4, 4, 4]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 32, 32, 32]}
@@ -296,31 +301,33 @@ class TrtConvertFlattenTest_dim_4(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()
 
 
 class TrtConvertFlattenTest_dim_5(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(batch):
             return np.random.random([batch, 8, 8, 8]).astype(np.float32)
 
@@ -332,34 +339,35 @@ class TrtConvertFlattenTest_dim_5(TrtLayerAutoScanTest):
                     else:
                         op_outputs = {
                             "Out": ["output_data"],
-                            "XShape": ["xshape_data"]
+                            "XShape": ["xshape_data"],
                         }
                     dics = [{"axis": axis}]
-                    ops_config = [{
-                        "op_type": "flatten",
-                        "op_inputs": {
-                            "X": ["input_data"]
-                        },
-                        "op_outputs": op_outputs,
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "flatten",
+                            "op_inputs": {"X": ["input_data"]},
+                            "op_outputs": op_outputs,
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, batch))
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input, batch)
+                            )
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 4, 4, 4]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 16, 16, 8]}
@@ -394,19 +402,23 @@ class TrtConvertFlattenTest_dim_5(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather.py
@@ -23,7 +23,6 @@ import unittest
 
 
 class TrtConvertGatherTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         attrs = [
@@ -35,7 +34,6 @@ class TrtConvertGatherTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -52,112 +50,126 @@ class TrtConvertGatherTest(TrtLayerAutoScanTest):
             for index in [[1, 4], [4, 8]]:
                 for axis in [0, 1, 2, 3]:
                     for overwrite in [True, False]:
-                        for input in [{
-                                "X": ["input_data"],
-                                "Index": ["index_data"]
-                        }, {
+                        for input in [
+                            {"X": ["input_data"], "Index": ["index_data"]},
+                            {
                                 "X": ["input_data"],
                                 "Index": ["index_data"],
-                                "Axis": ["axis_data"]
-                        }]:
+                                "Axis": ["axis_data"],
+                            },
+                        ]:
                             for index_type_int32 in [True, False]:
                                 self.shape = shape
                                 self.axis = axis
                                 self.input_num = len(input)
                                 self.index_type_int32 = index_type_int32
                                 dics = [{"overwrite": overwrite, "axis": axis}]
-                                ops_config = [{
-                                    "op_type": "gather",
-                                    "op_inputs": input,
-                                    "op_outputs": {
-                                        "Out": ["output_data"]
-                                    },
-                                    "op_attrs": dics[0]
-                                }]
+                                ops_config = [
+                                    {
+                                        "op_type": "gather",
+                                        "op_inputs": input,
+                                        "op_outputs": {"Out": ["output_data"]},
+                                        "op_attrs": dics[0],
+                                    }
+                                ]
                                 ops = self.generate_op_config(ops_config)
 
                                 program_config = ProgramConfig(
                                     ops=ops,
                                     weights={},
                                     inputs={
-                                        "input_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input1, shape)),
-                                        "index_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input2
-                                            if index_type_int32 ==
-                                            True else generate_input4, index)),
-                                    } if len(input) == 2 else {
-                                        "input_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input1, shape)),
-                                        "index_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input2, index)),
-                                        "axis_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input3, axis)),
+                                        "input_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input1, shape
+                                            )
+                                        ),
+                                        "index_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input2
+                                                if index_type_int32 == True
+                                                else generate_input4,
+                                                index,
+                                            )
+                                        ),
+                                    }
+                                    if len(input) == 2
+                                    else {
+                                        "input_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input1, shape
+                                            )
+                                        ),
+                                        "index_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input2, index
+                                            )
+                                        ),
+                                        "axis_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input3, axis
+                                            )
+                                        ),
                                     },
-                                    outputs=["output_data"])
+                                    outputs=["output_data"],
+                                )
 
                                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if len(self.shape) == 1:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [4],
-                    "index_data": [1]
+                    "index_data": [1],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [128],
-                    "index_data": [4]
+                    "index_data": [4],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [16],
-                    "index_data": [2]
+                    "index_data": [2],
                 }
             elif len(self.shape) == 2:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [2, 4],
-                    "index_data": [1]
+                    "index_data": [1],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [256, 256],
-                    "index_data": [4]
+                    "index_data": [4],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [64, 32],
-                    "index_data": [2]
+                    "index_data": [2],
                 }
             elif len(self.shape) == 3:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [2, 4, 4],
-                    "index_data": [1]
+                    "index_data": [1],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [128, 256, 256],
-                    "index_data": [4]
+                    "index_data": [4],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [16, 64, 32],
-                    "index_data": [2]
+                    "index_data": [2],
                 }
             elif len(self.shape) == 4:
                 self.dynamic_shape.min_input_shape = {
                     "input_data": [2, 4, 4, 2],
-                    "index_data": [1]
+                    "index_data": [1],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input_data": [128, 256, 64, 128],
-                    "index_data": [4]
+                    "index_data": [4],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input_data": [16, 64, 16, 32],
-                    "index_data": [2]
+                    "index_data": [2],
                 }
 
         def clear_dynamic_shape():
@@ -182,10 +194,12 @@ class TrtConvertGatherTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-3
+            False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -201,14 +215,17 @@ class TrtConvertGatherTest(TrtLayerAutoScanTest):
             def teller1(program_config, predictor_config):
                 if len(self.dynamic_shape.min_input_shape) != 0:
                     inputs = program_config.inputs
-                    if len(inputs['input_data'].shape) == 1 or len(
-                            inputs['index_data'].shape) == 1:
+                    if (
+                        len(inputs['input_data'].shape) == 1
+                        or len(inputs['index_data'].shape) == 1
+                    ):
                         return True
                 return False
 
             self.add_skip_case(
-                teller1, SkipReasons.TRT_NOT_SUPPORT,
-                "Need to repair the case: trt reshape out failed for dynamic shape mode when inputs' dims==1. under trt7.0 "
+                teller1,
+                SkipReasons.TRT_NOT_SUPPORT,
+                "Need to repair the case: trt reshape out failed for dynamic shape mode when inputs' dims==1. under trt7.0 ",
             )
 
     def test(self):

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather.py
@@ -185,7 +185,7 @@ class TrtConvertGatherTest(TrtLayerAutoScanTest):
             False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather_nd.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather_nd.py
@@ -95,14 +95,14 @@ class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 4), 1e-5
+        yield self.create_inference_config(), (0, 4), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
 
@@ -188,14 +188,14 @@ class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 4), 1e-5
+        yield self.create_inference_config(), (0, 4), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
 
@@ -281,14 +281,14 @@ class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 4), 1e-5
+        yield self.create_inference_config(), (0, 4), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
 
@@ -374,14 +374,14 @@ class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 4), 1e-5
+        yield self.create_inference_config(), (0, 4), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
 
@@ -467,14 +467,14 @@ class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 4), 1e-5
+        yield self.create_inference_config(), (0, 4), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
 
@@ -561,14 +561,14 @@ class TrtConvertGatherNdTest_dim_3_3(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 4), 1e-5
+        yield self.create_inference_config(), (0, 4), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather_nd.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gather_nd.py
@@ -23,7 +23,6 @@ import os
 
 
 class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         # The output has diff between gpu and trt in CI windows
         # if ( and self.trt_param.precision == paddle_infer.PrecisionType.Half):
@@ -31,54 +30,53 @@ class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([2, 32, 64, 64]).astype(np.float32)
 
         def generate_input2():
             return np.ones([1]).astype(np.int32)
 
-        ops_config = [{
-            "op_type": "gather_nd",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Index": ["index_data"]
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "gather_nd",
+                "op_inputs": {"X": ["input_data"], "Index": ["index_data"]},
+                "op_outputs": {"Out": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
         for i in range(10):
             program_config = ProgramConfig(
                 ops=ops,
                 weights={},
                 inputs={
-                    "input_data":
-                    TensorConfig(data_gen=partial(generate_input1)),
-                    "index_data":
-                    TensorConfig(data_gen=partial(generate_input2)),
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1)
+                    ),
+                    "index_data": TensorConfig(
+                        data_gen=partial(generate_input2)
+                    ),
                 },
-                outputs=["output_data"])
+                outputs=["output_data"],
+            )
 
             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 8, 8, 8],
-                "index_data": [1]
+                "index_data": [1],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data": [4, 32, 64, 64],
-                "index_data": [1]
+                "index_data": [1],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data": [2, 32, 64, 64],
-                "index_data": [1]
+                "index_data": [1],
             }
 
         def clear_dynamic_shape():
@@ -105,15 +103,16 @@ class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
         yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_SUPPORT,
-            "Under Windows Ci, this case will sporadically fail.")
+            teller1,
+            SkipReasons.TRT_NOT_SUPPORT,
+            "Under Windows Ci, this case will sporadically fail.",
+        )
 
     def test(self):
         self.add_skip_trt_case()
@@ -121,29 +120,24 @@ class TrtConvertGatherNdTest_dim_4_1(TrtLayerAutoScanTest):
 
 
 class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([2, 32, 64, 64]).astype(np.float32)
 
         def generate_input2():
             return np.array([1, 2]).astype(np.int32)
 
-        ops_config = [{
-            "op_type": "gather_nd",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Index": ["index_data"]
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "gather_nd",
+                "op_inputs": {"X": ["input_data"], "Index": ["index_data"]},
+                "op_outputs": {"Out": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
 
         program_config = ProgramConfig(
@@ -153,25 +147,26 @@ class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
                 "input_data": TensorConfig(data_gen=partial(generate_input1)),
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
-            outputs=["output_data"])
+            outputs=["output_data"],
+        )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 8, 8, 8],
-                "index_data": [2]
+                "index_data": [2],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data": [4, 32, 64, 64],
-                "index_data": [2]
+                "index_data": [2],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data": [2, 32, 64, 64],
-                "index_data": [2]
+                "index_data": [2],
             }
 
         def clear_dynamic_shape():
@@ -198,15 +193,16 @@ class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
         yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_SUPPORT,
-            "Under Windows Ci, this case will sporadically fail.")
+            teller1,
+            SkipReasons.TRT_NOT_SUPPORT,
+            "Under Windows Ci, this case will sporadically fail.",
+        )
 
     def test(self):
         self.add_skip_trt_case()
@@ -214,29 +210,24 @@ class TrtConvertGatherNdTest_dim_4_1_2(TrtLayerAutoScanTest):
 
 
 class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([2, 32, 64, 64]).astype(np.float32)
 
         def generate_input2():
             return np.ones([2, 2]).astype(np.int32)
 
-        ops_config = [{
-            "op_type": "gather_nd",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Index": ["index_data"]
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "gather_nd",
+                "op_inputs": {"X": ["input_data"], "Index": ["index_data"]},
+                "op_outputs": {"Out": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
 
         program_config = ProgramConfig(
@@ -246,25 +237,26 @@ class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
                 "input_data": TensorConfig(data_gen=partial(generate_input1)),
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
-            outputs=["output_data"])
+            outputs=["output_data"],
+        )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 8, 8, 8],
-                "index_data": [2, 2]
+                "index_data": [2, 2],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data": [4, 32, 64, 64],
-                "index_data": [2, 2]
+                "index_data": [2, 2],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data": [2, 32, 64, 64],
-                "index_data": [2, 2]
+                "index_data": [2, 2],
             }
 
         def clear_dynamic_shape():
@@ -291,15 +283,16 @@ class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
         yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_SUPPORT,
-            "Under Windows Ci, this case will sporadically fail.")
+            teller1,
+            SkipReasons.TRT_NOT_SUPPORT,
+            "Under Windows Ci, this case will sporadically fail.",
+        )
 
     def test(self):
         self.add_skip_trt_case()
@@ -307,29 +300,24 @@ class TrtConvertGatherNdTest_dim_4_2(TrtLayerAutoScanTest):
 
 
 class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([2, 32, 64, 64]).astype(np.float32)
 
         def generate_input2():
             return np.ones([2, 2, 4]).astype(np.int32)
 
-        ops_config = [{
-            "op_type": "gather_nd",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Index": ["index_data"]
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "gather_nd",
+                "op_inputs": {"X": ["input_data"], "Index": ["index_data"]},
+                "op_outputs": {"Out": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
 
         program_config = ProgramConfig(
@@ -339,25 +327,26 @@ class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
                 "input_data": TensorConfig(data_gen=partial(generate_input1)),
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
-            outputs=["output_data"])
+            outputs=["output_data"],
+        )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 8, 8, 8],
-                "index_data": [2, 2, 4]
+                "index_data": [2, 2, 4],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data": [4, 32, 64, 64],
-                "index_data": [2, 2, 4]
+                "index_data": [2, 2, 4],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data": [2, 32, 64, 64],
-                "index_data": [2, 2, 4]
+                "index_data": [2, 2, 4],
             }
 
         def clear_dynamic_shape():
@@ -384,15 +373,16 @@ class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
         yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_SUPPORT,
-            "Under Windows Ci, this case will sporadically fail.")
+            teller1,
+            SkipReasons.TRT_NOT_SUPPORT,
+            "Under Windows Ci, this case will sporadically fail.",
+        )
 
     def test(self):
         self.add_skip_trt_case()
@@ -400,29 +390,24 @@ class TrtConvertGatherNdTest_dim_4_3(TrtLayerAutoScanTest):
 
 
 class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([2, 32]).astype(np.float32)
 
         def generate_input2():
             return np.array([[0, 3], [1, 9]]).astype(np.int32)
 
-        ops_config = [{
-            "op_type": "gather_nd",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Index": ["index_data"]
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "gather_nd",
+                "op_inputs": {"X": ["input_data"], "Index": ["index_data"]},
+                "op_outputs": {"Out": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
 
         program_config = ProgramConfig(
@@ -432,25 +417,26 @@ class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
                 "input_data": TensorConfig(data_gen=partial(generate_input1)),
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
-            outputs=["output_data"])
+            outputs=["output_data"],
+        )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 4],
-                "index_data": [2, 2]
+                "index_data": [2, 2],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data": [4, 64],
-                "index_data": [2, 2]
+                "index_data": [2, 2],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data": [2, 8],
-                "index_data": [2, 2]
+                "index_data": [2, 2],
             }
 
         def clear_dynamic_shape():
@@ -477,15 +463,16 @@ class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
         yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(self.dynamic_shape.min_input_shape) != 0 and os.name == 'nt':
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_SUPPORT,
-            "Under Windows Ci, this case will sporadically fail.")
+            teller1,
+            SkipReasons.TRT_NOT_SUPPORT,
+            "Under Windows Ci, this case will sporadically fail.",
+        )
 
     def test(self):
         self.add_skip_trt_case()
@@ -493,30 +480,26 @@ class TrtConvertGatherNdTest_dim_2_2(TrtLayerAutoScanTest):
 
 
 class TrtConvertGatherNdTest_dim_3_3(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([16, 32, 256]).astype(np.float32)
 
         def generate_input2():
-            return np.array([[[2, 5], [3, 8]], [[0, 2], [0,
-                                                         3]]]).astype(np.int32)
+            return np.array([[[2, 5], [3, 8]], [[0, 2], [0, 3]]]).astype(
+                np.int32
+            )
 
-        ops_config = [{
-            "op_type": "gather_nd",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Index": ["index_data"]
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "gather_nd",
+                "op_inputs": {"X": ["input_data"], "Index": ["index_data"]},
+                "op_outputs": {"Out": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
 
         program_config = ProgramConfig(
@@ -526,25 +509,26 @@ class TrtConvertGatherNdTest_dim_3_3(TrtLayerAutoScanTest):
                 "input_data": TensorConfig(data_gen=partial(generate_input1)),
                 "index_data": TensorConfig(data_gen=partial(generate_input2)),
             },
-            outputs=["output_data"])
+            outputs=["output_data"],
+        )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 4, 4],
-                "index_data": [1, 1, 1]
+                "index_data": [1, 1, 1],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data": [16, 64, 512],
-                "index_data": [4, 2, 4]
+                "index_data": [4, 2, 4],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data": [2, 8, 64],
-                "index_data": [2, 2, 2]
+                "index_data": [2, 2, 2],
             }
 
         def clear_dynamic_shape():

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gelu.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gelu.py
@@ -22,12 +22,10 @@ import unittest
 
 
 class TrtConvertGeluTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(dims, attrs: List[Dict[str, Any]]):
             if dims == 1:
                 return np.ones([32]).astype(np.float32)
@@ -43,33 +41,32 @@ class TrtConvertGeluTest(TrtLayerAutoScanTest):
                 self.dims = dims
                 dics = [{"approximate": approximate}]
 
-                ops_config = [{
-                    "op_type": "gelu",
-                    "op_inputs": {
-                        "X": ["input_data"]
-                    },
-                    "op_outputs": {
-                        "Out": ["output_data"]
-                    },
-                    "op_attrs": dics[0]
-                }]
+                ops_config = [
+                    {
+                        "op_type": "gelu",
+                        "op_inputs": {"X": ["input_data"]},
+                        "op_outputs": {"Out": ["output_data"]},
+                        "op_attrs": dics[0],
+                    }
+                ]
                 ops = self.generate_op_config(ops_config)
 
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={},
                     inputs={
-                        "input_data":
-                        TensorConfig(
-                            data_gen=partial(generate_input1, dims, dics))
+                        "input_data": TensorConfig(
+                            data_gen=partial(generate_input1, dims, dics)
+                        )
                     },
-                    outputs=["output_data"])
+                    outputs=["output_data"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}
@@ -123,19 +120,23 @@ class TrtConvertGeluTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gelu.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_gelu.py
@@ -126,7 +126,7 @@ class TrtConvertGeluTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -135,7 +135,7 @@ class TrtConvertGeluTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_grid_sampler.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_grid_sampler.py
@@ -92,14 +92,14 @@ class TrtConvertGridSampler(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 4), 1e-5
+        yield self.create_inference_config(), (0, 4), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_grid_sampler.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_grid_sampler.py
@@ -22,29 +22,27 @@ import unittest
 
 
 class TrtConvertGridSampler(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([1, 3, 32, 32]).astype(np.float32)
 
         def generate_input2():
             return np.random.random([1, 3, 3, 2]).astype(np.float32)
 
-        ops_config = [{
-            "op_type": "grid_sampler",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Grid": ["grid_data"],
-            },
-            "op_outputs": {
-                "Output": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "grid_sampler",
+                "op_inputs": {
+                    "X": ["input_data"],
+                    "Grid": ["grid_data"],
+                },
+                "op_outputs": {"Output": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
 
         ops = self.generate_op_config(ops_config)
         for i in range(10):
@@ -52,30 +50,33 @@ class TrtConvertGridSampler(TrtLayerAutoScanTest):
                 ops=ops,
                 weights={},
                 inputs={
-                    "input_data":
-                    TensorConfig(data_gen=partial(generate_input1)),
-                    "grid_data":
-                    TensorConfig(data_gen=partial(generate_input2)),
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1)
+                    ),
+                    "grid_data": TensorConfig(
+                        data_gen=partial(generate_input2)
+                    ),
                 },
-                outputs=["output_data"])
+                outputs=["output_data"],
+            )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 3, 32, 32],
-                "grid_data": [1, 3, 3, 2]
+                "grid_data": [1, 3, 3, 2],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data": [1, 3, 64, 64],
-                "grid_data": [1, 3, 4, 4]
+                "grid_data": [1, 3, 4, 4],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data": [1, 3, 32, 32],
-                "grid_data": [1, 3, 3, 2]
+                "grid_data": [1, 3, 3, 2],
             }
 
         def clear_dynamic_shape():

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_group_norm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_group_norm.py
@@ -120,7 +120,7 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -129,7 +129,7 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_group_norm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_group_norm.py
@@ -22,7 +22,6 @@ import unittest
 
 
 class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -36,7 +35,6 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input(attrs: List[Dict[str, Any]], batch):
             if attrs[0]['data_layout'] == 'NCHW':
                 return np.random.random([batch, 32, 64, 64]).astype(np.float32)
@@ -53,47 +51,56 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
             for group in [1, 4, 32, -1]:
                 for epsilon in [0.0001, 0.0007, -1, 1]:
                     for data_layout in ['NCHW']:
-                        dics = [{
-                            "epsilon": epsilon,
-                            "groups": group,
-                            "data_layout": data_layout
-                        }]
-                        ops_config = [{
-                            "op_type": "group_norm",
-                            "op_inputs": {
-                                "X": ["input_data"],
-                                "Scale": ["scale_weight"],
-                                "Bias": ["bias_weight"]
-                            },
-                            "op_outputs": {
-                                "Y": ["y_output"],
-                                "Mean": ["mean_output"],
-                                "Variance": ["variance_output"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        dics = [
+                            {
+                                "epsilon": epsilon,
+                                "groups": group,
+                                "data_layout": data_layout,
+                            }
+                        ]
+                        ops_config = [
+                            {
+                                "op_type": "group_norm",
+                                "op_inputs": {
+                                    "X": ["input_data"],
+                                    "Scale": ["scale_weight"],
+                                    "Bias": ["bias_weight"],
+                                },
+                                "op_outputs": {
+                                    "Y": ["y_output"],
+                                    "Mean": ["mean_output"],
+                                    "Variance": ["variance_output"],
+                                },
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={
-                                "scale_weight":
-                                TensorConfig(data_gen=partial(generate_scale)),
-                                "bias_weight":
-                                TensorConfig(data_gen=partial(generate_bias))
+                                "scale_weight": TensorConfig(
+                                    data_gen=partial(generate_scale)
+                                ),
+                                "bias_weight": TensorConfig(
+                                    data_gen=partial(generate_bias)
+                                ),
                             },
                             inputs={
-                                "input_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, dics, batch))
+                                "input_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, dics, batch
+                                    )
+                                )
                             },
-                            outputs=["y_output"])
+                            outputs=["y_output"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 16, 16, 16]}
             self.dynamic_shape.max_input_shape = {
@@ -117,7 +124,8 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, False
@@ -127,7 +135,8 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
             attrs, True

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_group_norm.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_group_norm.py
@@ -120,7 +120,8 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -129,7 +130,8 @@ class TrtConvertGroupNormTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_sigmoid.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_sigmoid.py
@@ -98,14 +98,14 @@ class TrtConvertHardSigmoidTest_dim_2(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), 1e-5
+        yield self.create_inference_config(), (1, 2), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), 1e-5
+        yield self.create_inference_config(), (1, 2), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_sigmoid.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_sigmoid.py
@@ -22,12 +22,10 @@ import unittest
 
 
 class TrtConvertHardSigmoidTest_dim_2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -37,33 +35,34 @@ class TrtConvertHardSigmoidTest_dim_2(TrtLayerAutoScanTest):
                 for slope in [0.1, 0.5]:
                     for offset in [0.2, 0.7]:
                         dics = [{"slope": slope, "offset": offset}]
-                        ops_config = [{
-                            "op_type": "hard_sigmoid",
-                            "op_inputs": {
-                                "X": ["input_data"],
-                            },
-                            "op_outputs": {
-                                "Out": ["output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        ops_config = [
+                            {
+                                "op_type": "hard_sigmoid",
+                                "op_inputs": {
+                                    "X": ["input_data"],
+                                },
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={},
                             inputs={
-                                "input_data":
-                                TensorConfig(
-                                    data_gen=partial(generate_input, shape))
+                                "input_data": TensorConfig(
+                                    data_gen=partial(generate_input, shape)
+                                )
                             },
-                            outputs=["output_data"])
+                            outputs=["output_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.input_dim == 2:
                 self.dynamic_shape.min_input_shape = {"input_data": [1, 8]}

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_swish.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_swish.py
@@ -22,7 +22,6 @@ import unittest
 
 
 class TrtConvertHardSwishTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -36,46 +35,46 @@ class TrtConvertHardSwishTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]]):
             return np.ones([1, 3, 32, 32]).astype(np.float32)
 
         for threshold in [6.0, 7.0, 100.0, 0.0, -1.0]:
             for scale in [5.0, 7.0, -1.0, 0.0, 100.0]:
                 for offset in [3.0, 5.0, -1.0, 0.0, 100.0]:
-                    dics = [{
-                        "threshold": threshold,
-                        "scale": scale,
-                        "offset": offset
-                    }]
+                    dics = [
+                        {
+                            "threshold": threshold,
+                            "scale": scale,
+                            "offset": offset,
+                        }
+                    ]
 
-                    ops_config = [{
-                        "op_type": "hard_swish",
-                        "op_inputs": {
-                            "X": ["input_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["hard_swish_output_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "hard_swish",
+                            "op_inputs": {"X": ["input_data"]},
+                            "op_outputs": {"Out": ["hard_swish_output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, dics))
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input1, dics)
+                            )
                         },
-                        outputs=["hard_swish_output_data"])
+                        outputs=["hard_swish_output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 16, 16]}
             self.dynamic_shape.max_input_shape = {"input_data": [2, 3, 32, 32]}
@@ -97,19 +96,23 @@ class TrtConvertHardSwishTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_swish.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_hard_swish.py
@@ -100,7 +100,7 @@ class TrtConvertHardSwishTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -109,7 +109,7 @@ class TrtConvertHardSwishTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_inverse.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_inverse.py
@@ -22,41 +22,41 @@ import unittest
 
 
 class TrtConvertInverse(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([32, 32]).astype(np.float32)
 
-        ops_config = [{
-            "op_type": "inverse",
-            "op_inputs": {
-                "Input": ["input_data"],
-            },
-            "op_outputs": {
-                "Output": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "inverse",
+                "op_inputs": {
+                    "Input": ["input_data"],
+                },
+                "op_outputs": {"Output": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
         for i in range(10):
             program_config = ProgramConfig(
                 ops=ops,
                 weights={},
                 inputs={
-                    "input_data":
-                    TensorConfig(data_gen=partial(generate_input1)),
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1)
+                    ),
                 },
-                outputs=["output_data"])
+                outputs=["output_data"],
+            )
 
             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 1],

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_inverse.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_inverse.py
@@ -82,14 +82,14 @@ class TrtConvertInverse(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 3), 1e-5
+        yield self.create_inference_config(), (0, 3), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), 1e-5
+        yield self.create_inference_config(), (1, 2), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_leaky_relu.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_leaky_relu.py
@@ -23,12 +23,10 @@ import unittest
 
 
 class TrtConvertLeakyReluTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -37,32 +35,35 @@ class TrtConvertLeakyReluTest(TrtLayerAutoScanTest):
                 self.input_dim = len(shape)
                 for alpha in [0.02, 1.0, 100.0, -1.0, 0.0]:
                     dics = [{"alpha": alpha}]
-                    ops_config = [{
-                        "op_type": "leaky_relu",
-                        "op_inputs": {
-                            "X": ["input_data"],
-                        },
-                        "op_outputs": {
-                            "Out": ["y_data"],
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "leaky_relu",
+                            "op_inputs": {
+                                "X": ["input_data"],
+                            },
+                            "op_outputs": {
+                                "Out": ["y_data"],
+                            },
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, shape))
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input1, shape)
+                            )
                         },
-                        outputs=["y_data"])
+                        outputs=["y_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.input_dim == 2:
                 self.dynamic_shape.min_input_shape = {"input_data": [1, 8]}
@@ -101,25 +102,31 @@ class TrtConvertLeakyReluTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_leaky_relu.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_leaky_relu.py
@@ -104,10 +104,10 @@ class TrtConvertLeakyReluTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -116,10 +116,10 @@ class TrtConvertLeakyReluTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True), (1e-3, 1e-3)
         self.trt_param.precision = paddle_infer.PrecisionType.Int8
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True), (1e-3, 1e-3)
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul.py
@@ -22,12 +22,10 @@ import unittest
 
 
 class TrtConvertMatmulTest_static(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -47,48 +45,55 @@ class TrtConvertMatmulTest_static(TrtLayerAutoScanTest):
                         input1_shape = [batch, 32, 6]
                         input2_shape = [batch, 6, 11]
                     for alpha in [0.3, 1.0]:
-                        dics = [{
-                            "transpose_X": trans_x,
-                            "transpose_Y": trans_y,
-                            "alpha": alpha,
-                            "fused_reshape_X": [],
-                            "fused_reshape_Y": [],
-                            "fused_transpose_X": [],
-                            "fused_transpose_Y": [],
-                            "fused_reshape_Out": [],
-                            "fused_transpose_Out": []
-                        }]
-                        ops_config = [{
-                            "op_type": "matmul",
-                            "op_inputs": {
-                                "X": ["input1_data"],
-                                "Y": ["input2_data"]
-                            },
-                            "op_outputs": {
-                                "Out": ["output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        dics = [
+                            {
+                                "transpose_X": trans_x,
+                                "transpose_Y": trans_y,
+                                "alpha": alpha,
+                                "fused_reshape_X": [],
+                                "fused_reshape_Y": [],
+                                "fused_transpose_X": [],
+                                "fused_transpose_Y": [],
+                                "fused_reshape_Out": [],
+                                "fused_transpose_Out": [],
+                            }
+                        ]
+                        ops_config = [
+                            {
+                                "op_type": "matmul",
+                                "op_inputs": {
+                                    "X": ["input1_data"],
+                                    "Y": ["input2_data"],
+                                },
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={},
                             inputs={
-                                "input1_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, input1_shape)),
-                                "input2_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, input2_shape))
+                                "input1_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, input1_shape
+                                    )
+                                ),
+                                "input2_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, input2_shape
+                                    )
+                                ),
                             },
-                            outputs=["output_data"])
+                            outputs=["output_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             pass
 
@@ -109,12 +114,10 @@ class TrtConvertMatmulTest_static(TrtLayerAutoScanTest):
 
 
 class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -133,60 +136,63 @@ class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
                 #     input1_shape = [batch, 32, 6]
                 #     input2_shape = [batch, 6, 11]
                 for alpha in [0.3, 1.0]:
-                    dics = [{
-                        "transpose_X": trans_x,
-                        "transpose_Y": trans_y,
-                        "alpha": alpha,
-                        "fused_reshape_X": [],
-                        "fused_reshape_Y": [],
-                        "fused_transpose_X": [],
-                        "fused_transpose_Y": [],
-                        "fused_reshape_Out": [],
-                        "fused_transpose_Out": []
-                    }]
-                    ops_config = [{
-                        "op_type": "matmul",
-                        "op_inputs": {
-                            "X": ["input1_data"],
-                            "Y": ["input2_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    dics = [
+                        {
+                            "transpose_X": trans_x,
+                            "transpose_Y": trans_y,
+                            "alpha": alpha,
+                            "fused_reshape_X": [],
+                            "fused_reshape_Y": [],
+                            "fused_transpose_X": [],
+                            "fused_transpose_Y": [],
+                            "fused_reshape_Out": [],
+                            "fused_transpose_Out": [],
+                        }
+                    ]
+                    ops_config = [
+                        {
+                            "op_type": "matmul",
+                            "op_inputs": {
+                                "X": ["input1_data"],
+                                "Y": ["input2_data"],
+                            },
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input1_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, input1_shape)),
-                            "input2_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, input2_shape))
+                            "input1_data": TensorConfig(
+                                data_gen=partial(generate_input, input1_shape)
+                            ),
+                            "input2_data": TensorConfig(
+                                data_gen=partial(generate_input, input2_shape)
+                            ),
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input1_data": [1, 4, 4],
-                "input2_data": [1, 4, 4]
+                "input2_data": [1, 4, 4],
             }
             self.dynamic_shape.max_input_shape = {
                 "input1_data": [16, 4, 4],
-                "input2_data": [16, 4, 4]
+                "input2_data": [16, 4, 4],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input1_data": [8, 4, 4],
-                "input2_data": [8, 4, 4]
+                "input2_data": [8, 4, 4],
             }
 
         attrs = [

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul.py
@@ -102,7 +102,7 @@ class TrtConvertMatmulTest_static(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def test(self):
         self.run_test()
@@ -198,7 +198,7 @@ class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul_v2.py
@@ -23,9 +23,7 @@ import os
 
 
 class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
-
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -34,53 +32,56 @@ class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
                 for trans_y in [False]:
                     input1_shape = [batch, 64, 350, 75]
                     input2_shape = [75, 25]
-                    dics = [{
-                        "trans_x": trans_x,
-                        "trans_y": trans_y,
-                    }]
-                    ops_config = [{
-                        "op_type": "matmul_v2",
-                        "op_inputs": {
-                            "X": ["input1_data"],
-                            "Y": ["input2_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    dics = [
+                        {
+                            "trans_x": trans_x,
+                            "trans_y": trans_y,
+                        }
+                    ]
+                    ops_config = [
+                        {
+                            "op_type": "matmul_v2",
+                            "op_inputs": {
+                                "X": ["input1_data"],
+                                "Y": ["input2_data"],
+                            },
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input1_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, input1_shape)),
-                            "input2_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, input2_shape))
+                            "input1_data": TensorConfig(
+                                data_gen=partial(generate_input, input1_shape)
+                            ),
+                            "input2_data": TensorConfig(
+                                data_gen=partial(generate_input, input2_shape)
+                            ),
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input1_data": [10, 64, 350, 75],
-                "input2_data": [75, 25]
+                "input2_data": [75, 25],
             }
             self.dynamic_shape.max_input_shape = {
                 "input1_data": [100, 64, 350, 75],
-                "input2_data": [75, 25]
+                "input2_data": [75, 25],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input1_data": [15, 64, 350, 75],
-                "input2_data": [75, 25]
+                "input2_data": [75, 25],
             }
 
         attrs = [
@@ -90,7 +91,7 @@ class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
         # The output has little diff between gpu and trt in CI-Windows-Inference
         tol_fp32 = 1e-5
         tol_half = 1e-5
-        if (os.name == 'nt'):
+        if os.name == 'nt':
             tol_fp32 = 1e-3
             tol_half = 1e-3
         # for dynamic_shape
@@ -109,9 +110,7 @@ class TrtConvertMatmulTest_dynamic(TrtLayerAutoScanTest):
 
 
 class TrtConvertMatmulTest_dynamic2(TrtLayerAutoScanTest):
-
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -120,53 +119,56 @@ class TrtConvertMatmulTest_dynamic2(TrtLayerAutoScanTest):
                 for trans_y in [False]:
                     input1_shape = [60, 40]
                     input2_shape = [batch, 40, 90]
-                    dics = [{
-                        "trans_x": trans_x,
-                        "trans_y": trans_y,
-                    }]
-                    ops_config = [{
-                        "op_type": "matmul_v2",
-                        "op_inputs": {
-                            "X": ["input1_data"],
-                            "Y": ["input2_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    dics = [
+                        {
+                            "trans_x": trans_x,
+                            "trans_y": trans_y,
+                        }
+                    ]
+                    ops_config = [
+                        {
+                            "op_type": "matmul_v2",
+                            "op_inputs": {
+                                "X": ["input1_data"],
+                                "Y": ["input2_data"],
+                            },
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input1_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, input1_shape)),
-                            "input2_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input, input2_shape))
+                            "input1_data": TensorConfig(
+                                data_gen=partial(generate_input, input1_shape)
+                            ),
+                            "input2_data": TensorConfig(
+                                data_gen=partial(generate_input, input2_shape)
+                            ),
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input1_data": [60, 40],
-                "input2_data": [10, 40, 90]
+                "input2_data": [10, 40, 90],
             }
             self.dynamic_shape.max_input_shape = {
                 "input1_data": [60, 40],
-                "input2_data": [20, 40, 90]
+                "input2_data": [20, 40, 90],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input1_data": [60, 40],
-                "input2_data": [15, 40, 90]
+                "input2_data": [15, 40, 90],
             }
 
         attrs = [
@@ -175,7 +177,7 @@ class TrtConvertMatmulTest_dynamic2(TrtLayerAutoScanTest):
         # The output has little diff between gpu and trt in CI-Windows-Inference
         tol_fp32 = 1e-5
         tol_half = 1e-5
-        if (os.name == 'nt'):
+        if os.name == 'nt':
             tol_fp32 = 1e-3
             tol_half = 1e-3
         # for dynamic_shape
@@ -194,9 +196,7 @@ class TrtConvertMatmulTest_dynamic2(TrtLayerAutoScanTest):
 
 
 class TrtConvertMatmulTest_dynamic3(TrtLayerAutoScanTest):
-
     def sample_program_configs(self):
-
         def generate_input(shape):
             return np.random.random(shape).astype(np.float32)
 
@@ -219,86 +219,95 @@ class TrtConvertMatmulTest_dynamic3(TrtLayerAutoScanTest):
                         elif case == 2:
                             input1_shape = [50]
                             input2_shape = [50]
-                        if (case == 0 or case == 1):
-                            dics = [{
-                                "trans_x": False,
-                                "trans_y": False,
-                            }]
-                        elif (case == 2):
-                            dics = [{
-                                "trans_x": trans_x,
-                                "trans_y": trans_y,
-                            }]
-                        ops_config = [{
-                            "op_type": "matmul_v2",
-                            "op_inputs": {
-                                "X": ["input1_data"],
-                                "Y": ["input2_data"]
-                            },
-                            "op_outputs": {
-                                "Out": ["output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        if case == 0 or case == 1:
+                            dics = [
+                                {
+                                    "trans_x": False,
+                                    "trans_y": False,
+                                }
+                            ]
+                        elif case == 2:
+                            dics = [
+                                {
+                                    "trans_x": trans_x,
+                                    "trans_y": trans_y,
+                                }
+                            ]
+                        ops_config = [
+                            {
+                                "op_type": "matmul_v2",
+                                "op_inputs": {
+                                    "X": ["input1_data"],
+                                    "Y": ["input2_data"],
+                                },
+                                "op_outputs": {"Out": ["output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={},
                             inputs={
-                                "input1_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, input1_shape)),
-                                "input2_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_input, input2_shape))
+                                "input1_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, input1_shape
+                                    )
+                                ),
+                                "input2_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input, input2_shape
+                                    )
+                                ),
                             },
-                            outputs=["output_data"])
+                            outputs=["output_data"],
+                        )
 
                         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
-            if (self.case == 0):
+            if self.case == 0:
                 self.dynamic_shape.min_input_shape = {
                     "input1_data": [20, 50],
-                    "input2_data": [50]
+                    "input2_data": [50],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input1_data": [30, 50],
-                    "input2_data": [50]
+                    "input2_data": [50],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input1_data": [25, 50],
-                    "input2_data": [50]
+                    "input2_data": [50],
                 }
-            elif (self.case == 1):
+            elif self.case == 1:
                 self.dynamic_shape.min_input_shape = {
                     "input2_data": [50, 20],
-                    "input1_data": [50]
+                    "input1_data": [50],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input2_data": [50, 30],
-                    "input1_data": [50]
+                    "input1_data": [50],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input2_data": [50, 25],
-                    "input1_data": [50]
+                    "input1_data": [50],
                 }
-            elif (self.case == 2):
+            elif self.case == 2:
                 self.dynamic_shape.min_input_shape = {
                     "input2_data": [30],
-                    "input1_data": [50]
+                    "input1_data": [50],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input2_data": [50],
-                    "input1_data": [50]
+                    "input1_data": [50],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input2_data": [50],
-                    "input1_data": [50]
+                    "input1_data": [50],
                 }
 
         generate_dynamic_shape()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_matmul_v2.py
@@ -305,7 +305,7 @@ class TrtConvertMatmulTest_dynamic3(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), 1e-5
+        yield self.create_inference_config(), (1, 3), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_multihead_matmul.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_multihead_matmul.py
@@ -427,7 +427,7 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 4), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 4), (1e-5, 1e-5)
+        yield self.create_inference_config(), (1, 4), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -435,7 +435,7 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
         self.trt_param.workspace_size = 2013265920
         yield self.create_inference_config(), (1, 3), (1e-5, 1e-4)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 3), (1e-5, 1e-5)
+        yield self.create_inference_config(), (1, 3), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_multihead_matmul.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_multihead_matmul.py
@@ -22,12 +22,10 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(batch, dim1):
             return np.random.random((batch, dim1, 768)).astype(np.float32)
 
@@ -44,103 +42,86 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
             self.batch = batch
             for reshape_shape in [[0, 0, 12, 64]]:
                 for dim1 in [128]:
-                    input2_shapes = [[batch, reshape_shape[2], dim1, dim1],
-                                     [batch, 1, 1, dim1]]
+                    input2_shapes = [
+                        [batch, reshape_shape[2], dim1, dim1],
+                        [batch, 1, 1, dim1],
+                    ]
                     for input2_shape in input2_shapes:
                         for axis in [0]:
-                            dics = [{
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1
-                            }, {
-                                "axis": 2
-                            }, {
-                                "shape": reshape_shape
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1
-                            }, {
-                                "axis": 2
-                            }, {
-                                "shape": reshape_shape
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1
-                            }, {
-                                "axis": 2
-                            }, {
-                                "shape": reshape_shape
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "scale": 0.125,
-                                "bias": 0.0,
-                                "bias_after_scale": True
-                            }, {
-                                "alpha": 1.0,
-                                "transpose_X": False,
-                                "transpose_Y": True,
-                                "fused_reshape_X": [],
-                                "fused_reshape_Y": [],
-                                "fused_transpose_X": [],
-                                "fused_transpose_Y": [],
-                                "fused_reshape_Out": [],
-                                "fused_transpose_Out": []
-                            }, {
-                                "axis": axis
-                            }, {
-                                "axis": -1,
-                                "is_test": True
-                            }, {
-                                "seed": 0,
-                                "dropout_prob": 0.10000000149011612,
-                                "dropout_implementation": "upscale_in_train",
-                                "fix_seed": False,
-                                "is_test": True
-                            }, {
-                                "alpha": 1.0,
-                                "transpose_X": False,
-                                "transpose_Y": False,
-                                "fused_reshape_X": [],
-                                "fused_reshape_Y": [],
-                                "fused_transpose_X": [],
-                                "fused_transpose_Y": [],
-                                "fused_reshape_Out": [],
-                                "fused_transpose_Out": []
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "shape": [0, 0, 768]
-                            }, {
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1
-                            }]
+                            dics = [
+                                {"x_num_col_dims": 2, "y_num_col_dims": 1},
+                                {"axis": 2},
+                                {"shape": reshape_shape},
+                                {"axis": [0, 2, 1, 3]},
+                                {"x_num_col_dims": 2, "y_num_col_dims": 1},
+                                {"axis": 2},
+                                {"shape": reshape_shape},
+                                {"axis": [0, 2, 1, 3]},
+                                {"x_num_col_dims": 2, "y_num_col_dims": 1},
+                                {"axis": 2},
+                                {"shape": reshape_shape},
+                                {"axis": [0, 2, 1, 3]},
+                                {
+                                    "scale": 0.125,
+                                    "bias": 0.0,
+                                    "bias_after_scale": True,
+                                },
+                                {
+                                    "alpha": 1.0,
+                                    "transpose_X": False,
+                                    "transpose_Y": True,
+                                    "fused_reshape_X": [],
+                                    "fused_reshape_Y": [],
+                                    "fused_transpose_X": [],
+                                    "fused_transpose_Y": [],
+                                    "fused_reshape_Out": [],
+                                    "fused_transpose_Out": [],
+                                },
+                                {"axis": axis},
+                                {"axis": -1, "is_test": True},
+                                {
+                                    "seed": 0,
+                                    "dropout_prob": 0.10000000149011612,
+                                    "dropout_implementation": "upscale_in_train",
+                                    "fix_seed": False,
+                                    "is_test": True,
+                                },
+                                {
+                                    "alpha": 1.0,
+                                    "transpose_X": False,
+                                    "transpose_Y": False,
+                                    "fused_reshape_X": [],
+                                    "fused_reshape_Y": [],
+                                    "fused_transpose_X": [],
+                                    "fused_transpose_Y": [],
+                                    "fused_reshape_Out": [],
+                                    "fused_transpose_Out": [],
+                                },
+                                {"axis": [0, 2, 1, 3]},
+                                {"shape": [0, 0, 768]},
+                                {"x_num_col_dims": 2, "y_num_col_dims": 1},
+                            ]
 
                             ops_config = [
                                 {
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["input_data1"],
-                                        "Y": ["mul1_weight"]
+                                        "Y": ["mul1_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul1_output"]
-                                    },
-                                    "op_attrs": dics[0]
+                                    "op_outputs": {"Out": ["mul1_output"]},
+                                    "op_attrs": dics[0],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["mul1_output"],
-                                        "Y": ["elementwise_add1_weight"]
+                                        "Y": ["elementwise_add1_weight"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add1_output"]
                                     },
-                                    "op_attrs": dics[1]
+                                    "op_attrs": dics[1],
                                 },
                                 {
                                     "op_type": "reshape2",
@@ -149,42 +130,38 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
                                     },
                                     "op_outputs": {
                                         "Out": ["reshape21_output"],
-                                        "XShape": ["reshape21_output_xshape"]
+                                        "XShape": ["reshape21_output_xshape"],
                                     },
-                                    "op_attrs": dics[2]
+                                    "op_attrs": dics[2],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["reshape21_output"]
-                                    },
+                                    "op_inputs": {"X": ["reshape21_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose21_output"],
-                                        "XShape": ["transpose21_output_xshape"]
+                                        "XShape": ["transpose21_output_xshape"],
                                     },
-                                    "op_attrs": dics[3]
+                                    "op_attrs": dics[3],
                                 },
                                 {
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["input_data1"],
-                                        "Y": ["mul2_weight"]
+                                        "Y": ["mul2_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul2_output"]
-                                    },
-                                    "op_attrs": dics[4]
+                                    "op_outputs": {"Out": ["mul2_output"]},
+                                    "op_attrs": dics[4],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["mul2_output"],
-                                        "Y": ["elementwise_add2_weight"]
+                                        "Y": ["elementwise_add2_weight"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add2_output"]
                                     },
-                                    "op_attrs": dics[5]
+                                    "op_attrs": dics[5],
                                 },
                                 {
                                     "op_type": "reshape2",
@@ -193,42 +170,38 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
                                     },
                                     "op_outputs": {
                                         "Out": ["reshape22_output"],
-                                        "XShape": ["reshape22_output_xshape"]
+                                        "XShape": ["reshape22_output_xshape"],
                                     },
-                                    "op_attrs": dics[6]
+                                    "op_attrs": dics[6],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["reshape22_output"]
-                                    },
+                                    "op_inputs": {"X": ["reshape22_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose22_output"],
-                                        "XShape": ["transpose22_output_xshape"]
+                                        "XShape": ["transpose22_output_xshape"],
                                     },
-                                    "op_attrs": dics[7]
+                                    "op_attrs": dics[7],
                                 },
                                 {
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["input_data1"],
-                                        "Y": ["mul3_weight"]
+                                        "Y": ["mul3_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul3_output"]
-                                    },
-                                    "op_attrs": dics[8]
+                                    "op_outputs": {"Out": ["mul3_output"]},
+                                    "op_attrs": dics[8],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["mul3_output"],
-                                        "Y": ["elementwise_add3_weight"]
+                                        "Y": ["elementwise_add3_weight"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add3_output"]
                                     },
-                                    "op_attrs": dics[9]
+                                    "op_attrs": dics[9],
                                 },
                                 {
                                     "op_type": "reshape2",
@@ -237,30 +210,26 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
                                     },
                                     "op_outputs": {
                                         "Out": ["reshape23_output"],
-                                        "XShape": ["reshape23_output_xshape"]
+                                        "XShape": ["reshape23_output_xshape"],
                                     },
-                                    "op_attrs": dics[10]
+                                    "op_attrs": dics[10],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["reshape23_output"]
-                                    },
+                                    "op_inputs": {"X": ["reshape23_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose23_output"],
-                                        "XShape": ["transpose23_output_xshape"]
+                                        "XShape": ["transpose23_output_xshape"],
                                     },
-                                    "op_attrs": dics[11]
+                                    "op_attrs": dics[11],
                                 },
                                 {
                                     "op_type": "scale",
                                     "op_inputs": {
                                         "X": ["transpose23_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["scale_output"]
-                                    },
-                                    "op_attrs": dics[12]
+                                    "op_outputs": {"Out": ["scale_output"]},
+                                    "op_attrs": dics[12],
                                 },
                                 {
                                     "op_type": "matmul",
@@ -268,41 +237,35 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
                                         "X": ["scale_output"],
                                         "Y": ["transpose22_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["matmul1_output"]
-                                    },
-                                    "op_attrs": dics[13]
+                                    "op_outputs": {"Out": ["matmul1_output"]},
+                                    "op_attrs": dics[13],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["matmul1_output"],
-                                        "Y": ["input_data2"]
+                                        "Y": ["input_data2"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add4_output"]
                                     },
-                                    "op_attrs": dics[14]
+                                    "op_attrs": dics[14],
                                 },
                                 {
                                     "op_type": "softmax",
                                     "op_inputs": {
                                         "X": ["elementwise_add4_output"]
                                     },
-                                    "op_outputs": {
-                                        "Out": ["softmax_output"]
-                                    },
-                                    "op_attrs": dics[15]
+                                    "op_outputs": {"Out": ["softmax_output"]},
+                                    "op_attrs": dics[15],
                                 },
                                 {
                                     "op_type": "dropout",
                                     "op_inputs": {
                                         "X": ["softmax_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["dropout3_output"]
-                                    },
-                                    "op_attrs": dics[16]
+                                    "op_outputs": {"Out": ["dropout3_output"]},
+                                    "op_attrs": dics[16],
                                 },
                                 {
                                     "op_type": "matmul",
@@ -310,32 +273,26 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
                                         "X": ["dropout3_output"],
                                         "Y": ["transpose21_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["matmul2_output"]
-                                    },
-                                    "op_attrs": dics[17]
+                                    "op_outputs": {"Out": ["matmul2_output"]},
+                                    "op_attrs": dics[17],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["matmul2_output"]
-                                    },
+                                    "op_inputs": {"X": ["matmul2_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose24_output"],
-                                        "XShape": ["transpose24_output_xshape"]
+                                        "XShape": ["transpose24_output_xshape"],
                                     },
-                                    "op_attrs": dics[18]
+                                    "op_attrs": dics[18],
                                 },
                                 {
                                     "op_type": "reshape2",
-                                    "op_inputs": {
-                                        "X": ["transpose24_output"]
-                                    },
+                                    "op_inputs": {"X": ["transpose24_output"]},
                                     "op_outputs": {
                                         "Out": ["reshape24_output"],
-                                        "XShape": ["reshape24_output_xshape"]
+                                        "XShape": ["reshape24_output_xshape"],
                                     },
-                                    "op_attrs": dics[19]
+                                    "op_attrs": dics[19],
                                 },
                                 # In order to fuse ops with
                                 # multihead_matmul_fuse_pass_v2, the last op
@@ -344,72 +301,75 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["reshape24_output"],
-                                        "Y": ["mul4_weight"]
+                                        "Y": ["mul4_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul4_output"]
-                                    },
-                                    "op_attrs": dics[20]
-                                }
+                                    "op_outputs": {"Out": ["mul4_output"]},
+                                    "op_attrs": dics[20],
+                                },
                             ]
                             ops = self.generate_op_config(ops_config)
 
                             program_config = ProgramConfig(
                                 ops=ops,
                                 weights={
-                                    "mul1_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "mul2_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "mul3_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "mul4_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "elementwise_add1_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight2)),
-                                    "elementwise_add2_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight2)),
-                                    "elementwise_add3_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight2)),
+                                    "mul1_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "mul2_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "mul3_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "mul4_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "elementwise_add1_weight": TensorConfig(
+                                        data_gen=partial(generate_weight2)
+                                    ),
+                                    "elementwise_add2_weight": TensorConfig(
+                                        data_gen=partial(generate_weight2)
+                                    ),
+                                    "elementwise_add3_weight": TensorConfig(
+                                        data_gen=partial(generate_weight2)
+                                    ),
                                 },
                                 inputs={
-                                    "input_data1":
-                                    TensorConfig(data_gen=partial(
-                                        generate_input1, batch, dim1)),
-                                    "input_data2":
-                                    TensorConfig(data_gen=partial(
-                                        generate_input2, input2_shape)),
+                                    "input_data1": TensorConfig(
+                                        data_gen=partial(
+                                            generate_input1, batch, dim1
+                                        )
+                                    ),
+                                    "input_data2": TensorConfig(
+                                        data_gen=partial(
+                                            generate_input2, input2_shape
+                                        )
+                                    ),
                                 },
-                                outputs=["mul4_output"])
+                                outputs=["mul4_output"],
+                            )
 
                             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             # The last dim of input1 and input2 should be static.
             self.dynamic_shape.min_input_shape = {
                 "input_data1": [1, 8, 768],
                 "input_data2": [1, 1, 1, 128],
-                "reshape24_output": [1, 128, 768]
+                "reshape24_output": [1, 128, 768],
             }
             self.dynamic_shape.max_input_shape = {
                 "input_data1": [16, 512, 768],
                 "input_data2": [16, 256, 512, 128],
-                "reshape24_output": [1, 128, 768]
+                "reshape24_output": [1, 128, 768],
             }
             self.dynamic_shape.opt_input_shape = {
                 "input_data1": [8, 128, 768],
                 "input_data2": [8, 32, 64, 128],
-                "reshape24_output": [1, 128, 768]
+                "reshape24_output": [1, 128, 768],
             }
 
         def clear_dynamic_shape():
@@ -438,25 +398,30 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
         yield self.create_inference_config(), (1, 3), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if self.trt_param.precision == paddle_infer.PrecisionType.Half:
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_IMPLEMENTED,
-            "The output has diff between gpu and trt in fp16 mode.")
+            teller1,
+            SkipReasons.TRT_NOT_IMPLEMENTED,
+            "The output has diff between gpu and trt in fp16 mode.",
+        )
 
         def teller2(program_config, predictor_config):
-            if self.trt_param.precision == paddle_infer.PrecisionType.Float32 and len(
-                    self.dynamic_shape.min_input_shape) != 0 and self.batch > 2:
+            if (
+                self.trt_param.precision == paddle_infer.PrecisionType.Float32
+                and len(self.dynamic_shape.min_input_shape) != 0
+                and self.batch > 2
+            ):
                 return True
             return False
 
         self.add_skip_case(
-            teller2, SkipReasons.TRT_NOT_IMPLEMENTED,
-            "The output has diff between gpu and trt when dynamic fp32 mode and batch size > 2."
+            teller2,
+            SkipReasons.TRT_NOT_IMPLEMENTED,
+            "The output has diff between gpu and trt when dynamic fp32 mode and batch size > 2.",
         )
 
         def teller3(program_config, predictor_config):
@@ -465,8 +430,10 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
             return False
 
         self.add_skip_case(
-            teller3, SkipReasons.TRT_NOT_IMPLEMENTED,
-            "The output has diff between gpu and trt in int8 mode.")
+            teller3,
+            SkipReasons.TRT_NOT_IMPLEMENTED,
+            "The output has diff between gpu and trt in int8 mode.",
+        )
 
     def test(self):
         self.add_skip_trt_case()
@@ -474,9 +441,7 @@ class TrtConvertMultiHeadMatmulTest(TrtLayerAutoScanTest):
 
 
 class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
-
     def sample_program_configs(self):
-
         def generate_input1(batch, dim1):
             return np.random.random((batch, dim1, 768)).astype(np.float32)
 
@@ -493,112 +458,110 @@ class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
             self.batch = batch
             for reshape_shape in [[0, 0, 12, 64]]:
                 for dim1 in [128]:
-                    input2_shapes = [[batch, reshape_shape[2], dim1, dim1],
-                                     [batch, 1, 1, dim1]]
+                    input2_shapes = [
+                        [batch, reshape_shape[2], dim1, dim1],
+                        [batch, 1, 1, dim1],
+                    ]
                     for input2_shape in input2_shapes:
                         for axis in [0]:
-                            dics = [{
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1,
-                                "enable_int8": True,
-                                "Input_scale": 1.0,
-                            }, {
-                                "axis": 2,
-                                "out_threshold": 1.0,
-                            }, {
-                                "shape": reshape_shape
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1,
-                                "enable_int8": True,
-                                "Input_scale": 1.0,
-                            }, {
-                                "axis": 2,
-                                "out_threshold": 1.0,
-                            }, {
-                                "shape": reshape_shape
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1,
-                                "enable_int8": True,
-                                "Input_scale": 1.0,
-                            }, {
-                                "axis": 2,
-                                "out_threshold": 1.0,
-                            }, {
-                                "shape": reshape_shape
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "scale": 0.125,
-                                "bias": 0.0,
-                                "bias_after_scale": True
-                            }, {
-                                "alpha": 1.0,
-                                "transpose_X": False,
-                                "transpose_Y": True,
-                                "fused_reshape_X": [],
-                                "fused_reshape_Y": [],
-                                "fused_transpose_X": [],
-                                "fused_transpose_Y": [],
-                                "fused_reshape_Out": [],
-                                "fused_transpose_Out": []
-                            }, {
-                                "axis": axis
-                            }, {
-                                "axis": -1,
-                                "is_test": True
-                            }, {
-                                "seed": 0,
-                                "dropout_prob": 0.10000000149011612,
-                                "dropout_implementation": "upscale_in_train",
-                                "fix_seed": False,
-                                "is_test": True
-                            }, {
-                                "alpha": 1.0,
-                                "transpose_X": False,
-                                "transpose_Y": False,
-                                "fused_reshape_X": [],
-                                "fused_reshape_Y": [],
-                                "fused_transpose_X": [],
-                                "fused_transpose_Y": [],
-                                "fused_reshape_Out": [],
-                                "fused_transpose_Out": []
-                            }, {
-                                "axis": [0, 2, 1, 3]
-                            }, {
-                                "shape": [0, 0, 768]
-                            }, {
-                                "x_num_col_dims": 2,
-                                "y_num_col_dims": 1
-                            }]
+                            dics = [
+                                {
+                                    "x_num_col_dims": 2,
+                                    "y_num_col_dims": 1,
+                                    "enable_int8": True,
+                                    "Input_scale": 1.0,
+                                },
+                                {
+                                    "axis": 2,
+                                    "out_threshold": 1.0,
+                                },
+                                {"shape": reshape_shape},
+                                {"axis": [0, 2, 1, 3]},
+                                {
+                                    "x_num_col_dims": 2,
+                                    "y_num_col_dims": 1,
+                                    "enable_int8": True,
+                                    "Input_scale": 1.0,
+                                },
+                                {
+                                    "axis": 2,
+                                    "out_threshold": 1.0,
+                                },
+                                {"shape": reshape_shape},
+                                {"axis": [0, 2, 1, 3]},
+                                {
+                                    "x_num_col_dims": 2,
+                                    "y_num_col_dims": 1,
+                                    "enable_int8": True,
+                                    "Input_scale": 1.0,
+                                },
+                                {
+                                    "axis": 2,
+                                    "out_threshold": 1.0,
+                                },
+                                {"shape": reshape_shape},
+                                {"axis": [0, 2, 1, 3]},
+                                {
+                                    "scale": 0.125,
+                                    "bias": 0.0,
+                                    "bias_after_scale": True,
+                                },
+                                {
+                                    "alpha": 1.0,
+                                    "transpose_X": False,
+                                    "transpose_Y": True,
+                                    "fused_reshape_X": [],
+                                    "fused_reshape_Y": [],
+                                    "fused_transpose_X": [],
+                                    "fused_transpose_Y": [],
+                                    "fused_reshape_Out": [],
+                                    "fused_transpose_Out": [],
+                                },
+                                {"axis": axis},
+                                {"axis": -1, "is_test": True},
+                                {
+                                    "seed": 0,
+                                    "dropout_prob": 0.10000000149011612,
+                                    "dropout_implementation": "upscale_in_train",
+                                    "fix_seed": False,
+                                    "is_test": True,
+                                },
+                                {
+                                    "alpha": 1.0,
+                                    "transpose_X": False,
+                                    "transpose_Y": False,
+                                    "fused_reshape_X": [],
+                                    "fused_reshape_Y": [],
+                                    "fused_transpose_X": [],
+                                    "fused_transpose_Y": [],
+                                    "fused_reshape_Out": [],
+                                    "fused_transpose_Out": [],
+                                },
+                                {"axis": [0, 2, 1, 3]},
+                                {"shape": [0, 0, 768]},
+                                {"x_num_col_dims": 2, "y_num_col_dims": 1},
+                            ]
 
                             ops_config = [
                                 {
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["input_data1"],
-                                        "Y": ["mul1_weight"]
+                                        "Y": ["mul1_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul1_output"]
-                                    },
-                                    "op_attrs": dics[0]
+                                    "op_outputs": {"Out": ["mul1_output"]},
+                                    "op_attrs": dics[0],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["mul1_output"],
-                                        "Y": ["elementwise_add1_weight"]
+                                        "Y": ["elementwise_add1_weight"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add1_output"]
                                     },
-                                    "op_attrs": dics[1]
+                                    "op_attrs": dics[1],
                                 },
                                 {
                                     "op_type": "reshape2",
@@ -607,42 +570,38 @@ class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
                                     },
                                     "op_outputs": {
                                         "Out": ["reshape21_output"],
-                                        "XShape": ["reshape21_output_xshape"]
+                                        "XShape": ["reshape21_output_xshape"],
                                     },
-                                    "op_attrs": dics[2]
+                                    "op_attrs": dics[2],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["reshape21_output"]
-                                    },
+                                    "op_inputs": {"X": ["reshape21_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose21_output"],
-                                        "XShape": ["transpose21_output_xshape"]
+                                        "XShape": ["transpose21_output_xshape"],
                                     },
-                                    "op_attrs": dics[3]
+                                    "op_attrs": dics[3],
                                 },
                                 {
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["input_data1"],
-                                        "Y": ["mul2_weight"]
+                                        "Y": ["mul2_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul2_output"]
-                                    },
-                                    "op_attrs": dics[4]
+                                    "op_outputs": {"Out": ["mul2_output"]},
+                                    "op_attrs": dics[4],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["mul2_output"],
-                                        "Y": ["elementwise_add2_weight"]
+                                        "Y": ["elementwise_add2_weight"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add2_output"]
                                     },
-                                    "op_attrs": dics[5]
+                                    "op_attrs": dics[5],
                                 },
                                 {
                                     "op_type": "reshape2",
@@ -651,42 +610,38 @@ class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
                                     },
                                     "op_outputs": {
                                         "Out": ["reshape22_output"],
-                                        "XShape": ["reshape22_output_xshape"]
+                                        "XShape": ["reshape22_output_xshape"],
                                     },
-                                    "op_attrs": dics[6]
+                                    "op_attrs": dics[6],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["reshape22_output"]
-                                    },
+                                    "op_inputs": {"X": ["reshape22_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose22_output"],
-                                        "XShape": ["transpose22_output_xshape"]
+                                        "XShape": ["transpose22_output_xshape"],
                                     },
-                                    "op_attrs": dics[7]
+                                    "op_attrs": dics[7],
                                 },
                                 {
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["input_data1"],
-                                        "Y": ["mul3_weight"]
+                                        "Y": ["mul3_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul3_output"]
-                                    },
-                                    "op_attrs": dics[8]
+                                    "op_outputs": {"Out": ["mul3_output"]},
+                                    "op_attrs": dics[8],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["mul3_output"],
-                                        "Y": ["elementwise_add3_weight"]
+                                        "Y": ["elementwise_add3_weight"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add3_output"]
                                     },
-                                    "op_attrs": dics[9]
+                                    "op_attrs": dics[9],
                                 },
                                 {
                                     "op_type": "reshape2",
@@ -695,30 +650,26 @@ class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
                                     },
                                     "op_outputs": {
                                         "Out": ["reshape23_output"],
-                                        "XShape": ["reshape23_output_xshape"]
+                                        "XShape": ["reshape23_output_xshape"],
                                     },
-                                    "op_attrs": dics[10]
+                                    "op_attrs": dics[10],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["reshape23_output"]
-                                    },
+                                    "op_inputs": {"X": ["reshape23_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose23_output"],
-                                        "XShape": ["transpose23_output_xshape"]
+                                        "XShape": ["transpose23_output_xshape"],
                                     },
-                                    "op_attrs": dics[11]
+                                    "op_attrs": dics[11],
                                 },
                                 {
                                     "op_type": "scale",
                                     "op_inputs": {
                                         "X": ["transpose23_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["scale_output"]
-                                    },
-                                    "op_attrs": dics[12]
+                                    "op_outputs": {"Out": ["scale_output"]},
+                                    "op_attrs": dics[12],
                                 },
                                 {
                                     "op_type": "matmul",
@@ -726,41 +677,35 @@ class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
                                         "X": ["scale_output"],
                                         "Y": ["transpose22_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["matmul1_output"]
-                                    },
-                                    "op_attrs": dics[13]
+                                    "op_outputs": {"Out": ["matmul1_output"]},
+                                    "op_attrs": dics[13],
                                 },
                                 {
                                     "op_type": "elementwise_add",
                                     "op_inputs": {
                                         "X": ["matmul1_output"],
-                                        "Y": ["input_data2"]
+                                        "Y": ["input_data2"],
                                     },
                                     "op_outputs": {
                                         "Out": ["elementwise_add4_output"]
                                     },
-                                    "op_attrs": dics[14]
+                                    "op_attrs": dics[14],
                                 },
                                 {
                                     "op_type": "softmax",
                                     "op_inputs": {
                                         "X": ["elementwise_add4_output"]
                                     },
-                                    "op_outputs": {
-                                        "Out": ["softmax_output"]
-                                    },
-                                    "op_attrs": dics[15]
+                                    "op_outputs": {"Out": ["softmax_output"]},
+                                    "op_attrs": dics[15],
                                 },
                                 {
                                     "op_type": "dropout",
                                     "op_inputs": {
                                         "X": ["softmax_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["dropout3_output"]
-                                    },
-                                    "op_attrs": dics[16]
+                                    "op_outputs": {"Out": ["dropout3_output"]},
+                                    "op_attrs": dics[16],
                                 },
                                 {
                                     "op_type": "matmul",
@@ -768,32 +713,26 @@ class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
                                         "X": ["dropout3_output"],
                                         "Y": ["transpose21_output"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["matmul2_output"]
-                                    },
-                                    "op_attrs": dics[17]
+                                    "op_outputs": {"Out": ["matmul2_output"]},
+                                    "op_attrs": dics[17],
                                 },
                                 {
                                     "op_type": "transpose2",
-                                    "op_inputs": {
-                                        "X": ["matmul2_output"]
-                                    },
+                                    "op_inputs": {"X": ["matmul2_output"]},
                                     "op_outputs": {
                                         "Out": ["transpose24_output"],
-                                        "XShape": ["transpose24_output_xshape"]
+                                        "XShape": ["transpose24_output_xshape"],
                                     },
-                                    "op_attrs": dics[18]
+                                    "op_attrs": dics[18],
                                 },
                                 {
                                     "op_type": "reshape2",
-                                    "op_inputs": {
-                                        "X": ["transpose24_output"]
-                                    },
+                                    "op_inputs": {"X": ["transpose24_output"]},
                                     "op_outputs": {
                                         "Out": ["reshape24_output"],
-                                        "XShape": ["reshape24_output_xshape"]
+                                        "XShape": ["reshape24_output_xshape"],
                                     },
-                                    "op_attrs": dics[19]
+                                    "op_attrs": dics[19],
                                 },
                                 # In order to fuse ops with
                                 # multihead_matmul_fuse_pass_v2, the last op
@@ -802,61 +741,62 @@ class TrtConvertMultiHeadMatmulTestInt8(TrtConvertMultiHeadMatmulTest):
                                     "op_type": "mul",
                                     "op_inputs": {
                                         "X": ["reshape24_output"],
-                                        "Y": ["mul4_weight"]
+                                        "Y": ["mul4_weight"],
                                     },
-                                    "op_outputs": {
-                                        "Out": ["mul4_output"]
-                                    },
-                                    "op_attrs": dics[20]
-                                }
+                                    "op_outputs": {"Out": ["mul4_output"]},
+                                    "op_attrs": dics[20],
+                                },
                             ]
                             ops = self.generate_op_config(ops_config)
 
                             program_config = ProgramConfig(
                                 ops=ops,
                                 weights={
-                                    "mul1_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "mul2_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "mul3_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "mul4_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight1)),
-                                    "elementwise_add1_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight2)),
-                                    "elementwise_add2_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight2)),
-                                    "elementwise_add3_weight":
-                                    TensorConfig(
-                                        data_gen=partial(generate_weight2)),
+                                    "mul1_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "mul2_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "mul3_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "mul4_weight": TensorConfig(
+                                        data_gen=partial(generate_weight1)
+                                    ),
+                                    "elementwise_add1_weight": TensorConfig(
+                                        data_gen=partial(generate_weight2)
+                                    ),
+                                    "elementwise_add2_weight": TensorConfig(
+                                        data_gen=partial(generate_weight2)
+                                    ),
+                                    "elementwise_add3_weight": TensorConfig(
+                                        data_gen=partial(generate_weight2)
+                                    ),
                                 },
                                 inputs={
-                                    "input_data1":
-                                    TensorConfig(data_gen=partial(
-                                        generate_input1, batch, dim1)),
-                                    "input_data2":
-                                    TensorConfig(data_gen=partial(
-                                        generate_input2, input2_shape)),
+                                    "input_data1": TensorConfig(
+                                        data_gen=partial(
+                                            generate_input1, batch, dim1
+                                        )
+                                    ),
+                                    "input_data2": TensorConfig(
+                                        data_gen=partial(
+                                            generate_input2, input2_shape
+                                        )
+                                    ),
                                 },
-                                outputs=["mul4_output"])
+                                outputs=["mul4_output"],
+                            )
 
                             yield program_config
 
 
 class TrtConvertVitToMultiHeadMatmulTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(batch, length):
             return np.zeros((batch, length, 768), dtype=np.float32)
 
@@ -870,216 +810,190 @@ class TrtConvertVitToMultiHeadMatmulTest(TrtLayerAutoScanTest):
             self.batch = batch
             for length in [64, 384]:
                 self.length = length
-                ops_config = [{
-                    "op_type": "matmul_v2",
-                    "op_inputs": {
-                        "X": ["input_data1"],
-                        "Y": ["matmul1_weight"]
+                ops_config = [
+                    {
+                        "op_type": "matmul_v2",
+                        "op_inputs": {
+                            "X": ["input_data1"],
+                            "Y": ["matmul1_weight"],
+                        },
+                        "op_outputs": {"Out": ["matmul1_output"]},
+                        "op_attrs": {"trans_x": False, "trans_y": False},
                     },
-                    "op_outputs": {
-                        "Out": ["matmul1_output"]
+                    {
+                        "op_type": "elementwise_add",
+                        "op_inputs": {
+                            "X": ["matmul1_output"],
+                            "Y": ["elementwise_add1_weight"],
+                        },
+                        "op_outputs": {"Out": ["elementwise_add1_output"]},
+                        "op_attrs": {
+                            "Scale_out": 1.0,
+                            "Scale_x": 1.0,
+                            "Scale_y": 1.0,
+                            "axis": 2,
+                        },
                     },
-                    "op_attrs": {
-                        "trans_x": False,
-                        "trans_y": False
-                    }
-                }, {
-                    "op_type": "elementwise_add",
-                    "op_inputs": {
-                        "X": ["matmul1_output"],
-                        "Y": ["elementwise_add1_weight"]
+                    {
+                        "op_type": "reshape2",
+                        "op_inputs": {
+                            "X": ["elementwise_add1_output"],
+                        },
+                        "op_outputs": {
+                            "Out": ["reshape1_output"],
+                            "XShape": ["reshape1_output_xshape"],
+                        },
+                        "op_attrs": {"shape": [-1, self.length, 3, 12, 64]},
                     },
-                    "op_outputs": {
-                        "Out": ["elementwise_add1_output"]
+                    {
+                        "op_type": "transpose2",
+                        "op_inputs": {"X": ["reshape1_output"]},
+                        "op_outputs": {
+                            "Out": ["transpose1_output"],
+                            "XShape": ["transpose1_output_xshape"],
+                        },
+                        "op_attrs": {
+                            "axis": [2, 0, 3, 1, 4],
+                            "data_format": "AnyLayout",
+                        },
                     },
-                    "op_attrs": {
-                        "Scale_out": 1.0,
-                        "Scale_x": 1.0,
-                        "Scale_y": 1.0,
-                        "axis": 2
-                    }
-                }, {
-                    "op_type": "reshape2",
-                    "op_inputs": {
-                        "X": ["elementwise_add1_output"],
+                    {
+                        "op_type": "slice",
+                        "op_inputs": {
+                            "Input": ["transpose1_output"],
+                        },
+                        "op_outputs": {"Out": ["slice1_output"]},
+                        "op_attrs": {
+                            "axes": [0],
+                            "starts": [0],
+                            "ends": [1],
+                            "decrease_axis": [0],
+                            "infer_flags": [1],
+                        },
                     },
-                    "op_outputs": {
-                        "Out": ["reshape1_output"],
-                        "XShape": ["reshape1_output_xshape"]
+                    {
+                        "op_type": "slice",
+                        "op_inputs": {
+                            "Input": ["transpose1_output"],
+                        },
+                        "op_outputs": {"Out": ["slice2_output"]},
+                        "op_attrs": {
+                            "axes": [0],
+                            "starts": [1],
+                            "ends": [2],
+                            "decrease_axis": [0],
+                            "infer_flags": [1],
+                        },
                     },
-                    "op_attrs": {
-                        "shape": [-1, self.length, 3, 12, 64]
-                    }
-                }, {
-                    "op_type": "transpose2",
-                    "op_inputs": {
-                        "X": ["reshape1_output"]
+                    {
+                        "op_type": "slice",
+                        "op_inputs": {
+                            "Input": ["transpose1_output"],
+                        },
+                        "op_outputs": {"Out": ["slice3_output"]},
+                        "op_attrs": {
+                            "axes": [0],
+                            "starts": [2],
+                            "ends": [3],
+                            "decrease_axis": [0],
+                            "infer_flags": [1],
+                        },
                     },
-                    "op_outputs": {
-                        "Out": ["transpose1_output"],
-                        "XShape": ["transpose1_output_xshape"]
+                    {
+                        "op_type": "transpose2",
+                        "op_inputs": {"X": ["slice2_output"]},
+                        "op_outputs": {
+                            "Out": ["transpose2_output"],
+                        },
+                        "op_attrs": {
+                            "axis": [0, 1, 3, 2],
+                            "data_format": "AnyLayout",
+                        },
                     },
-                    "op_attrs": {
-                        "axis": [2, 0, 3, 1, 4],
-                        "data_format": "AnyLayout"
-                    }
-                }, {
-                    "op_type": "slice",
-                    "op_inputs": {
-                        "Input": ["transpose1_output"],
+                    {
+                        "op_type": "matmul_v2",
+                        "op_inputs": {
+                            "X": ["slice1_output"],
+                            "Y": ["transpose2_output"],
+                        },
+                        "op_outputs": {"Out": ["matmul2_output"]},
+                        "op_attrs": {"trans_x": False, "trans_y": False},
                     },
-                    "op_outputs": {
-                        "Out": ["slice1_output"]
+                    {
+                        "op_type": "scale",
+                        "op_inputs": {
+                            "X": ["matmul2_output"],
+                        },
+                        "op_outputs": {"Out": ["scale_output"]},
+                        "op_attrs": {
+                            "scale": 0.125,
+                            "bias": 0.0,
+                            "bias_after_scale": True,
+                        },
                     },
-                    "op_attrs": {
-                        "axes": [0],
-                        "starts": [0],
-                        "ends": [1],
-                        "decrease_axis": [0],
-                        "infer_flags": [1]
-                    }
-                }, {
-                    "op_type": "slice",
-                    "op_inputs": {
-                        "Input": ["transpose1_output"],
+                    {
+                        "op_type": "softmax",
+                        "op_inputs": {"X": ["scale_output"]},
+                        "op_outputs": {"Out": ["softmax_output"]},
+                        "op_attrs": {"axis": -1, "data_format": "AnyLayout"},
                     },
-                    "op_outputs": {
-                        "Out": ["slice2_output"]
+                    {
+                        "op_type": "matmul_v2",
+                        "op_inputs": {
+                            "X": ["softmax_output"],
+                            "Y": ["slice3_output"],
+                        },
+                        "op_outputs": {"Out": ["matmul3_output"]},
+                        "op_attrs": {"trans_x": False, "trans_y": False},
                     },
-                    "op_attrs": {
-                        "axes": [0],
-                        "starts": [1],
-                        "ends": [2],
-                        "decrease_axis": [0],
-                        "infer_flags": [1]
-                    }
-                }, {
-                    "op_type": "slice",
-                    "op_inputs": {
-                        "Input": ["transpose1_output"],
+                    {
+                        "op_type": "transpose2",
+                        "op_inputs": {"X": ["matmul3_output"]},
+                        "op_outputs": {
+                            "Out": ["transpose3_output"],
+                            "XShape": ["transpose3_output_xshape"],
+                        },
+                        "op_attrs": {
+                            "axis": [0, 2, 1, 3],
+                            "data_format": "AnyLayout",
+                        },
                     },
-                    "op_outputs": {
-                        "Out": ["slice3_output"]
+                    {
+                        "op_type": "reshape2",
+                        "op_inputs": {"X": ["transpose3_output"]},
+                        "op_outputs": {
+                            "Out": ["reshape2_output"],
+                            "XShape": ["reshape2_output_xshape"],
+                        },
+                        "op_attrs": {"shape": [-1, self.length, 768]},
                     },
-                    "op_attrs": {
-                        "axes": [0],
-                        "starts": [2],
-                        "ends": [3],
-                        "decrease_axis": [0],
-                        "infer_flags": [1]
-                    }
-                }, {
-                    "op_type": "transpose2",
-                    "op_inputs": {
-                        "X": ["slice2_output"]
-                    },
-                    "op_outputs": {
-                        "Out": ["transpose2_output"],
-                    },
-                    "op_attrs": {
-                        "axis": [0, 1, 3, 2],
-                        "data_format": "AnyLayout"
-                    }
-                }, {
-                    "op_type": "matmul_v2",
-                    "op_inputs": {
-                        "X": ["slice1_output"],
-                        "Y": ["transpose2_output"]
-                    },
-                    "op_outputs": {
-                        "Out": ["matmul2_output"]
-                    },
-                    "op_attrs": {
-                        "trans_x": False,
-                        "trans_y": False
-                    }
-                }, {
-                    "op_type": "scale",
-                    "op_inputs": {
-                        "X": ["matmul2_output"],
-                    },
-                    "op_outputs": {
-                        "Out": ["scale_output"]
-                    },
-                    "op_attrs": {
-                        "scale": 0.125,
-                        "bias": 0.0,
-                        "bias_after_scale": True
-                    }
-                }, {
-                    "op_type": "softmax",
-                    "op_inputs": {
-                        "X": ["scale_output"]
-                    },
-                    "op_outputs": {
-                        "Out": ["softmax_output"]
-                    },
-                    "op_attrs": {
-                        "axis": -1,
-                        "data_format": "AnyLayout"
-                    }
-                }, {
-                    "op_type": "matmul_v2",
-                    "op_inputs": {
-                        "X": ["softmax_output"],
-                        "Y": ["slice3_output"]
-                    },
-                    "op_outputs": {
-                        "Out": ["matmul3_output"]
-                    },
-                    "op_attrs": {
-                        "trans_x": False,
-                        "trans_y": False
-                    }
-                }, {
-                    "op_type": "transpose2",
-                    "op_inputs": {
-                        "X": ["matmul3_output"]
-                    },
-                    "op_outputs": {
-                        "Out": ["transpose3_output"],
-                        "XShape": ["transpose3_output_xshape"]
-                    },
-                    "op_attrs": {
-                        "axis": [0, 2, 1, 3],
-                        "data_format": "AnyLayout"
-                    }
-                }, {
-                    "op_type": "reshape2",
-                    "op_inputs": {
-                        "X": ["transpose3_output"]
-                    },
-                    "op_outputs": {
-                        "Out": ["reshape2_output"],
-                        "XShape": ["reshape2_output_xshape"]
-                    },
-                    "op_attrs": {
-                        "shape": [-1, self.length, 768]
-                    }
-                }]
+                ]
 
                 ops = self.generate_op_config(ops_config)
 
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={
-                        "matmul1_weight":
-                        TensorConfig(data_gen=partial(generate_weight1)),
-                        "elementwise_add1_weight":
-                        TensorConfig(data_gen=partial(generate_weight2))
+                        "matmul1_weight": TensorConfig(
+                            data_gen=partial(generate_weight1)
+                        ),
+                        "elementwise_add1_weight": TensorConfig(
+                            data_gen=partial(generate_weight2)
+                        ),
                     },
                     inputs={
-                        "input_data1":
-                        TensorConfig(
-                            data_gen=partial(generate_input1, batch, length))
+                        "input_data1": TensorConfig(
+                            data_gen=partial(generate_input1, batch, length)
+                        )
                     },
-                    outputs=["reshape2_output"])
+                    outputs=["reshape2_output"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             # The last dim of input1 and input2 should be static.
             self.dynamic_shape.min_input_shape = {
@@ -1111,11 +1025,15 @@ class TrtConvertVitToMultiHeadMatmulTest(TrtLayerAutoScanTest):
         generate_dynamic_shape(attrs)
         self.trt_param.workspace_size = 2013265920
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(), (1e-3,
-                                                                         1e-3)
+        yield self.create_inference_config(), generate_trt_nodes_num(), (
+            1e-3,
+            1e-3,
+        )
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
-        yield self.create_inference_config(), generate_trt_nodes_num(), (1e-5,
-                                                                         1e-5)
+        yield self.create_inference_config(), generate_trt_nodes_num(), (
+            1e-5,
+            1e-5,
+        )
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pad3d.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pad3d.py
@@ -22,30 +22,30 @@ import unittest
 
 
 class TrtConvertPad3d(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.ones([1, 1, 3, 64, 64]).astype(np.float32)
 
         for value in [True, False]:
-            for paddings in [[0, 0, 0, 0, 1, 1], [0, 0, 1, 2, 3, 4],
-                             [1, 1, 1, 1, 1, 1], [0, 0, -1, -1, 1, 1]]:
+            for paddings in [
+                [0, 0, 0, 0, 1, 1],
+                [0, 0, 1, 2, 3, 4],
+                [1, 1, 1, 1, 1, 1],
+                [0, 0, -1, -1, 1, 1],
+            ]:
                 dics = [{"value": value, "paddings": paddings}, {}]
 
-                ops_config = [{
-                    "op_type": "pad3d",
-                    "op_inputs": {
-                        "X": ["input_data"]
-                    },
-                    "op_outputs": {
-                        "Out": ["output_data"]
-                    },
-                    "op_attrs": dics[0]
-                }]
+                ops_config = [
+                    {
+                        "op_type": "pad3d",
+                        "op_inputs": {"X": ["input_data"]},
+                        "op_outputs": {"Out": ["output_data"]},
+                        "op_attrs": dics[0],
+                    }
+                ]
 
                 ops = self.generate_op_config(ops_config)
                 for i in range(10):
@@ -53,16 +53,18 @@ class TrtConvertPad3d(TrtLayerAutoScanTest):
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(data_gen=partial(generate_input1)),
+                            "input_data": TensorConfig(
+                                data_gen=partial(generate_input1)
+                            ),
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 1, 3, 64, 64]

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pad3d.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pad3d.py
@@ -88,14 +88,14 @@ class TrtConvertPad3d(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 3), 1e-5
+        yield self.create_inference_config(), (0, 3), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), 1e-5
+        yield self.create_inference_config(), (1, 2), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pool2d.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pool2d.py
@@ -20,6 +20,7 @@ from functools import partial
 from typing import Optional, List, Callable, Dict, Any, Set
 import unittest
 import itertools
+import copy
 
 
 class TrtConvertPool2dTest(TrtLayerAutoScanTest):
@@ -165,6 +166,39 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
             teller, SkipReasons.TRT_NOT_IMPLEMENTED,
             "The results of some cases are Nan, but the results of TensorRT and GPU are the same."
         )
+
+    def assert_tensors_near(
+        self,
+        atol: float,
+        rtol: float,
+        tensor: Dict[str, np.array],
+        baseline: Dict[str, np.array],
+    ):
+        for key, arr in tensor.items():
+            self.assertEqual(
+                baseline[key].shape,
+                arr.shape,
+                'The output shapes are not equal, the baseline shape is '
+                + str(baseline[key].shape)
+                + ', but got '
+                + str(arr.shape),
+            )
+
+            # The result of Pool2d may have some elements that is the least value (-65504 for FP16),
+            # but for FP32 and FP16 precision, their least value are different.
+            # We set a threshold that is the least value of FP16,
+            # and make the values less than the threshold to be the threshold.
+            def align_less_threshold(arr, threshold):
+                return np.clip(arr, threshold, None)
+
+            fp16_min = np.finfo(np.float16).min
+            baseline_threshold = align_less_threshold(
+                copy.deepcopy(baseline[key]), fp16_min
+            )
+            arr_threshold = align_less_threshold(copy.deepcopy(arr), fp16_min)
+            np.testing.assert_allclose(
+                baseline_threshold, arr_threshold, rtol=rtol, atol=atol
+            )
 
     def test(self):
         self.add_skip_trt_case()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pool2d.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_pool2d.py
@@ -24,7 +24,6 @@ import copy
 
 
 class TrtConvertPool2dTest(TrtLayerAutoScanTest):
-
     def is_paddings_valid(self, program_config: ProgramConfig) -> bool:
         exclusive = program_config.ops[0].attrs['exclusive']
         paddings = program_config.ops[0].attrs['paddings']
@@ -66,39 +65,54 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
         ceil_mode_options = [True, False]
 
         configurations = [
-            strides_options, paddings_options, pooling_type_options,
-            padding_algorithm_options, ksize_options, data_format_options,
-            global_pooling_options, exclusive_options, adaptive_option,
-            ceil_mode_options
+            strides_options,
+            paddings_options,
+            pooling_type_options,
+            padding_algorithm_options,
+            ksize_options,
+            data_format_options,
+            global_pooling_options,
+            exclusive_options,
+            adaptive_option,
+            ceil_mode_options,
         ]
 
-        for (strides, paddings, pooling_type, padding_algorithm, ksize,
-             data_format, global_pooling, exclusive, adaptive,
-             ceil_mode) in itertools.product(*configurations):
+        for (
+            strides,
+            paddings,
+            pooling_type,
+            padding_algorithm,
+            ksize,
+            data_format,
+            global_pooling,
+            exclusive,
+            adaptive,
+            ceil_mode,
+        ) in itertools.product(*configurations):
 
-            attrs = [{
-                "strides": strides,
-                "paddings": paddings,
-                "pooling_type": pooling_type,
-                "padding_algorithm": padding_algorithm,
-                "ksize": ksize,
-                "data_format": data_format,
-                "global_pooling": global_pooling,
-                "exclusive": exclusive,
-                "adaptive": adaptive,
-                "ceil_mode": ceil_mode,
-            }]
+            attrs = [
+                {
+                    "strides": strides,
+                    "paddings": paddings,
+                    "pooling_type": pooling_type,
+                    "padding_algorithm": padding_algorithm,
+                    "ksize": ksize,
+                    "data_format": data_format,
+                    "global_pooling": global_pooling,
+                    "exclusive": exclusive,
+                    "adaptive": adaptive,
+                    "ceil_mode": ceil_mode,
+                }
+            ]
 
-            ops_config = [{
-                "op_type": "pool2d",
-                "op_inputs": {
-                    "X": ["input_data"]
-                },
-                "op_outputs": {
-                    "Out": ["output_data"]
-                },
-                "op_attrs": attrs[0]
-            }]
+            ops_config = [
+                {
+                    "op_type": "pool2d",
+                    "op_inputs": {"X": ["input_data"]},
+                    "op_outputs": {"Out": ["output_data"]},
+                    "op_attrs": attrs[0],
+                }
+            ]
 
             ops = self.generate_op_config(ops_config)
 
@@ -106,16 +120,18 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
                 ops=ops,
                 weights={},
                 inputs={
-                    "input_data":
-                    TensorConfig(data_gen=partial(generate_input1, attrs))
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1, attrs)
+                    )
                 },
-                outputs=["output_data"])
+                outputs=["output_data"],
+            )
 
             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [1, 3, 64, 64]}
@@ -137,34 +153,40 @@ class TrtConvertPool2dTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
     def add_skip_trt_case(self):
-
         def teller(program_config, predictor_config):
-            if program_config.ops[0].attrs['pooling_type'] == 'avg' and \
-               program_config.ops[0].attrs['global_pooling'] == False and \
-               program_config.ops[0].attrs['exclusive'] == True and \
-               program_config.ops[0].attrs['adaptive'] == False and \
-               program_config.ops[0].attrs['ceil_mode'] == True:
+            if (
+                program_config.ops[0].attrs['pooling_type'] == 'avg'
+                and program_config.ops[0].attrs['global_pooling'] == False
+                and program_config.ops[0].attrs['exclusive'] == True
+                and program_config.ops[0].attrs['adaptive'] == False
+                and program_config.ops[0].attrs['ceil_mode'] == True
+            ):
                 return True
             return False
 
         self.add_skip_case(
-            teller, SkipReasons.TRT_NOT_IMPLEMENTED,
-            "The results of some cases are Nan, but the results of TensorRT and GPU are the same."
+            teller,
+            SkipReasons.TRT_NOT_IMPLEMENTED,
+            "The results of some cases are Nan, but the results of TensorRT and GPU are the same.",
         )
 
     def assert_tensors_near(

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reduce_sum.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reduce_sum.py
@@ -23,7 +23,6 @@ import unittest
 
 
 class TrtConvertReduceSumTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         attrs = [
@@ -41,7 +40,6 @@ class TrtConvertReduceSumTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(dtype, attrs: List[Dict[str, Any]]):
             if dtype == -1 or dtype == 5:
                 return np.random.random([1, 3, 32, 32]).astype(np.float32)
@@ -49,39 +47,52 @@ class TrtConvertReduceSumTest(TrtLayerAutoScanTest):
                 return np.random.random([1, 3, 32, 32]).astype(np.int32)
 
         for keep_dim in [True, False]:
-            for dim in [[], [1], [0], [0, 1], [1, 2, 3], [-2, 0, 3], [-3],
-                        [-4, 1], [3, 4, 5]]:
+            for dim in [
+                [],
+                [1],
+                [0],
+                [0, 1],
+                [1, 2, 3],
+                [-2, 0, 3],
+                [-3],
+                [-4, 1],
+                [3, 4, 5],
+            ]:
                 for reduce_all in [True, False]:
                     for out_dtype in [-1, 2, 5]:
-                        dics = [{
-                            "keep_dim": keep_dim,
-                            "dim": dim,
-                            "reduce_all": reduce_all,
-                            "out_dtype": out_dtype,
-                            "in_dtype": out_dtype,
-                        }, {}]
+                        dics = [
+                            {
+                                "keep_dim": keep_dim,
+                                "dim": dim,
+                                "reduce_all": reduce_all,
+                                "out_dtype": out_dtype,
+                                "in_dtype": out_dtype,
+                            },
+                            {},
+                        ]
 
-                        ops_config = [{
-                            "op_type": "reduce_sum",
-                            "op_inputs": {
-                                "X": ["input_data"]
-                            },
-                            "op_outputs": {
-                                "Out": ["reduce_output_data"]
-                            },
-                            "op_attrs": dics[0]
-                        }]
+                        ops_config = [
+                            {
+                                "op_type": "reduce_sum",
+                                "op_inputs": {"X": ["input_data"]},
+                                "op_outputs": {"Out": ["reduce_output_data"]},
+                                "op_attrs": dics[0],
+                            }
+                        ]
                         ops = self.generate_op_config(ops_config)
 
                         program_config = ProgramConfig(
                             ops=ops,
                             weights={},
                             inputs={
-                                "input_data":
-                                TensorConfig(data_gen=partial(
-                                    generate_input1, out_dtype, dics))
+                                "input_data": TensorConfig(
+                                    data_gen=partial(
+                                        generate_input1, out_dtype, dics
+                                    )
+                                )
                             },
-                            outputs=["reduce_output_data"])
+                            outputs=["reduce_output_data"],
+                        )
 
                         if not self.is_program_valid(program_config):
                             continue
@@ -89,7 +100,6 @@ class TrtConvertReduceSumTest(TrtLayerAutoScanTest):
                         yield program_config
 
     def sample_predictor_configs(self, program_config):
-
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}
@@ -120,19 +130,23 @@ class TrtConvertReduceSumTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-5, 1e-5)
+            attrs, False
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-3, 1e-3)
+            attrs, False
+        ), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-5, 1e-5)
+            attrs, True
+        ), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-3, 1e-3)
+            attrs, True
+        ), (1e-3, 1e-3)
 
         pass
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reduce_sum.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reduce_sum.py
@@ -123,7 +123,7 @@ class TrtConvertReduceSumTest(TrtLayerAutoScanTest):
             attrs, False), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), (1e-4, 1e-4)
+            attrs, False), (1e-3, 1e-3)
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -132,7 +132,7 @@ class TrtConvertReduceSumTest(TrtLayerAutoScanTest):
             attrs, True), (1e-5, 1e-5)
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), (1e-4, 1e-4)
+            attrs, True), (1e-3, 1e-3)
 
         pass
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reshape.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reshape.py
@@ -22,7 +22,6 @@ import unittest
 
 
 class TrtConvertReshapeTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
@@ -31,7 +30,7 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
             if len(attrs[0]['shape']) != 1:
                 return False
 
-        #To test if the shape contains 0
+        # To test if the shape contains 0
         if len(attrs[0]['shape']) == 3:
             if attrs[0]['shape'][1] == 0:
                 if self.dims != 3:
@@ -45,7 +44,6 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]]):
             if self.dims == 4:
                 self.input_shape = [1, 2, 4, 6]
@@ -70,9 +68,18 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
             return np.array([24]).astype(np.int32)
 
         for dims in [4, 3, 2, 1]:
-            for shape in [[1, 6, 8], [1, 2, 4, 6], [1, 1, 0, 12], [1, 0, 6],
-                          [1, -1, 12], [2, -1], [3, 16], [3, 4, 4], [48],
-                          [-1, 48]]:
+            for shape in [
+                [1, 6, 8],
+                [1, 2, 4, 6],
+                [1, 1, 0, 12],
+                [1, 0, 6],
+                [1, -1, 12],
+                [2, -1],
+                [3, 16],
+                [3, 4, 4],
+                [48],
+                [-1, 48],
+            ]:
                 dics = [
                     {
                         "shape": shape,
@@ -81,29 +88,31 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
                 self.dims = dims
                 dics_intput = [{"X": ["reshape_input"]}]
 
-                ops_config = [{
-                    "op_type": "reshape",
-                    "op_inputs": dics_intput[0],
-                    "op_outputs": {
-                        "Out": ["reshape_out"]
-                    },
-                    "op_attrs": dics[0]
-                }]
+                ops_config = [
+                    {
+                        "op_type": "reshape",
+                        "op_inputs": dics_intput[0],
+                        "op_outputs": {"Out": ["reshape_out"]},
+                        "op_attrs": dics[0],
+                    }
+                ]
                 ops = self.generate_op_config(ops_config)
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={},
                     inputs={
-                        "reshape_input":
-                        TensorConfig(data_gen=partial(generate_input1, dics))
+                        "reshape_input": TensorConfig(
+                            data_gen=partial(generate_input1, dics)
+                        )
                     },
-                    outputs=["reshape_out"])
+                    outputs=["reshape_out"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -141,13 +150,14 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
             # in static shape mode, here is consistent with op_teller.cc
-            if (not dynamic_shape):
-                if (attrs[0]['shape'][0] == 0):
+            if not dynamic_shape:
+                if attrs[0]['shape'][0] == 0:
                     return 1, 2
-                elif (len(attrs[0]['shape']) == 1):
+                elif len(attrs[0]['shape']) == 1:
                     return 0, 3
-                elif (np.prod(attrs[0]['shape'][1:]) == np.prod(
-                        self.input_shape[1:])):
+                elif np.prod(attrs[0]['shape'][1:]) == np.prod(
+                    self.input_shape[1:]
+                ):
                     return 1, 2
                 else:
                     return 0, 3
@@ -161,19 +171,23 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
         pass
@@ -185,12 +199,10 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
 
 # reshape having three inputs.
 class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]]):
             if self.dims == 4:
                 return np.random.random([1, 2, 4, 6]).astype(np.float32)
@@ -203,9 +215,12 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
 
         for dims in [4, 3, 2, 1]:
             for shape in [[-1, 48]]:
-                dics = [{
-                    "shape": shape,
-                }, {}]
+                dics = [
+                    {
+                        "shape": shape,
+                    },
+                    {},
+                ]
                 self.dims = dims
                 dics_intput = [
                     {
@@ -217,9 +232,7 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
                     {
                         "op_type": "fill_constant",
                         "op_inputs": {},
-                        "op_outputs": {
-                            "Out": ["shapeT1_data"]
-                        },
+                        "op_outputs": {"Out": ["shapeT1_data"]},
                         "op_attrs": {
                             "dtype": 2,
                             "str_value": "2",
@@ -229,9 +242,7 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
                     {
                         "op_type": "fill_constant",
                         "op_inputs": {},
-                        "op_outputs": {
-                            "Out": ["shapeT2_data"]
-                        },
+                        "op_outputs": {"Out": ["shapeT2_data"]},
                         "op_attrs": {
                             "dtype": 2,
                             "str_value": "24",
@@ -241,10 +252,8 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
                     {
                         "op_type": "reshape",
                         "op_inputs": dics_intput[0],
-                        "op_outputs": {
-                            "Out": ["reshape_out"]
-                        },
-                        "op_attrs": dics[0]
+                        "op_outputs": {"Out": ["reshape_out"]},
+                        "op_attrs": dics[0],
                     },
                 ]
                 ops = self.generate_op_config(ops_config)
@@ -252,16 +261,18 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
                     ops=ops,
                     weights={},
                     inputs={
-                        "reshape_input":
-                        TensorConfig(data_gen=partial(generate_input1, dics))
+                        "reshape_input": TensorConfig(
+                            data_gen=partial(generate_input1, dics)
+                        )
                     },
-                    outputs=["reshape_out"])
+                    outputs=["reshape_out"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -309,12 +320,10 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
 
 # reshape having 2 inputs.
 class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]]):
             if self.dims == 4:
                 return np.random.random([1, 2, 12, 6]).astype(np.float32)
@@ -327,9 +336,12 @@ class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
 
         for dims in [4, 3, 2, 1]:
             for shape in [[-1, 144]]:
-                dics = [{
-                    "shape": shape,
-                }, {}]
+                dics = [
+                    {
+                        "shape": shape,
+                    },
+                    {},
+                ]
                 self.dims = dims
                 dics_intput = [
                     {
@@ -341,9 +353,7 @@ class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
                     {
                         "op_type": "fill_constant",
                         "op_inputs": {},
-                        "op_outputs": {
-                            "Out": ["shape_data"]
-                        },
+                        "op_outputs": {"Out": ["shape_data"]},
                         "op_attrs": {
                             "dtype": 2,
                             "str_value": "12",
@@ -353,10 +363,8 @@ class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
                     {
                         "op_type": "reshape",
                         "op_inputs": dics_intput[0],
-                        "op_outputs": {
-                            "Out": ["reshape_out"]
-                        },
-                        "op_attrs": dics[0]
+                        "op_outputs": {"Out": ["reshape_out"]},
+                        "op_attrs": dics[0],
                     },
                 ]
                 ops = self.generate_op_config(ops_config)
@@ -364,16 +372,18 @@ class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
                     ops=ops,
                     weights={},
                     inputs={
-                        "reshape_input":
-                        TensorConfig(data_gen=partial(generate_input1, dics))
+                        "reshape_input": TensorConfig(
+                            data_gen=partial(generate_input1, dics)
+                        )
                     },
-                    outputs=["reshape_out"])
+                    outputs=["reshape_out"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reshape.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_reshape.py
@@ -164,7 +164,7 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -173,7 +173,7 @@ class TrtConvertReshapeTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass
@@ -297,7 +297,7 @@ class TrtConvertReshapeTest2(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), 1e-5
+        yield self.create_inference_config(), (1, 2), 1e-3
 
     def add_skip_trt_case(self):
         pass
@@ -409,7 +409,7 @@ class TrtConvertReshapeTest3(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), 1e-5
+        yield self.create_inference_config(), (1, 2), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roi_align.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roi_align.py
@@ -162,7 +162,7 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -171,7 +171,7 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roi_align.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roi_align.py
@@ -22,12 +22,10 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]], batch):
             return np.ones([batch, 256, 32, 32]).astype(np.float32)
 
@@ -47,92 +45,111 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
                                     self.num_input = num_input
                                     if num_input == 1:
                                         batch = 1
-                                    dics = [{
-                                        "spatial_scale": spatial_scale,
-                                        "pooled_height": pooled_height,
-                                        "pooled_width": pooled_width,
-                                        "sampling_ratio": sampling_ratio,
-                                        "aligned": aligned
-                                    }, {}]
-                                    dics_input = [{
-                                        "X": ["roi_align_input"],
-                                        "ROIs": ["ROIs"],
-                                        "RoisNum": ["RoisNum"]
-                                    }, {
-                                        "X": ["roi_align_input"],
-                                        "ROIs": ["ROIs"]
-                                    }]
-                                    program_input = [{
-                                        "roi_align_input":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input1, dics, batch)),
-                                        "ROIs":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input2, dics, batch)),
-                                        "RoisNum":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input3, dics, batch))
-                                    }, {
-                                        "roi_align_input":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input1, dics, batch)),
-                                        "ROIs":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input2, dics, batch),
-                                                     lod=[[32, 3]])
-                                    }]
-                                    ops_config = [{
-                                        "op_type":
-                                        "roi_align",
-                                        "op_inputs":
-                                        dics_input[num_input],
-                                        "op_outputs": {
-                                            "Out": ["roi_align_out"]
+                                    dics = [
+                                        {
+                                            "spatial_scale": spatial_scale,
+                                            "pooled_height": pooled_height,
+                                            "pooled_width": pooled_width,
+                                            "sampling_ratio": sampling_ratio,
+                                            "aligned": aligned,
                                         },
-                                        "op_attrs":
-                                        dics[0]
-                                    }]
+                                        {},
+                                    ]
+                                    dics_input = [
+                                        {
+                                            "X": ["roi_align_input"],
+                                            "ROIs": ["ROIs"],
+                                            "RoisNum": ["RoisNum"],
+                                        },
+                                        {
+                                            "X": ["roi_align_input"],
+                                            "ROIs": ["ROIs"],
+                                        },
+                                    ]
+                                    program_input = [
+                                        {
+                                            "roi_align_input": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_input1, dics, batch
+                                                )
+                                            ),
+                                            "ROIs": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_input2, dics, batch
+                                                )
+                                            ),
+                                            "RoisNum": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_input3, dics, batch
+                                                )
+                                            ),
+                                        },
+                                        {
+                                            "roi_align_input": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_input1, dics, batch
+                                                )
+                                            ),
+                                            "ROIs": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_input2, dics, batch
+                                                ),
+                                                lod=[[32, 3]],
+                                            ),
+                                        },
+                                    ]
+                                    ops_config = [
+                                        {
+                                            "op_type": "roi_align",
+                                            "op_inputs": dics_input[num_input],
+                                            "op_outputs": {
+                                                "Out": ["roi_align_out"]
+                                            },
+                                            "op_attrs": dics[0],
+                                        }
+                                    ]
                                     ops = self.generate_op_config(ops_config)
                                     program_config = ProgramConfig(
                                         ops=ops,
                                         weights={},
                                         inputs=program_input[num_input],
-                                        outputs=["roi_align_out"])
+                                        outputs=["roi_align_out"],
+                                    )
 
                                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.num_input == 0:
                 self.dynamic_shape.min_input_shape = {
                     "roi_align_input": [1, 256, 32, 32],
                     "ROIs": [3, 4],
-                    "RoisNum": [1]
+                    "RoisNum": [1],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "roi_align_input": [1, 256, 64, 64],
                     "ROIs": [3, 4],
-                    "RoisNum": [1]
+                    "RoisNum": [1],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "roi_align_input": [1, 256, 64, 64],
                     "ROIs": [3, 4],
-                    "RoisNum": [1]
+                    "RoisNum": [1],
                 }
             elif self.num_input == 1:
                 self.dynamic_shape.min_input_shape = {
                     "roi_align_input": [1, 256, 32, 32],
-                    "ROIs": [3, 4]
+                    "ROIs": [3, 4],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "roi_align_input": [1, 256, 64, 64],
-                    "ROIs": [3, 4]
+                    "ROIs": [3, 4],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "roi_align_input": [1, 256, 64, 64],
-                    "ROIs": [3, 4]
+                    "ROIs": [3, 4],
                 }
 
         def clear_dynamic_shape():
@@ -159,29 +176,33 @@ class TrtConvertRoiAlignTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(program_config.inputs) == 3:
                 return True
             return False
 
-        self.add_skip_case(teller1, SkipReasons.TRT_NOT_SUPPORT,
-                           "INPUT RoisNum NOT SUPPORT")
+        self.add_skip_case(
+            teller1, SkipReasons.TRT_NOT_SUPPORT, "INPUT RoisNum NOT SUPPORT"
+        )
 
     def test(self):
         self.add_skip_trt_case()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roll.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roll.py
@@ -106,7 +106,7 @@ class TrtConvertRollTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-4
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -115,7 +115,7 @@ class TrtConvertRollTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-4
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roll.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_roll.py
@@ -22,7 +22,6 @@ import unittest
 
 
 class TrtConvertRollTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -32,43 +31,44 @@ class TrtConvertRollTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]]):
             return np.ones([1, 56, 56, 192]).astype(np.float32)
 
         for axis in [[1, 2]]:
             for shifts in [[-1, -1], [-3, -3]]:
-                dics = [{
-                    "axis": axis,
-                    "shifts": shifts,
-                }]
+                dics = [
+                    {
+                        "axis": axis,
+                        "shifts": shifts,
+                    }
+                ]
 
-                ops_config = [{
-                    "op_type": "roll",
-                    "op_inputs": {
-                        "X": ["input_data"]
-                    },
-                    "op_outputs": {
-                        "Out": ["roll_output_data"]
-                    },
-                    "op_attrs": dics[0]
-                }]
+                ops_config = [
+                    {
+                        "op_type": "roll",
+                        "op_inputs": {"X": ["input_data"]},
+                        "op_outputs": {"Out": ["roll_output_data"]},
+                        "op_attrs": dics[0],
+                    }
+                ]
                 ops = self.generate_op_config(ops_config)
 
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={},
                     inputs={
-                        "input_data":
-                        TensorConfig(data_gen=partial(generate_input1, dics))
+                        "input_data": TensorConfig(
+                            data_gen=partial(generate_input1, dics)
+                        )
                     },
-                    outputs=["roll_output_data"])
+                    outputs=["roll_output_data"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 56, 56, 192]
@@ -103,19 +103,23 @@ class TrtConvertRollTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_scatter_nd_add.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_scatter_nd_add.py
@@ -100,14 +100,14 @@ class TrtConvertScatterNd(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 5), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 5), 1e-5
+        yield self.create_inference_config(), (0, 5), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 4), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 4), 1e-5
+        yield self.create_inference_config(), (1, 4), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_scatter_nd_add.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_scatter_nd_add.py
@@ -22,12 +22,10 @@ import unittest
 
 
 class TrtConvertScatterNd(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([6]).astype(np.float32)
 
@@ -37,38 +35,42 @@ class TrtConvertScatterNd(TrtLayerAutoScanTest):
         def generate_input3():
             return np.random.random([4]).astype(np.float32)
 
-        ops_config = [{
-            "op_type": "scatter_nd_add",
-            "op_inputs": {
-                "X": ["input_data"],
-                "Index": ["index_data"],
-                "Updates": ["update_data"]
-            },
-            "op_outputs": {
-                "Out": ["output_data"]
-            },
-            "op_attrs": {}
-        }]
+        ops_config = [
+            {
+                "op_type": "scatter_nd_add",
+                "op_inputs": {
+                    "X": ["input_data"],
+                    "Index": ["index_data"],
+                    "Updates": ["update_data"],
+                },
+                "op_outputs": {"Out": ["output_data"]},
+                "op_attrs": {},
+            }
+        ]
         ops = self.generate_op_config(ops_config)
         for i in range(10):
             program_config = ProgramConfig(
                 ops=ops,
                 weights={},
                 inputs={
-                    "input_data":
-                    TensorConfig(data_gen=partial(generate_input1)),
-                    "index_data":
-                    TensorConfig(data_gen=partial(generate_input2)),
-                    "update_data":
-                    TensorConfig(data_gen=partial(generate_input3)),
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1)
+                    ),
+                    "index_data": TensorConfig(
+                        data_gen=partial(generate_input2)
+                    ),
+                    "update_data": TensorConfig(
+                        data_gen=partial(generate_input3)
+                    ),
                 },
-                outputs=["output_data"])
+                outputs=["output_data"],
+            )
 
             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1],

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shape.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shape.py
@@ -22,12 +22,10 @@ import unittest
 
 
 class TrtConvertSumTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(batch):
             if self.dims == 4:
                 return np.ones([batch, 3, 24, 24]).astype(np.float32)
@@ -41,31 +39,31 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
         for dims in [1, 2, 3, 4]:
             for batch in [1, 4]:
                 self.dims = dims
-                ops_config = [{
-                    "op_type": "shape",
-                    "op_inputs": {
-                        "Input": ["input1"]
-                    },
-                    "op_outputs": {
-                        "Out": ["output"]
-                    },
-                    "op_attrs": {}
-                }]
+                ops_config = [
+                    {
+                        "op_type": "shape",
+                        "op_inputs": {"Input": ["input1"]},
+                        "op_outputs": {"Out": ["output"]},
+                        "op_attrs": {},
+                    }
+                ]
                 ops = self.generate_op_config(ops_config)
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={},
                     inputs={
-                        "input1":
-                        TensorConfig(data_gen=partial(generate_input1, batch))
+                        "input1": TensorConfig(
+                            data_gen=partial(generate_input1, batch)
+                        )
                     },
-                    outputs=["output"])
+                    outputs=["output"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {"input1": [1, 3, 24, 24]}
@@ -87,7 +85,7 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
                 }
 
         def generate_trt_nodes_num(dynamic_shape):
-            if (not dynamic_shape):
+            if not dynamic_shape:
                 return 0, 3
             return 1, 2
 
@@ -100,10 +98,12 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-3
+            False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shape.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shape.py
@@ -103,14 +103,14 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
             False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-5
+        yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -95,7 +95,7 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -104,7 +104,7 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_shuffle_channel.py
@@ -22,44 +22,41 @@ import unittest
 
 
 class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]], batch):
             return np.ones([batch, 6, 24, 24]).astype(np.float32)
 
         for batch in [1, 2, 4]:
             for group in [1, 2, 3]:
                 dics = [{"group": group}, {}]
-                ops_config = [{
-                    "op_type": "shuffle_channel",
-                    "op_inputs": {
-                        "X": ["shuffle_channel_input"]
-                    },
-                    "op_outputs": {
-                        "Out": ["shuffle_channel_out"]
-                    },
-                    "op_attrs": dics[0]
-                }]
+                ops_config = [
+                    {
+                        "op_type": "shuffle_channel",
+                        "op_inputs": {"X": ["shuffle_channel_input"]},
+                        "op_outputs": {"Out": ["shuffle_channel_out"]},
+                        "op_attrs": dics[0],
+                    }
+                ]
                 ops = self.generate_op_config(ops_config)
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={},
                     inputs={
-                        "shuffle_channel_input":
-                        TensorConfig(
-                            data_gen=partial(generate_input1, dics, batch))
+                        "shuffle_channel_input": TensorConfig(
+                            data_gen=partial(generate_input1, dics, batch)
+                        )
                     },
-                    outputs=["shuffle_channel_out"])
+                    outputs=["shuffle_channel_out"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "shuffle_channel_input": [1, 6, 24, 24]
@@ -78,8 +75,10 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
             ver = paddle_infer.get_trt_compile_version()
-            if ver[0] * 1000 + ver[1] * 100 + ver[
-                    2] * 10 < 8000 and dynamic_shape == True:
+            if (
+                ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 8000
+                and dynamic_shape == True
+            ):
                 return 0, 3
             else:
                 return 1, 2
@@ -92,19 +91,23 @@ class TrtConvertShuffleChannelTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_slice.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_slice.py
@@ -22,7 +22,6 @@ import unittest
 
 
 class TrtConvertSliceTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -34,13 +33,17 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
             start = 0
             end = 0
             if attrs[0]["starts"][x] < 0:
-                start = attrs[0]["starts"][x] + inputs['input_data'].shape[
-                    attrs[0]["axes"][x]]
+                start = (
+                    attrs[0]["starts"][x]
+                    + inputs['input_data'].shape[attrs[0]["axes"][x]]
+                )
             else:
                 start = attrs[0]["starts"][x]
             if attrs[0]["ends"][x] < 0:
-                end = attrs[0]["ends"][x] + inputs['input_data'].shape[
-                    attrs[0]["axes"][x]]
+                end = (
+                    attrs[0]["ends"][x]
+                    + inputs['input_data'].shape[attrs[0]["axes"][x]]
+                )
             else:
                 end = attrs[0]["ends"][x]
             start = max(0, start)
@@ -51,12 +54,11 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
         for x in attrs[0]["decrease_axis"]:
             if x < 0:
                 return False
-            if (out_shape[x] != 1):
+            if out_shape[x] != 1:
                 return False
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]]):
             return np.random.random([6, 6, 64, 64]).astype(np.float32)
 
@@ -65,41 +67,44 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
                 for ends in [[2, 2], [5, 5], [1, -1]]:
                     for decrease_axis in [[], [1], [2], [-1], [-100]]:
                         for infer_flags in [[-1]]:
-                            dics = [{
-                                "axes": axes,
-                                "starts": starts,
-                                "ends": ends,
-                                "decrease_axis": decrease_axis,
-                                "infer_flags": infer_flags
-                            }]
+                            dics = [
+                                {
+                                    "axes": axes,
+                                    "starts": starts,
+                                    "ends": ends,
+                                    "decrease_axis": decrease_axis,
+                                    "infer_flags": infer_flags,
+                                }
+                            ]
 
-                            ops_config = [{
-                                "op_type": "slice",
-                                "op_inputs": {
-                                    "Input": ["input_data"]
-                                },
-                                "op_outputs": {
-                                    "Out": ["slice_output_data"]
-                                },
-                                "op_attrs": dics[0]
-                            }]
+                            ops_config = [
+                                {
+                                    "op_type": "slice",
+                                    "op_inputs": {"Input": ["input_data"]},
+                                    "op_outputs": {
+                                        "Out": ["slice_output_data"]
+                                    },
+                                    "op_attrs": dics[0],
+                                }
+                            ]
                             ops = self.generate_op_config(ops_config)
 
                             program_config = ProgramConfig(
                                 ops=ops,
                                 weights={},
                                 inputs={
-                                    "input_data":
-                                    TensorConfig(
-                                        data_gen=partial(generate_input1, dics))
+                                    "input_data": TensorConfig(
+                                        data_gen=partial(generate_input1, dics)
+                                    )
                                 },
-                                outputs=["slice_output_data"])
+                                outputs=["slice_output_data"],
+                            )
 
                             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [8, 8, 64, 64]}
@@ -125,19 +130,23 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         # TODO(inference): fix.

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_slice.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_slice.py
@@ -128,7 +128,7 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-4
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -137,7 +137,7 @@ class TrtConvertSliceTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-4
+            attrs, True), 1e-3
 
     def test(self):
         # TODO(inference): fix.

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_split.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_split.py
@@ -219,7 +219,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -228,7 +228,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_split.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_split.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertSplitTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -35,13 +34,13 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         if len(inputs['split_input'].shape) <= attrs[0]['axis']:
             return False
 
-        #Sections and num cannot both be equal to 0.
+        # Sections and num cannot both be equal to 0.
         if len(attrs[0]['sections']) == 0:
             if attrs[0]['num'] == 0:
                 return False
 
-        #When sections and num are not both equal to 0, sections has higher priority.
-        #The sum of sections should be equal to the input size.
+        # When sections and num are not both equal to 0, sections has higher priority.
+        # The sum of sections should be equal to the input size.
         if len(attrs[0]['sections']) != 0:
             if attrs[0]['num'] != 0:
                 return False
@@ -53,16 +52,18 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             if sum != inputs['split_input'].shape[attrs[0]['axis']]:
                 return False
 
-        #The size of num should be equal to the input dimension.
+        # The size of num should be equal to the input dimension.
         if attrs[0]['num'] != 0:
             if len(outputs) != attrs[0]['num']:
                 return False
 
-        #Test AxisTensor and SectionsTensorList
+        # Test AxisTensor and SectionsTensorList
         if self.num_input == 0:
-            if self.dims == 2 and attrs[0]['sections'] == [
-                    10, 14
-            ] and len(outputs) == 2:
+            if (
+                self.dims == 2
+                and attrs[0]['sections'] == [10, 14]
+                and len(outputs) == 2
+            ):
                 return True
             else:
                 return False
@@ -70,7 +71,6 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 3, 24]).astype(np.float32)
@@ -93,72 +93,95 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         for num_input in [0, 1]:
             for dims in [1, 2, 3, 4]:
                 for batch in [3, 6, 9]:
-                    for Out in [["output_var0", "output_var1"],
-                                ["output_var0", "output_var1", "output_var2"]]:
-                        for sections in [[], [1, 2], [2, 1], [10, 14],
-                                         [1, 1, 1], [2, 2, 2], [3, 3, 3],
-                                         [3, 7, 14]]:
+                    for Out in [
+                        ["output_var0", "output_var1"],
+                        ["output_var0", "output_var1", "output_var2"],
+                    ]:
+                        for sections in [
+                            [],
+                            [1, 2],
+                            [2, 1],
+                            [10, 14],
+                            [1, 1, 1],
+                            [2, 2, 2],
+                            [3, 3, 3],
+                            [3, 7, 14],
+                        ]:
                             for num in [0, 3]:
                                 for axis in [0, 1, 2, 3]:
                                     self.batch = batch
                                     self.num_input = num_input
                                     self.dims = dims
-                                    dics = [{
-                                        "sections": sections,
-                                        "num": num,
-                                        "axis": axis
-                                    }, {}]
-
-                                    dics_intput = [{
-                                        "X": ["split_input"],
-                                        "AxisTensor": ["AxisTensor"],
-                                        "SectionsTensorList": [
-                                            "SectionsTensorList1",
-                                            "SectionsTensorList2"
-                                        ]
-                                    }, {
-                                        "X": ["split_input"]
-                                    }]
-                                    dics_intputs = [{
-                                        "AxisTensor":
-                                        TensorConfig(data_gen=partial(
-                                            generate_AxisTensor, dics)),
-                                        "SectionsTensorList1":
-                                        TensorConfig(data_gen=partial(
-                                            generate_SectionsTensorList1,
-                                            dics)),
-                                        "SectionsTensorList2":
-                                        TensorConfig(data_gen=partial(
-                                            generate_SectionsTensorList2, dics))
-                                    }, {}]
-
-                                    ops_config = [{
-                                        "op_type":
-                                        "split",
-                                        "op_inputs":
-                                        dics_intput[num_input],
-                                        "op_outputs": {
-                                            "Out": Out
+                                    dics = [
+                                        {
+                                            "sections": sections,
+                                            "num": num,
+                                            "axis": axis,
                                         },
-                                        "op_attrs":
-                                        dics[0]
-                                    }]
+                                        {},
+                                    ]
+
+                                    dics_intput = [
+                                        {
+                                            "X": ["split_input"],
+                                            "AxisTensor": ["AxisTensor"],
+                                            "SectionsTensorList": [
+                                                "SectionsTensorList1",
+                                                "SectionsTensorList2",
+                                            ],
+                                        },
+                                        {"X": ["split_input"]},
+                                    ]
+                                    dics_intputs = [
+                                        {
+                                            "AxisTensor": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_AxisTensor, dics
+                                                )
+                                            ),
+                                            "SectionsTensorList1": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_SectionsTensorList1,
+                                                    dics,
+                                                )
+                                            ),
+                                            "SectionsTensorList2": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_SectionsTensorList2,
+                                                    dics,
+                                                )
+                                            ),
+                                        },
+                                        {},
+                                    ]
+
+                                    ops_config = [
+                                        {
+                                            "op_type": "split",
+                                            "op_inputs": dics_intput[num_input],
+                                            "op_outputs": {"Out": Out},
+                                            "op_attrs": dics[0],
+                                        }
+                                    ]
                                     ops = self.generate_op_config(ops_config)
                                     program_config = ProgramConfig(
                                         ops=ops,
                                         weights=dics_intputs[num_input],
                                         inputs={
-                                            "split_input":
-                                            TensorConfig(data_gen=partial(
-                                                generate_input1, dics, batch))
+                                            "split_input": TensorConfig(
+                                                data_gen=partial(
+                                                    generate_input1, dics, batch
+                                                )
+                                            )
                                         },
-                                        outputs=Out)
+                                        outputs=Out,
+                                    )
 
                                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -216,30 +239,35 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
-
         def teller1(program_config, predictor_config):
             if len(program_config.weights) == 3:
                 return True
             return False
 
         self.add_skip_case(
-            teller1, SkipReasons.TRT_NOT_SUPPORT,
-            "INPUT AxisTensor AND SectionsTensorList NOT SUPPORT.")
+            teller1,
+            SkipReasons.TRT_NOT_SUPPORT,
+            "INPUT AxisTensor AND SectionsTensorList NOT SUPPORT.",
+        )
 
     def test(self):
         self.add_skip_trt_case()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_squeeze2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_squeeze2.py
@@ -115,7 +115,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -124,7 +124,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_squeeze2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_squeeze2.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertSplitTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         attrs = [
@@ -40,25 +39,25 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                     self.dims = dims
                     self.axes = axes
                     dics = [{"axes": axes}]
-                    ops_config = [{
-                        "op_type": "squeeze2",
-                        "op_inputs": {
-                            "X": ["in_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["out_data"],
-                            "XShape": ["XShape_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "squeeze2",
+                            "op_inputs": {"X": ["in_data"]},
+                            "op_outputs": {
+                                "Out": ["out_data"],
+                                "XShape": ["XShape_data"],
+                            },
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     # new_axes is the update of axes
                     new_axes = list(axes)
                     for i in range(len(new_axes)):
-                        if (new_axes[i] < 0):
+                        if new_axes[i] < 0:
                             new_axes[i] += dims
-                    if (max(new_axes) >= dims):
+                    if max(new_axes) >= dims:
                         continue
-                # generate input data
+                    # generate input data
                     self.input_shape = [1] * dims
                     for i in range(dims):
                         self.input_shape[i] = np.random.randint(1, 20)
@@ -68,24 +67,26 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                         for i in new_axes:
                             self.input_shape[i] = 1
                         return np.random.random(self.input_shape).astype(
-                            np.float32)
+                            np.float32
+                        )
 
                     ops = self.generate_op_config(ops_config)
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "in_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, dics, batch))
+                            "in_data": TensorConfig(
+                                data_gen=partial(generate_input1, dics, batch)
+                            )
                         },
-                        outputs=["out_data"])
+                        outputs=["out_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             max_shape = list(self.input_shape)
             min_shape = list(self.input_shape)
@@ -112,19 +113,23 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_stack.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_stack.py
@@ -22,7 +22,6 @@ import unittest
 
 
 class TrtConvertStackTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -31,14 +30,13 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
         attrs = [
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
-        #The input dimension should be less than the set axis.
+        # The input dimension should be less than the set axis.
         if len(inputs['stack_input1'].shape) < attrs[0]['axis']:
             return False
 
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]], batch):
             if self.dims == 4:
                 return np.random.random([batch, 3, 24, 24]).astype(np.float32)
@@ -74,103 +72,107 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
                 for axis in [-2, -1, 0, 1, 2, 3]:
                     self.dims = dims
                     dics = [{"axis": axis}, {}]
-                    ops_config = [{
-                        "op_type": "stack",
-                        "op_inputs": {
-                            "X":
-                            ["stack_input1", "stack_input2", "stack_input3"]
-                        },
-                        "op_outputs": {
-                            "Y": ["stack_output"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "stack",
+                            "op_inputs": {
+                                "X": [
+                                    "stack_input1",
+                                    "stack_input2",
+                                    "stack_input3",
+                                ]
+                            },
+                            "op_outputs": {"Y": ["stack_output"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "stack_input1":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, dics, batch)),
-                            "stack_input2":
-                            TensorConfig(
-                                data_gen=partial(generate_input2, dics, batch)),
-                            "stack_input3":
-                            TensorConfig(
-                                data_gen=partial(generate_input3, dics, batch))
+                            "stack_input1": TensorConfig(
+                                data_gen=partial(generate_input1, dics, batch)
+                            ),
+                            "stack_input2": TensorConfig(
+                                data_gen=partial(generate_input2, dics, batch)
+                            ),
+                            "stack_input3": TensorConfig(
+                                data_gen=partial(generate_input3, dics, batch)
+                            ),
                         },
-                        outputs=["stack_output"])
+                        outputs=["stack_output"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
                     "stack_input1": [1, 3, 24, 24],
                     "stack_input2": [1, 3, 24, 24],
-                    "stack_input3": [1, 3, 24, 24]
+                    "stack_input3": [1, 3, 24, 24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "stack_input1": [4, 3, 48, 48],
                     "stack_input2": [4, 3, 48, 48],
-                    "stack_input3": [4, 3, 48, 48]
+                    "stack_input3": [4, 3, 48, 48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "stack_input1": [1, 3, 24, 24],
                     "stack_input2": [1, 3, 24, 24],
-                    "stack_input3": [1, 3, 24, 24]
+                    "stack_input3": [1, 3, 24, 24],
                 }
             elif self.dims == 3:
                 self.dynamic_shape.min_input_shape = {
                     "stack_input1": [1, 3, 24],
                     "stack_input2": [1, 3, 24],
-                    "stack_input3": [1, 3, 24]
+                    "stack_input3": [1, 3, 24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "stack_input1": [4, 3, 48],
                     "stack_input2": [4, 3, 48],
-                    "stack_input3": [4, 3, 48]
+                    "stack_input3": [4, 3, 48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "stack_input1": [1, 3, 24],
                     "stack_input2": [1, 3, 24],
-                    "stack_input3": [1, 3, 24]
+                    "stack_input3": [1, 3, 24],
                 }
             elif self.dims == 2:
                 self.dynamic_shape.min_input_shape = {
                     "stack_input1": [1, 24],
                     "stack_input2": [1, 24],
-                    "stack_input3": [1, 24]
+                    "stack_input3": [1, 24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "stack_input1": [4, 48],
                     "stack_input2": [4, 48],
-                    "stack_input3": [4, 48]
+                    "stack_input3": [4, 48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "stack_input1": [1, 24],
                     "stack_input2": [1, 24],
-                    "stack_input3": [1, 24]
+                    "stack_input3": [1, 24],
                 }
             elif self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
                     "stack_input1": [24],
                     "stack_input2": [24],
-                    "stack_input3": [24]
+                    "stack_input3": [24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "stack_input1": [48],
                     "stack_input2": [48],
-                    "stack_input3": [48]
+                    "stack_input3": [48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "stack_input1": [24],
                     "stack_input2": [24],
-                    "stack_input3": [24]
+                    "stack_input3": [24],
                 }
 
         def clear_dynamic_shape():
@@ -191,19 +193,23 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_stack.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_stack.py
@@ -194,7 +194,7 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -203,7 +203,7 @@ class TrtConvertStackTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_sum.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_sum.py
@@ -173,14 +173,14 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
             False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-5
+        yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-3
 
     def test(self):
         self.run_test()
@@ -279,14 +279,14 @@ class TrtConvertSumTest1(TrtLayerAutoScanTest):
             False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-5
+        yield self.create_inference_config(), generate_trt_nodes_num(True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_sum.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_sum.py
@@ -22,12 +22,10 @@ import unittest
 
 
 class TrtConvertSumTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(batch):
             if self.dims == 4:
                 return np.ones([batch, 3, 24, 24]).astype(np.float32)
@@ -61,99 +59,101 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
         for dims in [1, 2, 3, 4]:
             for batch in [1, 4]:
                 self.dims = dims
-                ops_config = [{
-                    "op_type": "sum",
-                    "op_inputs": {
-                        "X": ["input1", "input2", "input3"]
-                    },
-                    "op_outputs": {
-                        "Out": ["output"]
-                    },
-                    "op_attrs": {}
-                }]
+                ops_config = [
+                    {
+                        "op_type": "sum",
+                        "op_inputs": {"X": ["input1", "input2", "input3"]},
+                        "op_outputs": {"Out": ["output"]},
+                        "op_attrs": {},
+                    }
+                ]
                 ops = self.generate_op_config(ops_config)
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={},
                     inputs={
-                        "input1":
-                        TensorConfig(data_gen=partial(generate_input1, batch)),
-                        "input2":
-                        TensorConfig(data_gen=partial(generate_input2, batch)),
-                        "input3":
-                        TensorConfig(data_gen=partial(generate_input3, batch))
+                        "input1": TensorConfig(
+                            data_gen=partial(generate_input1, batch)
+                        ),
+                        "input2": TensorConfig(
+                            data_gen=partial(generate_input2, batch)
+                        ),
+                        "input3": TensorConfig(
+                            data_gen=partial(generate_input3, batch)
+                        ),
                     },
-                    outputs=["output"])
+                    outputs=["output"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
                     "input1": [1, 3, 24, 24],
                     "input2": [1, 3, 24, 24],
-                    "input3": [1, 3, 24, 24]
+                    "input3": [1, 3, 24, 24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input1": [4, 3, 48, 48],
                     "input2": [4, 3, 48, 48],
-                    "input3": [4, 3, 48, 48]
+                    "input3": [4, 3, 48, 48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input1": [1, 3, 24, 24],
                     "input2": [1, 3, 24, 24],
-                    "input3": [1, 3, 24, 24]
+                    "input3": [1, 3, 24, 24],
                 }
             elif self.dims == 3:
                 self.dynamic_shape.min_input_shape = {
                     "input1": [1, 3, 24],
                     "input2": [1, 3, 24],
-                    "input3": [1, 3, 24]
+                    "input3": [1, 3, 24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input1": [4, 3, 48],
                     "input2": [4, 3, 48],
-                    "input3": [4, 3, 48]
+                    "input3": [4, 3, 48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input1": [1, 3, 24],
                     "input2": [1, 3, 24],
-                    "input3": [1, 3, 24]
+                    "input3": [1, 3, 24],
                 }
             elif self.dims == 2:
                 self.dynamic_shape.min_input_shape = {
                     "input1": [1, 24],
                     "input2": [1, 24],
-                    "input3": [1, 24]
+                    "input3": [1, 24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input1": [4, 48],
                     "input2": [4, 48],
-                    "input3": [4, 48]
+                    "input3": [4, 48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input1": [1, 24],
                     "input2": [1, 24],
-                    "input3": [1, 24]
+                    "input3": [1, 24],
                 }
             elif self.dims == 1:
                 self.dynamic_shape.min_input_shape = {
                     "input1": [24],
                     "input2": [24],
-                    "input3": [24]
+                    "input3": [24],
                 }
                 self.dynamic_shape.max_input_shape = {
                     "input1": [48],
                     "input2": [48],
-                    "input3": [48]
+                    "input3": [48],
                 }
                 self.dynamic_shape.opt_input_shape = {
                     "input1": [24],
                     "input2": [24],
-                    "input3": [24]
+                    "input3": [24],
                 }
 
         def clear_dynamic_shape():
@@ -162,7 +162,7 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(dynamic_shape):
-            if (self.dims == 1 and not dynamic_shape):
+            if self.dims == 1 and not dynamic_shape:
                 return 0, 5
             return 1, 4
 
@@ -170,10 +170,12 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-3
+            False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape()
@@ -188,12 +190,10 @@ class TrtConvertSumTest(TrtLayerAutoScanTest):
 
 # special case when sum having olny one input
 class TrtConvertSumTest1(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(batch):
             if self.dims == 4:
                 return np.ones([batch, 3, 24, 24]).astype(np.float32)
@@ -207,31 +207,31 @@ class TrtConvertSumTest1(TrtLayerAutoScanTest):
         for dims in [1, 2, 3, 4]:
             for batch in [1, 4]:
                 self.dims = dims
-                ops_config = [{
-                    "op_type": "sum",
-                    "op_inputs": {
-                        "X": ["input1"]
-                    },
-                    "op_outputs": {
-                        "Out": ["output"]
-                    },
-                    "op_attrs": {}
-                }]
+                ops_config = [
+                    {
+                        "op_type": "sum",
+                        "op_inputs": {"X": ["input1"]},
+                        "op_outputs": {"Out": ["output"]},
+                        "op_attrs": {},
+                    }
+                ]
                 ops = self.generate_op_config(ops_config)
                 program_config = ProgramConfig(
                     ops=ops,
                     weights={},
                     inputs={
-                        "input1":
-                        TensorConfig(data_gen=partial(generate_input1, batch)),
+                        "input1": TensorConfig(
+                            data_gen=partial(generate_input1, batch)
+                        ),
                     },
-                    outputs=["output"])
+                    outputs=["output"],
+                )
 
                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape():
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {"input1": [1, 3, 24, 24]}
@@ -268,7 +268,7 @@ class TrtConvertSumTest1(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(dynamic_shape):
-            if (self.dims == 1 and not dynamic_shape):
+            if self.dims == 1 and not dynamic_shape:
                 return 0, 3
             return 1, 2
 
@@ -276,10 +276,12 @@ class TrtConvertSumTest1(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-5
+            False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            False), 1e-3
+            False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_tile.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_tile.py
@@ -102,7 +102,7 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-4
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -111,7 +111,7 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-4
+            attrs, True), 1e-3
 
     @given(repeat_times=st.sampled_from([[100], [1, 2], [0, 3], [1, 2, 100]]))
     def test(self, *args, **kwargs):

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_tile.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_tile.py
@@ -26,7 +26,6 @@ import hypothesis.strategies as st
 
 
 class TrtConvertTileTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         attrs = [
@@ -39,38 +38,37 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self, *args, **kwargs):
-
         def generate_input1(attrs: List[Dict[str, Any]]):
             return np.ones([1, 2, 3, 4]).astype(np.float32)
 
         dics = [{"repeat_times": kwargs['repeat_times']}]
 
-        ops_config = [{
-            "op_type": "tile",
-            "op_inputs": {
-                "X": ["input_data"]
-            },
-            "op_outputs": {
-                "Out": ["tile_output_data"]
-            },
-            "op_attrs": dics[0]
-        }]
+        ops_config = [
+            {
+                "op_type": "tile",
+                "op_inputs": {"X": ["input_data"]},
+                "op_outputs": {"Out": ["tile_output_data"]},
+                "op_attrs": dics[0],
+            }
+        ]
         ops = self.generate_op_config(ops_config)
 
         program_config = ProgramConfig(
             ops=ops,
             weights={},
             inputs={
-                "input_data":
-                TensorConfig(data_gen=partial(generate_input1, dics))
+                "input_data": TensorConfig(
+                    data_gen=partial(generate_input1, dics)
+                )
             },
-            outputs=["tile_output_data"])
+            outputs=["tile_output_data"],
+        )
 
         yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
             self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}
@@ -99,19 +97,23 @@ class TrtConvertTileTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     @given(repeat_times=st.sampled_from([[100], [1, 2], [0, 3], [1, 2, 100]]))
     def test(self, *args, **kwargs):

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k.py
@@ -117,7 +117,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         ## for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -126,7 +126,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertActivationTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
@@ -44,34 +43,37 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
                 for k in [1, 3]:
                     self.dims = dims
                     dics = [{"k": k}]
-                    ops_config = [{
-                        "op_type": "top_k",
-                        "op_inputs": {
-                            "X": ["input_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"],
-                            "Indices": ["indices_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "top_k",
+                            "op_inputs": {"X": ["input_data"]},
+                            "op_outputs": {
+                                "Out": ["output_data"],
+                                "Indices": ["indices_data"],
+                            },
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(data_gen=partial(
-                                generate_input1, dims, batch, dics))
+                            "input_data": TensorConfig(
+                                data_gen=partial(
+                                    generate_input1, dims, batch, dics
+                                )
+                            )
                         },
-                        outputs=["output_data", "indices_data"])
+                        outputs=["output_data", "indices_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}
@@ -114,19 +116,23 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         ## for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k_v2.py
@@ -134,7 +134,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -143,7 +143,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k_v2.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertActivationTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         attrs = [
@@ -53,40 +52,48 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
                             for sort in [True, False]:
                                 self.dims = dims
                                 self.sort = sort
-                                dics = [{
-                                    "k": k,
-                                    "axis": axis,
-                                    "largest": largest,
-                                    "sorted": sort
-                                }]
-                                ops_config = [{
-                                    "op_type": "top_k_v2",
-                                    "op_inputs": {
-                                        "X": ["input_data"]
-                                    },
-                                    "op_outputs": {
-                                        "Out": ["output_data"],
-                                        "Indices": ["indices_data"]
-                                    },
-                                    "op_attrs": dics[0]
-                                }]
+                                dics = [
+                                    {
+                                        "k": k,
+                                        "axis": axis,
+                                        "largest": largest,
+                                        "sorted": sort,
+                                    }
+                                ]
+                                ops_config = [
+                                    {
+                                        "op_type": "top_k_v2",
+                                        "op_inputs": {"X": ["input_data"]},
+                                        "op_outputs": {
+                                            "Out": ["output_data"],
+                                            "Indices": ["indices_data"],
+                                        },
+                                        "op_attrs": dics[0],
+                                    }
+                                ]
                                 ops = self.generate_op_config(ops_config)
 
                                 program_config = ProgramConfig(
                                     ops=ops,
                                     weights={},
                                     inputs={
-                                        "input_data":
-                                        TensorConfig(data_gen=partial(
-                                            generate_input1, dims, batch, dics))
+                                        "input_data": TensorConfig(
+                                            data_gen=partial(
+                                                generate_input1,
+                                                dims,
+                                                batch,
+                                                dics,
+                                            )
+                                        )
                                     },
-                                    outputs=["output_data", "indices_data"])
+                                    outputs=["output_data", "indices_data"],
+                                )
 
                                 yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}
@@ -131,19 +138,23 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_transpose.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_transpose.py
@@ -137,7 +137,7 @@ class TrtConvertTransposeTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -146,7 +146,7 @@ class TrtConvertTransposeTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_transpose.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_transpose.py
@@ -22,7 +22,6 @@ import unittest
 
 
 class TrtConvertTransposeTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         inputs = program_config.inputs
         weights = program_config.weights
@@ -32,14 +31,13 @@ class TrtConvertTransposeTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        #The shape of input and axis should be equal.
+        # The shape of input and axis should be equal.
         if len(inputs['transpose_input'].shape) != len(attrs[0]['axis']):
             return False
 
         return True
 
     def sample_program_configs(self):
-
         def generate_input1(attrs: List[Dict[str, Any]], batch):
             if self.dims == 4:
                 return np.ones([batch, 3, 24, 24]).astype(np.float32)
@@ -50,37 +48,43 @@ class TrtConvertTransposeTest(TrtLayerAutoScanTest):
 
         for dims in [2, 3, 4]:
             for batch in [1, 2, 4]:
-                for axis in [[0, 1, 3, 2], [0, 3, 2, 1], [3, 2, 0, 1],
-                             [0, 1, 2, 3], [0, 1, 2], [2, 0, 1], [1, 0], [0,
-                                                                          1]]:
+                for axis in [
+                    [0, 1, 3, 2],
+                    [0, 3, 2, 1],
+                    [3, 2, 0, 1],
+                    [0, 1, 2, 3],
+                    [0, 1, 2],
+                    [2, 0, 1],
+                    [1, 0],
+                    [0, 1],
+                ]:
                     self.dims = dims
                     dics = [{"axis": axis}, {}]
-                    ops_config = [{
-                        "op_type": "transpose",
-                        "op_inputs": {
-                            "X": ["transpose_input"]
-                        },
-                        "op_outputs": {
-                            "Out": ["transpose_out"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "transpose",
+                            "op_inputs": {"X": ["transpose_input"]},
+                            "op_outputs": {"Out": ["transpose_out"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "transpose_input":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, dics, batch))
+                            "transpose_input": TensorConfig(
+                                data_gen=partial(generate_input1, dics, batch)
+                            )
                         },
-                        outputs=["transpose_out"])
+                        outputs=["transpose_out"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 4:
                 self.dynamic_shape.min_input_shape = {
@@ -134,19 +138,23 @@ class TrtConvertTransposeTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unary.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unary.py
@@ -121,7 +121,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -130,7 +130,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unary.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unary.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertActivationTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
@@ -42,40 +41,54 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         for dims in [1, 2, 3, 4]:
             for batch in [1, 4]:
                 for op_type in [
-                        "exp", "log", "sqrt", "abs", "sin", "cos", "tan",
-                        "sinh", "cosh", "asin", "acos", "atan", "asinh",
-                        "atanh", "ceil", "floor"
+                    "exp",
+                    "log",
+                    "sqrt",
+                    "abs",
+                    "sin",
+                    "cos",
+                    "tan",
+                    "sinh",
+                    "cosh",
+                    "asin",
+                    "acos",
+                    "atan",
+                    "asinh",
+                    "atanh",
+                    "ceil",
+                    "floor",
                 ]:
                     self.dims = dims
                     dics = [{}]
 
-                    ops_config = [{
-                        "op_type": op_type,
-                        "op_inputs": {
-                            "X": ["input_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["output_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": op_type,
+                            "op_inputs": {"X": ["input_data"]},
+                            "op_outputs": {"Out": ["output_data"]},
+                            "op_attrs": dics[0],
+                        }
+                    ]
                     ops = self.generate_op_config(ops_config)
 
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "input_data":
-                            TensorConfig(data_gen=partial(
-                                generate_input1, dims, batch, dics))
+                            "input_data": TensorConfig(
+                                data_gen=partial(
+                                    generate_input1, dims, batch, dics
+                                )
+                            )
                         },
-                        outputs=["output_data"])
+                        outputs=["output_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             if self.dims == 1:
                 self.dynamic_shape.min_input_shape = {"input_data": [1]}
@@ -118,19 +131,23 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unfold.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unfold.py
@@ -87,14 +87,14 @@ class TrtConvertUnfold(TrtLayerAutoScanTest):
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (0, 3), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (0, 3), 1e-5
+        yield self.create_inference_config(), (0, 3), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), (1, 2), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
-        yield self.create_inference_config(), (1, 2), 1e-5
+        yield self.create_inference_config(), (1, 2), 1e-3
 
     def test(self):
         self.run_test()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unfold.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unfold.py
@@ -22,46 +22,46 @@ import unittest
 
 
 class TrtConvertUnfold(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
     def sample_program_configs(self):
-
         def generate_input1():
             return np.random.random([1, 3, 24, 24]).astype(np.float32)
 
-        ops_config = [{
-            "op_type": "unfold",
-            "op_inputs": {
-                "X": ["input_data"],
-            },
-            "op_outputs": {
-                "Y": ["output_data"]
-            },
-            "op_attrs": {
-                "dilations": [1, 1],
-                "kernel_sizes": [4, 4],
-                "paddings": [0, 0, 0, 0],
-                "strides": [1, 1],
+        ops_config = [
+            {
+                "op_type": "unfold",
+                "op_inputs": {
+                    "X": ["input_data"],
+                },
+                "op_outputs": {"Y": ["output_data"]},
+                "op_attrs": {
+                    "dilations": [1, 1],
+                    "kernel_sizes": [4, 4],
+                    "paddings": [0, 0, 0, 0],
+                    "strides": [1, 1],
+                },
             }
-        }]
+        ]
         ops = self.generate_op_config(ops_config)
         for i in range(10):
             program_config = ProgramConfig(
                 ops=ops,
                 weights={},
                 inputs={
-                    "input_data":
-                    TensorConfig(data_gen=partial(generate_input1)),
+                    "input_data": TensorConfig(
+                        data_gen=partial(generate_input1)
+                    ),
                 },
-                outputs=["output_data"])
+                outputs=["output_data"],
+            )
 
             yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             self.dynamic_shape.min_input_shape = {
                 "input_data": [1, 3, 4, 4],

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unsqueeze2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unsqueeze2.py
@@ -101,7 +101,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             attrs, False), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
@@ -110,7 +110,7 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
             attrs, True), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unsqueeze2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unsqueeze2.py
@@ -22,7 +22,6 @@ from typing import Optional, List, Callable, Dict, Any, Set
 
 
 class TrtConvertSplitTest(TrtLayerAutoScanTest):
-
     def is_program_valid(self, program_config: ProgramConfig) -> bool:
         return True
 
@@ -34,17 +33,17 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                     self.dims = dims
                     self.axes = axes
                     dics = [{"axes": axes}]
-                    ops_config = [{
-                        "op_type": "unsqueeze2",
-                        "op_inputs": {
-                            "X": ["in_data"]
-                        },
-                        "op_outputs": {
-                            "Out": ["out_data"],
-                            "XShape": ["XShape_data"]
-                        },
-                        "op_attrs": dics[0]
-                    }]
+                    ops_config = [
+                        {
+                            "op_type": "unsqueeze2",
+                            "op_inputs": {"X": ["in_data"]},
+                            "op_outputs": {
+                                "Out": ["out_data"],
+                                "XShape": ["XShape_data"],
+                            },
+                            "op_attrs": dics[0],
+                        }
+                    ]
 
                     # generate input data
                     self.input_shape = [1] * dims
@@ -54,24 +53,26 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
                     def generate_input1(attrs: List[Dict[str, Any]], batch):
                         self.input_shape[0] = batch
                         return np.random.random(self.input_shape).astype(
-                            np.float32)
+                            np.float32
+                        )
 
                     ops = self.generate_op_config(ops_config)
                     program_config = ProgramConfig(
                         ops=ops,
                         weights={},
                         inputs={
-                            "in_data":
-                            TensorConfig(
-                                data_gen=partial(generate_input1, dics, batch))
+                            "in_data": TensorConfig(
+                                data_gen=partial(generate_input1, dics, batch)
+                            )
                         },
-                        outputs=["out_data"])
+                        outputs=["out_data"],
+                    )
 
                     yield program_config
 
     def sample_predictor_configs(
-            self, program_config) -> (paddle_infer.Config, List[int], float):
-
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
         def generate_dynamic_shape(attrs):
             max_shape = list(self.input_shape)
             min_shape = list(self.input_shape)
@@ -98,19 +99,23 @@ class TrtConvertSplitTest(TrtLayerAutoScanTest):
         clear_dynamic_shape()
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-5
+            attrs, False
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, False), 1e-3
+            attrs, False
+        ), 1e-3
 
         # for dynamic_shape
         generate_dynamic_shape(attrs)
         self.trt_param.precision = paddle_infer.PrecisionType.Float32
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-5
+            attrs, True
+        ), 1e-5
         self.trt_param.precision = paddle_infer.PrecisionType.Half
         yield self.create_inference_config(), generate_trt_nodes_num(
-            attrs, True), 1e-3
+            attrs, True
+        ), 1e-3
 
     def add_skip_trt_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_squeeze2_matmul_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_squeeze2_matmul_fuse_pass.py
@@ -47,7 +47,8 @@ class TestSqueeze2MatmulFusePass(PassAutoScanTest):
             min_subgraph_size=0,
             precision_mode=paddle_infer.PrecisionType.Float32,
             use_static=False,
-            use_calib_mode=False)
+            use_calib_mode=False,
+        )
         yield config, ['mul', 'elementwise_add'], (1e-4, 1e-1)
 
     def add_ignore_pass_case(self):
@@ -70,9 +71,10 @@ class TestSqueeze2MatmulFusePass(PassAutoScanTest):
     def sample_program_config(self, draw):
         # 1. Generate shape of input:X of squeeze2
         x_shape = draw(
-            st.lists(st.integers(min_value=1, max_value=8),
-                     min_size=2,
-                     max_size=2))
+            st.lists(
+                st.integers(min_value=1, max_value=8), min_size=2, max_size=2
+            )
+        )
         # axes of squeeze2 == [2, 3]
         x_shape += [1, 1]
         axes = [2, 3]
@@ -84,9 +86,10 @@ class TestSqueeze2MatmulFusePass(PassAutoScanTest):
 
         # 3. Generate legal shape of input:Y of matmul
         y_shape = draw(
-            st.lists(st.integers(min_value=1, max_value=8),
-                     min_size=2,
-                     max_size=2))
+            st.lists(
+                st.integers(min_value=1, max_value=8), min_size=2, max_size=2
+            )
+        )
         y_shape[0] = x_shape[1]
 
         # 4. Generate legal attr:axis of elementwise_add
@@ -108,17 +111,11 @@ class TestSqueeze2MatmulFusePass(PassAutoScanTest):
                 "X": ["squeeze2_x"],
             },
             axes=axes,
-            outputs={
-                "Out": ["squeeze2_out"],
-                "XShape": ["xshape"]
-            },
+            outputs={"Out": ["squeeze2_out"], "XShape": ["xshape"]},
         )
         matmul_op = OpConfig(
             "matmul",
-            inputs={
-                "X": ["squeeze2_out"],
-                "Y": ["matmul_y"]
-            },
+            inputs={"X": ["squeeze2_out"], "Y": ["matmul_y"]},
             outputs={"Out": ["matmul_out"]},
             alpha=alpha,
             transpose_X=transpose_X,
@@ -133,10 +130,7 @@ class TestSqueeze2MatmulFusePass(PassAutoScanTest):
 
         add_op = OpConfig(
             "elementwise_add",
-            inputs={
-                "X": ["matmul_out"],
-                "Y": ["bias"]
-            },
+            inputs={"X": ["matmul_out"], "Y": ["bias"]},
             outputs={"Out": ["add_out"]},
             axis=axis,
         )
@@ -157,9 +151,11 @@ class TestSqueeze2MatmulFusePass(PassAutoScanTest):
         return program_config
 
     def test(self):
-        self.run_and_statis(quant=False,
-                            max_examples=25,
-                            passes=["trt_squeeze2_matmul_fuse_pass"])
+        self.run_and_statis(
+            quant=False,
+            max_examples=25,
+            passes=["trt_squeeze2_matmul_fuse_pass"],
+        )
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_squeeze2_matmul_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_squeeze2_matmul_fuse_pass.py
@@ -158,7 +158,7 @@ class TestSqueeze2MatmulFusePass(PassAutoScanTest):
 
     def test(self):
         self.run_and_statis(quant=False,
-                            max_examples=50,
+                            max_examples=25,
                             passes=["trt_squeeze2_matmul_fuse_pass"])
 
 

--- a/python/paddle/fluid/tests/unittests/ir/test_fuse_resnet_unit.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_fuse_resnet_unit.py
@@ -24,13 +24,15 @@ paddle.enable_static()
 np.random.seed(0)
 
 
-@unittest.skipIf(not paddle.is_compiled_with_cuda()
-                 or paddle.get_cudnn_version() < 8000
-                 or paddle.device.cuda.get_device_capability()[0] < 7,
-                 "only support with cuda and cudnn version is at least 8.0 "
-                 "and device's compute capability is at least 7.0")
+@unittest.skipIf(
+    not paddle.is_compiled_with_cuda()
+    or paddle.get_cudnn_version() < 8000
+    or paddle.device.cuda.get_device_capability()[0] < 7
+    or paddle.device.cuda.get_device_capability()[0] >= 9,
+    "only support with cuda and cudnn version is at least 8.0 "
+    "and device's compute capability is at least 7.0 and less than 9.0",
+)
 class TestFuseResNetUnit(unittest.TestCase):
-
     def test_fuse_resenet_unit(self):
         place = paddle.CUDAPlace(0)
         program = paddle.static.Program()
@@ -38,14 +40,12 @@ class TestFuseResNetUnit(unittest.TestCase):
         with paddle.static.amp.fp16_guard():
             with paddle.static.program_guard(program, startup_program):
                 x = paddle.static.data("x", [1, 64, 64, 8])
-                conv2d = paddle.nn.Conv2D(8,
-                                          32,
-                                          1,
-                                          bias_attr=False,
-                                          data_format='NHWC')
-                batch_norm = paddle.nn.BatchNorm(32,
-                                                 act='relu',
-                                                 data_layout='NHWC')
+                conv2d = paddle.nn.Conv2D(
+                    8, 32, 1, bias_attr=False, data_format='NHWC'
+                )
+                batch_norm = paddle.nn.BatchNorm(
+                    32, act='relu', data_layout='NHWC'
+                )
                 out = batch_norm(conv2d(x))
         graph = core.Graph(program.desc)
         core.get_pass("fuse_resnet_unit").apply(graph)
@@ -54,15 +54,15 @@ class TestFuseResNetUnit(unittest.TestCase):
         after_params = paddle.static.amp.cast_model_to_fp16(after_program)
         exe = paddle.static.Executor(place)
         exe.run(startup_program)
-        paddle.static.amp.cast_parameters_to_fp16(place,
-                                                  program,
-                                                  to_fp16_var_names=params)
         paddle.static.amp.cast_parameters_to_fp16(
-            place, after_program, to_fp16_var_names=after_params)
+            place, program, to_fp16_var_names=params
+        )
+        paddle.static.amp.cast_parameters_to_fp16(
+            place, after_program, to_fp16_var_names=after_params
+        )
         feed = {"x": np.random.randn(1, 64, 64, 8).astype("float16")}
         before_out = exe.run(program, feed=feed, fetch_list=[out.name])
         after_out = exe.run(after_program, feed=feed, fetch_list=[out.name])
-        np.testing.assert_allclose(before_out[0],
-                                   after_out[0],
-                                   rtol=1e-05,
-                                   atol=0.005)
+        np.testing.assert_allclose(
+            before_out[0], after_out[0], rtol=1e-05, atol=0.005
+        )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Cherrypick 8 NV contributed fixes to `release/2.4`

- #47098
- #47100
- #47101
- #47106
- #46531
- #47053 
- #47285
- #47488

### Notes
- 修复 `FusedDropoutActBiasGrad` 在 H100 上不支援的错误 ([#47285](https://github.com/PaddlePaddle/Paddle/pull/47285))
- 新增 `debug_graphviz_path` 选项至 `build_strategy` ([#46531](https://github.com/PaddlePaddle/Paddle/pull/46531))
- 修复未关闭的 `popen` 物件 ([#47053](https://github.com/PaddlePaddle/Paddle/pull/47053))

- Fix the unsupported error for `FusedDropoutActBiasGrad` on H100 ([#47285](https://github.com/PaddlePaddle/Paddle/pull/47285))
- Add `debug_graphviz_path` option into `build_strategy` ([#46531](https://github.com/PaddlePaddle/Paddle/pull/46531))
- Fix the not closed `popen` object ([#47053](https://github.com/PaddlePaddle/Paddle/pull/47053))