### PR TITLE
fix xpu compile on phi::enforce.

### DIFF
--- a/paddle/fluid/platform/device/xpu/tests/enforce_xpu_test.cc
+++ b/paddle/fluid/platform/device/xpu/tests/enforce_xpu_test.cc
@@ -27,7 +27,7 @@ bool CheckXPUStatusFailure(T value, const std::string& msg) {
   try {
     PADDLE_ENFORCE_XPU_SUCCESS(value);
     return false;
-  } catch (paddle::platform::EnforceNotMet& error) {
+  } catch (phi::enforce::EnforceNotMet& error) {
     std::string ex_msg = error.what();
     std::cout << ex_msg << std::endl;
     return ex_msg.find(msg) != std::string::npos;
@@ -45,7 +45,7 @@ bool CheckXDNNStatusFailure(T value, const std::string& msg) {
   try {
     PADDLE_ENFORCE_XDNN_SUCCESS(value, "XDNN Error ");
     return false;
-  } catch (paddle::platform::EnforceNotMet& error) {
+  } catch (phi::enforce::EnforceNotMet& error) {
     std::string ex_msg = error.what();
     std::cout << ex_msg << std::endl;
     return ex_msg.find(msg) != std::string::npos;


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
前面的PR https://github.com/PaddlePaddle/Paddle/pull/48049 会导致XPU下编译不过。本PR修复了此问题。
