### PR TITLE
remove non-public apis from distributed module

### DIFF
--- a/python/paddle/distributed/communicator.py
+++ b/python/paddle/distributed/communicator.py
@@ -34,7 +34,7 @@ import paddle
 from paddle.distributed.ps.utils.public import DistributedMode
 from paddle.framework import core
 
-__all__ = ['Communicator', 'FLCommunicator', 'LargeScaleKV']
+__all__ = []
 
 
 class Communicator:

--- a/python/paddle/distributed/ps/utils/collective_transpiler.py
+++ b/python/paddle/distributed/ps/utils/collective_transpiler.py
@@ -21,7 +21,7 @@ from paddle.fluid import unique_name
 from paddle.framework import core
 from paddle.static import default_main_program, default_startup_program
 
-__all__ = ['GradAllReduce', 'LocalSGD', 'MultiThread']
+__all__ = []
 
 OpRole = core.op_proto_and_checker_maker.OpRole
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/Paddle/pull/47959 keeps the original `__all__`,  during fluid apis migration, leading some inner function being treated as public apis, including:
```
paddle.distributed.communicator.LargeScaleKV
paddle.distributed.communicator.Communicator
paddle.distributed.communicator.FLCommunicator
paddle.distributed.ps.utils.collective_transpiler.GradAllReduce
paddle.distributed.ps.utils.collective_transpiler.MultiThread
paddle.distributed.ps.utils.collective_transpiler.LocalSGD
```

This pr is to remove these six functions from public apis.
