### PR TITLE
Fix bilinear interp fp16 diff

### DIFF
--- a/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/interpolate_grad_kernel.cu
@@ -251,7 +251,8 @@ __global__ void KeBilinearInterpBwShareMemory(T* in,
                                               float ratio_w,
                                               const float align_type_value,
                                               bool is_nchw) {
-  __shared__ T s_data[2][1024];
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
+  __shared__ MT s_data[2][1024];
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   int stride = blockDim.x * gridDim.x;
   int in_chw = in_h * in_w * num_channels;
@@ -263,18 +264,18 @@ __global__ void KeBilinearInterpBwShareMemory(T* in,
     int out_id_w = tid % out_chw;
     const int in_img_size = in_h * in_w;
     const int out_img_size = out_h * out_w;
-    T value = out[out_id_h * out_chw + out_id_w];
+    MT value = static_cast<MT>(out[out_id_h * out_chw + out_id_w]);
 
     int channel_id = out_id_w / out_img_size;
     int out_img_idy = (out_id_w % out_img_size) / out_w;
     int out_img_idx = tid % out_w;
 
     int in_img_idx, in_img_idy, w_id, h_id;
-    T w1lambda, h1lambda, w2lambda, h2lambda;
-    T src_w = static_cast<T>(ratio_w * (out_img_idx + align_type_value) -
-                             align_type_value);
-    T src_h = static_cast<T>(ratio_h * (out_img_idy + align_type_value) -
-                             align_type_value);
+    MT w1lambda, h1lambda, w2lambda, h2lambda;
+    MT src_w = static_cast<MT>(ratio_w * (out_img_idx + align_type_value) -
+                               align_type_value);
+    MT src_h = static_cast<MT>(ratio_h * (out_img_idy + align_type_value) -
+                               align_type_value);
 
     PreCalculatorForLinearInterpInputIndex(
         &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_w);
@@ -289,8 +290,8 @@ __global__ void KeBilinearInterpBwShareMemory(T* in,
     int bot_right_index = input_index + h_id * in_w + w_id;
     int in_top_min_index, in_bot_min_index;
 
-    s_data[0][threadIdx.x] = static_cast<T>(0);
-    s_data[1][threadIdx.x] = static_cast<T>(0);
+    s_data[0][threadIdx.x] = static_cast<MT>(0);
+    s_data[1][threadIdx.x] = static_cast<MT>(0);
     int remain = nthreads - (tid & (-blockDim.x));
     int in_top_max_index =
         phi::funcs::blockReduceMax(top_right_index, FINAL_MASK);
@@ -327,9 +328,9 @@ __global__ void KeBilinearInterpBwShareMemory(T* in,
 
     if (threadIdx.x <= upper_limit_share_idx) {
       phi::CudaAtomicAdd(&in[in_top_min_index + threadIdx.x],
-                         s_data[0][threadIdx.x]);
+                         static_cast<T>(s_data[0][threadIdx.x]));
       phi::CudaAtomicAdd(&in[in_bot_min_index + threadIdx.x],
-                         s_data[1][threadIdx.x]);
+                         static_cast<T>(s_data[1][threadIdx.x]));
     }
   }
 }
