### PR TITLE
Set once_flag to thread_local for StreamSafeCUDAAllocation

### DIFF
--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.cc
@@ -266,7 +266,7 @@ uint64_t StreamSafeCUDAAllocator::ProcessUnfreedAllocationsAndRelease() {
   return underlying_allocator_->Release(place_);
 }
 
-std::once_flag StreamSafeCUDAAllocation::once_flag_;
+thread_local std::once_flag StreamSafeCUDAAllocation::once_flag_;
 
 std::map<platform::Place, std::vector<StreamSafeCUDAAllocator*>>
     StreamSafeCUDAAllocator::allocator_map_;

--- a/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
+++ b/paddle/fluid/memory/allocation/stream_safe_cuda_allocator.h
@@ -45,7 +45,7 @@ class StreamSafeCUDAAllocation : public Allocation {
   gpuStream_t GetOwningStream() const;
 
  private:
-  static std::once_flag once_flag_;
+  thread_local static std::once_flag once_flag_;
   void RecordGraphCapturingStreams();
   void RecordStreamWithNoGraphCapturing(gpuStream_t stream);
   DecoratedAllocationPtr underlying_allocation_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
In `StreamSafeCUDAAllocation`, set `once_flag` to `thread_local`, or it can not fix the errors mentioned in PR https://github.com/PaddlePaddle/Paddle/pull/49080