### PR TITLE
Fix adam/adamw thread num to update Beta1Pow/Beta2Pow

### DIFF
--- a/paddle/phi/kernels/gpu/adam_kernel.cu
+++ b/paddle/phi/kernels/gpu/adam_kernel.cu
@@ -253,7 +253,7 @@ void AdamDenseKernel(const Context& dev_ctx,
         param.numel());
     if (!use_global_beta_pow) {
       // Update with gpu
-      UpdateBetaPow<MPDType><<<1, 32, 0, dev_ctx.stream()>>>(
+      UpdateBetaPow<MPDType><<<1, 1, 0, dev_ctx.stream()>>>(
           beta1_,
           beta2_,
           beta1_pow.data<MPDType>(),
@@ -352,7 +352,7 @@ void MergedAdamKernel(
           param[idx]->numel());
       if (!use_global_beta_pow) {
         // Update with gpu
-        UpdateBetaPow<MPDType><<<1, 32, 0, dev_ctx.stream()>>>(
+        UpdateBetaPow<MPDType><<<1, 1, 0, dev_ctx.stream()>>>(
             beta1_,
             beta2_,
             beta1_pow[idx]->data<MPDType>(),

--- a/paddle/phi/kernels/gpu/adamw_kernel.cu
+++ b/paddle/phi/kernels/gpu/adamw_kernel.cu
@@ -282,7 +282,7 @@ void AdamwDenseKernel(const Context& dev_ctx,
         param.numel());
     if (!use_global_beta_pow) {
       // Update with gpu
-      UpdateAdamWBetaPow<MPDType><<<1, 32, 0, dev_ctx.stream()>>>(
+      UpdateAdamWBetaPow<MPDType><<<1, 1, 0, dev_ctx.stream()>>>(
           beta1_,
           beta2_,
           beta1_pow.data<MPDType>(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix the CUDA kernel thread num from 32 to 1 when updating `Beta1Pow` and `Beta2Pow` in the Adam/AdamW optimizer.