### PR TITLE
Clip intermediate output of operator in save_inference_model

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -6193,7 +6193,7 @@ class Program:
                     for output_proto in proto.outputs:
                         if output_proto.name != name:
                             continue
-                        if output_proto.extra:
+                        if output_proto.extra or output_proto.intermediate:
                             remove_output_list.append(name)
                         find = True
                         break

--- a/python/paddle/jit/translated_layer.py
+++ b/python/paddle/jit/translated_layer.py
@@ -559,7 +559,6 @@ class _ProgramHolder:
                             stop_gradient=True,
                         )
                         op.desc.set_output("ReserveSpace", [reserve_space.name])
-                    continue
 
                 proto = OpProtoHolder.instance().get_op_proto(op.type)
                 has_create_intermediate_out = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
使用`save_inference_model`保存模型Program时将标记为intermediate类型的输出参数进行裁剪。
