### PR TITLE
[Inference] memory_optimize and mkdlnn  problem

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -948,8 +948,18 @@ void AnalysisConfig::Update() {
 #endif
   }
 
+  // TODO(inference): When we enable memory_optimize and mkldnn, PaddleSeg model
+  // fail.
   if (enable_memory_optim_) {
-    pass_builder()->AppendAnalysisPass("memory_optimize_pass");
+    if (use_mkldnn_) {
+      enable_memory_optim_ = false;
+      LOG_FIRST_N(WARNING, 1)
+          << "It is detected that mkldnn and memory_optimize_pass are enabled "
+             "at the same time, but they are not supported yet. Currently, "
+             "memory_optimize_pass is explicitly disabled"
+    } else {
+      pass_builder()->AppendAnalysisPass("memory_optimize_pass");
+    }
   }
 
   if (use_lite_) {

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -951,6 +951,7 @@ void AnalysisConfig::Update() {
   // TODO(inference): When we enable memory_optimize and mkldnn, PaddleSeg model
   // fail.
   if (enable_memory_optim_) {
+#ifdef PADDLE_WITH_MKLDNN
     if (use_mkldnn_) {
       enable_memory_optim_ = false;
       LOG_FIRST_N(WARNING, 1)
@@ -960,6 +961,9 @@ void AnalysisConfig::Update() {
     } else {
       pass_builder()->AppendAnalysisPass("memory_optimize_pass");
     }
+#else
+    pass_builder()->AppendAnalysisPass("memory_optimize_pass");
+#endif
   }
 
   if (use_lite_) {

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -957,7 +957,7 @@ void AnalysisConfig::Update() {
       LOG_FIRST_N(WARNING, 1)
           << "It is detected that mkldnn and memory_optimize_pass are enabled "
              "at the same time, but they are not supported yet. Currently, "
-             "memory_optimize_pass is explicitly disabled"
+             "memory_optimize_pass is explicitly disabled";
     } else {
       pass_builder()->AppendAnalysisPass("memory_optimize_pass");
     }

--- a/paddle/fluid/inference/tests/api/analyzer_capi_exp_pd_config_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_exp_pd_config_tester.cc
@@ -55,6 +55,10 @@ TEST(PD_Config, interface) {
   bool ir_optim = PD_ConfigIrOptim(config);
   EXPECT_TRUE(ir_optim);
 
+  PD_ConfigEnableMemoryOptim(config, true);
+  bool memory_enabled = PD_ConfigMemoryOptimEnabled(config);
+  EXPECT_TRUE(memory_enabled);
+
 #ifndef PADDLE_WITH_LITE
   PD_ConfigEnableLiteEngine(
       config, PD_PRECISION_FLOAT32, TRUE, 0, nullptr, 0, nullptr);
@@ -94,10 +98,6 @@ TEST(PD_Config, interface) {
   bool onnxruntime_disabled = PD_ConfigONNXRuntimeEnabled(config);
   EXPECT_FALSE(onnxruntime_disabled);
   PD_ConfigEnableORTOptimization(config);
-
-  PD_ConfigEnableMemoryOptim(config, true);
-  bool memory_enabled = PD_ConfigMemoryOptimEnabled(config);
-  EXPECT_TRUE(memory_enabled);
 
   PD_ConfigEnableProfile(config);
   bool profile_enabled = PD_ConfigProfileEnabled(config);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

With mkldnn and memory_optimize_pass enabled at the same time, the PaddleSeg model will fail.

Fall back to the implementation logic of the past https://github.com/PaddlePaddle/Paddle/pull/48852