### PR TITLE
Fix data_ptr method return None bug

### DIFF
--- a/paddle/fluid/pybind/eager_method.cc
+++ b/paddle/fluid/pybind/eager_method.cc
@@ -1896,9 +1896,10 @@ static PyObject* tensor_data_ptr(TensorObject* self,
                                  PyObject* kwargs) {
   EAGER_TRY
   if (self->tensor.initialized() && self->tensor.is_dense_tensor()) {
-    ToPyObject((int64_t)std::dynamic_pointer_cast<phi::DenseTensor>(  // NOLINT
-                   self->tensor.impl())
-                   ->data());
+    return ToPyObject(
+        (int64_t)std::dynamic_pointer_cast<phi::DenseTensor>(  // NOLINT
+            self->tensor.impl())
+            ->data());
   }
   RETURN_PY_NONE
   EAGER_CATCH_AND_THROW_RETURN_NULL

--- a/python/paddle/fluid/tests/unittests/test_tensor_data_ptr.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_data_ptr.py
@@ -25,6 +25,7 @@ class TestTensorDataPtr(unittest.TestCase):
         src = paddle.to_tensor(np_src, dtype="float64")
         dst = paddle.Tensor()
         src._share_buffer_to(dst)
+        self.assertTrue(src.data_ptr() is not None)
         self.assertEqual(src.data_ptr(), dst.data_ptr())
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
Fix `Tensor.data_ptr()` always returns `None` error.