### PR TITLE
fuse-mt passes compatible with structured pruning

### DIFF
--- a/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.cc
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.cc
@@ -1354,9 +1354,10 @@ int FusedMultiTransformerEncoderPass::BuildFusion(Graph* graph,
         scope->FindVar(eltadd2_b->Name())->GetMutable<phi::DenseTensor>();
 
     // NOTE(minghaoBD): to make it compatible with strucutured pruning on
-    // num_head dimension: get dim_head from reshape.shape[3], dim_embed from
-    // layer_norm_bias.shape[0] calculate num_head according to
-    // wq_tensor.shape[1] and dim_head
+    // num_head dimension:
+    // 1. get dim_head from reshape.shape[3], dim_embed from
+    // layer_norm_bias.shape[0]
+    // 2. calculate num_head according to wq_tensor.shape[1] and dim_head
     auto reshape_desc = reshape2_0->Op();
     int dim_head =
         PADDLE_GET_CONST(std::vector<int>, reshape_desc->GetAttr("shape"))
@@ -2217,9 +2218,10 @@ int FusedMultiTransformerEncoderFuseQKVPass::BuildFusion(
         scope->FindVar(eltadd0_b->Name())->GetMutable<phi::DenseTensor>();
 
     // NOTE(minghaoBD): to make it compatible with strucutured pruning on
-    // num_head dimension: get dim_head from reshape.shape[3], dim_embed from
-    // layer_norm_bias.shape[0] calculate num_head according to
-    // wqkv_tensor.shape[1]/3 and dim_head
+    // num_head dimension:
+    // 1. get dim_head from reshape.shape[3], dim_embed from
+    // layer_norm_bias.shape[0]
+    // 2. calculate num_head according to wqkv_tensor.shape[1]/3 and dim_head
     auto reshape_desc = reshape2_0->Op();
     int dim_head =
         PADDLE_GET_CONST(std::vector<int>, reshape_desc->GetAttr("shape"))

--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cc
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cc
@@ -93,27 +93,6 @@ class FusedMultiTransformerOp : public framework::OperatorWithKernel {
             x_dim,
             y_dim));
 
-    if (ctx->Attrs().Get<int>("ring_id") == -1) {
-      if (trans_qkvw) {
-        PADDLE_ENFORCE_EQ(y_dim[1] * y_dim[2],
-                          y_dim[3],
-                          platform::errors::InvalidArgument(
-                              "The dimensions of qkv_weight must be 4"
-                              "(3, num_head, dim_head, dim_embed),"
-                              "and must satisfy the limitations: "
-                              "(num_head * dim_head == dim_embed)"));
-
-      } else {
-        PADDLE_ENFORCE_EQ(y_dim[2] * y_dim[3],
-                          y_dim[0],
-                          platform::errors::InvalidArgument(
-                              "The dimensions of qkv_weight must be 4"
-                              "(dim_embed, 3, num_head, dim_head),"
-                              "and must satisfy the limitations: "
-                              "(num_head * dim_head == dim_embed)"));
-      }
-    }
-
     if (ctx->HasInputs("CacheKV")) {
       // [2, batch_size, num_head, max_seq_len, head_size]
       const auto &c_dims = ctx->GetInputsDim("CacheKV");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Makes fuse-mt passes compatible with structured pruning.

1. get dim_head from reshape.shape[3], dim_embed from layer_norm_bias.shape[0] (not changed)
2. calculate num_head = wqkv_tensor.shape[1] / 3 / dim_head or num_head = w_tensor.shape[1] / dim_head
