### PR TITLE
Add to_hash func and paddle2arg map for cinn

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/cinn_cache_key.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_cache_key.cc
@@ -84,7 +84,7 @@ size_t CinnCacheKey::Hash::operator()(const CinnCacheKey& key) const {
 
   for (const auto& name_shape : key.input_shapes_) {
     has_str << name_shape.first;
-    has_str << name_shape.second.to_str();
+    has_str << name_shape.second.to_hash();
   }
 
   has_str << key.graph_hash_val_;

--- a/paddle/fluid/framework/paddle2cinn/cinn_cache_key.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_cache_key.cc
@@ -84,7 +84,7 @@ size_t CinnCacheKey::Hash::operator()(const CinnCacheKey& key) const {
 
   for (const auto& name_shape : key.input_shapes_) {
     has_str << name_shape.first;
-    has_str << name_shape.second.to_hash();
+    has_str << std::hash<phi::DDim>()(name_shape.second);
   }
 
   has_str << key.graph_hash_val_;

--- a/paddle/fluid/operators/cinn/cinn_launch_context.cc
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.cc
@@ -253,6 +253,8 @@ void CinnLaunchContext::InitializeArguments() {
         framework::DDim(cinn_buffer->dims, cinn_buffer->dimensions).to_str(),
         cinn_tensor->type());
     name2argument_.emplace(arg, cinn_buffer.get());
+    auto paddle_var = cinn2paddle_varmap_.at(arg);
+    paddle2argument_.emplace(paddle_var,cinn_buffer.get());
     hold_buffers_.emplace_back(std::move(cinn_buffer));
   }
   VLOG(4) << "Total argument size:" << name2argument_.size();
@@ -447,17 +449,11 @@ ParallelExecutor* CinnLaunchContext::InitializePE(const platform::Place& place,
 
 cinn_buffer_t* CinnLaunchContext::GetCinnBufferOfVar(
     const std::string& var_name) {
-  auto it = paddle2cinn_varmap_.find(var_name);
-  PADDLE_ENFORCE_NE(
-      it,
-      paddle2cinn_varmap_.end(),
-      platform::errors::InvalidArgument(
-          "Variable(%s) not found in compilation result", var_name));
-  auto res = name2argument_.find(it->second);
+  auto res = paddle2argument_.find(var_name);
   PADDLE_ENFORCE_NE(res,
-                    name2argument_.end(),
+                    paddle2argument_.end(),
                     platform::errors::NotFound(
-                        "Argument(%s) not be initialized", it->second));
+                        "Variable(%s) not found in compilation result", var_name));
   return static_cast<cinn_buffer_t*>(res->second);
 }
 

--- a/paddle/fluid/operators/cinn/cinn_launch_context.cc
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.cc
@@ -253,8 +253,8 @@ void CinnLaunchContext::InitializeArguments() {
         framework::DDim(cinn_buffer->dims, cinn_buffer->dimensions).to_str(),
         cinn_tensor->type());
     name2argument_.emplace(arg, cinn_buffer.get());
-    auto paddle_var = cinn2paddle_varmap_.at(arg);
-    paddle2argument_.emplace(paddle_var,cinn_buffer.get());
+    auto pdvar2cinnbuf_ = cinn2paddle_varmap_.at(arg);
+    paddle2argument_.emplace(pdvar2cinnbuf_, cinn_buffer.get());
     hold_buffers_.emplace_back(std::move(cinn_buffer));
   }
   VLOG(4) << "Total argument size:" << name2argument_.size();
@@ -450,10 +450,11 @@ ParallelExecutor* CinnLaunchContext::InitializePE(const platform::Place& place,
 cinn_buffer_t* CinnLaunchContext::GetCinnBufferOfVar(
     const std::string& var_name) {
   auto res = paddle2argument_.find(var_name);
-  PADDLE_ENFORCE_NE(res,
-                    paddle2argument_.end(),
-                    platform::errors::NotFound(
-                        "Variable(%s) not found in compilation result", var_name));
+  PADDLE_ENFORCE_NE(
+        res,
+        paddle2argument_.end(),
+        platform::errors::NotFound("Variable(%s) not found in compilation result", 
+			           var_name));
   return static_cast<cinn_buffer_t*>(res->second);
 }
 

--- a/paddle/fluid/operators/cinn/cinn_launch_context.cc
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.cc
@@ -451,10 +451,10 @@ cinn_buffer_t* CinnLaunchContext::GetCinnBufferOfVar(
     const std::string& var_name) {
   auto res = paddle2argument_.find(var_name);
   PADDLE_ENFORCE_NE(
-        res,
-        paddle2argument_.end(),
-        platform::errors::NotFound("Variable(%s) not found in compilation result", 
-			           var_name));
+      res,
+      paddle2argument_.end(),
+      platform::errors::NotFound("Variable(%s) not found in compilation result",
+                                 var_name));
   return static_cast<cinn_buffer_t*>(res->second);
 }
 

--- a/paddle/fluid/operators/cinn/cinn_launch_context.h
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.h
@@ -169,6 +169,9 @@ class CinnLaunchContext {
   // this map saves all execution arguments with their cinn names as key,
   // and it is passed to the Execute interface of a cinn runtime program.
   std::map<std::string, cinn_pod_value_t> name2argument_;
+  // this map saves all execution arguments with paddle variables as key,
+  // this map conbine name2argument_ and paddle2cinn_varmap_
+  std::map<std::string, cinn_pod_value_t> paddle2argument_;
 };
 
 }  // namespace operators::details

--- a/paddle/phi/core/ddim.cc
+++ b/paddle/phi/core/ddim.cc
@@ -58,6 +58,14 @@ std::string DDim::to_str() const {
   return ss.str();
 }
 
