### PR TITLE
[CodeStyle][isort][Dy2St] sort imports in test_error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,5 @@ extend_skip_glob = [
     "python/paddle/fluid/tests/unittests/mlu/**",
 
     # These files will be fixed in the future
-    "python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py",
     "python/paddle/jit/**",
 ]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import inspect
+import os
 import unittest
+
 import numpy as np
+
 import paddle
 import paddle.fluid as fluid
 from paddle.jit.dy2static import error

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -256,11 +256,11 @@ class TestErrorStaticLayerCallInCompiletime(TestErrorBase):
 
     def set_message(self):
         self.expected_message = [
-            'File "{}", line 33, in func_error_in_compile_time'.format(
+            'File "{}", line 35, in func_error_in_compile_time'.format(
                 self.filepath
             ),
             'inner_func()',
-            'File "{}", line 26, in inner_func'.format(self.filepath),
+            'File "{}", line 28, in inner_func'.format(self.filepath),
             'def inner_func():',
             'fluid.layers.fill_constant(shape=[1, 2], value=9, dtype="int")',
             '<--- HERE',
@@ -287,7 +287,7 @@ class TestErrorStaticLayerCallInCompiletime_2(
 
     def set_message(self):
         self.expected_message = [
-            'File "{}", line 44, in func_error_in_compile_time_2'.format(
+            'File "{}", line 46, in func_error_in_compile_time_2'.format(
                 self.filepath
             ),
             'def func_error_in_compile_time_2(x):',
@@ -313,7 +313,7 @@ class TestErrorStaticLayerCallInCompiletime_3(
 
     def set_message(self):
         self.expected_message = [
-            'File "{}", line 89, in forward'.format(self.filepath),
+            'File "{}", line 91, in forward'.format(self.filepath),
             '@paddle.jit.to_static',
             'def forward(self):',
             'self.test_func()',
@@ -337,7 +337,7 @@ class TestErrorStaticLayerCallInRuntime(TestErrorStaticLayerCallInCompiletime):
 
     def set_message(self):
         self.expected_message = [
-            'File "{}", line 52, in func_error_in_runtime'.format(
+            'File "{}", line 54, in func_error_in_runtime'.format(
                 self.filepath
             ),
             'x = fluid.dygraph.to_variable(x)',
@@ -354,7 +354,7 @@ class TestErrorStaticLayerCallInRuntime2(TestErrorStaticLayerCallInRuntime):
 
     def set_message(self):
         self.expected_message = [
-            'File "{}", line 104, in func_error_in_runtime_with_empty_line'.format(
+            'File "{}", line 106, in func_error_in_runtime_with_empty_line'.format(
                 self.filepath
             ),
             'two = fluid.layers.fill_constant(shape=[1], value=2, dtype="int32")',
@@ -401,7 +401,7 @@ class TestJitSaveInCompiletime(TestErrorBase):
 
     def set_message(self):
         self.expected_message = [
-            'File "{}", line 78, in forward'.format(self.filepath),
+            'File "{}", line 80, in forward'.format(self.filepath),
             'def forward(self, x):',
             'y = self._linear(x)',
             'z = fluid.layers.fill_constant(shape=[1, 2], value=9, dtype="int")',
@@ -435,9 +435,9 @@ class TestSuggestionErrorInRuntime(TestErrorBase):
 
     def set_message(self):
         self.expected_message = [
-            'File "{}", line 116, in forward'.format(self.filepath),
+            'File "{}", line 118, in forward'.format(self.filepath),
             'return self.inner_net.forward(x)',
-            'File "{}", line 125, in forward'.format(self.filepath),
+            'File "{}", line 127, in forward'.format(self.filepath),
             'def forward(self, x):',
             'out = paddle.matmul(self.w, x)',
             '<--- HERE',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

为对行号敏感的 `test_error` 使用 isort 进行格式化，更新了下行号（全 +2）

### Related links

- RFC：[Python 引入 import 区域自动重排工具 isort 方案](https://github.com/PaddlePaddle/community/blob/master/rfcs/CodeStyle/20221111_introducing_isort.md)
- part1: #46475
- part2: #48390
- part3: #48401
- part4: #48402
- part5: #48404
- part6: #48522