### PR TITLE
[TrtEngine]ResetContext clear profile_num

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -326,6 +326,7 @@ class TensorRTEngine {
     std::unique_lock<std::mutex> lock(mutex_);
     infer_context_[predictor_id_per_thread].reset(nullptr);
     infer_context_.erase(predictor_id_per_thread);
+    cur_profile_num_ = 0;
   }
 
   nvinfer1::IHostMemory* Serialize() {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
ResetContext时，应该把 profile_num 清零；
1.  解决非clone情况下，rebuild时，profile_num的不合理自增；
2. 对clone过程没有影响；
3. 当前不支持clone时，trt engine 的rebuild