### PR TITLE
fix gcc12 error while compiling eigen

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -149,6 +149,7 @@ if(NOT WIN32)
       -Wno-unused-parameter
       -Wno-unused-function
       -Wno-error=literal-suffix
+      -Wno-error=array-bounds #Warning in Eigen, gcc 12.2
       -Wno-error=ignored-attributes # Warnings in Eigen, gcc 6.3
       -Wno-error=terminate # Warning in PADDLE_ENFORCE
       -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
使用gcc12编译第三方库eigen时会报数组越界的错误
![image](https://user-images.githubusercontent.com/62429225/219057333-7e4d850d-8563-41ae-b5f2-a711aaaff247.png)
