### PR TITLE
[CodeStyle][py36] remove deprecated warnings for py36

### DIFF
--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -23,14 +23,6 @@ import paddle
 
 __all__ = []
 
-# NOTE(zhiqiu): Since python 3.2, DeprecationWarning is ignored by default,
-# and since python 3.7, it is once again shown by default when triggered directly by code in __main__.
-# See details: https://docs.python.org/3/library/warnings.html#default-warning-filter
-# The following line set DeprecationWarning to show once, which is expected to work in python 3.2 -> 3.6
-# However, doing this could introduce one samll side effect, i.e., the DeprecationWarning which is not issued by @deprecated.
-# The side effect is acceptable, and we will find better way to do this if we could.
-warnings.simplefilter('default', DeprecationWarning)
-
 
 def deprecated(update_to="", since="", reason="", level=0):
     """Decorate a function to signify its deprecation.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Since python 3.2, DeprecationWarning is ignored by default, and since python 3.7, it is once again shown by default when triggered directly by code in `__main__`. See details: https://docs.python.org/3/library/warnings.html#default-warning-filter

移除显式启用DeprecationWarning

related works
- https://github.com/PaddlePaddle/Paddle/pull/48630
- https://github.com/PaddlePaddle/Paddle/issues/46837
- https://github.com/PaddlePaddle/community/pull/338
