### PR TITLE
[Bugfix] recompute dep filter param

### DIFF
--- a/python/paddle/distributed/auto_parallel/reshard.py
+++ b/python/paddle/distributed/auto_parallel/reshard.py
@@ -2497,6 +2497,8 @@ class Resharder:
             "read",
             "write_to_array",
             "read_from_array",
+            "nop",
+            "depend",
         ]
         global _g_special_ops
         skip_ops += _g_special_ops

--- a/python/paddle/distributed/auto_parallel/utils.py
+++ b/python/paddle/distributed/auto_parallel/utils.py
@@ -2168,6 +2168,9 @@ def insert_dependencies_for_two_ops(
 
     def _select_best_depend_var(vars):
 
+        # parameter should not be dep var since it maybe partition in sharding pass
+        vars = [var for var in vars if not var.is_parameter]
+        assert len(vars) > 0
         vars_with_numels = [(var, get_var_numel(var)) for var in vars]
         vars_with_numels.sort(key=lambda x: x[1])
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Sharding would partition param to different rank, so param should not be choose as dep var for recompute when sharding on.
support recompute depend op for pipline reshard