### PR TITLE
CINN copy float16.h to package libs dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -832,8 +832,13 @@ def get_package_data_and_package_dir():
             + '/cinn/runtime/cuda/cinn_cuda_runtime_source.cuh',
             libs_path,
         )
+        shutil.copy(
+            env_dict.get("CINN_INCLUDE_DIR") + '/cinn/runtime/cuda/float16.h',
+            libs_path,
+        )
         package_data['paddle.libs'] += ['libcinnapi.so']
         package_data['paddle.libs'] += ['cinn_cuda_runtime_source.cuh']
+        package_data['paddle.libs'] += ['float16.h']
         if env_dict.get("CMAKE_BUILD_TYPE") == 'Release' and os.name != 'nt':
             command = (
                 "patchelf --set-rpath '$ORIGIN/' %s/" % libs_path


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
CINN支持float16类型后，自动生成的代码中需要包含float16.h文件，现由于只拷贝了cinn_cuda_runtime_source.cuh文件，导致编译时会报错找不到float16.h文件。