### PR TITLE
Fix test_fleet_exe_dist_model_run bug

### DIFF
--- a/paddle/fluid/distributed/fleet_executor/dist_model.cc
+++ b/paddle/fluid/distributed/fleet_executor/dist_model.cc
@@ -436,7 +436,11 @@ bool DistModel::PrepareFleetExe() {
   for (int i = 0; i < config_.nranks; ++i) {
     RankInfo *rank_info = executor_desc_.add_cluster_info();
     rank_info->set_rank(i);
-    rank_info->set_ip_port(config_.trainer_endpoints[i]);
+    if (config_.nranks == 1) {
+      rank_info->set_ip_port("");
+    } else {
+      rank_info->set_ip_port(config_.trainer_endpoints[i]);
+    }
     id_to_rank.insert({i, i});
   }
   fleet_exe.reset(new FleetExecutor(executor_desc_));

--- a/python/paddle/fluid/tests/unittests/test_fleet_exe_dist_model_run.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_exe_dist_model_run.py
@@ -64,8 +64,6 @@ class TestDistModelRun(unittest.TestCase):
         # step 3: init the dist model to inference with fake data
         config = core.DistModelConfig()
         config.model_dir = path_prefix
-        config.trainer_endpoints = ["127.0.0.1:8000"]
-        config.current_endpoint = "127.0.0.1:8000"
         config.place = 'GPU'
         dist = core.DistModel(config)
         dist.init()

--- a/python/paddle/fluid/tests/unittests/test_fleet_exe_dist_model_run.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_exe_dist_model_run.py
@@ -64,6 +64,8 @@ class TestDistModelRun(unittest.TestCase):
         # step 3: init the dist model to inference with fake data
         config = core.DistModelConfig()
         config.model_dir = path_prefix
+        config.trainer_endpoints = ["127.0.0.1:8000"]
+        config.current_endpoint = "127.0.0.1:8000"
         config.place = 'GPU'
         dist = core.DistModel(config)
         dist.init()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
在主框架升级protobuf之后，coverage流水线固定挂在dancetest_fleet_exe_dist_model_run.py上，此PR修复此问题
<img width="914" alt="0a21cea7b53865246e4e982b9efd5992" src="https://user-images.githubusercontent.com/62429225/217454847-d9d1e392-ed71-4d39-8ae9-77abae241b56.png">

