### PR TITLE
update fused_multi_transformer_encoder_pass support GPT new matmul API

### DIFF
--- a/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.cc
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.cc
@@ -478,7 +478,7 @@ PDNode* FusedMultiTransformerDecoderFuseQKVPattern::operator()() {
   auto* split0_q_out_var = pattern->NewNode(split0_q_out_repr())
                                ->assert_is_op_output("split")
                                ->AsIntermediate()
-                               ->assert_is_op_input("matmul", "X");
+                               ->assert_is_op_input("matmul_v2", "X");
   auto* split0_k_out_var = pattern->NewNode(split0_k_out_repr())
                                ->assert_is_op_output("split")
                                ->AsIntermediate()
@@ -496,7 +496,7 @@ PDNode* FusedMultiTransformerDecoderFuseQKVPattern::operator()() {
   auto* concat_k_out_var = pattern->NewNode(concat_k_out_repr())
                                ->assert_is_op_output("concat")
                                ->AsIntermediate()
-                               ->assert_is_op_input("matmul")
+                               ->assert_is_op_input("matmul_v2")
                                ->assert_is_op_input("assign");
   auto* concat_v_in_var = pattern
                               ->NewNode(concat_v_in_repr())
@@ -529,10 +529,16 @@ PDNode* FusedMultiTransformerDecoderFuseQKVPattern::operator()() {
   assign_v->LinksFrom({concat_v_out_var});
 
   // QK path Nodes
-  auto* matmul_qk = pattern->NewNode(matmul_qk_repr())->assert_is_op("matmul");
+  auto* matmul_qk =
+      pattern->NewNode(matmul_qk_repr())->assert_is_op("matmul_v2");
   auto* matmul_qk_out_var =
-      pattern->NewNode(matmul_qk_out_repr())->assert_is_op_output("matmul");
-  matmul_qk_out_var->AsIntermediate()->assert_is_op_input("elementwise_add");
+      pattern->NewNode(matmul_qk_out_repr())->assert_is_op_output("matmul_v2");
+  matmul_qk_out_var->AsIntermediate()->assert_is_op_input("scale");
+  auto* scale_q = pattern->NewNode(scale_q_repr())->assert_is_op("scale");
+  auto* scale_q_out_var = pattern->NewNode(scale_q_out_repr())
+                              ->assert_is_op_output("scale")
+                              ->AsIntermediate()
+                              ->assert_is_op_input("elementwise_add", "X");
 
   auto* eltadd_qk =
       pattern->NewNode(eltadd_qk_repr())->assert_is_op("elementwise_add");
@@ -554,7 +560,8 @@ PDNode* FusedMultiTransformerDecoderFuseQKVPattern::operator()() {
   // QK path Linsk
   matmul_qk->LinksFrom({split0_q_out_var, concat_k_out_var})
       .LinksTo({matmul_qk_out_var});
-  eltadd_qk->LinksFrom({matmul_qk_out_var, eltadd_qk_b_var})
+  scale_q->LinksFrom({matmul_qk_out_var}).LinksTo({scale_q_out_var});
+  eltadd_qk->LinksFrom({scale_q_out_var, eltadd_qk_b_var})
       .LinksTo({eltadd_qk_out_var});
   softmax_qk->LinksFrom({eltadd_qk_out_var}).LinksTo({softmax_qk_out_var});
 
@@ -2193,6 +2200,11 @@ int FusedMultiTransformerDecoderFuseQKVPass::BuildFusion(
         matmul_qk_out, matmul_qk_out, fused_multi_transformer_fuse_qkv_pattern);
 
     GET_IR_NODE_FROM_SUBGRAPH(
+        scale_q, scale_q, fused_multi_transformer_fuse_qkv_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        scale_q_out, scale_q_out, fused_multi_transformer_fuse_qkv_pattern);
+
+    GET_IR_NODE_FROM_SUBGRAPH(
         eltadd_qk, eltadd_qk, fused_multi_transformer_fuse_qkv_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(
         eltadd_qk_b, eltadd_qk_b, fused_multi_transformer_fuse_qkv_pattern);
@@ -2296,6 +2308,8 @@ int FusedMultiTransformerDecoderFuseQKVPass::BuildFusion(
                                                   assign_v,
                                                   matmul_qk,
                                                   matmul_qk_out,
+                                                  scale_q,
+                                                  scale_q_out,
                                                   eltadd_qk,
                                                   eltadd_qk_out,
                                                   softmax_qk,
@@ -2380,6 +2394,23 @@ FusedMultiTransformerDecoderFuseQKVPass::
       .End()
       .AddAttr("begin_norm_axis")
       .IsNumGT(0)
+      .End();
+
+  AddOpCompat(OpCompat("scale"))
+      .AddInput("X")
+      .IsTensor()
+      .End()
+      .AddOutput("Out")
+      .IsTensor()
+      .End()
+      .AddAttr("scale")
+      .IsType<float>()  // copy to new op. so unconstrained.
+      .End()
+      .AddAttr("bias")
+      .IsNumEQ(0.f)
+      .End()
+      .AddAttr("bias_after_scale")  // bias is 0, so unconstrained.
+      .IsType<bool>()
       .End();
 
   AddOpCompat(OpCompat("matmul_v2"))

--- a/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.h
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.h
@@ -182,8 +182,8 @@ struct FusedMultiTransformerDecoderFuseQKVPattern : public PatternBase {
   // Q, K matmul
   PATTERN_DECL_NODE(matmul_qk);
   PATTERN_DECL_NODE(matmul_qk_out);
-  PATTERN_DECL_NODE(scale_q);
-  PATTERN_DECL_NODE(scale_q_out);
+  PATTERN_DECL_NODE(scale_qk);
+  PATTERN_DECL_NODE(scale_qk_out);
   PATTERN_DECL_NODE(eltadd_qk);
   PATTERN_DECL_NODE(eltadd_qk_b);
   PATTERN_DECL_NODE(eltadd_qk_out);
@@ -284,6 +284,8 @@ struct MultiDevicesFusedMultiTransformerDecoderFuseQKVPattern
   // Q, K matmul
   PATTERN_DECL_NODE(matmul_qk);
   PATTERN_DECL_NODE(matmul_qk_out);
+  PATTERN_DECL_NODE(scale_qk);
+  PATTERN_DECL_NODE(scale_qk_out);
   PATTERN_DECL_NODE(eltadd_qk);
   PATTERN_DECL_NODE(eltadd_qk_b);
   PATTERN_DECL_NODE(eltadd_qk_out);

--- a/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.h
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_decoder_pass.h
@@ -182,6 +182,8 @@ struct FusedMultiTransformerDecoderFuseQKVPattern : public PatternBase {
   // Q, K matmul
   PATTERN_DECL_NODE(matmul_qk);
   PATTERN_DECL_NODE(matmul_qk_out);
+  PATTERN_DECL_NODE(scale_q);
+  PATTERN_DECL_NODE(scale_q_out);
   PATTERN_DECL_NODE(eltadd_qk);
   PATTERN_DECL_NODE(eltadd_qk_b);
   PATTERN_DECL_NODE(eltadd_qk_out);

--- a/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.cc
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.cc
@@ -472,11 +472,11 @@ PDNode* FusedMultiTransformerEncoderFuseQKVPattern::operator()() {
   auto* split0_q_out_var = pattern->NewNode(split0_q_out_repr())
                                ->assert_is_op_output("split")
                                ->AsIntermediate()
-                               ->assert_is_op_input("matmul", "X");
+                               ->assert_is_op_input("matmul_v2", "X");
   auto* split0_k_out_var = pattern->NewNode(split0_k_out_repr())
                                ->assert_is_op_output("split")
                                ->AsOutput()
-                               ->assert_is_op_input("matmul", "Y")
+                               ->assert_is_op_input("matmul_v2", "Y")
                                ->assert_is_op_input("while");
   auto* split0_v_out_var = pattern->NewNode(split0_v_out_repr())
                                ->assert_is_op_output("split")
@@ -499,10 +499,17 @@ PDNode* FusedMultiTransformerEncoderFuseQKVPattern::operator()() {
   while0->LinksFrom({split0_k_out_var, split0_v_out_var});
 
   // QK path Nodes
-  auto* matmul_qk = pattern->NewNode(matmul_qk_repr())->assert_is_op("matmul");
+  auto* matmul_qk =
+      pattern->NewNode(matmul_qk_repr())->assert_is_op("matmul_v2");
   auto* matmul_qk_out_var =
-      pattern->NewNode(matmul_qk_out_repr())->assert_is_op_output("matmul");
-  matmul_qk_out_var->AsIntermediate()->assert_is_op_input("elementwise_add");
+      pattern->NewNode(matmul_qk_out_repr())->assert_is_op_output("matmul_v2");
+  matmul_qk_out_var->AsIntermediate()->assert_is_op_input("scale");
+
+  auto* scale_q = pattern->NewNode(scale_q_repr())->assert_is_op("scale");
+  auto* scale_q_out_var = pattern->NewNode(scale_q_out_repr())
+                              ->assert_is_op_output("scale")
+                              ->AsIntermediate()
+                              ->assert_is_op_input("elementwise_add", "X");
 
   auto* eltadd_qk =
       pattern->NewNode(eltadd_qk_repr())->assert_is_op("elementwise_add");
@@ -524,7 +531,8 @@ PDNode* FusedMultiTransformerEncoderFuseQKVPattern::operator()() {
   // QK path Linsk
   matmul_qk->LinksFrom({split0_q_out_var, split0_k_out_var})
       .LinksTo({matmul_qk_out_var});
-  eltadd_qk->LinksFrom({matmul_qk_out_var, eltadd_qk_b_var})
+  scale_q->LinksFrom({matmul_qk_out_var}).LinksTo({scale_q_out_var});
+  eltadd_qk->LinksFrom({scale_q_out_var, eltadd_qk_b_var})
       .LinksTo({eltadd_qk_out_var});
   softmax_qk->LinksFrom({eltadd_qk_out_var}).LinksTo({softmax_qk_out_var});
 
@@ -2638,6 +2646,11 @@ int FusedMultiTransformerEncoderFuseQKVPass::BuildFusion(
         matmul_qk_out, matmul_qk_out, fused_multi_transformer_fuse_qkv_pattern);
 
     GET_IR_NODE_FROM_SUBGRAPH(
+        scale_q, scale_q, fused_multi_transformer_fuse_qkv_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(
+        scale_q_out, scale_q_out, fused_multi_transformer_fuse_qkv_pattern);
+
+    GET_IR_NODE_FROM_SUBGRAPH(
         eltadd_qk, eltadd_qk, fused_multi_transformer_fuse_qkv_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(
         eltadd_qk_b, eltadd_qk_b, fused_multi_transformer_fuse_qkv_pattern);
@@ -2739,6 +2752,8 @@ int FusedMultiTransformerEncoderFuseQKVPass::BuildFusion(
                                                   split0_v_out,
                                                   matmul_qk,
                                                   matmul_qk_out,
+                                                  scale_q,
+                                                  scale_q_out,
                                                   eltadd_qk,
                                                   eltadd_qk_out,
                                                   softmax_qk,
@@ -2824,6 +2839,23 @@ FusedMultiTransformerEncoderFuseQKVPass::
       .End()
       .AddAttr("begin_norm_axis")
       .IsNumGT(0)
+      .End();
+
+  AddOpCompat(OpCompat("scale"))
+      .AddInput("X")
+      .IsTensor()
+      .End()
+      .AddOutput("Out")
+      .IsTensor()
+      .End()
+      .AddAttr("scale")
+      .IsType<float>()  // copy to new op. so unconstrained.
+      .End()
+      .AddAttr("bias")
+      .IsNumEQ(0.f)
+      .End()
+      .AddAttr("bias_after_scale")  // bias is 0, so unconstrained.
+      .IsType<bool>()
       .End();
 
   AddOpCompat(OpCompat("matmul_v2"))

--- a/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.h
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.h
@@ -168,8 +168,8 @@ struct FusedMultiTransformerEncoderFuseQKVPattern : public PatternBase {
   // Q, K matmul
   PATTERN_DECL_NODE(matmul_qk);
   PATTERN_DECL_NODE(matmul_qk_out);
-  PATTERN_DECL_NODE(scale_q);
-  PATTERN_DECL_NODE(scale_q_out);
+  PATTERN_DECL_NODE(scale_qk);
+  PATTERN_DECL_NODE(scale_qk_out);
   PATTERN_DECL_NODE(eltadd_qk);
   PATTERN_DECL_NODE(eltadd_qk_b);
   PATTERN_DECL_NODE(eltadd_qk_out);
@@ -265,6 +265,8 @@ struct MultiDevicesFusedMultiTransformerEncoderFuseQKVPattern
   // Q, K matmul
   PATTERN_DECL_NODE(matmul_qk);
   PATTERN_DECL_NODE(matmul_qk_out);
+  PATTERN_DECL_NODE(scale_qk);
+  PATTERN_DECL_NODE(scale_qk_out);
   PATTERN_DECL_NODE(eltadd_qk);
   PATTERN_DECL_NODE(eltadd_qk_b);
   PATTERN_DECL_NODE(eltadd_qk_out);

--- a/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.h
+++ b/paddle/fluid/framework/ir/fused_multi_transformer_encoder_pass.h
@@ -168,6 +168,8 @@ struct FusedMultiTransformerEncoderFuseQKVPattern : public PatternBase {
   // Q, K matmul
   PATTERN_DECL_NODE(matmul_qk);
   PATTERN_DECL_NODE(matmul_qk_out);
+  PATTERN_DECL_NODE(scale_q);
+  PATTERN_DECL_NODE(scale_q_out);
   PATTERN_DECL_NODE(eltadd_qk);
   PATTERN_DECL_NODE(eltadd_qk_b);
   PATTERN_DECL_NODE(eltadd_qk_out);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
由于fluid API 清理导致GPT使用paddle.matmul进行网络构建，用于完成q * k的matmul从matmul_v2 op改为matmul op，后者无alpha参数，从而增加scale算子，fused_multi_transformer无法匹配，这里增加匹配。
![image](https://user-images.githubusercontent.com/37864677/206639183-0ad5d3c5-1294-423f-aa23-3665da7eeb5c.png)
--->
![image](https://user-images.githubusercontent.com/37864677/206639227-fd17b5e0-21b6-4825-bbfb-012ff7605411.png)
