### PR TITLE
delete legacy dygraph code in python/paddle/optimizer

### DIFF
--- a/python/paddle/optimizer/adadelta.py
+++ b/python/paddle/optimizer/adadelta.py
@@ -170,29 +170,29 @@ class Adadelta(Optimizer):
                     self._epsilon,
                 )
             return None
+        else:
+            if not isinstance(block, framework.Block):
+                raise TypeError("block is not instance of framework.Block.")
 
-        if not isinstance(block, framework.Block):
-            raise TypeError("block is not instance of framework.Block.")
+            # Create the adadelta optimizer op
+            adadelta_op = block.append_op(
+                type=self.type,
+                inputs={
+                    "Param": param_and_grad[0],
+                    "Grad": param_and_grad[1],
+                    "AvgSquaredGrad": avg_squared_grad_acc,
+                    "AvgSquaredUpdate": avg_squared_update_acc,
+                },
+                outputs={
+                    "ParamOut": param_and_grad[0],
+                    "AvgSquaredGradOut": avg_squared_grad_acc,
+                    "AvgSquaredUpdateOut": avg_squared_update_acc,
+                },
+                attrs={"epsilon": self._epsilon, "rho": self._rho},
+                stop_gradient=True,
+            )
 
-        # Create the adadelta optimizer op
-        adadelta_op = block.append_op(
-            type=self.type,
-            inputs={
-                "Param": param_and_grad[0],
-                "Grad": param_and_grad[1],
-                "AvgSquaredGrad": avg_squared_grad_acc,
-                "AvgSquaredUpdate": avg_squared_update_acc,
-            },
-            outputs={
-                "ParamOut": param_and_grad[0],
-                "AvgSquaredGradOut": avg_squared_grad_acc,
-                "AvgSquaredUpdateOut": avg_squared_update_acc,
-            },
-            attrs={"epsilon": self._epsilon, "rho": self._rho},
-            stop_gradient=True,
-        )
-
-        return adadelta_op
+            return adadelta_op
 
     def _update_param_group(self, parameters):
         self._epsilon = parameters.get('epsilon', self._default_dict['epsilon'])

--- a/python/paddle/optimizer/adamw.py
+++ b/python/paddle/optimizer/adamw.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 
 import paddle
 
-from .. import _C_ops, _legacy_C_ops
+from .. import _C_ops
 from ..fluid import core, framework, unique_name
 from ..fluid.clip import GradientClipBase
 from ..fluid.dygraph import base as imperative_base
@@ -473,7 +473,7 @@ class AdamW(Optimizer):
         lr = self._create_param_lr(param_and_grad)
 
         # create the adamw optimize op
-        if framework._non_static_mode():
+        if framework.in_dygraph_mode():
             lr_ratio_ = (
                 1.0
                 if self._lr_ratio is None
@@ -491,126 +491,90 @@ class AdamW(Optimizer):
                 else self._beta2.numpy().item(0)
             )
 
-            if framework.in_dygraph_mode():
-                found_inf = self._get_auxiliary_var('found_inf')
-                _, _, _, _, _, _ = _C_ops.adamw_(
-                    param_and_grad[0],
-                    param_and_grad[1],
-                    lr,
-                    moment1,
-                    moment2,
-                    beta1_pow_acc,
-                    beta2_pow_acc,
-                    master_weight,
-                    found_inf,
-                    _beta1,
-                    _beta2,
-                    self._epsilon,
-                    lr_ratio_,
-                    self._weight_decay,
-                    with_decay,
-                    self._lazy_mode,
-                    1000,
-                    find_master,
-                    False,
-                )
-            else:
-                _, _, _, _, _, _ = _legacy_C_ops.adamw(
-                    param_and_grad[0],
-                    param_and_grad[1],
-                    lr,
-                    moment1,
-                    moment2,
-                    beta1_pow_acc,
-                    beta2_pow_acc,
-                    master_weight,
-                    param_and_grad[0],
-                    moment1,
-                    moment2,
-                    beta1_pow_acc,
-                    beta2_pow_acc,
-                    master_weight,
-                    'epsilon',
-                    self._epsilon,
-                    'lazy_mode',
-                    self._lazy_mode,
-                    'min_row_size_to_use_multithread',
-                    1000,
-                    'beta1',
-                    _beta1,
-                    'beta2',
-                    _beta2,
-                    "with_decay",
-                    with_decay,
-                    'coeff',
-                    self._weight_decay,
-                    'multi_precision',
-                    find_master,
-                    'lr_ratio',
-                    lr_ratio_,
-                )
+            found_inf = self._get_auxiliary_var('found_inf')
+            _, _, _, _, _, _ = _C_ops.adamw_(
+                param_and_grad[0],
+                param_and_grad[1],
+                lr,
+                moment1,
+                moment2,
+                beta1_pow_acc,
+                beta2_pow_acc,
+                master_weight,
+                found_inf,
+                _beta1,
+                _beta2,
+                self._epsilon,
+                lr_ratio_,
+                self._weight_decay,
+                with_decay,
+                self._lazy_mode,
+                1000,
+                find_master,
+                False,
+            )
             return None
