### PR TITLE
[Type Hints] 为python/tensor目录下的函数添加类型注解

### DIFF
--- a/paddle/phi/api/yaml/generator/api_gen.py
+++ b/paddle/phi/api/yaml/generator/api_gen.py
@@ -409,7 +409,7 @@ def main():
         '--api_yaml_path',
         help='path to api yaml file',
         nargs='+',
-        default='paddle/phi/api/yaml/ops.yaml',
+        default=['paddle/phi/api/yaml/ops.yaml'],
     )
 
     parser.add_argument(

--- a/python/paddle/tensor/array.py
+++ b/python/paddle/tensor/array.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
 
 # Define functions about array.
 

--- a/python/paddle/tensor/array.py
+++ b/python/paddle/tensor/array.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 # Define functions about array.
 

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 # TODO: define functions to get tensor attributes
 
@@ -260,7 +254,7 @@ def is_integer(x):
     return is_int_dtype
 
 
-def real(x: Tensor, name: str = None) -> Tensor:
+def real(x, name=None):
     """
     Returns a new Tensor containing real values of the input Tensor.
 
@@ -307,7 +301,7 @@ def real(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def imag(x: Tensor, name: str = None) -> Tensor:
+def imag(x, name=None):
     """
     Returns a new tensor containing imaginary values of input tensor.
 

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define functions to get tensor attributes
 
@@ -254,7 +260,7 @@ def is_integer(x):
     return is_int_dtype
 
 
-def real(x, name=None):
+def real(x: Tensor, name: str = None) -> Tensor:
     """
     Returns a new Tensor containing real values of the input Tensor.
 
@@ -301,7 +307,7 @@ def real(x, name=None):
     return out
 
 
-def imag(x, name=None):
+def imag(x: Tensor, name: str = None) -> Tensor:
     """
     Returns a new tensor containing imaginary values of input tensor.
 

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define functions to get tensor attributes
 
@@ -254,7 +260,7 @@ def is_integer(x):
     return is_int_dtype
 
 
-def real(x, name=None):
+def real(x: Tensor, name: str | None = None) -> Tensor:
     """
     Returns a new Tensor containing real values of the input Tensor.
 
@@ -301,7 +307,7 @@ def real(x, name=None):
     return out
 
 
-def imag(x, name=None):
+def imag(x: Tensor, name: str | None = None) -> Tensor:
     """
     Returns a new tensor containing imaginary values of input tensor.
 

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define functions to get create a tensor
 
@@ -1702,7 +1708,7 @@ def empty_like(x, dtype=None, name=None):
     return out
 
 
-def assign(x, output=None):
+def assign(x: Tensor, output=None) -> Tensor:
     """
 
     Copy value of the :attr:`x` to the :attr:`output`.
@@ -1994,7 +2000,7 @@ def _memcpy(input, place=None, output=None):
     return output
 
 
-def complex(real, imag, name=None):
+def complex(real: Tensor, imag: Tensor, name: str | None = None) -> Tensor:
     """Return a compelx tensor given the real and image component.
 
     Args:

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 # TODO: define functions to get create a tensor
 
@@ -1708,7 +1702,7 @@ def empty_like(x, dtype=None, name=None):
     return out
 
 
-def assign(x: Tensor, output=None) -> Tensor:
+def assign(x, output=None):
     """
 
     Copy value of the :attr:`x` to the :attr:`output`.

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define functions to get create a tensor
 
@@ -1702,7 +1708,7 @@ def empty_like(x, dtype=None, name=None):
     return out
 
 
-def assign(x, output=None):
+def assign(x: Tensor, output=None) -> Tensor:
     """
 
     Copy value of the :attr:`x` to the :attr:`output`.

--- a/python/paddle/tensor/einsum.py
+++ b/python/paddle/tensor/einsum.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
 
 import collections
 import itertools

--- a/python/paddle/tensor/einsum.py
+++ b/python/paddle/tensor/einsum.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 import collections
 import itertools

--- a/python/paddle/tensor/layer_function_generator.py
+++ b/python/paddle/tensor/layer_function_generator.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
 
 import re
 import string

--- a/python/paddle/tensor/layer_function_generator.py
+++ b/python/paddle/tensor/layer_function_generator.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 import re
 import string

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 import numpy as np
 
@@ -1149,7 +1155,7 @@ def cond(x, p=None, name=None):
         )
 
 
