### PR TITLE
[CodeStyle][py2] remove python2 installation from `Dockerfile.ubuntu`

### DIFF
--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -4,6 +4,8 @@
 FROM nvidia/cuda:<baseimg>
 MAINTAINER PaddlePaddle Authors <paddle-dev@baidu.com>
 
+should crash the ci
+
 # ENV variables
 ARG WITH_GPU
 ARG WITH_AVX
@@ -93,13 +95,13 @@ WORKDIR /home
 RUN python3.9 -m pip uninstall -y pip setuptools && \
   python3.8 -m pip uninstall -y pip setuptools && \
   python3.7 -m pip uninstall -y pip setuptools
-  
+
 RUN wget https://files.pythonhosted.org/packages/a7/e0/30642b9c2df516506d40b563b0cbd080c49c6b3f11a70b4c7a670f13a78b/setuptools-50.3.2.zip && apt-get -y install unzip && unzip setuptools-50.3.2.zip
 WORKDIR /home/setuptools-50.3.2
 RUN python3.9 setup.py build && python3.9 setup.py install && \
   python3.8 setup.py build && python3.8 setup.py install && \
   python3.7 setup.py build && python3.7 setup.py install
-  
+
 WORKDIR /home
 RUN wget https://files.pythonhosted.org/packages/28/af/2c76c8aa46ccdf7578b83d97a11a2d1858794d4be4a1610ade0d30182e8b/pip-20.0.1.tar.gz && tar -zxvf pip-20.0.1.tar.gz
 WORKDIR pip-20.0.1
@@ -132,7 +134,7 @@ RUN curl -s -q https://glide.sh/get | sh
 # 2. Manually add ~IPluginFactory() in IPluginFactory class of NvInfer.h, otherwise, it couldn't work in paddle.
 #    See https://github.com/PaddlePaddle/Paddle/issues/10129 for details.
 
-# Downgrade TensorRT 
+# Downgrade TensorRT
 
 # Older versions of patchelf limited the size of the files being processed and were fixed in this pr.
 # # https://github.com/NixOS/patchelf/commit/ba2695a8110abbc8cc6baf0eea819922ee5007fa

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -159,16 +159,12 @@ RUN pip3.7 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.9 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.9 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0'
 
-#For docstring checker
+# For docstring checker
 RUN pip3.7 --no-cache-dir install pytest astroid isort && \
     pip3.8 --no-cache-dir install pytest astroid isort && \
     pip3.9 --no-cache-dir install pytest astroid isort
 
-#For pre-commit
-RUN pip3.7 --no-cache-dir install --upgrade pip && \
-    pip3.8 --no-cache-dir install --upgrade pip && \
-    pip3.9 --no-cache-dir install --upgrade pip
-
+# For pre-commit
 RUN pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.8 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
     pip3.9 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -80,7 +80,7 @@ RUN python3.9 -m pip uninstall -y pip setuptools && \
     python3.8 -m pip uninstall -y pip setuptools && \
     python3.7 -m pip uninstall -y pip setuptools
 
-RUN wget https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz && apt-get -y install unzip && unzip setuptools-65.6.3.zip
+RUN wget https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz && tar -zxvf setuptools-65.6.3.tar.gz
 WORKDIR /home/setuptools-65.6.3
 RUN python3.9 setup.py build && python3.9 setup.py install && \
     python3.8 setup.py build && python3.8 setup.py install && \
@@ -99,7 +99,7 @@ RUN python setup.py install && \
     ln -s /usr/local/bin/pip3.7 /usr/local/bin/pip3
 
 WORKDIR /home
-RUN rm setuptools-65.6.3.zip pip-22.3.1.tar.gz && \
+RUN rm setuptools-65.6.3.tar.gz pip-22.3.1.tar.gz && \
     rm -r setuptools-65.6.3 pip-22.3.1
 
 # Install Go and glide

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -4,8 +4,6 @@
 FROM nvidia/cuda:<baseimg>
 MAINTAINER PaddlePaddle Authors <paddle-dev@baidu.com>
 
-should crash the ci
-
 # ENV variables
 ARG WITH_GPU
 ARG WITH_AVX
@@ -162,24 +160,19 @@ RUN pip3.7 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
     pip3.8 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark && \
     pip3.9 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
     pip3.9 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
-    pip3.9 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark && \
-    pip --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
-    pip --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark
+    pip3.9 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark
 
 RUN pip3.7 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.7 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
     pip3.8 --no-cache-dir install 'ipython==5.3.0' && \
     pip3.8 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
     pip3.9 --no-cache-dir install 'ipython==5.3.0' && \
-    pip3.9 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0'
+    pip3.9 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0'
 
 #For docstring checker
 RUN pip3.7 --no-cache-dir install pytest astroid isort && \
     pip3.8 --no-cache-dir install pytest astroid isort && \
