### PR TITLE
[BugFix]Fix OneDNN Kernels Bug when use pass

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -3230,6 +3230,18 @@ void OperatorWithKernel::BuildPhiKernelContext(
   }
   VLOG(4) << "Done attributes";
 
+// Clear All old attrs before add new attrs,
+// because sometimes old attrs may be misused.
+#if defined(PADDLE_WITH_MKLDNN)
+  phi::OneDNNContext* one_dnn_ctx = static_cast<phi::OneDNNContext*>(dev_ctx);
+  one_dnn_ctx->ClearDnnAttr();
+#endif
+
+#if defined(PADDLE_WITH_CUDA)
+  phi::GPUContext* gpu_dnn_ctx = static_cast<phi::GPUContext*>(dev_ctx);
+  gpu_dnn_ctx->ClearDnnAttr();
+#endif
+
   // For compatible with Op with extra attrs for specific backend
 #if defined(PADDLE_WITH_MKLDNN) || defined(PADDLE_WITH_CUDA)
   auto& runtime_attrs = RuntimeAttrs();

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -3233,15 +3233,26 @@ void OperatorWithKernel::BuildPhiKernelContext(
 // Clear All old attrs before add new attrs,
 // because sometimes old attrs may be misused.
 #if defined(PADDLE_WITH_MKLDNN)
-  phi::OneDNNContext* one_dnn_ctx = static_cast<phi::OneDNNContext*>(dev_ctx);
-  one_dnn_ctx->ClearDnnAttr();
+  if (phi::OneDNNContext::classof(dev_ctx)) {
+    phi::OneDNNContext* one_dnn_ctx = static_cast<phi::OneDNNContext*>(dev_ctx);
+    one_dnn_ctx->ClearDnnAttr();
+  }
 #endif
 
-#if defined(PADDLE_WITH_CUDA)
-  phi::GPUContext* gpu_dnn_ctx = static_cast<phi::GPUContext*>(dev_ctx);
-  gpu_dnn_ctx->ClearDnnAttr();
-#endif
-
+  // Note(YuanRisheng): Now, we can't open code below.
+  // Because some unittest run OLD dygraph and ExtraAttr is not supported in OLD
+  // dygraph. So, here we use trick that dev_ctx is a global object. We can
+  // store ExtraAttr in static graph and when unittest run OLD dygraph, it can
+  // obtain these ExtraAttr. We can open this code when OLD dygraph is no longer
+  // used.
+  /*
+  #if defined(PADDLE_WITH_CUDA)
+    if(phi::GPUContext::classof(dev_ctx)) {
+      phi::GPUContext* gpu_dnn_ctx = static_cast<phi::GPUContext*>(dev_ctx);
+      gpu_dnn_ctx->ClearDnnAttr();
+    }
+  #endif
+  */
   // For compatible with Op with extra attrs for specific backend
 #if defined(PADDLE_WITH_MKLDNN) || defined(PADDLE_WITH_CUDA)
   auto& runtime_attrs = RuntimeAttrs();

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -740,6 +740,8 @@ struct GPUContext::Impl {
     dnn_attrs_[attr_name] = attr;
   }
 
+  void ClearDnnAttr() { dnn_attrs_.clear(); }
+
   // use one flag for all handles?
   // they should be accessed consistently
   bool owned_{false};
@@ -1041,5 +1043,7 @@ const Attribute& GPUContext::GetDnnAttr(const std::string& attr_name) const {
 void GPUContext::SetDnnAttr(const std::string& attr_name, Attribute attr) {
   return impl_->SetDnnAttr(attr_name, std::move(attr));
 }
+
+void GPUContext::ClearDnnAttr() { return impl_->ClearDnnAttr(); }
 
 }  // namespace phi

--- a/paddle/phi/backends/gpu/gpu_context.h
+++ b/paddle/phi/backends/gpu/gpu_context.h
@@ -172,6 +172,7 @@ class PADDLE_API GPUContext : public DeviceContext,
   bool HasDnnAttr(const std::string& attr_name) const;
   const Attribute& GetDnnAttr(const std::string& attr_name) const;
   void SetDnnAttr(const std::string& attr_name, Attribute attr);
+  void ClearDnnAttr();
 
   static const char* name() { return "GPUContext"; }
 

--- a/paddle/phi/backends/onednn/onednn_context.cc
+++ b/paddle/phi/backends/onednn/onednn_context.cc
@@ -301,6 +301,8 @@ struct OneDNNContext::Impl {
     dnn_attrs_[attr_name] = attr;
   }
 
+  void ClearDnnAttr() { dnn_attrs_.clear(); }
+
   bool HasDnnInput(const std::string& input_name) const {
     return dnn_inputs_.count(input_name) != 0UL;
   }
@@ -424,6 +426,8 @@ const Attribute& OneDNNContext::GetDnnAttr(const std::string& attr_name) const {
 void OneDNNContext::SetDnnAttr(const std::string& attr_name, Attribute attr) {
   return impl_->SetDnnAttr(attr_name, std::move(attr));
 }
+
+void OneDNNContext::ClearDnnAttr() { return impl_->ClearDnnAttr(); }
 
 bool OneDNNContext::HasDnnInput(const std::string& input_name) const {
   return impl_->HasDnnInput(input_name);

--- a/paddle/phi/backends/onednn/onednn_context.h
+++ b/paddle/phi/backends/onednn/onednn_context.h
@@ -146,6 +146,8 @@ class OneDNNContext : public CPUContext {
   const DenseTensor* GetDnnInput(const std::string& input_name) const;
   void SetDnnInput(const std::string& input_name, const DenseTensor* input);
 
+  void ClearDnnAttr();
+
   void SetInputsName(const TensorNameMap& inputs_name);
 
   void SetOutputsName(const TensorNameMap& outputs_name);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR Fix bugs of ExtraAttr's mechanism.
Because ExtraAttrs are stored in dev_ctx and dev_ctx is a global object. So, it is easy to use old ExtraAttrs in next program's iteration or next kernel execution. This will generate incorrect results. This PR fix this bug.
Related PR:https://github.com/PaddlePaddle/Paddle/pull/47657  https://github.com/PaddlePaddle/Paddle/pull/48162