### PR TITLE
[remove fluid.layers.cross_entropy] remove unit tests (part 7)

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_matmul.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_matmul.py
@@ -173,7 +173,9 @@ class TestImperativeQatMatmul(unittest.TestCase):
                 label = fluid.dygraph.to_variable(y_data)
                 out = lenet(img)
                 acc = paddle.static.accuracy(out, label)
-                loss = fluid.layers.cross_entropy(out, label)
+                loss = paddle.nn.functional.cross_entropy(
+                    out, label, reduction='none', use_softmax=False
+                )
                 avg_loss = paddle.mean(loss)
 
                 avg_loss.backward()

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_fp16_allreduce_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_fp16_allreduce_meta_optimizer.py
@@ -42,8 +42,11 @@ class TestFleetFP16CompressOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_2], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_graph_execution_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_graph_execution_meta_optimizer.py
@@ -72,8 +72,11 @@ class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_2], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
 
@@ -135,8 +138,11 @@ class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_2], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
 
@@ -210,8 +216,11 @@ class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_2], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
 
@@ -272,8 +281,11 @@ class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_2], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_graph_executor.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_graph_executor.py
@@ -59,8 +59,11 @@ class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_2], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_lamb_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_lamb_meta_optimizer.py
@@ -47,8 +47,11 @@ class TestFleetLambMetaOptimizer(unittest.TestCase):
                 prediction = paddle.fluid.layers.fc(
                     input=[fc_2], size=2, act='softmax'
                 )
