### PR TITLE
[Discard] Use `NCCLCommContext` to manage nccl comms in ProcessGroupNCCL

### DIFF
--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.cc
@@ -118,10 +118,6 @@ phi::DeviceContext* ProcessGroupNCCL::GetDeviceContext(
   }
 }
 
-ncclComm_t ProcessGroupNCCL::NCCLComm(const Place& place) const {
-  return platform::NCCLCommContext::Instance().Get(gid_, place)->comm();
-}
-
 std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::AllGather(
     phi::DenseTensor* out_tensor,
     const phi::DenseTensor& in_tensor,
@@ -545,7 +541,8 @@ std::shared_ptr<ProcessGroup::Task> ProcessGroupNCCL::RunFnInNCCLEnv(
 
   const auto* calc_ctx = place_to_calc_ctx_.at(key);
   const auto& comm_ctx = place_to_comm_ctx_.at(key);
-  auto nccl_comm = NCCLComm(place);
+  auto nccl_comm =
+      platform::NCCLCommContext::Instance().Get(gid_, place)->comm();
   auto nccl_stream = use_calc_stream ? calc_ctx->stream() : comm_ctx->stream();
   fn(nccl_comm, nccl_stream);
 

--- a/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
+++ b/paddle/fluid/distributed/collective/ProcessGroupNCCL.h
@@ -161,8 +161,6 @@ class ProcessGroupNCCL final : public ProcessGroupStream {
 
   static void GroupEnd();
 
-  ncclComm_t NCCLComm(const Place& place) const;
-
   // TODO(liyurui): This API will be moved later
   std::shared_ptr<ProcessGroup::Task> AllReduce(
       std::vector<phi::DenseTensor>& in_tensors,

--- a/paddle/phi/backends/CMakeLists.txt
+++ b/paddle/phi/backends/CMakeLists.txt
@@ -70,4 +70,4 @@ endif()
 cc_library(
   processgroup_comm_utils
   SRCS processgroup_comm_utils.cc
-  DEPS ${COMM_UTILS_DEPS})
+  DEPS ${COMM_UTILS_DEPS} ${DEVICE_EVENT_LIBS})

--- a/paddle/phi/backends/processgroup_comm_utils.cc
+++ b/paddle/phi/backends/processgroup_comm_utils.cc
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/fluid/distributed/collective/ProcessGroup.h"
 #include "paddle/fluid/platform/collective_helper.h"
 #include "paddle/phi/backends/c_comm_lib.h"
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
@@ -34,8 +33,7 @@ namespace detail {
 // In principle, the PHI Kernel cannot use the global singleton internally,
 // and the required members need to be passed in from the eucalyptus tree.
 ccl::CCLComm GetCCLComm(const Place& place, int global_gid) {
-#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || \
-    defined(PADDLE_WITH_CUSTOM_DEVICE)
+#if defined(PADDLE_WITH_CUSTOM_DEVICE)
   paddle::distributed::ProcessGroup* pg = nullptr;
   if (paddle::distributed::ProcessGroupMapFromGid::getInstance()->has(
           global_gid)) {

--- a/paddle/phi/backends/processgroup_comm_utils.cc
+++ b/paddle/phi/backends/processgroup_comm_utils.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/distributed/collective/ProcessGroup.h"
+#include "paddle/fluid/platform/collective_helper.h"
 #include "paddle/phi/backends/c_comm_lib.h"
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
 #include "paddle/fluid/distributed/collective/ProcessGroupNCCL.h"
@@ -46,8 +47,9 @@ ccl::CCLComm GetCCLComm(const Place& place, int global_gid) {
 #endif
   if (paddle::platform::is_gpu_place(place)) {
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
-    return static_cast<paddle::distributed::ProcessGroupNCCL*>(pg)->NCCLComm(
-        place);
+    return paddle::platform::NCCLCommContext::Instance()
+        .Get(global_gid, place)
+        ->comm();
 #else
     return nullptr;
 #endif

--- a/paddle/phi/kernels/gpu/sync_batch_norm_utils.h
+++ b/paddle/phi/kernels/gpu/sync_batch_norm_utils.h
@@ -27,9 +27,6 @@ limitations under the License. */
 namespace cub = hipcub;
 #endif
 #include "paddle/fluid/distributed/collective/ProcessGroup.h"
-#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
-#include "paddle/fluid/distributed/collective/ProcessGroupNCCL.h"
-#endif
 #include "paddle/fluid/memory/malloc.h"
 #include "paddle/fluid/platform/collective_helper.h"
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"

--- a/paddle/phi/kernels/gpu/sync_batch_norm_utils.h
+++ b/paddle/phi/kernels/gpu/sync_batch_norm_utils.h
@@ -31,6 +31,7 @@ namespace cub = hipcub;
 #include "paddle/fluid/distributed/collective/ProcessGroupNCCL.h"
 #endif
 #include "paddle/fluid/memory/malloc.h"
+#include "paddle/fluid/platform/collective_helper.h"
 #include "paddle/fluid/platform/device/gpu/nccl_helper.h"
 #include "paddle/phi/backends/gpu/gpu_dnn.h"
 #include "paddle/phi/common/layout.h"
@@ -421,10 +422,9 @@ void SyncBatchNormGradFunctor(
 
   if (paddle::distributed::ProcessGroupMapFromGid::getInstance()->has(
           global_gid)) {
-    auto *nccl_pg = static_cast<paddle::distributed::ProcessGroupNCCL *>(
-        paddle::distributed::ProcessGroupMapFromGid::getInstance()->get(
-            global_gid));
-    comm = nccl_pg->NCCLComm(x->place());
+    comm = paddle::platform::NCCLCommContext::Instance()
+               .Get(global_gid, x->place())
+               ->comm();
   } else {
     comm = ctx.nccl_comm();
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
使用 fluid/platform/collective_helper.h 中的 NCCLCommContext 对 ProcessGroupNCCL 中现有的 nccl_comm 进行管理