-def dot(x, y, name=None):
+def dot(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     This operator calculates inner product for vectors.
 
@@ -1649,7 +1655,7 @@ def matrix_rank(x, tol=None, hermitian=False, name=None):
     return out
 
 
-def bmm(x, y, name=None):
+def bmm(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Applies batched matrix multiplication to two tensors.
 
@@ -1826,7 +1832,7 @@ def bincount(x, weights=None, minlength=0, name=None):
     return out
 
 
-def mv(x, vec, name=None):
+def mv(x: Tensor, vec: Tensor, name: str = None) -> Tensor:
     """
     Performs a matrix-vector product of the matrix x and the vector vec.
 
@@ -1895,7 +1901,7 @@ def mv(x, vec, name=None):
             return out
 
 
-def det(x, name=None):
+def det(x: Tensor, name: str = None) -> Tensor:
     """
 
     Calculates determinant value of a square matrix or batches of square matrices.
@@ -1954,7 +1960,7 @@ def det(x, name=None):
     return out
 
 
-def slogdet(x, name=None):
+def slogdet(x: Tensor, name: str = None) -> Tensor:
     """
 
     Calculates the sign and natural logarithm of the absolute value of a square matrix's or batches square matrices' determinant.
@@ -2433,7 +2439,7 @@ def lu_unpack(x, y, unpack_ludata=True, unpack_pivots=True, name=None):
     return p, l, u
 
 
-def eig(x, name=None):
+def eig(x: Tensor, name: str = None) -> tuple[Tensor, Tensor]:
     """
     Performs the eigenvalue decomposition of a square matrix or a batch of square matrices.
 
@@ -2500,7 +2506,7 @@ def eig(x, name=None):
     return w, v
 
 
-def eigvals(x, name=None):
+def eigvals(x: Tensor, name: str = None) -> Tensor:
     """
     Compute the eigenvalues of one or more general matrices.
 
@@ -2566,7 +2572,7 @@ def eigvals(x, name=None):
     return out
 
 
-def multi_dot(x, name=None):
+def multi_dot(x: list[Tensor], name: str = None) -> Tensor:
     """
     Multi_dot is an operator that calculates multiple matrix multiplications.
 
@@ -3050,7 +3056,7 @@ def pinv(x, rcond=1e-15, hermitian=False, name=None):
             return out_2
 
 
-def solve(x, y, name=None):
+def solve(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     r"""
 
     Computes the solution of a square system of linear equations with a unique solution for input 'X' and 'Y'.

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 import numpy as np
 
@@ -1155,7 +1149,7 @@ def cond(x, p=None, name=None):
         )
 
 
-def dot(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def dot(x, y, name=None):
     """
     This operator calculates inner product for vectors.
 
@@ -1655,7 +1649,7 @@ def matrix_rank(x, tol=None, hermitian=False, name=None):
     return out
 
 
-def bmm(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def bmm(x, y, name=None):
     """
     Applies batched matrix multiplication to two tensors.
 
@@ -1832,7 +1826,7 @@ def bincount(x, weights=None, minlength=0, name=None):
     return out
 
 
-def mv(x: Tensor, vec: Tensor, name: str = None) -> Tensor:
+def mv(x, vec, name=None):
     """
     Performs a matrix-vector product of the matrix x and the vector vec.
 
@@ -1901,7 +1895,7 @@ def mv(x: Tensor, vec: Tensor, name: str = None) -> Tensor:
             return out
 
 
-def det(x: Tensor, name: str = None) -> Tensor:
+def det(x, name=None):
     """
 
     Calculates determinant value of a square matrix or batches of square matrices.
@@ -1960,7 +1954,7 @@ def det(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def slogdet(x: Tensor, name: str = None) -> Tensor:
+def slogdet(x, name=None):
     """
 
     Calculates the sign and natural logarithm of the absolute value of a square matrix's or batches square matrices' determinant.
@@ -2439,7 +2433,7 @@ def lu_unpack(x, y, unpack_ludata=True, unpack_pivots=True, name=None):
     return p, l, u
 
 
-def eig(x: Tensor, name: str = None) -> tuple[Tensor, Tensor]:
+def eig(x, name=None):
     """
     Performs the eigenvalue decomposition of a square matrix or a batch of square matrices.
 
@@ -2506,7 +2500,7 @@ def eig(x: Tensor, name: str = None) -> tuple[Tensor, Tensor]:
     return w, v
 
 
-def eigvals(x: Tensor, name: str = None) -> Tensor:
+def eigvals(x, name=None):
     """
     Compute the eigenvalues of one or more general matrices.
 
@@ -2572,7 +2566,7 @@ def eigvals(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def multi_dot(x: list[Tensor], name: str = None) -> Tensor:
+def multi_dot(x, name=None):
     """
     Multi_dot is an operator that calculates multiple matrix multiplications.
 
@@ -3056,7 +3050,7 @@ def pinv(x, rcond=1e-15, hermitian=False, name=None):
             return out_2
 
 
-def solve(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def solve(x, y, name=None):
     r"""
 
     Computes the solution of a square system of linear equations with a unique solution for input 'X' and 'Y'.

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 import numpy as np
 
@@ -1149,7 +1155,7 @@ def cond(x, p=None, name=None):
         )
 
 
-def dot(x, y, name=None):
+def dot(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     This operator calculates inner product for vectors.
 
@@ -1649,7 +1655,7 @@ def matrix_rank(x, tol=None, hermitian=False, name=None):
     return out
 
 
-def bmm(x, y, name=None):
+def bmm(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Applies batched matrix multiplication to two tensors.
 
@@ -1826,7 +1832,7 @@ def bincount(x, weights=None, minlength=0, name=None):
     return out
 
 
-def mv(x, vec, name=None):
+def mv(x: Tensor, vec: Tensor, name: str | None = None) -> Tensor:
     """
     Performs a matrix-vector product of the matrix x and the vector vec.
 
@@ -1895,7 +1901,7 @@ def mv(x, vec, name=None):
             return out
 
 
-def det(x, name=None):
+def det(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Calculates determinant value of a square matrix or batches of square matrices.
@@ -1954,7 +1960,7 @@ def det(x, name=None):
     return out
 
 
-def slogdet(x, name=None):
+def slogdet(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Calculates the sign and natural logarithm of the absolute value of a square matrix's or batches square matrices' determinant.
@@ -2433,7 +2439,7 @@ def lu_unpack(x, y, unpack_ludata=True, unpack_pivots=True, name=None):
     return p, l, u
 
 
-def eig(x, name=None):
+def eig(x: Tensor, name: str | None = None) -> tuple[Tensor, Tensor]:
     """
     Performs the eigenvalue decomposition of a square matrix or a batch of square matrices.
 
@@ -2500,7 +2506,7 @@ def eig(x, name=None):
     return w, v
 
 
-def eigvals(x, name=None):
+def eigvals(x: Tensor, name: str | None = None) -> Tensor:
     """
     Compute the eigenvalues of one or more general matrices.
 
@@ -2566,7 +2572,7 @@ def eigvals(x, name=None):
     return out
 
 
-def multi_dot(x, name=None):
+def multi_dot(x: list[Tensor], name: str | None = None) -> Tensor:
     """
     Multi_dot is an operator that calculates multiple matrix multiplications.
 
@@ -3050,7 +3056,7 @@ def pinv(x, rcond=1e-15, hermitian=False, name=None):
             return out_2
 
 
-def solve(x, y, name=None):
+def solve(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     r"""
 
     Computes the solution of a square system of linear equations with a unique solution for input 'X' and 'Y'.

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 # TODO: define logic functions of a tensor
 
@@ -251,7 +245,7 @@ def logical_not(x, out=None, name=None):
     )
 
 
-def is_empty(x: Tensor, name: str = None) -> Tensor:
+def is_empty(x, name=None):
     """
 
     Test whether a Tensor is empty.
@@ -300,7 +294,7 @@ def is_empty(x: Tensor, name: str = None) -> Tensor:
     return cond
 
 
-def equal_all(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def equal_all(x, y, name=None):
     """
     Returns the truth value of :math:`x == y`. True if two inputs have the same elements, False otherwise.
 
@@ -412,7 +406,7 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
 
 
 @templatedoc()
-def equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def equal(x, y, name=None):
     """
 
     This layer returns the truth value of :math:`x == y` elementwise.
@@ -480,7 +474,7 @@ def equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
 
 
 @templatedoc()
-def greater_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def greater_equal(x, y, name=None):
     """
     Returns the truth value of :math:`x >= y` elementwise, which is equivalent function to the overloaded operator `>=`.
 
@@ -536,7 +530,7 @@ def greater_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
 
 
 @templatedoc()
-def greater_than(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def greater_than(x, y, name=None):
     """
     Returns the truth value of :math:`x > y` elementwise, which is equivalent function to the overloaded operator `>`.
 
@@ -592,7 +586,7 @@ def greater_than(x: Tensor, y: Tensor, name: str = None) -> Tensor:
 
 
 @templatedoc()
-def less_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def less_equal(x, y, name=None):
     """
     Returns the truth value of :math:`x <= y` elementwise, which is equivalent function to the overloaded operator `<=`.
 
@@ -649,7 +643,7 @@ def less_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
 
 
 @templatedoc()
-def less_than(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def less_than(x, y, name=None):
     """
     Returns the truth value of :math:`x < y` elementwise, which is equivalent function to the overloaded operator `<`.
 
@@ -706,7 +700,7 @@ def less_than(x: Tensor, y: Tensor, name: str = None) -> Tensor:
 
 
 @templatedoc()
-def not_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def not_equal(x, y, name=None):
     """
     Returns the truth value of :math:`x != y` elementwise, which is equivalent function to the overloaded operator `!=`.
 

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define logic functions of a tensor
 
@@ -245,7 +251,7 @@ def logical_not(x, out=None, name=None):
     )
 
 
-def is_empty(x, name=None):
+def is_empty(x: Tensor, name: str = None) -> Tensor:
     """
 
     Test whether a Tensor is empty.
@@ -294,7 +300,7 @@ def is_empty(x, name=None):
     return cond
 
 
-def equal_all(x, y, name=None):
+def equal_all(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Returns the truth value of :math:`x == y`. True if two inputs have the same elements, False otherwise.
 
@@ -406,7 +412,7 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
 
 
 @templatedoc()
-def equal(x, y, name=None):
+def equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
 
     This layer returns the truth value of :math:`x == y` elementwise.
@@ -474,7 +480,7 @@ def equal(x, y, name=None):
 
 
 @templatedoc()
-def greater_equal(x, y, name=None):
+def greater_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Returns the truth value of :math:`x >= y` elementwise, which is equivalent function to the overloaded operator `>=`.
 
@@ -530,7 +536,7 @@ def greater_equal(x, y, name=None):
 
 
 @templatedoc()
-def greater_than(x, y, name=None):
+def greater_than(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Returns the truth value of :math:`x > y` elementwise, which is equivalent function to the overloaded operator `>`.
 
@@ -586,7 +592,7 @@ def greater_than(x, y, name=None):
 
 
 @templatedoc()
-def less_equal(x, y, name=None):
+def less_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Returns the truth value of :math:`x <= y` elementwise, which is equivalent function to the overloaded operator `<=`.
 
@@ -643,7 +649,7 @@ def less_equal(x, y, name=None):
 
 
 @templatedoc()
-def less_than(x, y, name=None):
+def less_than(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Returns the truth value of :math:`x < y` elementwise, which is equivalent function to the overloaded operator `<`.
 
@@ -700,7 +706,7 @@ def less_than(x, y, name=None):
 
 
 @templatedoc()
-def not_equal(x, y, name=None):
+def not_equal(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Returns the truth value of :math:`x != y` elementwise, which is equivalent function to the overloaded operator `!=`.
 

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define logic functions of a tensor
 
@@ -245,7 +251,7 @@ def logical_not(x, out=None, name=None):
     )
 
 
-def is_empty(x, name=None):
+def is_empty(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Test whether a Tensor is empty.
@@ -294,7 +300,7 @@ def is_empty(x, name=None):
     return cond
 
 
-def equal_all(x, y, name=None):
+def equal_all(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Returns the truth value of :math:`x == y`. True if two inputs have the same elements, False otherwise.
 
@@ -406,7 +412,7 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
 
 
 @templatedoc()
-def equal(x, y, name=None):
+def equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
 
     This layer returns the truth value of :math:`x == y` elementwise.
@@ -474,7 +480,7 @@ def equal(x, y, name=None):
 
 
 @templatedoc()
-def greater_equal(x, y, name=None):
+def greater_equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Returns the truth value of :math:`x >= y` elementwise, which is equivalent function to the overloaded operator `>=`.
 
@@ -530,7 +536,7 @@ def greater_equal(x, y, name=None):
 
 
 @templatedoc()
-def greater_than(x, y, name=None):
+def greater_than(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Returns the truth value of :math:`x > y` elementwise, which is equivalent function to the overloaded operator `>`.
 
@@ -586,7 +592,7 @@ def greater_than(x, y, name=None):
 
 
 @templatedoc()
-def less_equal(x, y, name=None):
+def less_equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Returns the truth value of :math:`x <= y` elementwise, which is equivalent function to the overloaded operator `<=`.
 
@@ -643,7 +649,7 @@ def less_equal(x, y, name=None):
 
 
 @templatedoc()
-def less_than(x, y, name=None):
+def less_than(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Returns the truth value of :math:`x < y` elementwise, which is equivalent function to the overloaded operator `<`.
 
@@ -700,7 +706,7 @@ def less_than(x, y, name=None):
 
 
 @templatedoc()
-def not_equal(x, y, name=None):
+def not_equal(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Returns the truth value of :math:`x != y` elementwise, which is equivalent function to the overloaded operator `!=`.
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define functions to manipulate a tensor
 
@@ -45,7 +51,7 @@ from .creation import _complex_to_real_dtype, _real_to_complex_dtype, zeros
 __all__ = []
 
 
-def cast(x, dtype):
+def cast(x: Tensor, dtype) -> Tensor:
     """
 
     This OP takes in the Tensor :attr:`x` with :attr:`x.dtype` and casts it
@@ -1215,7 +1221,9 @@ def concat(x, axis=0, name=None):
     return out
 
 
-def broadcast_tensors(input, name=None):
+def broadcast_tensors(
+    input: list[Tensor], name: str | None = None
+) -> list[Tensor]:
     """
     Broadcast a list of tensors following broadcast semantics
 
@@ -2791,7 +2799,7 @@ def gather(x, index, axis=None, name=None):
     return out
 
 
-def unbind(input, axis=0):
+def unbind(input: Tensor, axis: int = 0) -> list[Tensor]:
     """
 
     Removes a tensor dimension, then split the input tensor into multiple sub-Tensors.
@@ -2967,7 +2975,9 @@ def scatter_(x, index, updates, overwrite=True, name=None):
     return _legacy_C_ops.scatter_(x, index, updates, 'overwrite', overwrite)
 
 
-def scatter_nd_add(x, index, updates, name=None):
+def scatter_nd_add(
+    x: Tensor, index: Tensor, updates: Tensor, name: str | None = None
+) -> Tensor:
     r"""
 
     Output is obtained by applying sparse addition to a single value
@@ -3253,7 +3263,7 @@ def tile(x, repeat_times, name=None):
     return out
 
 
-def expand_as(x, y, name=None):
+def expand_as(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
 
     Expand the input tensor ``x`` to the same shape as the input tensor ``y``.
@@ -3752,7 +3762,7 @@ def reshape_(x, shape, name=None):
             return out
 
 
-def gather_nd(x, index, name=None):
+def gather_nd(x: Tensor, index: Tensor, name: str | None = None) -> Tensor:
     """
 
     This function is actually a high-dimensional extension of :code:`gather`
@@ -4266,7 +4276,7 @@ def tensordot(x, y, axes=2, name=None):
     return out
 
 
-def as_complex(x, name=None):
+def as_complex(x: Tensor, name: str | None = None) -> Tensor:
     """Transform a real tensor to a complex tensor.
 
     The data type of the input tensor is 'float32' or 'float64', and the data
@@ -4313,7 +4323,7 @@ def as_complex(x, name=None):
     return out
 
 
-def as_real(x, name=None):
+def as_real(x: Tensor, name: str | None = None) -> Tensor:
     """Transform a complex tensor to a real tensor.
 
     The data type of the input tensor is 'complex64' or 'complex128', and the data
@@ -4581,7 +4591,7 @@ def infer_broadcast_shape(arr, indices, axis):
     return broadcast_shape
 
 
-def take_along_axis(arr, indices, axis):
+def take_along_axis(arr: Tensor, indices: Tensor, axis) -> Tensor:
     """
     Take values from the input array by given indices matrix along the designated axis.
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 # TODO: define functions to manipulate a tensor
 
@@ -51,7 +45,7 @@ from .creation import _complex_to_real_dtype, _real_to_complex_dtype, zeros
 __all__ = []
 
 
-def cast(x: Tensor, dtype) -> Tensor:
+def cast(x, dtype):
     """
 
     This OP takes in the Tensor :attr:`x` with :attr:`x.dtype` and casts it
@@ -2797,7 +2791,7 @@ def gather(x, index, axis=None, name=None):
     return out
 
 
-def unbind(input: Tensor, axis: int = 0) -> list[Tensor]:
+def unbind(input, axis=0):
     """
 
     Removes a tensor dimension, then split the input tensor into multiple sub-Tensors.
@@ -2973,9 +2967,7 @@ def scatter_(x, index, updates, overwrite=True, name=None):
     return _legacy_C_ops.scatter_(x, index, updates, 'overwrite', overwrite)
 
 
-def scatter_nd_add(
-    x: Tensor, index: Tensor, updates: Tensor, name: str = None
-) -> Tensor:
+def scatter_nd_add(x, index, updates, name=None):
     r"""
 
     Output is obtained by applying sparse addition to a single value
@@ -3261,7 +3253,7 @@ def tile(x, repeat_times, name=None):
     return out
 
 
-def expand_as(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def expand_as(x, y, name=None):
     """
 
     Expand the input tensor ``x`` to the same shape as the input tensor ``y``.
@@ -3760,7 +3752,7 @@ def reshape_(x, shape, name=None):
             return out
 
 
-def gather_nd(x: Tensor, index: Tensor, name: str = None) -> Tensor:
+def gather_nd(x, index, name=None):
     """
 
     This function is actually a high-dimensional extension of :code:`gather`
@@ -4274,7 +4266,7 @@ def tensordot(x, y, axes=2, name=None):
     return out
 
 
-def as_complex(x: Tensor, name: str = None) -> Tensor:
+def as_complex(x, name=None):
     """Transform a real tensor to a complex tensor.
 
     The data type of the input tensor is 'float32' or 'float64', and the data
@@ -4321,7 +4313,7 @@ def as_complex(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def as_real(x: Tensor, name: str = None) -> Tensor:
+def as_real(x, name=None):
     """Transform a complex tensor to a real tensor.
 
     The data type of the input tensor is 'complex64' or 'complex128', and the data

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define functions to manipulate a tensor
 
@@ -45,7 +51,7 @@ from .creation import _complex_to_real_dtype, _real_to_complex_dtype, zeros
 __all__ = []
 
 
-def cast(x, dtype):
+def cast(x: Tensor, dtype) -> Tensor:
     """
 
     This OP takes in the Tensor :attr:`x` with :attr:`x.dtype` and casts it
@@ -2791,7 +2797,7 @@ def gather(x, index, axis=None, name=None):
     return out
 
 
-def unbind(input, axis=0):
+def unbind(input: Tensor, axis: int = 0) -> list[Tensor]:
     """
 
     Removes a tensor dimension, then split the input tensor into multiple sub-Tensors.
@@ -2967,7 +2973,9 @@ def scatter_(x, index, updates, overwrite=True, name=None):
     return _legacy_C_ops.scatter_(x, index, updates, 'overwrite', overwrite)
 
 
-def scatter_nd_add(x, index, updates, name=None):
+def scatter_nd_add(
+    x: Tensor, index: Tensor, updates: Tensor, name: str = None
+) -> Tensor:
     r"""
 
     Output is obtained by applying sparse addition to a single value
@@ -3253,7 +3261,7 @@ def tile(x, repeat_times, name=None):
     return out
 
 
-def expand_as(x, y, name=None):
+def expand_as(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
 
     Expand the input tensor ``x`` to the same shape as the input tensor ``y``.
@@ -3752,7 +3760,7 @@ def reshape_(x, shape, name=None):
             return out
 
 
-def gather_nd(x, index, name=None):
+def gather_nd(x: Tensor, index: Tensor, name: str = None) -> Tensor:
     """
 
     This function is actually a high-dimensional extension of :code:`gather`
@@ -4266,7 +4274,7 @@ def tensordot(x, y, axes=2, name=None):
     return out
 
 
-def as_complex(x, name=None):
+def as_complex(x: Tensor, name: str = None) -> Tensor:
     """Transform a real tensor to a complex tensor.
 
     The data type of the input tensor is 'float32' or 'float64', and the data
@@ -4313,7 +4321,7 @@ def as_complex(x, name=None):
     return out
 
 
-def as_real(x, name=None):
+def as_real(x: Tensor, name: str = None) -> Tensor:
     """Transform a complex tensor to a real tensor.
 
     The data type of the input tensor is 'complex64' or 'complex128', and the data

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 """
 math functions
 """
@@ -129,7 +135,7 @@ def _get_reduce_axis_with_tensor(axis, x):
     return reduce_all, axis
 
 
-def log(x, name=None):
+def log(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Calculates the natural log of the given input Tensor, element-wise.
 
@@ -311,7 +317,9 @@ def stanh(x, scale_a=0.67, scale_b=1.7159, name=None):
     return out
 
 
-def multiplex(inputs, index, name=None):
+def multiplex(
+    inputs: list[Tensor], index: Tensor, name: str | None = None
+) -> Tensor:
     """
 
     Based on the given index parameter, the OP selects a specific row from each input Tensor to construct the output Tensor.
@@ -583,7 +591,7 @@ def _elementwise_op(helper):
     return helper.append_activation(out)
 
 
-def add(x, y, name=None):
+def add(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Elementwise Add Operator.
     Add two tensors element-wise
@@ -671,7 +679,7 @@ def add_(x, y, name=None):
         return out
 
 
-def subtract(x, y, name=None):
+def subtract(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Substract two tensors element-wise. The equation is:
 
@@ -765,7 +773,7 @@ def subtract_(x, y, name=None):
         return out
 
 
-def divide(x, y, name=None):
+def divide(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Divide two tensors element-wise. The equation is:
 
@@ -809,7 +817,7 @@ def divide(x, y, name=None):
             return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def floor_divide(x, y, name=None):
+def floor_divide(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Floor divide two tensors element-wise and rounds the quotinents to the nearest integer toward zero. The equation is:
 
@@ -850,7 +858,7 @@ def floor_divide(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def remainder(x, y, name=None):
+def remainder(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     r"""
     Mod two tensors element-wise. The equation is:
 
@@ -916,7 +924,7 @@ mod = remainder  # noqa: F841
 floor_mod = remainder  # noqa: F841
 
 
-def multiply(x, y, name=None):
+def multiply(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     multiply two tensors element-wise. The equation is:
 
@@ -972,7 +980,7 @@ def multiply(x, y, name=None):
             return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def maximum(x, y, name=None):
+def maximum(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Compare two tensors and returns a new tensor containing the element-wise maxima. The equation is:
 
@@ -1038,7 +1046,7 @@ def maximum(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def minimum(x, y, name=None):
+def minimum(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Compare two tensors and return a new tensor containing the element-wise minima. The equation is:
 
@@ -1104,7 +1112,7 @@ def minimum(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def fmax(x, y, name=None):
+def fmax(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the maximum value of the element.
     If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
@@ -1172,7 +1180,7 @@ def fmax(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def fmin(x, y, name=None):
+def fmin(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
     Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the minimum value of the element.
     If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
@@ -1613,7 +1621,7 @@ def count_nonzero(x, axis=None, keepdim=False, name=None):
 
 
 @templatedoc(op_type="sum")
-def add_n(inputs, name=None):
+def add_n(inputs: list[Tensor], name: str | None = None) -> Tensor:
     """
     Sum one or more Tensor of the input.
 
@@ -1711,7 +1719,7 @@ def add_n(inputs, name=None):
     return out
 
 
-def trunc(input, name=None):
+def trunc(input: Tensor, name: str | None = None) -> Tensor:
     '''
     This API is used to returns a new tensor with the truncated integer values of input.
 
@@ -2251,7 +2259,7 @@ def logsumexp(x, axis=None, keepdim=False, name=None):
     return out
 
 
-def inverse(x, name=None):
+def inverse(x: Tensor, name: str | None = None) -> Tensor:
     """
     Takes the inverse of the square matrix. A square matrix is a matrix with
     the same number of rows and columns. The input can be a square matrix
@@ -2731,7 +2739,7 @@ def amin(x, axis=None, keepdim=False, name=None):
     return out
 
 
-def log1p(x, name=None):
+def log1p(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Calculates the natural log of the given input tensor, element-wise.
 
@@ -2769,7 +2777,7 @@ def log1p(x, name=None):
     return out
 
 
-def log2(x, name=None):
+def log2(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Calculates the log to the base 2 of the given input tensor, element-wise.
 
@@ -2821,7 +2829,7 @@ def log2(x, name=None):
     return out
 
 
-def log10(x, name=None):
+def log10(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Calculates the log to the base 10 of the given input tensor, element-wise.
 
@@ -3225,7 +3233,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1, name=None):
 
 
 @templatedoc(op_type="kron")
-def kron(x, y, name=None):
+def kron(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     """
 
     ${comment}
@@ -3494,7 +3502,7 @@ def cumprod(x, dim=None, dtype=None, name=None):
     return out
 
 
-def isfinite(x, name=None):
+def isfinite(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Return whether every element of input tensor is finite number or not.
@@ -3528,7 +3536,7 @@ def isfinite(x, name=None):
     return out
 
 
-def isinf(x, name=None):
+def isinf(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Return whether every element of input tensor is `+/-INF` or not.
@@ -3562,7 +3570,7 @@ def isinf(x, name=None):
     return out
 
 
-def isnan(x, name=None):
+def isnan(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Return whether every element of input tensor is `NaN` or not.
@@ -3681,7 +3689,7 @@ def prod(x, axis=None, keepdim=False, dtype=None, name=None):
     return out
 
 
-def sign(x, name=None):
+def sign(x: Tensor, name: str | None = None) -> Tensor:
     """
     Returns sign of every element in `x`: 1 for positive, -1 for negative and 0 for zero.
 
@@ -3716,7 +3724,7 @@ def sign(x, name=None):
     return out
 
 
-def tanh(x, name=None):
+def tanh(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Tanh Activation Operator.
 
@@ -3988,7 +3996,7 @@ def broadcast_shape(x_shape, y_shape):
     return core.broadcast_shape(x_shape, y_shape)
 
 
-def conj(x, name=None):
+def conj(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     This function computes the conjugate of the Tensor elementwisely.
 
@@ -4036,7 +4044,7 @@ def conj(x, name=None):
     return out
 
 
-def digamma(x, name=None):
+def digamma(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Calculates the digamma of the given input tensor, element-wise.
 
@@ -4075,7 +4083,7 @@ def digamma(x, name=None):
     return out
 
 
-def lgamma(x, name=None):
+def lgamma(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Calculates the lgamma of the given input tensor, element-wise.
 
@@ -4139,7 +4147,7 @@ def neg(x, name=None):
     )
 
 
-def atan2(x, y, name=None):
+def atan2(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
     r"""
     Element-wise arctangent of x/y with consideration of the quadrant.
 
@@ -4264,7 +4272,9 @@ def logit(x, eps=None, name=None):
     return out
 
 
-def lerp(x, y, weight, name=None):
+def lerp(
+    x: Tensor, y: Tensor, weight: Tensor, name: str | None = None
+) -> Tensor:
     r"""
     Does a linear interpolation between x and y based on weight.
 
@@ -4342,7 +4352,7 @@ def lerp_(x, y, weight, name=None):
     return _legacy_C_ops.lerp_(x, y, weight)
 
 
-def erfinv(x, name=None):
+def erfinv(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     The inverse error function of x. Please refer to :ref:`api_paddle_erf`
 
@@ -4825,7 +4835,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
             axes,
             'infer_flags',
             infer_flags,
-            *attrs_1
+            *attrs_1,
         )
         starts_2 = [1]
         attrs_2 += ('starts', starts_2)
@@ -4841,7 +4851,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
             axes,
             'infer_flags',
             infer_flags,
-            *attrs_2
+            *attrs_2,
         )
 
         if x.dtype == paddle.bool:
@@ -4916,7 +4926,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
         return out
 
 
-def angle(x, name=None):
+def angle(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Element-wise angle of complex numbers. For non-negative real numbers, the angle is 0 while
     for negative real numbers, the angle is :math:`\pi`.

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 """
 math functions
 """
@@ -135,7 +129,7 @@ def _get_reduce_axis_with_tensor(axis, x):
     return reduce_all, axis
 
 
-def log(x: Tensor, name: str = None) -> Tensor:
+def log(x, name=None):
     r"""
     Calculates the natural log of the given input Tensor, element-wise.
 
@@ -589,7 +583,7 @@ def _elementwise_op(helper):
     return helper.append_activation(out)
 
 
-def add(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def add(x, y, name=None):
     """
     Elementwise Add Operator.
     Add two tensors element-wise
@@ -677,7 +671,7 @@ def add_(x, y, name=None):
         return out
 
 
-def subtract(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def subtract(x, y, name=None):
     """
     Substract two tensors element-wise. The equation is:
 
@@ -771,7 +765,7 @@ def subtract_(x, y, name=None):
         return out
 
 
-def divide(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def divide(x, y, name=None):
     """
     Divide two tensors element-wise. The equation is:
 
@@ -815,7 +809,7 @@ def divide(x: Tensor, y: Tensor, name: str = None) -> Tensor:
             return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def floor_divide(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def floor_divide(x, y, name=None):
     """
     Floor divide two tensors element-wise and rounds the quotinents to the nearest integer toward zero. The equation is:
 
@@ -856,7 +850,7 @@ def floor_divide(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def remainder(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def remainder(x, y, name=None):
     r"""
     Mod two tensors element-wise. The equation is:
 
@@ -922,7 +916,7 @@ mod = remainder  # noqa: F841
 floor_mod = remainder  # noqa: F841
 
 
-def multiply(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def multiply(x, y, name=None):
     """
     multiply two tensors element-wise. The equation is:
 
@@ -978,7 +972,7 @@ def multiply(x: Tensor, y: Tensor, name: str = None) -> Tensor:
             return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def maximum(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def maximum(x, y, name=None):
     """
     Compare two tensors and returns a new tensor containing the element-wise maxima. The equation is:
 
@@ -1044,7 +1038,7 @@ def maximum(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def minimum(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def minimum(x, y, name=None):
     """
     Compare two tensors and return a new tensor containing the element-wise minima. The equation is:
 
@@ -1110,7 +1104,7 @@ def minimum(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def fmax(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def fmax(x, y, name=None):
     """
     Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the maximum value of the element.
     If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
@@ -1178,7 +1172,7 @@ def fmax(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def fmin(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def fmin(x, y, name=None):
     """
     Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the minimum value of the element.
     If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
@@ -2257,7 +2251,7 @@ def logsumexp(x, axis=None, keepdim=False, name=None):
     return out
 
 
-def inverse(x: Tensor, name: str = None) -> Tensor:
+def inverse(x, name=None):
     """
     Takes the inverse of the square matrix. A square matrix is a matrix with
     the same number of rows and columns. The input can be a square matrix
@@ -2737,7 +2731,7 @@ def amin(x, axis=None, keepdim=False, name=None):
     return out
 
 
-def log1p(x: Tensor, name: str = None) -> Tensor:
+def log1p(x, name=None):
     r"""
     Calculates the natural log of the given input tensor, element-wise.
 
@@ -2775,7 +2769,7 @@ def log1p(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def log2(x: Tensor, name: str = None) -> Tensor:
+def log2(x, name=None):
     r"""
     Calculates the log to the base 2 of the given input tensor, element-wise.
 
@@ -2827,7 +2821,7 @@ def log2(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def log10(x: Tensor, name: str = None) -> Tensor:
+def log10(x, name=None):
     r"""
     Calculates the log to the base 10 of the given input tensor, element-wise.
 
@@ -3231,7 +3225,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1, name=None):
 
 
 @templatedoc(op_type="kron")
-def kron(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def kron(x, y, name=None):
     """
 
     ${comment}
@@ -3500,7 +3494,7 @@ def cumprod(x, dim=None, dtype=None, name=None):
     return out
 
 
-def isfinite(x: Tensor, name: str = None) -> Tensor:
+def isfinite(x, name=None):
     """
 
     Return whether every element of input tensor is finite number or not.
@@ -3534,7 +3528,7 @@ def isfinite(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def isinf(x: Tensor, name: str = None) -> Tensor:
+def isinf(x, name=None):
     """
 
     Return whether every element of input tensor is `+/-INF` or not.
@@ -3568,7 +3562,7 @@ def isinf(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def isnan(x: Tensor, name: str = None) -> Tensor:
+def isnan(x, name=None):
     """
 
     Return whether every element of input tensor is `NaN` or not.
@@ -3687,7 +3681,7 @@ def prod(x, axis=None, keepdim=False, dtype=None, name=None):
     return out
 
 
-def sign(x: Tensor, name: str = None) -> Tensor:
+def sign(x, name=None):
     """
     Returns sign of every element in `x`: 1 for positive, -1 for negative and 0 for zero.
 
@@ -3722,7 +3716,7 @@ def sign(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def tanh(x: Tensor, name: str = None) -> Tensor:
+def tanh(x, name=None):
     r"""
     Tanh Activation Operator.
 
@@ -3994,7 +3988,7 @@ def broadcast_shape(x_shape, y_shape):
     return core.broadcast_shape(x_shape, y_shape)
 
 
-def conj(x: Tensor, name: str = None) -> Tensor:
+def conj(x, name=None):
     r"""
     This function computes the conjugate of the Tensor elementwisely.
 
@@ -4042,7 +4036,7 @@ def conj(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def digamma(x: Tensor, name: str = None) -> Tensor:
+def digamma(x, name=None):
     r"""
     Calculates the digamma of the given input tensor, element-wise.
 
@@ -4081,7 +4075,7 @@ def digamma(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def lgamma(x: Tensor, name: str = None) -> Tensor:
+def lgamma(x, name=None):
     r"""
     Calculates the lgamma of the given input tensor, element-wise.
 
@@ -4145,7 +4139,7 @@ def neg(x, name=None):
     )
 
 
-def atan2(x: Tensor, y: Tensor, name: str = None) -> Tensor:
+def atan2(x, y, name=None):
     r"""
     Element-wise arctangent of x/y with consideration of the quadrant.
 
@@ -4270,7 +4264,7 @@ def logit(x, eps=None, name=None):
     return out
 
 
-def lerp(x: Tensor, y: Tensor, weight: Tensor, name: str = None) -> Tensor:
+def lerp(x, y, weight, name=None):
     r"""
     Does a linear interpolation between x and y based on weight.
 
@@ -4348,7 +4342,7 @@ def lerp_(x, y, weight, name=None):
     return _legacy_C_ops.lerp_(x, y, weight)
 
 
-def erfinv(x: Tensor, name: str = None) -> Tensor:
+def erfinv(x, name=None):
     r"""
     The inverse error function of x. Please refer to :ref:`api_paddle_erf`
 
@@ -4831,7 +4825,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
             axes,
             'infer_flags',
             infer_flags,
-            *attrs_1,
+            *attrs_1
         )
         starts_2 = [1]
         attrs_2 += ('starts', starts_2)
@@ -4847,7 +4841,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
             axes,
             'infer_flags',
             infer_flags,
-            *attrs_2,
+            *attrs_2
         )
 
         if x.dtype == paddle.bool:
@@ -4922,7 +4916,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
         return out
 
 
-def angle(x: Tensor, name: str = None) -> Tensor:
+def angle(x, name=None):
     r"""
     Element-wise angle of complex numbers. For non-negative real numbers, the angle is 0 while
     for negative real numbers, the angle is :math:`\pi`.

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 """
 math functions
 """
@@ -129,7 +135,7 @@ def _get_reduce_axis_with_tensor(axis, x):
     return reduce_all, axis
 
 
-def log(x, name=None):
+def log(x: Tensor, name: str = None) -> Tensor:
     r"""
     Calculates the natural log of the given input Tensor, element-wise.
 
@@ -583,7 +589,7 @@ def _elementwise_op(helper):
     return helper.append_activation(out)
 
 
-def add(x, y, name=None):
+def add(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Elementwise Add Operator.
     Add two tensors element-wise
@@ -671,7 +677,7 @@ def add_(x, y, name=None):
         return out
 
 
-def subtract(x, y, name=None):
+def subtract(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Substract two tensors element-wise. The equation is:
 
@@ -765,7 +771,7 @@ def subtract_(x, y, name=None):
         return out
 
 
-def divide(x, y, name=None):
+def divide(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Divide two tensors element-wise. The equation is:
 
@@ -809,7 +815,7 @@ def divide(x, y, name=None):
             return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def floor_divide(x, y, name=None):
+def floor_divide(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Floor divide two tensors element-wise and rounds the quotinents to the nearest integer toward zero. The equation is:
 
@@ -850,7 +856,7 @@ def floor_divide(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def remainder(x, y, name=None):
+def remainder(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     r"""
     Mod two tensors element-wise. The equation is:
 
@@ -916,7 +922,7 @@ mod = remainder  # noqa: F841
 floor_mod = remainder  # noqa: F841
 
 
-def multiply(x, y, name=None):
+def multiply(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     multiply two tensors element-wise. The equation is:
 
@@ -972,7 +978,7 @@ def multiply(x, y, name=None):
             return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def maximum(x, y, name=None):
+def maximum(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Compare two tensors and returns a new tensor containing the element-wise maxima. The equation is:
 
@@ -1038,7 +1044,7 @@ def maximum(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def minimum(x, y, name=None):
+def minimum(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Compare two tensors and return a new tensor containing the element-wise minima. The equation is:
 
@@ -1104,7 +1110,7 @@ def minimum(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def fmax(x, y, name=None):
+def fmax(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the maximum value of the element.
     If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
@@ -1172,7 +1178,7 @@ def fmax(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-def fmin(x, y, name=None):
+def fmin(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
     Compares the elements at the corresponding positions of the two tensors and returns a new tensor containing the minimum value of the element.
     If one of them is a nan value, the other value is directly returned, if both are nan values, then the first nan value is returned.
@@ -2251,7 +2257,7 @@ def logsumexp(x, axis=None, keepdim=False, name=None):
     return out
 
 
-def inverse(x, name=None):
+def inverse(x: Tensor, name: str = None) -> Tensor:
     """
     Takes the inverse of the square matrix. A square matrix is a matrix with
     the same number of rows and columns. The input can be a square matrix
@@ -2731,7 +2737,7 @@ def amin(x, axis=None, keepdim=False, name=None):
     return out
 
 
-def log1p(x, name=None):
+def log1p(x: Tensor, name: str = None) -> Tensor:
     r"""
     Calculates the natural log of the given input tensor, element-wise.
 
@@ -2769,7 +2775,7 @@ def log1p(x, name=None):
     return out
 
 
-def log2(x, name=None):
+def log2(x: Tensor, name: str = None) -> Tensor:
     r"""
     Calculates the log to the base 2 of the given input tensor, element-wise.
 
@@ -2821,7 +2827,7 @@ def log2(x, name=None):
     return out
 
 
-def log10(x, name=None):
+def log10(x: Tensor, name: str = None) -> Tensor:
     r"""
     Calculates the log to the base 10 of the given input tensor, element-wise.
 
@@ -3225,7 +3231,7 @@ def diagonal(x, offset=0, axis1=0, axis2=1, name=None):
 
 
 @templatedoc(op_type="kron")
-def kron(x, y, name=None):
+def kron(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     """
 
     ${comment}
@@ -3494,7 +3500,7 @@ def cumprod(x, dim=None, dtype=None, name=None):
     return out
 
 
-def isfinite(x, name=None):
+def isfinite(x: Tensor, name: str = None) -> Tensor:
     """
 
     Return whether every element of input tensor is finite number or not.
@@ -3528,7 +3534,7 @@ def isfinite(x, name=None):
     return out
 
 
-def isinf(x, name=None):
+def isinf(x: Tensor, name: str = None) -> Tensor:
     """
 
     Return whether every element of input tensor is `+/-INF` or not.
@@ -3562,7 +3568,7 @@ def isinf(x, name=None):
     return out
 
 
-def isnan(x, name=None):
+def isnan(x: Tensor, name: str = None) -> Tensor:
     """
 
     Return whether every element of input tensor is `NaN` or not.
@@ -3681,7 +3687,7 @@ def prod(x, axis=None, keepdim=False, dtype=None, name=None):
     return out
 
 
-def sign(x, name=None):
+def sign(x: Tensor, name: str = None) -> Tensor:
     """
     Returns sign of every element in `x`: 1 for positive, -1 for negative and 0 for zero.
 
@@ -3716,7 +3722,7 @@ def sign(x, name=None):
     return out
 
 
-def tanh(x, name=None):
+def tanh(x: Tensor, name: str = None) -> Tensor:
     r"""
     Tanh Activation Operator.
 
@@ -3988,7 +3994,7 @@ def broadcast_shape(x_shape, y_shape):
     return core.broadcast_shape(x_shape, y_shape)
 
 
-def conj(x, name=None):
+def conj(x: Tensor, name: str = None) -> Tensor:
     r"""
     This function computes the conjugate of the Tensor elementwisely.
 
@@ -4036,7 +4042,7 @@ def conj(x, name=None):
     return out
 
 
-def digamma(x, name=None):
+def digamma(x: Tensor, name: str = None) -> Tensor:
     r"""
     Calculates the digamma of the given input tensor, element-wise.
 
@@ -4075,7 +4081,7 @@ def digamma(x, name=None):
     return out
 
 
-def lgamma(x, name=None):
+def lgamma(x: Tensor, name: str = None) -> Tensor:
     r"""
     Calculates the lgamma of the given input tensor, element-wise.
 
@@ -4139,7 +4145,7 @@ def neg(x, name=None):
     )
 
 
-def atan2(x, y, name=None):
+def atan2(x: Tensor, y: Tensor, name: str = None) -> Tensor:
     r"""
     Element-wise arctangent of x/y with consideration of the quadrant.
 
@@ -4264,7 +4270,7 @@ def logit(x, eps=None, name=None):
     return out
 
 
-def lerp(x, y, weight, name=None):
+def lerp(x: Tensor, y: Tensor, weight: Tensor, name: str = None) -> Tensor:
     r"""
     Does a linear interpolation between x and y based on weight.
 
@@ -4342,7 +4348,7 @@ def lerp_(x, y, weight, name=None):
     return _legacy_C_ops.lerp_(x, y, weight)
 
 
-def erfinv(x, name=None):
+def erfinv(x: Tensor, name: str = None) -> Tensor:
     r"""
     The inverse error function of x. Please refer to :ref:`api_paddle_erf`
 
@@ -4825,7 +4831,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
             axes,
             'infer_flags',
             infer_flags,
-            *attrs_1
+            *attrs_1,
         )
         starts_2 = [1]
         attrs_2 += ('starts', starts_2)
@@ -4841,7 +4847,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
             axes,
             'infer_flags',
             infer_flags,
-            *attrs_2
+            *attrs_2,
         )
 
         if x.dtype == paddle.bool:
@@ -4916,7 +4922,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
         return out
 
 
-def angle(x, name=None):
+def angle(x: Tensor, name: str = None) -> Tensor:
     r"""
     Element-wise angle of complex numbers. For non-negative real numbers, the angle is 0 while
     for negative real numbers, the angle is :math:`\pi`.

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 from .. import _C_ops, _legacy_C_ops
 from ..fluid.data_feeder import check_variable_and_dtype
@@ -191,7 +197,7 @@ Examples:
 )
 
 
-def acos(x, name=None):
+def acos(x: Tensor, name: str | None = None) -> Tensor:
     """
     Acos Activation Operator.
 
@@ -228,7 +234,7 @@ def acos(x, name=None):
     return out
 
 
-def acosh(x, name=None):
+def acosh(x: Tensor, name: str | None = None) -> Tensor:
     """
     Acosh Activation Operator.
 
@@ -265,7 +271,7 @@ def acosh(x, name=None):
     return out
 
 
-def asin(x, name=None):
+def asin(x: Tensor, name: str | None = None) -> Tensor:
     """
     Arcsine Operator.
 
@@ -302,7 +308,7 @@ def asin(x, name=None):
     return out
 
 
-def asinh(x, name=None):
+def asinh(x: Tensor, name: str | None = None) -> Tensor:
     """
     Asinh Activation Operator.
 
@@ -339,7 +345,7 @@ def asinh(x, name=None):
     return out
 
 
-def atan(x, name=None):
+def atan(x: Tensor, name: str | None = None) -> Tensor:
     """
     Arctangent Operator.
 
@@ -376,7 +382,7 @@ def atan(x, name=None):
     return out
 
 
-def atanh(x, name=None):
+def atanh(x: Tensor, name: str | None = None) -> Tensor:
     """
     Atanh Activation Operator.
 
@@ -413,7 +419,7 @@ def atanh(x, name=None):
     return out
 
 
-def ceil(x, name=None):
+def ceil(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Ceil Operator. Computes ceil of x element-wise.
@@ -451,7 +457,7 @@ def ceil(x, name=None):
     return out
 
 
-def cos(x, name=None):
+def cos(x: Tensor, name: str | None = None) -> Tensor:
     """
     Cosine Operator. Computes cosine of x element-wise.
 
@@ -490,7 +496,7 @@ def cos(x, name=None):
     return out
 
 
-def cosh(x, name=None):
+def cosh(x: Tensor, name: str | None = None) -> Tensor:
     """
     Cosh Activation Operator.
 
@@ -529,7 +535,7 @@ def cosh(x, name=None):
     return out
 
 
-def exp(x, name=None):
+def exp(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Computes exp of x element-wise with a natural number `e` as the base.
@@ -580,7 +586,7 @@ def exp(x, name=None):
     return out
 
 
-def expm1(x, name=None):
+def expm1(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Expm1 Operator. Computes expm1 of x element-wise with a natural number :math:`e` as the base.
@@ -618,7 +624,7 @@ def expm1(x, name=None):
     return out
 
 
-def floor(x, name=None):
+def floor(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Floor Activation Operator. Computes floor of x element-wise.
@@ -656,7 +662,7 @@ def floor(x, name=None):
     return out
 
 
-def reciprocal(x, name=None):
+def reciprocal(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Reciprocal Activation Operator.
@@ -696,7 +702,7 @@ def reciprocal(x, name=None):
     return out
 
 
-def round(x, name=None):
+def round(x: Tensor, name: str | None = None) -> Tensor:
     """
 
     Round the values in the input to the nearest integer value.
@@ -741,7 +747,7 @@ def round(x, name=None):
     return out
 
 
-def rsqrt(x, name=None):
+def rsqrt(x: Tensor, name: str | None = None) -> Tensor:
     """
     Rsqrt Activation Operator.
 
@@ -780,7 +786,7 @@ def rsqrt(x, name=None):
     return out
 
 
-def sigmoid(x, name=None):
+def sigmoid(x: Tensor, name: str | None = None) -> Tensor:
     """
     Sigmoid Activation.
 
@@ -820,7 +826,7 @@ def sigmoid(x, name=None):
     return out
 
 
-def sin(x, name=None):
+def sin(x: Tensor, name: str | None = None) -> Tensor:
     """
     Sine Activation Operator.
 
@@ -857,7 +863,7 @@ def sin(x, name=None):
     return out
 
 
-def sinh(x, name=None):
+def sinh(x: Tensor, name: str | None = None) -> Tensor:
     """
     Sinh Activation Operator.
 
@@ -894,7 +900,7 @@ def sinh(x, name=None):
     return out
 
 
-def sqrt(x, name=None):
+def sqrt(x: Tensor, name: str | None = None) -> Tensor:
     """
     Sqrt Activation Operator.
 
@@ -930,7 +936,7 @@ def sqrt(x, name=None):
     return out
 
 
-def square(x, name=None):
+def square(x: Tensor, name: str | None = None) -> Tensor:
     """
     Square each elements of the inputs.
 
@@ -979,7 +985,7 @@ def square(x, name=None):
     return out
 
 
-def tan(x, name=None):
+def tan(x: Tensor, name: str | None = None) -> Tensor:
     """
     Tangent Operator. Computes tangent of x element-wise.
 
@@ -1021,7 +1027,7 @@ def tan(x, name=None):
 _erf_ = generate_layer_fn('erf')
 
 
-def erf(x, name=None):
+def erf(x: Tensor, name: str | None = None) -> Tensor:
     if in_dygraph_mode():
         return _C_ops.erf(x)
 

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 from .. import _C_ops, _legacy_C_ops
 from ..fluid.data_feeder import check_variable_and_dtype
@@ -191,7 +197,7 @@ Examples:
 )
 
 
-def acos(x, name=None):
+def acos(x: Tensor, name: str = None) -> Tensor:
     """
     Acos Activation Operator.
 
@@ -228,7 +234,7 @@ def acos(x, name=None):
     return out
 
 
-def acosh(x, name=None):
+def acosh(x: Tensor, name: str = None) -> Tensor:
     """
     Acosh Activation Operator.
 
@@ -265,7 +271,7 @@ def acosh(x, name=None):
     return out
 
 
-def asin(x, name=None):
+def asin(x: Tensor, name: str = None) -> Tensor:
     """
     Arcsine Operator.
 
@@ -302,7 +308,7 @@ def asin(x, name=None):
     return out
 
 
-def asinh(x, name=None):
+def asinh(x: Tensor, name: str = None) -> Tensor:
     """
     Asinh Activation Operator.
 
@@ -339,7 +345,7 @@ def asinh(x, name=None):
     return out
 
 
-def atan(x, name=None):
+def atan(x: Tensor, name: str = None) -> Tensor:
     """
     Arctangent Operator.
 
@@ -376,7 +382,7 @@ def atan(x, name=None):
     return out
 
 
-def atanh(x, name=None):
+def atanh(x: Tensor, name: str = None) -> Tensor:
     """
     Atanh Activation Operator.
 
@@ -413,7 +419,7 @@ def atanh(x, name=None):
     return out
 
 
-def ceil(x, name=None):
+def ceil(x: Tensor, name: str = None) -> Tensor:
     """
 
     Ceil Operator. Computes ceil of x element-wise.
@@ -451,7 +457,7 @@ def ceil(x, name=None):
     return out
 
 
-def cos(x, name=None):
+def cos(x: Tensor, name: str = None) -> Tensor:
     """
     Cosine Operator. Computes cosine of x element-wise.
 
@@ -490,7 +496,7 @@ def cos(x, name=None):
     return out
 
 
-def cosh(x, name=None):
+def cosh(x: Tensor, name: str = None) -> Tensor:
     """
     Cosh Activation Operator.
 
@@ -529,7 +535,7 @@ def cosh(x, name=None):
     return out
 
 
-def exp(x, name=None):
+def exp(x: Tensor, name: str = None) -> Tensor:
     """
 
     Computes exp of x element-wise with a natural number `e` as the base.
@@ -580,7 +586,7 @@ def exp(x, name=None):
     return out
 
 
-def expm1(x, name=None):
+def expm1(x: Tensor, name: str = None) -> Tensor:
     """
 
     Expm1 Operator. Computes expm1 of x element-wise with a natural number :math:`e` as the base.
@@ -618,7 +624,7 @@ def expm1(x, name=None):
     return out
 
 
-def floor(x, name=None):
+def floor(x: Tensor, name: str = None) -> Tensor:
     """
 
     Floor Activation Operator. Computes floor of x element-wise.
@@ -656,7 +662,7 @@ def floor(x, name=None):
     return out
 
 
-def reciprocal(x, name=None):
+def reciprocal(x: Tensor, name: str = None) -> Tensor:
     """
 
     Reciprocal Activation Operator.
@@ -696,7 +702,7 @@ def reciprocal(x, name=None):
     return out
 
 
-def round(x, name=None):
+def round(x: Tensor, name: str = None) -> Tensor:
     """
 
     Round the values in the input to the nearest integer value.
@@ -741,7 +747,7 @@ def round(x, name=None):
     return out
 
 
-def rsqrt(x, name=None):
+def rsqrt(x: Tensor, name: str = None) -> Tensor:
     """
     Rsqrt Activation Operator.
 
@@ -780,7 +786,7 @@ def rsqrt(x, name=None):
     return out
 
 
-def sigmoid(x, name=None):
+def sigmoid(x: Tensor, name: str = None) -> Tensor:
     """
     Sigmoid Activation.
 
@@ -820,7 +826,7 @@ def sigmoid(x, name=None):
     return out
 
 
-def sin(x, name=None):
+def sin(x: Tensor, name: str = None) -> Tensor:
     """
     Sine Activation Operator.
 
@@ -857,7 +863,7 @@ def sin(x, name=None):
     return out
 
 
-def sinh(x, name=None):
+def sinh(x: Tensor, name: str = None) -> Tensor:
     """
     Sinh Activation Operator.
 
@@ -894,7 +900,7 @@ def sinh(x, name=None):
     return out
 
 
-def sqrt(x, name=None):
+def sqrt(x: Tensor, name: str = None) -> Tensor:
     """
     Sqrt Activation Operator.
 
@@ -930,7 +936,7 @@ def sqrt(x, name=None):
     return out
 
 
-def square(x, name=None):
+def square(x: Tensor, name: str = None) -> Tensor:
     """
     Square each elements of the inputs.
 
@@ -979,7 +985,7 @@ def square(x, name=None):
     return out
 
 
-def tan(x, name=None):
+def tan(x: Tensor, name: str = None) -> Tensor:
     """
     Tangent Operator. Computes tangent of x element-wise.
 
@@ -1021,7 +1027,7 @@ def tan(x, name=None):
 _erf_ = generate_layer_fn('erf')
 
 
-def erf(x, name=None):
+def erf(x: Tensor, name: str = None) -> Tensor:
     if in_dygraph_mode():
         return _C_ops.erf(x)
 

--- a/python/paddle/tensor/ops.py
+++ b/python/paddle/tensor/ops.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 from .. import _C_ops, _legacy_C_ops
 from ..fluid.data_feeder import check_variable_and_dtype
@@ -197,7 +191,7 @@ Examples:
 )
 
 
-def acos(x: Tensor, name: str = None) -> Tensor:
+def acos(x, name=None):
     """
     Acos Activation Operator.
 
@@ -234,7 +228,7 @@ def acos(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def acosh(x: Tensor, name: str = None) -> Tensor:
+def acosh(x, name=None):
     """
     Acosh Activation Operator.
 
@@ -271,7 +265,7 @@ def acosh(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def asin(x: Tensor, name: str = None) -> Tensor:
+def asin(x, name=None):
     """
     Arcsine Operator.
 
@@ -308,7 +302,7 @@ def asin(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def asinh(x: Tensor, name: str = None) -> Tensor:
+def asinh(x, name=None):
     """
     Asinh Activation Operator.
 
@@ -345,7 +339,7 @@ def asinh(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def atan(x: Tensor, name: str = None) -> Tensor:
+def atan(x, name=None):
     """
     Arctangent Operator.
 
@@ -382,7 +376,7 @@ def atan(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def atanh(x: Tensor, name: str = None) -> Tensor:
+def atanh(x, name=None):
     """
     Atanh Activation Operator.
 
@@ -419,7 +413,7 @@ def atanh(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def ceil(x: Tensor, name: str = None) -> Tensor:
+def ceil(x, name=None):
     """
 
     Ceil Operator. Computes ceil of x element-wise.
@@ -457,7 +451,7 @@ def ceil(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def cos(x: Tensor, name: str = None) -> Tensor:
+def cos(x, name=None):
     """
     Cosine Operator. Computes cosine of x element-wise.
 
@@ -496,7 +490,7 @@ def cos(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def cosh(x: Tensor, name: str = None) -> Tensor:
+def cosh(x, name=None):
     """
     Cosh Activation Operator.
 
@@ -535,7 +529,7 @@ def cosh(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def exp(x: Tensor, name: str = None) -> Tensor:
+def exp(x, name=None):
     """
 
     Computes exp of x element-wise with a natural number `e` as the base.
@@ -586,7 +580,7 @@ def exp(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def expm1(x: Tensor, name: str = None) -> Tensor:
+def expm1(x, name=None):
     """
 
     Expm1 Operator. Computes expm1 of x element-wise with a natural number :math:`e` as the base.
@@ -624,7 +618,7 @@ def expm1(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def floor(x: Tensor, name: str = None) -> Tensor:
+def floor(x, name=None):
     """
 
     Floor Activation Operator. Computes floor of x element-wise.
@@ -662,7 +656,7 @@ def floor(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def reciprocal(x: Tensor, name: str = None) -> Tensor:
+def reciprocal(x, name=None):
     """
 
     Reciprocal Activation Operator.
@@ -702,7 +696,7 @@ def reciprocal(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def round(x: Tensor, name: str = None) -> Tensor:
+def round(x, name=None):
     """
 
     Round the values in the input to the nearest integer value.
@@ -747,7 +741,7 @@ def round(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def rsqrt(x: Tensor, name: str = None) -> Tensor:
+def rsqrt(x, name=None):
     """
     Rsqrt Activation Operator.
 
@@ -786,7 +780,7 @@ def rsqrt(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def sigmoid(x: Tensor, name: str = None) -> Tensor:
+def sigmoid(x, name=None):
     """
     Sigmoid Activation.
 
@@ -826,7 +820,7 @@ def sigmoid(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def sin(x: Tensor, name: str = None) -> Tensor:
+def sin(x, name=None):
     """
     Sine Activation Operator.
 
@@ -863,7 +857,7 @@ def sin(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def sinh(x: Tensor, name: str = None) -> Tensor:
+def sinh(x, name=None):
     """
     Sinh Activation Operator.
 
@@ -900,7 +894,7 @@ def sinh(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def sqrt(x: Tensor, name: str = None) -> Tensor:
+def sqrt(x, name=None):
     """
     Sqrt Activation Operator.
 
@@ -936,7 +930,7 @@ def sqrt(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def square(x: Tensor, name: str = None) -> Tensor:
+def square(x, name=None):
     """
     Square each elements of the inputs.
 
@@ -985,7 +979,7 @@ def square(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def tan(x: Tensor, name: str = None) -> Tensor:
+def tan(x, name=None):
     """
     Tangent Operator. Computes tangent of x element-wise.
 
@@ -1027,7 +1021,7 @@ def tan(x: Tensor, name: str = None) -> Tensor:
 _erf_ = generate_layer_fn('erf')
 
 
-def erf(x: Tensor, name: str = None) -> Tensor:
+def erf(x, name=None):
     if in_dygraph_mode():
         return _C_ops.erf(x)
 

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define random functions
 
@@ -40,7 +46,7 @@ from ..framework import (
 __all__ = []
 
 
-def bernoulli(x, name=None):
+def bernoulli(x: Tensor, name: str | None = None) -> Tensor:
     r"""
 
     For each element :math:`x_i` in input ``x``, take a sample from the Bernoulli distribution, also called two-point distribution, with success probability :math:`x_i`. The Bernoulli distribution with success probability :math:`x_i` is a discrete probability distribution with probability mass function
@@ -97,7 +103,7 @@ def bernoulli(x, name=None):
     return out
 
 
-def poisson(x, name=None):
+def poisson(x: Tensor, name: str | None = None) -> Tensor:
     r"""
     Returns a tensor filled with random number from a Poisson Distribution.
 

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 # TODO: define random functions
 
@@ -46,7 +40,7 @@ from ..framework import (
 __all__ = []
 
 
-def bernoulli(x: Tensor, name: str = None) -> Tensor:
+def bernoulli(x, name=None):
     r"""
 
     For each element :math:`x_i` in input ``x``, take a sample from the Bernoulli distribution, also called two-point distribution, with success probability :math:`x_i`. The Bernoulli distribution with success probability :math:`x_i` is a discrete probability distribution with probability mass function
@@ -103,7 +97,7 @@ def bernoulli(x: Tensor, name: str = None) -> Tensor:
     return out
 
 
-def poisson(x: Tensor, name: str = None) -> Tensor:
+def poisson(x, name=None):
     r"""
     Returns a tensor filled with random number from a Poisson Distribution.
 

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define random functions
 
@@ -40,7 +46,7 @@ from ..framework import (
 __all__ = []
 
 
-def bernoulli(x, name=None):
+def bernoulli(x: Tensor, name: str = None) -> Tensor:
     r"""
 
     For each element :math:`x_i` in input ``x``, take a sample from the Bernoulli distribution, also called two-point distribution, with success probability :math:`x_i`. The Bernoulli distribution with success probability :math:`x_i` is a discrete probability distribution with probability mass function
@@ -97,7 +103,7 @@ def bernoulli(x, name=None):
     return out
 
 
-def poisson(x, name=None):
+def poisson(x: Tensor, name: str = None) -> Tensor:
     r"""
     Returns a tensor filled with random number from a Poisson Distribution.
 

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define searching & indexing functions of a tensor
 
@@ -599,7 +605,12 @@ def mode(x, axis=-1, keepdim=False, name=None):
     return values, indices
 
 
-def where(condition, x=None, y=None, name=None):
+def where(
+    condition: Tensor,
+    x: Tensor = None,
+    y: Tensor = None,
+    name: str | None = None,
+) -> Tensor:
     r"""
     Return a Tensor of elements selected from either :attr:`x` or :attr:`y` according to corresponding elements of :attr:`condition`. Concretely,
 
@@ -811,7 +822,7 @@ def index_sample(x, index):
             return out
 
 
-def masked_select(x, mask, name=None):
+def masked_select(x: Tensor, mask: Tensor, name: str | None = None) -> Tensor:
     """
     Returns a new 1-D tensor which indexes the input tensor according to the ``mask``
     which is a tensor with data type of bool.

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from .tensor import Tensor
 
 # TODO: define searching & indexing functions of a tensor
 
@@ -605,9 +599,7 @@ def mode(x, axis=-1, keepdim=False, name=None):
     return values, indices
 
 
-def where(
-    condition: Tensor, x: Tensor = None, y: Tensor = None, name: str = None
-) -> Tensor:
+def where(condition, x=None, y=None, name=None):
     r"""
     Return a Tensor of elements selected from either :attr:`x` or :attr:`y` according to corresponding elements of :attr:`condition`. Concretely,
 
@@ -819,7 +811,7 @@ def index_sample(x, index):
             return out
 
 
-def masked_select(x: Tensor, mask: Tensor, name: str = None) -> Tensor:
+def masked_select(x, mask, name=None):
     """
     Returns a new 1-D tensor which indexes the input tensor according to the ``mask``
     which is a tensor with data type of bool.

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define searching & indexing functions of a tensor
 
@@ -599,7 +605,9 @@ def mode(x, axis=-1, keepdim=False, name=None):
     return values, indices
 
 
-def where(condition, x=None, y=None, name=None):
+def where(
+    condition: Tensor, x: Tensor = None, y: Tensor = None, name: str = None
+) -> Tensor:
     r"""
     Return a Tensor of elements selected from either :attr:`x` or :attr:`y` according to corresponding elements of :attr:`condition`. Concretely,
 
@@ -811,7 +819,7 @@ def index_sample(x, index):
             return out
 
 
-def masked_select(x, mask, name=None):
+def masked_select(x: Tensor, mask: Tensor, name: str = None) -> Tensor:
     """
     Returns a new 1-D tensor which indexes the input tensor according to the ``mask``
     which is a tensor with data type of bool.

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tensor import Tensor
 
 # TODO: define statistical functions of a tensor
 
@@ -218,7 +224,7 @@ def std(x, axis=None, unbiased=True, keepdim=False, name=None):
     return paddle.sqrt(out)
 
 
-def numel(x, name=None):
+def numel(x: Tensor, name: str | None = None) -> Tensor:
     """
     Returns the number of elements for a tensor, which is a int64 Tensor with shape [1] in static mode
     or a scalar value in imperative mode.

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
 
 # TODO: define statistical functions of a tensor
 

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 # TODO: define statistical functions of a tensor
 

--- a/python/paddle/tensor/tensor.py
+++ b/python/paddle/tensor/tensor.py
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 # TODO: define the basic tensor classes
+class Tensor:
+    pass

--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -11,12 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 import numpy as np
 

--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -11,6 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
 
 import numpy as np
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
python/tensor目录下共有246个函数（更新前是253个，这个统计的是文件里的所有函数，感觉可能是因为部分工具函数被优化掉了），本pr为其中88个（更新后增加了7个）添加了类型注释，具体文件替换情况如下（自动化替换脚本在 https://github.com/zrr1999/TypeHinter/tree/paddle_modified ）
```python
{
    "paddle/tensor/manipulation.py": "9/56*",
    "paddle/tensor/attribute.py": "2/7",
    "paddle/tensor/creation.py": "2/29*",
    "paddle/tensor/einsum.py": "0/22",
    "paddle/tensor/random.py": "2/15",
    "paddle/tensor/logic.py": "8/21",
    "paddle/tensor/ops.py": "22/22",
    "paddle/tensor/layer_function_generator.py": "0/9",
    "paddle/tensor/linalg.py": "9/33",
    "paddle/tensor/stat.py": "1/9*",
    "paddle/tensor/to_string.py": "0/9",
    "paddle/tensor/search.py": "2/14",
    "paddle/tensor/math.py": "31/84*",
    "paddle/tensor/array.py": "0/4",
}
```
未替换的分为三种情况：
1.  yaml文件与python参数命名不同（在应用了新的yaml文件后这部分已经全部解决）
2. yaml文件中不存在相应算子，某算子使用 python实现（较多）
3. yaml文件中不存在相应算子，某算子不是使用 python实现（较多）

针对后二种情况，可以进一步通过在注释中获取参数类型从而添加注解。
实际上第二种情况使用 ide 可以自动推导出相应的返回值类型。

