### PR TITLE
[Bug Fix] Remove duplicate value check in `ContrastTransforms`

### DIFF
--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -861,8 +861,6 @@ class ContrastTransform(BaseTransform):
 
     def __init__(self, value, keys=None):
         super().__init__(keys)
-        if value < 0:
-            raise ValueError("contrast value should be non-negative")
         self.value = _check_input(value, 'contrast')
 
     def _apply_image(self, img):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
When the input value is a list, it will raise this ValueError. Since `_check_input` already check the input value type, just remove the duplicate value check