### PR TITLE
fix_mac_build_problem

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3652,7 +3652,7 @@ function run_setup(){
     # reset ccache zero stats for collect PR's actual hit rate
     ccache -z
 
-    python setup.py $2;build_error=$?
+    ${PYTHON_EXECUTABLE} setup.py $2;build_error=$?
     
     # ci will collect ccache hit rate
     collect_ccache_hits
@@ -3668,7 +3668,7 @@ function main() {
     init
     case $CMD in
       build_only)
-        run_setup ${PYTHON_ABI:-""} bdist_wheel
+        cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         ;;
       build_pr_dev)
         build_pr_and_develop

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3668,7 +3668,7 @@ function main() {
     init
     case $CMD in
       build_only)
-        cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
+        run_setup ${PYTHON_ABI:-""} bdist_wheel
         ;;
       build_pr_dev)
         build_pr_and_develop

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -3651,8 +3651,11 @@ function run_setup(){
 
     # reset ccache zero stats for collect PR's actual hit rate
     ccache -z
-
-    ${PYTHON_EXECUTABLE} setup.py $2;build_error=$?
+    if [ "${PYTHON_EXECUTABLE}" != "" ];then
+        ${PYTHON_EXECUTABLE} setup.py $2;build_error=$?
+    else
+        python setup.py $2;build_error=$?
+    fi
     
     # ci will collect ccache hit rate
     collect_ccache_hits


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
此PR修复了两个问题
① 在mac环境下编译的时候，如果编译paddle时候的python版本(export py_version设置的python)和打包python时候的版本(which python)不一致，导致mac环境下在python3.9环境下编译出来的whl包最后包的名字为(which python3.7)不一致。修复方案为在执行python setup.py时，使用的python限定为python_executable指定的python。

②有一些流水线，如PR-CI-Rocm，GPUps，在编译的时候没有export python_excutable。那么如果单纯使用${python_executable} setup.py bdist_wheel就会导致${python_executable} 为空，也会失败。此时使用当时环境下的python即可