### PR TITLE
[XPU] fix data overlapping issue in MatMulXPUFunction

### DIFF
--- a/paddle/phi/kernels/xpu/xpu_api_wrapper.h
+++ b/paddle/phi/kernels/xpu/xpu_api_wrapper.h
@@ -246,6 +246,7 @@ static void xpu_fc_wrapper(xpu::Context* ctx,
                                                        act);
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "fc_fusion");
   } else {
+    xpu_wait(ctx->xpu_stream);
     r = xpu::fc_fusion<XPUType, XPUType, XPUType, FCT>(ctx,
                                                        x,
                                                        w,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
A "wait" operation should be done before fc_fusion was called.
