### PR TITLE
[new-exec] Ahead-Of-Time choosing kernel

### DIFF
--- a/paddle/fluid/eager/eager_tensor.h
+++ b/paddle/fluid/eager/eager_tensor.h
@@ -137,7 +137,7 @@ class VariableCompatTensor
   void* AllocateFrom(phi::Allocator* allocator,
                      phi::DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = true) override {
+                     bool fake_alloc = false) override {
     PADDLE_THROW(paddle::platform::errors::Unavailable(
         "VariableCompatTensor does not support `AllocateFrom` method."));
   }

--- a/paddle/fluid/eager/eager_tensor.h
+++ b/paddle/fluid/eager/eager_tensor.h
@@ -136,7 +136,8 @@ class VariableCompatTensor
 
   void* AllocateFrom(phi::Allocator* allocator,
                      phi::DataType dtype,
-                     size_t requested_size = 0) override {
+                     size_t requested_size = 0,
+                     bool check_size = true) override {
     PADDLE_THROW(paddle::platform::errors::Unavailable(
         "VariableCompatTensor does not support `AllocateFrom` method."));
   }

--- a/paddle/fluid/framework/new_executor/interpreter/data_transfer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/data_transfer.cc
@@ -33,7 +33,8 @@ bool DataTranferHelper::apply(const OpKernelType& kernel_type_for_var,
                               std::string* new_var_name,
                               std::vector<OpFuncNode>* op_func_nodes,
                               bool use_local_scope,
-                              bool is_fetch_v2) {
+                              bool is_fetch_v2,
+                              bool skip_run) {
   bool is_transferred = false;
   auto* src_var_name = &var_name;
 
@@ -48,7 +49,7 @@ bool DataTranferHelper::apply(const OpKernelType& kernel_type_for_var,
                              is_fetch_v2);
     if (op) {
       RunAndConstructOpFuncNode(
-          op, *src_var_name, *new_var_name, op_func_nodes);
+          op, *src_var_name, *new_var_name, op_func_nodes, skip_run);
     }
     // update src_var_name
     src_var_name = new_var_name;
@@ -64,7 +65,7 @@ bool DataTranferHelper::apply(const OpKernelType& kernel_type_for_var,
                             scope_);
     if (op) {
       RunAndConstructOpFuncNode(
-          op, *src_var_name, *new_var_name, op_func_nodes);
+          op, *src_var_name, *new_var_name, op_func_nodes, skip_run);
     }
     // update src_var_name
     src_var_name = new_var_name;
@@ -79,7 +80,7 @@ bool DataTranferHelper::apply(const OpKernelType& kernel_type_for_var,
         *src_var_name, new_var_name, src_place, dst_place, var_scope_, scope_);
     if (op) {
       RunAndConstructOpFuncNode(
-          op, *src_var_name, *new_var_name, op_func_nodes);
+          op, *src_var_name, *new_var_name, op_func_nodes, skip_run);
     }
     is_transferred = true;
   }
@@ -89,7 +90,8 @@ bool DataTranferHelper::apply(const OpKernelType& kernel_type_for_var,
 void DataTranferHelper::RunAndConstructShareNode(
     const std::string& src_var_name,
     const std::string& dst_var_name,
-    std::vector<OpFuncNode>* op_func_nodes) {
+    std::vector<OpFuncNode>* op_func_nodes,
+    bool skip_run) {
   VariableNameMap in_name_map = {{"X", {src_var_name}}};
   VariableNameMap out_name_map = {{"Out", {dst_var_name}}};
   AttributeMap attr_map;
@@ -102,14 +104,16 @@ void DataTranferHelper::RunAndConstructShareNode(
   VLOG(3) << string::Sprintf(
       "Insert %s with %s -> %s.", op_type, src_var_name, dst_var_name);
 
-  RunAndConstructOpFuncNode(op, src_var_name, dst_var_name, op_func_nodes);
+  RunAndConstructOpFuncNode(
+      op, src_var_name, dst_var_name, op_func_nodes, skip_run);
 }
 
 void DataTranferHelper::RunAndConstructOpFuncNode(
     const std::shared_ptr<OperatorBase>& op,
     const std::string& var_name,
     const std::string& new_var_name,
-    std::vector<OpFuncNode>* new_op_func_nodes) {
+    std::vector<OpFuncNode>* new_op_func_nodes,
+    bool skip_run) {
   auto& op_type = op->Type();
 
   // 1. Construct RuntimeContext
@@ -181,7 +185,13 @@ void DataTranferHelper::RunAndConstructOpFuncNode(
     phi::KernelContext phi_kernel_context;
     op_with_kernel->BuildPhiKernelContext(
         runtime_context, dev_ctx, &phi_kernel_context);
-    (*new_op_func_node.phi_kernel_)(&phi_kernel_context);
+    if (!skip_run) {
+      (*new_op_func_node.phi_kernel_)(&phi_kernel_context);
+    } else {
+      FakeInitializeOutputs(new_op_func_node.phi_kernel_,
+                            op_with_kernel->PhiKernelSignature(),
+                            &phi_kernel_context);
+    }
   }
 
   const phi::Place& place = dev_ctx->GetPlace();
@@ -434,7 +444,8 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
                         VariableScope* var_scope,
                         OpFuncNode* op_func_node,
                         std::vector<OpFuncNode>* new_op_func_nodes,
-                        bool use_local_scope) {
+                        bool use_local_scope,
+                        bool skip_run) {
   Scope* local_scope = use_local_scope ? var_scope->GetMutableLocalScope()
                                        : var_scope->GetMutableScope();
 
@@ -509,7 +520,7 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
                                      op_base->Type() == "fetch_v2");
             if (op) {
               data_transfer_helper.RunAndConstructOpFuncNode(
-                  op, var_name, new_var_name, new_op_func_nodes);
+                  op, var_name, new_var_name, new_op_func_nodes, skip_run);
             }
             is_transferred = true;
           } else {
@@ -533,7 +544,8 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
                                        &new_var_name,
                                        new_op_func_nodes,
                                        use_local_scope,
-                                       op_base->Type() == "fetch_v2");
+                                       op_base->Type() == "fetch_v2",
+                                       skip_run);
       }
 
       if (is_transferred) {
@@ -584,7 +596,8 @@ void HandleComplexGradToRealGrad(const OpFuncNode& op_func_node,
                                  VariableValueMap* out_vars,
                                  VariableScope* var_scope,
                                  std::vector<OpFuncNode>* op_func_nodes,
-                                 framework::Scope* local_scope) {
+                                 framework::Scope* local_scope,
+                                 bool skip_run) {
   DataTranferHelper data_transfer_helper(place, var_scope, local_scope);
   for (auto& var_name_item : out_names) {
     std::vector<Variable*>& vars = out_vars->at(var_name_item.first);
@@ -660,9 +673,9 @@ void HandleComplexGradToRealGrad(const OpFuncNode& op_func_node,
       auto op = TransferDtype(
           var_name, &new_var_name, src_type, dst_type, var_scope, local_scope);
       data_transfer_helper.RunAndConstructOpFuncNode(
-          op, var_name, new_var_name, op_func_nodes);
+          op, var_name, new_var_name, op_func_nodes, skip_run);
       data_transfer_helper.RunAndConstructShareNode(
-          new_var_name, var_name, op_func_nodes);
+          new_var_name, var_name, op_func_nodes, skip_run);
     }
   }
 }

