### PR TITLE
remove new import of six

### DIFF
--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -81,30 +81,15 @@ def is_builtin(func, name=None):
         return False
 
 
-def builtin_modules():
-    """
-    Return builtin modules.
-    """
-    modules = [
-        collections,
-        pdb,
-        copy,
-        inspect,
-        re,
-        numpy,
-        logging,
-    ]
-    try:
-        import six
-
-        modules.append(six)
-    except ImportError:
-        pass  # do nothing
-
-    return modules
-
-
-BUILTIN_LIKELY_MODULES = builtin_modules()
+BUILTIN_LIKELY_MODULES = [
+    collections,
+    pdb,
+    copy,
+    inspect,
+    re,
+    numpy,
+    logging,
+]
 
 
 def is_unsupported(func):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
在 PR https://github.com/PaddlePaddle/Paddle/pull/46965, https://github.com/PaddlePaddle/Paddle/pull/47334 中，`six` 包已被移除，这里没有必要再引入
### Other Related Issues
Legacy python2 tracking issue: https://github.com/PaddlePaddle/Paddle/issues/46837
