### PR TITLE
[Perf]Fix interploate OutSize data transform problem

### DIFF
--- a/paddle/fluid/operators/interpolate_v2_op.cc
+++ b/paddle/fluid/operators/interpolate_v2_op.cc
@@ -466,7 +466,9 @@ class InterpolateV2Op : public framework::OperatorWithKernel {
       }
     }
 #endif
-    if (var_name == "OutSize" || var_name == "SizeTensor" || var_name == "Scale") {
+
+    if (var_name == "OutSize" || var_name == "SizeTensor" ||
+        var_name == "Scale") {
       return expected_kernel_type;
     }
     return framework::OpKernelType(

--- a/paddle/fluid/operators/interpolate_v2_op.cc
+++ b/paddle/fluid/operators/interpolate_v2_op.cc
@@ -466,7 +466,7 @@ class InterpolateV2Op : public framework::OperatorWithKernel {
       }
     }
 #endif
-    if (var_name == "SizeTensor" || var_name == "Scale") {
+    if (var_name == "OutSize" || var_name == "SizeTensor" || var_name == "Scale") {
       return expected_kernel_type;
     }
     return framework::OpKernelType(

--- a/paddle/fluid/operators/interpolate_v2_op.cc
+++ b/paddle/fluid/operators/interpolate_v2_op.cc
@@ -703,7 +703,8 @@ class InterpolateV2OpGrad : public framework::OperatorWithKernel {
       const std::string& var_name,
       const phi::DenseTensor& tensor,
       const framework::OpKernelType& expected_kernel_type) const override {
-    if (var_name == "SizeTensor" || var_name == "Scale") {
+    if (var_name == "OutSize" || var_name == "SizeTensor" ||
+        var_name == "Scale") {
       return expected_kernel_type;
     }
     return framework::OpKernelType(

--- a/paddle/phi/kernels/gpu/interpolate_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_kernel.cu
@@ -1458,6 +1458,7 @@ PD_REGISTER_KERNEL(bilinear_interp,
                    double,
                    phi::dtype::float16,
                    int) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);
 }
@@ -1471,6 +1472,7 @@ PD_REGISTER_KERNEL(nearest_interp,
                    phi::dtype::bfloat16,
                    int,
                    int64_t) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);
 }
@@ -1482,6 +1484,7 @@ PD_REGISTER_KERNEL(trilinear_interp,
                    double,
                    phi::dtype::float16,
                    int) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);
 }
@@ -1493,6 +1496,7 @@ PD_REGISTER_KERNEL(linear_interp,
                    double,
                    phi::dtype::float16,
                    int) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);
 }
@@ -1504,6 +1508,7 @@ PD_REGISTER_KERNEL(bicubic_interp,
                    double,
                    phi::dtype::float16,
                    int) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

### What's New?

![image](https://user-images.githubusercontent.com/9301846/204458337-04cc11e5-3524-461b-81dd-0ae5154daeee.png)
![image](https://user-images.githubusercontent.com/9301846/204458380-5071d248-4191-49dd-a4d1-ff9d4d563725.png)
![image](https://user-images.githubusercontent.com/9301846/204458418-93893f31-d573-4833-abe0-74ea845d175b.png)


此PR之后，则没有了多余的D2H的copy:
<img width="1604" alt="image" src="https://user-images.githubusercontent.com/9301846/204479906-dcdb59be-60a0-461a-9673-f6986163a146.png">

