### PR TITLE
memorty_optimize remove inplace op

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -222,6 +222,40 @@ void MakeSimpleReusePlan(
   }
 }
 
+// Remove the inplace operation from the plan because it does not support memory
+// reuse
+void DelInplaceOpFromPlan(
+    Graph* graph,
+    std::unordered_map<std::string, std::string>* node2cluster,
+    int sort_kind) {
+  auto topo_nodes = TopologyVarientSort(
+      *graph, static_cast<framework::ir::SortKind>(sort_kind));
+  for (auto* op_node : topo_nodes) {
+    if (!op_node->IsOp()) continue;
+    auto input_tensors = op_node->inputs;
+    auto output_tensors = op_node->outputs;
+
+    std::unordered_set<std::string> in_names;
+    for (const Node* node : input_tensors) {
+      if (!node->Var()) continue;
+      if (node->Var()->Persistable()) continue;
+      std::string var = node->Name();
+      in_names.insert(var);
+    }
+
+    for (const Node* node : output_tensors) {
+      if (!node->Var()) continue;
+      if (node->Var()->Persistable()) continue;
+      std::string var = node->Name();
+      if (in_names.find(var) != in_names.end()) {
+        if (node2cluster->count(var)) {
+          node2cluster->erase(var);
+        }
+      }
+    }
+  }
+}
+
 // NOTE The optimized opdesc doesn't match ir::Graph.
 void UpdateOpDescsByReuse(
     Graph* graph,
@@ -324,6 +358,7 @@ void MemoryOptimizePass::RunImpl(Argument* argument) {
   CollectLifeCycle(graph, &lifecycles, sort_kind);
   CollectVarMemorySize(graph, &space_table);
   MakeSimpleReusePlan(lifecycles, space_table, &node2cluster, &cluster_size);
+  DelInplaceOpFromPlan(graph, &node2cluster, sort_kind);
 
   auto* pass_res_info = PassResultInfoForRuntime::Instance();
   pass_res_info->Set(

--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -258,10 +258,8 @@ void DelInplaceOpFromPlan(
           if (it->second == var) {
             if (tmp_name == "") {
               tmp_name = it->first;
-              it->second = tmp_name;
-            } else {
-              it->second = tmp_name;
             }
+            it->second = tmp_name;
           }
         }
       }

--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -248,8 +248,21 @@ void DelInplaceOpFromPlan(
       if (node->Var()->Persistable()) continue;
       std::string var = node->Name();
       if (in_names.find(var) != in_names.end()) {
+        // delete key
         if (node2cluster->count(var)) {
           node2cluster->erase(var);
+        }
+        // delete value
+        std::string tmp_name = "";
+        for (auto it = node2cluster->begin(); it != node2cluster->end(); ++it) {
+          if (it->second == var) {
+            if (tmp_name == "") {
+              tmp_name = it->first;
+              it->second = tmp_name;
+            } else {
+              it->second = tmp_name;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
现有的内存复用策略在op执行之前通过ReusePlan(reuse_cache_)确定是否复用，然后在执行OP。
![9e36daea61d49942144e16b6ab1254fb](https://user-images.githubusercontent.com/117625383/209911183-77ed1acf-4a75-4e59-a32f-4d5a14d66083.png)

如果该op为inplace算子，输入和输出是相同的Tensor，发生内存复用时修改了该OP的tensor的data的指针，使得该OP输入Tensor的data指向错误的地址，数据错误，最终导致该OP计算错误。因此输入和输出Tensor相同的OP不能支持内存复用，在制定ReusePlan的时候过滤掉这种情况。
![未命名文件](https://user-images.githubusercontent.com/117625383/209913425-b5f0849e-d602-4d60-87bb-48d4e0735d0c.jpg)
