### PR TITLE
Support more activation in fused multi transformer

### DIFF
--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cc
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cc
@@ -270,7 +270,17 @@ class FusedMultiTransformerOpOpMaker
                   "dropout_implementation can only be downgrade_in_infer or "
                   "upscale_in_train"));
         });
-    AddAttr<std::string>("act_method", "act_method").SetDefault("gelu");
+    AddAttr<std::string>("act_method", "act_method")
+        .SetDefault("gelu")
+        .AddCustomChecker([](const std::string &act_type) {
+          PADDLE_ENFORCE_EQ(
+              act_type == "gelu" || act_type == "relu" || act_type == "none",
+              true,
+              platform::errors::InvalidArgument(
+                  "Only support `gelu`, `relu`, `none` activation in "
+                  "FusedMultiTransformer. "));
+        });
+
     AddAttr<bool>(
         "trans_qkvw",
         "Whether the weights of qkv should be transposed. If true,"

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -14,7 +14,554 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 
-#if CUDA_VERSION >= 11060  // Use cublasLt to fuse FFN operation.
+// #if CUDA_VERSION >= 11060  // Use cublasLt to fuse FFN operation.
+
+// template <typename T>
+// class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
+//  public:
+//   void Compute(const framework::ExecutionContext &ctx) const override {
+//     using U = LayerNormParamType<T>;
+//     auto &dev_ctx = ctx.cuda_device_context();
+
+//     auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
+//     // 0. input
+//     auto *input_x = ctx.Input<phi::DenseTensor>("X");
+//     const auto input_x_dims = input_x->dims();
+//     int bsz = input_x_dims[0];
+//     int seq_len = input_x_dims[1];
+//     int dim_embed = input_x_dims[2];
+//     int bsz_seq = bsz * seq_len;
+//     const std::string act_method = ctx.Attr<std::string>("act_method");
+//     printf("Act method is: %s \n", act_method.c_str());
+
+//     // 1. layer norm
+//     const auto pre_layer_norm = ctx.Attr<bool>("pre_layer_norm");
+//     const float epsilon = ctx.Attr<float>("epsilon");
+//     auto ln_scales = ctx.MultiInput<phi::DenseTensor>("LnScale");
+//     auto ln_biases = ctx.MultiInput<phi::DenseTensor>("LnBias");
+
+//     auto ln_compute = AttnLayerNorm<T>(dev_ctx, epsilon, bsz_seq, dim_embed);
+//     Tensor ln_mean, ln_var;
+//     ln_mean.Resize({{bsz_seq}});
+//     auto *ln_mean_data =
+//         dev_ctx.Alloc<U>(&ln_mean, ln_mean.numel() * sizeof(U));
+//     ln_var.Resize({{bsz_seq}});
+//     auto *ln_var_data = dev_ctx.Alloc<U>(&ln_var, ln_var.numel() *
+//     sizeof(U));
+
+//     // 2. qkv
+//     // x: qkv's input [batch_size, seq_len, dim_embed]
+//     // y: qkv's weight: [3, num_head, dim_head, dim_embed]
+//     auto qkv_weights = ctx.MultiInput<phi::DenseTensor>("QKVW");
+//     auto qkv_biases = ctx.MultiInput<phi::DenseTensor>("QKVBias");
+//     const bool trans_qkvw = ctx.Attr<bool>("trans_qkvw");
+//     const auto qkv_w_dims = qkv_weights[0]->dims();
+//     int num_head = trans_qkvw ? qkv_w_dims[1] : qkv_w_dims[2];
+//     int dim_head = trans_qkvw ? qkv_w_dims[2] : qkv_w_dims[3];
+//     int hidden_size = num_head * dim_head;
+//     int output_size = 3 * hidden_size;
+//     int input_size = dim_embed;
+
+//     bool compute_bias = qkv_biases.size() > 0 && time_step == nullptr;
+//     // (transA, transB, compute_bias) = (false, trans_qkvw, false)
+//     // Since we fused QKVBias into QKVBiasAddTransposeSplit kernel, here we
+//     set
+//     // compute_bias as false.
+//     auto qkv_compute = AttnMatMul<T>(dev_ctx,
+//                                      false,
+//                                      trans_qkvw,
+//                                      bsz_seq,
+//                                      output_size,
+//                                      input_size,
+//                                      /*compute_bias=*/false);
+
+//     Tensor qkv_out;
+//     qkv_out.Resize({{bsz, seq_len, 3, num_head, dim_head}});
+//     auto *qkv_out_data =
+//         dev_ctx.Alloc<T>(&qkv_out, qkv_out.numel() * sizeof(T));
+
+//     // 3. fmha
+//     AttnDropoutParam attn_param(
+//         true, "upscale_in_train", 0.0, true, true, 0, nullptr);
+//     auto fmha_compute =
+//         FMHARef<T>(dev_ctx, bsz, seq_len, num_head, dim_head, attn_param);
+//     auto *src_mask = ctx.Input<phi::DenseTensor>("SrcMask");
+//     auto cache_kvs = ctx.MultiInput<phi::DenseTensor>("CacheKV");
+//     auto cache_kv_outs = ctx.MultiOutput<phi::DenseTensor>("CacheKVOut");
+//     // auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
+//     auto pre_caches = ctx.MultiInput<phi::DenseTensor>("PreCaches");
+//     int cache_offset = 0;
+//     if (pre_caches.size() > 0) {
+//       cache_offset = pre_caches[0]->dims()[3];
+//     }
+
+//     auto out_seq_len = seq_len;
+//     if (time_step) {
+//       PADDLE_ENFORCE_EQ(time_step->place(),
+//                         platform::CPUPlace(),
+//                         platform::errors::PreconditionNotMet(
+//                             "The place of input(TimeStep) must be
+//                             CPUPlace."));
+//       // cache_seq_len
+//       int time_step_value = time_step->data<int>()[0];
+//       PADDLE_ENFORCE_GT(time_step_value,
+//                         0,
+//                         platform::errors::PreconditionNotMet(
+//                             "The value of time_step must > 0, but now is %d",
+//                             time_step_value));
+//       PADDLE_ENFORCE_EQ(
+//           seq_len,
+//           1,
+//           platform::errors::PreconditionNotMet(
+//               "In decode stage, the seq_len of input must be 1, but now is
+//               %d", seq_len));
+//       out_seq_len += time_step_value;
+//     } else {
+//       out_seq_len += cache_offset;
+//     }
+
+//     Tensor q_transpose_out, kv_transpose_out, qk_out;
+//     q_transpose_out.Resize({{bsz, num_head, seq_len, dim_head}});
+//     auto *q_transpose_out_data =
+//         dev_ctx.Alloc<T>(&q_transpose_out, q_transpose_out.numel() *
+//         sizeof(T));
+
+//     kv_transpose_out.Resize({{2, bsz, num_head, seq_len, dim_head}});
+//     auto *kv_transpose_out_data = dev_ctx.Alloc<T>(
+//         &kv_transpose_out, kv_transpose_out.numel() * sizeof(T));
+
+//     qk_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+//     auto *qk_out_data = dev_ctx.Alloc<T>(&qk_out, qk_out.numel() *
+//     sizeof(T));
+
+//     Tensor src_mask_out;
+//     if (cache_offset > 0) {
+//       src_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+//       auto *src_mask_out_data =
+//           dev_ctx.Alloc<T>(&src_mask_out, src_mask_out.numel() * sizeof(T));
+//     }
+
+//     // [2, bs, num_head, cache_seq_len + seq_len, head_dim]
+//     Tensor pre_cache_kv_out;
+//     if (cache_offset > 0) {
+//       pre_cache_kv_out.Resize(
+//           {{2, bsz, num_head, seq_len + cache_offset, dim_head}});
+//       auto *pre_cache_kv_out_data = dev_ctx.Alloc<T>(
+//           &pre_cache_kv_out, pre_cache_kv_out.numel() * sizeof(T));
+//     }
+
+//     Tensor softmax_out;
+//     Tensor attn_dropout_mask_out, attn_dropout_out;
+//     Tensor qktv_out, fmha_out;
+//     softmax_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+//     auto *softmax_out_data =
+//         dev_ctx.Alloc<T>(&softmax_out, softmax_out.numel() * sizeof(T));
+
+//     attn_dropout_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+//     auto *attn_dropout_mask_out_data = dev_ctx.Alloc<T>(
+//         &attn_dropout_mask_out, attn_dropout_mask_out.numel() * sizeof(T));
+//     attn_dropout_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+//     auto *attn_dropout_data_data = dev_ctx.Alloc<T>(
+//         &attn_dropout_out, attn_dropout_out.numel() * sizeof(T));
+
+//     qktv_out.Resize({{bsz, num_head, seq_len, dim_head}});
+//     auto *qktv_out_data =
+//         dev_ctx.Alloc<T>(&qktv_out, qktv_out.numel() * sizeof(T));
+//     fmha_out.Resize({{bsz, seq_len, num_head, dim_head}});
+//     auto *fmha_out_data =
+//         dev_ctx.Alloc<T>(&fmha_out, fmha_out.numel() * sizeof(T));
+
+//     // 4. out_linear
+//     auto out_linear_weights = ctx.MultiInput<phi::DenseTensor>("OutLinearW");
+//     auto out_linear_biases =
+//     ctx.MultiInput<phi::DenseTensor>("OutLinearBias"); int ring_id =
+//     ctx.Attr<int>("ring_id");
+//     // (transA, transB, compute_bias) = (false, false, false)
+//     auto out_linear_compute = AttnMatMul<T>(
+//         dev_ctx, false, false, bsz_seq, dim_embed, hidden_size, false);
+
+//     // 5. ln(residual + bias)
+//     DropoutParam dropout_param2(true, 0, true, true, 0.0, nullptr, 0);
+//     FusedDropoutLayerNormHelper<T, uint8_t> fused_dropout_layernorm_helper(
+//         dev_ctx, bsz_seq, dim_embed, dropout_param2, epsilon);
+//     auto ffn_ln_scales = ctx.MultiInput<phi::DenseTensor>("FFNLnScale");
+//     auto ffn_ln_biases = ctx.MultiInput<phi::DenseTensor>("FFNLnBias");
+//     Tensor bias_dropout_residual_out, dropout_mask_out;
+//     T *bias_dropout_residual_out_data = nullptr;
+//     if (pre_layer_norm) {
+//       bias_dropout_residual_out.Resize({{bsz, seq_len, dim_embed}});
+//       bias_dropout_residual_out_data =
+//           dev_ctx.Alloc<T>(&bias_dropout_residual_out,
+//                            bias_dropout_residual_out.numel() * sizeof(T));
+//     }
+//     dropout_mask_out.Resize({{bsz, seq_len, dim_embed}});
+//     auto *dropout_mask_out_data = dev_ctx.Alloc<uint8_t>(
+//         &dropout_mask_out, dropout_mask_out.numel() * sizeof(uint8_t));
+
+//     // 6. ffn matmul1
+//     auto ffn1_weights = ctx.MultiInput<phi::DenseTensor>("FFN1Weight");
+//     auto ffn1_biases = ctx.MultiInput<phi::DenseTensor>("FFN1Bias");
+//     auto ffn1_weight_dim = ffn1_weights[0]->dims();
+
+//     int dim_ffn = ffn1_weight_dim[1];
+//     auto ffn1_linear_compute = AttnMatMul<T>(
+//         dev_ctx, false, false, bsz_seq, dim_ffn, dim_embed, false);
+//     Tensor ffn1_out;
+//     ffn1_out.Resize({{bsz_seq, dim_ffn}});
+//     auto *ffn1_out_data =
+//         dev_ctx.Alloc<T>(&ffn1_out, ffn1_out.numel() * sizeof(T));
+
+//     // 7. ffn act + bias
+//     DropoutParam ffn1_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
+//     FusedDropoutHelper<T, uint8_t> fused_act_dropout_helper(
+//         dev_ctx, bsz_seq, dim_ffn, ffn1_dropout_param);
+//     Tensor ffn1_dropout_out, ffn1_dropout_mask;
+//     ffn1_dropout_out.Resize({{bsz_seq, dim_ffn}});
+//     auto *ffn1_dropout_out_data = dev_ctx.Alloc<T>(
+//         &ffn1_dropout_out, ffn1_dropout_out.numel() * sizeof(T));
+//     ffn1_dropout_mask.Resize({{bsz_seq, dim_ffn}});
+//     auto *ffn1_dropout_mask_data = dev_ctx.Alloc<uint8_t>(
+//         &ffn1_dropout_mask, ffn1_dropout_mask.numel() * sizeof(uint8_t));
+
+//     // 8. ffn2 matmul
+//     auto ffn2_weights = ctx.MultiInput<phi::DenseTensor>("FFN2Weight");
+//     auto ffn2_biases = ctx.MultiInput<phi::DenseTensor>("FFN2Bias");
+//     auto ffn2_linear_compute = AttnMatMul<T>(
+//         dev_ctx, false, false, bsz_seq, dim_embed, dim_ffn, false);
+
+//     // 9. ffn2 residual bias
+//     DropoutParam ffn2_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
+//     FusedDropoutLayerNormHelper<T, uint8_t> ffn2_fused_dropout_helper(
+//         dev_ctx, bsz_seq, dim_embed, ffn2_dropout_param, epsilon);
+
+//     // calc
+//     auto *out = ctx.Output<phi::DenseTensor>("Out");
+//     auto *from_data = dev_ctx.Alloc<T>(out, out->numel() * sizeof(T));
+//     Tensor *from_tensor = out;
+//     Tensor tmp_out;
+//     tmp_out.Resize({{bsz, seq_len, dim_embed}});
+//     auto *tmp_out_data =
+//         dev_ctx.Alloc<T>(&tmp_out, tmp_out.numel() * sizeof(T));
+
+//     auto *x_data = input_x->data<T>();
+//     Tensor *buf0 = nullptr;
+//     Tensor *buf1 = nullptr;
+
+//     // step0:  x   --> buf1
+//     // step1: buf1 --> buf0
+//     // step2: buf0 --> buf1
+//     int layers = qkv_weights.size();
+//     if (pre_layer_norm) {
+//       if (layers & 1) {
+//         // odd, set buf1 as out
+//         buf0 = &tmp_out;
+//         buf1 = out;
+//       } else {
+//         // even, set buf0 as out
+//         buf0 = out;
+//         buf1 = &tmp_out;
+//       }
+//     } else {
+//       buf0 = &tmp_out;
+//       buf1 = out;
+//     }
+
+//     for (int i = 0; i < layers; ++i) {
+//       // step1. layer_norm
+//       if (i == 0 && pre_layer_norm) {
+//         auto *ln_scale_data = ln_scales[i]->data<U>();
+//         auto *ln_bias_data = ln_biases[i]->data<U>();
+//         // TODO(wangxi): can remove mean var in inference
+//         ln_compute.ComputeForward(x_data,
+//                                   ln_scale_data,
+//                                   ln_bias_data,
+//                                   buf1->data<T>(),
+//                                   ln_mean_data,
+//                                   ln_var_data);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step1";
+// #endif
+
+//       // step2. qkv
+//       const Tensor *qkv_bias = qkv_biases.size() > 0 ? qkv_biases[i] :
+//       nullptr;
+//       // NOTE: in decoder stage, bias is fused in fmha
+//       const Tensor *bias = time_step ? nullptr : qkv_bias;
+//       if (!pre_layer_norm && i == 0) {
+//         qkv_compute.ComputeForward(
+//             qkv_weights[i], input_x, bias, &qkv_out, &qkv_out);
+//       } else {
+//         qkv_compute.ComputeForward(
+//             qkv_weights[i], buf1, bias, &qkv_out, &qkv_out);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step2";
+// #endif
+
+//       // step3. fmha
+//       const Tensor *cache_kv = cache_kvs.size() > 0 ? cache_kvs[i] : nullptr;
+//       Tensor *cache_kv_out = cache_kv ? cache_kv_outs[i] : nullptr;
+
+//       if (time_step) {  // generation decoder stage
+//         // [2, batch_size, num_head, max_seq_len, head_size]
+//         int max_seq_len = cache_kv->dims()[3];
+//         fmha<T>(dev_ctx,
+//                 qkv_out,
+//                 *qkv_bias,
+//                 *src_mask,
+//                 cache_kv_out,
+//                 &fmha_out,
+//                 bsz,
+//                 max_seq_len,
+//                 num_head,
+//                 dim_head,
+//                 time_step->data<int>()[0],
+//                 1. / sqrt(dim_head));
+//       } else if (cache_kv_out) {  // generation context stage
+//         const Tensor *pre_cache_kv_tensor =
+//             pre_caches.size() > 0 ? pre_caches[i] : nullptr;
+//         Tensor *pre_cache_kv_out_tmp =
+//             cache_offset > 0 ? &pre_cache_kv_out : nullptr;
+//         Tensor *src_mask_tmp = cache_offset > 0 ? &src_mask_out : nullptr;
+//         qkv_bias_add_transpose_split<T>(dev_ctx,
+//                                         q_transpose_out_data,
+//                                         kv_transpose_out_data,
+//                                         qkv_out_data,
+//                                         qkv_bias->data<T>(),
+//                                         bsz,
+//                                         num_head,
+//                                         seq_len,
+//                                         dim_head,
+//                                         compute_bias);
+//         fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
+//                                                     pre_cache_kv_tensor,
+//                                                     src_mask,
+//                                                     &q_transpose_out,
+//                                                     &kv_transpose_out,
+//                                                     pre_cache_kv_out_tmp,
+//                                                     &qk_out,
+//                                                     src_mask_tmp,
+//                                                     &softmax_out,
+//                                                     &attn_dropout_mask_out,
+//                                                     &attn_dropout_out,
+//                                                     &qktv_out,
+//                                                     &fmha_out);
+//         const T *k_ptr = nullptr;
+//         const T *v_ptr = nullptr;
+
+//         if (cache_offset > 0) {
+//           // [2, bsz, num_head, cache_offset + seq_len, head_dim]
+//           const T *kv_data = pre_cache_kv_out.data<T>();
+//           k_ptr = kv_data;
+//           int64_t k_size = bsz * num_head * (seq_len + cache_offset) *
+//           dim_head; v_ptr = k_ptr + k_size;
+//         } else {
+//           // [3, bsz, num_head, seq_len, head_dim]
+//           int64_t k_size = bsz * seq_len * num_head * dim_head;
+//           const T *q_ptr = q_transpose_out_data;
+//           k_ptr = kv_transpose_out_data;
+//           v_ptr = k_ptr + k_size;
+//         }
+
+//         // [2, bsz, num_head, max_seq_len, head_dim]
+//         int max_seq_len = cache_kv_out->dims()[3];
+//         T *cache_kv_data = cache_kv_out->data<T>();
+//         int64_t cache_k_size = bsz * num_head * max_seq_len * dim_head;
+
+//         T *cache_k_ptr = cache_kv_data;
+//         T *cache_v_ptr = cache_kv_data + cache_k_size;
+
+//         const int seq_len_tmp = seq_len + cache_offset;
+//         write_cache_kv<T>(dev_ctx,
+//                           cache_k_ptr,
+//                           cache_v_ptr,
+//                           k_ptr,
+//                           v_ptr,
+//                           bsz,
+//                           num_head,
+//                           seq_len_tmp,
+//                           max_seq_len,
+//                           dim_head);
+//       } else {  // not generation
+//         // TODO(wangxi): can remove dropout in inference
+//         qkv_bias_add_transpose_split<T>(dev_ctx,
+//                                         q_transpose_out_data,
+//                                         kv_transpose_out_data,
+//                                         qkv_out_data,
+//                                         qkv_bias->data<T>(),
+//                                         bsz,
+//                                         num_head,
+//                                         seq_len,
+//                                         dim_head,
+//                                         compute_bias);
+//         fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
+//                                                     cache_kv,
+//                                                     src_mask,
+//                                                     &q_transpose_out,
+//                                                     &kv_transpose_out,
+//                                                     cache_kv_out,
+//                                                     &qk_out,
+//                                                     nullptr,
+//                                                     &softmax_out,
+//                                                     &attn_dropout_mask_out,
+//                                                     &attn_dropout_out,
+//                                                     &qktv_out,
+//                                                     &fmha_out);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step3";
+// #endif
+
+//       if (pre_layer_norm) {
+//         out_linear_compute.ComputeForward(
+//             out_linear_weights[i], &fmha_out, nullptr, buf1, nullptr);
+//         AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
+//       } else {
+//         out_linear_compute.ComputeForward(
+//             out_linear_weights[i], &fmha_out, nullptr, buf0, nullptr);
+//         AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step4";
+// #endif
+
+//       // step5. ln(residual + dropout(input + bias))
+//       if (pre_layer_norm) {
+//         auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
+//         auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
+//         auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
+
+//         // inplace
+//         fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
+//             dev_ctx,
+//             buf1->data<T>(),
+//             x_data,
+//             out_linear_bias_data,
+//             ln_scale_data,
+//             ln_bias_data,
+//             bias_dropout_residual_out_data,
+//             dropout_mask_out_data,
+//             buf1->data<T>(),
+//             ln_mean_data,
+//             ln_var_data);
+//       } else {
+//         auto *ln_scale_data = ln_scales[i]->data<U>();
+//         auto *ln_bias_data = ln_biases[i]->data<U>();
+//         auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
+//         auto *residual_data = (i == 0 ? x_data : buf1->data<T>());
+//         fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
+//             dev_ctx,
+//             buf0->data<T>(),
+//             residual_data,
+//             out_linear_bias_data,
+//             ln_scale_data,
+//             ln_bias_data,
+//             buf0->data<T>(),
+//             dropout_mask_out_data,
+//             buf1->data<T>(),
+//             ln_mean_data,
+//             ln_var_data);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step5";
+// #endif
+
+//       // step6. ffn matmul1
+//       ffn1_linear_compute.ComputeForward(
+//           ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step6";
+// #endif
+
+//       // step7. act bias
+//       // TODO(wangxi): remove dropout mask in inference
+//       fused_act_dropout_helper.DropoutActBias(dev_ctx,
+//                                               ffn1_out_data,
+//                                               ffn1_biases[i]->data<T>(),
+//                                               act_method,
+//                                               ffn1_dropout_out_data,
+//                                               ffn1_dropout_mask_data);
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step7";
+// #endif
+
+//       // step8. ffn matmul2
+//       if (pre_layer_norm) {
+//         ffn2_linear_compute.ComputeForward(
+//             ffn2_weights[i], &ffn1_dropout_out, nullptr, buf1, nullptr);
+//       } else {
+//         ffn2_linear_compute.ComputeForward(
+//             ffn2_weights[i], &ffn1_dropout_out, nullptr, buf0, nullptr);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step8.0";
+// #endif
+
+//       if (pre_layer_norm) {
+//         AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
+//       } else {
+//         AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step8.1";
+// #endif
+
+//       // step9. residual bias
+//       if (pre_layer_norm) {
+//         // TODO(wangxi): remove dropout mask in inference
+//         if (i < layers - 1) {
+//           auto *ln_scale_data = ln_scales[i + 1]->data<U>();
+//           auto *ln_bias_data = ln_biases[i + 1]->data<U>();
+//           ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
+//               dev_ctx,
+//               buf1->data<T>(),
+//               bias_dropout_residual_out_data,
+//               ffn2_biases[i]->data<T>(),
+//               ln_scale_data,
+//               ln_bias_data,
+//               buf1->data<T>(),
+//               dropout_mask_out_data,
+//               buf0->data<T>(),
+//               ln_mean_data,
+//               ln_var_data);
+//         } else {
+//           ffn2_fused_dropout_helper.ResidualDropoutBias(
+//               dev_ctx,
+//               buf1->data<T>(),
+//               bias_dropout_residual_out_data,
+//               ffn2_biases[i]->data<T>(),
+//               buf1->data<T>(),
+//               dropout_mask_out_data);
+//         }
+//       } else {
+//         auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
+//         auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
+//         ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
+//             dev_ctx,
+//             buf0->data<T>(),
+//             buf1->data<T>(),
+//             ffn2_biases[i]->data<T>(),
+//             ln_scale_data,
+//             ln_bias_data,
+//             buf0->data<T>(),
+//             dropout_mask_out_data,
+//             buf1->data<T>(),
+//             ln_mean_data,
+//             ln_var_data);
+//       }
+// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+//       VLOG(0) << "step9";
+// #endif
+//       if (pre_layer_norm) {
+//         x_data = buf1->data<T>();
+//         std::swap(buf0, buf1);
+//       }
+//     }
+//   }
+// };
+
+// #else
 
 template <typename T>
 class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
@@ -32,520 +579,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     int dim_embed = input_x_dims[2];
     int bsz_seq = bsz * seq_len;
     const std::string act_method = ctx.Attr<std::string>("act_method");
-
-    // 1. layer norm
-    const auto pre_layer_norm = ctx.Attr<bool>("pre_layer_norm");
-    const float epsilon = ctx.Attr<float>("epsilon");
-    auto ln_scales = ctx.MultiInput<phi::DenseTensor>("LnScale");
-    auto ln_biases = ctx.MultiInput<phi::DenseTensor>("LnBias");
-
-    auto ln_compute = AttnLayerNorm<T>(dev_ctx, epsilon, bsz_seq, dim_embed);
-    Tensor ln_mean, ln_var;
-    ln_mean.Resize({{bsz_seq}});
-    auto *ln_mean_data =
-        dev_ctx.Alloc<U>(&ln_mean, ln_mean.numel() * sizeof(U));
-    ln_var.Resize({{bsz_seq}});
-    auto *ln_var_data = dev_ctx.Alloc<U>(&ln_var, ln_var.numel() * sizeof(U));
-
-    // 2. qkv
-    // x: qkv's input [batch_size, seq_len, dim_embed]
-    // y: qkv's weight: [3, num_head, dim_head, dim_embed]
-    auto qkv_weights = ctx.MultiInput<phi::DenseTensor>("QKVW");
-    auto qkv_biases = ctx.MultiInput<phi::DenseTensor>("QKVBias");
-    const bool trans_qkvw = ctx.Attr<bool>("trans_qkvw");
-    const auto qkv_w_dims = qkv_weights[0]->dims();
-    int num_head = trans_qkvw ? qkv_w_dims[1] : qkv_w_dims[2];
-    int dim_head = trans_qkvw ? qkv_w_dims[2] : qkv_w_dims[3];
-    int hidden_size = num_head * dim_head;
-    int output_size = 3 * hidden_size;
-    int input_size = dim_embed;
-
-    bool compute_bias = qkv_biases.size() > 0 && time_step == nullptr;
-    // (transA, transB, compute_bias) = (false, trans_qkvw, false)
-
-    // Since we fused QKVBias into QKVBiasAddTransposeSplit kernel, here we set
-    // compute_bias as false.
-    auto qkv_compute = AttnMatMul<T>(dev_ctx,
-                                     false,
-                                     trans_qkvw,
-                                     bsz_seq,
-                                     output_size,
-                                     input_size,
-                                     /*compute_bias=*/false);
-
-    Tensor qkv_out;
-    qkv_out.Resize({{bsz, seq_len, 3, num_head, dim_head}});
-    auto *qkv_out_data =
-        dev_ctx.Alloc<T>(&qkv_out, qkv_out.numel() * sizeof(T));
-
-    // 3. fmha
-    AttnDropoutParam attn_param(
-        true, "upscale_in_train", 0.0, true, true, 0, nullptr);
-    auto fmha_compute =
-        FMHARef<T>(dev_ctx, bsz, seq_len, num_head, dim_head, attn_param);
-    auto *src_mask = ctx.Input<phi::DenseTensor>("SrcMask");
-    auto cache_kvs = ctx.MultiInput<phi::DenseTensor>("CacheKV");
-    auto cache_kv_outs = ctx.MultiOutput<phi::DenseTensor>("CacheKVOut");
-    // auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
-    auto pre_caches = ctx.MultiInput<phi::DenseTensor>("PreCaches");
-    int cache_offset = 0;
-    if (pre_caches.size() > 0) {
-      cache_offset = pre_caches[0]->dims()[3];
-    }
-
-    auto out_seq_len = seq_len;
-    if (time_step) {
-      PADDLE_ENFORCE_EQ(time_step->place(),
-                        platform::CPUPlace(),
-                        platform::errors::PreconditionNotMet(
-                            "The place of input(TimeStep) must be CPUPlace."));
-      // cache_seq_len
-      int time_step_value = time_step->data<int>()[0];
-      PADDLE_ENFORCE_GT(time_step_value,
-                        0,
-                        platform::errors::PreconditionNotMet(
-                            "The value of time_step must > 0, but now is %d",
-                            time_step_value));
-      PADDLE_ENFORCE_EQ(
-          seq_len,
-          1,
-          platform::errors::PreconditionNotMet(
-              "In decode stage, the seq_len of input must be 1, but now is %d",
-              seq_len));
-      out_seq_len += time_step_value;
-    } else {
-      out_seq_len += cache_offset;
-    }
-
-    Tensor q_transpose_out, kv_transpose_out, qk_out;
-    q_transpose_out.Resize({{bsz, num_head, seq_len, dim_head}});
-    auto *q_transpose_out_data =
-        dev_ctx.Alloc<T>(&q_transpose_out, q_transpose_out.numel() * sizeof(T));
-
-    kv_transpose_out.Resize({{2, bsz, num_head, seq_len, dim_head}});
-    auto *kv_transpose_out_data = dev_ctx.Alloc<T>(
-        &kv_transpose_out, kv_transpose_out.numel() * sizeof(T));
-
-    qk_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-    auto *qk_out_data = dev_ctx.Alloc<T>(&qk_out, qk_out.numel() * sizeof(T));
-
-    Tensor src_mask_out;
-    if (cache_offset > 0) {
-      src_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-      auto *src_mask_out_data =
-          dev_ctx.Alloc<T>(&src_mask_out, src_mask_out.numel() * sizeof(T));
-    }
-
-    // [2, bs, num_head, cache_seq_len + seq_len, head_dim]
-    Tensor pre_cache_kv_out;
-    if (cache_offset > 0) {
-      pre_cache_kv_out.Resize(
-          {{2, bsz, num_head, seq_len + cache_offset, dim_head}});
-      auto *pre_cache_kv_out_data = dev_ctx.Alloc<T>(
-          &pre_cache_kv_out, pre_cache_kv_out.numel() * sizeof(T));
-    }
-
-    Tensor softmax_out;
-    Tensor attn_dropout_mask_out, attn_dropout_out;
-    Tensor qktv_out, fmha_out;
-    softmax_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-    auto *softmax_out_data =
-        dev_ctx.Alloc<T>(&softmax_out, softmax_out.numel() * sizeof(T));
-
-    attn_dropout_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-    auto *attn_dropout_mask_out_data = dev_ctx.Alloc<T>(
-        &attn_dropout_mask_out, attn_dropout_mask_out.numel() * sizeof(T));
-    attn_dropout_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-    auto *attn_dropout_data_data = dev_ctx.Alloc<T>(
-        &attn_dropout_out, attn_dropout_out.numel() * sizeof(T));
-
-    qktv_out.Resize({{bsz, num_head, seq_len, dim_head}});
-    auto *qktv_out_data =
-        dev_ctx.Alloc<T>(&qktv_out, qktv_out.numel() * sizeof(T));
-    fmha_out.Resize({{bsz, seq_len, num_head, dim_head}});
-    auto *fmha_out_data =
-        dev_ctx.Alloc<T>(&fmha_out, fmha_out.numel() * sizeof(T));
-
-    // 4. out_linear
-    auto out_linear_weights = ctx.MultiInput<phi::DenseTensor>("OutLinearW");
-    auto out_linear_biases = ctx.MultiInput<phi::DenseTensor>("OutLinearBias");
-    int ring_id = ctx.Attr<int>("ring_id");
-    // (transA, transB, compute_bias) = (false, false, false)
-    auto out_linear_compute = AttnMatMul<T>(
-        dev_ctx, false, false, bsz_seq, dim_embed, hidden_size, false);
-
-    // 5. ln(residual + bias)
-    DropoutParam dropout_param2(true, 0, true, true, 0.0, nullptr, 0);
-    FusedDropoutLayerNormHelper<T, uint8_t> fused_dropout_layernorm_helper(
-        dev_ctx, bsz_seq, dim_embed, dropout_param2, epsilon);
-    auto ffn_ln_scales = ctx.MultiInput<phi::DenseTensor>("FFNLnScale");
-    auto ffn_ln_biases = ctx.MultiInput<phi::DenseTensor>("FFNLnBias");
-    Tensor bias_dropout_residual_out, dropout_mask_out;
-    T *bias_dropout_residual_out_data = nullptr;
-    if (pre_layer_norm) {
-      bias_dropout_residual_out.Resize({{bsz, seq_len, dim_embed}});
-      bias_dropout_residual_out_data =
-          dev_ctx.Alloc<T>(&bias_dropout_residual_out,
-                           bias_dropout_residual_out.numel() * sizeof(T));
-    }
-    dropout_mask_out.Resize({{bsz, seq_len, dim_embed}});
-    auto *dropout_mask_out_data = dev_ctx.Alloc<uint8_t>(
-        &dropout_mask_out, dropout_mask_out.numel() * sizeof(uint8_t));
-
-    // 6. ffn1 matmul + bias_add + gelu.
-    auto ffn1_weights = ctx.MultiInput<phi::DenseTensor>("FFN1Weight");
-    auto ffn1_biases = ctx.MultiInput<phi::DenseTensor>("FFN1Bias");
-    auto ffn1_weight_dim = ffn1_weights[0]->dims();
-
-    int dim_ffn = ffn1_weight_dim[1];
-
-    Tensor ffn1_out;
-    ffn1_out.Resize({{bsz_seq, dim_ffn}});
-    auto *ffn1_out_data =
-        dev_ctx.Alloc<T>(&ffn1_out, ffn1_out.numel() * sizeof(T));
-
-    auto ffn1_linear_bias_gelu = CublasFusedMLP<T>(dev_ctx);
-    const phi::DDim ffn1_input_shape({bsz_seq, dim_ffn});
-    ffn1_linear_bias_gelu.Setup(
-        ffn1_input_shape, ffn1_weight_dim, false, false);
-
-    // 8. ffn2 matmul + bias_add + residual.
-    auto ffn2_weights = ctx.MultiInput<phi::DenseTensor>("FFN2Weight");
-    auto ffn2_biases = ctx.MultiInput<phi::DenseTensor>("FFN2Bias");
-
-    auto ffn2_linear_bias_residual = CublasFusedMLP<T>(dev_ctx);
-    ffn2_linear_bias_residual.Setup(
-        ffn1_out.dims(), ffn2_weights[0]->dims(), false, false);
-
-    // 9. ffn2 residual bias
-    DropoutParam ffn2_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
-    FusedDropoutLayerNormHelper<T, uint8_t> ffn2_fused_dropout_helper(
-        dev_ctx, bsz_seq, dim_embed, ffn2_dropout_param, epsilon);
-
-    // calc
-    auto *out = ctx.Output<phi::DenseTensor>("Out");
-    auto *from_data = dev_ctx.Alloc<T>(out, out->numel() * sizeof(T));
-    Tensor *from_tensor = out;
-    Tensor tmp_out;
-    tmp_out.Resize({{bsz, seq_len, dim_embed}});
-    auto *tmp_out_data =
-        dev_ctx.Alloc<T>(&tmp_out, tmp_out.numel() * sizeof(T));
-
-    auto *x_data = input_x->data<T>();
-    Tensor *buf0 = nullptr;
-    Tensor *buf1 = nullptr;
-
-    // step0:  x   --> buf1
-    // step1: buf1 --> buf0
-    // step2: buf0 --> buf1
-    int layers = qkv_weights.size();
-    if (pre_layer_norm) {
-      if (layers & 1) {
-        // odd, set buf1 as out
-        buf0 = &tmp_out;
-        buf1 = out;
-      } else {
-        // even, set buf0 as out
-        buf0 = out;
-        buf1 = &tmp_out;
-      }
-    } else {
-      buf0 = &tmp_out;
-      buf1 = out;
-    }
-
-    for (int i = 0; i < layers; ++i) {
-      // step1. layer_norm
-      if (i == 0 && pre_layer_norm) {
-        auto *ln_scale_data = ln_scales[i]->data<U>();
-        auto *ln_bias_data = ln_biases[i]->data<U>();
-        // TODO(wangxi): can remove mean var in inference
-        ln_compute.ComputeForward(x_data,
-                                  ln_scale_data,
-                                  ln_bias_data,
-                                  buf1->data<T>(),
-                                  ln_mean_data,
-                                  ln_var_data);
-      }
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step1";
-#endif
-
-      // step2. qkv
-      const Tensor *qkv_bias = qkv_biases.size() > 0 ? qkv_biases[i] : nullptr;
-      // NOTE: in decoder stage, bias is fused in fmha
-      const Tensor *bias = time_step ? nullptr : qkv_bias;
-      if (!pre_layer_norm && i == 0) {
-        qkv_compute.ComputeForward(
-            qkv_weights[i], input_x, bias, &qkv_out, &qkv_out);
-      } else {
-        qkv_compute.ComputeForward(
-            qkv_weights[i], buf1, bias, &qkv_out, &qkv_out);
-      }
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step2";
-#endif
-
-      // step3. fmha
-      const Tensor *cache_kv = cache_kvs.size() > 0 ? cache_kvs[i] : nullptr;
-      Tensor *cache_kv_out = cache_kv ? cache_kv_outs[i] : nullptr;
-
-      if (time_step) {  // generation decoder stage
-        // [2, batch_size, num_head, max_seq_len, head_size]
-        int max_seq_len = cache_kv->dims()[3];
-        fmha<T>(dev_ctx,
-                qkv_out,
-                *qkv_bias,
-                *src_mask,
-                cache_kv_out,
-                &fmha_out,
-                bsz,
-                max_seq_len,
-                num_head,
-                dim_head,
-                time_step->data<int>()[0],
-                1. / sqrt(dim_head));
-      } else if (cache_kv_out) {  // generation context stage
-        const Tensor *pre_cache_kv_tensor =
-            pre_caches.size() > 0 ? pre_caches[i] : nullptr;
-        Tensor *pre_cache_kv_out_tmp =
-            cache_offset > 0 ? &pre_cache_kv_out : nullptr;
-        Tensor *src_mask_tmp = cache_offset > 0 ? &src_mask_out : nullptr;
-        qkv_bias_add_transpose_split<T>(dev_ctx,
-                                        q_transpose_out_data,
-                                        kv_transpose_out_data,
-                                        qkv_out_data,
-                                        qkv_bias->data<T>(),
-                                        bsz,
-                                        num_head,
-                                        seq_len,
-                                        dim_head,
-                                        compute_bias);
-        fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
-                                                    pre_cache_kv_tensor,
-                                                    src_mask,
-                                                    &q_transpose_out,
-                                                    &kv_transpose_out,
-                                                    pre_cache_kv_out_tmp,
-                                                    &qk_out,
-                                                    src_mask_tmp,
-                                                    &softmax_out,
-                                                    &attn_dropout_mask_out,
-                                                    &attn_dropout_out,
-                                                    &qktv_out,
-                                                    &fmha_out);
-
-        const T *k_ptr = nullptr;
-        const T *v_ptr = nullptr;
-
-        if (cache_offset > 0) {
-          // [2, bsz, num_head, cache_offset + seq_len, head_dim]
-          const T *kv_data = pre_cache_kv_out.data<T>();
-          k_ptr = kv_data;
-          int64_t k_size = bsz * num_head * (seq_len + cache_offset) * dim_head;
-          v_ptr = k_ptr + k_size;
-        } else {
-          // [3, bsz, num_head, seq_len, head_dim]
-          int64_t k_size = bsz * seq_len * num_head * dim_head;
-          const T *q_ptr = q_transpose_out_data;
-          k_ptr = kv_transpose_out_data;
-          v_ptr = k_ptr + k_size;
-        }
-
-        // [2, bsz, num_head, max_seq_len, head_dim]
-        int max_seq_len = cache_kv_out->dims()[3];
-        T *cache_kv_data = cache_kv_out->data<T>();
-        int64_t cache_k_size = bsz * num_head * max_seq_len * dim_head;
-
-        T *cache_k_ptr = cache_kv_data;
-        T *cache_v_ptr = cache_kv_data + cache_k_size;
-
-        const int seq_len_tmp = seq_len + cache_offset;
-        write_cache_kv<T>(dev_ctx,
-                          cache_k_ptr,
-                          cache_v_ptr,
-                          k_ptr,
-                          v_ptr,
-                          bsz,
-                          num_head,
-                          seq_len_tmp,
-                          max_seq_len,
-                          dim_head);
-      } else {  // not generation
-        // TODO(wangxi): can remove dropout in inference
-        qkv_bias_add_transpose_split<T>(dev_ctx,
-                                        q_transpose_out_data,
-                                        kv_transpose_out_data,
-                                        qkv_out_data,
-                                        qkv_bias->data<T>(),
-                                        bsz,
-                                        num_head,
-                                        seq_len,
-                                        dim_head,
-                                        compute_bias);
-        fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
-                                                    cache_kv,
-                                                    src_mask,
-                                                    &q_transpose_out,
-                                                    &kv_transpose_out,
-                                                    cache_kv_out,
-                                                    &qk_out,
-                                                    nullptr,
-                                                    &softmax_out,
-                                                    &attn_dropout_mask_out,
-                                                    &attn_dropout_out,
-                                                    &qktv_out,
-                                                    &fmha_out);
-      }
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step3";
-#endif
-
-      if (pre_layer_norm) {
-        out_linear_compute.ComputeForward(
-            out_linear_weights[i], &fmha_out, nullptr, buf1, nullptr);
-        AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
-      } else {
-        out_linear_compute.ComputeForward(
-            out_linear_weights[i], &fmha_out, nullptr, buf0, nullptr);
-        AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
-      }
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step4";
-#endif
-
-      // step5. ln(residual + dropout(input + bias))
-      if (pre_layer_norm) {
-        auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
-        auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
-        auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
-
-        // inplace
-        fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
-            dev_ctx,
-            buf1->data<T>(),
-            x_data,
-            out_linear_bias_data,
-            ln_scale_data,
-            ln_bias_data,
-            bias_dropout_residual_out_data,
-            dropout_mask_out_data,
-            buf1->data<T>(),
-            ln_mean_data,
-            ln_var_data);
-      } else {
-        auto *ln_scale_data = ln_scales[i]->data<U>();
-        auto *ln_bias_data = ln_biases[i]->data<U>();
-        auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
-        auto *residual_data = (i == 0 ? x_data : buf1->data<T>());
-        fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
-            dev_ctx,
-            buf0->data<T>(),
-            residual_data,
-            out_linear_bias_data,
-            ln_scale_data,
-            ln_bias_data,
-            buf0->data<T>(),
-            dropout_mask_out_data,
-            buf1->data<T>(),
-            ln_mean_data,
-            ln_var_data);
-      }
-
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step5";
-#endif
-      // step6. ffn1 matmul + bias_add + act.
-
-      ffn1_linear_bias_gelu.ComputeForward(buf1,
-                                           ffn1_weights[i],
-                                           ffn1_biases[i],
-                                           nullptr,
-                                           &ffn1_out,
-                                           act_method);
-
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step6";
-#endif
-
-      // step7. ffn2 matmul + bias_add + residual.
-      if (pre_layer_norm) {
-        ffn2_linear_bias_residual.ComputeForward(&ffn1_out,
-                                                 ffn2_weights[i],
-                                                 ffn2_biases[i],
-                                                 &bias_dropout_residual_out,
-                                                 buf1,
-                                                 "none");
-
-      } else {
-        ffn2_linear_bias_residual.ComputeForward(
-            &ffn1_out, ffn2_weights[i], ffn2_biases[i], buf1, buf0, "none");
-      }
-
-      if (pre_layer_norm) {
-        AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
-      } else {
-        AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
-      }
-
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step7";
-#endif
-
-      // step8. layer norm or do nothing(because bias_add + residual has been
-      // fused into cublasFusedMLP. )
-      if (pre_layer_norm) {
-        if (i < layers - 1) {
-          auto *ln_scale_data = ln_scales[i + 1]->data<U>();
-          auto *ln_bias_data = ln_biases[i + 1]->data<U>();
-          ffn2_fused_dropout_helper.LayerNorm(dev_ctx,
-                                              buf1->data<T>(),
-                                              ln_scale_data,
-                                              ln_bias_data,
-                                              buf0->data<T>(),
-                                              ln_mean_data,
-                                              ln_var_data);
-        }
-      } else {
-        auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
-        auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
-        ffn2_fused_dropout_helper.LayerNorm(dev_ctx,
-                                            buf0->data<T>(),
-                                            ln_scale_data,
-                                            ln_bias_data,
-                                            buf1->data<T>(),
-                                            ln_mean_data,
-                                            ln_var_data);
-      }
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step8";
-#endif
-      if (pre_layer_norm) {
-        x_data = buf1->data<T>();
-        std::swap(buf0, buf1);
-      }
-    }
-  }
-};
-
-#else
-
-template <typename T>
-class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
- public:
-  void Compute(const framework::ExecutionContext &ctx) const override {
-    using U = LayerNormParamType<T>;
-    auto &dev_ctx = ctx.cuda_device_context();
-
-    auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
-    // 0. input
-    auto *input_x = ctx.Input<phi::DenseTensor>("X");
-    const auto input_x_dims = input_x->dims();
-    int bsz = input_x_dims[0];
-    int seq_len = input_x_dims[1];
-    int dim_embed = input_x_dims[2];
-    int bsz_seq = bsz * seq_len;
-    const std::string act_method = ctx.Attr<std::string>("act_method");
+    printf("Act method is: %s \n", act_method.c_str());
 
     // 1. layer norm
     const auto pre_layer_norm = ctx.Attr<bool>("pre_layer_norm");
@@ -713,6 +747,21 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     int dim_ffn = ffn1_weight_dim[1];
     auto ffn1_linear_compute = AttnMatMul<T>(
         dev_ctx, false, false, bsz_seq, dim_ffn, dim_embed, false);
+
+    auto ffn1_cublas_linear = CublasFusedMLP<T>(dev_ctx);
+    const phi::DDim ffn1_input_shape({bsz_seq, dim_embed});
+    ffn1_cublas_linear.Setup(ffn1_input_shape, ffn1_weight_dim, false, false);
+
+    // auto ffn1_cublas_linear = CublasFusedMLP<T>(dev_ctx);
+    // const phi::DDim ffn1_input_shape({bsz_seq, dim_embed});
+    // // printf("FFN1 input shape is: %ld, %ld \n", bsz_seq, dim_embed);
+
+    // printf("bsz_seq: %ld, dim_embed: %ld, dim_ffn: %ld \n", bsz_seq,
+    // dim_embed, dim_ffn);
+
+    // ffn1_cublas_linear.Setup(
+    //     ffn1_input_shape, ffn1_weight_dim, false, false);
+
     Tensor ffn1_out;
     ffn1_out.Resize({{bsz_seq, dim_ffn}});
     auto *ffn1_out_data =
@@ -974,8 +1023,21 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 #endif
 
       // step6. ffn matmul1
-      ffn1_linear_compute.ComputeForward(
-          ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
+      // ffn1_linear_compute.ComputeForward(
+      //     ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
+
+      ffn1_cublas_linear.Compute(
+          buf1, ffn1_weights[i], nullptr, &ffn1_out, "none");
+
+      // printf("Buf 1 weight \n");
+      // for(int i = 0; i < buf1->dims().size(); i++){
+      //   printf("shape is: %ld \n", buf1->dims()[i]);
+      // }
+      // printf("=========");
+      // ffn1_cublas_linear.ComputeForward(
+      //   buf1, ffn1_weights[i], nullptr, nullptr, &ffn1_out, "none"
+      // );
+
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step6";
 #endif
@@ -1067,7 +1129,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
   }
 };
 
