### PR TITLE
Reenabled reshape, squeeze and flatten oneDNN kernels

### DIFF
--- a/paddle/fluid/operators/flatten_op.cc
+++ b/paddle/fluid/operators/flatten_op.cc
@@ -87,6 +87,15 @@ class FlattenOp : public framework::OperatorWithKernel {
       const framework::ExecutionContext &ctx) const override {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
+
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
+
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -159,6 +168,15 @@ class FlattenGradOp : public framework::OperatorWithKernel {
       const framework::ExecutionContext &ctx) const override {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
+
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
+
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -223,6 +241,15 @@ class Flatten2Op : public framework::OperatorWithKernel {
       const framework::ExecutionContext &ctx) const override {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
+
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
+
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -275,6 +302,15 @@ class Flatten2GradOp : public framework::OperatorWithKernel {
       const framework::ExecutionContext &ctx) const override {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
+
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
+
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };

--- a/paddle/fluid/operators/flatten_op.cc
+++ b/paddle/fluid/operators/flatten_op.cc
@@ -88,13 +88,14 @@ class FlattenOp : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
 
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
@@ -169,13 +170,14 @@ class FlattenGradOp : public framework::OperatorWithKernel {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
 
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
@@ -242,13 +244,14 @@ class Flatten2Op : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
 
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
@@ -303,13 +306,14 @@ class Flatten2GradOp : public framework::OperatorWithKernel {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
 
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }

--- a/paddle/fluid/operators/mkldnn/reshape_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/reshape_mkldnn_op.cc
@@ -323,7 +323,9 @@ class ReshapeGradMKLDNNKernel : public ReshapeMKLDNNKernel<T, op_name> {
     auto reorder_src_memory_p = reorder_handler.AcquireSrcMemory(
         dout->mem_desc(), phi::funcs::to_void_cast(dout->data<T>()));
     auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
-        dx, phi::funcs::GetPlainOneDNNFormat(dout_vec_dims.size()), ctx.GetPlace());
+        dx,
+        phi::funcs::GetPlainOneDNNFormat(dout_vec_dims.size()),
+        ctx.GetPlace());
     auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
                                                     reorder_src_memory_p);
 

--- a/paddle/fluid/operators/mkldnn/reshape_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/reshape_mkldnn_op.cc
@@ -80,7 +80,7 @@ class ReshapeMKLDNNKernel : public framework::OpKernel<T> {
     out->Resize(x_dims);  // to match x numel, format is changed later
     // reorder is done into a plain tag to allow usage with blocked formats
     auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
-        out, getPlainFormatTag(x), ctx.GetPlace());
+        out, phi::funcs::GetPlainOneDNNFormat(x_dims.size()), ctx.GetPlace());
     auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
                                                     reorder_src_memory_p);
 
@@ -194,31 +194,6 @@ class ReshapeMKLDNNKernel : public framework::OpKernel<T> {
   }
 
  protected:
