### PR TITLE
Set WaiterType of kGpuSync to kCPU

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
@@ -356,7 +356,8 @@ void StreamAnalyzer::ShrinkEventInfo(
 
 platform::DeviceType StreamAnalyzer::GetWaiterType(
     const Instruction& instr) const {
-  if (instr.KernelType() == OpFuncType::kCpuSync) {
+  if (instr.KernelType() == OpFuncType::kCpuSync ||
+      instr.KernelType() == OpFuncType::kGpuSync) {
     return platform::kCPU;
   } else {
     if (platform::is_xpu_place(place_)) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
将kGpuSync类型的算子在多流同步中的WaiterType由kGPU修改为kCPU。
kGpuSync指示算子的place为Gpu，但kernel中不存在异步的CUDA操作（可能实际不存在CUDA调用，也可能存在CUDA调用但操作是同步的）。 WaiterType指示下游算子需要通过何种方式与上游算子进行多流同步，kGPU表示下游算子在device端需要进行同步（通过cudaEventWait进行），kCPU表示下游算子在host端需要进行同步（通过cudaEventSynchronize进行）。
对于存在同步CUDA操作的kGpuSync算子（如当前的memcpy_d2h），因同步行为本身就会阻塞host端线程，使用cudaEventWait和使用cudaEventSynchronize对host执行区别不大，但将cudaEventWait改成cudaEventSynchronize可减少device端流执行的上下文开销（cudaEventWait需要launch到stream上）。对于不存在CUDA操作的kGpuSync算子，若与上游算子之间存在数据依赖，仅通过cudaEventWait将无法正确进行同步（当前不存在这种情况，但从鲁棒性角度，需要加以考虑）。
综上，kGpuSync类型的算子指定WaiterType为kGPU是更为合理的设计，本PR对此进行修改。

另，当前memcoy_d2h跨线程cudaEventWait可能导致CUDA Error(2)错误，本PR改动可避免此问题。