### PR TITLE
[Fix Bug] Fix custom operator testcase CI error

### DIFF
--- a/python/paddle/fluid/tests/custom_op/utils.py
+++ b/python/paddle/fluid/tests/custom_op/utils.py
@@ -14,21 +14,24 @@
 
 import os
 import sys
-from distutils.sysconfig import get_python_lib
+from site import getsitepackages
 
 from paddle.utils.cpp_extension.extension_utils import IS_WINDOWS
 
 IS_MAC = sys.platform.startswith('darwin')
 
-site_packages_path = get_python_lib()
 # Note(Aurelius84): We use `add_test` in Cmake to config how to run unittest in CI.
 # `PYTHONPATH` will be set as `build/python/paddle` that will make no way to find
 # paddle include directory. Because the following path is generated after installing
 # PaddlePaddle whl. So here we specific `include_dirs` to avoid errors in CI.
-paddle_includes = [
-    os.path.join(site_packages_path, 'paddle', 'include'),
-    os.path.join(site_packages_path, 'paddle', 'include', 'third_party'),
-]
+paddle_includes = []
+for site_packages_path in getsitepackages():
+    paddle_includes.append(
+        os.path.join(site_packages_path, 'paddle', 'include')
+    )
+    paddle_includes.append(
+        os.path.join(site_packages_path, 'paddle', 'include', 'third_party')
+    )
 
 # Test for extra compile args
 extra_cc_args = ['-w', '-g'] if not IS_WINDOWS else ['/w']


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
After CI-coverage changes Linux version and python install command, `distutils.sysconfig.get_python_lib` function returns a different result, which makes the process of custom operator setup cannot find the correct include directory.

**Right directory:** /usr/local/lib/python3.8/dist-packages/
**Return result:** /usr/lib/python3/dist-packages/ (an empty directory)

Use `getsitepackages` function can fix this bug.
