### PR TITLE
Replace libpaddle_inference.a with interface lib

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -76,8 +76,9 @@ else()
   # message("${phi_kernels}")
   # message("${STATIC_INFERENCE_API}")
   # message("${utils_modules}")
-  create_static_lib(paddle_inference ${fluid_modules} ${phi_modules}
-                    ${phi_kernels} ${STATIC_INFERENCE_API} ${utils_modules})
+  add_library(paddle_inference INTERFACE)
+  target_link_libraries(paddle_inference INTERFACE ${fluid_moduels} ${phi_modules}
+                      ${phi_kernels} ${STATIC_INFERENCE_API} ${utils_modules})
 endif()
 
 if(NOT APPLE)

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -83,10 +83,10 @@ endif()
 
 if(NOT APPLE)
   # TODO(liuyiqu: Temporarily disable the link flag because it is not support on Mac.
-  set(LINK_FLAGS
+  set(LINK_OPTIONS
       "-Wl,--retain-symbols-file ${CMAKE_CURRENT_SOURCE_DIR}/paddle_inference.sym"
   )
-  set_target_properties(paddle_inference PROPERTIES LINK_FLAGS "${LINK_FLAGS}")
+  set_target_properties(paddle_inference PROPERTIES LINK_OPTIONS "${LINK_OPTIONS}")
 endif()
 
 # C inference API
@@ -157,15 +157,15 @@ set_target_properties(paddle_inference_shared PROPERTIES OUTPUT_NAME
 if(NOT APPLE AND NOT WIN32)
   # TODO(liuyiqun): Temporarily disable the link flag because it is not support on Mac.
   if(WITH_CUSTOM_DEVICE)
-    set(LINK_FLAGS
+    set(LINK_OPTIONS
         "-Wl,--version-script ${CMAKE_CURRENT_SOURCE_DIR}/paddle_inference_custom_device.map"
     )
   else()
-    set(LINK_FLAGS
+    set(LINK_OPTIONS
         "-Wl,--version-script ${CMAKE_CURRENT_SOURCE_DIR}/paddle_inference.map")
   endif()
-  set_target_properties(paddle_inference_shared PROPERTIES LINK_FLAGS
-                                                           "${LINK_FLAGS}")
+  set_target_properties(paddle_inference_shared PROPERTIES LINK_OPTIONS
+                                                           "${LINK_OPTIONS}")
   # check symbol hidden
   file(
     WRITE ${CMAKE_CURRENT_BINARY_DIR}/check_symbol.cmake


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
1. It is an optimization regarding https://github.com/PaddlePaddle/Paddle/issues/49148. We could consider use interface library for libphi_static instead of creating a new static library as an interface
2. Use `LINK_OPTIONS` instead of `LINK_FLAGS`, where it is deprecated in 3.13. reference: https://cmake.org/cmake/help/v3.16/prop_tgt/LINK_FLAGS.html#prop_tgt:LINK_FLAGS