### PR TITLE
Support elementwise_add operator for QAT in dynamic mode

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
@@ -46,6 +46,8 @@ layer_name_map = {
     'BatchNorm': paddle.nn.BatchNorm,
     'GroupNorm': paddle.nn.GroupNorm,
     'LayerNorm': paddle.nn.LayerNorm,
+    'Matmul': paddle.nn.quant.matmul,
+    'Add': paddle.nn.quant.add,
 }
 
 # Apply fake quant for the inputs of these layers
@@ -53,6 +55,8 @@ fake_quant_input_layers = [
     paddle.nn.Conv2D,
     paddle.nn.Linear,
     paddle.nn.Conv2DTranspose,
+    paddle.nn.quant.add,
+    paddle.nn.quant.matmul,
 ]
 
 # Apply fake quant for the output of these layers

--- a/python/paddle/nn/quant/__init__.py
+++ b/python/paddle/nn/quant/__init__.py
@@ -21,6 +21,7 @@ from .functional_layers import reshape  # noqa: F401
 from .functional_layers import transpose  # noqa: F401
 from .functional_layers import concat  # noqa: F401
 from .functional_layers import flatten  # noqa: F401
+from .functional_layers import matmul
 from .quant_layers import QuantStub  # noqa: F401
 
 __all__ = []

--- a/python/paddle/nn/quant/functional_layers.py
+++ b/python/paddle/nn/quant/functional_layers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...tensor import manipulation, math
+from ...tensor import linalg, manipulation, math
 from .. import Layer
 
 __all__ = []
@@ -85,3 +85,11 @@ class flatten(FloatFunctionalLayer):
 
     def forward(self, x, start_axis=0, stop_axis=-1, name=None):
         return manipulation.flatten(x, start_axis, stop_axis, name)
+
+
+class matmul(FloatFunctionalLayer):
+    def __init__(self):
+        super(matmul, self).__init__()
+
+    def forward(self, x, y, transpose_x=False, transpose_y=False, name=None):
+        return linalg.matmul(x, y, transpose_x, transpose_y, name)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Supports `elementwise_add` operator for QAT in dynamic mode

usage:
Step 1. For layer definition
```python
class MyLayer(Layer):
    def __init__(self):
        self.add = paddle.nn.quant.add()
    def forward(self, x, y):
        # Before: sum = x + y
        sum = self.add(x, y)
        return sum
```
Step2. For QAT

```python

from paddleslim import QAT

quant_config = {
      'activation_preprocess_type':
      args.activation_preprocess_type,  # PACT or None
      'weight_preprocess_type':
      args.weight_preprocess_type,  # PACT or None
      'weight_quantize_type':
      args.weight_quantize_type,
      'activation_quantize_type':
      'moving_average_abs_max' if args.activation_quantize_type is None else
      args.activation_quantize_type,
      'weight_bits':
      8,
      'activation_bits':
      8,
      'dtype':
      'int8',
      'window_size':
      10000,
      'quantizable_layer_type': ['Linear', 'Matmul', 'Add'], # 'Add' should be added here
      'moving_rate':
      args.moving_rate,
      'onnx_format': False, # QAT+PTQ only supports False now.
  }

quanter = QAT(config=quant_config)

quanter.quantize(model)
```