### PR TITLE
Add FLAGS for communication op dependency in standalone executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.cc
@@ -17,6 +17,13 @@
 #include <queue>
 #include "paddle/fluid/framework/new_executor/interpreter/interpreter_util.h"
 
+PADDLE_DEFINE_EXPORTED_bool(
+    add_dependency_for_communication_op,
+    true,
+    "Whether to add dependency for communication Ops. It is just a temporary "
+    "FLAGS especially for auto parallel to avoid the concurrency damage by the "
+    "communication dependency added in standalone executor.");
+
 // The difference between "sequential_run" and "serial_run":
 // "sequential_run" dispatches OPs one by one according to the sequence in the
 // Program, while "serial_run" ensures that all Ops are scheduled in a singal
@@ -71,7 +78,11 @@ const std::map<size_t, std::set<size_t>>& DependencyBuilder::Build(
   }
 
   AddDependencyForCoalesceTensorOp();
-  AddDependencyForCommunicationOp();
+
+  if (FLAGS_add_dependency_for_communication_op) {
+    AddDependencyForCommunicationOp();
+  }
+
   AddDependencyForRandomOp();
   AddDependencyForReadOp();
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
增加临时控制开关`FLAGS_add_dependency_for_communication_op`，用于控制新执行器底层是否自动为通信算子添加依赖。
该开关主要用于自动并行场景，在上层已在Prorgam中显式指定了必须的依赖关系后，开启该开关可避免新执行器中额外添加的依赖对通信操作的可并发性产生影响。