### PR TITLE
replace deprecated `load_module` with `exec_module`

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -16,6 +16,7 @@ import atexit
 import collections
 import glob
 import hashlib
+import importlib.util
 import json
 import logging
 import os
@@ -1070,7 +1071,9 @@ def _load_module_from_file(api_file_path, module_name, verbose=False):
 
     # load module with RWLock
     loader = machinery.SourceFileLoader(ext_name, api_file_path)
-    module = loader.load_module()
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
 
     return module
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

#48672 调试时候发现的 DeprecatedWarning `<frozen importlib._bootstrap>:283: DeprecationWarning: the load_module() method is deprecated and slated for removal in Python 3.12; use exec_module() instead`[^1]，因此替换 `load_module` 为 `exec_module`[^2]

[^1]: [importlib — The implementation of import - load_module - Python 3.11 docs](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module)
[^2]: [Import arbitrary python source file. (Python 3.3+) - StackOverflow](https://stackoverflow.com/a/19011259/17656881)


