### PR TITLE
[Framework]Support deliver stop_gradient in static mode

### DIFF
--- a/paddle/fluid/operators/recurrent_op.cc
+++ b/paddle/fluid/operators/recurrent_op.cc
@@ -758,7 +758,8 @@ class RecurrentGradOpShapeInference : public framework::InferShapeBase {
     }
 
     PADDLE_ENFORCE_EQ(
-        ctx->HasOutputs(framework::GradVarName(RecurrentBase::kInputs)),
+        ctx->HasOutputs(framework::GradVarName(RecurrentBase::kInputs),
+                        /*allow_null=*/true),
         true,
         platform::errors::InvalidArgument(
             "The output of(%s) should not be empty.",

--- a/paddle/fluid/operators/select_output_op.cc
+++ b/paddle/fluid/operators/select_output_op.cc
@@ -64,7 +64,9 @@ class SelectOutputOp : public framework::OperatorBase {
 
     const framework::Variable *x = scope.FindVar(Input("X"));
     framework::Variable *selected_out = scope.FindVar(out_names[output_branch]);
-    framework::VisitVarType(*x, AssignFunctor(selected_out, dev_ctx));
+    if (nullptr != selected_out) {
+      framework::VisitVarType(*x, AssignFunctor(selected_out, dev_ctx));
+    }
   }
 };
 

--- a/paddle/fluid/operators/select_output_op.cc
+++ b/paddle/fluid/operators/select_output_op.cc
@@ -95,8 +95,10 @@ class SelectOutputInferShape : public framework::InferShapeBase {
   void operator()(framework::InferShapeContext *context) const override {
     OP_INOUT_CHECK(context->HasInput("X"), "Input", "X", "SelectOutput");
     OP_INOUT_CHECK(context->HasInput("Mask"), "Input", "Mask", "SelectOutput");
-    OP_INOUT_CHECK(
-        context->HasOutputs("Out", true), "Output", "Out", "SelectOutput");
+    OP_INOUT_CHECK(context->HasOutputs("Out", /*allow_null=*/true),
+                   "Output",
+                   "Out",
+                   "SelectOutput");
   }
 };
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4074,6 +4074,9 @@ class Block:
             param = EagerParamBase(*args, **kwargs)
         else:
             param = Parameter(global_block, *args, **kwargs)
+        # NOTE(Aurelius84): we deliver stop_gradient in append_op, so we
+        # need recorde it state and reset it back after calling this API
+        stop_gradient = param.stop_gradient
 
         if 'initializer' in kwargs:
 
@@ -4109,6 +4112,7 @@ class Block:
                 pass
             else:
                 initializer(param, self)
+        param.stop_gradient = stop_gradient
         return param
 
     def append_op(self, *args, **kwargs):
@@ -4118,10 +4122,10 @@ class Block:
         Returns:
             Operator: the append Operator.
         """
+        op_type = kwargs.get("type", None)
         if _non_static_mode():
             attrs = kwargs.get("attrs", {})
             inplace_map = kwargs.get("inplace_map", None)
-            type = kwargs.get("type", None)
             warnings.warn(
                 "Op `%s` is executed through `append_op` under the dynamic mode, "
                 "the corresponding API implementation needs to be upgraded to "
@@ -4131,7 +4135,7 @@ class Block:
             op = Operator(
                 block=self,
                 desc=None,
-                type=type,
+                type=op_type,
                 inputs=None,
                 outputs=None,
                 attrs=attrs,
@@ -4143,7 +4147,7 @@ class Block:
             # currently, we only support stop_gradient in dygraph mode.
 
             _dygraph_tracer().trace_op(
-                type,
+                op_type,
                 kwargs.get("inputs", {}),
                 kwargs.get("outputs", {}),
                 attrs if attrs else {},
@@ -4160,7 +4164,7 @@ class Block:
                 """
                 need_reset = True
                 for var in flatten(ins):
-                    if isinstance(var, Variable) and var.stop_gradient is False:
+                    if getattr(var, 'stop_gradient', None) is False:
                         need_reset = False
                         break
                 if need_reset:
@@ -4169,18 +4173,26 @@ class Block:
                             var.stop_gradient = True
 
             op_desc = self.desc.append_op()
+            inputs = kwargs.get("inputs", None)
+            outputs = kwargs.get("outputs", None)
             # NOTE(Aurelius84): In case of @to_static, all VarBase(s) should
             # be converted into Variable(s) with same name and block location.
             # This is ONE and ONLY logic of type transformation of dy2static.
-            inputs = kwargs.get("inputs", None)
-            outputs = kwargs.get("outputs", None)
-
-            pass_stop_gradient(inputs, outputs)
+            ignore_ops = {
+                'conditional_block',
+                'conditional_block_grad',
+                'recurrent',
+                'recurrent_grad',
+                'while',
+                'while_grad',
+            }
+            if op_type not in ignore_ops:
+                pass_stop_gradient(inputs, outputs)
             with param_guard(inputs), param_guard(outputs):
                 op = Operator(
                     block=self,
                     desc=op_desc,
-                    type=kwargs.get("type", None),
+                    type=op_type,
                     inputs=inputs,
                     outputs=outputs,
                     attrs=kwargs.get("attrs", None),

--- a/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
@@ -189,9 +189,9 @@ class FusionGroupPassCastTest(FusionGroupPassTest):
             self.feed_vars = self._prepare_feed_vars([2, 2], dtype, 2)
 
             tmp_0 = paddle.add(self.feed_vars[0], self.feed_vars[1])
+            tmp_0.stop_gradient = False
             tmp_1 = paddle.cast(tmp_0, dtype="float64")
             tmp_2 = paddle.cast(tmp_1, dtype="float32")
-            tmp_0.stop_gradient = False
 
         self.append_gradients(tmp_2)
 

--- a/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
@@ -33,6 +33,7 @@ class FusionGroupPassTest(PassTest):
 
             # subgraph with only 1 op node
             tmp_0 = self.feed_vars[0] * self.feed_vars[1]
+            tmp_0.stop_gradient = False
             tmp_1 = paddle.matmul(tmp_0, self.feed_vars[2])
             # subgraph with 2 op nodes
             tmp_2 = paddle.nn.functional.relu(tmp_0 + tmp_1)
@@ -48,10 +49,11 @@ class FusionGroupPassTest(PassTest):
         self.pass_names = "fusion_group_pass"
         self.fused_op_type = "fusion_group"
 
-    def _prepare_feed_vars(self, shape, dtype, num_data):
+    def _prepare_feed_vars(self, shape, dtype, num_data, stop_gradient=True):
         feed_vars = []
         for i in range(num_data):
             var = fluid.data(name=("data" + str(i)), shape=shape, dtype=dtype)
+            var.stop_gradient = stop_gradient
             feed_vars.append(var)
         return feed_vars
 
@@ -82,7 +84,7 @@ class FusionGroupPassTest(PassTest):
 class FusionGroupPassComplicatedTest(FusionGroupPassTest):
     def build_program(self, dtype):
         with fluid.program_guard(self.main_program, self.startup_program):
-            self.feed_vars = self._prepare_feed_vars([32, 64], dtype, 5)
+            self.feed_vars = self._prepare_feed_vars([32, 64], dtype, 5, False)
 
             one = layers.fill_constant(shape=[1], dtype=dtype, value=1.0)
             tmp_0 = one * self.feed_vars[0]
@@ -138,6 +140,7 @@ class FusionGroupPassTestCastAndFP16(FusionGroupPassTest):
 
             # subgraph with 2 op nodes
             tmp_0 = self.feed_vars[0] * self.feed_vars[1]
+            tmp_0.stop_gradient = False
             tmp_1 = paddle.cast(tmp_0, dtype="float16")
             zero = layers.fill_constant(shape=[128], dtype="float16", value=0)
             # TODO(xreki): fix precision problem when using softmax of float16.
@@ -168,6 +171,7 @@ class FusionGroupPassSumTest(FusionGroupPassTest):
             tmp_0 = paddle.add_n(
                 [self.feed_vars[0], self.feed_vars[1], self.feed_vars[2]]
             )
+            tmp_0.stop_gradient = False
             tmp_1 = paddle.sqrt(tmp_0)
             tmp_2 = paddle.matmul(tmp_0, self.feed_vars[3])
             # subgraph with 2 op nodes
@@ -187,6 +191,7 @@ class FusionGroupPassCastTest(FusionGroupPassTest):
             tmp_0 = paddle.add(self.feed_vars[0], self.feed_vars[1])
             tmp_1 = paddle.cast(tmp_0, dtype="float64")
             tmp_2 = paddle.cast(tmp_1, dtype="float32")
+            tmp_0.stop_gradient = False
 
         self.append_gradients(tmp_2)
 
@@ -206,6 +211,7 @@ class FusionGroupPassFillConstantTest(FusionGroupPassTest):
             self.feed_vars = self._prepare_feed_vars([2, 2], dtype, 2)
 
             tmp_0 = paddle.add(self.feed_vars[0], self.feed_vars[1])
+            tmp_0.stop_gradient = False
             tmp_1 = layers.fill_constant(shape=[2, 2], dtype=dtype, value=2.0)
             tmp_2 = paddle.scale(
                 tmp_1, scale=3.0, bias=1.0, bias_after_scale=True

--- a/python/paddle/fluid/tests/unittests/test_cond.py
+++ b/python/paddle/fluid/tests/unittests/test_cond.py
@@ -464,6 +464,7 @@ class TestCondNestedControlFlow(unittest.TestCase):
         startup_program = Program()
         with program_guard(main_program, startup_program):
             i = fluid.data(name="i", shape=[1], dtype='float32')
+            i.stop_gradient = False
             a = 2.0 * i
             out = paddle.static.nn.cond(
                 i < 5.0,

--- a/python/paddle/fluid/tests/unittests/test_desc_clone.py
+++ b/python/paddle/fluid/tests/unittests/test_desc_clone.py
@@ -23,6 +23,7 @@ from paddle.fluid import core
 SEED = 1
 DTYPE = "float32"
 paddle.dataset.mnist.fetch()
+paddle.enable_static()
 
 
 # random seed must set before configuring the network.
@@ -207,7 +208,7 @@ class TestCloneWithStopGradient(unittest.TestCase):
             test_program.block(0).var(hidden1.name).stop_gradient, True
         )
         self.assertEqual(
-            test_program.block(0).var(hidden2.name).stop_gradient, False
+            test_program.block(0).var(hidden2.name).stop_gradient, True
         )
 
 

--- a/python/paddle/fluid/tests/unittests/test_eager_deletion_while_op.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_deletion_while_op.py
@@ -120,7 +120,7 @@ class TestEagerDeletionWhileOpBase(unittest.TestCase):
         gc_vars = core._get_eager_deletion_vars(
             fluid.default_main_program().desc, [loss.name]
         )
-        self.assertEqual(len(gc_vars), 5)
+        self.assertEqual(len(gc_vars), 3)
 
         exe = Executor(self.place)
         exe.run(fluid.default_startup_program())

--- a/python/paddle/fluid/tests/unittests/test_imperative_recurrent_usage.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_recurrent_usage.py
@@ -81,7 +81,9 @@ class TestRecurrentFeed(unittest.TestCase):
             fluid.default_startup_program().random_seed = seed
             fluid.default_main_program().random_seed = seed
             in1 = paddle.static.data(name="inp1", shape=[2, 2])
+            in1.stop_gradient = False
             in2 = paddle.static.data(name="inp2", shape=[2, 2])
+            in2.stop_gradient = False
             rt1 = RecurrentTest("RecurrentTest")
             static_sum_out, static_out = rt1(in1, in2)
             fluid.backward.append_backward(static_sum_out)

--- a/python/paddle/fluid/tests/unittests/test_nn_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_grad.py
@@ -349,6 +349,7 @@ class TestConstantPadDoubleGradCheck(unittest.TestCase):
 
         x = paddle.static.data('x', x_shape, dtype)
         x.persistable = True
+        x.stop_gradient = False
         out = paddle.nn.functional.pad(x, pad)
         x_arr = np.random.uniform(-1, 1, x_shape).astype(dtype)
 

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -1167,6 +1167,7 @@ class TestRecomputeOptimizer(unittest.TestCase):
             prediction = paddle.static.nn.fc(
                 x=[drop_res], size=2, activation='softmax'
             )
+            drop_res.stop_gradient = False
             cost = paddle.nn.functional.cross_entropy(
                 input=prediction,
                 label=input_y,
@@ -1231,6 +1232,7 @@ class TestRecomputeOptimizerCUDA(unittest.TestCase):
             prediction = paddle.static.nn.fc(
                 x=[drop_res], size=2, activation='softmax'
             )
+            drop_res.stop_gradient = False
             cost = paddle.nn.functional.cross_entropy(
                 input=prediction,
                 label=input_y,

--- a/python/paddle/fluid/tests/unittests/test_pass_stop_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_pass_stop_gradient.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+class TestStopGradient(unittest.TestCase):
+    def setUp(self):
+        paddle.enable_static()
+
+    def tearDown(self):
+        paddle.disable_static()
+
+    def create_var(self, stop_gradient):
+        x = paddle.randn([2, 4])
+        x.stop_gradient = stop_gradient
+        return x
+
+    def test_unary(self):
+        x = self.create_var(True)
+
+        out = x.reshape([4, -1])
+        self.assertTrue(out.stop_gradient)
+
+    def test_binary(self):
+        x = self.create_var(True)
+        y = self.create_var(True)
+
+        out = x + y
+        self.assertTrue(out.stop_gradient)
+
+    def test_binary2(self):
+        x = self.create_var(True)
+        y = self.create_var(False)
+
+        out = x + y
+        self.assertFalse(out.stop_gradient)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -996,6 +996,8 @@ class TestBackward(unittest.TestCase):
         with paddle.static.program_guard(main_program, startup_program):
             x = paddle.static.data(name="x", shape=[4, 4], dtype='float32')
             y = paddle.static.data(name="y", shape=[4, 4], dtype='float32')
+            x.stop_gradient = False
+            y.stop_gradient = False
 
             label = paddle.static.data(
                 name="label", shape=[4, 1], dtype='int64'

--- a/python/paddle/fluid/tests/unittests/test_where_op.py
+++ b/python/paddle/fluid/tests/unittests/test_where_op.py
@@ -95,6 +95,7 @@ class TestWhereAPI(unittest.TestCase):
                     y.stop_gradient = y_stop_gradient
                     y.desc.set_need_check_feed(False)
                     result = paddle.where(cond, x, y)
+                    result.stop_gradient = False
                     append_backward(paddle.mean(result))
                     for use_cuda in [False, True]:
                         if use_cuda and (

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -353,6 +353,7 @@ class TestApiWhileLoop_NestedWithBackwardAndLoDTensorArray(unittest.TestCase):
             init = layers.zeros(shape=[10], dtype='float32')
             mem_array = paddle.tensor.array_write(x=init, i=i)
             data_array = paddle.tensor.array_write(x=d0, i=i)
+            mem_array.stop_gradient = False
             i = paddle.increment(i)
             paddle.tensor.array_write(d1, i, array=data_array)
             i = paddle.increment(i)

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -3063,8 +3063,8 @@ class TestSundryAPIStatic(unittest.TestCase):
     @prog_scope()
     def test_unsqueeze(self):
         x1 = paddle.full([], 2)
-        out1 = paddle.unsqueeze(x1, axis=0)
         x1.stop_gradient = False
+        out1 = paddle.unsqueeze(x1, axis=0)
         paddle.static.append_backward(out1.sum())
 
         x2 = paddle.full([], 3)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-66972

[Framework]support pass stop_gradient in static mode

在动态图下，如果一个API的所有输入Tensor的stop_gradient 都是True，则其输出Tensor的stop_gradient 也是True，但静态图下stop_gradient的传递机制却不是这样的。

故此PR对齐了静态图下的append_op时的stop_gradient传递机制，以及时地进行反向剪枝

### 场景考虑

#### 1. 叶子节点OP
如 uniform_random 算子，inputs无Variable 类型，输出是否需要设置为stop_gradient? 存在如下冲突点

+ 框架中参数的创建使用了此类算子，但参数默认都是stop_gradient = False
+ 用户的代码也可能使用此类算子，但为非参数类型（如调用paddle.randn），其 stop_gradient = True

方案：在框架create_params统一逻辑出做了stop_gradient restore处理。


#### 2. 控制流场景
动态图下无控制流，但静态图下控制流借助了select_input 和 select_output 来实现不同分支的前向、反向选择。

+ 如果一个分支输出 stop_gradient = True，另一分支输出 stop_gradient  = False，select_output反向怎么做？

```bash
    var _generated_var_5 : LOD_TENSOR.shape(1,).dtype(float32).stop_gradient(False)
    var _generated_var_7 : LOD_TENSOR.shape(1,).dtype(float32).stop_gradient(True)

    {Out=['_generated_var_9']} = select_input(inputs={Mask=['cast_1.tmp_0'], X=['_generated_var_7', '_generated_var_5']}, op_device = , op_namescope = /, op_role = 256, op_role_var = [], with_quant_attr = False)
}

(Pdb) op_desc.output_arg_names()
['@EMPTY@', '_generated_var_5@GRAD']
```

上述case会报错，原因是在 select_output infer_shape时，不允许输出有@EMPTY@（即单分支无梯度）：
```cpp
bool CompileTimeInferShapeContext::HasOutputs(const std::string &name,
                                              bool allow_null) const {
  if (op_.Outputs().find(name) == op_.Outputs().end()) {
    return false;
  }
  const std::vector<std::string> &output_names = op_.Output(name);
  if (output_names.empty()) {
    return false;
  }
  if (!allow_null) {
    for (auto &output : output_names) {
      if (!block_.HasVarRecursive(output)) return false;   // <------ 这里 
    }
  }
  return true;
}
```

方案：在OpMaker里允许单分支的变量为@EMPTY@，同时在append_op逻辑中对可能产生sub block 的算子做了ignore处理，因为sub block内部可能会存在需要梯度计算的操作，不能完全根据inputs来判断

#### 3. recurrent 场景下
同控制流场景

#### 4. 组合算子场景下
在组合算子机制下，如果依旧保持框架静态图原生不传递stop_gradient的机制，则会导致训练执行时显存异常增长。
考虑如下样例：
```python
class TestLayerNorm(nn.Layer):
    def __init__(self):
         self.ln = paddle.nn.LayerNorm(xxx)
    
    def forward(self, x):
        x = x * 2   # <---- 静态图下x.stop_gradient 变为了 False，表明需要算梯度，导致显存异常增长
        y = self.ln(x)
        return y

net = TestLayerNorm()

x = paddle.randn([10, 1000]) # <--- stop_gradient = True
```

上述带 x = x *2 的组合算子前方向拆分的program如下：
```python
{ // block 0
    var eager_tmp_0 : LOD_TENSOR.shape(10, 100, 100, 100).dtype(float32).stop_gradient(True)
    persist trainable param layer_norm_0.b_0 : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    persist trainable param layer_norm_0.w_0 : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    var tmp_0 : LOD_TENSOR.shape(10, 100, 100, 100).dtype(float32).stop_gradient(False)
    
// .......
    var layer_norm_0.b_0@GRAD : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    var layer_norm_0.w_0@GRAD : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    var tmp_0@GRAD : LOD_TENSOR.shape(10, 100, 100, 100).dtype(float32).stop_gradient(False)
   
 {Out=['tmp_0']} = scale(inputs={ScaleTensor=[], X=['eager_tmp_0']}, bias = 0.0, bias_after_scale = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], scale = 2.0, with_quant_attr = False)
    
{Out=['mean_0.tmp_0']} = reduce_mean(inputs={X=['tmp_0']}, dim = [1, 2, 3], in_dtype = -1, keep_dim = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], out_dtype = -1, reduce_all = False, with_quant_attr = False)
    {Out=['tmp_2']} = elementwise_sub(inputs={X=['tmp_0'], Y=['mean_0.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['tmp_3']} = elementwise_mul(inputs={X=['tmp_2'], Y=['tmp_2']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['mean_1.tmp_0']} = reduce_mean(inputs={X=['tmp_3']}, dim = [1, 2, 3], in_dtype = -1, keep_dim = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], out_dtype = -1, reduce_all = False, with_quant_attr = False)
    {Out=['tmp_4']} = scale(inputs={ScaleTensor=[], X=['mean_1.tmp_0']}, bias = 9.999999747378752e-06, bias_after_scale = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], scale = 1.0, with_quant_attr = False)
    {Out=['sqrt_0.tmp_0']} = sqrt(inputs={X=['tmp_4']}, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['tmp_5']} = elementwise_div(inputs={X=['tmp_2'], Y=['sqrt_0.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['reshape2_0.tmp_0'], XShape=['reshape2_0.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['layer_norm_0.w_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [100, 100, 100], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['tmp_6']} = elementwise_mul(inputs={X=['tmp_5'], Y=['reshape2_0.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['reshape2_1.tmp_0'], XShape=['reshape2_1.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['layer_norm_0.b_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [100, 100, 100], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['layer_norm_1.tmp_2']} = elementwise_add(inputs={X=['tmp_6'], Y=['reshape2_1.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['layer_norm_1.tmp_0'], XShape=['reshape2_2.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['mean_0.tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [-1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['layer_norm_1.tmp_1'], XShape=['reshape2_3.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['mean_1.tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [-1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['tmp_1']} = scale(inputs={ScaleTensor=[], X=['layer_norm_1.tmp_2']}, bias = 0.0, bias_after_scale = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], scale = 2.0, with_quant_attr = False)
    {Out=['tmp_1@GRAD']} = fill_any_like(inputs={X=['tmp_1']}, dtype = 5, op_device = , op_namescope = , op_role = 1, op_role_var = [], value = 1.0, with_quant_attr = False)
    {Out=['layer_norm_1.tmp_2@GRAD']} = scale(inputs={ScaleTensor=[], X=['tmp_1@GRAD']}, bias = 0.0, bias_after_scale = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], scale = 2.0, with_quant_attr = False)
    {Out=['composite_tmp_0']} = reshape2(inputs={X=['layer_norm_0.w_0']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [1, 1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_1']} = reshape2(inputs={X=['tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_2']} = reshape2(inputs={X=['layer_norm_1.tmp_2@GRAD']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_3']} = reshape2(inputs={X=['layer_norm_1.tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_4']} = reshape2(inputs={X=['layer_norm_1.tmp_1']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_5']} = reduce_sum(inputs={X=['composite_tmp_2']}, dim = [0], in_dtype = -1, keep_dim = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], out_dtype = 5, reduce_all = False, with_quant_attr = False)
    {Out=['layer_norm_0.b_0@GRAD']} = reshape2(inputs={X=['composite_tmp_5']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_7']} = elementwise_sub(inputs={X=['composite_tmp_1'], Y=['composite_tmp_3']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_8']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = , op_role = 1, op_role_var = [], place_type = -1, shape = [10, 1], str_value = , value = 1.0, with_quant_attr = False)
    {Out=['composite_tmp_9']} = elementwise_div(inputs={X=['composite_tmp_8'], Y=['composite_tmp_4']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_10']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = , op_role = 1, op_role_var = [], place_type = -1, shape = [10, 1], str_value = , value = 1.0, with_quant_attr = False)
    {Out=['composite_tmp_11']} = elementwise_div(inputs={X=['composite_tmp_10'], Y=['composite_tmp_4']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_12']} = sqrt(inputs={X=['composite_tmp_11']}, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_13']} = elementwise_mul(inputs={X=['composite_tmp_7'], Y=['composite_tmp_12']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_14']} = elementwise_mul(inputs={X=['composite_tmp_13'], Y=['composite_tmp_2']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_15']} = reduce_sum(inputs={X=['composite_tmp_14']}, dim = [0], in_dtype = -1, keep_dim = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], out_dtype = 5, reduce_all = False, with_quant_attr = False)
    {Out=['layer_norm_0.w_0@GRAD']} = reshape2(inputs={X=['composite_tmp_15']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    
// <------ 如下是多余的算 x_scale@GRAD的逻辑
    {Out=['composite_tmp_17']} = elementwise_mul(inputs={X=['composite_tmp_0'], Y=['composite_tmp_12']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_18']} = elementwise_mul(inputs={X=['composite_tmp_17'], Y=['composite_tmp_2']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_19']} = scale(inputs={X=['composite_tmp_12']}, bias = 0.0, bias_after_scale = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], scale = -1.0, with_quant_attr = False)
    {Out=['composite_tmp_20']} = elementwise_mul(inputs={X=['composite_tmp_19'], Y=['composite_tmp_2']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_21']} = elementwise_mul(inputs={X=['composite_tmp_20'], Y=['composite_tmp_0']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_22']} = reduce_sum(inputs={X=['composite_tmp_21']}, dim = [1], in_dtype = -1, keep_dim = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], out_dtype = 5, reduce_all = False, with_quant_attr = False)
    {Out=['composite_tmp_23']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = , op_role = 1, op_role_var = [], place_type = -1, shape = [10, 1], str_value = , value = 9.999999974752427e-07, with_quant_attr = False)
    {Out=['composite_tmp_24']} = elementwise_mul(inputs={X=['composite_tmp_23'], Y=['composite_tmp_22']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_25']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = , op_role = 1, op_role_var = [], place_type = -1, shape = [10, 1], str_value = , value = 1.0, with_quant_attr = False)
    {Out=['composite_tmp_26']} = elementwise_div(inputs={X=['composite_tmp_25'], Y=['composite_tmp_4']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_27']} = scale(inputs={X=['composite_tmp_26']}, bias = 0.0, bias_after_scale = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], scale = -1.0, with_quant_attr = False)
    {Out=['composite_tmp_28']} = elementwise_mul(inputs={X=['composite_tmp_27'], Y=['composite_tmp_7']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_29']} = elementwise_mul(inputs={X=['composite_tmp_28'], Y=['composite_tmp_2']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_30']} = elementwise_mul(inputs={X=['composite_tmp_29'], Y=['composite_tmp_0']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_31']} = reduce_sum(inputs={X=['composite_tmp_30']}, dim = [1], in_dtype = -1, keep_dim = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], out_dtype = 5, reduce_all = False, with_quant_attr = False)
    {Out=['composite_tmp_32']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = , op_role = 1, op_role_var = [], place_type = -1, shape = [10, 1], str_value = , value = 9.999999974752427e-07, with_quant_attr = False)
    {Out=['composite_tmp_33']} = elementwise_mul(inputs={X=['composite_tmp_32'], Y=['composite_tmp_12']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_34']} = reshape2(inputs={X=['composite_tmp_33']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_35']} = elementwise_mul(inputs={X=['composite_tmp_34'], Y=['composite_tmp_7']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_36']} = elementwise_mul(inputs={X=['composite_tmp_31'], Y=['composite_tmp_35']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_37']} = elementwise_add(inputs={X=['composite_tmp_18'], Y=['composite_tmp_24']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_38']} = elementwise_add(inputs={X=['composite_tmp_37'], Y=['composite_tmp_36']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['tmp_0@GRAD']} = reshape2(inputs={X=['composite_tmp_38']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 100, 100, 100], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
}
```


如果保持静态图的stop_gradient传递机制与动态图一致，则理想的Program应该更加简洁，如下：
```python
{ // block 0
    var eager_tmp_0 : LOD_TENSOR.shape(10, 100, 100, 100).dtype(float32).stop_gradient(True)
    persist trainable param layer_norm_0.b_0 : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    persist trainable param layer_norm_0.w_0 : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    // ....
    var layer_norm_0.b_0@GRAD : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    var layer_norm_0.w_0@GRAD : LOD_TENSOR.shape(1000000,).dtype(float32).stop_gradient(False)
    var layer_norm_1.tmp_2@GRAD : LOD_TENSOR.shape(10, 100, 100, 100).dtype(float32).stop_gradient(False)
    var mean_0.tmp_0 : LOD_TENSOR.shape(10, 1, 1, 1).dtype(float32).stop_gradient(False)
    var tmp_0 : LOD_TENSOR.shape(10, 100, 100, 100).dtype(float32).stop_gradient(False)
   
    {Out=['mean_0.tmp_0']} = reduce_mean(inputs={X=['eager_tmp_0']}, dim = [1, 2, 3], in_dtype = -1, keep_dim = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], out_dtype = -1, reduce_all = False, with_quant_attr = False)
    {Out=['tmp_0']} = elementwise_sub(inputs={X=['eager_tmp_0'], Y=['mean_0.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['tmp_1']} = elementwise_mul(inputs={X=['tmp_0'], Y=['tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['mean_1.tmp_0']} = reduce_mean(inputs={X=['tmp_1']}, dim = [1, 2, 3], in_dtype = -1, keep_dim = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], out_dtype = -1, reduce_all = False, with_quant_attr = False)
    {Out=['tmp_2']} = scale(inputs={ScaleTensor=[], X=['mean_1.tmp_0']}, bias = 9.999999747378752e-06, bias_after_scale = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], scale = 1.0, with_quant_attr = False)
    {Out=['sqrt_0.tmp_0']} = sqrt(inputs={X=['tmp_2']}, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['tmp_3']} = elementwise_div(inputs={X=['tmp_0'], Y=['sqrt_0.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['reshape2_0.tmp_0'], XShape=['reshape2_0.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['layer_norm_0.w_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [100, 100, 100], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['tmp_4']} = elementwise_mul(inputs={X=['tmp_3'], Y=['reshape2_0.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['reshape2_1.tmp_0'], XShape=['reshape2_1.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['layer_norm_0.b_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [100, 100, 100], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['layer_norm_1.tmp_2']} = elementwise_add(inputs={X=['tmp_4'], Y=['reshape2_1.tmp_0']}, axis = -1, op_device = , op_namescope = /, op_role = 0, op_role_var = [], with_quant_attr = False)
    {Out=['layer_norm_1.tmp_0'], XShape=['reshape2_2.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['mean_0.tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [-1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['layer_norm_1.tmp_1'], XShape=['reshape2_3.tmp_1']} = reshape2(inputs={Shape=[], ShapeTensor=[], X=['mean_1.tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], shape = [-1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['layer_norm_1.tmp_2@GRAD']} = fill_any_like(inputs={X=['layer_norm_1.tmp_2']}, dtype = 5, op_device = , op_namescope = , op_role = 1, op_role_var = [], value = 1.0, with_quant_attr = False)
    {Out=['composite_tmp_0']} = reshape2(inputs={X=['layer_norm_0.w_0']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [1, 1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_1']} = reshape2(inputs={X=['eager_tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_2']} = reshape2(inputs={X=['layer_norm_1.tmp_2@GRAD']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_3']} = reshape2(inputs={X=['layer_norm_1.tmp_0']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_4']} = reshape2(inputs={X=['layer_norm_1.tmp_1']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [10, 1], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_5']} = reduce_sum(inputs={X=['composite_tmp_2']}, dim = [0], in_dtype = -1, keep_dim = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], out_dtype = 5, reduce_all = False, with_quant_attr = False)
    {Out=['layer_norm_0.b_0@GRAD']} = reshape2(inputs={X=['composite_tmp_5']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
    {Out=['composite_tmp_7']} = elementwise_sub(inputs={X=['composite_tmp_1'], Y=['composite_tmp_3']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_8']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = , op_role = 1, op_role_var = [], place_type = -1, shape = [10, 1], str_value = , value = 1.0, with_quant_attr = False)
    {Out=['composite_tmp_9']} = elementwise_div(inputs={X=['composite_tmp_8'], Y=['composite_tmp_4']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_10']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = , op_namescope = , op_role = 1, op_role_var = [], place_type = -1, shape = [10, 1], str_value = , value = 1.0, with_quant_attr = False)
    {Out=['composite_tmp_11']} = elementwise_div(inputs={X=['composite_tmp_10'], Y=['composite_tmp_4']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_12']} = sqrt(inputs={X=['composite_tmp_11']}, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_13']} = elementwise_mul(inputs={X=['composite_tmp_7'], Y=['composite_tmp_12']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_14']} = elementwise_mul(inputs={X=['composite_tmp_13'], Y=['composite_tmp_2']}, axis = -1, op_device = , op_namescope = , op_role = 1, op_role_var = [], with_quant_attr = False)
    {Out=['composite_tmp_15']} = reduce_sum(inputs={X=['composite_tmp_14']}, dim = [0], in_dtype = -1, keep_dim = True, op_device = , op_namescope = , op_role = 1, op_role_var = [], out_dtype = 5, reduce_all = False, with_quant_attr = False)
    {Out=['layer_norm_0.w_0@GRAD']} = reshape2(inputs={X=['composite_tmp_15']}, mkldnn_data_type = float32, op_device = , op_namescope = , op_role = 1, op_role_var = [], shape = [1000000], use_mkldnn = False, use_quantizer = False, with_quant_attr = False)
}
```