### PR TITLE
Support trt engine build in runtime for dynamic shape

### DIFF
--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -539,6 +539,7 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
       graph->Has(framework::ir::kEmbEltwiseLayernormPass) &&
       graph->Has(framework::ir::kMultiheadMatmulPass));
   trt_engine->SetContextMemorySharing(Get<bool>("context_memory_sharing"));
+  trt_engine->SetWithDynamicShape(Get<bool>("with_dynamic_shape"));
 
   if (use_static_engine) {
     trt_engine_serialized_data = GetTrtEngineSerializedData(
@@ -555,7 +556,7 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
 
   // 如果开启了动态shape，但没有给 shape_info
   // 表明要在运行时边 run 边 build
-  if (Get<bool>("with_dynamic_shape") && min_input_shape == {}) {
+  if (Get<bool>("with_dynamic_shape") && min_input_shape.empty()) {
     return;
   }
 

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -554,8 +554,8 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
     }
   }
 
-  // 如果开启了动态shape，但没有给 shape_info
-  // 表明要在运行时边 run 边 build
+  // If with_dynamic_shape is configured，but min_input_shape is empty,
+  // create trt engine in runtime instead of in pass.
   if (Get<bool>("with_dynamic_shape") && min_input_shape.empty()) {
     return;
   }

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -328,7 +328,7 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
   auto shape_range_info_path = Get<std::string>("trt_shape_range_info_path");
   auto trt_tuned_dynamic_shape = Get<bool>("trt_tuned_dynamic_shape");
   int max_batch_size = Get<int>("max_batch_size");
-  if (trt_tuned_dynamic_shape) {
+  if (trt_tuned_dynamic_shape && shape_range_info_path != "") {
     VLOG(1) << "trt dynamic_shape deserialize from " << shape_range_info_path;
     inference::DeserializeShapeRangeInfo(shape_range_info_path,
                                          &min_input_shape,
@@ -551,6 +551,12 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
                        Get<std::string>("model_opt_cache_dir"), engine_key);
       return;
     }
+  }
+
+  // 如果开启了动态shape，但没有给 shape_info
+  // 表明要在运行时边 run 边 build
+  if (Get<bool>("with_dynamic_shape") && min_input_shape == {}) {
+    return;
   }
 
   // the following code will NOT run in following situation:

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -617,8 +617,9 @@ struct PD_INFER_DECL AnalysisConfig {
   /// mode.
   /// \param allow_build_at_runtime allow build trt engine at runtime.
   ///
-  void EnableTunedTensorRtDynamicShape(const std::string& shape_range_info_path,
-                                       bool allow_build_at_runtime = true);
+  void EnableTunedTensorRtDynamicShape(
+      const std::string& shape_range_info_path = "",
+      bool allow_build_at_runtime = true);
 
   ///
   /// \brief A boolean state telling whether to use tuned tensorrt dynamic

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -479,6 +479,7 @@ class TensorRTEngine {
       if (!min_input_shape_.count(name)) {
         min_input_shape_[name] = input_shape;
         max_input_shape_[name] = input_shape;
+        optim_input_shape_[name] = input_shape;
         min_change = true;
         max_change = true;
         ret = true;
@@ -509,17 +510,16 @@ class TensorRTEngine {
             max_input_shape_[name][d] = input_shape[d];
           }
         }
+        if (min_change)
+          LOG(INFO) << "refactor shape range: " << name << ", min_shape from "
+                    << Vec2Str(bak_min_shape) << " to "
+                    << Vec2Str(min_input_shape_[name]);
+        if (max_change)
+          LOG(INFO) << "refactor shape range: " << name << ", max_shape from "
+                    << Vec2Str(bak_max_shape) << " to "
+                    << Vec2Str(max_input_shape_[name]);
+        if (min_change || max_change) changed->push_back(name);
       }
-
-      if (min_change)
-        LOG(INFO) << "refactor shape range: " << name << ", min_shape from "
-                  << Vec2Str(bak_min_shape) << " to "
-                  << Vec2Str(min_input_shape_[name]);
-      if (max_change)
-        LOG(INFO) << "refactor shape range: " << name << ", max_shape from "
-                  << Vec2Str(bak_max_shape) << " to "
-                  << Vec2Str(max_input_shape_[name]);
-      if (min_change || max_change) changed->push_back(name);
     }
     return ret;
   }

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -467,15 +467,8 @@ class TensorRTEngine {
     for (const auto& it : runtime_input_shape) {
       auto name = it.first;
       auto input_shape = it.second;
-      // PADDLE_ENFORCE_EQ(
-      //     min_input_shape_.count(name),
-      //     true,
-      //     platform::errors::InvalidArgument(
-      //         "TRT dynamic_shape min_input_shape %s not found.", name));
-
       bool min_change = false;
       bool max_change = false;
-      // 如果当前的 shape_info 中没有目前的 runtime_input，进行添加
       if (!min_input_shape_.count(name)) {
         min_input_shape_[name] = input_shape;
         max_input_shape_[name] = input_shape;

--- a/paddle/fluid/inference/utils/io_utils.cc
+++ b/paddle/fluid/inference/utils/io_utils.cc
@@ -277,7 +277,11 @@ void UpdateShapeRangeInfo(
     const std::map<std::string, std::vector<int32_t>> &min_shape,
     const std::map<std::string, std::vector<int32_t>> &max_shape,
     const std::map<std::string, std::vector<int32_t>> &opt_shape,
-    const std::vector<std::string> &names) {
+    const std::map<std::string, std::vector<int32_t>> &min_value,
+    const std::map<std::string, std::vector<int32_t>> &max_value,
+    const std::map<std::string, std::vector<int32_t>> &opt_value,
+    const std::vector<std::string> &names,
+    const std::vector<std::string> &tensor_names) {
   paddle::inference::proto::ShapeRangeInfos shape_range_infos;
   DeserializeShapeRangeInfo(path, &shape_range_infos);
 
@@ -294,6 +298,20 @@ void UpdateShapeRangeInfo(
           info->add_max_shape(max_shape.at(name)[j]);
         for (size_t j = 0; j < opt_shape.at(name).size(); ++j)
           info->add_opt_shape(opt_shape.at(name)[j]);
+        break;
+      }
+    }
+    for (const auto &name : tensor_names) {
+      if (info->name() == name) {
+        info->clear_min_value();
+        info->clear_max_value();
+        info->clear_opt_value();
+        for (size_t j = 0; j < min_value.at(name).size(); ++j)
+          info->add_min_value(min_value.at(name)[j]);
+        for (size_t j = 0; j < max_value.at(name).size(); ++j)
+          info->add_max_value(max_value.at(name)[j]);
+        for (size_t j = 0; j < opt_value.at(name).size(); ++j)
+          info->add_opt_value(opt_value.at(name)[j]);
         break;
       }
     }

--- a/paddle/fluid/inference/utils/io_utils.h
+++ b/paddle/fluid/inference/utils/io_utils.h
@@ -63,6 +63,10 @@ void UpdateShapeRangeInfo(
     const std::map<std::string, std::vector<int32_t>>& min_shape,
     const std::map<std::string, std::vector<int32_t>>& max_shape,
     const std::map<std::string, std::vector<int32_t>>& opt_shape,
-    const std::vector<std::string>& names);
+    const std::map<std::string, std::vector<int32_t>>& min_value,
+    const std::map<std::string, std::vector<int32_t>>& max_value,
+    const std::map<std::string, std::vector<int32_t>>& opt_value,
+    const std::vector<std::string>& names,
+    const std::vector<std::string>& tensor_names);
 }  // namespace inference
 }  // namespace paddle

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -345,7 +345,6 @@ class TensorRTEngineOp : public framework::OperatorBase {
         auto t_shape = phi::vectorize<int32_t>(t.dims());
         runtime_input_shape.insert(std::make_pair(name, t_shape));
       }
