### PR TITLE
Fix typos of managed_memory_msg when OOM

### DIFF
--- a/paddle/fluid/memory/allocation/cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_allocator.cc
@@ -75,7 +75,7 @@ phi::Allocation* CUDAAllocator::AllocateImpl(size_t size) {
     managed_memory_msg = string::Sprintf(
         "If the above ways do not solve the out of memory problem, you can try "
         "to use CUDA managed memory. The command is `export "
-        "FLAGS_use_cuda_managed_memory=false`.");
+        "FLAGS_use_cuda_managed_memory=true`.");
   }
 
   PADDLE_THROW_BAD_ALLOC(platform::errors::ResourceExhausted(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
When OOM, the threw message tell users to try to use CUDA managed memory by command `FLAGS_use_cuda_managed_memory=false`. However, the corrected command to enable managed memory should be `FLAGS_use_cuda_managed_memory=true`. The incorrect prompts mislead users (see issue https://github.com/PaddlePaddle/Paddle/issues/49225). This PR fixes it.