-#endif  // CUDA_VERSION >= 11060
+// #endif  // CUDA_VERSION >= 11060
 
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -1027,7 +1027,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
       //     ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
 
       ffn1_cublas_linear.Compute(
-          buf1, ffn1_weights[i], nullptr, &ffn1_out, "none");
+          buf1, ffn1_weights[i], nullptr, nullptr, &ffn1_out, "none");
 
       // printf("Buf 1 weight \n");
       // for(int i = 0; i < buf1->dims().size(); i++){

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -14,554 +14,7 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 
-// #if CUDA_VERSION >= 11060  // Use cublasLt to fuse FFN operation.
-
-// template <typename T>
-// class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
-//  public:
-//   void Compute(const framework::ExecutionContext &ctx) const override {
-//     using U = LayerNormParamType<T>;
-//     auto &dev_ctx = ctx.cuda_device_context();
-
-//     auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
-//     // 0. input
-//     auto *input_x = ctx.Input<phi::DenseTensor>("X");
-//     const auto input_x_dims = input_x->dims();
-//     int bsz = input_x_dims[0];
-//     int seq_len = input_x_dims[1];
-//     int dim_embed = input_x_dims[2];
-//     int bsz_seq = bsz * seq_len;
-//     const std::string act_method = ctx.Attr<std::string>("act_method");
-//     printf("Act method is: %s \n", act_method.c_str());
-
-//     // 1. layer norm
-//     const auto pre_layer_norm = ctx.Attr<bool>("pre_layer_norm");
-//     const float epsilon = ctx.Attr<float>("epsilon");
-//     auto ln_scales = ctx.MultiInput<phi::DenseTensor>("LnScale");
-//     auto ln_biases = ctx.MultiInput<phi::DenseTensor>("LnBias");
-
-//     auto ln_compute = AttnLayerNorm<T>(dev_ctx, epsilon, bsz_seq, dim_embed);
-//     Tensor ln_mean, ln_var;
-//     ln_mean.Resize({{bsz_seq}});
-//     auto *ln_mean_data =
-//         dev_ctx.Alloc<U>(&ln_mean, ln_mean.numel() * sizeof(U));
-//     ln_var.Resize({{bsz_seq}});
-//     auto *ln_var_data = dev_ctx.Alloc<U>(&ln_var, ln_var.numel() *
-//     sizeof(U));
-
-//     // 2. qkv
-//     // x: qkv's input [batch_size, seq_len, dim_embed]
-//     // y: qkv's weight: [3, num_head, dim_head, dim_embed]
-//     auto qkv_weights = ctx.MultiInput<phi::DenseTensor>("QKVW");
-//     auto qkv_biases = ctx.MultiInput<phi::DenseTensor>("QKVBias");
-//     const bool trans_qkvw = ctx.Attr<bool>("trans_qkvw");
-//     const auto qkv_w_dims = qkv_weights[0]->dims();
-//     int num_head = trans_qkvw ? qkv_w_dims[1] : qkv_w_dims[2];
-//     int dim_head = trans_qkvw ? qkv_w_dims[2] : qkv_w_dims[3];
-//     int hidden_size = num_head * dim_head;
-//     int output_size = 3 * hidden_size;
-//     int input_size = dim_embed;
-
-//     bool compute_bias = qkv_biases.size() > 0 && time_step == nullptr;
-//     // (transA, transB, compute_bias) = (false, trans_qkvw, false)
-//     // Since we fused QKVBias into QKVBiasAddTransposeSplit kernel, here we
-//     set
-//     // compute_bias as false.
-//     auto qkv_compute = AttnMatMul<T>(dev_ctx,
-//                                      false,
-//                                      trans_qkvw,
-//                                      bsz_seq,
-//                                      output_size,
-//                                      input_size,
-//                                      /*compute_bias=*/false);
-
-//     Tensor qkv_out;
-//     qkv_out.Resize({{bsz, seq_len, 3, num_head, dim_head}});
-//     auto *qkv_out_data =
-//         dev_ctx.Alloc<T>(&qkv_out, qkv_out.numel() * sizeof(T));
-
-//     // 3. fmha
-//     AttnDropoutParam attn_param(
-//         true, "upscale_in_train", 0.0, true, true, 0, nullptr);
-//     auto fmha_compute =
-//         FMHARef<T>(dev_ctx, bsz, seq_len, num_head, dim_head, attn_param);
-//     auto *src_mask = ctx.Input<phi::DenseTensor>("SrcMask");
-//     auto cache_kvs = ctx.MultiInput<phi::DenseTensor>("CacheKV");
-//     auto cache_kv_outs = ctx.MultiOutput<phi::DenseTensor>("CacheKVOut");
-//     // auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
-//     auto pre_caches = ctx.MultiInput<phi::DenseTensor>("PreCaches");
-//     int cache_offset = 0;
-//     if (pre_caches.size() > 0) {
-//       cache_offset = pre_caches[0]->dims()[3];
-//     }
-
-//     auto out_seq_len = seq_len;
-//     if (time_step) {
-//       PADDLE_ENFORCE_EQ(time_step->place(),
-//                         platform::CPUPlace(),
-//                         platform::errors::PreconditionNotMet(
-//                             "The place of input(TimeStep) must be
-//                             CPUPlace."));
-//       // cache_seq_len
-//       int time_step_value = time_step->data<int>()[0];
-//       PADDLE_ENFORCE_GT(time_step_value,
-//                         0,
-//                         platform::errors::PreconditionNotMet(
-//                             "The value of time_step must > 0, but now is %d",
-//                             time_step_value));
-//       PADDLE_ENFORCE_EQ(
-//           seq_len,
-//           1,
-//           platform::errors::PreconditionNotMet(
-//               "In decode stage, the seq_len of input must be 1, but now is
-//               %d", seq_len));
-//       out_seq_len += time_step_value;
-//     } else {
-//       out_seq_len += cache_offset;
-//     }
-
-//     Tensor q_transpose_out, kv_transpose_out, qk_out;
-//     q_transpose_out.Resize({{bsz, num_head, seq_len, dim_head}});
-//     auto *q_transpose_out_data =
-//         dev_ctx.Alloc<T>(&q_transpose_out, q_transpose_out.numel() *
-//         sizeof(T));
-
-//     kv_transpose_out.Resize({{2, bsz, num_head, seq_len, dim_head}});
-//     auto *kv_transpose_out_data = dev_ctx.Alloc<T>(
-//         &kv_transpose_out, kv_transpose_out.numel() * sizeof(T));
-
-//     qk_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-//     auto *qk_out_data = dev_ctx.Alloc<T>(&qk_out, qk_out.numel() *
-//     sizeof(T));
-
-//     Tensor src_mask_out;
-//     if (cache_offset > 0) {
-//       src_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-//       auto *src_mask_out_data =
-//           dev_ctx.Alloc<T>(&src_mask_out, src_mask_out.numel() * sizeof(T));
-//     }
-
-//     // [2, bs, num_head, cache_seq_len + seq_len, head_dim]
-//     Tensor pre_cache_kv_out;
-//     if (cache_offset > 0) {
-//       pre_cache_kv_out.Resize(
-//           {{2, bsz, num_head, seq_len + cache_offset, dim_head}});
-//       auto *pre_cache_kv_out_data = dev_ctx.Alloc<T>(
-//           &pre_cache_kv_out, pre_cache_kv_out.numel() * sizeof(T));
-//     }
-
-//     Tensor softmax_out;
-//     Tensor attn_dropout_mask_out, attn_dropout_out;
-//     Tensor qktv_out, fmha_out;
-//     softmax_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-//     auto *softmax_out_data =
-//         dev_ctx.Alloc<T>(&softmax_out, softmax_out.numel() * sizeof(T));
-
-//     attn_dropout_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-//     auto *attn_dropout_mask_out_data = dev_ctx.Alloc<T>(
-//         &attn_dropout_mask_out, attn_dropout_mask_out.numel() * sizeof(T));
-//     attn_dropout_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
-//     auto *attn_dropout_data_data = dev_ctx.Alloc<T>(
-//         &attn_dropout_out, attn_dropout_out.numel() * sizeof(T));
-
-//     qktv_out.Resize({{bsz, num_head, seq_len, dim_head}});
-//     auto *qktv_out_data =
-//         dev_ctx.Alloc<T>(&qktv_out, qktv_out.numel() * sizeof(T));
-//     fmha_out.Resize({{bsz, seq_len, num_head, dim_head}});
-//     auto *fmha_out_data =
-//         dev_ctx.Alloc<T>(&fmha_out, fmha_out.numel() * sizeof(T));
-
-//     // 4. out_linear
-//     auto out_linear_weights = ctx.MultiInput<phi::DenseTensor>("OutLinearW");
-//     auto out_linear_biases =
-//     ctx.MultiInput<phi::DenseTensor>("OutLinearBias"); int ring_id =
-//     ctx.Attr<int>("ring_id");
-//     // (transA, transB, compute_bias) = (false, false, false)
-//     auto out_linear_compute = AttnMatMul<T>(
-//         dev_ctx, false, false, bsz_seq, dim_embed, hidden_size, false);
-
-//     // 5. ln(residual + bias)
-//     DropoutParam dropout_param2(true, 0, true, true, 0.0, nullptr, 0);
-//     FusedDropoutLayerNormHelper<T, uint8_t> fused_dropout_layernorm_helper(
-//         dev_ctx, bsz_seq, dim_embed, dropout_param2, epsilon);
-//     auto ffn_ln_scales = ctx.MultiInput<phi::DenseTensor>("FFNLnScale");
-//     auto ffn_ln_biases = ctx.MultiInput<phi::DenseTensor>("FFNLnBias");
-//     Tensor bias_dropout_residual_out, dropout_mask_out;
-//     T *bias_dropout_residual_out_data = nullptr;
-//     if (pre_layer_norm) {
-//       bias_dropout_residual_out.Resize({{bsz, seq_len, dim_embed}});
-//       bias_dropout_residual_out_data =
-//           dev_ctx.Alloc<T>(&bias_dropout_residual_out,
-//                            bias_dropout_residual_out.numel() * sizeof(T));
-//     }
-//     dropout_mask_out.Resize({{bsz, seq_len, dim_embed}});
-//     auto *dropout_mask_out_data = dev_ctx.Alloc<uint8_t>(
-//         &dropout_mask_out, dropout_mask_out.numel() * sizeof(uint8_t));
-
-//     // 6. ffn matmul1
-//     auto ffn1_weights = ctx.MultiInput<phi::DenseTensor>("FFN1Weight");
-//     auto ffn1_biases = ctx.MultiInput<phi::DenseTensor>("FFN1Bias");
-//     auto ffn1_weight_dim = ffn1_weights[0]->dims();
-
-//     int dim_ffn = ffn1_weight_dim[1];
-//     auto ffn1_linear_compute = AttnMatMul<T>(
-//         dev_ctx, false, false, bsz_seq, dim_ffn, dim_embed, false);
-//     Tensor ffn1_out;
-//     ffn1_out.Resize({{bsz_seq, dim_ffn}});
-//     auto *ffn1_out_data =
-//         dev_ctx.Alloc<T>(&ffn1_out, ffn1_out.numel() * sizeof(T));
-
-//     // 7. ffn act + bias
-//     DropoutParam ffn1_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
-//     FusedDropoutHelper<T, uint8_t> fused_act_dropout_helper(
-//         dev_ctx, bsz_seq, dim_ffn, ffn1_dropout_param);
-//     Tensor ffn1_dropout_out, ffn1_dropout_mask;
-//     ffn1_dropout_out.Resize({{bsz_seq, dim_ffn}});
-//     auto *ffn1_dropout_out_data = dev_ctx.Alloc<T>(
-//         &ffn1_dropout_out, ffn1_dropout_out.numel() * sizeof(T));
-//     ffn1_dropout_mask.Resize({{bsz_seq, dim_ffn}});
-//     auto *ffn1_dropout_mask_data = dev_ctx.Alloc<uint8_t>(
-//         &ffn1_dropout_mask, ffn1_dropout_mask.numel() * sizeof(uint8_t));
-
-//     // 8. ffn2 matmul
-//     auto ffn2_weights = ctx.MultiInput<phi::DenseTensor>("FFN2Weight");
-//     auto ffn2_biases = ctx.MultiInput<phi::DenseTensor>("FFN2Bias");
-//     auto ffn2_linear_compute = AttnMatMul<T>(
-//         dev_ctx, false, false, bsz_seq, dim_embed, dim_ffn, false);
-
-//     // 9. ffn2 residual bias
-//     DropoutParam ffn2_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
-//     FusedDropoutLayerNormHelper<T, uint8_t> ffn2_fused_dropout_helper(
-//         dev_ctx, bsz_seq, dim_embed, ffn2_dropout_param, epsilon);
-
-//     // calc
-//     auto *out = ctx.Output<phi::DenseTensor>("Out");
-//     auto *from_data = dev_ctx.Alloc<T>(out, out->numel() * sizeof(T));
-//     Tensor *from_tensor = out;
-//     Tensor tmp_out;
-//     tmp_out.Resize({{bsz, seq_len, dim_embed}});
-//     auto *tmp_out_data =
-//         dev_ctx.Alloc<T>(&tmp_out, tmp_out.numel() * sizeof(T));
-
-//     auto *x_data = input_x->data<T>();
-//     Tensor *buf0 = nullptr;
-//     Tensor *buf1 = nullptr;
-
-//     // step0:  x   --> buf1
-//     // step1: buf1 --> buf0
-//     // step2: buf0 --> buf1
-//     int layers = qkv_weights.size();
-//     if (pre_layer_norm) {
-//       if (layers & 1) {
-//         // odd, set buf1 as out
-//         buf0 = &tmp_out;
-//         buf1 = out;
-//       } else {
-//         // even, set buf0 as out
-//         buf0 = out;
-//         buf1 = &tmp_out;
-//       }
-//     } else {
-//       buf0 = &tmp_out;
-//       buf1 = out;
-//     }
-
-//     for (int i = 0; i < layers; ++i) {
-//       // step1. layer_norm
-//       if (i == 0 && pre_layer_norm) {
-//         auto *ln_scale_data = ln_scales[i]->data<U>();
-//         auto *ln_bias_data = ln_biases[i]->data<U>();
-//         // TODO(wangxi): can remove mean var in inference
-//         ln_compute.ComputeForward(x_data,
-//                                   ln_scale_data,
-//                                   ln_bias_data,
-//                                   buf1->data<T>(),
-//                                   ln_mean_data,
-//                                   ln_var_data);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step1";
-// #endif
-
-//       // step2. qkv
-//       const Tensor *qkv_bias = qkv_biases.size() > 0 ? qkv_biases[i] :
-//       nullptr;
-//       // NOTE: in decoder stage, bias is fused in fmha
-//       const Tensor *bias = time_step ? nullptr : qkv_bias;
-//       if (!pre_layer_norm && i == 0) {
-//         qkv_compute.ComputeForward(
-//             qkv_weights[i], input_x, bias, &qkv_out, &qkv_out);
-//       } else {
-//         qkv_compute.ComputeForward(
-//             qkv_weights[i], buf1, bias, &qkv_out, &qkv_out);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step2";
-// #endif
-
-//       // step3. fmha
-//       const Tensor *cache_kv = cache_kvs.size() > 0 ? cache_kvs[i] : nullptr;
-//       Tensor *cache_kv_out = cache_kv ? cache_kv_outs[i] : nullptr;
-
-//       if (time_step) {  // generation decoder stage
-//         // [2, batch_size, num_head, max_seq_len, head_size]
-//         int max_seq_len = cache_kv->dims()[3];
-//         fmha<T>(dev_ctx,
-//                 qkv_out,
-//                 *qkv_bias,
-//                 *src_mask,
-//                 cache_kv_out,
-//                 &fmha_out,
-//                 bsz,
-//                 max_seq_len,
-//                 num_head,
-//                 dim_head,
-//                 time_step->data<int>()[0],
-//                 1. / sqrt(dim_head));
-//       } else if (cache_kv_out) {  // generation context stage
-//         const Tensor *pre_cache_kv_tensor =
-//             pre_caches.size() > 0 ? pre_caches[i] : nullptr;
-//         Tensor *pre_cache_kv_out_tmp =
-//             cache_offset > 0 ? &pre_cache_kv_out : nullptr;
-//         Tensor *src_mask_tmp = cache_offset > 0 ? &src_mask_out : nullptr;
-//         qkv_bias_add_transpose_split<T>(dev_ctx,
-//                                         q_transpose_out_data,
-//                                         kv_transpose_out_data,
-//                                         qkv_out_data,
-//                                         qkv_bias->data<T>(),
-//                                         bsz,
-//                                         num_head,
-//                                         seq_len,
-//                                         dim_head,
-//                                         compute_bias);
-//         fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
-//                                                     pre_cache_kv_tensor,
-//                                                     src_mask,
-//                                                     &q_transpose_out,
-//                                                     &kv_transpose_out,
-//                                                     pre_cache_kv_out_tmp,
-//                                                     &qk_out,
-//                                                     src_mask_tmp,
-//                                                     &softmax_out,
-//                                                     &attn_dropout_mask_out,
-//                                                     &attn_dropout_out,
-//                                                     &qktv_out,
-//                                                     &fmha_out);
-//         const T *k_ptr = nullptr;
-//         const T *v_ptr = nullptr;
-
-//         if (cache_offset > 0) {
-//           // [2, bsz, num_head, cache_offset + seq_len, head_dim]
-//           const T *kv_data = pre_cache_kv_out.data<T>();
-//           k_ptr = kv_data;
-//           int64_t k_size = bsz * num_head * (seq_len + cache_offset) *
-//           dim_head; v_ptr = k_ptr + k_size;
-//         } else {
-//           // [3, bsz, num_head, seq_len, head_dim]
-//           int64_t k_size = bsz * seq_len * num_head * dim_head;
-//           const T *q_ptr = q_transpose_out_data;
-//           k_ptr = kv_transpose_out_data;
-//           v_ptr = k_ptr + k_size;
-//         }
-
-//         // [2, bsz, num_head, max_seq_len, head_dim]
-//         int max_seq_len = cache_kv_out->dims()[3];
-//         T *cache_kv_data = cache_kv_out->data<T>();
-//         int64_t cache_k_size = bsz * num_head * max_seq_len * dim_head;
-
-//         T *cache_k_ptr = cache_kv_data;
-//         T *cache_v_ptr = cache_kv_data + cache_k_size;
-
-//         const int seq_len_tmp = seq_len + cache_offset;
-//         write_cache_kv<T>(dev_ctx,
-//                           cache_k_ptr,
-//                           cache_v_ptr,
-//                           k_ptr,
-//                           v_ptr,
-//                           bsz,
-//                           num_head,
-//                           seq_len_tmp,
-//                           max_seq_len,
-//                           dim_head);
-//       } else {  // not generation
-//         // TODO(wangxi): can remove dropout in inference
-//         qkv_bias_add_transpose_split<T>(dev_ctx,
-//                                         q_transpose_out_data,
-//                                         kv_transpose_out_data,
-//                                         qkv_out_data,
-//                                         qkv_bias->data<T>(),
-//                                         bsz,
-//                                         num_head,
-//                                         seq_len,
-//                                         dim_head,
-//                                         compute_bias);
-//         fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
-//                                                     cache_kv,
-//                                                     src_mask,
-//                                                     &q_transpose_out,
-//                                                     &kv_transpose_out,
-//                                                     cache_kv_out,
-//                                                     &qk_out,
-//                                                     nullptr,
-//                                                     &softmax_out,
-//                                                     &attn_dropout_mask_out,
-//                                                     &attn_dropout_out,
-//                                                     &qktv_out,
-//                                                     &fmha_out);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step3";
-// #endif
-
-//       if (pre_layer_norm) {
-//         out_linear_compute.ComputeForward(
-//             out_linear_weights[i], &fmha_out, nullptr, buf1, nullptr);
-//         AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
-//       } else {
-//         out_linear_compute.ComputeForward(
-//             out_linear_weights[i], &fmha_out, nullptr, buf0, nullptr);
-//         AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step4";
-// #endif
-
-//       // step5. ln(residual + dropout(input + bias))
-//       if (pre_layer_norm) {
-//         auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
-//         auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
-//         auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
-
-//         // inplace
-//         fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
-//             dev_ctx,
-//             buf1->data<T>(),
-//             x_data,
-//             out_linear_bias_data,
-//             ln_scale_data,
-//             ln_bias_data,
-//             bias_dropout_residual_out_data,
-//             dropout_mask_out_data,
-//             buf1->data<T>(),
-//             ln_mean_data,
-//             ln_var_data);
-//       } else {
-//         auto *ln_scale_data = ln_scales[i]->data<U>();
-//         auto *ln_bias_data = ln_biases[i]->data<U>();
-//         auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
-//         auto *residual_data = (i == 0 ? x_data : buf1->data<T>());
-//         fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
-//             dev_ctx,
-//             buf0->data<T>(),
-//             residual_data,
-//             out_linear_bias_data,
-//             ln_scale_data,
-//             ln_bias_data,
-//             buf0->data<T>(),
-//             dropout_mask_out_data,
-//             buf1->data<T>(),
-//             ln_mean_data,
-//             ln_var_data);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step5";
-// #endif
-
-//       // step6. ffn matmul1
-//       ffn1_linear_compute.ComputeForward(
-//           ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step6";
-// #endif
-
-//       // step7. act bias
-//       // TODO(wangxi): remove dropout mask in inference
-//       fused_act_dropout_helper.DropoutActBias(dev_ctx,
-//                                               ffn1_out_data,
-//                                               ffn1_biases[i]->data<T>(),
-//                                               act_method,
-//                                               ffn1_dropout_out_data,
-//                                               ffn1_dropout_mask_data);
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step7";
-// #endif
-
-//       // step8. ffn matmul2
-//       if (pre_layer_norm) {
-//         ffn2_linear_compute.ComputeForward(
-//             ffn2_weights[i], &ffn1_dropout_out, nullptr, buf1, nullptr);
-//       } else {
-//         ffn2_linear_compute.ComputeForward(
-//             ffn2_weights[i], &ffn1_dropout_out, nullptr, buf0, nullptr);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step8.0";
-// #endif
-
-//       if (pre_layer_norm) {
-//         AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
-//       } else {
-//         AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step8.1";
-// #endif
-
-//       // step9. residual bias
-//       if (pre_layer_norm) {
-//         // TODO(wangxi): remove dropout mask in inference
-//         if (i < layers - 1) {
-//           auto *ln_scale_data = ln_scales[i + 1]->data<U>();
-//           auto *ln_bias_data = ln_biases[i + 1]->data<U>();
-//           ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
-//               dev_ctx,
-//               buf1->data<T>(),
-//               bias_dropout_residual_out_data,
-//               ffn2_biases[i]->data<T>(),
-//               ln_scale_data,
-//               ln_bias_data,
-//               buf1->data<T>(),
-//               dropout_mask_out_data,
-//               buf0->data<T>(),
-//               ln_mean_data,
-//               ln_var_data);
-//         } else {
-//           ffn2_fused_dropout_helper.ResidualDropoutBias(
-//               dev_ctx,
-//               buf1->data<T>(),
-//               bias_dropout_residual_out_data,
-//               ffn2_biases[i]->data<T>(),
-//               buf1->data<T>(),
-//               dropout_mask_out_data);
-//         }
-//       } else {
-//         auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
-//         auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
-//         ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
-//             dev_ctx,
-//             buf0->data<T>(),
-//             buf1->data<T>(),
-//             ffn2_biases[i]->data<T>(),
-//             ln_scale_data,
-//             ln_bias_data,
-//             buf0->data<T>(),
-//             dropout_mask_out_data,
-//             buf1->data<T>(),
-//             ln_mean_data,
-//             ln_var_data);
-//       }
-// #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-//       VLOG(0) << "step9";
-// #endif
-//       if (pre_layer_norm) {
-//         x_data = buf1->data<T>();
-//         std::swap(buf0, buf1);
-//       }
-//     }
-//   }
-// };
-
-// #else
+#if CUDA_VERSION >= 11060  // Use cublasLt to fuse FFN operation.
 
 template <typename T>
 class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
