### PR TITLE
Fix default GetExpectedKernelType for ops supported tensor attrs

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2717,9 +2717,11 @@ proto::VarType::Type OperatorWithKernel::IndicateDataType(
   proto::VarType::Type data_type = dafault_data_type;
 
   std::vector<std::string> sup_tensor_attrs;
-  for (auto& attr : Info().Proto().attrs()) {
-    if (attr.support_tensor()) {
-      sup_tensor_attrs.emplace_back(attr.name());
+  if (Info().HasOpProtoAndChecker()) {
+    for (auto& attr : Info().Proto().attrs()) {
+      if (attr.support_tensor()) {
+        sup_tensor_attrs.emplace_back(attr.name());
+      }
     }
   }
 

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2715,7 +2715,20 @@ proto::VarType::Type OperatorWithKernel::IndicateDataType(
   proto::VarType::Type dafault_data_type =
       static_cast<proto::VarType::Type>(-1);
   proto::VarType::Type data_type = dafault_data_type;
+
+  std::vector<std::string> sup_tensor_attrs;
+  for (auto& attr : Info().Proto().attrs()) {
+    if (attr.support_tensor()) {
+      sup_tensor_attrs.emplace_back(attr.name());
+    }
+  }
+
   for (auto* name : ctx.InNameList()) {
+    if (std::find(sup_tensor_attrs.begin(), sup_tensor_attrs.end(), *name) !=
+        sup_tensor_attrs.end()) {
+      continue;
+    }
+
     if (ctx.InputSize(*name) == 1UL) {
       ParseInputDataType(ctx.InputVar(*name), *name, &data_type);
     } else {

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -178,6 +178,22 @@ class TestPaddingValueTensor2(TestPaddingValueTensor):
         return out
 
 
+class TestPaddingValueTensor3(unittest.TestCase):
+    def test_static(self):
+        np_x = np.random.random((16, 16)).astype('float32')
+        main_prog = Program()
+        starup_prog = Program()
+        with program_guard(main_prog, starup_prog):
+            x = paddle.assign(np_x).astype('float32')
+            pad_value = paddle.assign([0.0]).astype('float64')
+            y = paddle.nn.functional.pad(x, [0, 1, 2, 3], value=pad_value)
+
+        exe = paddle.static.Executor(paddle.CPUPlace())
+        [pd_out] = exe.run(main_prog, fetch_list=[y])
+        np_out = np.pad(np_x, [(0, 1), (2, 3)], constant_values=0.0)
+        np.testing.assert_allclose(pd_out, np_out)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
修改默认的GetExpectedKernelType逻辑。默认GetExpectedKernelType的逻辑是根据inputs最后一个var的type选择kernel类型，但是支持可变attrs后对于tensor类型的attr会被加入到inputs，导致会被错误的通过attr选择kernel类型，本PR对这个错误进行了修复