### PR TITLE
adam batax_pow not in cpu

### DIFF
--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -731,8 +731,10 @@ class Optimizer:
         if device is None:
             device = self._get_device_for_param(param.name)
 
-        if in_dygraph_mode() and (
-            device == 'cpu' or isinstance(device, core.CPUPlace)
+        if (
+            in_dygraph_mode()
+            and (device == 'cpu' or isinstance(device, core.CPUPlace))
+            and (not core.is_compiled_with_xpu())
         ):
             _C_ops.full_(
                 var,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
bata1_pow和bata2_pow 放在CPU上对GPU下有性能提升。
但是在XPU下导致了精度问题。因此XPU下不将这两个参数放到CPU。