### PR TITLE
[Paddle Inference]fix loopup_table plugin deserialize size error

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/lookup_table.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/lookup_table.cu
@@ -98,9 +98,11 @@ LookupTablePluginDynamic::LookupTablePluginDynamic(void const* data,
   deserialize_value(&data, &length, &mWeightSize);
   deserialize_value(&data, &length, &mWeightWidth);
   char const* d = static_cast<char const*>(data);
-  cudaMalloc(&mWeightDev, mWeightSize * sizeof(mType));
-  cudaMemcpy(
-      mWeightDev, d, mWeightSize * sizeof(mType), cudaMemcpyHostToDevice);
+  cudaMalloc(&mWeightDev, mWeightSize * getElementSize(mType));
+  cudaMemcpy(mWeightDev,
+             d,
+             mWeightSize * getElementSize(mType),
+             cudaMemcpyHostToDevice);
 }
 
 // IPluginV2DynamicExt Methods

--- a/paddle/fluid/inference/tensorrt/plugin/lookup_table.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/lookup_table.cu
@@ -103,6 +103,7 @@ LookupTablePluginDynamic::LookupTablePluginDynamic(void const* data,
              d,
              mWeightSize * getElementSize(mType),
              cudaMemcpyHostToDevice);
+
 }
 
 // IPluginV2DynamicExt Methods

--- a/paddle/fluid/inference/tensorrt/plugin/lookup_table.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/lookup_table.cu
@@ -98,9 +98,9 @@ LookupTablePluginDynamic::LookupTablePluginDynamic(void const* data,
   deserialize_value(&data, &length, &mWeightSize);
   deserialize_value(&data, &length, &mWeightWidth);
   char const* d = static_cast<char const*>(data);
-  cudaMalloc(&mWeightDev, mWeightSize * sizeof(mType));
+  cudaMalloc(&mWeightDev, mWeightSize * getElementSize(mType));
   cudaMemcpy(
-      mWeightDev, d, mWeightSize * sizeof(mType), cudaMemcpyHostToDevice);
+      mWeightDev, d, mWeightSize * getElementSize(mType), cudaMemcpyHostToDevice);
 }
 
 // IPluginV2DynamicExt Methods


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
use getElementSize to get type size instead of sizeof which may case diff in size between serialize and deserialize in LookupTablePluginDynamic