-                cost = paddle.fluid.layers.cross_entropy(
-                    input=prediction, label=input_y
+                cost = paddle.nn.functional.cross_entropy(
+                    input=prediction,
+                    label=input_y,
+                    reduction='none',
+                    use_softmax=False,
                 )
                 avg_cost = paddle.mean(x=cost)
 
@@ -122,8 +125,8 @@ class TestFleetLambMetaOptimizer(unittest.TestCase):
         fc_1 = paddle.fluid.layers.fc(input=input_x, size=64, act='tanh')
         fc_2 = paddle.fluid.layers.fc(input=fc_1, size=64, act='tanh')
         prediction = paddle.fluid.layers.fc(input=[fc_2], size=2, act='softmax')
-        cost = paddle.fluid.layers.cross_entropy(
-            input=prediction, label=input_y
+        cost = paddle.nn.functional.cross_entropy(
+            input=prediction, label=input_y, reduction='none', use_softmax=False
         )
         avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_lars_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_lars_meta_optimizer.py
@@ -47,8 +47,11 @@ class TestFleetLarsMetaOptimizer(unittest.TestCase):
                 prediction = paddle.fluid.layers.fc(
                     input=[fc_2], size=2, act='softmax'
                 )
-                cost = paddle.fluid.layers.cross_entropy(
-                    input=prediction, label=input_y
+                cost = paddle.nn.functional.cross_entropy(
+                    input=prediction,
+                    label=input_y,
+                    reduction='none',
+                    use_softmax=False,
                 )
                 avg_cost = paddle.mean(x=cost)
 
@@ -127,8 +130,8 @@ class TestFleetLarsMetaOptimizer(unittest.TestCase):
         fc_1 = paddle.fluid.layers.fc(input=input_x, size=64, act='tanh')
         fc_2 = paddle.fluid.layers.fc(input=fc_1, size=64, act='tanh')
         prediction = paddle.fluid.layers.fc(input=[fc_2], size=2, act='softmax')
-        cost = paddle.fluid.layers.cross_entropy(
-            input=prediction, label=input_y
+        cost = paddle.nn.functional.cross_entropy(
+            input=prediction, label=input_y, reduction='none', use_softmax=False
         )
         avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_meta_optimizer_base.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_meta_optimizer_base.py
@@ -43,8 +43,11 @@ class TestFleetMetaOptimizerBase(unittest.TestCase):
                 prediction = paddle.fluid.layers.fc(
                     input=[fc_2], size=2, act='softmax'
                 )
-                cost = paddle.fluid.layers.cross_entropy(
-                    input=prediction, label=input_y
+                cost = paddle.nn.functional.cross_entropy(
+                    input=prediction,
+                    label=input_y,
+                    reduction='none',
+                    use_softmax=False,
                 )
                 avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_pipeline_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_pipeline_meta_optimizer.py
@@ -56,8 +56,11 @@ class TestFleetMetaOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_2], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
         return avg_cost

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_pipeline_meta_optimizer_with_recompute.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_pipeline_meta_optimizer_with_recompute.py
@@ -52,8 +52,11 @@ class TestFleetMetaOptimizer(unittest.TestCase):
             prediction = paddle.fluid.layers.fc(
                 input=[fc_7], size=2, act='softmax'
             )
-            cost = paddle.fluid.layers.cross_entropy(
-                input=prediction, label=input_y
+            cost = paddle.nn.functional.cross_entropy(
+                input=prediction,
+                label=input_y,
+                reduction='none',
+                use_softmax=False,
             )
             avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_raw_program_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_raw_program_meta_optimizer.py
@@ -41,8 +41,8 @@ class TestFleetMetaOptimizer(unittest.TestCase):
 
         fc_2 = paddle.fluid.layers.fc(input=fc_1, size=64, act='tanh')
         prediction = paddle.fluid.layers.fc(input=[fc_2], size=2, act='softmax')
-        cost = paddle.fluid.layers.cross_entropy(
-            input=prediction, label=input_y
+        cost = paddle.nn.functional.cross_entropy(
+            input=prediction, label=input_y, reduction='none', use_softmax=False
         )
         avg_cost = paddle.mean(x=cost)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
@@ -531,8 +531,11 @@ def train_mobilenet(args, to_static):
 
                 t_end = time.time()
                 softmax_out = paddle.nn.functional.softmax(out)
-                loss = fluid.layers.cross_entropy(
-                    input=softmax_out, label=label
+                loss = paddle.nn.functional.cross_entropy(
+                    input=softmax_out,
+                    label=label,
+                    reduction='none',
+                    use_softmax=False,
                 )
                 avg_loss = paddle.mean(x=loss)
                 acc_top1 = paddle.static.accuracy(input=out, label=label, k=1)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tsm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tsm.py
@@ -329,8 +329,12 @@ def train(args, fake_data_reader, to_static):
                 labels = to_variable(y_data)
                 labels.stop_gradient = True
                 outputs = video_model(imgs)
-                loss = fluid.layers.cross_entropy(
-                    input=outputs, label=labels, ignore_index=-1
+                loss = paddle.nn.functional.cross_entropy(
+                    input=outputs,
+                    label=labels,
+                    ignore_index=-1,
+                    reduction='none',
+                    use_softmax=False,
                 )
                 avg_loss = paddle.mean(loss)
                 acc_top1 = paddle.static.accuracy(

--- a/python/paddle/fluid/tests/unittests/ipu/test_cross_entropy2_op_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_cross_entropy2_op_ipu.py
@@ -63,8 +63,12 @@ class TestBase(IPUOpTest):
             label = paddle.static.data(
                 name=self.feed_list[1], shape=self.feed_shape[1], dtype='int64'
             )
-        out = paddle.fluid.layers.cross_entropy(
-            input=x, label=label, **self.attrs
+        out = paddle.nn.functional.cross_entropy(
+            input=x,
+            label=label,
+            reduction='none',
+            use_softmax=False,
+            **self.attrs
         )
         self.fetch_list = [out.name]
 

--- a/python/paddle/fluid/tests/unittests/ipu/test_dy2static_ipu.py
+++ b/python/paddle/fluid/tests/unittests/ipu/test_dy2static_ipu.py
@@ -49,12 +49,9 @@ class SimpleLayer(paddle.nn.Layer):
         if target is not None:
             if self.use_softmax:
                 x = paddle.nn.functional.softmax(x)
-            if self.loss_op:
-                loss = self.loss_op(x, target)
-            else:
-                loss = paddle.paddle.nn.functional.cross_entropy(
-                    x, target, reduction='none', use_softmax=False
-                )
+            loss = paddle.paddle.nn.functional.cross_entropy(
+                x, target, reduction='none', use_softmax=False
+            )
             if self.use_reduction:
                 loss = paddle.mean(loss)
             if self.use_identity_loss:
@@ -69,7 +66,7 @@ class TestBase(IPUD2STest):
         self.set_data_feed()
 
     def set_op_attrs(self):
-        self.loss_op = paddle.fluid.layers.cross_entropy
+        pass
 
     def set_data_feed(self):
         self.data = paddle.uniform((8, 3, 10, 10), dtype='float32')

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -2022,7 +2022,9 @@ class TestBook(LayerTest):
                 act='softmax',
                 param_attr=["sftmax.w1", "sftmax.w2"],
             )
-            cost = layers.cross_entropy(input=predict, label=label)
+            cost = paddle.nn.functional.cross_entropy(
+                input=predict, label=label, reduction='none', use_softmax=False
+            )
             avg_cost = paddle.mean(cost)
             return avg_cost
 
@@ -2061,7 +2063,9 @@ class TestBook(LayerTest):
             )
 
             predict = layers.fc(input=conv_pool_2, size=10, act="softmax")
-            cost = layers.cross_entropy(input=predict, label=label)
+            cost = paddle.nn.functional.cross_entropy(
+                input=predict, label=label, reduction='none', use_softmax=False
+            )
             avg_cost = paddle.mean(cost)
             return avg_cost
 
@@ -2114,7 +2118,12 @@ class TestBook(LayerTest):
             predict_word = layers.fc(
                 input=hidden1, size=dict_size, act='softmax'
             )
-            cost = layers.cross_entropy(input=predict_word, label=next_word)
+            cost = paddle.nn.functional.cross_entropy(
+                input=predict_word,
+                label=next_word,
+                reduction='none',
+                use_softmax=False,
+            )
             avg_cost = paddle.mean(cost)
             return avg_cost
 
@@ -2346,7 +2355,14 @@ class TestBook(LayerTest):
             x = self._get_data(name="x", shape=[30, 10], dtype="float32")
             label = self._get_data(name="label", shape=[30, 1], dtype="int64")
             mode = 'channel'
-            out = layers.cross_entropy(x, label, False, 4)
+            out = paddle.nn.functional.cross_entropy(
+                x,
+                label,
+                soft_label=False,
+                ignore_index=4,
+                reduction='none',
+                use_softmax=False,
+            )
             return out
 
     def make_uniform_random_batch_size_like(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
remove reset reference in unittest for `fluid.layers.cross_entropy`

### Relevant PR
- #48726
- #48913
- #48918
- #48919 
- #48920 
- #48922