### PR TITLE
fix bug in paddle/phi/api/yaml/generator

### DIFF
--- a/paddle/fluid/operators/generator/cross_validate.py
+++ b/paddle/fluid/operators/generator/cross_validate.py
@@ -40,14 +40,14 @@ if __name__ == "__main__":
         '--forward_yaml_paths',
         type=str,
         nargs='+',
-        default=str(current_dir / "op .parsed.yaml"),
+        default=[str(current_dir / "op .parsed.yaml")],
         help="forward op yaml file.",
     )
     parser.add_argument(
         '--backward_yaml_paths',
         type=str,
         nargs='+',
-        default=str(current_dir / "backward_op .parsed.yaml"),
+        default=[str(current_dir / "backward_op .parsed.yaml")],
         help="backward op yaml file.",
     )
 

--- a/paddle/phi/api/yaml/generator/api_gen.py
+++ b/paddle/phi/api/yaml/generator/api_gen.py
@@ -409,7 +409,7 @@ def main():
         '--api_yaml_path',
         help='path to api yaml file',
         nargs='+',
-        default='paddle/phi/api/yaml/ops.yaml',
+        default=['paddle/phi/api/yaml/ops.yaml'],
     )
 
     parser.add_argument(

--- a/paddle/phi/api/yaml/generator/backward_api_gen.py
+++ b/paddle/phi/api/yaml/generator/backward_api_gen.py
@@ -351,7 +351,7 @@ def main():
         '--backward_yaml_path',
         help='path to backward yaml file',
         nargs='+',
-        default='paddle/phi/api/yaml/backward.yaml',
+        default=['paddle/phi/api/yaml/backward.yaml'],
     )
     parser.add_argument(
         '--backward_header_path',

--- a/paddle/phi/api/yaml/generator/intermediate_api_gen.py
+++ b/paddle/phi/api/yaml/generator/intermediate_api_gen.py
@@ -147,7 +147,7 @@ def main():
         '--api_yaml_path',
         nargs='+',
         help='path to api yaml file',
-        default='paddle/phi/api/yaml/ops.yaml',
+        default=['paddle/phi/api/yaml/ops.yaml'],
     )
 
     parser.add_argument(

--- a/paddle/phi/api/yaml/generator/wrapped_infermeta_gen.py
+++ b/paddle/phi/api/yaml/generator/wrapped_infermeta_gen.py
@@ -181,7 +181,7 @@ def main():
         '--api_yaml_path',
         help='path to api yaml file',
         nargs='+',
-        default='paddle/phi/api/yaml/ops.yaml',
+        default=['paddle/phi/api/yaml/ops.yaml'],
     )
     parser.add_argument(
         '--wrapped_infermeta_header_path',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
因为apigen相关工具的实现方法的改进，现在很多函数要求传入的yaml路径是一个列表，但是其默认值还是一个字符串，本pr主要将这些字符串改成了列表 related https://github.com/PaddlePaddle/Paddle/pull/48632#discussion_r1037886428