### PR TITLE
new precise_test map

### DIFF
--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -306,7 +306,7 @@ class PRChecker:
         file_ut_map = None
 
         ret = self.__urlretrieve(
-            'https://paddle-docker-tar.bj.bcebos.com/precision_test_map_store/ut_file_map.json',
+            'https://paddle-docker-tar.bj.bcebos.com/new_precise_test_map/ut_file_map.json',
             'ut_file_map.json',
         )
         if not ret:
@@ -362,7 +362,7 @@ class PRChecker:
         if len(file_list) == 0:
             ut_list.append('filterfiles_placeholder')
             ret = self.__urlretrieve(
-                'https://paddle-docker-tar.bj.bcebos.com/precision_test_map_store/prec_delta',
+                'https://paddle-docker-tar.bj.bcebos.com/new_precise_test_map/prec_delta',
                 'prec_delta',
             )
             if ret:
@@ -474,7 +474,7 @@ class PRChecker:
             else:
                 if ut_list:
                     ret = self.__urlretrieve(
-                        'https://paddle-docker-tar.bj.bcebos.com/precision_test_map_store/prec_delta',
+                        'https://paddle-docker-tar.bj.bcebos.com/new_precise_test_map/prec_delta',
                         'prec_delta',
                     )
                     if ret:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
新的精准测试map应用到coverage流水线
1 修复了69个单测成功因为没有拷贝gcda文件到单测目录下而导致覆盖率分析失败的问题