### PR TITLE
Save nan log to file when output_dir is setted

### DIFF
--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -30,6 +30,23 @@ DECLARE_int32(check_nan_inf_level);
 namespace paddle {
 namespace framework {
 namespace details {
+struct DebugTools {
+  DebugTools() {}
+  std::string path = "";
+};
+static DebugTools debug_nan_inf;
+
+void SetNanInfDebugPath(const std::string& nan_inf_path) {
+  debug_nan_inf.path = nan_inf_path;
+  VLOG(4) << "Set the log's path of debug tools : " << nan_inf_path;
+}
+
+std::string GetNanPath() {
+  if (debug_nan_inf.path.empty()) {
+    return "";
+  }
+  return debug_nan_inf.path + "/";
+}
 
 static std::once_flag white_list_init_flag;
 

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -134,112 +134,6 @@ static void InitWhiteListFormEnv() {
   }
 }
 
-template <
-    typename T,
-    std::enable_if_t<!std::is_same<T, phi::dtype::complex<float>>::value &&
-                         !std::is_same<T, phi::dtype::complex<double>>::value,
-                     bool> = true>
-static void CheckNanInfCpuImpl(const T* value_ptr,
-                               const int64_t numel,
-                               const std::string& cpu_hint_str) {
-  using MT = typename phi::dtype::template MPTypeTrait<T>::Type;
-
-#ifdef _OPENMP
-  // Use maximum 4 threads to collect the nan and inf information.
-  int num_threads = std::max(omp_get_num_threads(), 1);
-  num_threads = std::min(num_threads, 4);
-#else
-  int num_threads = 1;
-#endif
-
-  std::vector<int64_t> thread_num_nan(num_threads, 0);
-  std::vector<int64_t> thread_num_inf(num_threads, 0);
-  std::vector<MT> thread_min_value(num_threads, static_cast<MT>(value_ptr[0]));
-  std::vector<MT> thread_max_value(num_threads, static_cast<MT>(value_ptr[0]));
-  std::vector<MT> thread_mean_value(num_threads, static_cast<MT>(0));
-
-#ifdef _OPENMP
-#pragma omp parallel num_threads(num_threads)
-#endif
-  {
-#ifdef _OPENMP
-    int64_t tid = omp_get_thread_num();
-    int64_t chunk_size = (numel + num_threads - 1) / num_threads;
-    int64_t begin = tid * chunk_size;
-    int64_t end = chunk_size + begin > numel ? numel : chunk_size + begin;
-#else
-    int64_t tid = 0;
-    int64_t begin = 0;
-    int64_t end = numel;
-#endif
-    for (int64_t i = begin; i < end; ++i) {
-      MT value = static_cast<MT>(value_ptr[i]);
-
-      thread_min_value[tid] = std::min(thread_min_value[tid], value);
-      thread_max_value[tid] = std::max(thread_max_value[tid], value);
-      thread_mean_value[tid] += value / static_cast<MT>(numel);
-
-      if (std::isnan(value)) {
-        thread_num_nan[tid] += 1;
-      } else if (std::isinf(value)) {
-        thread_num_inf[tid] += 1;
-      }
-    }
-  }
-
-  int64_t num_nan = 0;
-  int64_t num_inf = 0;
-  MT min_value = thread_min_value[0];
-  MT max_value = thread_max_value[0];
-  MT mean_value = static_cast<MT>(0);
-  for (int i = 0; i < num_threads; ++i) {
-    num_nan += thread_num_nan[i];
-    num_inf += thread_num_inf[i];
-    min_value = std::min(thread_min_value[i], min_value);
-    max_value = std::max(thread_max_value[i], max_value);
-    mean_value += thread_mean_value[i];
-  }
-
-  PrintForDifferentLevelFile<T, MT>(cpu_hint_str.c_str(),
-                                    numel,
-                                    num_nan,
-                                    num_inf,
-                                    max_value,
-                                    min_value,
-                                    mean_value,
-                                    FLAGS_check_nan_inf_level);
-}
-
-template <
-    typename T,
-    std::enable_if_t<std::is_same<T, phi::dtype::complex<float>>::value ||
-                         std::is_same<T, phi::dtype::complex<double>>::value,
-                     bool> = true>
-void CheckNanInfCpuImpl(const T* value_ptr,
-                        const int64_t numel,
-                        const std::string& cpu_hint_str) {
-  using RealType = typename T::value_type;
-
-  RealType real_sum = 0.0f, imag_sum = 0.0f;
-
-#ifdef _OPENMP
-#pragma omp parallel for reduction(+ : real_sum) reduction(+ : imag_sum)
-#endif
-  for (int64_t i = 0; i < numel; ++i) {
-    T value = value_ptr[i];
-    real_sum += (value.real - value.real);
-    imag_sum += (value.imag - value.imag);
-  }
-
-  if (std::isnan(real_sum) || std::isinf(real_sum) || std::isnan(imag_sum) ||
-      std::isinf(imag_sum)) {
-    // hot fix for compile failed in gcc4.8
-    // here also need print detail info of nan or inf later
-    PADDLE_THROW(platform::errors::PreconditionNotMet(
-        "There are NAN or INF in %s.", cpu_hint_str));
-  }
-}
-
 template <>
 template <typename T>
 void TensorCheckerVisitor<phi::CPUContext>::apply(
@@ -248,7 +142,8 @@ void TensorCheckerVisitor<phi::CPUContext>::apply(
         std::is_same<T, ::paddle::platform::complex<float>>::value ||
         std::is_same<T, ::paddle::platform::complex<double>>::value>::type*)
     const {
-  std::string cpu_hint_str = GetCpuHintString<T>(op_type, var_name, place, device_id);
+  std::string cpu_hint_str =
+      GetCpuHintString<T>(op_type, var_name, tensor.place());
   CheckNanInfCpuImpl(tensor.data<T>(), tensor.numel(), cpu_hint_str);
 }
 
@@ -259,22 +154,6 @@ void tensor_check<phi::CPUContext>(const std::string& op_type,
                                    const platform::Place& place) {
   TensorCheckerVisitor<phi::CPUContext> vistor(
       op_type, var_name, tensor, place);
-  VisitDataType(framework::TransToProtoVarType(tensor.dtype()), vistor);
-}
-
-template <>
-void tensor_check<phi::GPUContext>(const std::string& op_type,
-                                   const std::string& var_name,
-                                   const phi::DenseTensor& tensor,
-                                   const platform::Place& place) {
-  std::call_once(init_multi_gpu_op_var_map_flag, InitMultiGPUOpVarMap);
-  phi::DenseTensor cpu_tensor;
-  cpu_tensor.Resize(tensor.dims());
-  platform::CPUPlace cpu_place;
-  // copy data from gpu to cpu
-  paddle::framework::TensorCopySync(tensor, cpu_place, &cpu_tensor);
-  TensorCheckerVisitor<phi::CPUContext> vistor(
-      op_type, var_name, cpu_tensor, place, place.device);
   VisitDataType(framework::TransToProtoVarType(tensor.dtype()), vistor);
 }
 

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cu
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cu
@@ -31,36 +31,6 @@ namespace paddle {
 namespace framework {
 namespace details {
 
-static std::once_flag init_multi_gpu_op_var_map_flag;
-
-// lazy init
-static std::vector<std::unordered_map<std::string, memory::AllocationPtr>>&
-multi_op_var2gpu_str() {
-  static std::vector<std::unordered_map<std::string, memory::AllocationPtr>>
-      _multi_op_var2gpu_str;
-  return _multi_op_var2gpu_str;
-}
-
-static std::vector<std::mutex>& multi_op_var2gpu_str_mutex() {
-  static std::vector<std::mutex> _multi_op_var2gpu_str_mutex;
-  return _multi_op_var2gpu_str_mutex;
-}
-
-static void InitMultiGPUOpVarMap() {
-  int dev_count = platform::GetGPUDeviceCount();
-  PADDLE_ENFORCE_GT(dev_count,
-                    0,
-                    platform::errors::NotFound(
-                        "cuda device must > 0, now dev_count=%d", dev_count));
-
-  // https://stackoverflow.com/questions/16465633/how-can-i-use-something-like-stdvectorstdmutex
-  std::vector<std::unordered_map<std::string, memory::AllocationPtr>> tmp_multi(
-      dev_count);
-  std::vector<std::mutex> tmp_multi_mutex(dev_count);
-
-  multi_op_var2gpu_str().swap(tmp_multi);
-  multi_op_var2gpu_str_mutex().swap(tmp_multi_mutex);
-}
 
 template <typename T>
 __device__ __forceinline__ void PrintNanInfKernel(const T* value,

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cu
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cu
@@ -309,7 +309,7 @@ __global__ void FindGlobalMaxMinAndPrint(const int64_t* block_num_nan_ptr,
         mean_value += tmp_mean_value;
       }
     }
-
+    printf("this is error");
     PrintForDifferentLevel<T, MT>(debug_info,
                                   numel,
                                   num_nan,
@@ -460,17 +460,17 @@ void TensorCheckerVisitor<phi::GPUContext>::apply(
 #endif
 }
 
-template <>
-void tensor_check<phi::GPUContext>(const std::string& op_type,
-                                   const std::string& var_name,
-                                   const phi::DenseTensor& tensor,
-                                   const platform::Place& place) {
-  std::call_once(init_multi_gpu_op_var_map_flag, InitMultiGPUOpVarMap);
-
-  TensorCheckerVisitor<phi::GPUContext> vistor(
-      op_type, var_name, tensor, place);
-  VisitDataType(framework::TransToProtoVarType(tensor.dtype()), vistor);
-}
+// template <>
+// void tensor_check<phi::GPUContext>(const std::string& op_type,
+//                                    const std::string& var_name,
+//                                    const phi::DenseTensor& tensor,
+//                                    const platform::Place& place) {
+//   std::call_once(init_multi_gpu_op_var_map_flag, InitMultiGPUOpVarMap);
+//
+//   TensorCheckerVisitor<phi::GPUContext> vistor(
+//       op_type, var_name, tensor, place);
+//   VisitDataType(framework::TransToProtoVarType(tensor.dtype()), vistor);
+// }
 
 }  // namespace details
 }  // namespace framework

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cu
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cu
@@ -408,13 +408,13 @@ void TensorCheckerVisitor<phi::GPUContext>::apply(
     phi::DenseTensor cpu_tensor;
     platform::CPUPlace cpu_place;
     cpu_tensor.Resize(tensor.dims());
+    // 1. copy from gpu to cpu
     paddle::framework::TensorCopySync(tensor, cpu_place, &cpu_tensor);
     auto* dev_ctx = reinterpret_cast<phi::GPUContext*>(
         platform::DeviceContextPool::Instance().Get(tensor.place()));
     const std::string debug_info =
         GetHintString<T>(op_type, var_name, place, dev_id);
-    // copy from gpu to cpu
-    // copy data from gpu to cpu
+    // 2. write log to file
     CheckNanInfCpuImpl(cpu_tensor.data<T>(), tensor.numel(), debug_info, "gpu");
     return;
   }

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cu
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cu
@@ -309,7 +309,6 @@ __global__ void FindGlobalMaxMinAndPrint(const int64_t* block_num_nan_ptr,
         mean_value += tmp_mean_value;
       }
     }
-    printf("this is error");
     PrintForDifferentLevel<T, MT>(debug_info,
                                   numel,
                                   num_nan,

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cu
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cu
@@ -459,18 +459,6 @@ void TensorCheckerVisitor<phi::GPUContext>::apply(
 #endif
 }
 
-// template <>
-// void tensor_check<phi::GPUContext>(const std::string& op_type,
-//                                    const std::string& var_name,
-//                                    const phi::DenseTensor& tensor,
-//                                    const platform::Place& place) {
-//   std::call_once(init_multi_gpu_op_var_map_flag, InitMultiGPUOpVarMap);
-//
-//   TensorCheckerVisitor<phi::GPUContext> vistor(
-//       op_type, var_name, tensor, place);
-//   VisitDataType(framework::TransToProtoVarType(tensor.dtype()), vistor);
-// }
-
 }  // namespace details
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cu
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cu
@@ -404,7 +404,9 @@ void TensorCheckerVisitor<phi::GPUContext>::apply(
   auto* dev_ctx = reinterpret_cast<phi::GPUContext*>(
       platform::DeviceContextPool::Instance().Get(tensor.place()));
   int dev_id = tensor.place().device;
-  if (FLAGS_check_nan_inf_level >= 4) {
+  // Write log to file
+  auto file_path = GetNanPath();
+  if (file_path.size() > 0) {
     phi::DenseTensor cpu_tensor;
     platform::CPUPlace cpu_place;
     cpu_tensor.Resize(tensor.dims());
@@ -418,6 +420,8 @@ void TensorCheckerVisitor<phi::GPUContext>::apply(
     CheckNanInfCpuImpl(cpu_tensor.data<T>(), tensor.numel(), debug_info, "gpu");
     return;
   }
+
+  // Write log to window
   char* gpu_str_ptr =
       GetGpuHintStringPtr<T>(*dev_ctx, op_type, var_name, dev_id);
 

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.h
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.h
@@ -125,6 +125,7 @@ HOSTDEVICE void PrintForDifferentLevelFile(const char* debug_info,
   std::string file_name = "worker_" + log_name + "." + std::to_string(dev_id);
   std::string path = "log_dir_nan/" + file_name;
   std::ofstream outfile(path, std::ios::app);
+
   if (!outfile.is_open()) {
     return;
   }

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.h
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.h
@@ -15,19 +15,12 @@
 #pragma once
 
 #include <sys/file.h>
-#include <fstream>
-#include <iostream>
 #include <string>
 
 #include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/platform/complex.h"
 #include "paddle/fluid/platform/place.h"
-#include "paddle/phi/backends/dynload/port.h"
 #include "paddle/phi/common/amp_type_traits.h"
-#ifdef PADDLE_WITH_ASCEND_CL
-#include "paddle/fluid/platform/device/npu/npu_op_runner.h"
-#endif
-#include "paddle/fluid/framework/convert_utils.h"
 #include "paddle/phi/kernels/funcs/eigen/extensions.h"
 
 DECLARE_int32(check_nan_inf_level);
@@ -154,7 +147,7 @@ HOSTDEVICE void PrintForDifferentLevelFile(const char* debug_info,
     }
   } else if (NeedPrint<T, MT>(max_value, min_value, check_nan_inf_level)) {
     outfile << "[PRECISION] in " << debug_info
-            << ", numel=" << static_cast<long long>(numel)
+            << ", numel=" << static_cast<long long>(numel)  // NOLINT
             << ", max=" << static_cast<float>(max_value)
             << ", min=" << static_cast<float>(min_value)
             << ", mean=" << static_cast<float>(mean_value) << std::endl;

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.h
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.h
@@ -112,7 +112,6 @@ HOSTDEVICE void PrintForDifferentLevelFile(const char* debug_info,
                                            MT min_value,
                                            MT mean_value,
                                            int check_nan_inf_level) {
-  // 以写模式打开文件
   std::string file_name = std::to_string(check_nan_inf_level);
   std::string path = "nan_inf_level_" + file_name;
   std::ofstream outfile(path, std::ios::app);

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.h
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.h
@@ -108,7 +108,11 @@ HOSTDEVICE void PrintForDifferentLevelFile(const char* debug_info,
                                            int check_nan_inf_level,
                                            const std::string& log_name) {
   int dev_id = 0;
+#ifdef PADDLE_WITH_HIP
+  hipGetDevice(&dev_id);
+#elif PADDLE_WITH_CUDA
   cudaGetDevice(&dev_id);
+#endif
   MkDir("log_dir_nan");
   std::string file_name = "worker_" + log_name + "." + std::to_string(dev_id);
   std::string path = "log_dir_nan/" + file_name;

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.h
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.h
@@ -144,12 +144,11 @@ HOSTDEVICE void PrintForDifferentLevelFile(const char* debug_info,
 #endif
     }
   } else if (NeedPrint<T, MT>(max_value, min_value, check_nan_inf_level)) {
-    outfile << "[PRECISION] in "
-            << debug_info;  // << ", numel=" << static_cast<long long>(numel)
-                            //<< ", max=" << static_cast<float>(max_value)
-                            //<< ", min=" << static_cast<float>(min_value)
-                            //<< ", mean=" << static_cast<float>(mean_value) <<
-                            // std::endl;
+    outfile << "[PRECISION] in " << debug_info
+            << ", numel=" << static_cast<long long>(numel)
+            << ", max=" << static_cast<float>(max_value)
+            << ", min=" << static_cast<float>(min_value)
+            << ", mean=" << static_cast<float>(mean_value) << std::endl;
   }
   outfile.close();
 }

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.h
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.h
@@ -130,21 +130,6 @@ HOSTDEVICE void PrintForDifferentLevelFile(const char* debug_info,
             << ", max=" << static_cast<float>(max_value)
             << ", min=" << static_cast<float>(min_value)
             << ", mean=" << static_cast<float>(mean_value) << std::endl;
-    if (check_nan_inf_level == 0) {
-#if defined(__NVCC__) || defined(__HIPCC__)
-      PADDLE_ENFORCE(false,
-                     "There are NAN or INF (num_nan=%ld, num_inf=%lld) in %s.",
-                     static_cast<long long>(num_nan),  // NOLINT
-                     static_cast<long long>(num_inf),  // NOLINT
-                     debug_info);
-#else
-      PADDLE_THROW(platform::errors::PreconditionNotMet(
-          "There are NAN or INF (num_nan=%lld, num_inf=%lld) in %s.",
-          static_cast<long long>(num_nan),  // NOLINT
-          static_cast<long long>(num_inf),  // NOLINT
-          debug_info));
-#endif
-    }
   } else if (NeedPrint<T, MT>(max_value, min_value, check_nan_inf_level)) {
     outfile << "[PRECISION] in " << debug_info
             << ", numel=" << static_cast<long long>(numel)  // NOLINT

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.h
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.h
@@ -67,7 +67,6 @@ HOSTDEVICE void PrintForDifferentLevel(const char* debug_info,
                                        MT min_value,
                                        MT mean_value,
                                        int check_nan_inf_level) {
-  printf("no----------------------attention-----------------");
   if (num_nan > 0 || num_inf > 0) {
     printf(
         "[PRECISION] [ERROR] in %s, numel=%lld, num_nan=%lld, "

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -34,6 +34,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/custom_operator.h"
 #include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/data_type_transform.h"
+#include "paddle/fluid/framework/details/nan_inf_utils_detail.h"
 #include "paddle/fluid/framework/executor.h"
 #include "paddle/fluid/framework/executor_cache.h"
 #include "paddle/fluid/framework/executor_gc_helper.h"
@@ -2567,6 +2568,9 @@ All parameter, weight, gradient are variables in Paddle.
 
   m.def("use_layout_autotune",
         [] { return egr::Controller::Instance().UseLayoutAutoTune(); });
+  // Add the api for nan op debug
+  m.def("set_nan_inf_debug_path",
+        &paddle::framework::details::SetNanInfDebugPath);
 
   BindFleetWrapper(&m);
   BindIO(&m);

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -161,6 +161,14 @@ class TestNanInfCheckResult(unittest.TestCase):
         if paddle.fluid.core.is_compiled_with_cuda():
             self.check_nan_inf_level(use_cuda=True, dtype="float16")
 
+    def test_check_nan_inf_to_file(self):
+        paddle.fluid.core.set_nan_inf_debug_path("nan_inf_log_dir")
+        paddle.set_flags(
+            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 3}
+        )
+        if paddle.fluid.core.is_compiled_with_cuda():
+            self.check_nan_inf_level(use_cuda=True, dtype="float16")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -162,6 +162,7 @@ class TestNanInfCheckResult(unittest.TestCase):
             self.check_nan_inf_level(use_cuda=True, dtype="float16")
 
     def test_check_nan_inf_to_file(self):
+        # set output_dir
         paddle.fluid.core.set_nan_inf_debug_path("nan_inf_log_dir")
         paddle.set_flags(
             {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 3}

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -161,15 +161,6 @@ class TestNanInfCheckResult(unittest.TestCase):
         if paddle.fluid.core.is_compiled_with_cuda():
             self.check_nan_inf_level(use_cuda=True, dtype="float16")
 
-    def test_check_nan_inf_to_file(self):
-        # set output_dir
-        paddle.fluid.core.set_nan_inf_debug_path("nan_inf_log_dir")
-        paddle.set_flags(
-            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 3}
-        )
-        if paddle.fluid.core.is_compiled_with_cuda():
-            self.check_nan_inf_level(use_cuda=True, dtype="float16")
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_nan_inf_dir.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf_dir.py
@@ -94,7 +94,7 @@ class TestNanInfDirCheckResult(unittest.TestCase):
                 assert num_nan == num_nan_np and num_inf == num_inf_np
 
         paddle.set_flags(
-            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 0}
+            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 3}
         )
         _check_num_nan_inf(use_cuda=False)
         if paddle.fluid.core.is_compiled_with_cuda():

--- a/python/paddle/fluid/tests/unittests/test_nan_inf_dir.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf_dir.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class TestNanInfDirCheckResult(unittest.TestCase):
+    def generate_inputs(self, shape, dtype="float32"):
+        data = np.random.random(size=shape).astype(dtype)
+        # [-10, 10)
+        x = (data * 20 - 10) * np.random.randint(
+            low=0, high=2, size=shape
+        ).astype(dtype)
+        y = np.random.randint(low=0, high=2, size=shape).astype(dtype)
+        return x, y
+
+    def get_reference_num_nan_inf(self, x):
+        out = np.log(x)
+        num_nan = np.sum(np.isnan(out))
+        num_inf = np.sum(np.isinf(out))
+        print("[reference] num_nan={}, num_inf={}".format(num_nan, num_inf))
+        return num_nan, num_inf
+
+    def get_num_nan_inf(
+        self, x_np, use_cuda=True, add_assert=False, pt="nan_inf_log_dir"
+    ):
+        num_nan = 0
+        num_inf = 0
+        if add_assert:
+            if use_cuda:
+                paddle.device.set_device("gpu:0")
+            else:
+                paddle.device.set_device("cpu")
+            x = paddle.to_tensor(x_np)
+            out = paddle.log(x)
+            sys.stdout.flush()
+            if not use_cuda:
+                os.path.exists(pt)
+                num_nan = 0
+                num_inf = 0
+                for root, dirs, files in os.walk(pt):
+                    for file_name in files:
+                        if file_name.startswith('worker_cpu'):
+                            file_path = os.path.join(root, file_name)
+                            with open(file_path, "rb") as fp:
+                                for e in fp:
+                                    err_str_list = (
+                                        str(e)
+                                        .replace("(", " ")
+                                        .replace(")", " ")
+                                        .replace(",", " ")
+                                        .split(" ")
+                                    )
+                                    for err_str in err_str_list:
+                                        if "num_nan" in err_str:
+                                            num_nan = int(err_str.split("=")[1])
+                                        elif "num_inf" in err_str:
+                                            num_inf = int(err_str.split("=")[1])
+                print(
+                    "[asfasfpaddle] num_nan={}, num_inf={}".format(
+                        num_nan, num_inf
+                    )
+                )
+        return num_nan, num_inf
+
+    def test_num_nan_inf(self):
+        path = "nan_inf_log_dir"
+        paddle.fluid.core.set_nan_inf_debug_path(path)
+
+        def _check_num_nan_inf(use_cuda):
+            shape = [32, 32]
+            x_np, _ = self.generate_inputs(shape)
+            num_nan_np, num_inf_np = self.get_reference_num_nan_inf(x_np)
+            add_assert = (num_nan_np + num_inf_np) > 0
+            num_nan, num_inf = self.get_num_nan_inf(
+                x_np, use_cuda, add_assert, path
+            )
+            if not use_cuda:
+                assert num_nan == num_nan_np and num_inf == num_inf_np
+
+        paddle.set_flags(
+            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 0}
+        )
+        _check_num_nan_inf(use_cuda=False)
+        if paddle.fluid.core.is_compiled_with_cuda():
+            _check_num_nan_inf(use_cuda=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_nan_inf_dir.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf_dir.py
@@ -74,9 +74,7 @@ class TestNanInfDirCheckResult(unittest.TestCase):
                                         elif "num_inf" in err_str:
                                             num_inf = int(err_str.split("=")[1])
                 print(
-                    "[asfasfpaddle] num_nan={}, num_inf={}".format(
-                        num_nan, num_inf
-                    )
+                    "[paddle] num_nan={}, num_inf={}".format(num_nan, num_inf)
                 )
         return num_nan, num_inf
 
@@ -101,6 +99,9 @@ class TestNanInfDirCheckResult(unittest.TestCase):
         _check_num_nan_inf(use_cuda=False)
         if paddle.fluid.core.is_compiled_with_cuda():
             _check_num_nan_inf(use_cuda=True)
+        x = paddle.to_tensor([2, 3, 4], 'float32')
+        y = paddle.to_tensor([1, 5, 2], 'float32')
+        z = paddle.add(x, y)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### 环境变量

当开启环境变量（1）（2）后将对OP进行精度检查并输出到屏幕（具体使用请参考： https://github.com/PaddlePaddle/Paddle/pull/47672 ）本次修改是将log存储到指定文件夹
export FLAGS_check_nan_inf=1
export FLAGS_check_nan_inf_level= 请参考https://github.com/PaddlePaddle/Paddle/pull/47672

### 使用方法 

在python代码中添加以下调用：
paddle.fluid.core.set_nan_inf_debug_path("output_dir")
填写的为日志输出路径，后续会将日志打印到指定文件夹
当用户设置output_dir时，将check_nan_inf输出的日志打印到output_dir文件夹中，当使用多卡运行时将区分_gpu.*， *用于表示当前卡号, workerlog_cpu.0

### 效果如图：
<img width="132" alt="image" src="https://user-images.githubusercontent.com/51102941/210324896-fa40c9a3-29ba-4b04-bd91-a29de75d3edb.png">

注意：打印到文件中耗时较长，请按需使用