### PR TITLE
remove  unnecessary fluid header file in phi, test=develop

### DIFF
--- a/paddle/phi/core/enforce.h
+++ b/paddle/phi/core/enforce.h
@@ -98,7 +98,6 @@ limitations under the License. */
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 #include "paddle/phi/backends/gpu/gpu_types.h"
 #endif
-#include "paddle/fluid/platform/flags.h"
 
 #include "paddle/utils/variant.h"
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

Paddle custom device will fail due to 

```bash
compilation terminated.
CMakeFiles/paddle-custom-npu.dir/build.make:146: recipe for target 'CMakeFiles/paddle-custom-npu.dir/kernels/add_n_kernel.cc.o' failed
make[2]: *** [CMakeFiles/paddle-custom-npu.dir/kernels/add_n_kernel.cc.o] Error 1
CMakeFiles/paddle-custom-npu.dir/build.make:120: recipe for target 'CMakeFiles/paddle-custom-npu.dir/kernels/activation_kernel.cc.o' failed
make[2]: *** [CMakeFiles/paddle-custom-npu.dir/kernels/activation_kernel.cc.o] Error 1
In file included from /workspace/PaddleCustomDevice/backends/npu/kernels/funcs/npu_enforce.h:21,
                 from /workspace/PaddleCustomDevice/backends/npu/kernels/funcs/npu_funcs.h:19,
                 from /workspace/PaddleCustomDevice/backends/npu/kernels/adam_kernel.cc:15:
/opt/py37env/lib/python3.7/site-packages/paddle/include/paddle/phi/core/enforce.h:101:10: fatal error: paddle/fluid/platform/flags.h: No such file or directory
 #include "paddle/fluid/platform/flags.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Remove "paddle/fluid/platform/flags.h" as it's not necessary of enforce.h.

