### PR TITLE
Add a persistent ibuilder to speedup unit tests

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -852,6 +852,15 @@ class TRTEngineManager {
   size_t max_ctx_mem_size_{0};
   std::unordered_map<PredictorID, AllocationPtr> context_memorys_;
   std::unordered_map<std::string, std::unique_ptr<TensorRTEngine>> engines_;
+  // createInferBuilder loads trt kernels and take a few second
+  // But as long as one IBuilder lives, trt kernel will not be unloaded
+  // Hence, a persistent IBuilder to avoid TensorRT unload/reload kernels
+  std::unique_ptr<nvinfer1::IBuilder, std::function<void(nvinfer1::IBuilder*)>>
+      holder{createInferBuilder(&NaiveLogger::Global()), [](auto* ptr) {
+               if (ptr) {
+                 ptr->destroy();
+               }
+             }};
 };
 
 }  // namespace tensorrt


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
目前的 `test_trt_convert_xxx` 相關單測十分花時間，在對單測做熱點分析後發現 (A100 with `test_trt_convert_elementwise`):
- Paddle ir passes: 0.3 sec
- nvinfer1::createInferBuilder: 2.5 sec
- buildSerializedNetwork: 0.09 sec

可以看到 `createInferBuilder` 是單測熱點，原因是當程式生命週期內沒有 `IBuilder` 存在的時候，`createInferBuilder` 的過程會對所需要的 kernel libraries 做初始化。但是只要有任一個 IBuilder 存在，第二個 IBuilder 就不需要初始化並且能迅速地被創造。

目前初步的單測時間改善如下:
| Test configuration |  Speedup |
| ------ | ----- |
| P100 (4gpus)      | 1.62x |
| T4   (2gpus)      | 2.38x |
| V100 (4gpus)      | 1.36x |
| A100 (2gpus)      | 2.00x |