### PR TITLE
offload_params

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -704,7 +704,23 @@ if(TENSORRT_FOUND)
          feed_fetch_method
          graph_to_program_pass
          variable_helper
-         tensorrt_engine_op)
+         tensorrt_engine_op
+         sched_layers_pool)
+elseif(WITH_GPU)
+  cc_library(
+    naive_executor
+    SRCS naive_executor.cc
+    DEPS op_registry
+         denormal
+         device_context
+         scope
+         framework_proto
+         glog
+         lod_rank_table
+         feed_fetch_method
+         graph_to_program_pass
+         variable_helper
+         sched_layers_pool)
 else()
   cc_library(
     naive_executor
@@ -783,7 +799,8 @@ if(WITH_DISTRIBUTE)
            monitor
            heter_service_proto
            fleet_executor
-           ${BRPC_DEP})
+           ${BRPC_DEP}
+           sched_layers_pool)
     set(DISTRIBUTE_COMPILE_FLAGS
         "-Wno-non-virtual-dtor -Wno-error=non-virtual-dtor -Wno-error=delete-non-virtual-dtor -Wno-error=parentheses"
     )
@@ -867,7 +884,8 @@ if(WITH_DISTRIBUTE)
            heter_server
            brpc
            fleet_executor
-           flags)
+           flags
+           sched_layers_pool)
     set(DISTRIBUTE_COMPILE_FLAGS
         "-Wno-non-virtual-dtor -Wno-error=non-virtual-dtor -Wno-error=delete-non-virtual-dtor -Wno-error=parentheses"
     )
@@ -938,7 +956,8 @@ if(WITH_DISTRIBUTE)
            variable_helper
            timer
            monitor