-    pip3.9 --no-cache-dir install pytest astroid isort && \
-    pip --no-cache-dir install pylint pytest astroid isort
+    pip3.9 --no-cache-dir install pytest astroid isort
 
 #For pre-commit
 RUN pip3.7 --no-cache-dir install --upgrade pip && \
@@ -195,8 +188,7 @@ RUN pip3.7 --no-cache-dir install pre-commit==2.17.0 pylint==2.12.0 && \
 
 RUN pip3.7 --no-cache-dir install coverage && \
     pip3.8 --no-cache-dir install coverage && \
-    pip3.9 --no-cache-dir install coverage && \
-    pip --no-cache-dir install coverage
+    pip3.9 --no-cache-dir install coverage
 
 COPY ./python/requirements.txt /root/
 RUN pip3.7 --no-cache-dir install -r /root/requirements.txt && \
@@ -208,8 +200,7 @@ RUN pip3.7 --no-cache-dir install -r /root/requirements.txt && \
 RUN apt-get install -y libssl-dev libffi-dev && apt-get clean -y && \
     pip3.7 --no-cache-dir install certifi urllib3[secure] && \
     pip3.8 --no-cache-dir install certifi urllib3[secure] && \
-    pip3.9 --no-cache-dir install certifi urllib3[secure] && \
-    pip --no-cache-dir install certifi urllib3[secure]
+    pip3.9 --no-cache-dir install certifi urllib3[secure]
 
 # ar mishandles 4GB files
 # https://sourceware.org/bugzilla/show_bug.cgi?id=14625

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -67,50 +67,40 @@ ENV PATH=/usr/local/python3.7.0/include:${PATH}
 ENV PATH=/usr/local/python3.7.0/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/python3.7.0/lib:${LD_LIBRARY_PATH}
 ENV CPLUS_INCLUDE_PATH=/usr/local/python3.7.0/include/python3.7:$CPLUS_INCLUDE_PATH
-RUN ln -sf /usr/local/python3.7.0/bin/python3.7 /usr/local/bin/python3 && ln -sf /usr/local/python3.7.0/bin/python3.7 /usr/bin/python3
+RUN ln -sf /usr/local/python3.7.0/bin/python3.7 /usr/local/bin/python3 && \
+    ln -sf /usr/local/python3.7.0/bin/python3.7 /usr/bin/python3 && \
+    ln -sf /usr/local/python3.7.0/bin/python3.7 /usr/local/bin/python && \
+    ln -sf /usr/local/python3.7.0/bin/python3.7 /usr/bin/python
 
 RUN rm -rf /root/python_build
 
-# Install Python2.7.15 to replace original python
-WORKDIR /home
-ENV version=2.7.15
-RUN wget https://www.python.org/ftp/python/$version/Python-$version.tgz && tar -xvf Python-$version.tgz
-WORKDIR /home/Python-$version
-RUN ./configure --enable-unicode=ucs4 --enable-shared CFLAGS=-fPIC --prefix=/usr/local/python2.7.15 && make && make install
-
-RUN echo "export PATH=/usr/local/python2.7.15/include:${PATH}" >> ~/.bashrc && echo "export PATH=/usr/local/python2.7.15/bin:${PATH}" >> ~/.bashrc && echo "export LD_LIBRARY_PATH=/usr/local/python2.7.15/lib:${LD_LIBRARY_PATH}" >> ~/.bashrc && echo "export CPLUS_INCLUDE_PATH=/usr/local/python2.7.15/include/python2.7:$CPLUS_INCLUDE_PATH" >> ~/.bashrc
-ENV PATH=/usr/local/python2.7.15/include:${PATH}
-ENV PATH=/usr/local/python2.7.15/bin:${PATH}
-ENV LD_LIBRARY_PATH=/usr/local/python2.7.15/lib:${LD_LIBRARY_PATH}
-ENV CPLUS_INCLUDE_PATH=/usr/local/python2.7.15/include/python2.7:$CPLUS_INCLUDE_PATH
-RUN mv /usr/bin/python /usr/bin/python.bak && ln -s /usr/local/python2.7.15/bin/python2.7 /usr/local/bin/python && ln -s /usr/local/python2.7.15/bin/python2.7 /usr/bin/python
-
-WORKDIR /home
-RUN wget https://files.pythonhosted.org/packages/b0/d1/8acb42f391cba52e35b131e442e80deffbb8d0676b93261d761b1f0ef8fb/setuptools-40.6.2.zip && apt-get -y install unzip && unzip setuptools-40.6.2.zip
-WORKDIR /home/setuptools-40.6.2
-RUN python setup.py build && python setup.py install
+# Replace pip and setuptools with updated version
 WORKDIR /home
 RUN python3.9 -m pip uninstall -y pip setuptools && \
-  python3.8 -m pip uninstall -y pip setuptools && \
-  python3.7 -m pip uninstall -y pip setuptools
+    python3.8 -m pip uninstall -y pip setuptools && \
+    python3.7 -m pip uninstall -y pip setuptools
 
