### PR TITLE
Allow to specify train_bs and eval_bs separately in hapi.fit() to release 2.4

### DIFF
--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1867,8 +1867,8 @@ class Model(object):
                  len(batch_size) == 2
              ), "batch_size length error, expected train_batch_size and eval_batch_size."
              train_batch_size, eval_batch_size = batch_size
-         elif isinstance(batch_size, int):
-             train_batch_size, eval_batch_size = batch_size, batch_size
+        elif isinstance(batch_size, int):
+            train_batch_size, eval_batch_size = batch_size, batch_size
         
         if isinstance(train_data, Dataset):
             train_sampler = DistributedBatchSampler(

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -300,6 +300,8 @@ class TestModel(unittest.TestCase):
         result = model.evaluate(self.val_dataset,
                                 batch_size=64,
                                 num_iters=num_iters)
+        
+        model.fit(self.train_dataset, batch_size=(64, 64), shuffle=False)
 
         train_sampler = DistributedBatchSampler(self.train_dataset,
                                                 batch_size=64,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs, Docs

### Describe
<!-- Describe what this PR does -->

Cherry-pick from https://github.com/PaddlePaddle/Paddle/pull/48032