### PR TITLE
fux bug of UT test_version

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_version.py
+++ b/python/paddle/fluid/tests/unittests/test_version.py
@@ -34,12 +34,6 @@ class VersionTest(unittest.TestCase):
 
         # check version format
         if fluid_version.istaged:
-            self.assertEqual(fluid_version.major, 0)
-            self.assertEqual(fluid_version.minor, 0)
-            self.assertEqual(fluid_version.patch, "0")
-            self.assertEqual(fluid_version.rc, 0)
-            self.assertEqual(fluid_version.full_version, "0.0.0")
-        else:
             self.assertTrue(re.match(self._major_regex, fluid_version.major))
             self.assertTrue(re.match(self._minor_regex, fluid_version.minor))
             self.assertTrue(re.match(self._patch_regex, fluid_version.patch))
@@ -47,3 +41,13 @@ class VersionTest(unittest.TestCase):
             self.assertTrue(
                 re.match(self._version_regex, fluid_version.full_version)
             )
+        else:
+            self.assertEqual(fluid_version.major, "0")
+            self.assertEqual(fluid_version.minor, "0")
+            self.assertEqual(fluid_version.patch, "0")
+            self.assertEqual(fluid_version.rc, "0")
+            self.assertEqual(fluid_version.full_version, "0.0.0")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复test_vetsion的单测bug：
- 有tag应该匹配正则表达式
- 没有tag应该匹配`0.0.0` 

原来的逻辑写反了，是错误的