### PR TITLE
support conv1d quant & skip calibrate zero-size tensor

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -398,7 +398,8 @@ class PostTrainingQuantization:
         self._best_calibration_loss = {}
         # The threshold for algo = abs_max, mse or avg
         self._quantized_threshold = {}
-        # If the tensor is zero-size during calibration, it will skip quantization
+        # If the tensor is zero-size during any calibration step,
+        # it will be stored in self._zero_size_var_names
         self._zero_size_var_names = set()
         self._same_scale_tensor_list = same_scale_tensor_list
         self._freeze_model = freeze_model
@@ -467,10 +468,7 @@ class PostTrainingQuantization:
 
         if self._algo == 'avg':
             for var_name in self._quantized_act_var_name:
-                if (
-                    var_name in self._zero_size_var_names
-                    and var_name not in self._quantized_var_avg
-                ):
+                if var_name not in self._quantized_var_avg:
                     continue
                 self._quantized_threshold[var_name] = np.array(
                     self._quantized_var_avg[var_name]

--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -1367,6 +1367,7 @@ class PostTrainingQuantization:
                     out_var_name,
                     self._quantized_var_min,
                     "out_min",
+                    argname_index,
                     "post_min_max",
                 )
                 save_info(
@@ -1374,6 +1375,7 @@ class PostTrainingQuantization:
                     out_var_name,
                     self._quantized_var_max,
                     "out_max",
+                    argname_index,
                     "post_min_max",
                 )
 

--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -398,6 +398,8 @@ class PostTrainingQuantization:
         self._best_calibration_loss = {}
         # The threshold for algo = abs_max, mse or avg
         self._quantized_threshold = {}
+        # If the tensor is zero-size during calibration, it will skip quantization
+        self._zero_size_var_names = set()
         self._same_scale_tensor_list = same_scale_tensor_list
         self._freeze_model = freeze_model
         self._scale_dict = scale_dict
@@ -465,9 +467,15 @@ class PostTrainingQuantization:
 
         if self._algo == 'avg':
             for var_name in self._quantized_act_var_name:
+                if (
+                    var_name in self._zero_size_var_names
+                    and var_name not in self._quantized_var_avg
+                ):
+                    continue
                 self._quantized_threshold[var_name] = np.array(
                     self._quantized_var_avg[var_name]
                 ).mean()
+
         if self._algo in ["KL", "hist"]:
             self._calculate_kl_hist_threshold()
 
@@ -741,6 +749,9 @@ class PostTrainingQuantization:
         _logger.info("MSE searching stage ...")
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if not var_tensor.any():
+                self._zero_size_var_names.add(var_name)
+                continue
             var_tensor = var_tensor.flatten()
             abs_max_value = float(np.max(np.abs(var_tensor)))
             abs_max_value = 1e-8 if abs_max_value == 0.0 else abs_max_value
@@ -792,6 +803,9 @@ class PostTrainingQuantization:
         _logger.info("EMD searching stage ...")
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if not var_tensor.any():
+                self._zero_size_var_names.add(var_name)
+                continue
             var_tensor = var_tensor.flatten()
             abs_max_value = float(np.max(np.abs(var_tensor)))
             abs_max_value = 1e-8 if abs_max_value == 0.0 else abs_max_value
@@ -845,6 +859,9 @@ class PostTrainingQuantization:
 
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if not var_tensor.any():
+                self._zero_size_var_names.add(var_name)
+                continue
             abs_max_value = float(np.max(np.abs(var_tensor)))
             if var_name not in self._quantized_var_avg:
                 self._quantized_var_avg[var_name] = []
@@ -857,7 +874,6 @@ class PostTrainingQuantization:
                 )
             )
             self._quantized_var_avg[var_name].append(abs_avg_value)
-            continue
 
     def _sample_abs_max(self):
         if self._quantized_threshold == {}:
