### PR TITLE
update xpu.cmake date to 20221207 for fixing reduce_mt kernel bugs.

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -10,7 +10,7 @@ set(XPU_RT_LIB_NAME "libxpurt.so")
 if(NOT DEFINED XPU_BASE_URL)
   set(XPU_BASE_URL_WITHOUT_DATE
       "https://baidu-kunlun-product.su.bcebos.com/KL-SDK/klsdk-dev")
-  set(XPU_BASE_URL "${XPU_BASE_URL_WITHOUT_DATE}/20221227")
+  set(XPU_BASE_URL "${XPU_BASE_URL_WITHOUT_DATE}/20230102")
 else()
   set(XPU_BASE_URL "${XPU_BASE_URL}")
 endif()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
update xpu.cmake date to 20221207 for fixing reduce_mt kernel bugs.