-
       if (!allow_build_at_runtime_) {
         std::map<std::string, std::vector<int>> min_input_shape =
             trt_engine->min_input_shape();
@@ -374,8 +373,10 @@ class TensorRTEngineOp : public framework::OperatorBase {
             runtime_input_shape, &shape_changed_name);
         if (is_adjusted) {
           LOG(INFO) << "Adjust dynamic shape range, rebuild trt engine!";
-          trt_engine->ResetContext();
-          trt_engine->ClearTensorMap();
+          if (trt_engine->engine()) {
+            trt_engine->ResetContext();
+            trt_engine->ClearTensorMap();
+          }
           auto *anc = scope.parent();
           while (anc && anc->parent()) {
             anc = anc->parent();

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -335,8 +335,9 @@ class TensorRTEngineOp : public framework::OperatorBase {
       trt_engine->GetEngineInfo();
     }
     if (trt_engine->with_dynamic_shape()) {
-      // get runtime input shapes.
+      // get runtime input shapes and shape tensors.
       std::map<std::string, std::vector<int32_t>> runtime_input_shape;
+      std::map<std::string, std::vector<int32_t>> runtime_shape_tensor;
       for (auto name : runtime_input_names_) {
         auto &t =
             inference::analysis::GetFromScope<phi::DenseTensor>(scope, name);
@@ -344,6 +345,36 @@ class TensorRTEngineOp : public framework::OperatorBase {
                 << t.dims() << ")";
         auto t_shape = phi::vectorize<int32_t>(t.dims());
         runtime_input_shape.insert(std::make_pair(name, t_shape));
+        // We need collect value range for shape tensor for Paddle-TRT's use.
+        // To be noticed, this method to identify all shape tensors is based on
+        // assumption that all shape tensors in the model have numbers <= 7.
+        // This is a simple method to identify all shape tensors with some
+        // mistakes, but it doesn't matter.
+        auto is_shape_tensor = t.numel() <= 7 && t.numel() >= 1;
+        if (trt_engine->engine()) {
+          is_shape_tensor = trt_engine->GetITensor(name)->isShapeTensor();
+        }
+        if (t.dtype() == paddle::experimental::DataType::INT32 &&
+            is_shape_tensor) {
+          std::vector<int> int32_host(t.numel());
+          if (t.place() == platform::CPUPlace()) {
+            paddle::memory::Copy(platform::CPUPlace(),
+                                 int32_host.data(),
+                                 platform::CPUPlace(),
+                                 t.data<int>(),
+                                 t.numel() * sizeof(int));
+          } else if (t.place() == platform::CUDAPlace()) {
+#if defined(PADDLE_WITH_CUDA)
+            paddle::memory::Copy(platform::CPUPlace(),
+                                 int32_host.data(),
+                                 platform::CUDAPlace(),
+                                 t.data<int>(),
+                                 t.numel() * sizeof(int),
+                                 nullptr);
+#endif
+          }
+          runtime_shape_tensor[name] = int32_host;
+        }
       }
       if (!allow_build_at_runtime_) {
         std::map<std::string, std::vector<int>> min_input_shape =
@@ -369,8 +400,12 @@ class TensorRTEngineOp : public framework::OperatorBase {
       } else {
         // compare runtime_input_shape and trt_engine dynamic shapes.
         std::vector<std::string> shape_changed_name;
-        bool is_adjusted = trt_engine->AdjustDynamicShapeRange(
-            runtime_input_shape, &shape_changed_name);
+        std::vector<std::string> tensor_changed_name;
+        bool is_adjusted =
+            trt_engine->AdjustDynamicShapeRange(runtime_input_shape,
+                                                runtime_shape_tensor,
+                                                &shape_changed_name,
+                                                &tensor_changed_name);
         if (is_adjusted) {
           LOG(INFO) << "Adjust dynamic shape range, rebuild trt engine!";
           if (trt_engine->engine()) {
@@ -391,7 +426,11 @@ class TensorRTEngineOp : public framework::OperatorBase {
                                             trt_engine->min_input_shape(),
                                             trt_engine->max_input_shape(),
                                             trt_engine->optim_input_shape(),
-                                            shape_changed_name);
+                                            trt_engine->min_shape_tensor(),
+                                            trt_engine->max_shape_tensor(),
+                                            trt_engine->optim_shape_tensor(),
+                                            shape_changed_name,
+                                            tensor_changed_name);
           }
 
           if (use_static_engine_) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
添加配置Paddle-Trt动态Shape的新方式：
1. 接口 EnableTunedTensorRtDynamicShape() ，不传任何参数时，表明在运行时构建 trt engine。
2. 不再需要先收集再运行，但为了避免运行时的重新构建，需要在前几次运行时，覆盖最小及最大Shape的情况。

接口文档待添加。