### PR TITLE
Enable softmax use fp16 in amp pass

### DIFF
--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -178,7 +178,6 @@ void AutoMixedPrecisionPass::SetDefaultBlacklist() const {
       "rsqrt",
       "sum",
       "cos_sim",
-      "softmax",
       "softmax_with_cross_entropy",
       "sigmoid_cross_entropy_with_logits",
       "c_softmax_with_cross_entropy",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization
### PR changes
Others

### Describe
允许softmax在AMP Inference Pass下使用fp16，经过前后测试发现不影响diff，这样可以消除前后不必要的cast
<img width="529" alt="image" src="https://user-images.githubusercontent.com/42901638/208616191-a46d4db5-b78f-4892-a8a4-9406adeab2e9.png">

PS：softma fp16在trt下有时候有精度问题，后续原生推理也要持续关注
