### PR TITLE
[Custom operator] Fix custom operator backward=None bug

### DIFF
--- a/paddle/fluid/eager/custom_operator/custom_operator_node.cc
+++ b/paddle/fluid/eager/custom_operator/custom_operator_node.cc
@@ -217,18 +217,20 @@ RunCustomOpNode::operator()(
   VLOG(6) << "Prepare Grad outputs for size: " << grad_outputs_names.size();
   for (size_t i = 0; i < OutputMeta().size(); i++) {
     if (map[0][0].find(i) != map[0][0].end()) {
+      int grad_output_idx = map[0][0][i];
       VLOG(7) << "Insert grad outputs: " << i
-              << " with size: " << OutputMeta()[i].size()
-              << " to tmp_outputs: " << map[0][0][i];
-      for (size_t j = 0; j < OutputMeta()[i].size(); j++) {
-        outs[i].emplace_back(/* init it incase of copy nullptr of shared_ptr */
-                             std::make_shared<phi::DenseTensor>(
-                                 phi::DataType::UNDEFINED),
-                             egr::Controller::Instance().GenerateUniqueName(
-                                 "custom_tmp_grad"));
-        egr::EagerUtils::autograd_meta(&(outs[i][j]));
+              << " with size: " << OutputMeta()[grad_output_idx].size()
+              << " to tmp_outputs: " << grad_output_idx;
+      for (size_t j = 0; j < OutputMeta()[grad_output_idx].size(); j++) {
+        outs[grad_output_idx]
+            .emplace_back(/* init it incase of copy nullptr of shared_ptr */
+                          std::make_shared<phi::DenseTensor>(
+                              phi::DataType::UNDEFINED),
+                          egr::Controller::Instance().GenerateUniqueName(
+                              "custom_tmp_grad"));
+        egr::EagerUtils::autograd_meta(&(outs[grad_output_idx][j]));
       }
-      tmp_outs[map[0][0][i]] = outs[i];
+      tmp_outs[grad_output_idx] = outs[grad_output_idx];
     }
   }
   for (size_t i = 0; i < tmp_outs.size(); i++) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
**Bug describes:** when custom backward op outputs gradient with a discrete order, the output of some gradient=None.

**For example:** backward op's input = {a, b, c, d, e}, output = {a@GRAD, d@GRAD, e@GRAD}, the output of d@GRAD and e@GRAD will be None.

**Reason:** The order of `RunCustomOpNode::operator(): line220` in `custom_operator_node.cc` is {a@GRAD, null, null, d@GRAD, e@GRAD}. However, the order of `eager_api_run_custom_op: line560` in `eager_functions.cc` is {a@GRAD, d@GRAD, e@GRAD, null, null}.

**Change:** Change the order in `RunCustomOpNode::operator()` to {a@GRAD, d@GRAD, e@GRAD, null, null}

本 PR 修复了自定义算子反向 op 的输出值可能为 None 的 bug，当用户的输出梯度不是连续输出时（例如输出第0、3、4个前向输入的梯度时），第3、4个梯度会被置为 None，这是由于对反向 op 的输出梯度进行处理时，`RunCustomOpNode::operator(): line220` 和 `eager_api_run_custom_op: line560`的动作不一致。更改为按照`RunCustomOpNode::operator()`对齐，在反向 op 的输出梯度后面，填充不需要梯度的输出，修改后的返回值为 {第 0 个梯度，第 3 个梯度，第 4 个梯度，null, null}