@@ -884,6 +900,9 @@ class PostTrainingQuantization:
 
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if not var_tensor.any():
+                self._zero_size_var_names.add(var_name)
+                continue
             abs_max_value = float(np.max(np.abs(var_tensor)))
             if (var_name not in self._quantized_threshold) or (
                 abs_max_value > self._quantized_threshold[var_name]
@@ -916,6 +935,9 @@ class PostTrainingQuantization:
 
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if not var_tensor.any():
+                self._zero_size_var_names.add(var_name)
+                continue
             min_value = float(np.min(var_tensor))
             max_value = float(np.max(var_tensor))
             if (var_name not in self._quantized_var_min) or (
@@ -930,6 +952,11 @@ class PostTrainingQuantization:
     def _sample_histogram(self):
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if (not var_tensor.any()) or (
+                var_name not in self._sampling_act_histogram
+            ):
+                self._zero_size_var_names.add(var_name)
+                continue
             var_tensor_abs = np.abs(var_tensor)
             bins = self._sampling_act_histogram[var_name][1]
             hist, _ = np.histogram(var_tensor_abs, bins=bins)
@@ -964,6 +991,9 @@ class PostTrainingQuantization:
 
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if not var_tensor.any():
+                self._zero_size_var_names.add(var_name)
+                continue
             abs_max_value = float(np.max(np.abs(var_tensor)))
             q_max = 2 ** (self._activation_bits - 1) - 1
             scale8 = abs_max_value / q_max
@@ -1020,6 +1050,9 @@ class PostTrainingQuantization:
         '''
         for var_name in self._quantized_act_var_name:
             var_tensor = utils.load_variable_data(self._scope, var_name)
+            if not var_tensor.any():
+                self._zero_size_var_names.add(var_name)
+                continue
             var_tensor = np.abs(var_tensor)
             min_value = float(np.min(var_tensor))
             max_value = float(np.max(var_tensor))
@@ -1039,6 +1072,10 @@ class PostTrainingQuantization:
         Based on the min/max value, init the sampling_act_histogram.
         '''
         for var_name in self._quantized_act_var_name:
+            if (var_name in self._zero_size_var_names) and (
+                var_name not in self._sampling_act_abs_min_max
+            ):
+                continue
             if var_name not in self._sampling_act_histogram:
                 min_val = self._sampling_act_abs_min_max[var_name][0]
                 max_val = self._sampling_act_abs_min_max[var_name][1]
@@ -1077,6 +1114,10 @@ class PostTrainingQuantization:
             self._quantized_var_threshold[var_name] = weight_threshold
 
         for var_name in self._quantized_act_var_name:
+            if (var_name in self._zero_size_var_names) and (
+                var_name not in self._sampling_act_histogram
+            ):
+                continue
             hist, hist_edeges = self._sampling_act_histogram[var_name]
             if self._algo == "KL":
                 bin_width = hist_edeges[1] - hist_edeges[0]
@@ -1162,7 +1203,6 @@ class PostTrainingQuantization:
             if self._same_scale_tensor_list is not None:
                 for tensor_list in self._same_scale_tensor_list:
                     max_scale = None
-                    tmp_tensor_list = []
                     for tensor_name in tensor_list:
                         if '#' in tensor_name:
                             real_tensor_name, opera, scalar = tensor_name.split(
@@ -1261,21 +1301,40 @@ class PostTrainingQuantization:
         self._calibration_scales = {}
 
         def save_info(
-            op_node, out_var_name, threshold_map, out_info_name, quantized_type
+            op_node,
+            out_var_name,
+            threshold_map,
+            out_info_name,
+            argname_index,
+            quantized_type,
         ):
-            assert (
-                out_var_name in threshold_map
-            ), "The output ({}) of {} node does not have threshold.".format(
-                out_var_name, op_node.type
-            )
+            if (out_var_name in self._zero_size_var_names) and (
+                out_var_name not in threshold_map
+            ):
+                _logger.warning(
+                    "{} is zero-size tensor and unable to calibrate, so skip quant it.".format(
+                        out_var_name
+                    )
+                )
+                return
+            else:
+                assert (
+                    out_var_name in threshold_map
+                ), "The output ({}) of {} node does not have threshold.".format(
+                    out_var_name, op_node.type
+                )
             if self._onnx_format:
                 # For easy extension, every var_node set a dict to save parameters of quant.
-                self._calibration_scales[var_name] = {}
-                self._calibration_scales[var_name]['scale'] = threshold_map[
-                    var_name
+                self._calibration_scales[out_var_name] = {}
+                self._calibration_scales[out_var_name]['scale'] = threshold_map[
+                    out_var_name
                 ]
             else:
-                op_node._set_attr(out_info_name, threshold_map[var_name])
+                op_node._set_attr(out_info_name, threshold_map[out_var_name])
+                op_node._set_attr(
+                    argname_index[0] + str(argname_index[1]) + "_threshold",
+                    threshold_map[out_var_name],
+                )
                 op_node._set_attr("with_quant_attr", True)
                 if op_node.type in self._quantizable_op_type:
                     op._set_attr("quantization_type", quantized_type)
@@ -1285,52 +1344,23 @@ class PostTrainingQuantization:
             assert argname_index is not None, (
                 out_var_name + " is not the output of the op"
             )
-            if self._algo == "KL":
+            if self._algo in ["KL", "hist"]:
                 # For compatibility, we save output threshold by two methods.
                 save_info(
                     op_node,
                     out_var_name,
                     self._quantized_var_threshold,
                     "out_threshold",
-                    "post_kl",
+                    argname_index,
+                    "post_" + str(self._algo).lower(),
                 )
-                save_info(
-                    op_node,
-                    out_var_name,
-                    self._quantized_var_threshold,
-                    argname_index[0] + str(argname_index[1]) + "_threshold",
-                    "post_kl",
-                )
-            elif self._algo == "hist":
-                # For compatibility, we save output threshold by two methods.
-                save_info(
-                    op_node,
-                    out_var_name,
-                    self._quantized_var_threshold,
-                    "out_threshold",
-                    "post_hist",
-                )
-                save_info(
-                    op_node,
-                    out_var_name,
-                    self._quantized_var_threshold,
-                    argname_index[0] + str(argname_index[1]) + "_threshold",
-                    "post_hist",
-                )
-
             elif self._algo in ["avg", "abs_max", "mse", "emd", "ptf"]:
                 save_info(
                     op_node,
                     out_var_name,
                     self._quantized_threshold,
                     "out_threshold",
-                    "post_" + str(self._algo),
-                )
-                save_info(
-                    op_node,
-                    out_var_name,
-                    self._quantized_threshold,
-                    argname_index[0] + str(argname_index[1]) + "_threshold",
+                    argname_index,
                     "post_" + str(self._algo),
                 )
             elif self._algo == "min_max":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. Skip calibrate zero-size tensor in PTQ.
2. support conv1d quant.
- conv1d in Inference model: 
<img width="306" alt="image" src="https://user-images.githubusercontent.com/15628872/206412307-e8abf200-56fa-49b4-8830-ff94cb45fd18.png">

- After quant: unsqueeze2 and conv2d share weight scale.
<img width="307" alt="image" src="https://user-images.githubusercontent.com/15628872/206422660-2c145bd8-4df0-4d62-8b87-b67ce3938cbc.png">
