### PR TITLE
Revert "[zero-dim] Support 0-d for kthvalue and mode"

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -1751,15 +1751,13 @@ void KthvalueInferMeta(const MetaTensor& x,
                         dim_size,
                         dim_size,
                         axis));
-  if (dim_size > 0) {
-    PADDLE_ENFORCE_GE(axis,
-                      -dim_size,
-                      phi::errors::InvalidArgument(
-                          "the axis must be [-%d, %d), but received %d .",
-                          dim_size,
-                          dim_size,
-                          axis));
-  }
+  PADDLE_ENFORCE_GE(axis,
+                    -dim_size,
+                    phi::errors::InvalidArgument(
+                        "the axis must be [-%d, %d), but received %d .",
+                        dim_size,
+                        dim_size,
+                        axis));
   if (axis < 0) axis += dim_size;
   PADDLE_ENFORCE_GE(
       k,
@@ -1768,8 +1766,8 @@ void KthvalueInferMeta(const MetaTensor& x,
           "the k in the kthvalue must >= 1, but received %d .", k));
   PADDLE_ENFORCE_GE(
       input_dims.size(),
-      0,
-      phi::errors::InvalidArgument("input of kthvalue must have >= 0d shape"));
+      1,
+      phi::errors::InvalidArgument("input of kthvalue must have >= 1d shape"));
   if (config.is_runtime) {
     PADDLE_ENFORCE_GE(
         input_dims[axis],
@@ -1783,7 +1781,7 @@ void KthvalueInferMeta(const MetaTensor& x,
   for (int64_t i = 0; i < axis; i++) {
     dimvec.emplace_back(input_dims[i]);
   }
-  if (keepdim && dim_size > 0) {
+  if (keepdim) {
     dimvec.emplace_back(static_cast<int64_t>(1));
   }
   for (int64_t i = axis + 1; i < dim_size; i++) {
@@ -2032,38 +2030,33 @@ void ModeInferMeta(const MetaTensor& x,
                    MetaTensor* indices) {
   auto input_dims = x.dims();
   const int& dim_size = input_dims.size();
-  PADDLE_ENFORCE_LT(axis,
-                    dim_size,
-                    phi::errors::InvalidArgument(
-                        "the axis must be [-%d, %d), but received %d .",
-                        dim_size,
-                        dim_size,
-                        axis));
-  if (dim_size > 0) {
-    PADDLE_ENFORCE_GE(axis,
-                      -dim_size,
-                      phi::errors::InvalidArgument(
-                          "the axis must be [-%d, %d), but received %d .",
-                          dim_size,
-                          dim_size,
-                          axis));
-  }
+  PADDLE_ENFORCE_EQ(
+      (axis < dim_size) && (axis >= (-1 * dim_size)),
+      true,
+      errors::InvalidArgument(
+          "the axis of ModeOp must be [-%d, %d), but you set axis is %d",
+          dim_size,
+          dim_size,
+          axis));
   PADDLE_ENFORCE_GE(
       input_dims.size(),
-      0,
-      errors::InvalidArgument("input of ModeOp must have >= 0d shape"));
+      1,
+      errors::InvalidArgument("input of ModeOp must have >= 1d shape"));
   if (axis < 0) axis += dim_size;
   std::vector<int64_t> dimvec;
   for (int64_t i = 0; i < axis; i++) {
     dimvec.emplace_back(input_dims[i]);
   }
-  if (keepdim && dim_size > 0) {
+  if (keepdim) {
     dimvec.emplace_back(static_cast<int64_t>(1));
   }
   for (int64_t i = axis + 1; i < dim_size; i++) {
     dimvec.emplace_back(input_dims[i]);
   }
   DDim dims = phi::make_ddim(dimvec);
+  PADDLE_ENFORCE_GE(input_dims.size(),
+                    1,
+                    errors::InvalidArgument("input shape should >= 1d"));
   out->set_dims(dims);
   out->share_lod(x);
   out->set_dtype(x.dtype());

--- a/paddle/phi/kernels/cpu/kthvalue_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/kthvalue_grad_kernel.cc
@@ -55,14 +55,6 @@ void KthvalueGradKernel(const Context& dev_ctx,
                         DenseTensor* d_x) {
   auto in_dims = x.dims();
   auto out_dims = indices.dims();
-  T* x_grad_data = dev_ctx.template Alloc<T>(d_x);
-
-  // For 0D Tensor
-  if (in_dims.size() == 0) {
-    phi::funcs::set_constant(dev_ctx, d_x, 1.0);
-    return;
-  }
-
   axis = (axis < 0) ? (in_dims.size() + axis) : axis;
   if (!keepdim) {
     std::vector<int> tmp_out_shape;
@@ -75,7 +67,7 @@ void KthvalueGradKernel(const Context& dev_ctx,
     }
     out_dims = phi::make_ddim(tmp_out_shape);
   }
-
+  T* x_grad_data = dev_ctx.template Alloc<T>(d_x);
   if (axis == in_dims.size() - 1) {
     const int64_t input_height =
         phi::product(phi::slice_ddim(in_dims, 0, in_dims.size() - 1));

--- a/paddle/phi/kernels/cpu/kthvalue_kernel.cc
+++ b/paddle/phi/kernels/cpu/kthvalue_kernel.cc
@@ -82,22 +82,8 @@ void KthvalueKernel(const Context& dev_ctx,
                     DenseTensor* indices) {
   const auto& in_dims = x.dims();
   if (axis < 0) axis += in_dims.size();
-
   T* output_data = dev_ctx.template Alloc<T>(output);
   int64_t* indices_data = dev_ctx.template Alloc<int64_t>(indices);
-  // For 0D Tensor
-  if (in_dims.size() == 0) {
-    PADDLE_ENFORCE_EQ(k,
-                      1,
-                      phi::errors::InvalidArgument(
-                          "the k in the kthvalue must less equal than the "
-                          "elemenents number of the input X, but received %d .",
-                          k));
-
-    phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, output);
-    phi::funcs::set_constant(dev_ctx, indices, 0);
-    return;
-  }
   auto out_dims = output->dims();
   if (axis == in_dims.size() - 1) {
     const int64_t& input_height =

--- a/paddle/phi/kernels/cpu/mode_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/mode_grad_kernel.cc
@@ -17,7 +17,6 @@
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/mode.h"
 
 namespace phi {
@@ -33,16 +32,8 @@ void ModeGradKernel(const Context& dev_ctx,
   auto in_dims = x.dims();
   auto out_dims = indices.dims();
 
-  T* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
-
   // axis < 0, get the real axis
   axis = (axis < 0) ? (in_dims.size() + axis) : axis;
-
-  // For 0D Tensor
-  if (in_dims.size() == 0) {
-    phi::funcs::set_constant(dev_ctx, x_grad, 1.0);
-    return;
-  }
 
   if (!keepdim) {
     std::vector<int> tmp_out_shape;
@@ -55,6 +46,7 @@ void ModeGradKernel(const Context& dev_ctx,
     }
     out_dims = phi::make_ddim(tmp_out_shape);
   }
+  T* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
 
   if (axis == in_dims.size() - 1) {
     // allocate the memory for the input_grad

--- a/paddle/phi/kernels/cpu/mode_kernel.cc
+++ b/paddle/phi/kernels/cpu/mode_kernel.cc
@@ -16,7 +16,6 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/mode.h"
 
 namespace phi {
@@ -35,13 +34,6 @@ void ModeKernel(const Context& dev_ctx,
 
   T* output_data = dev_ctx.template Alloc<T>(out);
   int64_t* indices_data = dev_ctx.template Alloc<int64_t>(indices);
-
-  if (in_dims.size() == 0) {
-    phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, out);
-    phi::funcs::set_constant(dev_ctx, indices, 0);
-    return;
-  }
-
   // if axis is not the last dim, transpose it to the last dim, do the
   // calculation, then tranpose it back to original axis.
   if (axis == in_dims.size() - 1) {

--- a/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_grad_kernel.cu
@@ -16,7 +16,6 @@
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/top_k_function_cuda.h"
 
 namespace phi {
@@ -44,15 +43,8 @@ void KthvalueGradKernel(const Context& dev_ctx,
                         DenseTensor* d_x) {
   const auto& in_dims = x.dims();
   auto out_dims = indices.dims();
-  T* x_grad_data = dev_ctx.template Alloc<T>(d_x);
-  // For 0D Tensor
-  if (in_dims.size() == 0) {
-    phi::funcs::set_constant(dev_ctx, d_x, 1.0);
-    return;
-  }
-
   if (axis < 0) axis += in_dims.size();
-
+  T* x_grad_data = dev_ctx.template Alloc<T>(d_x);
   const T* out_grad_data = d_out.data<T>();
   const int64_t* indices_data = indices.data<int64_t>();
   int pre, n, post;

--- a/paddle/phi/kernels/gpu/kthvalue_kernel.cu
+++ b/paddle/phi/kernels/gpu/kthvalue_kernel.cu
@@ -167,19 +167,6 @@ void KthvalueKernel(const Context& dev_ctx,
   T* output_data = dev_ctx.template Alloc<T>(output);
   int64_t* indices_data = dev_ctx.template Alloc<int64_t>(indices);
 
-  // For 0D Tensor
-  if (in_dims.size() == 0) {
-    PADDLE_ENFORCE_EQ(k,
-                      1,
-                      phi::errors::InvalidArgument(
-                          "the k in the kthvalue must less equal than the "
-                          "elemenents number of the input X, but received %d .",
-                          k));
-
-    phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, output);
-    phi::funcs::set_constant(dev_ctx, indices, 0);
-    return;
-  }
   if (axis == in_dims.size() - 1) {
     const int64_t& input_height =
         phi::product(phi::slice_ddim(in_dims, 0, in_dims.size() - 1));

--- a/paddle/phi/kernels/gpu/mode_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/mode_grad_kernel.cu
@@ -16,7 +16,6 @@
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/mode.h"
 
 namespace phi {
@@ -61,12 +60,6 @@ void ModeGradKernel(const Context& dev_ctx,
   T* x_grad_data = dev_ctx.template Alloc<T>(x_grad);
   const T* out_grad_data = out_grad.data<T>();
   const int64_t* indices_data = indices.data<int64_t>();
-
-  // For 0D Tensor
-  if (in_dims.size() == 0) {
-    phi::funcs::set_constant(dev_ctx, x_grad, 1.0);
-    return;
-  }
 
   int pre, n, post;
   funcs::GetDims(in_dims, axis, &pre, &n, &post);

--- a/paddle/phi/kernels/gpu/mode_kernel.cu
+++ b/paddle/phi/kernels/gpu/mode_kernel.cu
@@ -16,7 +16,6 @@
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/mode.h"
 
 namespace phi {
@@ -38,13 +37,6 @@ void ModeKernel(const Context& dev_ctx,
   const T* input_data = x.data<T>();
   T* output_data = dev_ctx.template Alloc<T>(out);
   int64_t* indices_data = dev_ctx.template Alloc<int64_t>(indices);
-
-  // For 0D Tensor
-  if (in_dims.size() == 0) {
-    phi::Copy<Context>(dev_ctx, x, dev_ctx.GetPlace(), false, out);
-    phi::funcs::set_constant(dev_ctx, indices, 0);
-    return;
-  }
 
   if (axis == in_dims.size() - 1) {
     const int64_t& input_height =

--- a/python/paddle/fluid/tests/unittests/test_kthvalue_op.py
+++ b/python/paddle/fluid/tests/unittests/test_kthvalue_op.py
@@ -177,12 +177,6 @@ class TestKthvalueOpErrors(unittest.TestCase):
 
         self.assertRaises(ValueError, test_dim_range_error)
 
-        def test_k_error_0_dim_input():
-            x_0d = paddle.full([], 1)
-            x_0d.kthvalue(k=8)
-
-        self.assertRaises(ValueError, test_k_error_0_dim_input)
-
 
 class TestModeOpInStatic(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -712,36 +712,6 @@ class TestSundryAPI(unittest.TestCase):
         self.assertEqual(out.numpy()[3], 2)
         self.assertEqual(out.grad.shape, [5])
 
-    def test_kthvalue(self):
-        places = ['cpu']
-        if paddle.is_compiled_with_cuda():
-            places.append('gpu')
-        for place in places:
-            paddle.set_device(place)
-
-            x = paddle.randn(())
-            x.stop_gradient = False
-
-            out = paddle.kthvalue(x, 1)
-            out[0].backward()
-            self.assertEqual(out[0].shape, [])
-            self.assertEqual(out[1].shape, [])
-
-    def test_mode(self):
-        places = ['cpu']
-        if paddle.is_compiled_with_cuda():
-            places.append('gpu')
-        for place in places:
-            paddle.set_device(place)
-
-            x = paddle.randn(())
-            x.stop_gradient = False
-
-            out = paddle.mode(x)
-            out[0].backward()
-            self.assertEqual(out[0].shape, [])
-            self.assertEqual(out[1].shape, [])
-
 
 class TestSundryAPIStatic(unittest.TestCase):
     def setUp(self):
@@ -943,28 +913,6 @@ class TestSundryAPIStatic(unittest.TestCase):
         res = self.exe.run(prog, feed={'index': index_data}, fetch_list=[out])
         self.assertEqual(res[0].shape, (5,))
         self.assertEqual(res[0][3], 2)
-
-    @prog_scope()
-    def test_kthvalue(self):
-        x = paddle.full([], 1, 'float32')
-        out = paddle.kthvalue(x, 1)
-        paddle.static.append_backward(out[0])
-
-        prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out])
-        self.assertEqual(len(res[0].shape), 0)
-        self.assertEqual(len(res[0].shape), 0)
-
-    @prog_scope()
-    def test_mode(self):
-        x = paddle.full([], 1, 'float32')
-        out = paddle.mode(x)
-        paddle.static.append_backward(out[0])
-
-        prog = paddle.static.default_main_program()
-        res = self.exe.run(prog, fetch_list=[out])
-        self.assertEqual(len(res[0].shape), 0)
-        self.assertEqual(len(res[0].shape), 0)
 
 
 # Use to test API whose zero-dim input tensors don't have grad and not need to test backward in OpTest.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Reverts PaddlePaddle/Paddle#49122

The ci-windows-inference will met a unitest error