-
-        inputs = {
-            "Param": [param_and_grad[0]],
-            "Grad": [param_and_grad[1]],
-            "LearningRate": [lr],
-            "Moment1": [moment1],
-            "Moment2": [moment2],
-            "Beta1Pow": [beta1_pow_acc],
-            "Beta2Pow": [beta2_pow_acc],
-        }
-
-        # Pass found_inf to adamw, to skip update for not only param, but also momentum and beta_pow
-        found_inf = self._get_auxiliary_var('found_inf')
-
-        if found_inf:
-            inputs['SkipUpdate'] = found_inf
-
-        outputs = {
-            "ParamOut": [param_and_grad[0]],
-            "Moment1Out": [moment1],
-            "Moment2Out": [moment2],
-            "Beta1PowOut": [beta1_pow_acc],
-            "Beta2PowOut": [beta2_pow_acc],
-        }
-        attrs = {
-            "lazy_mode": self._lazy_mode,
-            "min_row_size_to_use_multithread": 1000,
-            "multi_precision": find_master,
-            "with_decay": with_decay,
-            "coeff": self._weight_decay,
-            "lr_ratio": 1.0
-            if self._lr_ratio is None
-            else self._lr_ratio(param_and_grad[0]),
-        }
-
-        if isinstance(self._beta1, Variable):
-            inputs['Beta1Tensor'] = self._beta1
         else:
-            attrs['beta1'] = self._beta1
-        if isinstance(self._beta2, Variable):
-            inputs['Beta2Tensor'] = self._beta2
-        else:
-            attrs['beta2'] = self._beta2
-        if isinstance(self._epsilon, Variable):
-            inputs['EpsilonTensor'] = self._epsilon
-        else:
-            attrs['epsilon'] = self._epsilon
+            inputs = {
+                "Param": [param_and_grad[0]],
+                "Grad": [param_and_grad[1]],
+                "LearningRate": [lr],
+                "Moment1": [moment1],
+                "Moment2": [moment2],
+                "Beta1Pow": [beta1_pow_acc],
+                "Beta2Pow": [beta2_pow_acc],
+            }
 
-        if find_master:
-            inputs["MasterParam"] = master_weight
-            outputs["MasterParamOut"] = master_weight
+            # Pass found_inf to adamw, to skip update for not only param, but also momentum and beta_pow
+            found_inf = self._get_auxiliary_var('found_inf')
 
-        adamw_op = block.append_op(
-            type=self.type,
-            inputs=inputs,
-            outputs=outputs,
-            attrs=attrs,
-            stop_gradient=True,
-        )
+            if found_inf:
+                inputs['SkipUpdate'] = found_inf
 
-        return adamw_op
+            outputs = {
+                "ParamOut": [param_and_grad[0]],
+                "Moment1Out": [moment1],
+                "Moment2Out": [moment2],
+                "Beta1PowOut": [beta1_pow_acc],
+                "Beta2PowOut": [beta2_pow_acc],
+            }
+            attrs = {
+                "lazy_mode": self._lazy_mode,
+                "min_row_size_to_use_multithread": 1000,
+                "multi_precision": find_master,
+                "with_decay": with_decay,
+                "coeff": self._weight_decay,
+                "lr_ratio": 1.0
+                if self._lr_ratio is None
+                else self._lr_ratio(param_and_grad[0]),
+            }
+
+            if isinstance(self._beta1, Variable):
+                inputs['Beta1Tensor'] = self._beta1
+            else:
+                attrs['beta1'] = self._beta1
+            if isinstance(self._beta2, Variable):
+                inputs['Beta2Tensor'] = self._beta2
+            else:
+                attrs['beta2'] = self._beta2
+            if isinstance(self._epsilon, Variable):
+                inputs['EpsilonTensor'] = self._epsilon
+            else:
+                attrs['epsilon'] = self._epsilon
+
+            if find_master:
+                inputs["MasterParam"] = master_weight
+                outputs["MasterParamOut"] = master_weight
+
+            adamw_op = block.append_op(
+                type=self.type,
+                inputs=inputs,
+                outputs=outputs,
+                attrs=attrs,
+                stop_gradient=True,
+            )
+
+            return adamw_op
 
     def __str__(self):
         return " ".join(["Weight Decay, params:", ",".join(self._params_name)])