@@ -579,6 +32,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     int dim_embed = input_x_dims[2];
     int bsz_seq = bsz * seq_len;
     const std::string act_method = ctx.Attr<std::string>("act_method");
+    printf("Here is cublas fused mlp. \n");
     printf("Act method is: %s \n", act_method.c_str());
 
     // 1. layer norm
@@ -739,7 +193,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     auto *dropout_mask_out_data = dev_ctx.Alloc<uint8_t>(
         &dropout_mask_out, dropout_mask_out.numel() * sizeof(uint8_t));
 
-    // 6. ffn matmul1
+    // 6. ffn matmul1 + act + bias
     auto ffn1_weights = ctx.MultiInput<phi::DenseTensor>("FFN1Weight");
     auto ffn1_biases = ctx.MultiInput<phi::DenseTensor>("FFN1Bias");
     auto ffn1_weight_dim = ffn1_weights[0]->dims();
@@ -757,29 +211,15 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     auto *ffn1_out_data =
         dev_ctx.Alloc<T>(&ffn1_out, ffn1_out.numel() * sizeof(T));
 
-    // 7. ffn act + bias
-    DropoutParam ffn1_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
-    FusedDropoutHelper<T, uint8_t> fused_act_dropout_helper(
-        dev_ctx, bsz_seq, dim_ffn, ffn1_dropout_param);
-    Tensor ffn1_dropout_out, ffn1_dropout_mask;
-    ffn1_dropout_out.Resize({{bsz_seq, dim_ffn}});
-    auto *ffn1_dropout_out_data = dev_ctx.Alloc<T>(
-        &ffn1_dropout_out, ffn1_dropout_out.numel() * sizeof(T));
-    ffn1_dropout_mask.Resize({{bsz_seq, dim_ffn}});
-    auto *ffn1_dropout_mask_data = dev_ctx.Alloc<uint8_t>(
-        &ffn1_dropout_mask, ffn1_dropout_mask.numel() * sizeof(uint8_t));
-
-    // 8. ffn2 matmul
+    // 7. ffn2 matmul + bias + residual.
     auto ffn2_weights = ctx.MultiInput<phi::DenseTensor>("FFN2Weight");
     auto ffn2_biases = ctx.MultiInput<phi::DenseTensor>("FFN2Bias");
