### PR TITLE
Fix ninja error while python>=3.9 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ import re
 import shutil
 import subprocess
 import sys
-import sysconfig
 from contextlib import contextmanager
 from distutils.spawn import find_executable
 from subprocess import CalledProcessError
@@ -43,6 +42,12 @@ else:
         print("export PY_VERSION = %s" % platform.python_version())
         python_version = platform.python_version()
         os.environ["PY_VERSION"] = python_version
+    else:
+        if os.getenv("PY_VERSION") != platform.python_version()[:3]:
+            raise RuntimeError(
+                "You set PY_VERSION=%s, but your current python environment is %s, you should keep them consistent!"
+                % (os.getenv("PY_VERSION"), platform.python_version()[:3])
+            )
 
 # check cmake
 CMAKE = find_executable('cmake3') or find_executable('cmake')
@@ -50,27 +55,6 @@ assert (
     CMAKE
 ), 'The "cmake" executable is not found. Please check if Cmake is installed.'
 
-# CMAKE: full path to python library
-if platform.system() == "Windows":
-    cmake_python_library = "{}/libs/python{}.lib".format(
-        sysconfig.get_config_var("prefix"), sysconfig.get_config_var("VERSION")
-    )
-    # Fix virtualenv builds
-    if not os.path.exists(cmake_python_library):
-        cmake_python_library = "{}/libs/python{}.lib".format(
-            sys.base_prefix, sysconfig.get_config_var("VERSION")
-        )
-else:
-    cmake_python_library = "{}/{}".format(
-        sysconfig.get_config_var("LIBDIR"),
-        sysconfig.get_config_var("INSTSONAME"),
-    )
-    if not os.path.exists(cmake_python_library):
-        libname = sysconfig.get_config_var("INSTSONAME")
-        libdir = sysconfig.get_config_var('LIBDIR') + (
-            sysconfig.get_config_var("multiarchsubdir") or ""
-        )
-        cmake_python_library = os.path.join(libdir, libname)
 
 TOP_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -642,16 +626,6 @@ def options_process(args, build_options):
     for key, value in sorted(build_options.items()):
         if value is not None:
             args.append("-D{}={}".format(key, value))
-    if 'PYTHON_EXECUTABLE:FILEPATH' not in build_options.keys():
-        args.append("-D{}={}".format('PYTHON_EXECUTABLE', sys.executable))
-    if 'PYTHON_INCLUDE_DIR:PATH' not in build_options.keys():
-        args.append(
-            '-D{}={}'.format(
-                'PYTHON_INCLUDE_DIR', sysconfig.get_path("include")
-            )
-        )
-    if 'PYTHON_LIBRARY:FILEPATH' not in build_options.keys():
-        args.append('-D{}={}'.format('PYTHON_LIBRARY', cmake_python_library))
 
 
 def get_cmake_generator():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
优化setup.py的逻辑
1 当用户export PY_VERSION=3.8，当前python环境不是3.8的时候，会进行提示，在一开始就报错，之前的逻辑会在编译的时候报错
![image](https://user-images.githubusercontent.com/62429225/217842948-47f9299f-a4c0-427f-8de0-61d79520ec38.png)
2 当使用python大于等于3.9的时候，ninja编译会报错，原因是sconfig.get_config_var("INSTSONAME")获取python_libary和cmake里的find_packages()获取的python_libary不一致导致的