@@ -358,6 +359,7 @@ __global__ void KeBilinearInterpNCHWBw(T* in,
   int stride = blockDim.x * gridDim.x;
   int num_out = n * num_channels * out_h * out_w;
   int num_in = n * num_channels * in_h * in_w;
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
 
   for (; index < num_out; index += stride) {
     int index_tmp = index;
@@ -367,29 +369,29 @@ __global__ void KeBilinearInterpNCHWBw(T* in,
     int nc = index_tmp / out_h;
 
     int h1, y_id;
-    T h1lambda, h0lambda;
-    T src_y =
-        static_cast<T>(ratio_h * (h2 + align_type_value) - align_type_value);
+    MT h1lambda, h0lambda;
+    MT src_y =
+        static_cast<MT>(ratio_h * (h2 + align_type_value) - align_type_value);
 
     PreCalculatorForLinearInterpInputIndex(
         &h1, &y_id, &h1lambda, &h0lambda, src_y, in_h);
     int w1, x_id;
-    T w1lambda, w0lambda;
-    T src_x =
-        static_cast<T>(ratio_w * (w2 + align_type_value) - align_type_value);
+    MT w1lambda, w0lambda;
+    MT src_x =
+        static_cast<MT>(ratio_w * (w2 + align_type_value) - align_type_value);
     PreCalculatorForLinearInterpInputIndex(
         &w1, &x_id, &w1lambda, &w0lambda, src_x, in_w);
 
-    T d2val = out[index];
+    MT d2val = static_cast<MT>(out[index]);
 
     phi::CudaAtomicAdd(in + GetInputIndex(nc, in_h, in_w, h1, w1),
-                       h0lambda * w0lambda * d2val);
+                       static_cast<T>(h0lambda * w0lambda * d2val));
     phi::CudaAtomicAdd(in + GetInputIndex(nc, in_h, in_w, h1, w1 + x_id),
-                       h0lambda * w1lambda * d2val);
+                       static_cast<T>(h0lambda * w1lambda * d2val));
     phi::CudaAtomicAdd(in + GetInputIndex(nc, in_h, in_w, h1 + y_id, w1),
-                       h1lambda * w0lambda * d2val);
+                       static_cast<T>(h1lambda * w0lambda * d2val));
     phi::CudaAtomicAdd(in + GetInputIndex(nc, in_h, in_w, h1 + y_id, w1 + x_id),
-                       h1lambda * w1lambda * d2val);
+                       static_cast<T>(h1lambda * w1lambda * d2val));
   }
 }
 
@@ -411,6 +413,7 @@ __global__ void KeBilinearInterpBw(T* in,
   int stride = blockDim.x * gridDim.x;
   int in_chw = in_h * in_w * num_channels;
   int nthreads = n * out_chw;
+  using MT = typename phi::dtype::MPTypeTrait<T>::Type;
 
   for (; tid < nthreads; tid += stride) {
     auto out_id_divmod = divmods.output_w_div.Divmod(tid);
@@ -424,28 +427,28 @@ __global__ void KeBilinearInterpBw(T* in,
         divmods.channels_div.Divmod(outimg_id_divmod.val[1]).val[0];
 
     int in_img_idx, in_img_idy, w_id, h_id;
-    T w1lambda, h1lambda, w2lambda, h2lambda;
-    T src_w = static_cast<T>(ratio_w * (out_img_idx + align_type_value) -
-                             align_type_value);
-    T src_h = static_cast<T>(ratio_h * (out_img_idy + align_type_value) -
-                             align_type_value);
+    MT w1lambda, h1lambda, w2lambda, h2lambda;
+    MT src_w = static_cast<MT>(ratio_w * (out_img_idx + align_type_value) -
+                               align_type_value);
+    MT src_h = static_cast<MT>(ratio_h * (out_img_idy + align_type_value) -
+                               align_type_value);
 
     PreCalculatorForLinearInterpInputIndex(
         &in_img_idx, &w_id, &w1lambda, &w2lambda, src_w, in_w);
     PreCalculatorForLinearInterpInputIndex(
         &in_img_idy, &h_id, &h1lambda, &h2lambda, src_h, in_h);
 
-    T value = out[tid];
+    MT value = static_cast<MT>(out[tid]);
     T* in_pos = &in[out_id_h * in_chw + in_img_idy * in_w * num_channels +
                     in_img_idx * num_channels + channel_id];
-    phi::CudaAtomicAdd(&in_pos[0], h2lambda * w2lambda * value);
+    phi::CudaAtomicAdd(&in_pos[0], static_cast<T>(h2lambda * w2lambda * value));
     phi::CudaAtomicAdd(&in_pos[w_id * num_channels],
-                       h2lambda * w1lambda * value);
+                       static_cast<T>(h2lambda * w1lambda * value));
     phi::CudaAtomicAdd(&in_pos[h_id * in_w * num_channels],
-                       h1lambda * w2lambda * value);
+                       static_cast<T>(h1lambda * w2lambda * value));
     phi::CudaAtomicAdd(
         &in_pos[h_id * in_w * num_channels + w_id * num_channels],
-        h1lambda * w1lambda * value);
+        static_cast<T>(h1lambda * w1lambda * value));
   }
 }
 

--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_v2_op.py
@@ -733,7 +733,7 @@ class TestBilinearInterpOpAPI_dy4(unittest.TestCase):
 @unittest.skipIf(
     not fluid.core.is_compiled_with_cuda(), "core is not compiled with CUDA"
 )