--- a/python/paddle/optimizer/lamb.py
+++ b/python/paddle/optimizer/lamb.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 from paddle.fluid.executor import global_scope
 
 from ..fluid import core, framework, unique_name
@@ -313,76 +313,48 @@ class Lamb(Optimizer):
                 find_master,
             )
             return None
-        if framework._non_static_mode():
-            _legacy_C_ops.lamb(
-                param_and_grad[0],
-                param_and_grad[1],
-                lr,
-                moment1,
-                moment2,
-                beta1_pow_acc,
-                beta2_pow_acc,
-                master_weight,
-                param_and_grad[0],
-                moment1,
-                moment2,
-                beta1_pow_acc,
-                beta2_pow_acc,
-                master_weight,
-                'beta1',
-                self._beta1,
-                'beta2',
-                self._beta2,
-                'epsilon',
-                self._epsilon,
-                'weight_decay',
-                weight_decay,
-                'multi_precision',
-                find_master,
+        else:
+            # create the lamb optimize op
+            inputs = {
+                "Param": param_and_grad[0],
+                "Grad": param_and_grad[1],
+                "LearningRate": lr,
+                "Moment1": moment1,
+                "Moment2": moment2,
+                "Beta1Pow": beta1_pow_acc,
+                "Beta2Pow": beta2_pow_acc,
+            }
+            outputs = {
+                "ParamOut": param_and_grad[0],
+                "Moment1Out": moment1,
+                "Moment2Out": moment2,
+                "Beta1PowOut": beta1_pow_acc,
+                "Beta2PowOut": beta2_pow_acc,
+            }
+            attrs = {
+                "beta1": self._beta1,
+                "beta2": self._beta2,
+                "epsilon": self._epsilon,
+                "weight_decay": weight_decay,
+                "multi_precision": find_master,
+            }
+
+            if find_master:
+                inputs["MasterParam"] = master_weight
+                outputs["MasterParamOut"] = master_weight
+
+            if found_inf:
+                inputs["SkipUpdate"] = found_inf
+
+            lamb_op = block.append_op(
+                type=self.type,
+                inputs=inputs,
+                outputs=outputs,
+                attrs=attrs,
+                stop_gradient=True,
             )
-            return None
 
-        # create the lamb optimize op
-        inputs = {
-            "Param": param_and_grad[0],
-            "Grad": param_and_grad[1],
-            "LearningRate": lr,
-            "Moment1": moment1,
-            "Moment2": moment2,
-            "Beta1Pow": beta1_pow_acc,
-            "Beta2Pow": beta2_pow_acc,
-        }
-        outputs = {
-            "ParamOut": param_and_grad[0],
-            "Moment1Out": moment1,
-            "Moment2Out": moment2,
-            "Beta1PowOut": beta1_pow_acc,
-            "Beta2PowOut": beta2_pow_acc,
-        }
-        attrs = {
-            "beta1": self._beta1,
-            "beta2": self._beta2,
-            "epsilon": self._epsilon,
-            "weight_decay": weight_decay,
-            "multi_precision": find_master,
-        }
-
-        if find_master:
-            inputs["MasterParam"] = master_weight
-            outputs["MasterParamOut"] = master_weight
-
-        if found_inf:
-            inputs["SkipUpdate"] = found_inf
-
-        lamb_op = block.append_op(
-            type=self.type,
-            inputs=inputs,
-            outputs=outputs,
-            attrs=attrs,
-            stop_gradient=True,
-        )
-
-        return lamb_op
+            return lamb_op
 
     def _update_param_group(self, parameters):
         self._beta1 = parameters.get('beta1', self._default_dict['beta1'])

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -20,8 +20,6 @@ import numpy
 import paddle.fluid.core as core
 from paddle import Tensor
 
-from ..fluid.framework import _in_legacy_dygraph
-
 __all__ = [  # noqa
     'LRScheduler',
     'NoamDecay',
@@ -1395,15 +1393,8 @@ class ReduceOnPlateau(LRScheduler):
         else:
             self.last_epoch = epoch
 
-        if not _in_legacy_dygraph():
-            tmp = core.eager.Tensor
-        else:
-            # need to declarate explicitly
-            from paddle.framework import VarBase as Tensor
-
-            tmp = Tensor
         # loss must be float, numpy.ndarray or 1-D Tensor with shape [1]
-        if isinstance(metrics, (tmp, numpy.ndarray)):
+        if isinstance(metrics, (core.eager.Tensor, numpy.ndarray)):
             assert len(metrics.shape) == 1 and metrics.shape[0] == 1, (
                 "the metrics.shape "
                 "should be (1L,), but the current metrics.shape is {}. Maybe that "

--- a/python/paddle/optimizer/sgd.py
+++ b/python/paddle/optimizer/sgd.py
@@ -15,11 +15,11 @@
 import warnings
 
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops
 
 from ..fluid import core, framework, unique_name
 from ..fluid.dygraph import no_grad
-from ..fluid.framework import _in_legacy_dygraph, in_dygraph_mode
+from ..fluid.framework import in_dygraph_mode
 from ..fluid.layer_helper import LayerHelper
 from .optimizer import Optimizer
 
@@ -166,42 +166,32 @@ class SGD(Optimizer):
                 find_master,
             )
             return None
-        if _in_legacy_dygraph():
-            _legacy_C_ops.sgd(
-                param_and_grad[0],
-                lr,
-                param_and_grad[1],
-                master_weight,
-                param_and_grad[0],
-                master_weight,
+        else:
+            assert isinstance(block, framework.Block)
+            # create the optimize op
+            inputs = {
+                "Param": param_and_grad[0],
+                "Grad": param_and_grad[1],
+                "LearningRate": lr,
+            }
+
+            outputs = {"ParamOut": param_and_grad[0]}
+
+            attrs = {"multi_precision": find_master}
+
+            if find_master:
+                inputs["MasterParam"] = master_weight
+                outputs["MasterParamOut"] = master_weight
+
+            sgd_op = block.append_op(
+                type=self.type,
+                inputs=inputs,
+                outputs=outputs,
+                attrs=attrs,
+                stop_gradient=True,
             )
-            return None
 
-        assert isinstance(block, framework.Block)
-        # create the optimize op
-        inputs = {
-            "Param": param_and_grad[0],
-            "Grad": param_and_grad[1],
-            "LearningRate": lr,
-        }
-
-        outputs = {"ParamOut": param_and_grad[0]}
-
-        attrs = {"multi_precision": find_master}
-
-        if find_master:
-            inputs["MasterParam"] = master_weight
-            outputs["MasterParamOut"] = master_weight
-
-        sgd_op = block.append_op(
-            type=self.type,
-            inputs=inputs,
-            outputs=outputs,
-            attrs=attrs,
-            stop_gradient=True,
-        )
-
-        return sgd_op
+            return sgd_op
 
     def _update_param_group(self, parameters):
         parameters = parameters.get('params')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
删除python/paddle/distributed、python/paddle/distribution下的Python API中的老动态图逻辑：
1. 删除所有_in_legacy_dygraph的使用，以及这个if下面的老动态图逻辑分支
2. 删除_non_static_mode、in_dynamic_mode的使用。因为这两个主要用在了老动态图上
3. 删除_legacy_C_ops的错误使用。因为有些API，没有使用_in_legacy_dygraph、_non_static_mode、in_dynamic_mode而直接是：
```
if in_dygraph_mode():
    return _C_ops.xxx
return _legacy_C_ops.xxx
```
4. 删除不必要的in_dygraph_mode，比如：
```
if in_dygraph_mode():
	return _C_ops.xxx
#可直接改成：
return _C_ops.xxx
```
5. 删除一些不必要的Python API预处理逻辑，或者将预处理逻辑放到只对静态图生效
6. 优化API格式，尽可能保证API的格式如下（但不是100%）：
```
if in_dygraph_mode():
   预处理
   return _C_ops.xxx
else:
   静态图
```