### PR TITLE
[Inference] Fix error tensor dtype when ShareBufferWith.

### DIFF
--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -68,7 +68,7 @@ void NaiveExecutor::Run() {
     // According to reuse table, we share the out tensor's holder.
     if (reuse_cache_.count(op.get())) {
       for (auto &it : reuse_cache_[op.get()]) {
-        it.first->ShareBufferWith(*cluster_buffer_[it.second]);
+        it.first->ShareBufferWith(*cluster_buffer_[it.second], true);
       }
     }
 

--- a/paddle/phi/core/dense_tensor.inl
+++ b/paddle/phi/core/dense_tensor.inl
@@ -62,7 +62,7 @@ void clear() {
   meta_.offset = 0;
 }
 
-void ShareBufferWith(const DenseTensor& tensor);
+void ShareBufferWith(const DenseTensor& tensor, bool only_buffer=false);
 
 void ShareDataTypeWith(const DenseTensor& tensor) {
   meta_.dtype = tensor.meta().dtype;

--- a/paddle/phi/core/dense_tensor_impl.cc
+++ b/paddle/phi/core/dense_tensor_impl.cc
@@ -172,10 +172,12 @@ inline T* DenseTensor::mutable_data(const Place& place, size_t requested_size) {
                    requested_size));
 }
 
-void DenseTensor::ShareBufferWith(const DenseTensor& tensor) {
+void DenseTensor::ShareBufferWith(const DenseTensor& tensor, bool only_buffer) {
   holder_ = tensor.holder_;
-  meta_.offset = tensor.meta().offset;
-  meta_.dtype = tensor.dtype();
+  if (!only_buffer) {
+    meta_.offset = tensor.meta().offset;
+    meta_.dtype = tensor.dtype();
+  }
 }
 
 #define LEGACY_DATA_MEMBER_FUNC_INSTANTIATION(dtype)                \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
patch for https://github.com/PaddlePaddle/Paddle/pull/48476

`ShareBufferWith`接口改了tensor的dtype信息，语义比较奇怪，导致大模型复用过程中挂出：
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/26377421/205273559-21ff4c2b-9714-4abe-9d7c-455a5825e473.png">

该pr更新了`ShareBufferWith`接口，增加`only_buffer`选项，默认值false，向前兼容；