### PR TITLE
rm legacy unittest part5

### DIFF
--- a/python/paddle/fluid/tests/custom_op/test_custom_relu_model.py
+++ b/python/paddle/fluid/tests/custom_op/test_custom_relu_model.py
@@ -21,7 +21,6 @@ from utils import IS_MAC, extra_cc_args, extra_nvcc_args, paddle_includes
 
 import paddle
 from paddle import nn
-from paddle.fluid.framework import _in_legacy_dygraph
 from paddle.utils.cpp_extension import get_build_directory, load
 from paddle.utils.cpp_extension.extension_utils import run_cmd
 
@@ -123,14 +122,6 @@ class TestDygraphModel(unittest.TestCase):
             # for train
             origin_relu_train_out = self.train_model(use_custom_op=False)
             custom_relu_train_out = self.train_model(use_custom_op=True)
-            # open this when dy2stat is ready for eager
-            if _in_legacy_dygraph():
-                custom_relu_dy2stat_train_out = self.train_model(
-                    use_custom_op=True, dy2stat=True
-                )  # for to_static
-                np.testing.assert_array_equal(
-                    origin_relu_train_out, custom_relu_dy2stat_train_out
-                )
 
             np.testing.assert_array_equal(
                 origin_relu_train_out, custom_relu_train_out
@@ -139,13 +130,6 @@ class TestDygraphModel(unittest.TestCase):
             # for eval
             origin_relu_eval_out = self.eval_model(use_custom_op=False)
             custom_relu_eval_out = self.eval_model(use_custom_op=True)
-            if _in_legacy_dygraph():
-                custom_relu_dy2stat_eval_out = self.eval_model(
-                    use_custom_op=True, dy2stat=True
-                )  # for to_static
-                np.testing.assert_array_equal(
-                    origin_relu_eval_out, custom_relu_dy2stat_eval_out
-                )
 
             np.testing.assert_array_equal(
                 origin_relu_eval_out, custom_relu_eval_out

--- a/python/paddle/fluid/tests/unittests/test_eager_run_program.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_run_program.py
@@ -24,7 +24,7 @@ from paddle.fluid.executor import (
     _is_dy2st_enable_standalone_executor,
     _is_enable_standalone_executor,
 )
-from paddle.fluid.framework import Variable, _in_legacy_dygraph
+from paddle.fluid.framework import Variable
 from paddle.fluid.layers.utils import _hash_with_id
 
 
@@ -63,22 +63,13 @@ def _create_out(var):
     assert isinstance(var, Variable)
     var_desc = var.desc
     varbase = None
-    if _in_legacy_dygraph():
-        var_base = core.VarBase(
-            var_desc.dtype(),
-            var_desc.shape(),
-            var_desc.name(),
-            var_desc.type(),
-            False,
-        )
-    else:
-        var_base = core.eager.Tensor(
-            var_desc.dtype(),
-            var_desc.shape(),
-            var_desc.name(),
-            var_desc.type(),
-            False,
-        )
+    var_base = core.eager.Tensor(
+        var_desc.dtype(),
+        var_desc.shape(),
+        var_desc.name(),
+        var_desc.type(),
+        False,
+    )
     return var_base
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_group.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_group.py
@@ -16,7 +16,7 @@ import unittest
 
 import paddle
 import paddle.fluid.core as core
-from paddle.fluid.framework import _in_legacy_dygraph, in_dygraph_mode
+from paddle.fluid.framework import in_dygraph_mode
 
 
 class TestDataParallelGroup(unittest.TestCase):
@@ -26,8 +26,6 @@ class TestDataParallelGroup(unittest.TestCase):
     def assign_group_by_size(self, *args):
         if in_dygraph_mode():
             return core.eager_assign_group_by_size(*args)
-        elif _in_legacy_dygraph():
-            return core.assign_group_by_size(*args)
 
     def test_construct_group0(self):
         # one dtype & one limit capability

--- a/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
@@ -18,7 +18,6 @@ import warnings
 import numpy as np
 
 import paddle.fluid as fluid
-from paddle.fluid.framework import _in_legacy_dygraph
 
 
 class TestImperativeNumpyBridge(unittest.TestCase):
@@ -44,12 +43,7 @@ class TestImperativeNumpyBridge(unittest.TestCase):
             np.testing.assert_array_equal(var2.numpy(), data_np)
             data_np[0][0] = -1
             self.assertEqual(data_np[0][0], -1)
-            if not _in_legacy_dygraph():
-                # eager_mode, var2 is Tensor, is not subscriptable
-                # TODO(wuweilong): to support slice in eager mode later
-                self.assertNotEqual(var2.numpy()[0][0], -1)
-            else:
-                self.assertNotEqual(var2[0][0].numpy()[0], -1)
+            self.assertNotEqual(var2[0][0].numpy()[0], -1)
             self.assertFalse(np.array_equal(var2.numpy(), data_np))
 
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
@@ -22,7 +22,6 @@ import paddle.fluid as fluid
 import paddle.nn.functional as F
 from paddle.fluid import Layer, core
 from paddle.fluid.dygraph import guard, to_variable
-from paddle.fluid.framework import _in_legacy_dygraph
 from paddle.nn import Linear
 
 np.set_printoptions(suppress=True)
@@ -1193,18 +1192,6 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
                 dy_param_updated,
             )
 
-        with guard():
-            fluid.set_flags({'FLAGS_sort_sum_gradient': True})
-            if _in_legacy_dygraph():
-                (
-                    dy_avg_cost_value,
-                    dy_sum_cost_value,
-                    dy_predict_value,
-                    dy_token_num_value,
-                    dy_param_init,
-                    dy_param_updated,
-                ) = run_dygraph()
-
         with new_program_scope():
             paddle.seed(seed)
             paddle.framework.random._manual_program_seed(seed)
@@ -1296,24 +1283,6 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
                         static_param_updated[
                             static_param_name_list[k - 4]
                         ] = out[k]
-        if _in_legacy_dygraph():
-            np.testing.assert_array_equal(
-                static_avg_cost_value, dy_avg_cost_value
-            )
-            np.testing.assert_array_equal(
-                static_sum_cost_value, dy_sum_cost_value
-            )
-            np.testing.assert_array_equal(
-                static_predict_value, dy_predict_value
-            )
-            np.testing.assert_array_equal(
-                static_token_num_value, dy_token_num_value
-            )
-
-            for key, value in static_param_init.items():
-                np.testing.assert_array_equal(value, dy_param_init[key])
-            for key, value in static_param_updated.items():
-                np.testing.assert_array_equal(value, dy_param_updated[key])
 
         # compare eager result with imperative result
         with guard():

--- a/python/paddle/fluid/tests/unittests/test_norm_all.py
+++ b/python/paddle/fluid/tests/unittests/test_norm_all.py
@@ -20,8 +20,8 @@ from op_test import OpTest, convert_float_to_uint16
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle import _C_ops, _legacy_C_ops
-from paddle.fluid.framework import _in_legacy_dygraph, in_dygraph_mode
+from paddle import _C_ops
+from paddle.fluid.framework import in_dygraph_mode
 
 
 # hack method for test p_norm final state
@@ -30,20 +30,6 @@ def p_norm_python_api(
 ):
     if in_dygraph_mode():
         return _C_ops.p_norm(x, p, axis, epsilon, keepdim, as_vector)
-    if _in_legacy_dygraph():
-        return _legacy_C_ops.p_norm(
-            x,
-            'axis',
-            axis,
-            'porder',
-            float(p),
-            'keepdim',
-            keepdim,
-            'epsilon',
-            epsilon,
-            'as_vector',
-            as_vector,
-        )
 
 
 def p_norm(x, axis, porder, keepdims=False, reduce_all=False):

--- a/python/paddle/fluid/tests/unittests/test_optimizer_for_varbase.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_for_varbase.py
@@ -18,7 +18,6 @@ import numpy as np
 
 import paddle
 import paddle.optimizer as optimizer
-from paddle.fluid.framework import _in_legacy_dygraph
 
 
 class TestOptimizerForVarBase(unittest.TestCase):
@@ -89,22 +88,13 @@ class TestOptimizerForVarBase(unittest.TestCase):
             optimizer.Adam(learning_rate=self.lr, parameters=x)
 
     def test_create_param_lr_with_1_for_coverage(self):
-        if _in_legacy_dygraph():
-            x = paddle.fluid.framework.ParamBase(
-                dtype="float32",
-                shape=[5, 10],
-                lod_level=0,
-                name="x",
-                optimize_attr={'learning_rate': 1.0},
-            )
-        else:
-            x = paddle.fluid.framework.EagerParamBase(
-                dtype="float32",
-                shape=[5, 10],
-                lod_level=0,
-                name="x",
-                optimize_attr={'learning_rate': 1.0},
-            )
+        x = paddle.fluid.framework.EagerParamBase(
+            dtype="float32",
+            shape=[5, 10],
+            lod_level=0,
+            name="x",
+            optimize_attr={'learning_rate': 1.0},
+        )
         x.value().get_tensor().set(
             np.random.random((5, 10)).astype('float32'),
             paddle.fluid.framework._current_expected_place(),
@@ -117,22 +107,13 @@ class TestOptimizerForVarBase(unittest.TestCase):
         opt.step()
 
     def test_create_param_lr_with_no_1_value_for_coverage(self):
-        if _in_legacy_dygraph():
-            x = paddle.fluid.framework.ParamBase(
-                dtype="float32",
-                shape=[5, 10],
-                lod_level=0,
-                name="x",
-                optimize_attr={'learning_rate': 0.12},
-            )
-        else:
-            x = paddle.fluid.framework.EagerParamBase(
-                dtype="float32",
-                shape=[5, 10],
-                lod_level=0,
-                name="x",
-                optimize_attr={'learning_rate': 0.12},
-            )
+        x = paddle.fluid.framework.EagerParamBase(
+            dtype="float32",
+            shape=[5, 10],
+            lod_level=0,
+            name="x",
+            optimize_attr={'learning_rate': 0.12},
+        )
         x.value().get_tensor().set(
             np.random.random((5, 10)).astype('float32'),
             paddle.fluid.framework._current_expected_place(),

--- a/python/paddle/fluid/tests/unittests/test_paddle_imperative_double_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_imperative_double_grad.py
@@ -20,7 +20,6 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.nn.functional as F
-from paddle.fluid.framework import _in_legacy_dygraph
 from paddle.fluid.wrapped_decorator import wrap_decorator
 
 
@@ -239,22 +238,6 @@ class TestDygraphDoubleGrad(TestCase):
         ).astype('float32')
         np.testing.assert_allclose(dx_actual.numpy(), dx_expected, rtol=1e-05)
 
-        if not _in_legacy_dygraph():
-            pass
-        else:
-            loss = paddle.mean(dx_actual * dx_actual + x * x)
-            loss.backward()
-
-            x_grad_actual = x.gradient()
-            x_grad_expected = (
-                2.0
-                / float(numel)
-                * (x_np + dx_expected * (x_np > 0) * 2 / float(numel))
-            ).astype('float32')
-            np.testing.assert_allclose(
-                x_grad_actual, x_grad_expected, rtol=1e-05
-            )
-
     @dygraph_guard
     def test_example_with_gradient_accumulation_and_no_grad_vars(self):
         x = random_var(self.shape)
@@ -286,22 +269,6 @@ class TestDygraphDoubleGrad(TestCase):
         ).astype('float32')
         np.testing.assert_allclose(dx_actual.numpy(), dx_expected, rtol=1e-05)
 
-        if not _in_legacy_dygraph():
-            pass
-        else:
-            loss = paddle.mean(dx_actual * dx_actual + x * x)
-            loss.backward()
-
-            x_grad_actual = x.gradient()
-            x_grad_expected = (
-                2.0
-                / float(numel)
-                * (x_np + dx_expected * (x_np > 0) * 4 / float(numel))
-            ).astype('float32')
-            np.testing.assert_allclose(
-                x_grad_actual, x_grad_expected, rtol=1e-05
-            )
-
     @dygraph_guard
     def test_example_with_gradient_accumulation_and_not_create_graph(self):
         x = random_var(self.shape)
@@ -326,18 +293,6 @@ class TestDygraphDoubleGrad(TestCase):
         ).astype('float32')
 
         np.testing.assert_allclose(dx_actual.numpy(), dx_expected, rtol=1e-05)
