### PR TITLE
[ bugfix ] fix bugs in Indexable and support LayerDict

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -441,5 +441,39 @@ class TestErrorInForLoop(TestTransformForLoop):
         self.dyfunc = for_loop_dyfunc_not_support
 
 
+class Net(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_dict = paddle.nn.LayerDict(
+            {
+                "conv1": paddle.nn.Conv2D(3, 3, 1),
+                "conv2": paddle.nn.Conv2D(3, 3, 1),
+                "conv3": paddle.nn.Conv2D(3, 3, 1),
+            }
+        )
+
+    def forward(self, x):
+        out = 0
+        for layer_name in self.layer_dict:
+            out += self.layer_dict[layer_name](x)
+        return out
+
+
+class TestForLoopMeetDict(unittest.TestCase):
+    def test_start(self):
+
+        net = Net()
+        model = paddle.jit.to_static(
+            net,
+            input_spec=[
+                paddle.static.InputSpec(
+                    shape=[None, 3, 224, 224], dtype='float32'
+                )
+            ],
+        )
+        paddle.jit.save(model, "./inference/inference")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -42,8 +42,6 @@ def convert_attr(x, attr):
 def indexable(x, code=None):
     if isinstance(x, Variable):
         return x
-    if hasattr(x, '__len__') and hasattr(x, '__getitem__'):
-        return x
     if hasattr(x, '__iter__'):
         return [i for i in x]
     else:

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -42,8 +42,12 @@ def convert_attr(x, attr):
 def indexable(x, code=None):
     if isinstance(x, Variable):
         return x
-    if hasattr(x, '__iter__'):
+    elif hasattr(x, '__iter__'):
         return [i for i in x]
+    elif hasattr(x, '__len__') and hasattr(
+        x, '__getitem__'
+    ):  # used for customed type and non-iterable type.
+        return x
     else:
         raise RuntimeError("X can't be convert into indexable.")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix Cases like this: 
```
class Net(paddle.nn.Layer):
    def __init__(self):
        super().__init__()

        self.layer_dict = paddle.nn.LayerDict{
            "conv1": paddle.nn.Conv2D(3, 3, 1),
            "conv2": paddle.nn.Conv2D(3, 3, 1),
            "conv3": paddle.nn.Conv2D(3, 3, 1)
        }

    def forward(self, x):
        out = 0
        for layer_name in self.layer_dict:
            out += self.layer_dict[layer_name](x)
        return out

class TestForLoopMeetDict(unittest.TestCase):
    def test_start(self):

        net = Net()
        model = paddle.jit.to_static(
            net,
            input_spec=[
                paddle.static.InputSpec(
                    shape=[None, 3, 224, 224],
                    dtype='float32')
            ])
        paddle.jit.save(model, "./inference/inference")
```
修复前报错： 
![截屏2022-12-28 17 33 27](https://user-images.githubusercontent.com/16025309/209790757-c7bb310f-d993-4ca3-a119-0cacfa39e975.png)

修复后支持。
