### PR TITLE
Set output type of TRT network and fix related UTs

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/cast_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/cast_op.cc
@@ -41,28 +41,26 @@ class CastOpConverter : public OpConverter {
 
     auto* layer = TRT_ENGINE_ADD_LAYER(engine_, Identity, *input);
 
+    auto trt_out_dtype = nvinfer1::DataType::kFLOAT;
     switch (out_dtype) {
       case 0:  // BOOL = 0
-        layer->setOutputType(0, nvinfer1::DataType::kBOOL);
-        layer->getOutput(0)->setType(nvinfer1::DataType::kBOOL);
+        trt_out_dtype = nvinfer1::DataType::kBOOL;
         break;
       case 2:  // INT32 = 2
-        layer->setOutputType(0, nvinfer1::DataType::kINT32);
-        layer->getOutput(0)->setType(nvinfer1::DataType::kINT32);
+        trt_out_dtype = nvinfer1::DataType::kINT32;
         break;
       case 4:  // FP16 = 4
-        layer->setOutputType(0, nvinfer1::DataType::kHALF);
-        layer->getOutput(0)->setType(nvinfer1::DataType::kHALF);
+        trt_out_dtype = nvinfer1::DataType::kHALF;
         break;
       case 5:  // FP32 = 5
-        layer->setOutputType(0, nvinfer1::DataType::kFLOAT);
-        layer->getOutput(0)->setType(nvinfer1::DataType::kFLOAT);
+        trt_out_dtype = nvinfer1::DataType::kFLOAT;
         break;
       default:
-        LOG(ERROR) << "Unable to convert a fluid data type(" << out_dtype
-                   << ") to a nvinfer DataType";
+        PADDLE_THROW(platform::errors::Unimplemented(
+            "Unsupport output data type of cast op"));
         break;
     }
+    layer->setOutputType(0, trt_out_dtype);
 
     auto output_name = op_desc.Output("Out")[0];
     RreplenishLayerAndOutput(layer, "cast", {output_name}, test_mode);

--- a/paddle/fluid/inference/tensorrt/convert/conv2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/conv2d_op.cc
@@ -170,7 +170,7 @@ void ConvertConv2d(TensorRTEngine* engine,
   engine->SetITensor(output_name, layer->getOutput(0));
 
   if (test_mode) {
-    engine->DeclareOutput(output_name);
+    engine->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
   }
 }
 

--- a/paddle/fluid/inference/tensorrt/convert/conv3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/conv3d_op.cc
@@ -138,7 +138,7 @@ void ConvertConv3d(TensorRTEngine* engine,
   engine->SetITensor(output_name, layer->getOutput(0));
 
   if (test_mode) {
-    engine->DeclareOutput(output_name);
+    engine->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
   }
 }
 

--- a/paddle/fluid/inference/tensorrt/convert/gather_nd_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/gather_nd_op.cc
@@ -56,7 +56,7 @@ class GatherNdOpConverter : public OpConverter {
     engine_->SetITensor(output_name, layer->getOutput(0));
     layer_name += output_name;
     if (test_mode) {
-      engine_->DeclareOutput(output_name);
+      engine_->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
     }
     layer->setName((layer_name + ")").c_str());
 #endif

--- a/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/matmul_op.cc
@@ -186,7 +186,7 @@ class MatMulOpConverter : public OpConverter {
         engine_->SetITensor(output_name, scale_out);
         if (test_mode) {  // the test framework can not determine which is the
                           // output, so place the declaration inside.
-          engine_->DeclareOutput(output_name);
+          engine_->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
         }
       }
     }

--- a/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool2d_op.cc
@@ -243,7 +243,7 @@ class Pool2dOpConverter : public OpConverter {
       layer->getOutput(0)->setName(output_name.c_str());
       engine_->SetITensor(output_name, layer->getOutput(0));
       if (test_mode) {
-        engine_->DeclareOutput(output_name);
+        engine_->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
       }
       return;
     }
@@ -261,7 +261,7 @@ class Pool2dOpConverter : public OpConverter {
       engine_->SetITensor(output_name, pool_layer->getOutput(0));
       layer = pool_layer;
       if (test_mode) {
-        engine_->DeclareOutput(output_name);
+        engine_->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
       }
       return;
     }

--- a/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/pool3d_op.cc
@@ -161,7 +161,7 @@ class Pool3dOpConverter : public OpConverter {
       layer->getOutput(0)->setName(output_name.c_str());
       engine_->SetITensor(output_name, layer->getOutput(0));
       if (test_mode) {
-        engine_->DeclareOutput(output_name);
+        engine_->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
       }
       return;
     }
@@ -175,7 +175,7 @@ class Pool3dOpConverter : public OpConverter {
       layer->getOutput(0)->setName(output_name.c_str());
       engine_->SetITensor(output_name, layer->getOutput(0));
       if (test_mode) {
-        engine_->DeclareOutput(output_name);
+        engine_->DeclareOutput(output_name, nvinfer1::DataType::kFLOAT);
       }
       return;
     }

--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -384,7 +384,8 @@ nvinfer1::ITensor *TensorRTEngine::DeclareInput(const std::string &name,
 
 void TensorRTEngine::DeclareOutput(const nvinfer1::ILayer *layer,
                                    int offset,
-                                   const std::string &name) {
+                                   const std::string &name,
+                                   nvinfer1::DataType dtype) {
   auto *output = layer->getOutput(offset);
   SetITensor(name, output);
   PADDLE_ENFORCE_NOT_NULL(
@@ -405,9 +406,11 @@ void TensorRTEngine::DeclareOutput(const nvinfer1::ILayer *layer,
       platform::errors::InvalidArgument(
           "The output %s of TRT engine should be the output of the network.",
           name));
+  output->setType(dtype);
 }
 
-void TensorRTEngine::DeclareOutput(const std::string &name) {
+void TensorRTEngine::DeclareOutput(const std::string &name,
+                                   nvinfer1::DataType dtype) {
   auto *output = TensorRTEngine::GetITensor(name);
   PADDLE_ENFORCE_NOT_NULL(
       output,
@@ -421,6 +424,7 @@ void TensorRTEngine::DeclareOutput(const std::string &name) {
                         "of the network at the same time.",
                         name));
   network()->markOutput(*output);
+  output->setType(dtype);
 }
 void TensorRTEngine::DeleteITensor(const std::string &name,
                                    nvinfer1::ITensor *tensor) {

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -287,9 +287,10 @@ class TensorRTEngine {
   // name.
   void DeclareOutput(const nvinfer1::ILayer* layer,
                      int offset,
-                     const std::string& name);
+                     const std::string& name,
+                     nvinfer1::DataType dtype);
   // Set the itensor_map_[name] as the network's output, and set its name.
-  void DeclareOutput(const std::string& name);
+  void DeclareOutput(const std::string& name, nvinfer1::DataType dtype);
   void ClearTensorMap() { itensor_map_.clear(); }
 
   void DeleteITensor(const std::string& name, nvinfer1::ITensor* tensor);

--- a/paddle/fluid/inference/tensorrt/test_dynamic_engine.cc
+++ b/paddle/fluid/inference/tensorrt/test_dynamic_engine.cc
@@ -441,10 +441,14 @@ TEST_F(TensorRTDynamicTestFusedTokenPrune, test_fused_token_prune) {
                           platform::errors::InvalidArgument(
                               "TRT fused_token_prune layer building failed."));
   std::vector<std::string> output_tensor_names{"out_slimmed_x", "out_cls_inds"};
+  // In FusedTokenPrunePluginDynamic plugin, the first output is FLOAT; the
+  // second output is INT32.
+  std::vector<nvinfer1::DataType> layer_output_dtype = {
+      nvinfer1::DataType::kFLOAT, nvinfer1::DataType::kINT32};
   for (size_t i = 0; i < 2; i++) {
     layer->getOutput(i)->setName(output_tensor_names[i].c_str());
     engine_->DeclareOutput(
-        layer, i, output_tensor_names[i], nvinfer1::DataType::kFLOAT);
+        layer, i, output_tensor_names[i], layer_output_dtype[i]);
   }
   engine_->FreezeNetwork();
 

--- a/paddle/fluid/inference/tensorrt/test_dynamic_engine.cc
+++ b/paddle/fluid/inference/tensorrt/test_dynamic_engine.cc
@@ -124,7 +124,7 @@ TEST_F(TensorRTDynamicShapeValueEngineTest, test_trt_dynamic_shape_value) {
   PADDLE_ENFORCE_NOT_NULL(
       layer,
       platform::errors::InvalidArgument("TRT shuffle layer building failed."));
-  engine_->DeclareOutput(layer, 0, "y");
+  engine_->DeclareOutput(layer, 0, "y", nvinfer1::DataType::kFLOAT);
   engine_->FreezeNetwork();
   ASSERT_EQ(engine_->engine()->getNbBindings(), 3);
 
@@ -292,7 +292,7 @@ TEST_F(TensorRTDynamicEngineTest, test_spmm) {
       fc_layer,
       platform::errors::InvalidArgument("TRT SPMM layer building failed."));
 
-  engine_->DeclareOutput(fc_layer, 0, "y");
+  engine_->DeclareOutput(fc_layer, 0, "y", nvinfer1::DataType::kFLOAT);
   engine_->FreezeNetwork();
   ASSERT_EQ(engine_->engine()->getNbBindings(), 2);
 
@@ -443,7 +443,8 @@ TEST_F(TensorRTDynamicTestFusedTokenPrune, test_fused_token_prune) {
   std::vector<std::string> output_tensor_names{"out_slimmed_x", "out_cls_inds"};
   for (size_t i = 0; i < 2; i++) {
     layer->getOutput(i)->setName(output_tensor_names[i].c_str());
-    engine_->DeclareOutput(layer, i, output_tensor_names[i]);
+    engine_->DeclareOutput(
+        layer, i, output_tensor_names[i], nvinfer1::DataType::kFLOAT);
   }
   engine_->FreezeNetwork();
 

--- a/paddle/fluid/inference/tensorrt/test_engine.cc
+++ b/paddle/fluid/inference/tensorrt/test_engine.cc
@@ -95,7 +95,7 @@ TEST_F(TensorRTEngineTest, add_layer) {
                           platform::errors::InvalidArgument(
                               "TRT fully connected layer building failed."));
 
-  engine_->DeclareOutput(fc_layer, 0, "y");
+  engine_->DeclareOutput(fc_layer, 0, "y", nvinfer1::DataType::kFLOAT);
   LOG(INFO) << "freeze network";
   engine_->FreezeNetwork();
   ASSERT_EQ(engine_->engine()->getNbBindings(), 2);
@@ -150,7 +150,7 @@ TEST_F(TensorRTEngineTest, add_layer_multi_dim) {
                           platform::errors::InvalidArgument(
                               "TRT fully connected layer building failed."));
 
-  engine_->DeclareOutput(fc_layer, 0, "y");
+  engine_->DeclareOutput(fc_layer, 0, "y", nvinfer1::DataType::kFLOAT);
   engine_->FreezeNetwork();
   ASSERT_EQ(engine_->engine()->getNbBindings(), 2);
 
@@ -202,7 +202,7 @@ TEST_F(TensorRTEngineTest, test_conv2d) {
   conv_layer->setStride(nvinfer1::DimsHW{1, 1});
   conv_layer->setPadding(nvinfer1::DimsHW{1, 1});
 
-  engine_->DeclareOutput(conv_layer, 0, "y");
+  engine_->DeclareOutput(conv_layer, 0, "y", nvinfer1::DataType::kFLOAT);
   engine_->FreezeNetwork();
   ASSERT_EQ(engine_->engine()->getNbBindings(), 2);
 
@@ -259,7 +259,7 @@ TEST_F(TensorRTEngineTest, test_pool2d) {
   pool_layer->setStride(nvinfer1::DimsHW{1, 1});
   pool_layer->setPadding(nvinfer1::DimsHW{0, 0});
 
-  engine_->DeclareOutput(pool_layer, 0, "y");
+  engine_->DeclareOutput(pool_layer, 0, "y", nvinfer1::DataType::kFLOAT);
   engine_->FreezeNetwork();
   ASSERT_EQ(engine_->engine()->getNbBindings(), 2);
 

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op_test.cc
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op_test.cc
@@ -92,6 +92,7 @@ void DynamicShapeTest(bool allow_build_at_runtime) {
   AddTensorToBlockDesc(block_, "y", std::vector<int64_t>({4, 6}));
   AddTensorToBlockDesc(block_, "y0", std::vector<int64_t>({6, 8}));
   AddTensorToBlockDesc(block_, "z", std::vector<int64_t>({2, 6}));
+  AddTensorToBlockDesc(block_, "z0", std::vector<int64_t>({2, 8, 1, 1}));
 
   // It is wired, need to copy manually.
   *block_->add_ops() = *fc0->Proto();

--- a/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/auto_scan_test.py
@@ -14,6 +14,7 @@
 
 import abc
 import enum
+import inspect
 import logging
 import os
 import shutil
@@ -182,25 +183,21 @@ class AutoScanTest(unittest.TestCase):
         ops = []
         for i in range(len(ops_config)):
             op_config = ops_config[i]
-            if 'outputs_dtype' in op_config:
-                ops.append(
-                    OpConfig(
-                        type=op_config['op_type'],
-                        inputs=op_config['op_inputs'],
-                        outputs=op_config['op_outputs'],
-                        attrs=op_config['op_attrs'],
-                        outputs_dtype=op_config['outputs_dtype'],
-                    )
+            outputs_dtype = op_config.get(
+                'outputs_dtype',
+                inspect.signature(OpConfig.__init__)
+                .parameters['outputs_dtype']
+                .default,
+            )
+            ops.append(
+                OpConfig(
+                    type=op_config['op_type'],
+                    inputs=op_config['op_inputs'],
+                    outputs=op_config['op_outputs'],
+                    attrs=op_config['op_attrs'],
+                    outputs_dtype=outputs_dtype,
                 )
-            else:
-                ops.append(
-                    OpConfig(
-                        type=op_config['op_type'],
-                        inputs=op_config['op_inputs'],
-                        outputs=op_config['op_outputs'],
-                        attrs=op_config['op_attrs'],
-                    )
-                )
+            )
         return ops
 
     @abc.abstractmethod

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_cast.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_cast.py
@@ -21,6 +21,7 @@ from program_config import ProgramConfig, TensorConfig
 from trt_layer_auto_scan_test import TrtLayerAutoScanTest
 
 import paddle.inference as paddle_infer
+from paddle.framework import convert_np_dtype_to_dtype_
 
 
 class TrtConvertCastTest(TrtLayerAutoScanTest):
@@ -46,22 +47,20 @@ class TrtConvertCastTest(TrtLayerAutoScanTest):
         return True
 
     def sample_program_configs(self):
-        def generate_input(type):
-            if type == 0:
-                return np.ones([1, 3, 64, 64]).astype(np.bool)
-            elif type == 2:
-                return np.ones([1, 3, 64, 64]).astype(np.int32)
-            elif type == 4:
-                return np.ones([1, 3, 64, 64]).astype(np.float16)
-            else:
-                return np.ones([1, 3, 64, 64]).astype(np.float32)
+        def generate_input(dtype):
+            return np.ones([1, 3, 64, 64]).astype(dtype)
 
-        for in_dtype in [0, 2, 5, 6]:
-            for out_dtype in [0, 2, 5, 6]:
-                self.out_dtype = out_dtype
+        for in_dtype in [np.bool_, np.int32, np.float32, np.float64]:
+            for out_dtype in [np.bool_, np.int32, np.float32, np.float64]:
                 dics = [
-                    {"in_dtype": in_dtype, "out_dtype": out_dtype},
-                    {"in_dtype": out_dtype, "out_dtype": in_dtype},
+                    {
+                        "in_dtype": convert_np_dtype_to_dtype_(in_dtype),
+                        "out_dtype": convert_np_dtype_to_dtype_(out_dtype),
+                    },
+                    {
+                        "in_dtype": convert_np_dtype_to_dtype_(out_dtype),
+                        "out_dtype": convert_np_dtype_to_dtype_(in_dtype),
+                    },
                 ]
 
                 ops_config = [
@@ -70,12 +69,14 @@ class TrtConvertCastTest(TrtLayerAutoScanTest):
                         "op_inputs": {"X": ["input_data"]},
                         "op_outputs": {"Out": ["cast_output_data0"]},
                         "op_attrs": dics[0],
+                        "op_outputs_dtype": {"cast_output_data0": out_dtype},
                     },
                     {
                         "op_type": "cast",
                         "op_inputs": {"X": ["cast_output_data0"]},
                         "op_outputs": {"Out": ["cast_output_data1"]},
                         "op_attrs": dics[1],
+                        "op_outputs_dtype": {"cast_output_data1": in_dtype},
                     },
                 ]
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_top_k.py
@@ -54,6 +54,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
                                 "Indices": ["indices_data"],
                             },
                             "op_attrs": dics[0],
+                            "outputs_dtype": {"indices_data": np.int32},
                         }
                     ]
                     ops = self.generate_op_config(ops_config)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
This PR manually set the TensorRT network output data type according to the paddle program.
Also, this PR fixed UTs of some OPs that has INT32 or BOOL output data type.

Currently, some UTs still fail and are fixed in progress.
