### PR TITLE
register float16 for slice

### DIFF
--- a/paddle/phi/kernels/cpu/slice_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/slice_grad_kernel.cc
@@ -27,10 +27,11 @@ PD_REGISTER_KERNEL(slice_grad,
                    int,
                    int64_t,
                    float,
+                   phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    double,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::complex<double>) {}
 
 PD_REGISTER_KERNEL(slice_array_grad,
                    CPU,
@@ -40,10 +41,11 @@ PD_REGISTER_KERNEL(slice_array_grad,
                    int,
                    int64_t,
                    float,
+                   phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    double,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::complex<double>) {}
 
 PD_REGISTER_KERNEL(slice_array_dense_grad,
                    CPU,
@@ -53,7 +55,8 @@ PD_REGISTER_KERNEL(slice_array_dense_grad,
                    int,
                    int64_t,
                    float,
+                   phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    double,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::complex<double>) {}

--- a/paddle/phi/kernels/cpu/slice_kernel.cc
+++ b/paddle/phi/kernels/cpu/slice_kernel.cc
@@ -27,10 +27,11 @@ PD_REGISTER_KERNEL(slice,
                    int,
                    int64_t,
                    float,
+                   phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    double,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::complex<double>) {}
 
 PD_REGISTER_KERNEL(slice_array,
                    CPU,
@@ -41,10 +42,11 @@ PD_REGISTER_KERNEL(slice_array,
                    uint8_t,
                    int64_t,
                    float,
+                   phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    double,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::complex<double>) {}
 
 PD_REGISTER_KERNEL(slice_array_dense,
                    CPU,
@@ -55,7 +57,8 @@ PD_REGISTER_KERNEL(slice_array_dense,
                    uint8_t,
                    int64_t,
                    float,
+                   phi::dtype::bfloat16,
+                   phi::dtype::float16,
                    double,
                    phi::dtype::complex<float>,
-                   phi::dtype::complex<double>,
-                   phi::dtype::bfloat16) {}
+                   phi::dtype::complex<double>) {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
之前slice op on cpu只注册了bfloat16精度，混合精度推理需要float16精度的slice on cpu，故补上。