### PR TITLE
Fix test_fused_multi_transformer_int8

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_int8_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multi_transformer_int8_op.py
@@ -15,8 +15,10 @@
 import unittest
 
 import numpy as np
+from test_sparse_attention_op import get_cuda_version
 
 import paddle
+import paddle.fluid.core as core
 import paddle.nn.functional as F
 from paddle import _legacy_C_ops, tensor
 from paddle.fluid.framework import default_main_program
@@ -128,6 +130,12 @@ def fused_multi_transformer_int8(
     return final_out
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8Op(unittest.TestCase):
     def setUp(self):
         self.config()
@@ -781,6 +789,12 @@ class TestFusedMultiTransformerInt8Op(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpFp16(TestFusedMultiTransformerInt8Op):
     def config(self):
         super().config()
@@ -788,6 +802,12 @@ class TestFusedMultiTransformerInt8OpFp16(TestFusedMultiTransformerInt8Op):
         self.layers = 3  # odd layers
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpCacheKV(TestFusedMultiTransformerInt8Op):
     def config(self):
         super().config()
@@ -798,6 +818,12 @@ class TestFusedMultiTransformerInt8OpCacheKV(TestFusedMultiTransformerInt8Op):
         self.layers = 3  # odd layers
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpCacheKVFp16(
     TestFusedMultiTransformerInt8Op
 ):
@@ -809,6 +835,12 @@ class TestFusedMultiTransformerInt8OpCacheKVFp16(
         self.x_type = np.float16
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpGenCacheKV(
     TestFusedMultiTransformerInt8Op
 ):
@@ -818,6 +850,12 @@ class TestFusedMultiTransformerInt8OpGenCacheKV(
         self.gen_cache_kv = True
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpGenCacheKVFp16(
     TestFusedMultiTransformerInt8Op
 ):
@@ -829,6 +867,12 @@ class TestFusedMultiTransformerInt8OpGenCacheKVFp16(
         self.layers = 3  # odd layers
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpPostLayerNormFp16(
     TestFusedMultiTransformerInt8Op
 ):
@@ -839,6 +883,12 @@ class TestFusedMultiTransformerInt8OpPostLayerNormFp16(
         self.pre_layer_norm = False
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpCacheKVPostLayerNorm(
     TestFusedMultiTransformerInt8Op
 ):
@@ -851,6 +901,12 @@ class TestFusedMultiTransformerInt8OpCacheKVPostLayerNorm(
         self.pre_layer_norm = False
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpCacheKVPostLayerNormFp16(
     TestFusedMultiTransformerInt8Op
 ):
@@ -863,6 +919,12 @@ class TestFusedMultiTransformerInt8OpCacheKVPostLayerNormFp16(
         self.pre_layer_norm = False
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpGenCacheKVPostLayerNorm(
     TestFusedMultiTransformerInt8Op
 ):
@@ -873,6 +935,12 @@ class TestFusedMultiTransformerInt8OpGenCacheKVPostLayerNorm(
         self.pre_layer_norm = False
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or get_cuda_version() < 11020
+    or paddle.device.cuda.get_device_capability()[0] < 8,
+    "FusedMultiTransformerInt8 requires CUDA >= 11.2 and CUDA_ARCH >= 8",
+)
 class TestFusedMultiTransformerInt8OpGenCacheKVPostLayerNormFp16(
     TestFusedMultiTransformerInt8Op
 ):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
CI-coverage is migrating to V100/CUDA11.2,  where fused_multi_transformer cannot run properly with currently cublasLt settings. Thus, we skip unittest in this env(cuda < 11.2, cuda_arch < 8). cublasLt helper will be updated soon to adapt all archs.