### PR TITLE
[CodeStyle] fix c++17-extensions warning on macos

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -220,7 +220,8 @@ if(APPLE)
       -Werror=uninitialized
       -Werror=tautological-constant-out-of-range-compare
       -Werror=literal-conversion
-      -Werror=pragma-pack)
+      -Werror=pragma-pack
+      -Werror=c++17-extensions)
 endif()
 
 if(WITH_HETERPS AND WITH_PSLIB)

--- a/paddle/phi/kernels/cpu/viterbi_decode_kernel.cc
+++ b/paddle/phi/kernels/cpu/viterbi_decode_kernel.cc
@@ -109,7 +109,7 @@ struct Gather {
 };
 
 template <typename Context,
-          template <typename InT, typename OutT>
+          template <class InT, class OutT>
           typename CompareFunctor,
           typename T>
 struct GetMask {
@@ -123,7 +123,7 @@ struct GetMask {
 };
 
 template <typename Context,
-          template <typename T>
+          template <class T>
           typename BinaryFunctor,
           typename T>
 struct BinaryOperation {

--- a/paddle/phi/kernels/cpu/viterbi_decode_kernel.cc
+++ b/paddle/phi/kernels/cpu/viterbi_decode_kernel.cc
@@ -109,8 +109,8 @@ struct Gather {
 };
 
 template <typename Context,
-          template <class InT, class OutT>
-          typename CompareFunctor,
+          template <typename InT, typename OutT>
+          class CompareFunctor,
           typename T>
 struct GetMask {
   void operator()(const Context& dev_ctx,
@@ -123,8 +123,8 @@ struct GetMask {
 };
 
 template <typename Context,
-          template <class T>
-          typename BinaryFunctor,
+          template <typename T>
+          class BinaryFunctor,
           typename T>
 struct BinaryOperation {
   void operator()(const Context& dev_ctx,

--- a/paddle/phi/kernels/strings/strings_lower_upper_kernel.h
+++ b/paddle/phi/kernels/strings/strings_lower_upper_kernel.h
@@ -93,7 +93,7 @@ struct AsciiCaseConverter {
 };
 
 template <typename DeviceContext,
-          template <typename DeviceContextT>
+          template <class DeviceContextT>
           typename CharConverter>
 struct UTF8CaseConverter {
   void operator()(const DeviceContext& dev_ctx,

--- a/paddle/phi/kernels/strings/strings_lower_upper_kernel.h
+++ b/paddle/phi/kernels/strings/strings_lower_upper_kernel.h
@@ -93,8 +93,8 @@ struct AsciiCaseConverter {
 };
 
 template <typename DeviceContext,
-          template <class DeviceContextT>
-          typename CharConverter>
+          template <typename DeviceContextT>
+          class CharConverter>
 struct UTF8CaseConverter {
   void operator()(const DeviceContext& dev_ctx,
                   const pstring* in,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
### PR changes
Others

### Describe
<!-- Describe what this PR does -->

- https://github.com/PaddlePaddle/Paddle/issues/47143

before

```shell
(base) ➜ cat before.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
   6 [-Wtautological-undefined-compare]
   4 [-Wc++17-extensions]
   2 [-Wunknown-warning-option]
   2 [-Wexceptions]
   1 [-Wreturn-type-c-linkage]

```

after 

```shell
(base) ➜ cat build.log | grep "\[\-W" |grep -v party | awk '{print $NF}'|sort|uniq -c|sort -nr
   6 [-Wtautological-undefined-compare]
   2 [-Wexceptions]
   1 [-Wreturn-type-c-linkage]
```
