### PR TITLE
[Paddle Inference] ir_params_sync_pass memory released

### DIFF
--- a/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.cc
@@ -232,6 +232,7 @@ void IrParamsSyncAmongDevicesPass::RunImpl(Argument *argument) {
     CopyParamsToCustomDevice(argument);
   }
 #endif
+  paddle::memory::Release(platform::CPUPlace());
 }
 
 std::string IrParamsSyncAmongDevicesPass::repr() const {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
ir_params_sync_pass memory released