-class TestBilinearInterpOpForFloat16(unittest.TestCase):
+class TestBilinearInterpOpZoomOutForFloat16(unittest.TestCase):
     def init_test_case(self):
         self.interp_method = 'bilinear'
         self.input_shape = [2, 3, 5, 5]
@@ -768,8 +768,52 @@ class TestBilinearInterpOpForFloat16(unittest.TestCase):
         y_np_1, x_g_np_1 = self.check_main(x_np, 'float16')
         y_np_2, x_g_np_2 = self.check_main(x_np, 'float32')
 
-        np.testing.assert_allclose(y_np_1, y_np_2)
-        np.testing.assert_allclose(x_g_np_1, x_g_np_2)
+        np.testing.assert_allclose(y_np_1, y_np_2, atol=1e-3, rtol=1e-3)
+        # Since atomicAdd half will bring some diff, here we relax tolerance to 1e-2.
+        np.testing.assert_allclose(x_g_np_1, x_g_np_2, atol=1e-2, rtol=1e-2)
+
+
+@unittest.skipIf(
+    not fluid.core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
+class TestBilinearInterpOpZoomInForFloat16(unittest.TestCase):
+    def init_test_case(self):
+        self.interp_method = 'bilinear'
+        self.input_shape = [2, 3, 5, 5]
+        self.out_size = np.array([10, 10]).astype("int32")
+        self.align_corners = True
+        self.align_mode = 1
+        self.data_layout = 'NCHW'
+
+    def check_main(self, x_np, dtype):
+        paddle.disable_static()
+        x_np = x_np.astype(dtype)
+        x = paddle.to_tensor(x_np)
+        x.stop_gradient = False
+        y = interpolate(
+            x,
+            size=self.out_size.tolist(),
+            mode=self.interp_method,
+            align_mode=self.align_mode,
+            align_corners=self.align_corners,
+            data_format=self.data_layout,
+        )
+        x_g = paddle.grad(y, x)
+        y_np = y[0].numpy().astype('float32')
+        x_g_np = x_g[0].numpy().astype('float32')
+        paddle.enable_static()
+        return y_np, x_g_np
+
+    def test_main(self):
+        self.init_test_case()
+        x_np = np.random.random(self.input_shape).astype("float16")
+
+        y_np_1, x_g_np_1 = self.check_main(x_np, 'float16')
+        y_np_2, x_g_np_2 = self.check_main(x_np, 'float32')
+
+        np.testing.assert_allclose(y_np_1, y_np_2, atol=1e-3, rtol=1e-3)
+        # Since atomicAdd half will bring some diff, here we relax tolerance to 1e-2.
+        np.testing.assert_allclose(x_g_np_1, x_g_np_2, atol=1e-2, rtol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
业务反馈Paddle inference原生GPU推理当bilinear进fp16下，diff比较大。

原因是kernel内部存在累加操作，而对于这种累加操作我们需要cast到更高精度（float）来做，最后再static_cast<T>存储回去，下面是测试：

![image](https://user-images.githubusercontent.com/42901638/207778802-20537b90-dd55-442c-a9f7-e044b53a4d3e.png)
第一行结果是原生GPU fp32和fp16的diff
第二行结果是原生GPU fp32 和 FP16（但是禁止bilinear进fp16）的diff
第三行结果是原生GPU fp32 和 当前PR修复bilinear后的diff

backward部分：
原来的写法，在业务提供的case 600 * 1008 -> 1200 * 2016 下，atol=1e-3 rtol=1e-3是过不去的
<img width="834" alt="image" src="https://user-images.githubusercontent.com/42901638/207787845-20236380-553a-4e1d-846f-151b2abfc1a2.png">

修复后backward部分在1e-3依旧过不了，但是diff明显能降低，下面是`np.max(np.abs(fp32_grad) - (fp16_grad))`的diff。从1.619降低到0.01037（随机生成的输入固定了seed）

<img width="692" alt="image" src="https://user-images.githubusercontent.com/42901638/207794200-eaf6dc4b-2ec5-4f76-9b7a-e5f1a4589075.png">

重命名单测分别是ZoomIn，ZoomOut。分别表示放大，缩小两个操作。
在单测里，对于backward的tolerance放松到1e-2
