### PR TITLE
Setuptools optimization

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3468,20 +3468,7 @@ function run_setup(){
     SYSTEM=`uname -s`
     if [ "$SYSTEM" == "Darwin" ]; then
         echo "Using python abi: $1"
-        if [ "$1" == "cp36-cp36m" ] || [ "$1" == "" ]; then
-            if [ -d "/Library/Frameworks/Python.framework/Versions/3.6" ]; then
-                export LD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.6/lib/
-                export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:/Library/Frameworks/Python.framework/Versions/3.6/lib/
-                export PATH=/Library/Frameworks/Python.framework/Versions/3.6/bin/:${PATH}
-                #after changing "PYTHON_LIBRARY:FILEPATH" to "PYTHON_LIBRARY" ,we can use export
-                export PYTHON_EXECUTABLE=/Library/Frameworks/Python.framework/Versions/3.6/bin/python3
-                export PYTHON_INCLUDE_DIR=/Library/Frameworks/Python.framework/Versions/3.6/include/python3.6m/
-                export PYTHON_LIBRARY=/Library/Frameworks/Python.framework/Versions/3.6/lib/libpython3.6m.dylib
-                pip3.6 install --user -r ${PADDLE_ROOT}/python/requirements.txt
-            else
-                exit 1
-            fi
-        elif [ "$1" == "cp37-cp37m" ]; then
+        if [ "$1" == "cp37-cp37m" ]; then
             if [ -d "/Library/Frameworks/Python.framework/Versions/3.7" ]; then
                 export LD_LIBRARY_PATH=/Library/Frameworks/Python.framework/Versions/3.7/lib/
                 export DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:/Library/Frameworks/Python.framework/Versions/3.7/lib/

--- a/setup.py
+++ b/setup.py
@@ -583,13 +583,13 @@ def build_run(args, build_path, envrion_var):
 
 def build_steps():
     print('------- Building start ------')
-    build_dir=os.getenv("BUILD_DIR")
+    build_dir = os.getenv("BUILD_DIR")
     if build_dir is not None:
-        build_dir=TOP_DIR + '/'+build_dir
+        build_dir = TOP_DIR + '/' + build_dir
         if not os.path.exists(build_dir):
             _mkdir_p(build_dir)
     else:
-        build_dir=TOP_DIR + '/build'
+        build_dir = TOP_DIR + '/build'
         if not os.path.exists(build_dir):
             _mkdir_p(build_dir)
     build_path = build_dir
@@ -1283,14 +1283,13 @@ def main():
     # Execute the build process,cmake and make
     if cmake_and_build:
         build_steps()
-        
-    build_dir=os.getenv("BUILD_DIR")
+    build_dir = os.getenv("BUILD_DIR")
     if build_dir is not None:
-        env_dict_path=TOP_DIR +'/'+build_dir+'/python'
+        env_dict_path = TOP_DIR + '/' + build_dir + '/python'
         sys.path.append(env_dict_path)
         from env_dict import env_dict as env_dict
     else:
-        env_dict_path=TOP_DIR + "/build/python/"
+        env_dict_path = TOP_DIR + "/build/python/"
         sys.path.append(env_dict_path)
         from env_dict import env_dict as env_dict
 

--- a/setup.py
+++ b/setup.py
@@ -1283,6 +1283,7 @@ def main():
     # Execute the build process,cmake and make
     if cmake_and_build:
         build_steps()
+        
     build_dir=os.getenv("BUILD_DIR")
     if build_dir is not None:
         env_dict_path=TOP_DIR +'/'+build_dir+'/python'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from distutils.spawn import find_executable
 from subprocess import CalledProcessError
 
-from setuptools import Command, Distribution, Extension, setup
+from setuptools import Command, Extension, setup
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install as InstallCommandBase
 from setuptools.command.install_lib import install_lib

--- a/setup.py
+++ b/setup.py
@@ -586,12 +586,10 @@ def build_steps():
     build_dir = os.getenv("BUILD_DIR")
     if build_dir is not None:
         build_dir = TOP_DIR + '/' + build_dir
-        if not os.path.exists(build_dir):
-            _mkdir_p(build_dir)
     else:
         build_dir = TOP_DIR + '/build'
-        if not os.path.exists(build_dir):
-            _mkdir_p(build_dir)
+    if not os.path.exists(build_dir):
+        _mkdir_p(build_dir)
     build_path = build_dir
     # run cmake to generate native build files
     cmake_cache_file_path = os.path.join(build_path, "CMakeCache.txt")
@@ -1286,12 +1284,10 @@ def main():
     build_dir = os.getenv("BUILD_DIR")
     if build_dir is not None:
         env_dict_path = TOP_DIR + '/' + build_dir + '/python'
-        sys.path.append(env_dict_path)
-        from env_dict import env_dict as env_dict
     else:
         env_dict_path = TOP_DIR + "/build/python/"
-        sys.path.append(env_dict_path)
-        from env_dict import env_dict as env_dict
+    sys.path.append(env_dict_path)
+    from env_dict import env_dict as env_dict
 
     global env_dict
     global paddle_binary_dir, paddle_source_dir

--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ def _mkdir_p(dir_str):
     try:
         os.makedirs(dir_str)
     except OSError as e:
-        raise RuntimeError("Failed to create folder build/")
+        raise RuntimeError("Failed to create build folder")
 
 
 def get_major():
@@ -583,9 +583,16 @@ def build_run(args, build_path, envrion_var):
 
 def build_steps():
     print('------- Building start ------')
-    if not os.path.exists(TOP_DIR + '/build'):
-        _mkdir_p(TOP_DIR + '/build')
-    build_path = TOP_DIR + '/build'
+    build_dir=os.getenv("BUILD_DIR")
+    if build_dir is not None:
+        build_dir=TOP_DIR + '/'+build_dir
+        if not os.path.exists(build_dir):
+            _mkdir_p(build_dir)
+    else:
+        build_dir=TOP_DIR + '/build'
+        if not os.path.exists(build_dir):
+            _mkdir_p(build_dir)
+    build_path = build_dir
     # run cmake to generate native build files
     cmake_cache_file_path = os.path.join(build_path, "CMakeCache.txt")
     # if rerun_cmake is True,remove CMakeCache.txt and rerun camke
@@ -1276,9 +1283,15 @@ def main():
     # Execute the build process,cmake and make
     if cmake_and_build:
         build_steps()
-
-    sys.path.append(TOP_DIR + "/build/python/")
-    from build.python.env_dict import env_dict as env_dict
+    build_dir=os.getenv("BUILD_DIR")
+    if build_dir is not None:
+        env_dict_path=TOP_DIR +'/'+build_dir+'/python'
+        sys.path.append(env_dict_path)
+        from env_dict import env_dict as env_dict
+    else:
+        env_dict_path=TOP_DIR + "/build/python/"
+        sys.path.append(env_dict_path)
+        from env_dict import env_dict as env_dict
 
     global env_dict
     global paddle_binary_dir, paddle_source_dir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
此PR做了两件事情：
1根据@zhiqiu建议新增功能，修改setup.py，用户可以自己指定存放编译产物的目录，如export BUILD_DIR=build_test; python setup.py install，那么编译产物就都存在在build_test里面，如果不默认指定，就会存在build里面，会覆盖掉原来的build目录里的编译产物
2 根据@luotao1建议，清理掉paddle_build.sh引入的python3.6