### PR TITLE
[Bug fix] elementwise_div + scale fuse pass

### DIFF
--- a/paddle/fluid/operators/ops_extra_info.h
+++ b/paddle/fluid/operators/ops_extra_info.h
@@ -95,6 +95,7 @@ const std::unordered_map<std::string, ExtraAttrPropertySet>
         {"fuse_activation_alpha", ExtraAttrProperty::ONEDNN},
         {"fuse_activation_beta", ExtraAttrProperty::ONEDNN},
         {"fuse_activation_scale", ExtraAttrProperty::ONEDNN},
+        {"fused_output_scale", ExtraAttrProperty::ONEDNN},
         {"fuse_alpha", ExtraAttrProperty::ONEDNN},
         {"fuse_beta", ExtraAttrProperty::ONEDNN},
         {"fuse_relu", ExtraAttrProperty::ONEDNN},

--- a/paddle/phi/kernels/onednn/elementwise_kernel.cc
+++ b/paddle/phi/kernels/onednn/elementwise_kernel.cc
@@ -43,6 +43,12 @@ void ElementwiseKernel(const OneDNNContext& dev_ctx,
 
   dnnl::post_ops post_operations;
   funcs::AppendActivation(dev_ctx, post_operations);
+  if (dev_ctx.HasDnnAttr("fused_output_scale")) {
+    float scale_alpha =
+        PADDLE_GET_CONST(float, dev_ctx.GetDnnAttr("fused_output_scale"));
+    post_operations.append_eltwise(
+        1.0, dnnl::algorithm::eltwise_linear, scale_alpha, 0.0f);
+  }
 
   auto* non_const_x = &x;
   auto* non_const_y = &y;

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_elt_act_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_mkldnn_elt_act_fuse_pass.py
@@ -356,6 +356,42 @@ class ElementwiseActivationMkldnnFusePassTest_Mul_Sigmoid(
         self.act = paddle.nn.functional.sigmoid
 
 
+class ElementwiseScaleOneDNNFusePassTest_Add(
+    ElementwiseActivationMkldnnFusePassTest
+):
+    def set_params(self):
+        self.operand = fluid.layers.elementwise_add
+        self.act_alpha = 0.6
+        self.act = paddle.scale
+
+
+class ElementwiseScaleOneDNNFusePassTest_Sub(
+    ElementwiseActivationMkldnnFusePassTest
+):
+    def set_params(self):
+        self.operand = fluid.layers.elementwise_sub
+        self.act_alpha = 0.6
+        self.act = paddle.scale
+
+
+class ElementwiseScaleOneDNNFusePassTest_Mul(
+    ElementwiseActivationMkldnnFusePassTest
+):
+    def set_params(self):
+        self.operand = fluid.layers.elementwise_mul
+        self.act_alpha = 0.6
+        self.act = paddle.scale
+
+
+class ElementwiseScaleOneDNNFusePassTest_Div(
+    ElementwiseActivationMkldnnFusePassTest
+):
+    def set_params(self):
+        self.operand = fluid.layers.elementwise_div
+        self.act_alpha = 0.6
+        self.act = paddle.scale
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
- https://github.com/PaddlePaddle/Paddle/pull/48400 introduced `elementwises + scale` fuse pass, but `elementwise` kernels are currently being migrated to PHI, and previous PR covered only scale calculation for fluid kernels, which resulted in accuracy difference for `elementwise_div` kernel.
- this PR adds support for PHI kernels and adds more unit tests.