### PR TITLE
[XPU] fix exception in xpu executor

### DIFF
--- a/paddle/fluid/framework/details/bind_threaded_ssa_graph_executor.cc
+++ b/paddle/fluid/framework/details/bind_threaded_ssa_graph_executor.cc
@@ -274,8 +274,8 @@ void BindThreadedSSAGraphExecutor::RunMultiDeviceOpAsync(
       }
     } catch (...) {
       error_state = 1;
-      ready_ops->Push(nullptr);
       exception_.Catch(std::current_exception());
+      ready_ops->Push(nullptr);
     }
     {
       std::lock_guard<std::mutex> lock(mutex_);
@@ -308,8 +308,8 @@ void BindThreadedSSAGraphExecutor::RunOpAsyncMainStream(
       }
     } catch (...) {
       error_state = 1;
-      ready_ops->Push(nullptr);
       exception_.Catch(std::current_exception());
+      ready_ops->Push(nullptr);
     }
     {
       std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe

在`bind_threaded_ssa_graph_executor`中，如果执行某个OP时遇到了异常，会往变量`ready_ops`里面塞进去一个`nullptr`，并且记录到成员变量`exception_`中。在`RunMainStream`函数里面，拿到这个`nullptr`就会跳出循环，然后去判断是否已经有异常发生（判断`exception_.IsCaught()`），决定要不要执行`ExecutionFinal`。

问题来了，有可能出现的情况是，在“塞`nullptr`”和“记录`exception_`”这两行代码之间，`RunMainStream`恰好去检查了是否有异常，所以拿到的信息会不准确，造成后续各种诡异的现象。

因此修改了一下代码顺序，当执行OP遇到异常的时候，先记录，然后塞`nullptr`。