### PR TITLE
[Clean fluid] Clean fluid unittest test_op_name_conflict

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_op_name_conflict.py
+++ b/python/paddle/fluid/tests/unittests/test_op_name_conflict.py
@@ -16,37 +16,35 @@ import unittest
 
 import numpy as np
 
+import paddle
 import paddle.fluid as fluid
 
 
 class TestOpNameConflict(unittest.TestCase):
     def test_conflict(self):
+        paddle.enable_static()
         main = fluid.Program()
         startup = fluid.Program()
         with fluid.unique_name.guard():
             with fluid.program_guard(main, startup):
                 x = fluid.data(name="x", shape=[1], dtype='float32')
                 y = fluid.data(name="y", shape=[1], dtype='float32')
-                z = fluid.data(name="z", shape=[1], dtype='float32')
 
-                m = fluid.layers.elementwise_add(x, y, name="add")
-                n = fluid.layers.elementwise_add(y, z, name="add")
-                p = m + n
+                m = paddle.log2(x, name="log2")
+                n = paddle.log2(y, name="log2")
 
                 place = fluid.CPUPlace()
                 exe = fluid.Executor(place)
-                m_v, n_v, p_v = exe.run(
+                m_v, n_v = exe.run(
                     feed={
-                        "x": np.ones((1), "float32") * 2,
-                        "y": np.ones((1), "float32") * 3,
-                        "z": np.ones((1), "float32") * 5,
+                        "x": np.ones((1), "float32") * 1,
+                        "y": np.ones((1), "float32") * 2,
                     },
-                    fetch_list=[m, n, p],
+                    fetch_list=[m, n],
                 )
 
-                self.assertEqual(m_v[0], 5.0)
-                self.assertEqual(n_v[0], 8.0)
-                self.assertEqual(p_v[0], 13.0)
+                self.assertEqual(m_v[0], 0.0)
+                self.assertEqual(n_v[0], 1.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
`elementwise_add` and `paddle.add` have different logic for handling attribute `name`, `paddle.add` uses attribute `name` to initialize output, so we cannot replace `elementwise_add` with `paddle.add` directly. Considering that this unittest is used to test conflict of op_name, we can change `elementwise_add` to `paddle.log2`, this change also meets the target of this unittest.

elementwise_add 和 paddle.add 对于参数 name 的处理不一致，paddle.add 会额外使用 name 来初始化 output。因此无法直接进行替换，考虑到本 unittest 是为了测试 op_name 冲突，因此将调用的 API 更换为 paddle.log2，可以达到相同的单测效果。
