### PR TITLE
move fluid.layers.l2_normalize to nn.functional.normalize

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_normalize.py
+++ b/python/paddle/fluid/tests/unittests/test_normalize.py
@@ -52,7 +52,7 @@ class TestNNFunctionalNormalize(unittest.TestCase):
         y = F.normalize(x, axis=0)
         np.testing.assert_allclose(y.numpy(), self.expected3, rtol=1e-05)
 
-        self.assertRaises(BaseException, F.normalize, x)
+        self.assertRaises(BaseException, F.normalize, x, 1)
 
     def run_static(self, use_gpu=False):
         x = paddle.fluid.data(name='input', shape=[10, 10], dtype='float32')
@@ -76,7 +76,7 @@ class TestNNFunctionalNormalize(unittest.TestCase):
         np.testing.assert_allclose(static_result[2], self.expected2, rtol=1e-05)
         self.assertTrue('aaa' in result3.name)
         np.testing.assert_allclose(static_result[3], self.expected3, rtol=1e-05)
-        self.assertRaises(ValueError, F.normalize, x2)
+        self.assertRaises(ValueError, F.normalize, x2, 1)
 
     def test_cpu(self):
         paddle.disable_static(place=paddle.fluid.CPUPlace())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

https://github.com/PaddlePaddle/Paddle/pull/48274 直接清理掉 `fluid.layers.l2_normalize`

本 PR 主要是将 `l2_normalize` 的功能代码迁入到 `nn.functional.normalize` 中

有两个原因：
（1）`_C_ops.norm` 一个 Op 解决了 norm 值求解，以及归一化除法，速度更快
（2）`_C_ops.norm` 中针对 FP16 做了优化，在求 norm 值（分母）时，使用的是多精度（FP32），因此在Op 内做除法，数值更稳定，在训练期，FP16 O2 模式下更稳健。