--- a/paddle/fluid/framework/new_executor/interpreter/data_transfer.h
+++ b/paddle/fluid/framework/new_executor/interpreter/data_transfer.h
@@ -40,16 +40,19 @@ class DataTranferHelper {
              std::string* new_var_name,
              std::vector<OpFuncNode>* new_op_func_nodes,
              bool use_local_scope,
-             bool is_fetch_v2);
+             bool is_fetch_v2,
+             bool skip_run = false);
 
   void RunAndConstructShareNode(const std::string& src_var_name,
                                 const std::string& dst_var_name,
-                                std::vector<OpFuncNode>* op_func_nodes);
+                                std::vector<OpFuncNode>* op_func_nodes,
+                                bool skip_run = false);
 
   void RunAndConstructOpFuncNode(const std::shared_ptr<OperatorBase>& op,
                                  const std::string& var_name,
                                  const std::string& new_var_name,
-                                 std::vector<OpFuncNode>* op_func_nodes);
+                                 std::vector<OpFuncNode>* op_func_nodes,
+                                 bool skip_run = false);
 
  private:
   platform::Place place_;
@@ -64,7 +67,8 @@ void ApplyDataTransform(const OpKernelType& expected_kernel_key,
                         VariableScope* var_scope,
                         OpFuncNode* op_func_node,
                         std::vector<OpFuncNode>* op_func_nodes,
-                        bool use_local_scope = true);
+                        bool use_local_scope = true,
+                        bool skip_run = false);
 
 void HandleComplexGradToRealGrad(const OpFuncNode& op_func_node,
                                  const platform::Place& place,
@@ -72,7 +76,8 @@ void HandleComplexGradToRealGrad(const OpFuncNode& op_func_node,
                                  VariableValueMap* out_vars,
                                  VariableScope* var_scope,
                                  std::vector<OpFuncNode>* op_func_nodes,
-                                 framework::Scope* local_scope);
+                                 framework::Scope* local_scope,
+                                 bool skip_run = false);
 
 inline bool need_device_transform(const OpKernelType& kernel_type_for_var,
                                   const OpKernelType& expected_kernel_key) {

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -761,7 +761,9 @@ bool BuildOpFuncList(const platform::Place& place,
                 dev_ctx->template Alloc(
                     out_tensor,
                     out_tensor->dtype(),
-                    /*requested_size=*/phi::backends::gpu::GpuMinChunkSize());
+                    /*requested_size=*/phi::backends::gpu::GpuMinChunkSize(),
+                    /*pinned=*/false,
+                    /*check_size=*/true);
               } else if (phi::SparseCooTensor::classof(out_tensor)) {
                 VLOG(4) << "SparseCooTensor";
               } else if (phi::SparseCsrTensor::classof(out_tensor)) {

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -534,12 +534,12 @@ void FakeInitializeOutputs(phi::Kernel* phi_kernel,
           VLOG(4) << "DenseTensor alloc 0 bytes of type " << out_tensor->dtype()
                   << " " << out_tensor;
 
-          phi_kernel_context->GetDeviceContext<phi::DeviceContext>()
-              .template Alloc(out_tensor,
-                              out_tensor->dtype(),
-                              /*requested_size=*/0,
-                              /*pinned=*/false,
-                              /*check_size=*/false);
+          phi_kernel_context->GetDeviceContext<phi::DeviceContext>().Alloc(
+              out_tensor,
+              out_tensor->dtype(),
+              /*requested_size=*/0,
+              /*pinned=*/false,
+              /*check_size=*/false);
         }
       } else if (phi::SparseCooTensor::classof(out_tensor)) {
         VLOG(4) << "SparseCooTensor";

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -535,21 +535,22 @@ void FakeInitializeOutputs(phi::Kernel* phi_kernel,
 
       if (phi::DenseTensor::classof(out_tensor)) {
         if (!out_tensor->initialized()) {
-          VLOG(4) << "DenseTensor alloc 0 bytes of type " << out_tensor->dtype()
-                  << " " << out_tensor;
+          VLOG(4) << "DenseTensor fake alloc 0 bytes of type "
+                  << out_tensor->dtype() << " on backend " << backend << " "
+                  << out_tensor;
           if (backend == phi::TransToPhiBackend(dev_ctx->GetPlace())) {
             dev_ctx->Alloc(out_tensor,
                            out_tensor->dtype(),
                            /*requested_size=*/0,
                            /*pinned=*/false,
-                           /*check_size=*/false);
+                           /*fake_alloc=*/true);
           } else {
             if (backend == phi::Backend::CPU ||
                 backend == phi::Backend::ONEDNN) {
               dev_ctx->HostAlloc(out_tensor,
                                  out_tensor->dtype(),
                                  /*requested_size=*/0,
-                                 /*check_size=*/false);
+                                 /*fake_alloc=*/true);
             }
           }
         }

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
@@ -96,6 +96,10 @@ void BuildVariableScope(const framework::BlockDesc& block,
 
 void LogDeviceMemoryStats(const platform::Place& place);
 
+void FakeInitializeOutputs(phi::Kernel* phi_kernel,
+                           phi::KernelSignature* kernel_sig,
+                           phi::KernelContext* phi_kernel_context);
+
 }  // namespace interpreter
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
@@ -82,7 +82,7 @@ bool IsSupportedHeterPlace(const phi::Place& place);
 void AddFetch(const std::vector<std::string>& fetch_names,
               framework::BlockDesc* block);
 
-void BuildOpFuncList(const platform::Place& place,
+bool BuildOpFuncList(const platform::Place& place,
                      const framework::BlockDesc& block,
                      const std::set<std::string>& skip_gc_vars,
                      std::vector<OpFuncNode>* vec_func_list,

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -175,31 +175,31 @@ interpreter::CostInfo InterpreterCore::DryRun(
 }
 
 void InterpreterCore::RunImpl() {
-      // For the program that only run once, it is no need to
-    // create work_queue, so the async_work_queue_ is created
-    // until the second step run.
-    async_work_queue_ = GetWorkQueue();
+  // For the program that only run once, it is no need to
+  // create work_queue, so the async_work_queue_ is created
+  // until the second step run.
+  async_work_queue_ = GetWorkQueue();
 
-    // lazy initialization of gc, do not create gc is the program only run once
-    if (!gc_) {
-      gc_ = CreateInterpreterCoreGarbageCollector(place_, vec_instruction_);
-    }
+  // lazy initialization of gc, do not create gc is the program only run once
+  if (!gc_) {
+    gc_ = CreateInterpreterCoreGarbageCollector(place_, vec_instruction_);
+  }
 
-    if (execution_config_.used_for_jit && (sync_op_num_ == 0)) {
-      VLOG(4) << "Tracing Instruction List";
-      TraceInstructionList(vec_instruction_);
-    } else {
-      ExecuteInstructionList(vec_instruction_);
-    }
+  if (execution_config_.used_for_jit && (sync_op_num_ == 0)) {
+    VLOG(4) << "Tracing Instruction List";
+    TraceInstructionList(vec_instruction_);
+  } else {
+    ExecuteInstructionList(vec_instruction_);
+  }
 #ifdef PADDLE_WITH_ASCEND_CL
-    if (platform::is_npu_place(place_)) {
-      platform::DeviceContextPool::Instance().Get(place_)->Wait();
-    }
+  if (platform::is_npu_place(place_)) {
+    platform::DeviceContextPool::Instance().Get(place_)->Wait();
+  }
 #endif
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
-    if (platform::is_custom_place(place_)) {
-      platform::DeviceContextPool::Instance().Get(place_)->Wait();
-    }
+  if (platform::is_custom_place(place_)) {
+    platform::DeviceContextPool::Instance().Get(place_)->Wait();
+  }
 #endif
 }
 
@@ -231,7 +231,6 @@ paddle::framework::FetchList InterpreterCore::Run(
     return {};
   }
 }
-
 
 paddle::framework::FetchList InterpreterCore::Run(
     const std::vector<std::string>& feed_names, bool need_fetch) {

--- a/paddle/fluid/framework/new_executor/interpretercore.h
+++ b/paddle/fluid/framework/new_executor/interpretercore.h
@@ -93,6 +93,7 @@ class InterpreterCore {
   void SetFeedVarsInplaceSkip(const std::vector<std::string>& feed_names);
 
   // execution
+  void RunImpl();
   void ExecuteInstructionList(const std::vector<Instruction>& vec_instr);
   void RunInstructionAsync(size_t instr_id);
   void RunInstruction(const Instruction& instr_node);

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -3029,6 +3029,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
         (i == 0 ? 0 : phi_kernel_context->OutputRangeAt(i - 1).second);
 
     if (it == ctx.outputs.end() || it->second.empty()) {
+      VLOG(4) << "Output " << output_names[i] << " not found";
       // Deal with the case that some outputs are not found or be NULL when run
       // the kernel.
       // For example : the outputs of matmul_grad are dx and dy,
@@ -3074,6 +3075,7 @@ void OperatorWithKernel::BuildPhiKernelContext(
               framework::ToTypeName(var->Type())));
         }
       } else {
+        VLOG(4) << "Output " << output_names[i] << " is nullptr";
         phi_kernel_context->EmplaceBackOutputWithoutSetRange(tensor_out);
       }
     }

--- a/paddle/fluid/operators/batch_norm_op.cc
+++ b/paddle/fluid/operators/batch_norm_op.cc
@@ -553,6 +553,7 @@ REGISTER_OPERATOR(batch_norm,
                   ops::BatchNormOpInferVarType,
                   ops::BatchNormGradMaker<paddle::framework::OpDesc>,
                   ops::BatchNormGradMaker<paddle::imperative::OpBase>);
+
 REGISTER_OPERATOR(batch_norm_grad,
                   ops::BatchNormGradOp,
                   ops::BatchNormDoubleGradMaker<paddle::framework::OpDesc>,

--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -108,13 +108,14 @@ void* DenseTensor::AllocateFrom(Allocator* allocator,
     VLOG(10) << "change data type in mutbale_data, target dtype - " << dtype;
     meta_.dtype = dtype;
   }
-  PADDLE_ENFORCE(
-      valid(),
-      phi::errors::PreconditionNotMet(
-          "The meta data must be valid when call the mutable data function."));
+
   size_t bytes = numel() * SizeOf(this->dtype());
   if (requested_size) {
     if (check_size) {
+      PADDLE_ENFORCE(
+          valid(),
+          phi::errors::PreconditionNotMet("The meta data must be valid when "
+                                          "call the mutable data function."));
       PADDLE_ENFORCE_GE(requested_size,
                         bytes,
                         phi::errors::InvalidArgument(

--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -125,6 +125,10 @@ void* DenseTensor::AllocateFrom(Allocator* allocator,
                             bytes));
     }
     bytes = requested_size;
+  } else {
+    if (!check_size) {
+      bytes = requested_size;
+    }
   }
   // NOTE(paddle-dev): In case of the allocator of storage_ is different with
   // the incoming allocator, we will re-alloc data using the incoming

--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -114,11 +114,11 @@ void* DenseTensor::AllocateFrom(Allocator* allocator,
   if (fake_alloc) {
     bytes = 0;
   } else {
+    PADDLE_ENFORCE(
+        valid(),
+        phi::errors::PreconditionNotMet("The meta data must be valid when "
+                                        "call the mutable data function."));
     if (requested_size) {
-      PADDLE_ENFORCE(
-          valid(),
-          phi::errors::PreconditionNotMet("The meta data must be valid when "
-                                          "call the mutable data function."));
       PADDLE_ENFORCE_GE(requested_size,
                         bytes,
                         phi::errors::InvalidArgument(

--- a/paddle/phi/core/dense_tensor.cc
+++ b/paddle/phi/core/dense_tensor.cc
@@ -98,7 +98,8 @@ bool DenseTensor::IsSharedWith(const DenseTensor& b) const {
 
 void* DenseTensor::AllocateFrom(Allocator* allocator,
                                 DataType dtype,
-                                size_t requested_size) {
+                                size_t requested_size,
+                                bool check_size) {
   PADDLE_ENFORCE_NOT_NULL(
       allocator,
       phi::errors::InvalidArgument(
@@ -113,13 +114,15 @@ void* DenseTensor::AllocateFrom(Allocator* allocator,
           "The meta data must be valid when call the mutable data function."));
   size_t bytes = numel() * SizeOf(this->dtype());
   if (requested_size) {
-    PADDLE_ENFORCE_GE(requested_size,
-                      bytes,
-                      phi::errors::InvalidArgument(
-                          "The reserved size %d should be enough to meet the "
-                          "volume required by metadata %d.",
-                          requested_size,
-                          bytes));
+    if (check_size) {
+      PADDLE_ENFORCE_GE(requested_size,
+                        bytes,
+                        phi::errors::InvalidArgument(
+                            "The reserved size %d should be enough to meet the "
+                            "volume required by metadata %d.",
+                            requested_size,
+                            bytes));
+    }
     bytes = requested_size;
   }
   // NOTE(paddle-dev): In case of the allocator of storage_ is different with

--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -126,7 +126,7 @@ class DenseTensor : public TensorBase,
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = 0) override;
+                     bool fake_alloc = false) override;
 
   /// \brief Check if allocation is shared with other objects.
   /// \return Whether the allocation is shared with other objects.

--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -125,7 +125,8 @@ class DenseTensor : public TensorBase,
   /// \return The mutable data pointer value of type T.
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0) override;
+                     size_t requested_size = 0,
+                     bool check_size = 0) override;
 
   /// \brief Check if allocation is shared with other objects.
   /// \return Whether the allocation is shared with other objects.

--- a/paddle/phi/core/device_context.cc
+++ b/paddle/phi/core/device_context.cc
@@ -149,9 +149,10 @@ struct DeviceContext::Impl {
     if (tensor->initialized() && tensor->place() != place) {
       ClearHolder(tensor);
     }
-    auto* allocator = tensor->numel() == 0 && requested_size == 0
-                          ? zero_allocator_
-                          : (pinned ? pinned_allocator_ : device_allocator_);
+    auto* allocator =
+        (tensor->numel() == 0 || check_size == false) && requested_size == 0
+            ? zero_allocator_
+            : (pinned ? pinned_allocator_ : device_allocator_);
 #ifdef PADDLE_WITH_CUDA
     bool must_cuda_graph_allocator = (tensor->numel() != 0) && !pinned;
     if (must_cuda_graph_allocator &&

--- a/paddle/phi/core/device_context.cc
+++ b/paddle/phi/core/device_context.cc
@@ -134,7 +134,8 @@ struct DeviceContext::Impl {
               const Place& place,
               DataType dtype = DataType::UNDEFINED,
               size_t requested_size = 0,
-              bool pinned = false) const {
+              bool pinned = false,
+              bool check_size = true) const {
     PADDLE_ENFORCE_NOT_NULL(
         tensor,
         phi::errors::InvalidArgument(
@@ -164,7 +165,7 @@ struct DeviceContext::Impl {
     }
 #endif
     return tensor->AllocateFrom(
-        const_cast<Allocator*>(allocator), dtype, requested_size);
+        const_cast<Allocator*>(allocator), dtype, requested_size, check_size);
   }
 
   template <typename T>
@@ -342,12 +343,18 @@ const Allocator& DeviceContext::GetPinnedAllocator() const {
 void* DeviceContext::Alloc(TensorBase* tensor,
                            DataType dtype,
                            size_t requested_size,
-                           bool pinned) const {
+                           bool pinned,
+                           bool check_size) const {
   if (pinned) {
-    return impl_->Alloc(
-        tensor, GetPinnedPlace(GetPlace()), dtype, requested_size, pinned);
+    return impl_->Alloc(tensor,
+                        GetPinnedPlace(GetPlace()),
+                        dtype,
+                        requested_size,
+                        pinned,
+                        check_size);
   }
-  return impl_->Alloc(tensor, GetPlace(), dtype, requested_size, pinned);
+  return impl_->Alloc(
+      tensor, GetPlace(), dtype, requested_size, pinned, check_size);
 }
 
 template <typename T>

--- a/paddle/phi/core/device_context.h
+++ b/paddle/phi/core/device_context.h
@@ -149,7 +149,8 @@ class PADDLE_API DeviceContext {
   void* Alloc(TensorBase*,
               DataType dtype,
               size_t requested_size = 0,
-              bool pinned = false) const;
+              bool pinned = false,
+              bool check_size = true) const;
 
   template <typename T>
   T* Alloc(TensorBase* tensor,

--- a/paddle/phi/core/device_context.h
+++ b/paddle/phi/core/device_context.h
@@ -150,7 +150,7 @@ class PADDLE_API DeviceContext {
               DataType dtype,
               size_t requested_size = 0,
               bool pinned = false,
-              bool check_size = true) const;
+              bool fake_alloc = false) const;
 
   template <typename T>
   T* Alloc(TensorBase* tensor,
@@ -163,7 +163,7 @@ class PADDLE_API DeviceContext {
   void* HostAlloc(TensorBase* tensor,
                   DataType dtype,
                   size_t requested_size = 0,
-                  bool check_size = true) const;
+                  bool fake_alloc = false) const;
 
   template <typename T>
   T* HostAlloc(TensorBase* tensor, size_t requested_size = 0) const;

--- a/paddle/phi/core/device_context.h
+++ b/paddle/phi/core/device_context.h
@@ -162,7 +162,8 @@ class PADDLE_API DeviceContext {
    */
   void* HostAlloc(TensorBase* tensor,
                   DataType dtype,
-                  size_t requested_size = 0) const;
+                  size_t requested_size = 0,
+                  bool check_size = true) const;
 
   template <typename T>
   T* HostAlloc(TensorBase* tensor, size_t requested_size = 0) const;

--- a/paddle/phi/core/extended_tensor.cc
+++ b/paddle/phi/core/extended_tensor.cc
@@ -54,7 +54,7 @@ bool ExtendedTensor::initialized() const {
 void* ExtendedTensor::AllocateFrom(Allocator* allocator,
                                    DataType dtype,
                                    size_t requested_size,
-                                   bool check_size) {
+                                   bool fake_alloc) {
   PADDLE_THROW(phi::errors::Unavailable(
       "ExtendedTensor does not support `AllocateFrom` method."));
 }

--- a/paddle/phi/core/extended_tensor.cc
+++ b/paddle/phi/core/extended_tensor.cc
@@ -53,7 +53,8 @@ bool ExtendedTensor::initialized() const {
 
 void* ExtendedTensor::AllocateFrom(Allocator* allocator,
                                    DataType dtype,
-                                   size_t requested_size) {
+                                   size_t requested_size,
+                                   bool check_size) {
   PADDLE_THROW(phi::errors::Unavailable(
       "ExtendedTensor does not support `AllocateFrom` method."));
 }

--- a/paddle/phi/core/extended_tensor.h
+++ b/paddle/phi/core/extended_tensor.h
@@ -50,7 +50,7 @@ class ExtendedTensor : public TensorBase {
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = 0) override;
+                     bool fake_alloc = false) override;
 };
 
 }  // namespace phi

--- a/paddle/phi/core/extended_tensor.h
+++ b/paddle/phi/core/extended_tensor.h
@@ -49,7 +49,8 @@ class ExtendedTensor : public TensorBase {
 
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0) override;
+                     size_t requested_size = 0,
+                     bool check_size = 0) override;
 };
 
 }  // namespace phi

--- a/paddle/phi/core/kernel_context.h
+++ b/paddle/phi/core/kernel_context.h
@@ -119,6 +119,8 @@ class KernelContext {
     return static_cast<TensorType*>(outputs_.at(idx));
   }
 
+  TensorBase* MutableOutputAt(size_t idx) { return outputs_.at(idx); }
+
   template <typename TensorType>
   std::vector<TensorType*> MutableOutputBetween(size_t start, size_t end) {
     std::vector<TensorType*> v;

--- a/paddle/phi/core/selected_rows.h
+++ b/paddle/phi/core/selected_rows.h
@@ -90,8 +90,9 @@ class SelectedRows : public TensorBase,
 
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0) override {
-    return impl_->AllocateFrom(allocator, dtype, requested_size);
+                     size_t requested_size = 0,
+                     bool check_size = true) override {
+    return impl_->AllocateFrom(allocator, dtype, requested_size, check_size);
   }
 
   /*

--- a/paddle/phi/core/selected_rows.h
+++ b/paddle/phi/core/selected_rows.h
@@ -91,8 +91,8 @@ class SelectedRows : public TensorBase,
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = true) override {
-    return impl_->AllocateFrom(allocator, dtype, requested_size, check_size);
+                     bool fake_alloc = false) override {
+    return impl_->AllocateFrom(allocator, dtype, requested_size, fake_alloc);
   }
 
   /*

--- a/paddle/phi/core/selected_rows_impl.cc
+++ b/paddle/phi/core/selected_rows_impl.cc
@@ -94,8 +94,9 @@ struct TensorFillVisitor {
 
 void* SelectedRowsImpl::AllocateFrom(Allocator* allocator,
                                      DataType dtype,
-                                     size_t requested_size) {
-  return value_->AllocateFrom(allocator, dtype, requested_size);
+                                     size_t requested_size,
+                                     bool check_size) {
+  return value_->AllocateFrom(allocator, dtype, requested_size, check_size);
 }
 
 bool SelectedRowsImpl::HasKey(int64_t key) const {

--- a/paddle/phi/core/selected_rows_impl.cc
+++ b/paddle/phi/core/selected_rows_impl.cc
@@ -95,8 +95,8 @@ struct TensorFillVisitor {
 void* SelectedRowsImpl::AllocateFrom(Allocator* allocator,
                                      DataType dtype,
                                      size_t requested_size,
-                                     bool check_size) {
-  return value_->AllocateFrom(allocator, dtype, requested_size, check_size);
+                                     bool fake_alloc) {
+  return value_->AllocateFrom(allocator, dtype, requested_size, fake_alloc);
 }
 
 bool SelectedRowsImpl::HasKey(int64_t key) const {

--- a/paddle/phi/core/selected_rows_impl.h
+++ b/paddle/phi/core/selected_rows_impl.h
@@ -110,7 +110,7 @@ class SelectedRowsImpl {
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = true);
+                     bool fake_alloc = false);
 
   /*
    * @brief Get the index of the key from id_to_index_ map. If the key not

--- a/paddle/phi/core/selected_rows_impl.h
+++ b/paddle/phi/core/selected_rows_impl.h
@@ -109,7 +109,8 @@ class SelectedRowsImpl {
 
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0);
+                     size_t requested_size = 0,
+                     bool check_size = true);
 
   /*
    * @brief Get the index of the key from id_to_index_ map. If the key not

--- a/paddle/phi/core/sparse_coo_tensor.cc
+++ b/paddle/phi/core/sparse_coo_tensor.cc
@@ -67,8 +67,10 @@ SparseCooTensor SparseCooTensor::operator=(const SparseCooTensor& other) {
 
 void* SparseCooTensor::AllocateFrom(Allocator* allocator,
                                     DataType dtype,
-                                    size_t requested_size) {
-  return non_zero_elements_.AllocateFrom(allocator, dtype, requested_size);
+                                    size_t requested_size,
+                                    bool check_size) {
+  return non_zero_elements_.AllocateFrom(
+      allocator, dtype, requested_size, check_size);
 }
 
 int64_t SparseCooTensor::nnz() const {

--- a/paddle/phi/core/sparse_coo_tensor.cc
+++ b/paddle/phi/core/sparse_coo_tensor.cc
@@ -68,9 +68,9 @@ SparseCooTensor SparseCooTensor::operator=(const SparseCooTensor& other) {
 void* SparseCooTensor::AllocateFrom(Allocator* allocator,
                                     DataType dtype,
                                     size_t requested_size,
-                                    bool check_size) {
+                                    bool fake_alloc) {
   return non_zero_elements_.AllocateFrom(
-      allocator, dtype, requested_size, check_size);
+      allocator, dtype, requested_size, fake_alloc);
 }
 
 int64_t SparseCooTensor::nnz() const {

--- a/paddle/phi/core/sparse_coo_tensor.h
+++ b/paddle/phi/core/sparse_coo_tensor.h
@@ -170,7 +170,8 @@ class SparseCooTensor : public TensorBase,
   /// \brief This function is not recommended
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0) override;
+                     size_t requested_size = 0,
+                     bool check_size = true) override;
 
   /// \brief get the sparse dim
   int32_t sparse_dim() const;

--- a/paddle/phi/core/sparse_coo_tensor.h
+++ b/paddle/phi/core/sparse_coo_tensor.h
@@ -171,7 +171,7 @@ class SparseCooTensor : public TensorBase,
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = true) override;
+                     bool fake_alloc = false) override;
 
   /// \brief get the sparse dim
   int32_t sparse_dim() const;

--- a/paddle/phi/core/sparse_csr_tensor.cc
+++ b/paddle/phi/core/sparse_csr_tensor.cc
@@ -82,8 +82,10 @@ SparseCsrTensor& SparseCsrTensor::operator=(const SparseCsrTensor& other) {
 
 void* SparseCsrTensor::AllocateFrom(Allocator* allocator,
                                     DataType dtype,
-                                    size_t requested_size) {
-  return non_zero_elements_.AllocateFrom(allocator, dtype, requested_size);
+                                    size_t requested_size,
+                                    bool check_size) {
+  return non_zero_elements_.AllocateFrom(
+      allocator, dtype, requested_size, check_size);
 }
 
 void SparseCsrTensor::Resize(const DDim& dense_dims,

--- a/paddle/phi/core/sparse_csr_tensor.cc
+++ b/paddle/phi/core/sparse_csr_tensor.cc
@@ -83,9 +83,9 @@ SparseCsrTensor& SparseCsrTensor::operator=(const SparseCsrTensor& other) {
 void* SparseCsrTensor::AllocateFrom(Allocator* allocator,
                                     DataType dtype,
                                     size_t requested_size,
-                                    bool check_size) {
+                                    bool fake_alloc) {
   return non_zero_elements_.AllocateFrom(
-      allocator, dtype, requested_size, check_size);
+      allocator, dtype, requested_size, fake_alloc);
 }
 
 void SparseCsrTensor::Resize(const DDim& dense_dims,

--- a/paddle/phi/core/sparse_csr_tensor.h
+++ b/paddle/phi/core/sparse_csr_tensor.h
@@ -63,7 +63,7 @@ class SparseCsrTensor : public TensorBase,
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = true) override;
+                     bool fake_alloc = false) override;
 
  public:
   /// \brief Returns the name of the class for type traits.

--- a/paddle/phi/core/sparse_csr_tensor.h
+++ b/paddle/phi/core/sparse_csr_tensor.h
@@ -62,7 +62,8 @@ class SparseCsrTensor : public TensorBase,
   /// \brief This function is not recommended
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0) override;
+                     size_t requested_size = 0,
+                     bool check_size = true) override;
 
  public:
   /// \brief Returns the name of the class for type traits.

--- a/paddle/phi/core/string_tensor.cc
+++ b/paddle/phi/core/string_tensor.cc
@@ -130,7 +130,8 @@ void StringTensor::init_holder() {
 
 void* StringTensor::AllocateFrom(Allocator* allocator,
                                  DataType dtype,
-                                 size_t requested_size) {
+                                 size_t requested_size,
+                                 bool check_size) {
   PADDLE_ENFORCE_NOT_NULL(
       allocator,
       errors::InvalidArgument(
@@ -141,13 +142,15 @@ void* StringTensor::AllocateFrom(Allocator* allocator,
           "The meta data must be valid when call the mutable data function."));
   size_t bytes = numel() * SizeOf(this->dtype());
   if (requested_size) {
-    PADDLE_ENFORCE_GE(requested_size,
-                      bytes,
-                      errors::InvalidArgument(
-                          "The reserved size %d should be enough to meet the "
-                          "volume required by metadata %d.",
-                          requested_size,
-                          bytes));
+    if (check_size) {
+      PADDLE_ENFORCE_GE(requested_size,
+                        bytes,
+                        errors::InvalidArgument(
+                            "The reserved size %d should be enough to meet the "
+                            "volume required by metadata %d.",
+                            requested_size,
+                            bytes));
+    }
     bytes = requested_size;
   }
 

--- a/paddle/phi/core/string_tensor.h
+++ b/paddle/phi/core/string_tensor.h
@@ -123,7 +123,8 @@ class StringTensor : public TensorBase,
   }
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0) override;
+                     size_t requested_size = 0,
+                     bool check_size = true) override;
   dtype::pstring* mutable_data(const phi::Place& place,
                                size_t requested_size = 0);
 

--- a/paddle/phi/core/string_tensor.h
+++ b/paddle/phi/core/string_tensor.h
@@ -124,7 +124,7 @@ class StringTensor : public TensorBase,
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = true) override;
+                     bool fake_alloc = false) override;
   dtype::pstring* mutable_data(const phi::Place& place,
                                size_t requested_size = 0);
 

--- a/paddle/phi/core/tensor_array.cc
+++ b/paddle/phi/core/tensor_array.cc
@@ -65,9 +65,11 @@ bool TensorArray::valid() const {
 /// \return Void pointer
 void* TensorArray::AllocateFrom(Allocator* allocator,
                                 DataType dtype,
-                                size_t requested_size) {
+                                size_t requested_size,
+                                bool check_size) {
   for (size_t i = 0; i < tensors_.size(); i++) {
-    tensors_[i].AllocateFrom(allocator, tensors_[i].dtype(), requested_size);
+    tensors_[i].AllocateFrom(
+        allocator, tensors_[i].dtype(), requested_size, check_size);
   }
   return nullptr;
 }

--- a/paddle/phi/core/tensor_array.cc
+++ b/paddle/phi/core/tensor_array.cc
@@ -66,10 +66,10 @@ bool TensorArray::valid() const {
 void* TensorArray::AllocateFrom(Allocator* allocator,
                                 DataType dtype,
                                 size_t requested_size,
-                                bool check_size) {
+                                bool fake_allc) {
   for (size_t i = 0; i < tensors_.size(); i++) {
     tensors_[i].AllocateFrom(
-        allocator, tensors_[i].dtype(), requested_size, check_size);
+        allocator, tensors_[i].dtype(), requested_size, fake_allc);
   }
   return nullptr;
 }

--- a/paddle/phi/core/tensor_array.h
+++ b/paddle/phi/core/tensor_array.h
@@ -84,7 +84,7 @@ class TensorArray : public TensorBase,
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
                      size_t requested_size = 0,
-                     bool check_size = true) override;
+                     bool fake_alloc = false) override;
 
   bool empty() const { return tensors_.empty(); }
 

--- a/paddle/phi/core/tensor_array.h
+++ b/paddle/phi/core/tensor_array.h
@@ -83,7 +83,8 @@ class TensorArray : public TensorBase,
   /// \return Void pointer
   void* AllocateFrom(Allocator* allocator,
                      DataType dtype,
-                     size_t requested_size = 0) override;
+                     size_t requested_size = 0,
+                     bool check_size = true) override;
 
   bool empty() const { return tensors_.empty(); }
 

--- a/paddle/phi/core/tensor_base.h
+++ b/paddle/phi/core/tensor_base.h
@@ -67,7 +67,7 @@ class TensorBase {
   virtual void* AllocateFrom(Allocator* allocator,
                              DataType dtype,
                              size_t requested_size = 0,
-                             bool check_size = true) = 0;
+                             bool fake_alloc = false) = 0;
 
   /// \brief Return the type information of the derived class to support
   /// safely downcast in non-rtti environment.

--- a/paddle/phi/core/tensor_base.h
+++ b/paddle/phi/core/tensor_base.h
@@ -66,7 +66,8 @@ class TensorBase {
   /// \return The mutable data pointer value of type T.
   virtual void* AllocateFrom(Allocator* allocator,
                              DataType dtype,
-                             size_t requested_size = 0) = 0;
+                             size_t requested_size = 0,
+                             bool check_size = true) = 0;
 
   /// \brief Return the type information of the derived class to support
   /// safely downcast in non-rtti environment.

--- a/python/paddle/fluid/tests/unittests/standalone_executor/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/standalone_executor/CMakeLists.txt
@@ -25,3 +25,5 @@ py_test_modules(
   FLAGS_host_trace_level=10 FLAGS_static_executor_perfstat_filepath=./perfstat)
 
 set_tests_properties(test_standalone_cross_step_overlap PROPERTIES TIMEOUT 30)
+set_tests_properties(test_standalone_executor_aot_choose_kernel
+                     PROPERTIES TIMEOUT 60)

--- a/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
+++ b/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
+++ b/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
@@ -67,7 +67,7 @@ class TestAOTChooseKernel(unittest.TestCase):
             with paddle.static.scope_guard(scope):
                 exe.run(startup_program)
 
-                for i in range(2):
+                for i in range(10):
                     feed = {
                         'image': np.random.randint(
                             0, 256, size=[32, 3, 224, 224]

--- a/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
+++ b/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.framework import set_flags
+
+paddle.enable_static()
+
+
+def build_resnet50():
+    main_program = paddle.static.Program()
+    startup_program = paddle.static.Program()
+
+    with paddle.static.program_guard(main_program, startup_program):
+        image = paddle.static.data(
+            name='image', shape=[32, 3, 224, 224], dtype='float32'
+        )
+        label = paddle.static.data(name='label', shape=[32], dtype='int64')
+        model = paddle.vision.models.resnet50()
+        prediction = model(image)
+        loss = paddle.nn.functional.cross_entropy(input=prediction, label=label)
+        loss = paddle.mean(loss)
+        adam = paddle.optimizer.Adam(learning_rate=0.001)
+        adam.minimize(loss)
+
+    return main_program, startup_program, loss
+
+
+class TestAOTChooseKernel(unittest.TestCase):
+    def setUp(self):
+        self.place = (
+            paddle.CUDAPlace(0)
+            if paddle.fluid.core.is_compiled_with_cuda()
+            else paddle.CPUPlace()
+        )
+
+    def test_aot_choose_kernel(self):
+        def run(aot_choose_kernel=None):
+            paddle.seed(2022)
+            np.random.seed(2022)
+
+            main_program, startup_program, loss = build_resnet50()
+
+            scope = paddle.static.Scope()
+            exe = paddle.static.Executor(self.place)
+
+            if aot_choose_kernel:
+                set_flags({'FLAGS_new_executor_static_build': 1})
+            else:
+                set_flags({'FLAGS_new_executor_static_build': 0})
+
+            with paddle.static.scope_guard(scope):
+                exe.run(startup_program)
+
+                for i in range(2):
+                    feed = {
+                        'image': np.random.randint(
+                            0, 256, size=[32, 3, 224, 224]
+                        ).astype('float32'),
+                        'label': np.random.randint(0, 1000, size=[32]).astype(
+                            'int64'
+                        ),
+                    }
+                    loss_ = exe.run(main_program, feed=feed, fetch_list=[loss])
+            return loss_
+
+        loss1 = run(aot_choose_kernel=True)
+        loss2 = run(aot_choose_kernel=False)
+
+        self.assertEqual(loss1, loss2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
+++ b/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
@@ -42,14 +42,10 @@ def build_resnet50():
 
 
 class TestAOTChooseKernel(unittest.TestCase):
-    def setUp(self):
-        self.place = (
-            paddle.CUDAPlace(0)
-            if paddle.fluid.core.is_compiled_with_cuda()
-            else paddle.CPUPlace()
-        )
-
     def test_aot_choose_kernel(self):
+        if not paddle.fluid.core.is_compiled_with_cuda():
+            return
+
         def run(aot_choose_kernel=None):
             paddle.seed(2022)
             np.random.seed(2022)
@@ -57,7 +53,7 @@ class TestAOTChooseKernel(unittest.TestCase):
             main_program, startup_program, loss = build_resnet50()
 
             scope = paddle.static.Scope()
-            exe = paddle.static.Executor(self.place)
+            exe = paddle.static.Executor()
 
             if aot_choose_kernel:
                 set_flags({'FLAGS_new_executor_static_build': 1})

--- a/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
+++ b/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_executor_aot_choose_kernel.py
@@ -55,6 +55,7 @@ class TestAOTChooseKernel(unittest.TestCase):
             scope = paddle.static.Scope()
             exe = paddle.static.Executor()
 
+            set_flags({'FLAGS_cudnn_deterministic': 1})
             if aot_choose_kernel:
                 set_flags({'FLAGS_new_executor_static_build': 1})
             else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[new-exec] Ahead-Of-Time choosing kernel

The kernel choosing need the `dtype`, `place`, `layout` of input tensors and `attributes` of the operator. 

- For each operator, once the phi kernel is detemined, the `dtype` and `layout` of  output can be infered and stored in `meta_`.
- The `place` info is not existed in `meta_`  of tensor but in `holder_`, it is needed to alloc memory for output.
