### PR TITLE
SetDeviceId in StreamSafeCUDAAllocation

### DIFF
--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
@@ -16,6 +16,7 @@
 #include <thread>
 
 #include "paddle/fluid/platform/profiler/event_tracing.h"
+#include "paddle/phi/backends/gpu/gpu_info.h"
 
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/fluid/platform/device/gpu/cuda/cuda_graph.h"
@@ -43,6 +44,9 @@ void StreamSafeCUDAAllocation::RecordStream(gpuStream_t stream) {
     return;
   }
 
+  std::call_once(once_flag_,
+                 [this] { phi::backends::gpu::SetDeviceId(place_.device); });
+
   std::lock_guard<SpinLock> lock_guard(outstanding_event_map_lock_);
 #ifdef PADDLE_WITH_CUDA
   if (UNLIKELY(platform::CUDAGraph::IsThisThreadCapturing())) {
@@ -62,6 +66,9 @@ bool StreamSafeCUDAAllocation::CanBeFreed() {
            outstanding_event_map_.empty();
   }
 #endif
+
+  std::call_once(once_flag_,
+                 [this] { phi::backends::gpu::SetDeviceId(place_.device); });
 
   RecordGraphCapturingStreams();
 
@@ -258,6 +265,8 @@ uint64_t StreamSafeCUDAAllocator::ProcessUnfreedAllocationsAndRelease() {
   ProcessUnfreedAllocations();
   return underlying_allocator_->Release(place_);
 }
+
+std::once_flag StreamSafeCUDAAllocation::once_flag_;
 
 std::map<platform::Place, std::vector<StreamSafeCUDAAllocator*>>
     StreamSafeCUDAAllocator::allocator_map_;

--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
@@ -45,6 +45,7 @@ class StreamSafeCUDAAllocation : public Allocation {
   gpuStream_t GetOwningStream() const;
 
  private:
+  static std::once_flag once_flag_;
   void RecordGraphCapturingStreams();
   void RecordStreamWithNoGraphCapturing(gpuStream_t stream);
   DecoratedAllocationPtr underlying_allocation_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
`StreamSafeCUDAAllocation` utilizes `cudaEvent` to achieve cross-stream synchronization. If the `SetDeviceId` is not called, the default `cudaDeviceId` will be 0, and all event-releated API calls are launched to gpu-0. 
This leads to an error in ResNet50_bs256_fp32 N1C8 static-graph training.  In this case, a cross-stream Allocation records events in a thread (the `DeviceThread` of the standalone executor) and queries events in another (the data loader thread).  Since data loader thread never call `SetDeviceId`, it launches event queries to gpu-0 even though the process is not trained in gpu-0 (and thus the events are not created and recorded for gpu-0). Then a CUDA error occurs: 

![ac2ac4b70a76479774a0e983517d0e1b](https://user-images.githubusercontent.com/17673696/207588912-99610d7d-8b24-4928-a686-5a6cebd510fa.jpg)

This PR fixes it by calling `SetDeviceID` before event-releated API call in `StreamSafeCUDAAllocation`.
 