### PR TITLE
Fix the name map of operator  from Phi to fluid

### DIFF
--- a/paddle/fluid/operators/size_op.cc
+++ b/paddle/fluid/operators/size_op.cc
@@ -62,7 +62,7 @@ DECLARE_NO_NEED_BUFFER_VARS_INFERER(SizeOpNoNeedBufferVarInferer, "Input");
 namespace ops = paddle::operators;
 DECLARE_INFER_SHAPE_FUNCTOR(size,
                             SizeInferShapeFunctor,
-                            PD_INFER_META(phi::SizeInferMeta));
+                            PD_INFER_META(phi::NumelInferMeta));
 REGISTER_OPERATOR(
     size,
     ops::SizeOp,

--- a/paddle/phi/api/yaml/legacy_ops.yaml
+++ b/paddle/phi/api/yaml/legacy_ops.yaml
@@ -1475,9 +1475,9 @@
   args : (Tensor x)
   output : Tensor(size)
   infer_meta :
-    func : SizeInferMeta
+    func : NumelInferMeta
   kernel :
-    func : size
+    func : numel
   data_transform:
     skip_transform : x
 

--- a/paddle/phi/core/compat/op_utils.h
+++ b/paddle/phi/core/compat/op_utils.h
@@ -223,21 +223,22 @@ struct ArgumentMappingFnRegistrar {
   }
 };
 
-#define PD_REGISTER_BASE_KERNEL_NAME(op_type, base_kernel_name)                \
-  PD_STATIC_ASSERT_GLOBAL_NAMESPACE(                                           \
-      PD_REGISTER_base_kernel_name_ns_check_##op_type,                         \
-      "PD_REGISTER_BASE_KERNEL_NAME must be called in global namespace.");     \
-  static const ::phi::BaseKernelNameRegistrar                                  \
-      __registrar_base_kernel_name_for_##op_type(#op_type, #base_kernel_name); \
-  int TouchBaseKernelNameSymbol_##op_type() { return 0; }
+#define PD_REGISTER_BASE_KERNEL_NAME(op_type, base_kernel_name)               \
+  PD_STATIC_ASSERT_GLOBAL_NAMESPACE(                                          \
+      PD_REGISTER_base_kernel_name_ns_check_##base_kernel_name,               \
+      "PD_REGISTER_BASE_KERNEL_NAME must be called in global namespace.");    \
+  static const ::phi::BaseKernelNameRegistrar                                 \
+      __registrar_base_kernel_name_for_##base_kernel_name(#op_type,           \
+                                                          #base_kernel_name); \
+  int TouchBaseKernelNameSymbol_##base_kernel_name() { return 0; }
 