-  static dnnl::memory::format_tag getPlainFormatTag(
-      const phi::DenseTensor* tensor) {
-    auto tensor_dims_size = tensor->dims().size();
-    PADDLE_ENFORCE_EQ(
-        tensor_dims_size <= 6 && tensor_dims_size >= 1,
-        true,
-        platform::errors::InvalidArgument(
-            "Dims for squeeze_grad oneDNN op must be in range <1, 6>"));
-
-    switch (tensor_dims_size) {
-      case 1:
-        return dnnl::memory::format_tag::a;
-      case 2:
-        return dnnl::memory::format_tag::ab;
-      case 3:
-        return dnnl::memory::format_tag::abc;
-      case 4:
-        return dnnl::memory::format_tag::abcd;
-      case 5:
-        return dnnl::memory::format_tag::abcde;
-      default:
-        return dnnl::memory::format_tag::abcdef;
-    }
-  }
-
   static framework::DDim ValidateShape(const std::vector<int>& shape,
                                        const framework::DDim& in_dims) {
     const int64_t in_size = phi::product(in_dims);
@@ -348,7 +323,7 @@ class ReshapeGradMKLDNNKernel : public ReshapeMKLDNNKernel<T, op_name> {
     auto reorder_src_memory_p = reorder_handler.AcquireSrcMemory(
         dout->mem_desc(), phi::funcs::to_void_cast(dout->data<T>()));
     auto reorder_dst_memory_p = reorder_handler.AcquireDstMemory(
-        dx, this->getPlainFormatTag(dout), ctx.GetPlace());
+        dx, phi::funcs::GetPlainOneDNNFormat(dout_vec_dims.size()), ctx.GetPlace());
     auto reorder_p = reorder_handler.AcquireReorder(reorder_dst_memory_p,
                                                     reorder_src_memory_p);
 

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -258,13 +258,14 @@ class ReshapeOp : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
 
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
@@ -626,13 +627,14 @@ class Reshape2GradOp : public framework::OperatorWithKernel {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
 
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -258,6 +258,14 @@ class ReshapeOp : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
+
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 
@@ -617,6 +625,14 @@ class Reshape2GradOp : public framework::OperatorWithKernel {
       const framework::ExecutionContext &ctx) const override {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
+
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
 
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }

--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -125,13 +125,14 @@ class SqueezeOp : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -152,13 +153,14 @@ class SqueezeGradOp : public framework::OperatorWithKernel {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -219,13 +221,14 @@ class Squeeze2Op : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -267,13 +270,14 @@ class Squeeze2GradOp : public framework::OperatorWithKernel {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
 
-    #ifdef PADDLE_WITH_MKLDNN
-       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-                                        phi::DataLayout::ONEDNN,
-                                        framework::LibraryType::kMKLDNN);
-       }
-    #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+      return framework::OpKernelType(input_data_type,
+                                     ctx.GetPlace(),
+                                     phi::DataLayout::ONEDNN,
+                                     framework::LibraryType::kMKLDNN);
+    }
+#endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };

--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -125,13 +125,13 @@ class SqueezeOp : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
-    // #ifdef PADDLE_WITH_MKLDNN
-    //    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-    //      return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-    //                                     phi::DataLayout::ONEDNN,
-    //                                     framework::LibraryType::kMKLDNN);
-    //    }
-    // #endif
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -152,13 +152,13 @@ class SqueezeGradOp : public framework::OperatorWithKernel {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
 
-    // #ifdef PADDLE_WITH_MKLDNN
-    //    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-    //      return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-    //                                     phi::DataLayout::ONEDNN,
-    //                                     framework::LibraryType::kMKLDNN);
-    //    }
-    // #endif
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -219,13 +219,13 @@ class Squeeze2Op : public framework::OperatorWithKernel {
     auto input_data_type =
         framework::OperatorWithKernel::IndicateVarDataType(ctx, "X");
 
-    // #ifdef PADDLE_WITH_MKLDNN
-    //    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-    //      return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-    //                                     phi::DataLayout::ONEDNN,
-    //                                     framework::LibraryType::kMKLDNN);
-    //    }
-    // #endif
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
@@ -267,13 +267,13 @@ class Squeeze2GradOp : public framework::OperatorWithKernel {
     auto input_data_type = framework::OperatorWithKernel::IndicateVarDataType(
         ctx, framework::GradVarName("Out"));
 
-    // #ifdef PADDLE_WITH_MKLDNN
-    //    if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
-    //      return framework::OpKernelType(input_data_type, ctx.GetPlace(),
-    //                                     phi::DataLayout::ONEDNN,
-    //                                     framework::LibraryType::kMKLDNN);
-    //    }
-    // #endif
+    #ifdef PADDLE_WITH_MKLDNN
+       if (this->CanMKLDNNBeUsed(ctx, input_data_type)) {
+         return framework::OpKernelType(input_data_type, ctx.GetPlace(),
+                                        phi::DataLayout::ONEDNN,
+                                        framework::LibraryType::kMKLDNN);
+       }
+    #endif
     return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
Reenabled reshape, squeeze and flatten oneDNN kernels. They were disabled due to some bugs which were fixed in #46768.