### PR TITLE
[Simplify interpreter] Remove expected_kernel_key in interpreter

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/data_transfer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/data_transfer.cc
@@ -132,15 +132,6 @@ void DataTranferHelper::RunAndConstructOpFuncNode(
   platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(place_);
   auto exec_ctx = ExecutionContext(*op, Scope(), *dev_ctx, runtime_context);
-  auto expected_kernel_key = op_with_kernel->GetExpectedKernelType(exec_ctx);
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-  if (op_with_kernel->CanCUDNNBeUsed(exec_ctx,
-                                     expected_kernel_key.data_type_)) {
-    expected_kernel_key.library_type_ = framework::LibraryType::kCUDNN;
-  }
-#endif
-
-  VLOG(6) << "expected_kernel_key " << expected_kernel_key << "\n";
   VLOG(6) << "op_with_kernel Type() " << op_with_kernel->Type() << "\n";
 
   bool run_phi_kernel = false;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
Remove `expected_kernel_key` in `data_transfer.cc (line135)`, because this variable has not been used.
