### PR TITLE
add 0d tensor support for searchsorted for gpu and cpu

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -594,6 +594,7 @@ class TestSundryAPI(unittest.TestCase):
         out = paddle.searchsorted(x, y)
 
         self.assertEqual(out.shape, [])
+        self.assertEqual(out.numpy(), 0)
 
 
 class TestSundryAPIStatic(unittest.TestCase):
@@ -667,13 +668,14 @@ class TestSundryAPIStatic(unittest.TestCase):
 
     @prog_scope()
     def test_searchsorted(self):
-        x = paddle.full([5], 1.0, 'float32')
+        x = paddle.full([10], 1.0, 'float32')
         y = paddle.full([], 1.0, 'float32')
         out = paddle.searchsorted(x, y)
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, fetch_list=[out])
         self.assertEqual(res[0].shape, ())
+        self.assertEqual(res[0], 0)
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -586,6 +586,15 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out.shape, [])
 
+    def test_searchsorted(self):
+        x = paddle.to_tensor([1, 3, 5, 7, 9])
+        y = paddle.rand([])
+
+        # only has forward kernel
+        out = paddle.searchsorted(x, y)
+
+        self.assertEqual(out.shape, [])
+
 
 class TestSundryAPIStatic(unittest.TestCase):
     def setUp(self):
@@ -651,6 +660,16 @@ class TestSundryAPIStatic(unittest.TestCase):
         x = paddle.randint(0, 1, [])
         out = paddle.logical_not(x)
         paddle.static.append_backward(out)
+
+        prog = paddle.static.default_main_program()
+        res = self.exe.run(prog, fetch_list=[out])
+        self.assertEqual(res[0].shape, ())
+
+    @prog_scope()
+    def test_searchsorted(self):
+        x = paddle.full([5], 1.0, 'float32')
+        y = paddle.full([], 1.0, 'float32')
+        out = paddle.searchsorted(x, y)
 
         prog = paddle.static.default_main_program()
         res = self.exe.run(prog, fetch_list=[out])

--- a/python/paddle/fluid/tests/unittests/xpu/test_zero_dim_tensor_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_zero_dim_tensor_xpu.py
@@ -422,6 +422,7 @@ class TestSundryAPI(unittest.TestCase):
         out = paddle.searchsorted(x, y)
 
         self.assertEqual(out.shape, [])
+        self.assertEqual(out.numpy(), 0)
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.

--- a/python/paddle/fluid/tests/unittests/xpu/test_zero_dim_tensor_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_zero_dim_tensor_xpu.py
@@ -414,6 +414,15 @@ class TestSundryAPI(unittest.TestCase):
 
         self.assertEqual(out.shape, [])
 
+    def test_searchsorted(self):
+        x = paddle.to_tensor([1, 3, 5, 7, 9])
+        y = paddle.rand([])
+
+        # only has forward kernel
+        out = paddle.searchsorted(x, y)
+
+        self.assertEqual(out.shape, [])
+
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.
 class TestNoBackwardAPI(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
0d tensor support for searchsorted

xpu and mlu: https://github.com/PaddlePaddle/PaddleCustomDevice/pull/233