### PR TITLE
Improve stream analyzer

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.h
+++ b/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.h
@@ -64,7 +64,8 @@ class StreamAnalyzer {
       const std::vector<std::vector<std::vector<size_t>>>& run_type_info,
       const size_t cur_instr_id,
       const size_t next_instr_id,
-      std::set<size_t>* waiter_instr_ids) const;
+      std::set<size_t>* waiter_instr_ids,
+      std::set<size_t>* visited_next_instr_id) const;
 
   void ShrinkEventInfo(
       const DependencyBuilder& dependency_builder,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
优化新执行器多流预分析模块StreamAnalyzer
1. 在StreamAnalyzer对上下游OP分析同步位置时，引入记忆化搜索，防止在网络规模较大时多流预分析时间过长。当前在自动并行的部分大模型场景下，由于模型训练时开启FLAGS_new_executor_sequencial_run引入了较多控制边，再加上新执行器跨step overlap的同步分析会重叠处理两个step的计算图，导致多流同步的搜索空间较大，实际运行时容易让人误以为是hang住。本PR的优化可大幅降低这种网络规模较大且具有较多控制边场景下的多流预分析时间。
2. 增强StreamAnalyzer剪枝逻辑，去除冗余event同步操作。对于A->B->C，若A处于一个流，B和C同处另一个流，则在B和A之间已经插入多流同步操作的情况下，C和A之间不需要再进行同步操作。之前StreamAnalyzer不处理这种冗余操作，是因为DependencyBuilder在建立依赖时已经做过类似的剪枝，在剪枝彻底的情况下，后续多流的处理不会引入这种冗余同步操作。但由于控制边的存在，DependencyBuilder的剪枝是不彻底的（数据边不能被控制边剪去），因而在一些情况下，仍可能由于控制边的引入而出现冗余的同步操作。本PR增强StreamAnalyzer的剪枝逻辑，以在出现这种情况时可以进一步剪掉多余的event同步。