### PR TITLE
Fix ONEDNN squeeze kernel when Xshape does not exist

### DIFF
--- a/paddle/phi/kernels/onednn/squeeze_kernel.cc
+++ b/paddle/phi/kernels/onednn/squeeze_kernel.cc
@@ -68,6 +68,9 @@ void SqueezeWithXShapeKernel(const Context& dev_ctx,
                              const IntArray& axes,
                              DenseTensor* out,
                              DenseTensor* xshape) {
+  if (xshape == nullptr) {
+    return SqueezeKernel<T, Context>(dev_ctx, x, axes, out);
+  }
   auto x_dims = slice_ddim(xshape->dims(), 1, xshape->dims().size());
   auto out_dims = out->dims();
   ExecuteSqueeze<T, Context>(dev_ctx, x, x_dims, out_dims, out);

--- a/paddle/phi/kernels/onednn/squeeze_kernel.cc
+++ b/paddle/phi/kernels/onednn/squeeze_kernel.cc
@@ -69,11 +69,12 @@ void SqueezeWithXShapeKernel(const Context& dev_ctx,
                              DenseTensor* out,
                              DenseTensor* xshape) {
   if (xshape == nullptr) {
-    return SqueezeKernel<T, Context>(dev_ctx, x, axes, out);
+    SqueezeKernel<T, Context>(dev_ctx, x, axes, out);
+  } else {
+    auto x_dims = slice_ddim(xshape->dims(), 1, xshape->dims().size());
+    auto out_dims = out->dims();
+    ExecuteSqueeze<T, Context>(dev_ctx, x, x_dims, out_dims, out);
   }
-  auto x_dims = slice_ddim(xshape->dims(), 1, xshape->dims().size());
-  auto out_dims = out->dims();
-  ExecuteSqueeze<T, Context>(dev_ctx, x, x_dims, out_dims, out);
 }
 }  // namespace phi
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_squeeze2_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_squeeze2_mkldnn_op.py
@@ -111,6 +111,16 @@ class TestSqueeze2OneDNNOp3(TestSqueeze2OneDNNOp):
         self.new_shape = (25, 1, 4)
 
 
+class TestSqueeze2OneDNNOp4(TestSqueeze2OneDNNOp):
+    def set_outputs(self):
+        self.outputs = {"Out": self.x.reshape(self.new_shape)}
+
+    def init_test_case(self):
+        self.ori_shape = (25, 1, 1, 4, 1)
+        self.axes = (1, -1)
+        self.new_shape = (25, 1, 4)
+
+
 class TestSqueezeOneDNNOp3(TestSqueezeOneDNNOp):
     def init_test_case(self):
         self.ori_shape = (25, 1, 1, 4, 1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix ONEDNN squeeze kernel when Xshape does not exist