-           fleet_executor)
+           fleet_executor
+           sched_layers_pool)
   endif()
 elseif(WITH_PSLIB)
   set(DISTRIBUTE_COMPILE_FLAGS
@@ -1001,7 +1020,8 @@ elseif(WITH_PSLIB)
          timer
          monitor
          fleet_executor
-         ${BRPC_DEP})
+         ${BRPC_DEP}
+         sched_layers_pool)
 else()
   cc_library(
     executor
@@ -1048,7 +1068,8 @@ else()
          variable_helper
          timer
          monitor
-         fleet_executor)
+         fleet_executor
+         sched_layers_pool)
 endif()
 
 target_link_libraries(executor while_op_helper executor_gc_helper
@@ -1248,3 +1269,10 @@ cc_test(
   DEPS phi_utils)
 
 cc_test(convert_utils_test SRCS convert_utils_test.cc)
+
+if(WITH_GPU)
+  cc_library(
+    sched_layers_pool
+    SRCS sched_layers_pool.cc
+    DEPS op_registry phi_tensor device_context)
+endif()

--- a/paddle/fluid/framework/executor.cc
+++ b/paddle/fluid/framework/executor.cc
@@ -69,7 +69,9 @@ ExecutorPrepareContext::~ExecutorPrepareContext() {
   VLOG(5) << "destroy ExecutorPrepareContext";
 }
 
-Executor::Executor(const platform::Place& place) : place_(place) {}
+Executor::Executor(const platform::Place& place) : place_(place) {
+  sched_layer_pools_ = &framework::VectorSchedLayersPool::Instance();
+}
 
 Executor::~Executor() {
 #ifdef PADDLE_WITH_MKLDNN
@@ -486,7 +488,6 @@ void Executor::RunPartialPreparedContext(ExecutorPrepareContext* ctx,
     }
     CreateVariables(ctx->prog_, local_scope, ctx->block_id_);
   }
-
   int64_t max_memory_size = GetEagerDeletionThreshold();
   std::unique_ptr<GarbageCollector> gc;
   if (!ctx->force_disable_gc_ && max_memory_size >= 0) {
@@ -561,16 +562,56 @@ void Executor::RunPartialPreparedContext(ExecutorPrepareContext* ctx,
 #endif
     }
   }
-
+#if defined(PADDLE_WITH_CUDA)
+  if (ctx->block_id_ < sched_layer_pools_->Size() &&
+      sched_layer_pools_->Get(ctx->block_id_).IsValid())
+    sched_layer_pools_->Get(ctx->block_id_).FillPool();
+#endif
   for (int64_t i = start_op_index; i < end_op_index; ++i) {
     auto& op = ctx->ops_[i];
+    // LOG(INFO) << "Run i " << i << ", " << op->Type();
+#if defined(PADDLE_WITH_CUDA)
+    if (ctx->block_id_ < sched_layer_pools_->Size() &&
+        sched_layer_pools_->Get(ctx->block_id_).IsValid()) {
+      if (!sched_layer_pools_->Get(ctx->block_id_).IsSchedLayer(i)) {
+        op->Run(*local_scope, place_);
+      } else {
+        // sched_layer_pools_->Get(ctx->block_id_).Debug();
+        sched_layer_pools_->Get(ctx->block_id_).FillPool();
+        // sched_layer_pools_->Get(ctx->block_id_).Debug();
+        size_t buf_id =
+            sched_layer_pools_->Get(ctx->block_id_).active_layers_[i];
+        cudaStreamWaitEvent(
+            sched_layer_pools_->Get(ctx->block_id_).kernel_run_stream_,
+            sched_layer_pools_->Get(ctx->block_id_).buffer_nodes_[buf_id].event,
+            0);
+        op->Run(*local_scope, place_);
+        cudaEventRecord(
+            sched_layer_pools_->Get(ctx->block_id_).buffer_nodes_[buf_id].event,
+            sched_layer_pools_->Get(ctx->block_id_).kernel_run_stream_);
+        sched_layer_pools_->Get(ctx->block_id_)
+            .buffer_nodes_[buf_id]
+            .ResetBuffer();
+      }
+    } else {
+      op->Run(*local_scope, place_);
+    }
+#else
     op->Run(*local_scope, place_);
+#endif
+
     if (gc) {
       platform::RecordEvent record(
           "CheckGC", platform::TracerEventType::UserDefined, 10);
       DeleteUnusedTensors(*local_scope, op.get(), ctx->unused_vars_, gc.get());
     }
   }
+
+#if defined(PADDLE_WITH_CUDA)
+  if (ctx->block_id_ < sched_layer_pools_->Size() &&
+      sched_layer_pools_->Get(ctx->block_id_).IsValid())
+    sched_layer_pools_->Get(ctx->block_id_).Reset();
+#endif
 
   auto callback = [scope, local_scope, keep_kids]() {
     if (local_scope != scope) {

--- a/paddle/fluid/framework/executor.h
+++ b/paddle/fluid/framework/executor.h
@@ -28,6 +28,10 @@ limitations under the License. */
 #include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/platform/device_context.h"
 
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/fluid/framework/sched_layers_pool.h"
+#endif
+
 namespace paddle {
 namespace framework {
 
@@ -158,6 +162,7 @@ class Executor {
 
  private:
   const platform::Place place_;
+  framework::VectorSchedLayersPool* sched_layer_pools_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/naive_executor.h
+++ b/paddle/fluid/framework/naive_executor.h
@@ -26,6 +26,10 @@
 #include "paddle/fluid/platform/device_context.h"
 #include "paddle/fluid/platform/place.h"
 
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/fluid/framework/sched_layers_pool.h"
+#endif
+
 namespace paddle {
 namespace framework {
 
@@ -40,7 +44,9 @@ class NaiveExecutor {
  public:
   using HookFunc = std::function<void(OperatorBase*)>;
 
-  explicit NaiveExecutor(const platform::Place& place) : place_(place) {}
+  explicit NaiveExecutor(const platform::Place& place) : place_(place) {
+    sched_layer_pools_ = &framework::VectorSchedLayersPool::Instance();
+  }
 
   ~NaiveExecutor();
 
@@ -92,6 +98,10 @@ class NaiveExecutor {
   std::unordered_map<OperatorBase*, std::unordered_map<phi::DenseTensor*, int>>
       reuse_cache_;
   std::vector<phi::DenseTensor*> cluster_buffer_;
+
+#if defined(PADDLE_WITH_CUDA)
+  VectorSchedLayersPool* sched_layer_pools_;
+#endif
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/sched_layers_pool.cc
+++ b/paddle/fluid/framework/sched_layers_pool.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/sched_layers_pool.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
+namespace paddle {
+
+namespace framework {
+
+void ResourceHolder::mutable_data(size_t required_size) {
+  platform::CUDAPlace place(platform::GetCurrentDeviceId());
+  tensor_.mutable_data(
+      place, paddle::experimental::DataType::FLOAT32, required_size);
+}
+
+Buffer::Buffer(size_t required_size) {
+  gpu_resource.mutable_data(required_size);
+  cudaEventCreate(&event);
+}
+
+Buffer::~Buffer() {}
+
+SchedLayersPool::~SchedLayersPool() { cudaStreamDestroy(load_stream_); }
+
+void SchedLayersPool::Transfer(const phi::DenseTensor& src,
+                               phi::DenseTensor* dst,
+                               size_t n,
+                               cudaStream_t stream) {
+  cudaMemcpyAsync(dst->data(), src.data(), n, cudaMemcpyHostToDevice, stream);
+}
+void SchedLayersPool::Init(size_t init_size,
+                           const std::list<OpIdx2ParamsTensors>& weights_queue,
+                           const std::vector<size_t>& sched_layers) {
+  paddle::platform::DeviceContextPool& pool =
+      paddle::platform::DeviceContextPool::Instance();
+  platform::Place place = platform::CUDAPlace(platform::GetCurrentDeviceId());
+  auto* dev_ctx_ = static_cast<phi::GPUContext*>(pool.Get(place));
+  kernel_run_stream_ = dev_ctx_->stream();
+  cudaStreamCreateWithFlags(&load_stream_, cudaStreamNonBlocking);
+
+  is_valied_ = true;
+  buffer_nodes_.reserve(2);
+  for (size_t i = 0; i < 2u; i++) {
+    buffer_nodes_.push_back(Buffer(init_size));
+  }
+
+  weights_queue_ = weights_queue;
+  weights_queue_cpy_ = weights_queue;
+  sched_layers_ = sched_layers;
+
+  for (auto& pair : weights_queue_) {
+    CHECK_EQ(pair.second.first.size(), pair.second.second.size());
+    for (size_t i = 0; i < pair.second.first.size(); i++) {
+      CHECK_EQ(pair.second.first[i]->numel(), pair.second.second[i]->numel());
+      CHECK_EQ(pair.second.first[i]->dtype(), pair.second.second[i]->dtype());
+    }
+  }
+}
+
+void SchedLayersPool::FillPool() {
+  // fill free node
+  for (size_t i = 0; i < buffer_nodes_.size(); i++) {
+    if (weights_queue_.empty()) return;
+    if (buffer_nodes_[i].free) {
+      OpIdx2ParamsTensors op_params_info = weights_queue_.front();
+      weights_queue_.pop_front();
+      buffer_nodes_[i].layer_id = op_params_info.first;
+      cudaStreamWaitEvent(load_stream_, buffer_nodes_[i].event, 0);
+      for (size_t j = 0; j < op_params_info.second.first.size(); j++) {
+        auto* src_tensor = op_params_info.second.first[j];
+        auto* dst_tensor = op_params_info.second.second[j];
+        dst_tensor->set_type(src_tensor->dtype());
+        dst_tensor->Resize(src_tensor->dims());
+        buffer_nodes_[i].gpu_resource.PartionMemoryTo(
+            dst_tensor, dst_tensor->numel() * SizeOf(dst_tensor->dtype()));
+        Transfer(*src_tensor,
+                 dst_tensor,
+                 src_tensor->numel() * SizeOf(src_tensor->dtype()),
+                 load_stream_);
+      }
+      cudaEventRecord(buffer_nodes_[i].event, load_stream_);
+      buffer_nodes_[i].free = false;
+      active_layers_[buffer_nodes_[i].layer_id] = i;
+    }
+  }
+}
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/sched_layers_pool.h
+++ b/paddle/fluid/framework/sched_layers_pool.h
@@ -1,0 +1,140 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <list>
+
+#include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/tensor_utils.h"
+
+namespace paddle {
+
+namespace framework {
+
+using OpIdx2ParamsTensors = std::pair<
+    size_t,
+    std::pair<std::vector<phi::DenseTensor*>, std::vector<phi::DenseTensor*>>>;
+
+struct ResourceHolder {
+  ResourceHolder() {}
+
+  void mutable_data(size_t required_size);
+
+  void InitOffset() { tensor_.set_offset(0); }
+
+  void PartionMemoryTo(phi::DenseTensor* tensor, size_t byte_size) {
+    auto& holder = phi::DenseTensorUtils::GetHolder(tensor_);
+    tensor->set_offset(tensor_.offset());
+    tensor->ResetHolder(holder);
+    tensor_.set_offset(tensor_.offset() + byte_size);
+  }
+  phi::DenseTensor tensor_;
+};
+
+struct Buffer {
+  explicit Buffer(size_t required_size);
+
+  ~Buffer();
+
+  void ResetBuffer() {
+    free = true;
+    gpu_resource.InitOffset();
+  }
+
+  ResourceHolder gpu_resource;
+  size_t layer_id;
+  bool free{true};
+  cudaEvent_t event;
+};
+
+class SchedLayersPool {
+ public:
+  ~SchedLayersPool();
+
+  void Init(size_t init_size,
+            const std::list<OpIdx2ParamsTensors>& weights_queue,
+            const std::vector<size_t>& sched_layers);
+
+  bool IsValid() { return is_valied_; }
+
+  void Transfer(const phi::DenseTensor& src,
+                phi::DenseTensor* dst,
+                size_t n,
+                cudaStream_t stream);
+
+  void FillPool();
+
+  bool IsSchedLayer(size_t layer_idx) {
+    auto find =
+        std::find(sched_layers_.begin(), sched_layers_.end(), layer_idx);
+    return find != sched_layers_.end();
+  }
+
+  void Debug() {
+    LOG(INFO) << "buf id 0: free?: " << buffer_nodes_[0].free
+              << ", layer_id: " << buffer_nodes_[0].layer_id;
+    LOG(INFO) << "buf id 1: free?: " << buffer_nodes_[1].free
+              << ", layer_id: " << buffer_nodes_[1].layer_id;
+  }
+
+  void Reset() { weights_queue_ = weights_queue_cpy_; }
+
+ public:
+  // layer id to buffer id
+  std::map<size_t, size_t> active_layers_;
+  std::vector<Buffer> buffer_nodes_;
+  cudaStream_t kernel_run_stream_;
+
+ private:
+  std::list<OpIdx2ParamsTensors> weights_queue_;
+  std::list<OpIdx2ParamsTensors> weights_queue_cpy_;
+  std::vector<size_t> sched_layers_;
+  cudaStream_t load_stream_;
+
+  bool is_valied_{false};
+};
+
+class VectorSchedLayersPool {
+ public:
+  static VectorSchedLayersPool& Instance() {
+    static VectorSchedLayersPool instance;
+    return instance;
+  }
+
+  ~VectorSchedLayersPool() {
+    for (auto* ptr : sched_layers_pools) delete ptr;
+  }
+
+  void Init(size_t idx,
+            size_t init_size,
+            const std::list<OpIdx2ParamsTensors>& weights_queue,
+            const std::vector<size_t>& sched_layers) {
+    sched_layers_pools[idx]->Init(init_size, weights_queue, sched_layers);
+  }
+
+  SchedLayersPool& Get(size_t idx) { return *sched_layers_pools[idx]; }
+
+  size_t Size() { return sched_layers_pools.size(); }
+
+ private:
+  std::vector<SchedLayersPool*> sched_layers_pools;
+  VectorSchedLayersPool() {
+    sched_layers_pools.push_back(new SchedLayersPool());
+    sched_layers_pools.push_back(new SchedLayersPool());
+  }
+};
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -377,6 +377,11 @@ struct Argument {
   DECL_ARGUMENT_FIELD(custom_device_type, CustomDeviceType, std::string);
   DECL_ARGUMENT_FIELD(custom_device_id, CustomDeviceId, int);
 
+  // memory limit filed
+  DECL_ARGUMENT_FIELD(memory_limit, MemoryLimit, int64_t);
+  DECL_ARGUMENT_FIELD(pin_memory, UsePinMemory, bool);
+  DECL_ARGUMENT_FIELD(fixedlayer_algorithm, FixedLayerAlgorithm, int);
+
  private:
   std::unordered_set<std::string> valid_fields_;
 };

--- a/paddle/fluid/inference/analysis/passes/CMakeLists.txt
+++ b/paddle/fluid/inference/analysis/passes/CMakeLists.txt
@@ -30,7 +30,10 @@ cc_library(
   inference_op_replace_pass
   SRCS inference_op_replace_pass.cc
   DEPS analysis_pass graph_to_program_pass)
-
+cc_library(
+  offload_params_pass
+  SRCS offload_params_pass.cc
+  DEPS analysis_pass graph_to_program_pass)
 cc_library(
   analysis_passes
   SRCS passes.cc
@@ -41,7 +44,8 @@ cc_library(
        memory_optim_pass
        convert_to_mixed_precision
        inference_op_replace_pass
-       ir_graph_to_program_pass)
+       ir_graph_to_program_pass
+       offload_params_pass)
 
 set(analysis_deps
     ${analysis_deps} analysis_passes subgraph_detector

--- a/paddle/fluid/inference/analysis/passes/offload_params_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/offload_params_pass.cc
@@ -1,0 +1,509 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/inference/analysis/passes/offload_params_pass.h"
+
+#include <string>
+#include <unordered_set>
+
+#include "paddle/fluid/framework/framework.pb.h"
+#include "paddle/fluid/framework/ir/graph_helper.h"
+#include "paddle/fluid/framework/lod_tensor.h"
+#include "paddle/fluid/framework/sched_layers_pool.h"
+#include "paddle/fluid/framework/tensor_util.h"
+
+namespace paddle {
+namespace inference {
+namespace analysis {
+
+#if defined(PADDLE_WITH_CUDA)
+std::pair<std::vector<size_t>, std::vector<size_t>> DivideLayer(
+    std::map<size_t, std::vector<phi::DenseTensor *>>
+        &op_idx_2_params_tensors,  // NOLINT
+    std::map<size_t, std::vector<std::string>>
+        &op_idx_2_params_var_names,                                // NOLINT
+    std::map<size_t, std::string> &op_idx_2_op_name,               // NOLINT
+    std::map<std::string, phi::DenseTensor *> &varname_2_tensor,   // NOLINT
+    std::vector<std::pair<size_t, size_t>> &op_idx_2_params_size,  // NOLINT
+    std::map<std::string, size_t> varname_2_varsize,               // NOLINT
+    std::unordered_set<std::string> &fixed_vars,                   // NOLINT
+    long long rest_memory,                                         // NOLINT
+    int fixedlayer_algorithm,
+    size_t &buffer_size) {  // NOLINT
+
+  std::vector<size_t> fixed_layers;
+  std::vector<size_t> sched_layers;
+
+  // 下面根据不同的方式来划分 fixed_layers
+  // fixedlayer_algorithm == 0 优先把权重较大的 op 划入 fixed layer
+  // fixedlayer_algorithm == 1 优先把权重较小的 op 划入 fixed layer
+  if (fixedlayer_algorithm == 0 || fixedlayer_algorithm == 1) {
+    if (fixedlayer_algorithm == 0) {
+      std::sort(op_idx_2_params_size.begin(),
+                op_idx_2_params_size.end(),
+                [](std::pair<size_t, size_t> &a, std::pair<size_t, size_t> &b) {
+                  return a.second > b.second;
+                });
+    }
+    if (fixedlayer_algorithm == 1) {
+      std::sort(op_idx_2_params_size.begin(),
+                op_idx_2_params_size.end(),
+                [](std::pair<size_t, size_t> &a, std::pair<size_t, size_t> &b) {
+                  return a.second < b.second;
+                });
+    }
+    size_t i = 0;
+    while (i < op_idx_2_params_size.size()) {
+      auto &pair = op_idx_2_params_size[i];
+      for (auto var_name : op_idx_2_params_var_names.at(pair.first)) {
+        if (!fixed_vars.count(var_name)) {
+          rest_memory -= varname_2_varsize.at(var_name);
+        }
+      }
+      if (rest_memory >= 0) {
+        fixed_layers.push_back(pair.first);
+        fixed_vars.insert(op_idx_2_params_var_names.at(pair.first).begin(),
+                          op_idx_2_params_var_names.at(pair.first).end());
+      } else {
+        break;
+      }
+      i++;
+    }
+
+    for (; i < op_idx_2_params_size.size(); i++) {
+      if (op_idx_2_params_size[i].second > buffer_size)
+        buffer_size = op_idx_2_params_size[i].second;
+      sched_layers.push_back(op_idx_2_params_size[i].first);
+    }
+  } else if (fixedlayer_algorithm == 2) {
+    // 专门针对 transformer 模型
+    std::vector<size_t> fused_multi_transformer_op_idx;
+    std::map<size_t, size_t>fused_multi_transformer_op_idx_2_params_size;
+    for(auto op_idx_and_params_size : op_idx_2_params_size) {
+      auto idx = op_idx_and_params_size.first;
+      auto params_size = op_idx_and_params_size.second;
+      if(op_idx_2_op_name.at(idx) == "fused_multi_transformer") {
+        fused_multi_transformer_op_idx.push_back(idx);
+        LOG(INFO) << "idx: " << idx;
+        fused_multi_transformer_op_idx_2_params_size[idx] = params_size;
+      } else {
+        fixed_layers.push_back(idx);
+        fixed_vars.insert(op_idx_2_params_var_names.at(idx).begin(),
+                          op_idx_2_params_var_names.at(idx).end());
+      }
+      buffer_size = 402792448;
+      
+    }
+    auto max_fixed = std::min(size_t(rest_memory / buffer_size), fused_multi_transformer_op_idx.size());
+    LOG(INFO) << "max_fixed: " << max_fixed << ", total fused transformer layers: " << fused_multi_transformer_op_idx.size();
+    auto scheduled_layers = fused_multi_transformer_op_idx.size() - max_fixed;
+    /*
+    max_fixed = min(max_fixed, total_layers)
+    scheduled_layers = total_layers - max_fixed
+    vals = [(i + 1) * scheduled_layers // total_layers for i in range(total_layers)]
+    ret : List[int] = []
+    last_v = 0
+    for i, v in enumerate(vals):
+        if v == last_v:
+            ret.append(i)
+        else:
+            last_v = v
+    return ret
+    */
+    std::vector<size_t> vals;
+    for (size_t i = 0; i < fused_multi_transformer_op_idx.size(); i++) {
+      vals.push_back((i + 1) * scheduled_layers / fused_multi_transformer_op_idx.size());
+    }
+
+    std::cout << "vals: ";
+    for(auto i : vals)
+      std::cout << i << " ";
+    std::cout << std::endl;
+
+    std::vector<size_t> tmp;
+    size_t last_v = 0;
+    for(size_t i = 0; i < vals.size(); i++) {
+      auto v = vals[i];
+      if(v == last_v)
+        tmp.push_back(i);
+      else
+        last_v = v;
+    }
+
+    std::cout << "tmp: ";
+    for(auto i : tmp)
+      std::cout << i << " ";
+    std::cout << std::endl;
+
+    for(size_t i = 0; i < tmp.size(); i++) {
+      auto fixed_layer = fused_multi_transformer_op_idx.at(tmp.at(i));
+      fixed_layers.push_back(fixed_layer);
+      fixed_vars.insert(op_idx_2_params_var_names.at(fixed_layer).begin(),
+                          op_idx_2_params_var_names.at(fixed_layer).end());
+    }
+    for (auto i : fused_multi_transformer_op_idx) {
+      if(std::find(fixed_layers.begin(),
+                  fixed_layers.end(),
+                  i) == fixed_layers.end()) {
+        sched_layers.push_back(i);    
+      }
+    }
+  } else {
+    CHECK(false) << "fixedlayer_algorithm invalid";
+  }
+
+  LOG(INFO) << "fixed_vars: " << fixed_vars.size();
+  LOG(INFO) << "fixed_layers: " << fixed_layers.size();
+  for (size_t i : fixed_layers) {
+    std::cout << i << " ";
+  }
+  std::cout << std::endl;
+
+  std::sort(sched_layers.begin(), sched_layers.end());
+  LOG(INFO) << "sched_layers: " << sched_layers.size();
+  for (auto i : sched_layers) {
+    std::cout << i << " ";
+  }
+  std::cout << std::endl;
+
+  return std::pair<std::vector<size_t>, std::vector<size_t>>(fixed_layers,
+                                                             sched_layers);
+}
+
+void CopyFixedlyer2Gpu(
+    std::vector<size_t> &fixed_layers,  // NOLINT
+    std::map<size_t, std::vector<std::string>>
+        &op_idx_2_params_var_names,                               // NOLINT
+    std::map<std::string, phi::DenseTensor *> &varname_2_tensor,  // NOLINT
+    std::unordered_set<std::string> &copy_completed_fixed_vars,   // NOLINT
+    platform::Place &place) {                                     // NOLINT
+  size_t avail = 0;
+  size_t total = 0;
+  cudaSetDevice(platform::GetCurrentDeviceId());
+  cudaMemGetInfo(&avail, &total);
+  LOG(INFO) << "Before fixed_layers copy, used mem: "
+            << (total - avail) / 1024 / 1024 << "MiB";
+
+  for (size_t layer : fixed_layers) {
+    for (auto var_name : op_idx_2_params_var_names[layer]) {
+      if (copy_completed_fixed_vars.count(var_name)) continue;
+      // LOG(INFO) << "copy var_name: " << var_name;
+      copy_completed_fixed_vars.insert(var_name);
+      auto *t = varname_2_tensor.at(var_name);
+      platform::CPUPlace cpu_place;
+      phi::DenseTensor temp_tensor;
+      temp_tensor.Resize(t->dims());
+      paddle::framework::TensorCopySync(*t, cpu_place, &temp_tensor);
+      t->clear();
+      paddle::framework::TensorCopySync(temp_tensor, place, t);
+    }
+    // cudaSetDevice(platform::GetCurrentDeviceId());
+    // cudaMemGetInfo(&avail, &total);
+    // LOG(INFO) << "After layer idx_" << layer
+    //           << "_copy, used mem: " << (total - avail) / 1024 / 1024 << "MiB";
+  }
+  cudaSetDevice(platform::GetCurrentDeviceId());
+  cudaMemGetInfo(&avail, &total);
+  LOG(INFO) << "After fixed_layers copy, used mem: "
+            << (total - avail) / 1024 / 1024 << "MiB";
+}
+
+std::list<framework::OpIdx2ParamsTensors> CopySchedlyer2Cpu(
+    std::vector<size_t> &sched_layers,  // NOLINT
+    std::map<size_t, std::vector<std::string>>
+        &op_idx_2_params_var_names,                              // NOLINT
+    std::unordered_set<std::string> &copy_completed_sched_vars,  // NOLINT
+    std::unordered_set<std::string> &fixed_vars,                 // NOLINT
+    framework::Scope *scope,
+    bool pin_memory) {
+  std::list<framework::OpIdx2ParamsTensors> weight_queue;
+  for (size_t layer : sched_layers) {
+    framework::OpIdx2ParamsTensors info;
+    info.first = layer;
+    for (std::string &var_name : op_idx_2_params_var_names[layer]) {
+      if (fixed_vars.count(var_name)) continue;
+      auto *src_var = scope->GetVar(var_name);
+      CHECK(src_var->IsType<phi::DenseTensor>());
+      auto *src_tensor = src_var->GetMutable<phi::DenseTensor>();
+      framework::Variable *dst_var = nullptr;
+      phi::DenseTensor *dst_tensor = nullptr;
+      if (copy_completed_sched_vars.count(var_name)) {
+        dst_var = scope->GetVar(var_name + "_cpu");
+        dst_tensor = dst_var->GetMutable<phi::DenseTensor>();
+        info.second.first.push_back(dst_tensor);
+        info.second.second.push_back(src_tensor);
+        continue;
+      } else {
+        copy_completed_sched_vars.insert(var_name);
+        dst_var = scope->Var(var_name + "_cpu");
+        dst_tensor = dst_var->GetMutable<phi::DenseTensor>();
+        dst_tensor->Resize(src_tensor->dims());
+        dst_tensor->set_layout(src_tensor->layout());
+        dst_tensor->set_type(src_tensor->dtype());
+        if (pin_memory) {
+          platform::CUDAPinnedPlace cpu_pin_place;
+          paddle::framework::TensorCopySync(
+              *src_tensor, cpu_pin_place, dst_tensor);
+        } else {
+          platform::CPUPlace cpu_place;
+          paddle::framework::TensorCopySync(*src_tensor, cpu_place, dst_tensor);
+        }
+        src_tensor->clear();
+        info.second.first.push_back(dst_tensor);
+        info.second.second.push_back(src_tensor);
+      }
+    }
+    if (info.second.first.size()) weight_queue.push_back(info);
+  }
+
+  sched_layers.clear();
+  for (auto &ele : weight_queue) {
+    sched_layers.push_back(ele.first);
+  }
+
+  return weight_queue;
+}
+#endif
+
+void OffLoadParamsPass::RunImpl(Argument *argument) {
+#if defined(PADDLE_WITH_CUDA)
+  PADDLE_ENFORCE_EQ(
+      argument->scope_valid(),
+      true,
+      platform::errors::PreconditionNotMet("The scope field should be valid"));
+
+  if (!argument->use_gpu()) return;
+  if (!argument->memory_limit_valid()) return;
+
+  auto &graph = argument->main_graph();
+  PADDLE_ENFORCE_EQ(argument->gpu_device_id_valid(),
+                    true,
+                    platform::errors::PreconditionNotMet(
+                        "The gpu_device_id field should be valid"));
+  auto *scope = argument->scope_ptr();
+
+  platform::Place place = platform::CUDAPlace(argument->gpu_device_id());
+
+  auto main_block_topo_order =
+      paddle::framework::ir::TopologySortOperations(graph);
+
+  // remove feed, fetch and while op。在执行的时候，并不会执行feed、 fetch
+  // op；while op对应的子 block 我们后续需要特殊处理，所以这里也一并删除
+  paddle::framework::OpDesc *while_op = nullptr;
+  for (auto iter = main_block_topo_order.begin();
+       iter != main_block_topo_order.end();) {
+    auto &node = *iter;
+    if (node->Op()->Type() == "feed" || node->Op()->Type() == "fetch" ||
+        node->Op()->Type() == "while") {
+      if (node->Op()->Type() == "while") while_op = node->Op();
+      iter = main_block_topo_order.erase(iter);
+    } else {
+      iter++;
+    }
+  }
+  std::unordered_set<std::string> fixed_vars;
+  std::unordered_set<std::string> copy_completed_fixed_vars;
+  std::unordered_set<std::string> copy_completed_sched_vars;
+
+  // 这些都是 block 中关于 op 的 params
+  // var统计信息，后面的任务我们需要根据限制的显存值来以及这些统计信息来划分
+  // fixed layer， sched layer
+  unsigned long long total_params_size = 0;  // NOLINT
+  std::map<size_t, std::string> op_idx_2_op_name;
+  std::map<size_t, std::vector<std::string>> op_idx_2_params_var_names;
+  std::map<size_t, std::vector<phi::DenseTensor *>> op_idx_2_params_tensors;
+  std::vector<std::pair<size_t, size_t>> op_idx_2_params_size;
+  std::map<std::string, phi::DenseTensor *> varname_2_tensor;
+  std::map<std::string, size_t> varname_2_varsize;
+  std::set<std::string> all_params_vars;
+
+  // 在这个for循环中，我们完成上述信息的初始化
+  for (size_t i = 0; i < main_block_topo_order.size(); i++) {
+    auto &node = main_block_topo_order[i];
+    if (!node->IsOp()) continue;
+    op_idx_2_op_name[i] = node->Op()->Type();
+    size_t params_size = 0;
+    for (auto *var_node : node->inputs) {
+      if (!var_node->Var()->Persistable()) continue;
+      auto var_name = var_node->Var()->Name();
+
+      auto *var = scope->FindLocalVar(var_name);
+      PADDLE_ENFORCE_NOT_NULL(var,
+                              platform::errors::PreconditionNotMet(
+                                  "The var should not be nullptr"));
+      if (var->IsType<phi::DenseTensor>()) {
+        auto *t = var->GetMutable<phi::DenseTensor>();
+        op_idx_2_params_tensors[i].push_back(t);
+        op_idx_2_params_var_names[i].push_back(var_name);
+        varname_2_tensor[var_name] = t;
+        auto var_size = t->numel() * SizeOf(t->dtype());
+        varname_2_varsize[var_name] = var_size;
+        params_size += var_size;
+        if (!all_params_vars.count(var_name)) total_params_size += var_size;
+      }
+      all_params_vars.insert(var_name);
+    }
+    if (params_size > 0) {
+      op_idx_2_params_size.emplace_back(i, params_size);
+    }
+  }
+  LOG(INFO) << "total_params_size: " << total_params_size;
+
+  // 这部分的逻辑就是根据上述统计得到的信息，划分 fixed layer， sched
+  // layer，以及得到显存池 buffer 的大小、需要加载的权重队列、fixed_vars
+  size_t buffer_size = 0;
+  auto res = DivideLayer(op_idx_2_params_tensors,
+                         op_idx_2_params_var_names,
+                         op_idx_2_op_name,
+                         varname_2_tensor,
+                         op_idx_2_params_size,
+                         varname_2_varsize,
+                         fixed_vars,
+                         // 614400000,
+                         argument->memory_limit(),
+                         argument->fixedlayer_algorithm(),
+                         buffer_size);
+  LOG(INFO) << "buffer_size: " << buffer_size;
+  auto fixed_layers = res.first;
+  auto sched_layers = res.second;
+
+  // 将fixed layer对应的 op 的权重数据拷贝到 GPU
+  if (fixed_layers.size())
+    CopyFixedlyer2Gpu(fixed_layers,
+                      op_idx_2_params_var_names,
+                      varname_2_tensor,
+                      copy_completed_fixed_vars,
+                      place);
+
+  // 接下来处理 while op， while op 对应的子block的处理逻辑与主block 完全一致
+  if (while_op) {
+    auto *sub_block = PADDLE_GET_CONST(framework::BlockDesc *,
+                                       while_op->GetAttr("sub_block"));
+    LOG(INFO) << "sub_block->ID(): " << sub_block->ID();
+    auto while_op_sub_graph = graph.GetSubGraph(sub_block->ID());
+    auto while_block_topo_order =
+        paddle::framework::ir::TopologySortOperations(*while_op_sub_graph);
+
+    unsigned long long total_params_size = 0;  // NOLINT
+    std::map<size_t, std::vector<phi::DenseTensor *>> op_idx_2_params_tensors;
+    std::map<size_t, std::vector<std::string>> op_idx_2_params_var_names;
+    std::map<size_t, std::string> op_idx_2_op_name;
+    std::map<std::string, phi::DenseTensor *> varname_2_tensor;
+    std::vector<std::pair<size_t, size_t>> op_idx_2_params_size;
+    std::map<std::string, size_t> varname_2_varsize;
+
+    // 在这个 for 循环中，我们完成所有统计信息的初始化
+    for (size_t i = 0; i < while_block_topo_order.size(); i++) {
+      auto &node = while_block_topo_order[i];
+      if (!node->IsOp()) continue;
+      op_idx_2_op_name[i] = node->Op()->Type();
+      size_t params_size = 0;
+      for (auto *var_node : node->inputs) {
+        if (!var_node->Var()->Persistable()) continue;
+        auto var_name = var_node->Var()->Name();
+        auto *var = scope->FindLocalVar(var_name);
+        PADDLE_ENFORCE_NOT_NULL(var,
+                                platform::errors::PreconditionNotMet(
+                                    "The var should not be nullptr"));
+        if (var->IsType<phi::DenseTensor>()) {
+          auto *t = var->GetMutable<phi::DenseTensor>();
+          op_idx_2_params_tensors[i].push_back(t);
+          op_idx_2_params_var_names[i].push_back(var_name);
+          varname_2_tensor[var_name] = t;
+          auto var_size = t->numel() * SizeOf(t->dtype());
+          varname_2_varsize[var_name] = var_size;
+          params_size += var_size;
+          if (!all_params_vars.count(var_name)) total_params_size += var_size;
+        }
+        all_params_vars.insert(var_name);
+      }
+      if (params_size > 0) {
+        op_idx_2_params_size.emplace_back(i, params_size);
+      }
+    }
+    LOG(INFO) << "total_params_size: " << total_params_size;
+
+    size_t buffer_size = 0;
+    auto res = DivideLayer(op_idx_2_params_tensors,
+                           op_idx_2_params_var_names,
+                           op_idx_2_op_name,
+                           varname_2_tensor,
+                           op_idx_2_params_size,
+                           varname_2_varsize,
+                           fixed_vars,
+                           argument->memory_limit(),
+                           argument->fixedlayer_algorithm(),
+                           buffer_size);
+
+    LOG(INFO) << "buffer_size: " << buffer_size;
+    auto fixed_layers = res.first;
+    auto sched_layers = res.second;
+
+    // 将fixed layer对应的 op 的权重数据拷贝到 GPU
+    if (fixed_layers.size())
+      CopyFixedlyer2Gpu(fixed_layers,
+                        op_idx_2_params_var_names,
+                        varname_2_tensor,
+                        copy_completed_fixed_vars,
+                        place);
+
+    // 将sched layer对应的 op 的权重数据拷贝到 新的 CPU 变量中
+    if (sched_layers.size()) {
+      auto weight_queue = CopySchedlyer2Cpu(sched_layers,
+                                            op_idx_2_params_var_names,
+                                            copy_completed_sched_vars,
+                                            fixed_vars,
+                                            scope,
+                                            argument->pin_memory());
+
+      // 初始化主block 对应的显存池：init sched_layers_pool
+      paddle::framework::VectorSchedLayersPool::Instance()
+          .Get(sub_block->ID())
+          .Init(buffer_size, weight_queue, sched_layers);
+    }
+
+    LOG(INFO) << "sub block sched_layers: " << sched_layers.size();
+    for (auto i : sched_layers) {
+      std::cout << i << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  // 最后 将主 block 中 sched layer对应的 op 的权重数据拷贝到 新的 CPU 变量中
+  if (sched_layers.size()) {
+    auto weight_queue = CopySchedlyer2Cpu(sched_layers,
+                                          op_idx_2_params_var_names,
+                                          copy_completed_sched_vars,
+                                          fixed_vars,
+                                          scope,
+                                          argument->pin_memory());
+
+    // 初始化主block 对应的显存池：init sched_layers_pool
+    paddle::framework::VectorSchedLayersPool::Instance().Get(0).Init(
+        buffer_size, weight_queue, sched_layers);
+  }
+
+  LOG(INFO) << "main block sched_layers: " << sched_layers.size();
+  for (auto i : sched_layers) {
+    std::cout << i << " ";
+  }
+  std::cout << std::endl;
+#endif
+}
+
+std::string OffLoadParamsPass::repr() const { return "offload-params-pass"; }
+
+}  // namespace analysis
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/inference/analysis/passes/offload_params_pass.h
+++ b/paddle/fluid/inference/analysis/passes/offload_params_pass.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "paddle/fluid/framework/scope.h"
+#include "paddle/fluid/inference/analysis/analysis_pass.h"
+#include "paddle/fluid/platform/place.h"
+
+namespace paddle {
+namespace inference {
+namespace analysis {
+
+class OffLoadParamsPass : public AnalysisPass {
+ public:
+  void RunImpl(Argument *argument) override;
+  std::string repr() const override;
+};
+
+}  // namespace analysis
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/inference/analysis/passes/passes.cc
+++ b/paddle/fluid/inference/analysis/passes/passes.cc
@@ -21,6 +21,7 @@
 #include "paddle/fluid/inference/analysis/passes/ir_graph_to_program_pass.h"
 #include "paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.h"
 #include "paddle/fluid/inference/analysis/passes/memory_optimize_pass.h"
+#include "paddle/fluid/inference/analysis/passes/offload_params_pass.h"
 
 namespace paddle {
 namespace inference {
@@ -45,6 +46,9 @@ PassRegistry::PassRegistry() {
   passes_.emplace(
       "ir_graph_to_program_pass",
       std::unique_ptr<IrGraphToProgramPass>(new IrGraphToProgramPass));
+
+  passes_.emplace("offload_params_pass",
+                  std::unique_ptr<OffLoadParamsPass>(new OffLoadParamsPass));
 }
 
 }  // namespace analysis

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -535,6 +535,12 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(apply_optim_);
   CP_MEMBER(skip_load_params_);
 
+  // limit memory
+  CP_MEMBER(enable_memory_limit_);
+  CP_MEMBER(memory_limit_);
+  CP_MEMBER(fixedlayer_algorithm_);
+  CP_MEMBER(pin_memory_);
+
   if (use_gpu_) {
     PADDLE_ENFORCE_EQ(use_xpu_,
                       false,
@@ -1037,6 +1043,10 @@ void AnalysisConfig::Update() {
         "but did not have the option -DWITH_CUSTOM_DEVICE compiled."));
 #endif
   }
+  if (enable_memory_limit_) {
+    pass_builder()->ReplaceAnalysisPass("ir_params_sync_among_devices_pass",
+                                        "offload_params_pass");
+  }
 }
 
 std::string AnalysisConfig::SerializeInfoCache() {
@@ -1199,6 +1209,16 @@ void AnalysisConfig::SwitchIrDebug(int x) {
 
 void AnalysisConfig::EnableProfile() {
   with_profile_ = true;
+  Update();
+}
+
+void AnalysisConfig::EnableMemoryLimit(int64_t limit_byte_size,
+                                       int fixedlayer_algorithm,
+                                       bool pin_momery) {
+  enable_memory_limit_ = true;
+  memory_limit_ = limit_byte_size;
+  pin_memory_ = pin_momery;
+  fixedlayer_algorithm_ = fixedlayer_algorithm;
   Update();
 }
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1309,6 +1309,13 @@ void AnalysisPredictor::PrepareArgument() {
   argument_->SetEnableGPUMixed(config_.enable_gpu_mixed_);
   argument_->SetMixedPrecisionMode(static_cast<int>(
       paddle::ConvertPrecision(config_.mixed_precision_mode_)));
+
+  // params memory limit
+  if (config_.enable_memory_limit_) {
+    argument_->SetMemoryLimit(config_.memory_limit_);
+    argument_->SetUsePinMemory(config_.pin_memory_);
+    argument_->SetFixedLayerAlgorithm(config_.fixedlayer_algorithm_);
+  }
 }
 
 // NOTE All the members in AnalysisConfig should be copied to Argument.

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -1035,6 +1035,10 @@ struct PD_INFER_DECL AnalysisConfig {
   ///
   bool cinn_compiler_enabled() const;
 
+  void EnableMemoryLimit(int64_t limit_byte_size,
+                         int fixedlayer_algorithm = 1,
+                         bool pin_momery = true);
+
  protected:
   // Update the config.
   void Update();
@@ -1262,6 +1266,12 @@ struct PD_INFER_DECL AnalysisConfig {
   // PrepareProgram(). So we add this flag to control the process.
   bool apply_optim_{false};
   bool skip_load_params_{false};
+
+  // limit the size of gpu memory occupied by params data
+  bool enable_memory_limit_{false};
+  int64_t memory_limit_{0};
+  bool pin_memory_{true};
+  int fixedlayer_algorithm_{0};
 };
 
 }  // namespace paddle

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -82,6 +82,14 @@ void PaddlePassBuilder::AppendAnalysisPass(const std::string &pass) {
   analysis_passes_.push_back(pass);
 }
 
+void PaddlePassBuilder::ReplaceAnalysisPass(const std::string &old_pass,
+                                            const std::string &new_pass) {
+  auto find =
+      std::find(analysis_passes_.begin(), analysis_passes_.end(), old_pass);
+  if (find == analysis_passes_.end()) return;
+  *find = new_pass;
+}
+
 void PaddlePassBuilder::ClearPasses() { passes_.clear(); }
 
 const std::vector<std::string> kTRTSubgraphPasses({

--- a/paddle/fluid/inference/api/paddle_pass_builder.h
+++ b/paddle/fluid/inference/api/paddle_pass_builder.h
@@ -87,6 +87,12 @@ class PD_INFER_DECL PaddlePassBuilder {
   /// \param[in] pass the type of the new analysis pass.
   void AppendAnalysisPass(const std::string &pass);
 
+  /// \brief Replace an analysis pass.
+  /// \param[in] old_pass the type of the replaced analysis pass.
+  /// \param[in] new_pass the type of the new analysis pass.
+  void ReplaceAnalysisPass(const std::string &old_pass,
+                           const std::string &new_pass);
+
   /// \brief Visualize the computation graph after each pass by generating a DOT
   /// language file, one can draw them with the Graphviz toolkit.
   void TurnOnDebug();

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -181,21 +181,23 @@ class WhileOp : public framework::OperatorBase {
     // the place of every inputs and restore their place after
     // InterpreterCore.run().
     std::map<std::string, phi::Place> input_var_original_places;
-    for (const auto &in_name : Inputs(kX)) {
-      framework::Variable *var = scope.FindVar(in_name);
-      if (var == nullptr) {
-        VLOG(4) << "[while op]"
-                << "input not found:" << in_name;
-      }
+    if (FLAGS_control_flow_use_new_executor) {
+      for (const auto &in_name : Inputs(kX)) {
+        framework::Variable *var = scope.FindVar(in_name);
+        if (var == nullptr) {
+          VLOG(4) << "[while op]"
+                  << "input not found:" << in_name;
+        }
 
-      if (var->Type() == framework::proto::VarType::LOD_TENSOR) {
-        input_var_original_places[in_name] =
-            (var->Get<phi::DenseTensor>()).place();
-      } else {
-        VLOG(10) << "[while op]"
-                 << "skip backup input " << in_name << " type:"
-                 << framework::TransToPhiDataType(
-                        framework::ToVarType(var->Type()));
+        if (var->Type() == framework::proto::VarType::LOD_TENSOR) {
+          input_var_original_places[in_name] =
+              (var->Get<phi::DenseTensor>()).place();
+        } else {
+          VLOG(10) << "[while op]"
+                   << "skip backup input " << in_name << " type:"
+                   << framework::TransToPhiDataType(
+                          framework::ToVarType(var->Type()));
+        }
       }
     }
 

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -683,6 +683,7 @@ void BindAnalysisConfig(py::module *m) {
            [](AnalysisConfig &self, phi::CUDAStream &stream) {
              self.SetExecStream(stream.raw_stream());
            })
+      .def("enable_memory_limit", &AnalysisConfig::EnableMemoryLimit)
 #endif
       .def("enable_xpu",
            &AnalysisConfig::EnableXpu,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
APIs

### Describe
大模型显存二级存储：
# 1. 接口
为保证兼容性，config 接口增加一个设置 **memory_limit** 的限制，用户可以通过此接口来限制权重数据最大占用的显存数、选择 fixed layer 的不同算法、同时选择是否选择 pin memory。不使用此接口时，执行器的行为没有改变。
![image](https://user-images.githubusercontent.com/63448337/204424066-f955c330-654b-4870-8797-3e7f7c6d9fc3.png)

# 2. 增加一个 Analysis Pass：**offload_params_pass**
当 config 设置了 **EnableMemoryLimit** 时，就会将原来的 “ir_params_sync_among_device_pass” 替换为 “offload_params_pass”
原来的 "ir_params_sync_among_device_pass" 会把所有的权重数据拷贝到 GPU，替换为 "offload_params_pass" 后，只将 fixed layer 的权重数据拷贝到 GPU
![image](https://user-images.githubusercontent.com/63448337/204424236-b18d91ba-7054-4151-af87-171b97337495.png)
该pass会根据设置的 memory_limit 的大小，尽可能的把更多的权重数据常驻 gpu，只留下能容纳两层权重数据的显存空间，用于运行时的交换。即把 limited memory 分成两部分，一部分 fixed memory，储存 fixed layer 的权重， 一部分 sched memory， 这部分显存用于运行时交换。

**memory_limit** 的设置：
根据 op 权重数据的大小，对 op 进行从大到小的排序。
理论上 memory_limit 的极限最小值为前两个 Op 的权重大小之和， 为了方便，实际 memory_limit 的极限最小值为 2*第一个Op的权重大小。低于这个极限值则报错并提示。

**fixed layer** 的计算：
当 fixedlayer_algorithm 设为 0 时，尽可能把大权重的 Op 放入 fixed_layer；
1. 遍历所有 op，计算出每一个 op 的权重大小，对 Op 从大到小进行排序；
2. 从第 i 个 op 开始（i = 0），把第 i 个 op 划入fixed layers，判断剩余的 memory 能否容纳第 i+1 op 和 i+2 op
3. 如果能；i++， 继续第2步
4. 如果不能，fix layers 删除第 i op， 循环结束。

当 fixedlayer_algorim 设为 1 时，尽可能把更多的 Op 放入 fixed_layer（默认设置）
1. 预留出极限最小值的显存，用于运行时交换
2. 根据剩余的显存，尽可能把更多的 op 划入 fixed_layer

把所有的 fixed layer 权重数据拷贝到 GPU， 其他的 sched layer，把权重数据存入 cpu。如一个 sched layer 的权重变量 weight_1， 此时数据在 cpu 中，把它的数据存入一个 weight_1_cpu 的变量中，清空原来 weight_1 里面的数据。运行时，weight_1变成一个 gpu 变量，从 cpu 变量 weight_1_cpu 中拷贝数据。

# 3. sched_layers 设计
sched_layers 表示这些 op 的权重需要在运行时加载，类似一个“显存池”，由一个链表（数组）组成，链表中每一个节点表示一个 Buffer。链表节点数恒定为2。
一个 Buffer 形式如下：
![image](https://user-images.githubusercontent.com/63448337/204432097-3966b5b5-8aff-4992-8b40-3ed32ac462ee.png)
layer_id 表示该 buffer 储存的是哪一个 op 的权重；
free 表示该 buffer 是否已经被占用。
gpu_resource 是一个表示该 buffer hold 的总显存资源的数据结构， 由于op的权重个数可以不同，需要把 gpu_resource 里面的显存资源分配到不同个数的权重 tensor中

**ResourceHolder**
![image](https://user-images.githubusercontent.com/63448337/204432150-00f10714-bfda-40c0-b0e7-79c49641f079.png)
paddle内部的 dense tensor也是一个 hold 显存资源的数据结构，进行简单的封装后构成 ResourceHolder。PartionMemoryTo API 则表示把该显存资源划分到不通的权重 dense tensor 中。dense tensor 从内部显存池获取资源。也可以不用封装 dense tensor，直接使用 cuda api 获取显存资源。

**SchedLayersPool**
![image](https://user-images.githubusercontent.com/63448337/204432197-ea2d698c-199b-4ac8-81c4-f4e5af5c9d1d.png)
buffer_nodes_: 该 pool 拥有的 buffer 集合，大小始终为2；
active_layers_: 记录 buffer 中的 layer id（op）
weight_queue_: 根据 op 的执行顺序得到的运行时需要进行权重加载的 dense tensor的集合
sched_layers_: 运行时需要加在权重的 op 的集合
FillPool API ： 找出状态为 free 的 buffer，从 weight_queue_ 中拿出拷贝的权重 tensor，在 load stream 流上发起异步拷贝操作。 

# 4. Runtime
![image](https://user-images.githubusercontent.com/63448337/204424801-82c576cb-f91d-4156-bd24-f2c9bfa65e00.png)

在调度上，如果 config 开启了内存限制，sched_layer_pool 就是有效的。此时的调度逻辑为：
调度前： 填充pool，找出pool两个节点中为 free状态的，然后从 weight_queue 中拿信息，发起数据异步拷贝操作
如果当前层是 fixed_layer(非 sched_layer)，直接 lauch 该层
否的话，做一些同步操作，lauch 完之后，修改占据的 buffer状态。