-    // auto ffn2_linear_compute = AttnMatMul<T>(
-    //     dev_ctx, false, false, bsz_seq, dim_embed, dim_ffn, false);
 
     auto ffn2_linear_bias_residual = CublasFusedMLP<T>(dev_ctx);
     ffn2_linear_bias_residual.Setup(
         ffn1_out.dims(), ffn2_weights[0]->dims(), false, false);
 
-    // 9. ffn2 Layernorm
+    // 8. ffn2 Layernorm
     DropoutParam ffn2_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
     FusedDropoutLayerNormHelper<T, uint8_t> ffn2_fused_dropout_helper(
         dev_ctx, bsz_seq, dim_embed, ffn2_dropout_param, epsilon);
@@ -1024,6 +464,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
       VLOG(0) << "step6";
 #endif
 
+      // step7. ffn matmul2
       if (pre_layer_norm) {
         ffn2_linear_bias_residual.ComputeForward(&ffn1_out,
                                                  ffn2_weights[i],
@@ -1038,7 +479,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
       }
 
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step8.0";
+      VLOG(0) << "step7";
 #endif
 
       if (pre_layer_norm) {
@@ -1047,10 +488,11 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
         AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
       }
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step8.1";
+      VLOG(0) << "step7.1";
 #endif
 
-      // step9. residual bias
+      // step8. layer norm or do nothing
+      // because bias_add + residual has been fused into cublasFusedMLP
       if (pre_layer_norm) {
         if (i < layers - 1) {
           auto *ln_scale_data = ln_scales[i + 1]->data<U>();
@@ -1086,7 +528,548 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
   }
 };
 
-// #endif  // CUDA_VERSION >= 11060
+#else
+
+template <typename T>
+class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    using U = LayerNormParamType<T>;
+    auto &dev_ctx = ctx.cuda_device_context();
+
+    auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
+    // 0. input
+    auto *input_x = ctx.Input<phi::DenseTensor>("X");
+    const auto input_x_dims = input_x->dims();
+    int bsz = input_x_dims[0];
+    int seq_len = input_x_dims[1];
+    int dim_embed = input_x_dims[2];
+    int bsz_seq = bsz * seq_len;
+    const std::string act_method = ctx.Attr<std::string>("act_method");
+    printf("Act method is: %s \n", act_method.c_str());
+
+    // 1. layer norm
+    const auto pre_layer_norm = ctx.Attr<bool>("pre_layer_norm");
+    const float epsilon = ctx.Attr<float>("epsilon");
+    auto ln_scales = ctx.MultiInput<phi::DenseTensor>("LnScale");
+    auto ln_biases = ctx.MultiInput<phi::DenseTensor>("LnBias");
+
+    auto ln_compute = AttnLayerNorm<T>(dev_ctx, epsilon, bsz_seq, dim_embed);
+    Tensor ln_mean, ln_var;
+    ln_mean.Resize({{bsz_seq}});
+    auto *ln_mean_data =
+        dev_ctx.Alloc<U>(&ln_mean, ln_mean.numel() * sizeof(U));
+    ln_var.Resize({{bsz_seq}});
+    auto *ln_var_data = dev_ctx.Alloc<U>(&ln_var, ln_var.numel() * sizeof(U));
+
+    // 2. qkv
+    // x: qkv's input [batch_size, seq_len, dim_embed]
+    // y: qkv's weight: [3, num_head, dim_head, dim_embed]
+    auto qkv_weights = ctx.MultiInput<phi::DenseTensor>("QKVW");
+    auto qkv_biases = ctx.MultiInput<phi::DenseTensor>("QKVBias");
+    const bool trans_qkvw = ctx.Attr<bool>("trans_qkvw");
+    const auto qkv_w_dims = qkv_weights[0]->dims();
+    int num_head = trans_qkvw ? qkv_w_dims[1] : qkv_w_dims[2];
+    int dim_head = trans_qkvw ? qkv_w_dims[2] : qkv_w_dims[3];
+    int hidden_size = num_head * dim_head;
+    int output_size = 3 * hidden_size;
+    int input_size = dim_embed;
+
+    bool compute_bias = qkv_biases.size() > 0 && time_step == nullptr;
+    // (transA, transB, compute_bias) = (false, trans_qkvw, false)
+    // Since we fused QKVBias into QKVBiasAddTransposeSplit kernel, here we
+    set
+        // compute_bias as false.
+        auto qkv_compute = AttnMatMul<T>(dev_ctx,
+                                         false,
+                                         trans_qkvw,
+                                         bsz_seq,
+                                         output_size,
+                                         input_size,
+                                         /*compute_bias=*/false);
+
+    Tensor qkv_out;
+    qkv_out.Resize({{bsz, seq_len, 3, num_head, dim_head}});
+    auto *qkv_out_data =
+        dev_ctx.Alloc<T>(&qkv_out, qkv_out.numel() * sizeof(T));
+
+    // 3. fmha
+    AttnDropoutParam attn_param(
+        true, "upscale_in_train", 0.0, true, true, 0, nullptr);
+    auto fmha_compute =
+        FMHARef<T>(dev_ctx, bsz, seq_len, num_head, dim_head, attn_param);
+    auto *src_mask = ctx.Input<phi::DenseTensor>("SrcMask");
+    auto cache_kvs = ctx.MultiInput<phi::DenseTensor>("CacheKV");
+    auto cache_kv_outs = ctx.MultiOutput<phi::DenseTensor>("CacheKVOut");
+    // auto *time_step = ctx.Input<phi::DenseTensor>("TimeStep");
+    auto pre_caches = ctx.MultiInput<phi::DenseTensor>("PreCaches");
+    int cache_offset = 0;
+    if (pre_caches.size() > 0) {
+      cache_offset = pre_caches[0]->dims()[3];
+    }
+
+    auto out_seq_len = seq_len;
+    if (time_step) {
+      PADDLE_ENFORCE_EQ(time_step->place(),
+                        platform::CPUPlace(),
+                        platform::errors::PreconditionNotMet(
+                            "The place of input(TimeStep) must be CPUPlace."));
+      // cache_seq_len
+      int time_step_value = time_step->data<int>()[0];
+      PADDLE_ENFORCE_GT(time_step_value,
+                        0,
+                        platform::errors::PreconditionNotMet(
+                            "The value of time_step must > 0, but now is %d",
+                            time_step_value));
+      PADDLE_ENFORCE_EQ(
+          seq_len,
+          1,
+          platform::errors::PreconditionNotMet(
+              "In decode stage, the seq_len of input must be 1, but now is %d",
+              seq_len));
+      out_seq_len += time_step_value;
+    } else {
+      out_seq_len += cache_offset;
+    }
+
+    Tensor q_transpose_out, kv_transpose_out, qk_out;
+    q_transpose_out.Resize({{bsz, num_head, seq_len, dim_head}});
+    auto *q_transpose_out_data =
+        dev_ctx.Alloc<T>(&q_transpose_out, q_transpose_out.numel() * sizeof(T));
+
+    kv_transpose_out.Resize({{2, bsz, num_head, seq_len, dim_head}});
+    auto *kv_transpose_out_data = dev_ctx.Alloc<T>(
+        &kv_transpose_out, kv_transpose_out.numel() * sizeof(T));
+
+    qk_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+    auto *qk_out_data = dev_ctx.Alloc<T>(&qk_out, qk_out.numel() * sizeof(T));
+
+    Tensor src_mask_out;
+    if (cache_offset > 0) {
+      src_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+      auto *src_mask_out_data =
+          dev_ctx.Alloc<T>(&src_mask_out, src_mask_out.numel() * sizeof(T));
+    }
+
+    // [2, bs, num_head, cache_seq_len + seq_len, head_dim]
+    Tensor pre_cache_kv_out;
+    if (cache_offset > 0) {
+      pre_cache_kv_out.Resize(
+          {{2, bsz, num_head, seq_len + cache_offset, dim_head}});
+      auto *pre_cache_kv_out_data = dev_ctx.Alloc<T>(
+          &pre_cache_kv_out, pre_cache_kv_out.numel() * sizeof(T));
+    }
+
+    Tensor softmax_out;
+    Tensor attn_dropout_mask_out, attn_dropout_out;
+    Tensor qktv_out, fmha_out;
+    softmax_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+    auto *softmax_out_data =
+        dev_ctx.Alloc<T>(&softmax_out, softmax_out.numel() * sizeof(T));
+
+    attn_dropout_mask_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+    auto *attn_dropout_mask_out_data = dev_ctx.Alloc<T>(
+        &attn_dropout_mask_out, attn_dropout_mask_out.numel() * sizeof(T));
+    attn_dropout_out.Resize({{bsz, num_head, seq_len, out_seq_len}});
+    auto *attn_dropout_data_data = dev_ctx.Alloc<T>(
+        &attn_dropout_out, attn_dropout_out.numel() * sizeof(T));
+
+    qktv_out.Resize({{bsz, num_head, seq_len, dim_head}});
+    auto *qktv_out_data =
+        dev_ctx.Alloc<T>(&qktv_out, qktv_out.numel() * sizeof(T));
+    fmha_out.Resize({{bsz, seq_len, num_head, dim_head}});
+    auto *fmha_out_data =
+        dev_ctx.Alloc<T>(&fmha_out, fmha_out.numel() * sizeof(T));
+
+    // 4. out_linear
+    auto out_linear_weights = ctx.MultiInput<phi::DenseTensor>("OutLinearW");
+    auto out_linear_biases = ctx.MultiInput<phi::DenseTensor>("OutLinearBias");
+    int ring_id = ctx.Attr<int>("ring_id");
+    // (transA, transB, compute_bias) = (false, false, false)
+    auto out_linear_compute = AttnMatMul<T>(
+        dev_ctx, false, false, bsz_seq, dim_embed, hidden_size, false);
+
+    // 5. ln(residual + bias)
+    DropoutParam dropout_param2(true, 0, true, true, 0.0, nullptr, 0);
+    FusedDropoutLayerNormHelper<T, uint8_t> fused_dropout_layernorm_helper(
+        dev_ctx, bsz_seq, dim_embed, dropout_param2, epsilon);
+    auto ffn_ln_scales = ctx.MultiInput<phi::DenseTensor>("FFNLnScale");
+    auto ffn_ln_biases = ctx.MultiInput<phi::DenseTensor>("FFNLnBias");
+    Tensor bias_dropout_residual_out, dropout_mask_out;
+    T *bias_dropout_residual_out_data = nullptr;
+    if (pre_layer_norm) {
+      bias_dropout_residual_out.Resize({{bsz, seq_len, dim_embed}});
+      bias_dropout_residual_out_data =
+          dev_ctx.Alloc<T>(&bias_dropout_residual_out,
+                           bias_dropout_residual_out.numel() * sizeof(T));
+    }
+    dropout_mask_out.Resize({{bsz, seq_len, dim_embed}});
+    auto *dropout_mask_out_data = dev_ctx.Alloc<uint8_t>(
+        &dropout_mask_out, dropout_mask_out.numel() * sizeof(uint8_t));
+
+    // 6. ffn matmul1
+    auto ffn1_weights = ctx.MultiInput<phi::DenseTensor>("FFN1Weight");
+    auto ffn1_biases = ctx.MultiInput<phi::DenseTensor>("FFN1Bias");
+    auto ffn1_weight_dim = ffn1_weights[0]->dims();
+
+    int dim_ffn = ffn1_weight_dim[1];
+    auto ffn1_linear_compute = AttnMatMul<T>(
+        dev_ctx, false, false, bsz_seq, dim_ffn, dim_embed, false);
+    Tensor ffn1_out;
+    ffn1_out.Resize({{bsz_seq, dim_ffn}});
+    auto *ffn1_out_data =
+        dev_ctx.Alloc<T>(&ffn1_out, ffn1_out.numel() * sizeof(T));
+
+    // 7. ffn act + bias
+    DropoutParam ffn1_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
+    FusedDropoutHelper<T, uint8_t> fused_act_dropout_helper(
+        dev_ctx, bsz_seq, dim_ffn, ffn1_dropout_param);
+    Tensor ffn1_dropout_out, ffn1_dropout_mask;
+    ffn1_dropout_out.Resize({{bsz_seq, dim_ffn}});
+    auto *ffn1_dropout_out_data = dev_ctx.Alloc<T>(
+        &ffn1_dropout_out, ffn1_dropout_out.numel() * sizeof(T));
+    ffn1_dropout_mask.Resize({{bsz_seq, dim_ffn}});
+    auto *ffn1_dropout_mask_data = dev_ctx.Alloc<uint8_t>(
+        &ffn1_dropout_mask, ffn1_dropout_mask.numel() * sizeof(uint8_t));
+
+    // 8. ffn2 matmul
+    auto ffn2_weights = ctx.MultiInput<phi::DenseTensor>("FFN2Weight");
+    auto ffn2_biases = ctx.MultiInput<phi::DenseTensor>("FFN2Bias");
+    auto ffn2_linear_compute = AttnMatMul<T>(
+        dev_ctx, false, false, bsz_seq, dim_embed, dim_ffn, false);
+
+    // 9. ffn2 residual bias
+    DropoutParam ffn2_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
+    FusedDropoutLayerNormHelper<T, uint8_t> ffn2_fused_dropout_helper(
+        dev_ctx, bsz_seq, dim_embed, ffn2_dropout_param, epsilon);
+
+    // calc
+    auto *out = ctx.Output<phi::DenseTensor>("Out");
+    auto *from_data = dev_ctx.Alloc<T>(out, out->numel() * sizeof(T));
+    Tensor *from_tensor = out;
+    Tensor tmp_out;
+    tmp_out.Resize({{bsz, seq_len, dim_embed}});
+    auto *tmp_out_data =
+        dev_ctx.Alloc<T>(&tmp_out, tmp_out.numel() * sizeof(T));
+
+    auto *x_data = input_x->data<T>();
+    Tensor *buf0 = nullptr;
+    Tensor *buf1 = nullptr;
+
+    // step0:  x   --> buf1
+    // step1: buf1 --> buf0
+    // step2: buf0 --> buf1
+    int layers = qkv_weights.size();
+    if (pre_layer_norm) {
+      if (layers & 1) {
+        // odd, set buf1 as out
+        buf0 = &tmp_out;
+        buf1 = out;
+      } else {
+        // even, set buf0 as out
+        buf0 = out;
+        buf1 = &tmp_out;
+      }
+    } else {
+      buf0 = &tmp_out;
+      buf1 = out;
+    }
+
+    for (int i = 0; i < layers; ++i) {
+      // step1. layer_norm
+      if (i == 0 && pre_layer_norm) {
+        auto *ln_scale_data = ln_scales[i]->data<U>();
+        auto *ln_bias_data = ln_biases[i]->data<U>();
+        // TODO(wangxi): can remove mean var in inference
+        ln_compute.ComputeForward(x_data,
+                                  ln_scale_data,
+                                  ln_bias_data,
+                                  buf1->data<T>(),
+                                  ln_mean_data,
+                                  ln_var_data);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step1";
+#endif
+
+      // step2. qkv
+      const Tensor *qkv_bias = qkv_biases.size() > 0 ? qkv_biases[i] : nullptr;
+      // NOTE: in decoder stage, bias is fused in fmha
+      const Tensor *bias = time_step ? nullptr : qkv_bias;
+      if (!pre_layer_norm && i == 0) {
+        qkv_compute.ComputeForward(
+            qkv_weights[i], input_x, bias, &qkv_out, &qkv_out);
+      } else {
+        qkv_compute.ComputeForward(
+            qkv_weights[i], buf1, bias, &qkv_out, &qkv_out);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step2";
+#endif
+
+      // step3. fmha
+      const Tensor *cache_kv = cache_kvs.size() > 0 ? cache_kvs[i] : nullptr;
+      Tensor *cache_kv_out = cache_kv ? cache_kv_outs[i] : nullptr;
+
+      if (time_step) {  // generation decoder stage
+        // [2, batch_size, num_head, max_seq_len, head_size]
+        int max_seq_len = cache_kv->dims()[3];
+        fmha<T>(dev_ctx,
+                qkv_out,
+                *qkv_bias,
+                *src_mask,
+                cache_kv_out,
+                &fmha_out,
+                bsz,
+                max_seq_len,
+                num_head,
+                dim_head,
+                time_step->data<int>()[0],
+                1. / sqrt(dim_head));
+      } else if (cache_kv_out) {  // generation context stage
+        const Tensor *pre_cache_kv_tensor =
+            pre_caches.size() > 0 ? pre_caches[i] : nullptr;
+        Tensor *pre_cache_kv_out_tmp =
+            cache_offset > 0 ? &pre_cache_kv_out : nullptr;
+        Tensor *src_mask_tmp = cache_offset > 0 ? &src_mask_out : nullptr;
+        qkv_bias_add_transpose_split<T>(dev_ctx,
+                                        q_transpose_out_data,
+                                        kv_transpose_out_data,
+                                        qkv_out_data,
+                                        qkv_bias->data<T>(),
+                                        bsz,
+                                        num_head,
+                                        seq_len,
+                                        dim_head,
+                                        compute_bias);
+        fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
+                                                    pre_cache_kv_tensor,
+                                                    src_mask,
+                                                    &q_transpose_out,
+                                                    &kv_transpose_out,
+                                                    pre_cache_kv_out_tmp,
+                                                    &qk_out,
+                                                    src_mask_tmp,
+                                                    &softmax_out,
+                                                    &attn_dropout_mask_out,
+                                                    &attn_dropout_out,
+                                                    &qktv_out,
+                                                    &fmha_out);
+        const T *k_ptr = nullptr;
+        const T *v_ptr = nullptr;
+
+        if (cache_offset > 0) {
+          // [2, bsz, num_head, cache_offset + seq_len, head_dim]
+          const T *kv_data = pre_cache_kv_out.data<T>();
+          k_ptr = kv_data;
+          int64_t k_size = bsz * num_head * (seq_len + cache_offset) * dim_head;
+          v_ptr = k_ptr + k_size;
+        } else {
+          // [3, bsz, num_head, seq_len, head_dim]
+          int64_t k_size = bsz * seq_len * num_head * dim_head;
+          const T *q_ptr = q_transpose_out_data;
+          k_ptr = kv_transpose_out_data;
+          v_ptr = k_ptr + k_size;
+        }
+
+        // [2, bsz, num_head, max_seq_len, head_dim]
+        int max_seq_len = cache_kv_out->dims()[3];
+        T *cache_kv_data = cache_kv_out->data<T>();
+        int64_t cache_k_size = bsz * num_head * max_seq_len * dim_head;
+
+        T *cache_k_ptr = cache_kv_data;
+        T *cache_v_ptr = cache_kv_data + cache_k_size;
+
+        const int seq_len_tmp = seq_len + cache_offset;
+        write_cache_kv<T>(dev_ctx,
+                          cache_k_ptr,
+                          cache_v_ptr,
+                          k_ptr,
+                          v_ptr,
+                          bsz,
+                          num_head,
+                          seq_len_tmp,
+                          max_seq_len,
+                          dim_head);
+      } else {  // not generation
+        // TODO(wangxi): can remove dropout in inference
+        qkv_bias_add_transpose_split<T>(dev_ctx,
+                                        q_transpose_out_data,
+                                        kv_transpose_out_data,
+                                        qkv_out_data,
+                                        qkv_bias->data<T>(),
+                                        bsz,
+                                        num_head,
+                                        seq_len,
+                                        dim_head,
+                                        compute_bias);
+        fmha_compute.ComputeForwardWithoutTranspose(qkv_out,
+                                                    cache_kv,
+                                                    src_mask,
+                                                    &q_transpose_out,
+                                                    &kv_transpose_out,
+                                                    cache_kv_out,
+                                                    &qk_out,
+                                                    nullptr,
+                                                    &softmax_out,
+                                                    &attn_dropout_mask_out,
+                                                    &attn_dropout_out,
+                                                    &qktv_out,
+                                                    &fmha_out);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step3";
+#endif
+
+      if (pre_layer_norm) {
+        out_linear_compute.ComputeForward(
+            out_linear_weights[i], &fmha_out, nullptr, buf1, nullptr);
+        AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
+      } else {
+        out_linear_compute.ComputeForward(
+            out_linear_weights[i], &fmha_out, nullptr, buf0, nullptr);
+        AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step4";
+#endif
+
+      // step5. ln(residual + dropout(input + bias))
+      if (pre_layer_norm) {
+        auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
+        auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
+        auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
+
+        // inplace
+        fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
+            dev_ctx,
+            buf1->data<T>(),
+            x_data,
+            out_linear_bias_data,
+            ln_scale_data,
+            ln_bias_data,
+            bias_dropout_residual_out_data,
+            dropout_mask_out_data,
+            buf1->data<T>(),
+            ln_mean_data,
+            ln_var_data);
+      } else {
+        auto *ln_scale_data = ln_scales[i]->data<U>();
+        auto *ln_bias_data = ln_biases[i]->data<U>();
+        auto *out_linear_bias_data = out_linear_biases[i]->data<T>();
+        auto *residual_data = (i == 0 ? x_data : buf1->data<T>());
+        fused_dropout_layernorm_helper.LayernormResidualDropoutBias(
+            dev_ctx,
+            buf0->data<T>(),
+            residual_data,
+            out_linear_bias_data,
+            ln_scale_data,
+            ln_bias_data,
+            buf0->data<T>(),
+            dropout_mask_out_data,
+            buf1->data<T>(),
+            ln_mean_data,
+            ln_var_data);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step5";
+#endif
+
+      // step6. ffn matmul1
+      ffn1_linear_compute.ComputeForward(
+          ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step6";
+#endif
+
+      // step7. act bias
+      // TODO(wangxi): remove dropout mask in inference
+      fused_act_dropout_helper.DropoutActBias(dev_ctx,
+                                              ffn1_out_data,
+                                              ffn1_biases[i]->data<T>(),
+                                              act_method,
+                                              ffn1_dropout_out_data,
+                                              ffn1_dropout_mask_data);
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step7";
+#endif
+
+      // step8. ffn matmul2
+      if (pre_layer_norm) {
+        ffn2_linear_compute.ComputeForward(
+            ffn2_weights[i], &ffn1_dropout_out, nullptr, buf1, nullptr);
+      } else {
+        ffn2_linear_compute.ComputeForward(
+            ffn2_weights[i], &ffn1_dropout_out, nullptr, buf0, nullptr);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step8.0";
+#endif
+
+      if (pre_layer_norm) {
+        AllReduce<T>(*buf1, ring_id, buf1->numel(), dev_ctx);
+      } else {
+        AllReduce<T>(*buf0, ring_id, buf0->numel(), dev_ctx);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step8.1";
+#endif
+
+      // step9. residual bias
+      if (pre_layer_norm) {
+        // TODO(wangxi): remove dropout mask in inference
+        if (i < layers - 1) {
+          auto *ln_scale_data = ln_scales[i + 1]->data<U>();
+          auto *ln_bias_data = ln_biases[i + 1]->data<U>();
+          ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
+              dev_ctx,
+              buf1->data<T>(),
+              bias_dropout_residual_out_data,
+              ffn2_biases[i]->data<T>(),
+              ln_scale_data,
+              ln_bias_data,
+              buf1->data<T>(),
+              dropout_mask_out_data,
+              buf0->data<T>(),
+              ln_mean_data,
+              ln_var_data);
+        } else {
+          ffn2_fused_dropout_helper.ResidualDropoutBias(
+              dev_ctx,
+              buf1->data<T>(),
+              bias_dropout_residual_out_data,
+              ffn2_biases[i]->data<T>(),
+              buf1->data<T>(),
+              dropout_mask_out_data);
+        }
+      } else {
+        auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
+        auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
+        ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
+            dev_ctx,
+            buf0->data<T>(),
+            buf1->data<T>(),
+            ffn2_biases[i]->data<T>(),
+            ln_scale_data,
+            ln_bias_data,
+            buf0->data<T>(),
+            dropout_mask_out_data,
+            buf1->data<T>(),
+            ln_mean_data,
+            ln_var_data);
+      }
+#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
+      VLOG(0) << "step9";
+#endif
+      if (pre_layer_norm) {
+        x_data = buf1->data<T>();
+        std::swap(buf0, buf1);
+      }
+    }
+  }
+};
+
+#endif  // CUDA_VERSION >= 11060
 
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -191,7 +191,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     auto *dropout_mask_out_data = dev_ctx.Alloc<uint8_t>(
         &dropout_mask_out, dropout_mask_out.numel() * sizeof(uint8_t));
 
-    // 6. ffn matmul1 + act + bias
+    // 6. ffn1 matmul + act + bias
     auto ffn1_weights = ctx.MultiInput<phi::DenseTensor>("FFN1Weight");
     auto ffn1_biases = ctx.MultiInput<phi::DenseTensor>("FFN1Bias");
     auto ffn1_weight_dim = ffn1_weights[0]->dims();
@@ -464,7 +464,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
       VLOG(0) << "step6";
 #endif
 
-      // step7. ffn matmul2
+      // step7. ffn2 matmul
       if (pre_layer_norm) {
         ffn2_linear_bias_residual.ComputeForward(&ffn1_out,
                                                  ffn2_weights[i],
@@ -518,7 +518,7 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
       }
 
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step9";
+      VLOG(0) << "step8";
 #endif
       if (pre_layer_norm) {
         x_data = buf1->data<T>();

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -457,8 +457,12 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 #endif
 
       // step6. ffn matmul1
-      ffn1_cublas_linear.ComputeForward(
-          buf1, ffn1_weights[i], ffn1_biases[i], nullptr, &ffn1_out, "gelu");
+      ffn1_cublas_linear.ComputeForward(buf1,
+                                        ffn1_weights[i],
+                                        ffn1_biases[i],
+                                        nullptr,
+                                        &ffn1_out,
+                                        act_method);
 
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step6";

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -32,8 +32,6 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     int dim_embed = input_x_dims[2];
     int bsz_seq = bsz * seq_len;
     const std::string act_method = ctx.Attr<std::string>("act_method");
-    printf("Here is cublas fused mlp. \n");
-    printf("Act method is: %s \n", act_method.c_str());
 
     // 1. layer norm
     const auto pre_layer_norm = ctx.Attr<bool>("pre_layer_norm");
@@ -550,7 +548,6 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     int dim_embed = input_x_dims[2];
     int bsz_seq = bsz * seq_len;
     const std::string act_method = ctx.Attr<std::string>("act_method");
-    printf("Act method is: %s \n", act_method.c_str());
 
     // 1. layer norm
     const auto pre_layer_norm = ctx.Attr<bool>("pre_layer_norm");
@@ -582,15 +579,14 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     bool compute_bias = qkv_biases.size() > 0 && time_step == nullptr;
     // (transA, transB, compute_bias) = (false, trans_qkvw, false)
     // Since we fused QKVBias into QKVBiasAddTransposeSplit kernel, here we
-    set
-        // compute_bias as false.
-        auto qkv_compute = AttnMatMul<T>(dev_ctx,
-                                         false,
-                                         trans_qkvw,
-                                         bsz_seq,
-                                         output_size,
-                                         input_size,
-                                         /*compute_bias=*/false);
+    // set compute_bias as false.
+    auto qkv_compute = AttnMatMul<T>(dev_ctx,
+                                     false,
+                                     trans_qkvw,
+                                     bsz_seq,
+                                     output_size,
+                                     input_size,
+                                     /*compute_bias=*/false);
 
     Tensor qkv_out;
     qkv_out.Resize({{bsz, seq_len, 3, num_head, dim_head}});

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -752,16 +752,6 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     const phi::DDim ffn1_input_shape({bsz_seq, dim_embed});
     ffn1_cublas_linear.Setup(ffn1_input_shape, ffn1_weight_dim, false, false);
 
-    // auto ffn1_cublas_linear = CublasFusedMLP<T>(dev_ctx);
-    // const phi::DDim ffn1_input_shape({bsz_seq, dim_embed});
-    // // printf("FFN1 input shape is: %ld, %ld \n", bsz_seq, dim_embed);
-
-    // printf("bsz_seq: %ld, dim_embed: %ld, dim_ffn: %ld \n", bsz_seq,
-    // dim_embed, dim_ffn);
-
-    // ffn1_cublas_linear.Setup(
-    //     ffn1_input_shape, ffn1_weight_dim, false, false);
-
     Tensor ffn1_out;
     ffn1_out.Resize({{bsz_seq, dim_ffn}});
     auto *ffn1_out_data =
@@ -782,10 +772,14 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     // 8. ffn2 matmul
     auto ffn2_weights = ctx.MultiInput<phi::DenseTensor>("FFN2Weight");
     auto ffn2_biases = ctx.MultiInput<phi::DenseTensor>("FFN2Bias");
-    auto ffn2_linear_compute = AttnMatMul<T>(
-        dev_ctx, false, false, bsz_seq, dim_embed, dim_ffn, false);
+    // auto ffn2_linear_compute = AttnMatMul<T>(
+    //     dev_ctx, false, false, bsz_seq, dim_embed, dim_ffn, false);
 
-    // 9. ffn2 residual bias
+    auto ffn2_linear_bias_residual = CublasFusedMLP<T>(dev_ctx);
+    ffn2_linear_bias_residual.Setup(
+        ffn1_out.dims(), ffn2_weights[0]->dims(), false, false);
+
+    // 9. ffn2 Layernorm
     DropoutParam ffn2_dropout_param(true, 0, true, true, 0.0, nullptr, 0);
     FusedDropoutLayerNormHelper<T, uint8_t> ffn2_fused_dropout_helper(
         dev_ctx, bsz_seq, dim_embed, ffn2_dropout_param, epsilon);
@@ -1023,45 +1017,26 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 #endif
 
       // step6. ffn matmul1
-      // ffn1_linear_compute.ComputeForward(
-      //     ffn1_weights[i], buf1, nullptr, &ffn1_out, nullptr);
-
-      ffn1_cublas_linear.Compute(
-          buf1, ffn1_weights[i], nullptr, nullptr, &ffn1_out, "none");
-
-      // printf("Buf 1 weight \n");
-      // for(int i = 0; i < buf1->dims().size(); i++){
-      //   printf("shape is: %ld \n", buf1->dims()[i]);
-      // }
-      // printf("=========");
-      // ffn1_cublas_linear.ComputeForward(
-      //   buf1, ffn1_weights[i], nullptr, nullptr, &ffn1_out, "none"
-      // );
+      ffn1_cublas_linear.ComputeForward(
+          buf1, ffn1_weights[i], ffn1_biases[i], nullptr, &ffn1_out, "gelu");
 
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step6";
 #endif
 
-      // step7. act bias
-      // TODO(wangxi): remove dropout mask in inference
-      fused_act_dropout_helper.DropoutActBias(dev_ctx,
-                                              ffn1_out_data,
-                                              ffn1_biases[i]->data<T>(),
-                                              act_method,
-                                              ffn1_dropout_out_data,
-                                              ffn1_dropout_mask_data);
-#ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
-      VLOG(0) << "step7";
-#endif
-
-      // step8. ffn matmul2
       if (pre_layer_norm) {
-        ffn2_linear_compute.ComputeForward(
-            ffn2_weights[i], &ffn1_dropout_out, nullptr, buf1, nullptr);
+        ffn2_linear_bias_residual.ComputeForward(&ffn1_out,
+                                                 ffn2_weights[i],
+                                                 ffn2_biases[i],
+                                                 &bias_dropout_residual_out,
+                                                 buf1,
+                                                 "none");
+
       } else {
-        ffn2_linear_compute.ComputeForward(
-            ffn2_weights[i], &ffn1_dropout_out, nullptr, buf0, nullptr);
+        ffn2_linear_bias_residual.ComputeForward(
+            &ffn1_out, ffn2_weights[i], ffn2_biases[i], buf1, buf0, "none");
       }
+
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step8.0";
 #endif
@@ -1077,47 +1052,29 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
 
       // step9. residual bias
       if (pre_layer_norm) {
-        // TODO(wangxi): remove dropout mask in inference
         if (i < layers - 1) {
           auto *ln_scale_data = ln_scales[i + 1]->data<U>();
           auto *ln_bias_data = ln_biases[i + 1]->data<U>();
-          ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
-              dev_ctx,
-              buf1->data<T>(),
-              bias_dropout_residual_out_data,
-              ffn2_biases[i]->data<T>(),
-              ln_scale_data,
-              ln_bias_data,
-              buf1->data<T>(),
-              dropout_mask_out_data,
-              buf0->data<T>(),
-              ln_mean_data,
-              ln_var_data);
-        } else {
-          ffn2_fused_dropout_helper.ResidualDropoutBias(
-              dev_ctx,
-              buf1->data<T>(),
-              bias_dropout_residual_out_data,
-              ffn2_biases[i]->data<T>(),
-              buf1->data<T>(),
-              dropout_mask_out_data);
+          ffn2_fused_dropout_helper.LayerNorm(dev_ctx,
+                                              buf1->data<T>(),
+                                              ln_scale_data,
+                                              ln_bias_data,
+                                              buf0->data<T>(),
+                                              ln_mean_data,
+                                              ln_var_data);
         }
       } else {
         auto *ln_scale_data = ffn_ln_scales[i]->data<U>();
         auto *ln_bias_data = ffn_ln_biases[i]->data<U>();
-        ffn2_fused_dropout_helper.LayernormResidualDropoutBias(
-            dev_ctx,
-            buf0->data<T>(),
-            buf1->data<T>(),
-            ffn2_biases[i]->data<T>(),
-            ln_scale_data,
-            ln_bias_data,
-            buf0->data<T>(),
-            dropout_mask_out_data,
-            buf1->data<T>(),
-            ln_mean_data,
-            ln_var_data);
+        ffn2_fused_dropout_helper.LayerNorm(dev_ctx,
+                                            buf0->data<T>(),
+                                            ln_scale_data,
+                                            ln_bias_data,
+                                            buf1->data<T>(),
+                                            ln_mean_data,
+                                            ln_var_data);
       }
+
 #ifdef _DEBUG_FUSED_MULTI_TRANSFORMER
       VLOG(0) << "step9";
 #endif

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu
@@ -197,8 +197,6 @@ class FusedMultiTransformerOpKernel : public framework::OpKernel<T> {
     auto ffn1_weight_dim = ffn1_weights[0]->dims();
 
     int dim_ffn = ffn1_weight_dim[1];
-    auto ffn1_linear_compute = AttnMatMul<T>(
-        dev_ctx, false, false, bsz_seq, dim_ffn, dim_embed, false);
 
     auto ffn1_cublas_linear = CublasFusedMLP<T>(dev_ctx);
     const phi::DDim ffn1_input_shape({bsz_seq, dim_embed});

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1476,9 +1476,9 @@ class CublasFusedMLP {
             &cublas_transB,
             sizeof(cublas_transB)));
 
-    SetCublasMatrixLayout_(x_desc_, trans_x, M, K);
-    SetCublasMatrixLayout_(w_desc_, trans_w, K, N);
-    SetCublasMatrixLayout_(out_desc_, false, M, N);
+    SetCublasMatrixLayout(x_desc_, trans_x, M, K);
+    SetCublasMatrixLayout(w_desc_, trans_w, K, N);
+    SetCublasMatrixLayout(out_desc_, false, M, N);
   }
 
   void ComputeForward(const phi::DenseTensor *x,
@@ -1503,7 +1503,7 @@ class CublasFusedMLP {
             &bias_data,
             sizeof(bias_data)));
 
-    cublasLtEpilogue_t epiloque_func = GetEpilogueType_(activation, add_bias);
+    cublasLtEpilogue_t epiloque_func = GetEpilogueType(activation, add_bias);
     PADDLE_ENFORCE_GPU_SUCCESS(
         platform::dynload::cublasLtMatmulDescSetAttribute(
             operation_desc_,
@@ -1583,8 +1583,8 @@ class CublasFusedMLP {
   }
 
  private:
-  cublasLtEpilogue_t GetEpilogueType_(const std::string &activation,
-                                      const bool add_bias) {
+  cublasLtEpilogue_t GetEpilogueType(const std::string &activation,
+                                     const bool add_bias) {
     if (activation == "relu") {
       if (add_bias) {
         return CUBLASLT_EPILOGUE_RELU_BIAS;
@@ -1615,10 +1615,10 @@ class CublasFusedMLP {
     }
   }
 
-  void SetCublasMatrixLayout_(cublasLtMatrixLayout_t layout_desc,
-                              const bool transpose,
-                              const uint64_t cublas_row,
-                              const uint64_t cublas_col) {
+  void SetCublasMatrixLayout(cublasLtMatrixLayout_t layout_desc,
+                             const bool transpose,
+                             const uint64_t cublas_row,
+                             const uint64_t cublas_col) {
     cudaDataType_t mat_type = CUDA_R_32F;
     if (std::is_same<T, paddle::platform::float16>::value) {
       mat_type = CUDA_R_16F;

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1517,12 +1517,12 @@ class CublasFusedMLP {
     SetCublasMatrixLayout_(out_desc_, false, M, N);
   }
 
-  void Compute(const phi::DenseTensor *x,
-               const phi::DenseTensor *weight,
-               const phi::DenseTensor *bias,
-               phi::DenseTensor *residual,
-               phi::DenseTensor *output,
-               const std::string &activation) {
+  void ComputeForward(const phi::DenseTensor *x,
+                      const phi::DenseTensor *weight,
+                      const phi::DenseTensor *bias,
+                      phi::DenseTensor *residual,
+                      phi::DenseTensor *output,
+                      const std::string &activation) {
     T *out_data = output->data<T>();
 
     const bool add_residual = (residual == nullptr) ? false : true;

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1557,8 +1557,8 @@ class CublasFusedMLP {
         workspace_size,
         phi::Stream(reinterpret_cast<phi::StreamId>(dev_ctx_.stream())));
 
-    // if add_residual, we compute result + 1.0 * residual, else result + 0.0 *
-    // out.
+    // if add_residual, we compute result + 1.0 * residual,
+    // else result + 0.0 * out.
     double alpha64 = 1.0, beta64 = add_residual ? 1.0 : 0.0;
     float alpha32 = 1.0f, beta32 = add_residual ? 1.0f : 0.0f;
     void *alpha = nullptr, *beta = nullptr;

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
@@ -145,21 +145,27 @@ class TestFusedMultiTransformerOp(OpTest):
         )
 
     def generate_input_data(self):
-        self.query = np.random.rand(
-            self.batch_size, self.query_length, self.embed_dim
+        self.query = np.random.uniform(
+            -1, 1, (self.batch_size, self.query_length, self.embed_dim)
         ).astype(self.x_type)
+
         out_seq_len = self.key_length
         if self.has_cache_kv:
             assert self.training is False, ValueError(
                 'cache_kv can only used in inference'
             )
-            self.cache_kv = np.random.rand(
-                2,
-                self.batch_size,
-                self.num_heads,
-                self.cache_length,
-                self.head_dim,
+            self.cache_kv = np.random.uniform(
+                -1,
+                1,
+                (
+                    2,
+                    self.batch_size,
+                    self.num_heads,
+                    self.cache_length,
+                    self.head_dim,
+                ),
             ).astype(self.x_type)
+
             if self.gen_cache_kv:
                 self.cache_kv[:] = 0
             else:
@@ -169,12 +175,16 @@ class TestFusedMultiTransformerOp(OpTest):
 
         if self.has_pre_cache:
             out_seq_len += self.pre_cache_num
-            self.pre_cache_kv = np.random.rand(
-                2,
-                self.batch_size,
-                self.num_heads,
-                self.pre_cache_num,
-                self.head_dim,
+            self.pre_cache_kv = np.random.uniform(
+                -1,
+                1,
+                (
+                    2,
+                    self.batch_size,
+                    self.num_heads,
+                    self.pre_cache_num,
+                    self.head_dim,
+                ),
             ).astype(self.x_type)
 
         if self.has_attn_mask:
@@ -205,8 +215,8 @@ class TestFusedMultiTransformerOp(OpTest):
             self.attn_mask = None
         self.key, self.value = self.query, self.query
 
-        self.dout = np.random.random(
-            (self.batch_size, self.query_length, self.embed_dim)
+        self.dout = np.random.uniform(
+            -1, 1, (self.batch_size, self.query_length, self.embed_dim)
         ).astype(self.x_type)
 
     def GetBaselineOut(self):

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
@@ -101,7 +101,6 @@ class TestFusedMultiTransformerOp(OpTest):
 
         paddle.set_default_dtype(self.x_type)
         self.dropout = Dropout(self.dropout_prob, mode="upscale_in_train")
-        print("========== Here init activation is: ", self.act_method)
         self.activation = getattr(F, self.act_method)
 
     def config(self):
@@ -124,8 +123,7 @@ class TestFusedMultiTransformerOp(OpTest):
 
         self.training = False
 
-        # self.layers = 4
-        self.layers = 1
+        self.layers = 4
 
         self.batch_size = 8
         self.query_length = 128
@@ -667,7 +665,6 @@ class TestFusedMultiTransformerOp(OpTest):
             ffn_ln_scales_attr.append(self.ln_w_attr)
             ffn_ln_biases_attr.append(self.ln_b_attr)
 
-        print("Here is Multi transformer, its activation is: ", self.act_method)
         transformer = FusedMultiTransformer(
             self.embed_dim,
             self.num_heads,
@@ -803,137 +800,135 @@ class TestFusedMultiTransformerOpFp16(TestFusedMultiTransformerOp):
         self.layers = 3  # odd layers
 
 
-# class TestFusedMultiTransformerOpActReluFp16(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.x_type = np.float16
-#         # self.act_method = "relu".
-#         # self.act_method = "gelu"
-#         # self.layers = 3  # odd layers
-#         self.layers = 1  # odd layers
+class TestFusedMultiTransformerOpActReluFp16(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.x_type = np.float16
+        self.act_method = "relu"
+        self.layers = 3  # odd layers
 
 
-# class TestFusedMultiTransformerOpCacheKV(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.query_length = 1
-#         self.key_length, self.value_length = 1, 1
-#         self.layers = 3  # odd layers
+class TestFusedMultiTransformerOpCacheKV(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.query_length = 1
+        self.key_length, self.value_length = 1, 1
+        self.layers = 3  # odd layers
 
 
-# class TestFusedMultiTransformerOpCacheKVFp16(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.query_length = 1
-#         self.key_length, self.value_length = 1, 1
-#         self.x_type = np.float16
+class TestFusedMultiTransformerOpCacheKVFp16(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.query_length = 1
+        self.key_length, self.value_length = 1, 1
+        self.x_type = np.float16
 
 
-# class TestFusedMultiTransformerOpGenCacheKV(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.gen_cache_kv = True
+class TestFusedMultiTransformerOpGenCacheKV(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.gen_cache_kv = True
 
 
-# class TestFusedMultiTransformerOpGenCacheKVFp16(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.gen_cache_kv = True
-#         self.x_type = np.float16
-#         self.layers = 3  # odd layers
+class TestFusedMultiTransformerOpGenCacheKVFp16(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.gen_cache_kv = True
+        self.x_type = np.float16
+        self.layers = 3  # odd layers
 
 
-# class TestFusedMultiTransformerOpPostLayerNormFp16(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.x_type = np.float16
-#         self.layers = 3  # odd layers
-#         self.pre_layer_norm = False
+class TestFusedMultiTransformerOpPostLayerNormFp16(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.x_type = np.float16
+        self.layers = 3  # odd layers
+        self.pre_layer_norm = False
 
 
-# class TestFusedMultiTransformerOpCacheKVPostLayerNorm(
-#     TestFusedMultiTransformerOp
-# ):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.query_length = 1
-#         self.key_length, self.value_length = 1, 1
-#         self.layers = 3  # odd layers
-#         self.pre_layer_norm = False
+class TestFusedMultiTransformerOpCacheKVPostLayerNorm(
+    TestFusedMultiTransformerOp
+):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.query_length = 1
+        self.key_length, self.value_length = 1, 1
+        self.layers = 3  # odd layers
+        self.pre_layer_norm = False
 
 
-# class TestFusedMultiTransformerOpCacheKVPostLayerNormFp16(
-#     TestFusedMultiTransformerOp
-# ):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.query_length = 1
-#         self.key_length, self.value_length = 1, 1
-#         self.x_type = np.float16
-#         self.pre_layer_norm = False
+class TestFusedMultiTransformerOpCacheKVPostLayerNormFp16(
+    TestFusedMultiTransformerOp
+):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.query_length = 1
+        self.key_length, self.value_length = 1, 1
+        self.x_type = np.float16
+        self.pre_layer_norm = False
 
 
-# class TestFusedMultiTransformerOpGenCacheKVPostLayerNorm(
-#     TestFusedMultiTransformerOp
-# ):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.gen_cache_kv = True
-#         self.pre_layer_norm = False
+class TestFusedMultiTransformerOpGenCacheKVPostLayerNorm(
+    TestFusedMultiTransformerOp
+):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.gen_cache_kv = True
+        self.pre_layer_norm = False
 
 
-# class TestFusedMultiTransformerOpGenCacheKVPostLayerNormFp16(
-#     TestFusedMultiTransformerOp
-# ):
-#     def config(self):
-#         super().config()
-#         self.has_cache_kv = True
-#         self.gen_cache_kv = True
-#         self.x_type = np.float16
-#         self.layers = 3  # odd layers
-#         self.pre_layer_norm = False
+class TestFusedMultiTransformerOpGenCacheKVPostLayerNormFp16(
+    TestFusedMultiTransformerOp
+):
+    def config(self):
+        super().config()
+        self.has_cache_kv = True
+        self.gen_cache_kv = True
+        self.x_type = np.float16
+        self.layers = 3  # odd layers
+        self.pre_layer_norm = False
 
 
-# class TestFusedMultiTransformerOpPreCache(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.has_pre_cache = True
-#         self.x_type = np.float16
+class TestFusedMultiTransformerOpPreCache(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.has_pre_cache = True
+        self.x_type = np.float16
 
 
-# class TestFusedMultiTransformerOpPreCacheStatic(TestFusedMultiTransformerOp):
-#     def config(self):
-#         super().config()
-#         self.has_pre_cache = True
-#         self.has_attn_mask = False
-#         self.x_type = np.float32
-#         self.weight_attr = paddle.ParamAttr(
-#             initializer=paddle.fluid.initializer.Constant(0.0)
-#         )
-#         self.bias_attr = paddle.ParamAttr(
-#             initializer=paddle.fluid.initializer.Constant(0.0005)
-#         )
-#         self.ln_w_attr = paddle.ParamAttr(
-#             initializer=paddle.fluid.initializer.Constant(1.0)
-#         )
-#         self.ln_b_attr = paddle.ParamAttr(
-#             initializer=paddle.fluid.initializer.Constant(0.0)
-#         )
+class TestFusedMultiTransformerOpPreCacheStatic(TestFusedMultiTransformerOp):
+    def config(self):
+        super().config()
+        self.has_pre_cache = True
+        self.has_attn_mask = False
+        self.x_type = np.float32
+        self.weight_attr = paddle.ParamAttr(
+            initializer=paddle.fluid.initializer.Constant(0.0)
+        )
+        self.bias_attr = paddle.ParamAttr(
+            initializer=paddle.fluid.initializer.Constant(0.0005)
+        )
+        self.ln_w_attr = paddle.ParamAttr(
+            initializer=paddle.fluid.initializer.Constant(1.0)
+        )
+        self.ln_b_attr = paddle.ParamAttr(
+            initializer=paddle.fluid.initializer.Constant(0.0)
+        )
 
-#     def test_fused_multi_transformer_op(self):
-#         final_out_ref = self.GetBaselineOut()
-#         final_out = self.GetFusedMultiTransformerOutStatic()
+    def test_fused_multi_transformer_op(self):
+        final_out_ref = self.GetBaselineOut()
+        final_out = self.GetFusedMultiTransformerOutStatic()
 
-#         np.testing.assert_allclose(
-#             final_out_ref, final_out, rtol=self.rtol, atol=self.atol
-#         )
+        np.testing.assert_allclose(
+            final_out_ref, final_out, rtol=self.rtol, atol=self.atol
+        )
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
@@ -101,6 +101,7 @@ class TestFusedMultiTransformerOp(OpTest):
 
         paddle.set_default_dtype(self.x_type)
         self.dropout = Dropout(self.dropout_prob, mode="upscale_in_train")
+        print("========== Here init activation is: ", self.act_method)
         self.activation = getattr(F, self.act_method)
 
     def config(self):
@@ -123,7 +124,9 @@ class TestFusedMultiTransformerOp(OpTest):
 
         self.training = False
 
-        self.layers = 4
+        # self.layers = 4
+        self.layers = 1
+
         self.batch_size = 8
         self.query_length = 128
         self.cache_length = 128
@@ -544,6 +547,7 @@ class TestFusedMultiTransformerOp(OpTest):
             time_step=time_step,
             attn_mask=attn_mask,
             dropout_rate=self.dropout_prob,
+            activation=self.act_method,
             training=self.training,
         )
 
@@ -663,11 +667,13 @@ class TestFusedMultiTransformerOp(OpTest):
             ffn_ln_scales_attr.append(self.ln_w_attr)
             ffn_ln_biases_attr.append(self.ln_b_attr)
 
+        print("Here is Multi transformer, its activation is: ", self.act_method)
         transformer = FusedMultiTransformer(
             self.embed_dim,
             self.num_heads,
             4 * self.embed_dim,
             self.dropout_prob,
+            activation=self.act_method,
             normalize_before=self.pre_layer_norm,
             ln_scale_attrs=ln_scales_attr,
             ln_bias_attrs=ln_biases_attr,
@@ -790,142 +796,144 @@ class TestFusedMultiTransformerOp(OpTest):
         )
 
 
-class TestFusedMultiTransformerOpFp16(TestFusedMultiTransformerOp):
+# class TestFusedMultiTransformerOpFp16(TestFusedMultiTransformerOp):
+# def config(self):
+# super().config()
+# self.x_type = np.float16
+# self.layers = 3  # odd layers
+
+
+class TestFusedMultiTransformerOpActReluFp16(TestFusedMultiTransformerOp):
     def config(self):
         super().config()
         self.x_type = np.float16
-        self.layers = 3  # odd layers
+        # self.act_method = "relu".
+        # self.act_method = "gelu"
+        # self.layers = 3  # odd layers
+        self.layers = 1  # odd layers
 
 
-# class TestFusedMultiTransformerOpActReluFp16(TestFusedMultiTransformerOp):
+# class TestFusedMultiTransformerOpCacheKV(TestFusedMultiTransformerOp):
 #     def config(self):
 #         super().config()
-#         self.x_type = np.float16
-#         self.act_method = "relu"
+#         self.has_cache_kv = True
+#         self.query_length = 1
+#         self.key_length, self.value_length = 1, 1
 #         self.layers = 3  # odd layers
 
 
-class TestFusedMultiTransformerOpCacheKV(TestFusedMultiTransformerOp):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.query_length = 1
-        self.key_length, self.value_length = 1, 1
-        self.layers = 3  # odd layers
+# class TestFusedMultiTransformerOpCacheKVFp16(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.has_cache_kv = True
+#         self.query_length = 1
+#         self.key_length, self.value_length = 1, 1
+#         self.x_type = np.float16
 
 
-class TestFusedMultiTransformerOpCacheKVFp16(TestFusedMultiTransformerOp):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.query_length = 1
-        self.key_length, self.value_length = 1, 1
-        self.x_type = np.float16
+# class TestFusedMultiTransformerOpGenCacheKV(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.has_cache_kv = True
+#         self.gen_cache_kv = True
 
 
-class TestFusedMultiTransformerOpGenCacheKV(TestFusedMultiTransformerOp):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.gen_cache_kv = True
+# class TestFusedMultiTransformerOpGenCacheKVFp16(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.has_cache_kv = True
+#         self.gen_cache_kv = True
+#         self.x_type = np.float16
+#         self.layers = 3  # odd layers
 
 
-class TestFusedMultiTransformerOpGenCacheKVFp16(TestFusedMultiTransformerOp):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.gen_cache_kv = True
-        self.x_type = np.float16
-        self.layers = 3  # odd layers
+# class TestFusedMultiTransformerOpPostLayerNormFp16(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.x_type = np.float16
+#         self.layers = 3  # odd layers
+#         self.pre_layer_norm = False
 
 
-class TestFusedMultiTransformerOpPostLayerNormFp16(TestFusedMultiTransformerOp):
-    def config(self):
-        super().config()
-        self.x_type = np.float16
-        self.layers = 3  # odd layers
-        self.pre_layer_norm = False
+# class TestFusedMultiTransformerOpCacheKVPostLayerNorm(
+#     TestFusedMultiTransformerOp
+# ):
+#     def config(self):
+#         super().config()
+#         self.has_cache_kv = True
+#         self.query_length = 1
+#         self.key_length, self.value_length = 1, 1
+#         self.layers = 3  # odd layers
+#         self.pre_layer_norm = False
 
 
-class TestFusedMultiTransformerOpCacheKVPostLayerNorm(
-    TestFusedMultiTransformerOp
-):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.query_length = 1
-        self.key_length, self.value_length = 1, 1
-        self.layers = 3  # odd layers
-        self.pre_layer_norm = False
+# class TestFusedMultiTransformerOpCacheKVPostLayerNormFp16(
+#     TestFusedMultiTransformerOp
+# ):
+#     def config(self):
+#         super().config()
+#         self.has_cache_kv = True
+#         self.query_length = 1
+#         self.key_length, self.value_length = 1, 1
+#         self.x_type = np.float16
+#         self.pre_layer_norm = False
 
 
-class TestFusedMultiTransformerOpCacheKVPostLayerNormFp16(
-    TestFusedMultiTransformerOp
-):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.query_length = 1
-        self.key_length, self.value_length = 1, 1
-        self.x_type = np.float16
-        self.pre_layer_norm = False
+# class TestFusedMultiTransformerOpGenCacheKVPostLayerNorm(
+#     TestFusedMultiTransformerOp
+# ):
+#     def config(self):
+#         super().config()
+#         self.has_cache_kv = True
+#         self.gen_cache_kv = True
+#         self.pre_layer_norm = False
 
 
-class TestFusedMultiTransformerOpGenCacheKVPostLayerNorm(
-    TestFusedMultiTransformerOp
-):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.gen_cache_kv = True
-        self.pre_layer_norm = False
+# class TestFusedMultiTransformerOpGenCacheKVPostLayerNormFp16(
+#     TestFusedMultiTransformerOp
+# ):
+#     def config(self):
+#         super().config()
+#         self.has_cache_kv = True
+#         self.gen_cache_kv = True
+#         self.x_type = np.float16
+#         self.layers = 3  # odd layers
+#         self.pre_layer_norm = False
 
 
-class TestFusedMultiTransformerOpGenCacheKVPostLayerNormFp16(
-    TestFusedMultiTransformerOp
-):
-    def config(self):
-        super().config()
-        self.has_cache_kv = True
-        self.gen_cache_kv = True
-        self.x_type = np.float16
-        self.layers = 3  # odd layers
-        self.pre_layer_norm = False
+# class TestFusedMultiTransformerOpPreCache(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.has_pre_cache = True
+#         self.x_type = np.float16
 
 
-class TestFusedMultiTransformerOpPreCache(TestFusedMultiTransformerOp):
-    def config(self):
-        super().config()
-        self.has_pre_cache = True
-        self.x_type = np.float16
+# class TestFusedMultiTransformerOpPreCacheStatic(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.has_pre_cache = True
+#         self.has_attn_mask = False
+#         self.x_type = np.float32
+#         self.weight_attr = paddle.ParamAttr(
+#             initializer=paddle.fluid.initializer.Constant(0.0)
+#         )
+#         self.bias_attr = paddle.ParamAttr(
+#             initializer=paddle.fluid.initializer.Constant(0.0005)
+#         )
+#         self.ln_w_attr = paddle.ParamAttr(
+#             initializer=paddle.fluid.initializer.Constant(1.0)
+#         )
+#         self.ln_b_attr = paddle.ParamAttr(
+#             initializer=paddle.fluid.initializer.Constant(0.0)
+#         )
 
+#     def test_fused_multi_transformer_op(self):
+#         final_out_ref = self.GetBaselineOut()
+#         final_out = self.GetFusedMultiTransformerOutStatic()
 
-class TestFusedMultiTransformerOpPreCacheStatic(TestFusedMultiTransformerOp):
-    def config(self):
-        super().config()
-        self.has_pre_cache = True
-        self.has_attn_mask = False
-        self.x_type = np.float32
-        self.weight_attr = paddle.ParamAttr(
-            initializer=paddle.fluid.initializer.Constant(0.0)
-        )
-        self.bias_attr = paddle.ParamAttr(
-            initializer=paddle.fluid.initializer.Constant(0.0005)
-        )
-        self.ln_w_attr = paddle.ParamAttr(
-            initializer=paddle.fluid.initializer.Constant(1.0)
-        )
-        self.ln_b_attr = paddle.ParamAttr(
-            initializer=paddle.fluid.initializer.Constant(0.0)
-        )
-
-    def test_fused_multi_transformer_op(self):
-        final_out_ref = self.GetBaselineOut()
-        final_out = self.GetFusedMultiTransformerOutStatic()
-
-        np.testing.assert_allclose(
-            final_out_ref, final_out, rtol=self.rtol, atol=self.atol
-        )
+#         np.testing.assert_allclose(
+#             final_out_ref, final_out, rtol=self.rtol, atol=self.atol
+#         )
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
@@ -797,6 +797,14 @@ class TestFusedMultiTransformerOpFp16(TestFusedMultiTransformerOp):
         self.layers = 3  # odd layers
 
 
+# class TestFusedMultiTransformerOpActReluFp16(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.x_type = np.float16
+#         self.act_method = "relu"
+#         self.layers = 3  # odd layers
+
+
 class TestFusedMultiTransformerOpCacheKV(TestFusedMultiTransformerOp):
     def config(self):
         super().config()

--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_op.py
@@ -796,21 +796,21 @@ class TestFusedMultiTransformerOp(OpTest):
         )
 
 
-# class TestFusedMultiTransformerOpFp16(TestFusedMultiTransformerOp):
-# def config(self):
-# super().config()
-# self.x_type = np.float16
-# self.layers = 3  # odd layers
-
-
-class TestFusedMultiTransformerOpActReluFp16(TestFusedMultiTransformerOp):
+class TestFusedMultiTransformerOpFp16(TestFusedMultiTransformerOp):
     def config(self):
         super().config()
         self.x_type = np.float16
-        # self.act_method = "relu".
-        # self.act_method = "gelu"
-        # self.layers = 3  # odd layers
-        self.layers = 1  # odd layers
+        self.layers = 3  # odd layers
+
+
+# class TestFusedMultiTransformerOpActReluFp16(TestFusedMultiTransformerOp):
+#     def config(self):
+#         super().config()
+#         self.x_type = np.float16
+#         # self.act_method = "relu".
+#         # self.act_method = "gelu"
+#         # self.layers = 3  # odd layers
+#         self.layers = 1  # odd layers
 
 
 # class TestFusedMultiTransformerOpCacheKV(TestFusedMultiTransformerOp):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe
1. Fix cublasFusedMLP bug(sry for that silly bug)
2. Get `act_method` attribute to set other activation in FFN such as ReLU, GeLU

单测新增了relu激活的测试，并且调整输入范围在-1, 1的uniform分布

Bug 原因，FLAGS_gemm_use_half_precision_compute_type默认为true，而FasterTransformer在fp16下，会设置scale_type, compute_type=fp16，相比fp32累加速度会更快，但是这么设置在单测下很容易溢出，单测不对，后续使用需要注意。

此外发现zhenyu的 MMHA 在fp16下累加也有类似精度问题，待修复

简单来说这两个选项只适合刷榜用