-RUN wget https://files.pythonhosted.org/packages/a7/e0/30642b9c2df516506d40b563b0cbd080c49c6b3f11a70b4c7a670f13a78b/setuptools-50.3.2.zip && apt-get -y install unzip && unzip setuptools-50.3.2.zip
-WORKDIR /home/setuptools-50.3.2
+RUN wget https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz && apt-get -y install unzip && unzip setuptools-65.6.3.zip
+WORKDIR /home/setuptools-65.6.3
 RUN python3.9 setup.py build && python3.9 setup.py install && \
-  python3.8 setup.py build && python3.8 setup.py install && \
-  python3.7 setup.py build && python3.7 setup.py install
+    python3.8 setup.py build && python3.8 setup.py install && \
+    python3.7 setup.py build && python3.7 setup.py install
 
 WORKDIR /home
-RUN wget https://files.pythonhosted.org/packages/28/af/2c76c8aa46ccdf7578b83d97a11a2d1858794d4be4a1610ade0d30182e8b/pip-20.0.1.tar.gz && tar -zxvf pip-20.0.1.tar.gz
-WORKDIR pip-20.0.1
+RUN wget https://files.pythonhosted.org/packages/a3/50/c4d2727b99052780aad92c7297465af5fe6eec2dbae490aa9763273ffdc1/pip-22.3.1.tar.gz && tar -zxvf pip-22.3.1.tar.gz
+WORKDIR pip-22.3.1
 RUN python setup.py install && \
-  python3.9 setup.py install && \
-  python3.8 setup.py install && \
-  python3.7 setup.py install
+    python3.9 setup.py install && \
+    python3.8 setup.py install && \
+    python3.7 setup.py install && \
+    rm /usr/local/bin/pip && \
+    ln -s /usr/local/bin/pip3.7 /usr/local/bin/pip && \
+    rm /usr/local/bin/pip3 && \
+    ln -s /usr/local/bin/pip3.7 /usr/local/bin/pip3
 
 WORKDIR /home
-RUN rm Python-$version.tgz setuptools-40.6.2.zip setuptools-50.3.2.zip pip-20.0.1.tar.gz && \
-    rm -r Python-$version setuptools-40.6.2 setuptools-50.3.2 pip-20.0.1
+RUN rm setuptools-65.6.3.zip pip-22.3.1.tar.gz && \
+    rm -r setuptools-65.6.3 pip-22.3.1
 
 # Install Go and glide
 WORKDIR /home

--- a/tools/dockerfile/Dockerfile.ubuntu
+++ b/tools/dockerfile/Dockerfile.ubuntu
@@ -80,8 +80,8 @@ RUN python3.9 -m pip uninstall -y pip setuptools && \
     python3.8 -m pip uninstall -y pip setuptools && \
     python3.7 -m pip uninstall -y pip setuptools
 
-RUN wget https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz && tar -zxvf setuptools-65.6.3.tar.gz
-WORKDIR /home/setuptools-65.6.3
+RUN wget https://files.pythonhosted.org/packages/a7/e0/30642b9c2df516506d40b563b0cbd080c49c6b3f11a70b4c7a670f13a78b/setuptools-50.3.2.zip && apt-get -y install unzip && unzip setuptools-50.3.2.zip
+WORKDIR /home/setuptools-50.3.2
 RUN python3.9 setup.py build && python3.9 setup.py install && \
     python3.8 setup.py build && python3.8 setup.py install && \
     python3.7 setup.py build && python3.7 setup.py install
@@ -99,8 +99,8 @@ RUN python setup.py install && \
     ln -s /usr/local/bin/pip3.7 /usr/local/bin/pip3
 
 WORKDIR /home
-RUN rm setuptools-65.6.3.tar.gz pip-22.3.1.tar.gz && \
-    rm -r setuptools-65.6.3 pip-22.3.1
+RUN rm setuptools-50.3.2.zip pip-22.3.1.tar.gz && \
+    rm -r setuptools-50.3.2 pip-22.3.1
 
 # Install Go and glide
 WORKDIR /home


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

- [x] 测试下 CI 上是否会 build docker image
- [x] 移除 `pip install xxx`
- [x] 移除 `python2`
- [x] 将 `python` 软链到 `python3.7`

本 PR 完成 Python2 退场计划[^1]中的「删除非必要的环境依赖」，将 `Dockerfile.ubuntu` 中安装的 Python2 移除，并将对应的 pip（即命令 `pip`）安装相关依赖项命令移除

移除 Python2.7 后，将通过软链接的方式将 `python`、`pip` 链接到 Python3.7，即 `python`、`pip`、`python3`、`pip3`、`python3.7`、`pip3.7` 命令都是对应 3.7 版本的 Python / pip。

此外做了如下修改：

- 直接安装最新版本 pip，移除命令 `pip3.x --no-cache-dir install --upgrade pip`，以精简 Dockerfile 步数
- 清理专门给 Python2 安装的 `setuptools-40.6.2`，仅仅下载并安装 `setuptools-50.3.2`

[^1]: #46837