### PR TITLE
reshape onednn test reimplemented

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -19,7 +19,6 @@ import numpy as np
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import (
-    OpTest,
     OpTestTool,
     convert_float_to_uint16,
 )
@@ -31,6 +30,7 @@ paddle.enable_static()
 class TestReshape2OneDNNOp(TestReshapeOp):
     def setUp(self):
         super().setUp()
+        self.x = self.inputs["X"]
         self.attrs['use_mkldnn'] = True
         self.set_additional_inputs()
         self.set_outputs()
@@ -39,10 +39,11 @@ class TestReshape2OneDNNOp(TestReshapeOp):
         self.dtype = np.float32
 
     def set_additional_inputs(self):
-       pass
+        pass
 
     def set_outputs(self):
         pass
+
 
 class TestReshape2OneDNNOpDimInfer1(TestReshape2OneDNNOp):
     def init_data(self):
@@ -70,7 +71,6 @@ class TestReshape2OneDNNOpDimInfer2(TestReshape2OneDNNOp):
 class TestReshape2OneDNNOp_attr_OnlyShape(TestReshape2OneDNNOp):
     def set_additional_inputs(self):
         self.inputs["Shape"] = np.array(self.new_shape, dtype="int32")
-
 
     def set_outputs(self):
         self.outputs = {
@@ -173,7 +173,6 @@ def create_reshape_bf16_test_classes(parent):
         def setUp(self):
             super().setUp()
             self.dtype = np.uint16
-            self.x = np.random.random(self.ori_shape).astype("float32")
             self.inputs = {"X": convert_float_to_uint16(self.x)}
 
         def calculate_grads(self):
@@ -201,7 +200,6 @@ def create_reshape_bf16_test_classes(parent):
 
     class TestReshapeBF16OneDNNOp(TestReshape2BF16OneDNNOp):
         def setUp(self):
-            self.x = np.random.random(self.ori_shape).astype("float32")
             super().setUp()
             self.dtype = np.uint16
             self.op_type = "reshape"

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -28,7 +28,7 @@ from paddle.fluid.tests.unittests.test_reshape_op import TestReshapeOp
 paddle.enable_static()
 
 
-class TestReshapeOneDNNOp(TestReshapeOp):
+class TestReshape2OneDNNOp(TestReshapeOp):
     def setUp(self):
         super().setUp()
         self.attrs['use_mkldnn'] = True

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -56,7 +56,7 @@ class TestReshape2OneDNNOpDimInfer2(TestReshape2OneDNNOp):
     def init_data(self):
         self.ori_shape = (6, 20)
         self.new_shape = (0, -1, 20)
-        self.actual_shape = (2, 3, 20)
+        self.infered_shape = (2, 3, 20)
 
     def set_additional_inputs(self):
         self.inputs["Shape"] = np.array(self.actual_shape, dtype="int32")

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -203,7 +203,6 @@ def create_reshape_bf16_test_classes(parent):
         def setUp(self):
             super().setUp()
             self.dtype = np.uint16
-            self.op_type = "reshape"
 
         def set_outputs(self):
             self.outputs = {"Out": self.x.reshape(self.new_shape)}

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -59,11 +59,11 @@ class TestReshape2OneDNNOpDimInfer2(TestReshape2OneDNNOp):
         self.infered_shape = (2, 3, 20)
 
     def set_additional_inputs(self):
-        self.inputs["Shape"] = np.array(self.actual_shape, dtype="int32")
+        self.inputs["Shape"] = np.array(self.infered_shape, dtype="int32")
 
     def set_outputs(self):
         self.outputs = {
-            "Out": self.inputs["X"].reshape(self.actual_shape),
+            "Out": self.inputs["X"].reshape(self.infered_shape),
             'XShape': np.random.random(self.ori_shape).astype("float32"),
         }
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -174,6 +174,7 @@ def create_reshape_bf16_test_classes(parent):
             super().setUp()
             self.dtype = np.uint16
             self.inputs = {"X": convert_float_to_uint16(self.x)}
+            self.attrs['use_mkldnn'] = True
 
         def calculate_grads(self):
             self.dout = self.outputs['Out']

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -201,9 +201,9 @@ def create_reshape_bf16_test_classes(parent):
 
     class TestReshapeBF16OneDNNOp(TestReshape2BF16OneDNNOp):
         def setUp(self):
+            self.x = np.random.random(self.ori_shape).astype("float32")
             super().setUp()
             self.dtype = np.uint16
-            self.x = np.random.random(self.ori_shape).astype("float32")
             self.op_type = "reshape"
 
         def set_outputs(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -173,6 +173,7 @@ def create_reshape_bf16_test_classes(parent):
         def setUp(self):
             super().setUp()
             self.dtype = np.uint16
+            self.x = np.random.random(self.ori_shape).astype("float32")
             self.inputs = {"X": convert_float_to_uint16(self.x)}
 
         def calculate_grads(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -203,6 +203,7 @@ def create_reshape_bf16_test_classes(parent):
         def setUp(self):
             super().setUp()
             self.dtype = np.uint16
+            self.x = np.random.random(self.ori_shape).astype("float32")
             self.op_type = "reshape"
 
         def set_outputs(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_mkldnn_op.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,51 +23,26 @@ from paddle.fluid.tests.unittests.op_test import (
     OpTestTool,
     convert_float_to_uint16,
 )
+from paddle.fluid.tests.unittests.test_reshape_op import TestReshapeOp
+
+paddle.enable_static()
 
 
-@OpTestTool.skip_if(
-    core.is_compiled_with_cuda(),
-    "CUDA has to be skipped because it forces dygraph",
-)
-class TestReshape2OneDNNOp(OpTest):
+class TestReshapeOneDNNOp(TestReshapeOp):
     def setUp(self):
-        self.init_data()
-        self.set_op_type()
-        self.x = np.random.random(self.ori_shape).astype("float32")
-        self.set_inputs()
+        super().setUp()
+        self.attrs['use_mkldnn'] = True
         self.set_additional_inputs()
-        self.set_attrs()
         self.set_outputs()
 
-    def set_op_type(self):
-        self.op_type = "reshape2"
-
-    def set_inputs(self):
-        self.inputs = {"X": self.x}
+    def init_dtype(self):
+        self.dtype = np.float32
 
     def set_additional_inputs(self):
-        pass
-
-    def set_attrs(self):
-        self.attrs = {"shape": self.new_shape, 'use_mkldnn': True}
+       pass
 
     def set_outputs(self):
-        self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
-            'XShape': np.random.random(self.ori_shape).astype("float32"),
-        }
-
-    def init_data(self):
-        self.ori_shape = (2, 60)
-        self.new_shape = (12, 10)
-        self.infered_shape = (12, 10)
-
-    def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
-
-    def test_check_grad(self):
-        self.check_grad(["X"], "Out")
-
+        pass
 
 class TestReshape2OneDNNOpDimInfer1(TestReshape2OneDNNOp):
     def init_data(self):
@@ -96,8 +71,6 @@ class TestReshape2OneDNNOp_attr_OnlyShape(TestReshape2OneDNNOp):
     def set_additional_inputs(self):
         self.inputs["Shape"] = np.array(self.new_shape, dtype="int32")
 
-    def set_attrs(self):
-        self.attrs = {'use_mkldnn': True}
 
     def set_outputs(self):
         self.outputs = {
@@ -153,7 +126,8 @@ class TestReshape2OneDNNOpDimInfer1_attr_ShapeTensorAndShape(
 
 
 class TestReshapeOneDNNOp(TestReshape2OneDNNOp):
-    def set_op_type(self):
+    def setUp(self):
+        super().setUp()
         self.op_type = "reshape"
 
     def set_outputs(self):
@@ -171,7 +145,8 @@ class TestReshapeOneDNNOpDimInfer1(TestReshapeOneDNNOp):
 
 
 class TestReshapeOneDNNOp_attr_OnlyShape(TestReshape2OneDNNOp_attr_OnlyShape):
-    def set_op_type(self):
+    def setUp(self):
+        super().setUp()
         self.op_type = "reshape"
 
     def set_outputs(self):
@@ -195,7 +170,8 @@ class TestReshapeOneDNNOpDimInfer1_attr_OnlyShape(
 def create_reshape_bf16_test_classes(parent):
     @OpTestTool.skip_if_not_cpu_bf16()
     class TestReshape2BF16OneDNNOp(parent):
-        def set_inputs(self):
+        def setUp(self):
+            super().setUp()
             self.dtype = np.uint16
             self.inputs = {"X": convert_float_to_uint16(self.x)}
 
@@ -223,7 +199,8 @@ def create_reshape_bf16_test_classes(parent):
     globals()[cls_name] = TestReshape2BF16OneDNNOp
 
     class TestReshapeBF16OneDNNOp(TestReshape2BF16OneDNNOp):
-        def set_op_type(self):
+        def setUp(self):
+            super().setUp()
             self.dtype = np.uint16
             self.op_type = "reshape"
 
@@ -252,5 +229,4 @@ create_reshape_bf16_test_classes(TestReshape2OneDNNOp)
 create_reshape_bf16_test_classes(TestReshape2OneDNNOpDimInfer1)
 
 if __name__ == "__main__":
-    paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import unittest
-
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
 
+from op_test import OpTest, convert_float_to_uint16
 import paddle
 import paddle.fluid as fluid
 from paddle.static import Program, program_guard

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import unittest
-import numpy as np
 
+import numpy as np
 from op_test import OpTest, convert_float_to_uint16
+
 import paddle
 import paddle.fluid as fluid
 from paddle.static import Program, program_guard


### PR DESCRIPTION

### PR types
Others 

### PR changes
Others 

### Describe
reshape onednn test was not really working due to condition of having it skipped for CUDA builds. This condition is gone
