### PR TITLE
Fix scale type in fused_multi_transformer

### DIFF
--- a/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
+++ b/paddle/fluid/operators/fused/fused_multi_transformer_op.cu.h
@@ -1530,21 +1530,16 @@ class CublasFusedMLP {
          beta16 =
              add_residual ? static_cast<half>(1.0) : static_cast<half>(0.0);
 
-    void *alpha = nullptr, *beta = nullptr;
+    void *alpha = &alpha32, *beta = &beta32;
     if (std::is_same<T, double>::value) {
       alpha = &alpha64;
       beta = &beta64;
-    } else if (std::is_same<T, float>::value) {
-      alpha = &alpha64;
-      beta = &beta64;
-    } else if (std::is_same<T, phi::dtype::float16>::value) {
+    }
+
+    if (std::is_same<T, phi::dtype::float16>::value &&
+        FLAGS_gemm_use_half_precision_compute_type) {
       alpha = &alpha16;
       beta = &beta16;
-    } else {
-      PADDLE_ENFORCE_EQ(true,
-                        false,
-                        platform::errors::InvalidArgument(
-                            "Only support double, float, half data type. "));
     }
 
     const auto *x_data = x->data<T>();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
### PR changes
OPs

### Describe
<!-- Describe what this PR does -->
1. 之前复制粘贴出错，fp32下，alpha beta类型应该是float32
2. 涉及到一个开关 FLAGS_gemm_use_half_precision_compute_type。这个开关打开后，在FP16下，累加类型为fp16，**并且scale类型也是fp16**。如果scale类型是fp16，那么alpha beta给的指针应该是fp16类型，如果scale类型是fp32，alpha beta给的指针应为fp32类型（之前理解错误，以为是输入矩阵类型是fp16就给fp16的scale）