### PR TITLE
[DataParallel] Fix bug of DataParallel in best_fit allocator strategy

### DIFF
--- a/paddle/fluid/distributed/collective/reducer.h
+++ b/paddle/fluid/distributed/collective/reducer.h
@@ -75,7 +75,7 @@ class EagerGroup {
 
   // context is used to select the stream for split
 
-  void SplitTensorsDev(const platform::DeviceContext &);
+  void SplitTensors(const platform::DeviceContext &);
 
   friend std::ostream &operator<<(std::ostream &, const EagerGroup &);
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The best_fit allocator strategy is multi-stream insecure. In the Split operator, additional memory will be applied for calculation, and if it is asynchronous, an illegal memory access may be encountered.

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/19485646/205284011-b54af1f5-0ed6-4824-ad24-8652d13946a8.png">