### PR TITLE
remove triu from fluid

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -68,7 +68,6 @@ __all__ = [
     'zeros_like',
     'ones_like',
     'diag',
-    'triu',
 ]
 
 
@@ -1830,10 +1829,3 @@ def ones_like(x, out=None):
         outputs={'Out': [out]},
     )
     return out
-
-
-@deprecated(since="2.0.0", update_to="paddle.triu")
-def triu(input, diagonal=0, name=None):
-    import paddle
-
-    return paddle.tensor.triu(x=input, diagonal=diagonal, name=name)

--- a/python/paddle/fluid/tests/unittests/mlu/test_tril_triu_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_tril_triu_op_mlu.py
@@ -184,7 +184,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
             with program_guard(prog, startup_prog):
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = fluid.data(shape=[1, 9, -1, 4], dtype=dtype, name='x')
-                triu_out = fluid.layers.triu(x)
+                triu_out = tensor.triu(x)
 
                 place = fluid.MLUPlace(0)
                 exe = fluid.Executor(place)

--- a/python/paddle/fluid/tests/unittests/mlu/test_tril_triu_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_tril_triu_op_mlu.py
@@ -184,7 +184,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
             with program_guard(prog, startup_prog):
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = fluid.data(shape=[1, 9, -1, 4], dtype=dtype, name='x')
-                triu_out = tensor.triu(x)
+                triu_out = paddle.triu(x)
 
                 place = fluid.MLUPlace(0)
                 exe = fluid.Executor(place)

--- a/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
@@ -185,7 +185,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
             with program_guard(prog, startup_prog):
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = fluid.data(shape=[1, 9, -1, 4], dtype=dtype, name='x')
-                triu_out = tensor.triu(x)
+                triu_out = paddle.triu(x)
 
                 place = fluid.NPUPlace(0)
                 exe = fluid.Executor(place)

--- a/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
@@ -185,7 +185,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
             with program_guard(prog, startup_prog):
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = fluid.data(shape=[1, 9, -1, 4], dtype=dtype, name='x')
-                triu_out = fluid.layers.triu(x)
+                triu_out = tensor.triu(x)
 
                 place = fluid.NPUPlace(0)
                 exe = fluid.Executor(place)

--- a/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
@@ -183,7 +183,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
             with program_guard(prog, startup_prog):
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = fluid.data(shape=[1, 9, -1, 4], dtype=dtype, name='x')
-                triu_out = tensor.triu(x)
+                triu_out = paddle.triu(x)
 
                 place = (
                     fluid.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
@@ -183,7 +183,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
             with program_guard(prog, startup_prog):
                 data = np.random.random([1, 9, 9, 4]).astype(dtype)
                 x = fluid.data(shape=[1, 9, -1, 4], dtype=dtype, name='x')
-                triu_out = fluid.layers.triu(x)
+                triu_out = tensor.triu(x)
 
                 place = (
                     fluid.CUDAPlace(0)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
To clean the code in paddle.fluid, the useless codes should be removed and code still be used should move to a new position.

For function paddle.fluid.layers.tensor.triu, since it is not used in version 2.x, should be removed.
