### PR TITLE
[CodeStyle][isort] introduce isort (part6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,6 @@ extend_skip_glob = [
     "python/paddle/fluid/tests/unittests/mlu/**",
 
     # These files will be fixed in the future
-    "cmake/**",
-    "paddle/**",
-    "r/**",
-    "tools/**",
-    "python/paddle/[!f]**",
-    "python/paddle/fluid/tests/unittests/[t-z]**",
     "python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py",
-    "python/paddle/fluid/tests/unittests/dygraph_to_static/**",
-    "python/paddle/fluid/tests/unittests/ipu/test_dy2static_ipu.py",
+    "python/paddle/jit/**",
 ]

--- a/python/paddle/distributed/passes/auto_parallel_data_parallel_optimization.py
+++ b/python/paddle/distributed/passes/auto_parallel_data_parallel_optimization.py
@@ -15,24 +15,25 @@
 from collections import OrderedDict
 
 import paddle
-from paddle.fluid import unique_name
-from paddle.fluid.framework import default_main_program
-from paddle.distributed.fleet.meta_optimizers.common import OP_ROLE_KEY, OpRole
-from .pass_base import PassBase, PassType, register_pass
 from paddle.distributed.auto_parallel.operators.common import (
-    is_data_parallel_scale_op,
     is_data_parallel_reduce_op,
+    is_data_parallel_scale_op,
 )
 from paddle.distributed.auto_parallel.utils import (
     find_higher_order_backward_op,
+    get_var_numel,
+    insert_dependencies_for_two_vars,
+    is_forward_op,
     is_loss_grad_op,
     is_optimize_op,
-    is_forward_op,
     ring_id_to_process_group,
-    get_var_numel,
     use_standalone_executor,
-    insert_dependencies_for_two_vars,
 )
+from paddle.distributed.fleet.meta_optimizers.common import OP_ROLE_KEY, OpRole
+from paddle.fluid import unique_name
+from paddle.fluid.framework import default_main_program
+
+from .pass_base import PassBase, PassType, register_pass
 
 # add new optimizers supporting rescale_grad here
 __rescale_grad_supported_opts__ = [

--- a/python/paddle/distributed/passes/auto_parallel_grad_clip.py
+++ b/python/paddle/distributed/passes/auto_parallel_grad_clip.py
@@ -12,27 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 from functools import reduce
+
+import numpy as np
 
 import paddle
 
-from .pass_base import PassBase, register_pass
-from ..auto_parallel.reshard import Resharder
+from ..auto_parallel.dist_attribute import (
+    OperatorDistributedAttribute,
+    TensorDistributedAttribute,
+)
 from ..auto_parallel.process_group import get_world_process_group
+from ..auto_parallel.reshard import Resharder
 from ..auto_parallel.utils import (
-    is_gradient_clip_op,
-    is_optimize_op,
     OP_ROLE_KEY,
     OpRole,
     _get_comm_group,
     insert_dependencies_for_two_vars,
+    is_gradient_clip_op,
+    is_optimize_op,
     use_standalone_executor,
 )
-from ..auto_parallel.dist_attribute import (
-    TensorDistributedAttribute,
-    OperatorDistributedAttribute,
-)
+from .pass_base import PassBase, register_pass
 
 
 def _get_params_grads(block):

--- a/python/paddle/distribution/normal.py
+++ b/python/paddle/distribution/normal.py
@@ -21,10 +21,7 @@ import paddle
 from paddle.distribution import distribution
 from paddle.fluid.data_feeder import check_type, convert_dtype
 from paddle.fluid.framework import _non_static_mode
-from paddle.fluid.layers import (
-    nn,
-    tensor,
-)
+from paddle.fluid.layers import nn, tensor
 
 
 class Normal(distribution.Distribution):

--- a/python/paddle/distribution/uniform.py
+++ b/python/paddle/distribution/uniform.py
@@ -23,12 +23,7 @@ from paddle.fluid.framework import (
     _non_static_mode,
     in_dygraph_mode,
 )
-from paddle.fluid.layers import (
-    nn,
-    tensor,
-)
-
-import paddle
+from paddle.fluid.layers import nn, tensor
 from paddle.tensor import random
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/bert_dygraph_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/bert_dygraph_model.py
@@ -17,8 +17,8 @@ from transformer_dygraph_model import MultiHeadAttention, PrePostProcessLayer
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph import Embedding, Layer
-from paddle.nn import Linear
 from paddle.jit.api import declarative
+from paddle.nn import Linear
 
 
 class PositionwiseFeedForwardLayer(Layer):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/simnet_dygraph_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/simnet_dygraph_model.py
@@ -17,9 +17,6 @@ from functools import reduce
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.param_attr as attr
-
-from functools import reduce
-
 from paddle.fluid.dygraph import Embedding, Layer
 from paddle.jit.api import declarative
 from paddle.static import Variable

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import unittest
 
-import logging
 import numpy as np
+from test_program_translator import get_source_code
 
 import paddle
 import paddle.fluid as fluid
-from paddle.jit import ProgramTranslator
-from paddle.jit.dy2static.convert_call_func import (
-    CONVERSION_OPTIONS,
-)
-from test_program_translator import get_source_code
 import paddle.jit.dy2static as _jst
+from paddle.jit import ProgramTranslator
+from paddle.jit.dy2static.convert_call_func import CONVERSION_OPTIONS
 
 program_translator = ProgramTranslator()
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
@@ -24,10 +24,8 @@ os.environ["CUDA_VISIBLE_DEVICES"] = "2"
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid.dygraph import to_variable
-from paddle.fluid.dygraph import Embedding, GRUUnit
-
 from paddle import _legacy_C_ops
+from paddle.fluid.dygraph import Embedding, GRUUnit, to_variable
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 from paddle.fluid.framework import _non_static_mode
 from paddle.jit import ProgramTranslator

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
@@ -15,6 +15,7 @@
 import unittest
 
 import numpy as np
+
 import paddle
 import paddle.fluid as fluid
 from paddle.jit.api import declarative

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logical.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logical.py
@@ -22,10 +22,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.jit import ProgramTranslator
-from paddle.jit.dy2static.logical_transformer import (
-    cmpop_node_to_str,
-)
-from paddle.jit import ProgramTranslator
+from paddle.jit.dy2static.logical_transformer import cmpop_node_to_str
 from paddle.utils import gast
 
 program_translator = ProgramTranslator()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle.utils import gast
 import inspect
-import numpy as np
-import paddle
-import paddle.fluid as fluid
 import unittest
 
-from paddle.jit.dy2static.loop_transformer import NameVisitor
+import numpy as np
+
+import paddle
+import paddle.fluid as fluid
 from paddle.jit.api import declarative
+from paddle.jit.dy2static.loop_transformer import NameVisitor
+from paddle.utils import gast
 
 SEED = 2020
 np.random.seed(SEED)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist.py
@@ -23,11 +23,11 @@ from predictor_utils import PredictorTools
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph import to_variable
-from paddle.nn import Linear
 from paddle.fluid.dygraph.base import switch_to_static_graph
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.optimizer import AdamOptimizer
+from paddle.nn import Linear
 
 SEED = 2020
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
@@ -26,16 +26,9 @@ from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 from paddle.fluid.dygraph.nn import BatchNorm, Linear
 from paddle.fluid.initializer import MSRA
 from paddle.fluid.param_attr import ParamAttr
-from paddle.fluid.dygraph.nn import BatchNorm
-from paddle.nn import Linear
-from paddle.jit.api import declarative
 from paddle.jit import ProgramTranslator
-
-from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
-
-import unittest
-
-from predictor_utils import PredictorTools
+from paddle.jit.api import declarative
+from paddle.nn import Linear
 
 # Note: Set True to eliminate randomness.
 #     1. For one operation, cuDNN has several algorithms,

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py
@@ -21,7 +21,7 @@ import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid.dygraph import to_variable, Layer
+from paddle.fluid.dygraph import Layer, to_variable
 from paddle.jit import ProgramTranslator
 from paddle.jit.api import declarative
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet.py
@@ -17,16 +17,14 @@ import os
 import tempfile
 import time
 import unittest
-import paddle
+
 import numpy as np
 from predictor_utils import PredictorTools
 
 import paddle
 import paddle.fluid as fluid
-
-from paddle.fluid.dygraph.nn import BatchNorm
-from paddle.jit import ProgramTranslator
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
+from paddle.fluid.dygraph.nn import BatchNorm
 from paddle.jit import ProgramTranslator
 
 SEED = 2020

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_inference_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_inference_model.py
@@ -15,16 +15,15 @@
 import os
 import tempfile
 import unittest
+
 import numpy as np
 
 import paddle
 import paddle.fluid as fluid
+from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
 from paddle.jit import ProgramTranslator
 from paddle.jit.api import declarative
-from paddle.jit.dy2static.partial_program import (
-    partial_program_from,
-)
-from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
+from paddle.jit.dy2static.partial_program import partial_program_from
 
 SEED = 2020
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_load.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_load.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import os
 import tempfile
+import unittest
 
 import numpy as np
-import paddle.fluid as fluid
-
-from paddle.jit import ProgramTranslator
-from paddle.fluid.optimizer import AdamOptimizer
 from test_fetch_feed import Linear
+
+import paddle.fluid as fluid
+from paddle.fluid.optimizer import AdamOptimizer
+from paddle.jit import ProgramTranslator
 
 np.random.seed(2020)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
@@ -25,11 +25,11 @@ from predictor_utils import PredictorTools
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.base import to_variable
-from paddle.fluid.dygraph.nn import BatchNorm
-from paddle.nn import Linear
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
+from paddle.fluid.dygraph.nn import BatchNorm
 from paddle.jit import ProgramTranslator
 from paddle.jit.api import declarative
+from paddle.nn import Linear
 
 SEED = 2020
 np.random.seed(SEED)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_sentiment.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_sentiment.py
@@ -19,12 +19,11 @@ from test_lac import DynamicGRU
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid.dygraph.nn import Embedding
-from paddle.nn import Linear
 from paddle.fluid.dygraph import to_variable
 from paddle.fluid.dygraph.nn import Embedding, Linear
 from paddle.jit import ProgramTranslator
 from paddle.jit.api import declarative
+from paddle.nn import Linear
 
 SEED = 2020
 program_translator = ProgramTranslator()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_seq2seq.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_seq2seq.py
@@ -18,13 +18,12 @@ import time
 import unittest
 
 import numpy as np
+from seq2seq_dygraph_model import AttentionModel, BaseModel
+from seq2seq_utils import Seq2SeqModelHyperParams, get_data_iter
+
 import paddle.fluid as fluid
 from paddle.fluid.clip import GradientClipByGlobalNorm
 from paddle.jit import ProgramTranslator
-
-from seq2seq_dygraph_model import BaseModel, AttentionModel
-from seq2seq_utils import Seq2SeqModelHyperParams
-from seq2seq_utils import get_data_iter
 
 place = (
     fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() else fluid.CPUPlace()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tsm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tsm.py
@@ -23,12 +23,11 @@ from tsm_config_utils import merge_configs, parse_config, print_configs
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid.dygraph.nn import BatchNorm
-from paddle.nn import Linear
-from paddle.jit.api import declarative
-from paddle.jit import ProgramTranslator
 from paddle.fluid.dygraph import to_variable
-from tsm_config_utils import merge_configs, parse_config, print_configs
+from paddle.fluid.dygraph.nn import BatchNorm
+from paddle.jit import ProgramTranslator
+from paddle.jit.api import declarative
+from paddle.nn import Linear
 
 random.seed(0)
 np.random.seed(0)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_word2vec.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_word2vec.py
@@ -14,13 +14,12 @@
 
 import math
 import random
-import paddle
-import numpy as np
-import paddle
-import paddle.fluid as fluid
 import unittest
 
+import numpy as np
+
 import paddle
+import paddle.fluid as fluid
 from paddle.fluid.dygraph.nn import Embedding
 from paddle.jit import ProgramTranslator
 from paddle.jit.api import declarative

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/transformer_dygraph_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/transformer_dygraph_model.py
@@ -18,15 +18,10 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 import paddle.nn.functional as F
-from paddle.fluid.dygraph import (
-    Embedding,
-    Layer,
-    LayerNorm,
-    to_variable,
-)
-from paddle.nn import Linear
+from paddle.fluid.dygraph import Embedding, Layer, LayerNorm, to_variable
 from paddle.fluid.layers.utils import map_structure
 from paddle.jit.api import dygraph_to_static_func
+from paddle.nn import Linear
 
 
 def position_encoding_init(n_position, d_pos_vec):

--- a/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
+++ b/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
-import numpy as np
 import math
+import unittest
+
+import numpy as np
 from op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
+++ b/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
@@ -16,6 +16,7 @@ Unit testing for affine_channel_op
 """
 
 import unittest
+
 import numpy as np
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -14,13 +14,15 @@
 """This is unit test of Test data_norm Op."""
 
 import unittest
+
 import numpy as np
-import paddle
-import paddle.fluid.core as core
-from paddle.fluid.op import Operator
-import paddle.fluid as fluid
 from op_test import OpTest
+
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard
+from paddle.fluid.op import Operator
 
 
 def _reference_testing(x, batch_size, batch_sum, batch_square_sum, slot_dim=-1):

--- a/python/paddle/fluid/tests/unittests/test_detach.py
+++ b/python/paddle/fluid/tests/unittests/test_detach.py
@@ -18,8 +18,8 @@ import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-from paddle.nn import Linear
 from paddle.fluid.dygraph.base import to_variable
+from paddle.nn import Linear
 
 
 class Test_Detach(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
@@ -18,8 +18,8 @@ import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-from paddle.nn import Linear
 from paddle.fluid.framework import _test_eager_guard
+from paddle.nn import Linear
 
 
 class SimpleImgConvPool(fluid.dygraph.Layer):

--- a/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
@@ -20,9 +20,9 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
-from paddle.nn import Linear
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.optimizer import SGDOptimizer
+from paddle.nn import Linear
 
 SEED = 123123111
 

--- a/python/paddle/fluid/tests/unittests/test_executor_return_tensor_not_overwriting.py
+++ b/python/paddle/fluid/tests/unittests/test_executor_return_tensor_not_overwriting.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import unittest
-import paddle
+
 import numpy as np
 from op_test import OpTest, skip_check_grad_ci
 
+import paddle
 import paddle.fluid as fluid
 
 

--- a/python/paddle/fluid/tests/unittests/test_fill_zeros_like2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_zeros_like2_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest
+
 from paddle.fluid.framework import convert_np_dtype_to_dtype_
 
 

--- a/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
@@ -14,10 +14,11 @@
 
 import os
 import unittest
-import numpy
 
+import numpy
 from parallel_executor_test_base import DeviceType, TestParallelExecutorBase
 from simple_nets import fc_with_batchnorm, init_data, simple_fc_net
+
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 import unittest
+
 import numpy as np
+from op_test import OpTest, skip_check_grad_ci
+from testsuite import create_op
 
 import paddle
-import paddle.fluid.core as core
 import paddle.fluid as fluid
-from op_test import OpTest, skip_check_grad_ci
+import paddle.fluid.core as core
 from paddle.fluid.framework import _test_eager_guard
-from testsuite import create_op
 
 
 def group_norm_naive(x, scale, bias, epsilon, groups, data_layout):

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -19,8 +19,8 @@ from test_imperative_base import new_program_scope
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
 import paddle.fluid.dygraph_utils as dygraph_utils
+from paddle.fluid import core
 from paddle.fluid.dygraph.layer_object_helper import LayerObjectHelper
 from paddle.fluid.framework import _in_legacy_dygraph, _test_eager_guard
 from paddle.fluid.layer_helper import LayerHelper

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_sequential.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_sequential.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
-from paddle.nn import Linear
 
 import paddle.fluid as fluid
 from paddle.fluid.framework import _test_eager_guard
+from paddle.nn import Linear
 
 
 class TestImperativeContainerSequential(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_imperative_deepcf.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_deepcf.py
@@ -24,8 +24,8 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.dygraph.base import to_variable
-from paddle.nn import Linear
 from paddle.fluid.framework import _test_eager_guard
+from paddle.nn import Linear
 
 
 class DMF(fluid.Layer):

--- a/python/paddle/fluid/tests/unittests/test_imperative_framework.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_framework.py
@@ -20,7 +20,6 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.framework import _test_eager_guard
-import paddle
 
 
 class MLP(fluid.Layer):

--- a/python/paddle/fluid/tests/unittests/test_imperative_gan.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_gan.py
@@ -20,10 +20,10 @@ from test_imperative_base import new_program_scope
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.nn import Linear
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.optimizer import SGDOptimizer
+from paddle.nn import Linear
 
 
 class Discriminator(fluid.Layer):

--- a/python/paddle/fluid/tests/unittests/test_imperative_layer_trainable.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_layer_trainable.py
@@ -16,10 +16,10 @@ import unittest
 
 import numpy as np
 
+import paddle
 import paddle.fluid as fluid
 import paddle.fluid.dygraph as dygraph
 from paddle.fluid.framework import _test_eager_guard
-import paddle
 
 
 class TestImperativeLayerTrainable(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_imperative_load_static_param.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_load_static_param.py
@@ -27,13 +27,9 @@ from paddle.fluid.dygraph.nn import (
     Embedding,
     GroupNorm,
     LayerNorm,
-    NCE,
     PRelu,
 )
 from paddle.nn import Linear
-import numpy as np
-import os
-import tempfile
 
 
 class TestDygraphLoadStatic(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
@@ -15,16 +15,15 @@
 import unittest
 
 import numpy as np
+from test_imperative_base import new_program_scope
 from utils import DyGraphProgramDescTracerTestHelper
 
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
+from paddle.fluid.framework import _in_legacy_dygraph, _test_eager_guard
 from paddle.fluid.optimizer import SGDOptimizer
 from paddle.nn import Linear
-from test_imperative_base import new_program_scope
-from utils import DyGraphProgramDescTracerTestHelper
-from paddle.fluid.framework import _test_eager_guard, _in_legacy_dygraph
 
 
 class SimpleImgConvPool(fluid.dygraph.Layer):

--- a/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
@@ -21,14 +21,9 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.dygraph.base import to_variable
-from paddle.fluid.dygraph.nn import (
-    BatchNorm,
-    Embedding,
-    GRUUnit,
-    Linear,
-)
-from paddle.nn import Linear
+from paddle.fluid.dygraph.nn import BatchNorm, Embedding, GRUUnit, Linear
 from paddle.fluid.framework import _test_eager_guard
+from paddle.nn import Linear
 
 
 class Config:

--- a/python/paddle/fluid/tests/unittests/test_imperative_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_optimizer.py
@@ -16,10 +16,13 @@ import itertools
 import unittest
 
 import numpy as np
+from test_imperative_base import new_program_scope
 
 import paddle
 import paddle.fluid as fluid
+from paddle.distributed.fleet.meta_optimizers import DGCMomentumOptimizer
 from paddle.fluid import core
+from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.optimizer import (
     AdadeltaOptimizer,
     AdagradOptimizer,
@@ -39,10 +42,6 @@ from paddle.fluid.optimizer import (
     RMSPropOptimizer,
     SGDOptimizer,
 )
-from test_imperative_base import new_program_scope
-from paddle.fluid.framework import _test_eager_guard
-
-from paddle.distributed.fleet.meta_optimizers import DGCMomentumOptimizer
 
 # Note(wangzhongpu)
 # In dygraph, don't support ModelAverage, DGCMomentumOptimizer, ExponentialMovingAverage, PipelineOptimizer, LookaheadOptimizer, RecomputeOptimizer.

--- a/python/paddle/fluid/tests/unittests/test_imperative_optimizer_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_optimizer_v2.py
@@ -16,10 +16,13 @@ import itertools
 import unittest
 
 import numpy as np
+from test_imperative_base import new_program_scope
 
 import paddle
 import paddle.fluid as fluid
+from paddle.distributed.fleet.meta_optimizers import DGCMomentumOptimizer
 from paddle.fluid import core
+from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.optimizer import (
     AdadeltaOptimizer,
     AdagradOptimizer,
@@ -36,10 +39,6 @@ from paddle.fluid.optimizer import (
     RecomputeOptimizer,
     RMSPropOptimizer,
 )
-from test_imperative_base import new_program_scope
-from paddle.fluid.framework import _test_eager_guard
-
-from paddle.distributed.fleet.meta_optimizers import DGCMomentumOptimizer
 
 # Note(wangzhongpu)
 # In dygraph, don't support ModelAverage, DGCMomentumOptimizer, ExponentialMovingAverage, PipelineOptimizer, LookaheadOptimizer, RecomputeOptimizer.

--- a/python/paddle/fluid/tests/unittests/test_imperative_partitial_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_partitial_backward.py
@@ -16,9 +16,9 @@ import unittest
 
 import numpy as np
 
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.framework import _test_eager_guard
-import paddle
 
 
 class TestImperativePartitialBackward(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_imperative_reinforcement.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_reinforcement.py
@@ -15,11 +15,11 @@
 import unittest
 
 import numpy as np
+from test_imperative_base import new_program_scope
 
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
-from test_imperative_base import new_program_scope
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.optimizer import SGDOptimizer
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -20,8 +20,7 @@ from utils import DyGraphProgramDescTracerTestHelper, is_equal_program
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import core
-from paddle.fluid import BatchNorm
+from paddle.fluid import BatchNorm, core
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.framework import _in_legacy_dygraph, _test_eager_guard
 from paddle.fluid.layer_helper import LayerHelper

--- a/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
@@ -21,7 +21,6 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.dygraph.nn import BatchNorm
-from test_imperative_base import new_program_scope
 from paddle.fluid.framework import _test_eager_guard
 from paddle.fluid.layer_helper import LayerHelper
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_trace_non_persistable_inputs.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_trace_non_persistable_inputs.py
@@ -16,7 +16,7 @@ import os
 import unittest
 
 import numpy as np
-import os
+
 import paddle
 import paddle.fluid as fluid
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
@@ -19,15 +19,12 @@ from test_imperative_base import new_program_scope
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Embedding, LayerNorm, Layer
-from paddle.nn import Linear
-from paddle.fluid.dygraph import to_variable, guard
-from test_imperative_base import new_program_scope
-from paddle.fluid.framework import _in_legacy_dygraph, _test_eager_guard
-from paddle.fluid import core
-import numpy as np
 import paddle.nn.functional as F
+from paddle.fluid import Embedding, Layer, LayerNorm, core
+from paddle.fluid.dygraph import guard, to_variable
+from paddle.fluid.framework import _in_legacy_dygraph, _test_eager_guard
 from paddle.jit import TracedLayer
+from paddle.nn import Linear
 
 np.set_printoptions(suppress=True)
 

--- a/python/paddle/fluid/tests/unittests/test_isfinite_op.py
+++ b/python/paddle/fluid/tests/unittests/test_isfinite_op.py
@@ -16,6 +16,7 @@ import unittest
 
 import numpy as np
 from op_test import OpTest
+
 import paddle.fluid.core as core
 
 

--- a/python/paddle/fluid/tests/unittests/test_jit_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_jit_save_load.py
@@ -23,11 +23,11 @@ import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-from paddle.nn import Linear
 from paddle.fluid import unique_name
 from paddle.fluid.dygraph.io import INFER_PARAMS_INFO_SUFFIX
 from paddle.fluid.layers.utils import flatten
 from paddle.jit.api import declarative
+from paddle.nn import Linear
 from paddle.static import InputSpec
 
 BATCH_SIZE = 32

--- a/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
@@ -14,13 +14,15 @@
 
 import copy
 import math
-import numpy as np
 import unittest
+
+import numpy as np
+
 import paddle
 import paddle.fluid as fluid
-import paddle.fluid.layers as layers
-import paddle.fluid.framework as framework
 import paddle.fluid.core as core
+import paddle.fluid.framework as framework
+import paddle.fluid.layers as layers
 
 
 def exponential_decay(

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_dynamic.py
@@ -15,9 +15,6 @@
 import sys
 import time
 import unittest
-import numpy as np
-import paddle
-from paddle.nn import Linear
 
 import numpy as np
 from test_multiprocess_dataloader_static import (
@@ -31,8 +28,10 @@ from test_multiprocess_dataloader_static import (
     prepare_places,
 )
 
+import paddle
 import paddle.fluid as fluid
 from paddle.io import DataLoader
+from paddle.nn import Linear
 
 
 class SimpleFCNet(fluid.dygraph.Layer):

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_dynamic.py
@@ -15,10 +15,6 @@
 import sys
 import time
 import unittest
-import numpy as np
-
-import paddle
-from paddle.nn import Linear
 
 import numpy as np
 from test_multiprocess_dataloader_iterable_dataset_static import (
@@ -32,8 +28,10 @@ from test_multiprocess_dataloader_iterable_dataset_static import (
     prepare_places,
 )
 
+import paddle
 import paddle.fluid as fluid
 from paddle.io import DataLoader
+from paddle.nn import Linear
 
 
 class SimpleFCNet(fluid.dygraph.Layer):

--- a/python/paddle/fluid/tests/unittests/test_ones_op.py
+++ b/python/paddle/fluid/tests/unittests/test_ones_op.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 
 import paddle
-import numpy as np
 
 
 class ApiOnesTest(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import numpy as np
 import os
-from io import BytesIO
 import tempfile
+import unittest
+from io import BytesIO
+
+import numpy as np
+from test_imperative_base import new_program_scope
 
 import paddle
+import paddle.fluid as fluid
+import paddle.fluid.framework as framework
 import paddle.nn as nn
 import paddle.optimizer as opt
-import paddle.fluid as fluid
 from paddle.fluid.optimizer import Adam
-import paddle.fluid.framework as framework
-from test_imperative_base import new_program_scope
 from paddle.optimizer.lr import LRScheduler
 
 BATCH_SIZE = 16

--- a/python/paddle/fluid/tests/unittests/test_pool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_op.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import unittest
+
 import numpy as np
+from op_test import OpTest
 
 import paddle
 import paddle.fluid.core as core
-from op_test import OpTest
 
 
 def adaptive_start_index(index, input_size, output_size):

--- a/python/paddle/fluid/tests/unittests/test_roi_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roi_pool_op.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
-import unittest
-import numpy as np
 import math
 import sys
+import unittest
+from decimal import ROUND_HALF_UP, Decimal
+
+import numpy as np
 from op_test import OpTest
 
-from decimal import Decimal, ROUND_HALF_UP
+import paddle
 
 
 def _round(x):

--- a/python/paddle/fluid/tests/unittests/test_sigmoid_cross_entropy_with_logits_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sigmoid_cross_entropy_with_logits_op.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
 import numpy as np
 from op_test import OpTest
-from scipy.special import logit
-from scipy.special import expit
-import unittest
-from paddle.fluid import Program, program_guard
-import paddle.fluid as fluid
+from scipy.special import expit, logit
+
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
 class TestSigmoidCrossEntropyWithLogitsOp1(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_similarity_focus_op.py
+++ b/python/paddle/fluid/tests/unittests/test_similarity_focus_op.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+
 import numpy as np
 from op_test import OpTest
 

--- a/python/paddle/fluid/tests/unittests/test_size_op.py
+++ b/python/paddle/fluid/tests/unittests/test_size_op.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import unittest
+
 import numpy as np
+from op_test import OpTest
+
 import paddle
 import paddle.fluid as fluid
-from op_test import OpTest
-import paddle
 
 
 class TestSizeOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_static_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load.py
@@ -13,18 +13,20 @@
 # limitations under the License.
 
 
+import errno
+import os
+import pickle
+import tempfile
 import unittest
+
+import numpy as np
+from test_imperative_base import new_program_scope
+
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import paddle.fluid.framework as framework
 from paddle.fluid.optimizer import Adam
-from test_imperative_base import new_program_scope
-import numpy as np
-import pickle
-import os
-import errno
-import tempfile
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/utils.py
+++ b/python/paddle/fluid/tests/unittests/utils.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from paddle.fluid.framework import _dygraph_guard
-import paddle.fluid as fluid
 import numpy as np
+
+import paddle.fluid as fluid
+from paddle.fluid.framework import _dygraph_guard
 
 __all__ = ['DyGraphProgramDescTracerTestHelper', 'is_equal_program']
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_affine_channel_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_affine_channel_op_xpu.py
@@ -20,8 +20,10 @@ import sys
 sys.path.append("..")
 
 import unittest
+
 import numpy as np
 from op_test_xpu import XPUOpTest
+
 import paddle
 import paddle.fluid.core as core
 

--- a/python/paddle/hapi/progressbar.py
+++ b/python/paddle/hapi/progressbar.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import os
+import struct
 import sys
 import time
+
 import numpy as np
-import struct
 
 __all__ = []
 

--- a/python/paddle/incubate/multiprocessing/reductions.py
+++ b/python/paddle/incubate/multiprocessing/reductions.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
+import copy
 
 # TODO: check the hooks of tensor
 # TODO: check serializing named tensor
 # TODO: check influence on autograd
 import sys
-import copy
 import threading
-from multiprocessing.util import register_after_fork
-from multiprocessing.reduction import ForkingPickler
-
 from collections import OrderedDict
+from multiprocessing.reduction import ForkingPickler
+from multiprocessing.util import register_after_fork
+
+import paddle
 
 
 def _supported_check():

--- a/python/paddle/inference/wrapper.py
+++ b/python/paddle/inference/wrapper.py
@@ -12,14 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.fluid.core as core
-from paddle.fluid.core import AnalysisConfig, PaddleDType, PaddlePlace
-from paddle.fluid.core import PaddleInferPredictor, PaddleInferTensor
-from paddle.fluid.core import convert_to_mixed_precision_bind
-
 import os
-import numpy as np
 from typing import Set
+
+import numpy as np
+
+import paddle.fluid.core as core
+from paddle.fluid.core import (
+    AnalysisConfig,
+    PaddleDType,
+    PaddleInferPredictor,
+    PaddleInferTensor,
+    PaddlePlace,
+    convert_to_mixed_precision_bind,
+)
 
 DataType = PaddleDType
 PlaceType = PaddlePlace

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -13,19 +13,17 @@
 # limitations under the License.
 
 import paddle
-from paddle.fluid.param_attr import ParamAttr
-from paddle.fluid.initializer import Normal, Constant
-from paddle.fluid.framework import static_only, Variable, _non_static_mode
-from paddle.fluid.layers.layer_function_generator import templatedoc
-
-from paddle.fluid.data_feeder import check_dtype
-
 from paddle.common_ops_import import (
+    LayerHelper,
     check_type,
     check_variable_and_dtype,
     utils,
-    LayerHelper,
 )
+from paddle.fluid.data_feeder import check_dtype
+from paddle.fluid.framework import Variable, _non_static_mode, static_only
+from paddle.fluid.initializer import Constant, Normal
+from paddle.fluid.layers.layer_function_generator import templatedoc
+from paddle.fluid.param_attr import ParamAttr
 
 __all__ = []
 

--- a/python/paddle/vision/datasets/folder.py
+++ b/python/paddle/vision/datasets/folder.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 from PIL import Image
 
 import paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

引入 isort 第六部分，主要是前几个 PR 因为避免冲突而 revert 掉的一些文件，以及本 PR 修改配置文件以阻止前几个 PR 修改部分出现增量

剩余的 TODOs（后续 PR）:

- 动转静目录（原 `python/paddle/fluid/dygraph/dygraph_to_static` 现 `python/paddle/jit` 目录），目前正在迁移，且目前貌似有隐式循环依赖（fluid 内外的动转静模块之间），导致直接 sort 会出现模块找不到的问题，待全部迁移完成后再单独提 PR sort
- dy2static 单测 test_error.py 需要根据修改行号，单独提 PR
- 应该可能会有一些增量，如果有的话过一段时间一起修一下就好了

### Related links

- RFC：[Python 引入 import 区域自动重排工具 isort 方案](https://github.com/PaddlePaddle/community/blob/master/rfcs/CodeStyle/20221111_introducing_isort.md)
- part1: #46475
- part2: #48390
- part3: #48401
- part4: #48402
- part5: #48404