-#define PD_DECLARE_BASE_KERNEL_NAME(op_type)                              \
-  PD_STATIC_ASSERT_GLOBAL_NAMESPACE(                                      \
-      PD_DECLARE_ai_name_ns_check_##op_type,                              \
-      "PD_DECLARE_BASE_KERNEL_NAME must be called in global namespace."); \
-  extern int TouchBaseKernelNameSymbol_##op_type();                       \
-  UNUSED static int __declare_base_kernel_name_symbol_for_##op_type =     \
-      TouchBaseKernelNameSymbol_##op_type()
+#define PD_DECLARE_BASE_KERNEL_NAME(op_type, base_kernel_name)                 \
+  PD_STATIC_ASSERT_GLOBAL_NAMESPACE(                                           \
+      PD_DECLARE_ai_name_ns_check_##base_kernel_name,                          \
+      "PD_DECLARE_BASE_KERNEL_NAME must be called in global namespace.");      \
+  extern int TouchBaseKernelNameSymbol_##base_kernel_name();                   \
+  UNUSED static int __declare_base_kernel_name_symbol_for_##base_kernel_name = \
+      TouchBaseKernelNameSymbol_##base_kernel_name()
 
 #define PD_REGISTER_ARG_MAPPING_FN(op_type, arg_mapping_fn)              \
   PD_STATIC_ASSERT_GLOBAL_NAMESPACE(                                     \

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -3243,7 +3243,7 @@ void ShardIndexInferMeta(const MetaTensor& in,
   out->set_dtype(in.dtype());
 }
 
-void SizeInferMeta(const MetaTensor& input, MetaTensor* out) {
+void NumelInferMeta(const MetaTensor& input, MetaTensor* out) {
   out->set_dtype(DataType::INT64);
   if (input.dims().size() == 0) {
     out->set_dims(phi::make_ddim({}));

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -478,7 +478,7 @@ void ShardIndexInferMeta(const MetaTensor& in,
                          MetaTensor* out,
                          MetaConfig config = MetaConfig());
 
-void SizeInferMeta(const MetaTensor& input, MetaTensor* out);
+void NumelInferMeta(const MetaTensor& input, MetaTensor* out);
 
 void SliceRawInferMeta(const MetaTensor& input,
                        const std::vector<int64_t>& axes,

--- a/paddle/phi/kernels/cpu/numel_kernel.cc
+++ b/paddle/phi/kernels/cpu/numel_kernel.cc
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/size_kernel.h"
+#include "paddle/phi/kernels/numel_kernel.h"
 
-#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/size_kernel_impl.h"
+#include "paddle/phi/kernels/impl/numel_kernel_impl.h"
 
-PD_REGISTER_KERNEL(size,
-                   GPU,
+PD_REGISTER_KERNEL(numel,
+                   CPU,
                    ALL_LAYOUT,
-                   phi::SizeKernel,
+                   phi::NumelKernel,
+                   uint8_t,
                    int16_t,
                    int,
                    int64_t,

--- a/paddle/phi/kernels/gpu/numel_kernel.cu
+++ b/paddle/phi/kernels/gpu/numel_kernel.cu
@@ -12,17 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/phi/kernels/size_kernel.h"
+#include "paddle/phi/kernels/numel_kernel.h"
 
-#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/size_kernel_impl.h"
+#include "paddle/phi/kernels/impl/numel_kernel_impl.h"
 
-PD_REGISTER_KERNEL(size,
-                   CPU,
+PD_REGISTER_KERNEL(numel,
+                   GPU,
                    ALL_LAYOUT,
-                   phi::SizeKernel,
-                   uint8_t,
+                   phi::NumelKernel,
                    int16_t,
                    int,
                    int64_t,

--- a/paddle/phi/kernels/impl/numel_kernel_impl.h
+++ b/paddle/phi/kernels/impl/numel_kernel_impl.h
@@ -19,9 +19,9 @@
 namespace phi {
 
 template <typename T, typename Context>
-void SizeKernel(const Context& ctx,
-                const DenseTensor& input,
-                DenseTensor* out) {
+void NumelKernel(const Context& ctx,
+                 const DenseTensor& input,
+                 DenseTensor* out) {
   auto place = ctx.GetPlace();
   auto out_data = ctx.template Alloc<int64_t>(out);
 

--- a/paddle/phi/kernels/numel_kernel.h
+++ b/paddle/phi/kernels/numel_kernel.h
@@ -19,6 +19,8 @@
 namespace phi {
 
 template <typename T, typename Context>
-void SizeKernel(const Context& ctx, const DenseTensor& input, DenseTensor* out);
+void NumelKernel(const Context& ctx,
+                 const DenseTensor& input,
+                 DenseTensor* out);
 
 }  // namespace phi

--- a/paddle/phi/ops/compat/einsum_sig.cc
+++ b/paddle/phi/ops/compat/einsum_sig.cc
@@ -31,5 +31,7 @@ KernelSignature EinsumGradOpArgumentMapping(const ArgumentMappingContext& ctx) {
 }
 }  // namespace phi
 
+PD_REGISTER_BASE_KERNEL_NAME(einsum, einsum_raw);
+
 PD_REGISTER_ARG_MAPPING_FN(einsum, phi::EinsumOpArgumentMapping);
 PD_REGISTER_ARG_MAPPING_FN(einsum_grad, phi::EinsumGradOpArgumentMapping);

--- a/paddle/phi/ops/compat/embedding_sig.cc
+++ b/paddle/phi/ops/compat/embedding_sig.cc
@@ -62,7 +62,7 @@ PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2_grad, embedding_sparse_grad);
 PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2_grad,
                              sparse_weight_embedding_grad);
 PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2_grad,
-                             sparse_weight_embedding_grad);
+                             sparse_weight_embedding_sparse_grad);
 
 PD_REGISTER_ARG_MAPPING_FN(lookup_table_v2, phi::EmbeddingOpArgumentMapping);
 PD_REGISTER_ARG_MAPPING_FN(lookup_table_v2_grad,

--- a/paddle/phi/ops/compat/embedding_sig.cc
+++ b/paddle/phi/ops/compat/embedding_sig.cc
@@ -58,6 +58,11 @@ KernelSignature EmbeddingGradOpArgumentMapping(
 
 PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2, embedding);
 PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2_grad, embedding_grad);
+PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2_grad, embedding_sparse_grad);
+PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2_grad,
+                             sparse_weight_embedding_grad);
+PD_REGISTER_BASE_KERNEL_NAME(lookup_table_v2_grad,
+                             sparse_weight_embedding_grad);
 
 PD_REGISTER_ARG_MAPPING_FN(lookup_table_v2, phi::EmbeddingOpArgumentMapping);
 PD_REGISTER_ARG_MAPPING_FN(lookup_table_v2_grad,

--- a/paddle/phi/ops/compat/size_sig.cc
+++ b/paddle/phi/ops/compat/size_sig.cc
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/paddle/phi/ops/compat/size_sig.cc
+++ b/paddle/phi/ops/compat/size_sig.cc
@@ -1,0 +1,18 @@
+
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/core/compat/op_utils.h"
+
+PD_REGISTER_BASE_KERNEL_NAME(size, numel);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
对`size` kernel进行重命名以及为部分算子Kernel增加与fluid算子名的映射关系注册，修复相关算子在动态图下转为fluid算子名不正确的问题。