### PR TITLE
[Paddle Inference] Add_moe_arch_check

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/moe_kernel.cu
+++ b/paddle/phi/kernels/fusion/cutlass/moe_kernel.cu
@@ -19,6 +19,7 @@
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
 #include "paddle/phi/kernels/fusion/cutlass/moe_kernel_impl.h"
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
 // Ignore CUTLASS warnings about type punning
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
@@ -36,9 +37,12 @@
 #include "paddle/phi/kernels/fusion/cutlass/linear_combination_ft_gelu.h"
 #include "paddle/phi/kernels/fusion/cutlass/moe_cutlass_kernel.h"
 #pragma GCC diagnostic pop
+#endif
+
 namespace phi {
 
 namespace {
+
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
 inline int getSMVersion() {
   const int device = phi::backends::gpu::GetCurrentDeviceId();
@@ -121,9 +125,11 @@ struct Epilogue<ElementType,
       cutlass::epilogue::thread::ScaleType::Nothing>;
 };
 #endif
+
 }  // namespace
 
 namespace fusion {
+
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
 template <typename T>
 void InitExpertChoiceRouteKernelLauncher(
@@ -659,6 +665,7 @@ void finalize_moe_routing_kernelLauncher(
   }
 }
 #endif
+
 template <typename T, typename Context>
 void MoeKernel(const Context& ctx,
                const DenseTensor& x,

--- a/paddle/phi/kernels/fusion/cutlass/moe_kernel_impl.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe_kernel_impl.h
@@ -12,13 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
 #pragma once
 #include <string>
 #include "cub/cub.cuh"
 #include "paddle/phi/kernels/funcs/math_cuda_utils.h"
 
 namespace phi {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
+
 static const float HALF_FLT_MAX = 65504.F;
 static const float HALF_FLT_MIN = -65504.F;
 static inline size_t AlignTo16(const size_t& input) {
@@ -775,5 +776,5 @@ __global__ void initialize_moe_routing_kernel(
     }
   }
 }
-#endif
 }  // namespace phi
+#endif

--- a/paddle/phi/kernels/fusion/cutlass/moe_kernel_impl.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe_kernel_impl.h
@@ -18,7 +18,7 @@ limitations under the License. */
 #include "paddle/phi/kernels/funcs/math_cuda_utils.h"
 
 namespace phi {
-
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
 static const float HALF_FLT_MAX = 65504.F;
 static const float HALF_FLT_MIN = -65504.F;
 static inline size_t AlignTo16(const size_t& input) {
@@ -775,5 +775,5 @@ __global__ void initialize_moe_routing_kernel(
     }
   }
 }
-
+#endif
 }  // namespace phi

--- a/paddle/phi/kernels/fusion/cutlass/moe_kernel_impl.h
+++ b/paddle/phi/kernels/fusion/cutlass/moe_kernel_impl.h
@@ -776,5 +776,6 @@ __global__ void initialize_moe_routing_kernel(
     }
   }
 }
+
 }  // namespace phi
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Moe kernel only support cuda arch >= 700.
Add_moe_arch_check
