### PR TITLE
remove non-public apis

### DIFF
--- a/python/paddle/jit/translated_layer.py
+++ b/python/paddle/jit/translated_layer.py
@@ -33,7 +33,7 @@ from paddle.jit.dy2static.partial_program import (
     add_build_strategy_for,
 )
 
-__all__ = ['TranslatedLayer']
+__all__ = []
 
 INFER_MODEL_SUFFIX = ".pdmodel"
 INFER_PARAMS_SUFFIX = ".pdiparams"

--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -73,15 +73,11 @@ from ..fluid.io import batch  # noqa: F401
 from ..fluid.contrib.layers import ctr_metric_bundle  # noqa: F401
 from ..fluid.layers import exponential_decay  # noqa: F401
 
-from .nn.common import batch_norm  # noqa: F401
-from .nn.common import conv2d  # noqa: F401
 from .nn.metric import auc  # noqa: F401
 from .nn.metric import accuracy  # noqa: F401
 
 __all__ = [  # noqa
     'append_backward',
-    'batch_norm',
-    'conv2d',
     'gradients',
     'Executor',
     'global_scope',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
remove following 3 non-public APIs from `__all__` 
```
paddle.static.conv2d (already have paddle.static.nn.conv2d)
paddle.static.batch_norm (already have paddle.static.nn.batch_norm)
paddle.jit.translated_layer.TranslatedLayer (already have paddle.jit.TranslatedLayer)
```