-
-        if not _in_legacy_dygraph():
-            pass
-        else:
-            loss = paddle.mean(dx_actual * dx_actual + x * x)
-            loss.backward()
-
-            x_grad_actual = x.gradient()
-            x_grad_expected = (2.0 * x_np / float(numel)).astype('float32')
-            np.testing.assert_allclose(
-                x_grad_actual, x_grad_expected, rtol=1e-05
-            )
 
 
 class TestDygraphDoubleGradSortGradient(TestDygraphDoubleGrad):

--- a/python/paddle/fluid/tests/unittests/test_tensor_uva.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_uva.py
@@ -18,7 +18,6 @@ import numpy as np
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.framework import _in_legacy_dygraph
 
 
 class TestTensorCopyFrom(unittest.TestCase):
@@ -46,12 +45,8 @@ class TestUVATensorFromNumpy(unittest.TestCase):
             ]
             for dtype in dtype_list:
                 data = np.random.randint(10, size=[4, 5]).astype(dtype)
-                if _in_legacy_dygraph():
-                    tensor = paddle.fluid.core.to_uva_tensor(data, 0)
-                    tensor2 = paddle.fluid.core.to_uva_tensor(data)
-                else:
-                    tensor = core.eager.to_uva_tensor(data, 0)
-                    tensor2 = core.eager.to_uva_tensor(data)
+                tensor = core.eager.to_uva_tensor(data, 0)
+                tensor2 = core.eager.to_uva_tensor(data)
 
                 self.assertTrue(tensor.place.is_gpu_place())
                 self.assertTrue(tensor2.place.is_gpu_place())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
rm _in_legacy in `python/paddle/fluid/tests/unittests`
删除所有_in_legacy_dygraph的使用，以及这个if下面的老动态图逻辑分支
删除_non_static_mode、in_dynamic_mode的使用。因为这两个主要用在了老动态图上
删除_legacy_C_ops的错误使用。因为有些API，没有使用_in_legacy_dygraph、_non_static_mode、in_dynamic_mode而直接是：
```python
if in_dygraph_mode():
    return _C_ops.xxx
return _legacy_C_ops.xxx
```

删除不必要的in_dygraph_mode，比如：
```python
if in_dygraph_mode():
	return _C_ops.xxx
``
#可直接改成：
return _C_ops.xxx
```
删除一些不必要的Python API预处理逻辑，或者将预处理逻辑放到只对静态图生效
优化API格式，尽可能保证API的格式如下（但不是100%）：
```
if in_dygraph_mode():
   预处理
   return _C_ops.xxx
else:
   静态图
```