+std::size_t DDim::to_hash() const {
+  std::size_t seed = rank_;
+  for (int i = 0; i < rank_; ++i) {
+    seed ^= dim_[i] + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
+  return seed;
+}
+
 struct ProductVisitor {
   template <int D>
   inline int64_t operator()(const Dim<D>& dim) {

--- a/paddle/phi/core/ddim.cc
+++ b/paddle/phi/core/ddim.cc
@@ -58,14 +58,6 @@ std::string DDim::to_str() const {
   return ss.str();
 }
 
-std::size_t DDim::to_hash() const {
-  std::size_t seed = rank_;
-  for (int i = 0; i < rank_; ++i) {
-    seed ^= dim_[i] + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-  }
-  return seed;
-}
-
 struct ProductVisitor {
   template <int D>
   inline int64_t operator()(const Dim<D>& dim) {
@@ -211,3 +203,17 @@ DDim DDim::transpose(const std::vector<int>& axis) const {
 }
 
 }  // namespace phi
+
+namespace std {
+
+    std::size_t hash<phi::DDim>::operator()(phi::DDim const& ddim) const {
+      int ndim = ddim.size();
+      std::size_t seed = ndim;
+      for (int i = 0; i < ndim; ++i) {
+        seed ^= ddim.Get()[i] + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+      }
+      return seed;
+    }
+    
+}  // namespace std
+

--- a/paddle/phi/core/ddim.cc
+++ b/paddle/phi/core/ddim.cc
@@ -206,14 +206,13 @@ DDim DDim::transpose(const std::vector<int>& axis) const {
 
 namespace std {
 
-    std::size_t hash<phi::DDim>::operator()(phi::DDim const& ddim) const {
-      int ndim = ddim.size();
-      std::size_t seed = ndim;
-      for (int i = 0; i < ndim; ++i) {
-        seed ^= ddim.Get()[i] + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-      }
-      return seed;
-    }
-    
-}  // namespace std
+std::size_t hash<phi::DDim>::operator()(phi::DDim const& ddim) const {
+  int ndim = ddim.size();
+  std::size_t seed = ndim;
+  for (int i = 0; i < ndim; ++i) {
+    seed ^= ddim.Get()[i] + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+  }
+  return seed;
+}
 
+}  // namespace std

--- a/paddle/phi/core/ddim.h
+++ b/paddle/phi/core/ddim.h
@@ -155,6 +155,8 @@ class DDim {
 
   std::string to_str() const;
 
+  std::size_t to_hash() const;
+
   DDim reshape(std::vector<int>& shape) const;
 
   DDim transpose(const std::vector<int>& axis) const;

--- a/paddle/phi/core/ddim.h
+++ b/paddle/phi/core/ddim.h
@@ -155,8 +155,6 @@ class DDim {
 
   std::string to_str() const;
 
-  std::size_t to_hash() const;
-
   DDim reshape(std::vector<int>& shape) const;
 
   DDim transpose(const std::vector<int>& axis) const;
@@ -264,3 +262,10 @@ using DDim = phi::DDim;
 
 }  // namespace framework
 }  // namespace paddle
+
+namespace std {
+  template<>
+  struct hash<phi::DDim> {
+    std::size_t operator()(phi::DDim const& ddim) const ;
+  };
+}  // namespace std

--- a/paddle/phi/core/ddim.h
+++ b/paddle/phi/core/ddim.h
@@ -155,7 +155,7 @@ class DDim {
 
   std::string to_str() const;
 
-  DDim reshape(std::vector<int>& shape) const;
+  DDim reshape(std::vector<int>& shape) const;  // NOLINT
 
   DDim transpose(const std::vector<int>& axis) const;
 
@@ -264,8 +264,8 @@ using DDim = phi::DDim;
 }  // namespace paddle
 
 namespace std {
-  template<>
-  struct hash<phi::DDim> {
-    std::size_t operator()(phi::DDim const& ddim) const ;
-  };
+template <>
+struct hash<phi::DDim> {
+  std::size_t operator()(phi::DDim const& ddim) const;
+};
 }  // namespace std

--- a/paddle/phi/tests/core/test_ddim.cc
+++ b/paddle/phi/tests/core/test_ddim.cc
@@ -124,5 +124,13 @@ TEST(DDim, Print) {
   EXPECT_EQ("", ss2.str());
 }
 
+TEST(DDim, Hash) {
+  // hash a DDim
+  std::size_t h;
+  phi::DDim ddim = phi::make_ddim({2, 3, 4});
+  h = std::hash<phi::DDim>()(ddim);
+  EXPECT_EQ(h, 0xa16fb2b2967);
+}
+
 }  // namespace tests
 }  // namespace phi

--- a/paddle/phi/tests/core/test_ddim.cc
+++ b/paddle/phi/tests/core/test_ddim.cc
@@ -129,7 +129,7 @@ TEST(DDim, Hash) {
   std::size_t h;
   phi::DDim ddim = phi::make_ddim({2, 3, 4});
   h = std::hash<phi::DDim>()(ddim);
-  EXPECT_EQ(h, 0xa16fb2b2967);
+  EXPECT_EQ(h, 0xa16fb2b2967ul);
 }
 
 }  // namespace tests


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
we find CinnCacheKey::Hash::operator() and CinnInstructionRunOp::InferShape cost a lot time while running ernie-relative using paddle-cinn with gperftool.
we found some room for optimization for this two functions.

1.I add to_hash for CinnCacheKey::Hash and use to_hash instead of to_str for calculating hash for dim vector
2.I fold paddle2cinn_varmap_ and name2argument_ into paddle2argument map so i only need one find operation in CinnLaunchContext::GetCinnBufferOfVar.