### PR TITLE
fix_static_problem

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -87,7 +87,6 @@ if(WIN32)
   endif()
 else()
   if(WITH_SETUP_INSTALL)
-
     add_custom_command(
       OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
       COMMAND touch stub.cc

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -87,6 +87,7 @@ if(WIN32)
   endif()
 else()
   if(WITH_SETUP_INSTALL)
+
     add_custom_command(
       OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
       COMMAND touch stub.cc

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -106,7 +106,7 @@ __all__ = ['cuda', 'cudnn', 'show']
 
 def show():
     """Get the version of paddle if `paddle` package if tagged. Otherwise, output the corresponding commit id.
-    
+
     Returns:
         If paddle package is not tagged, the commit-id of paddle will be output.
         Otherwise, the following information will be output.
@@ -118,13 +118,13 @@ def show():
         minor: the minor version of paddle
 
         patch: the patch level version of paddle
-        
+
         rc: whether it's rc version
 
         cuda: the cuda version of package. It will return `False` if CPU version paddle package is installed
 
         cudnn: the cudnn version of package. It will return `False` if CPU version paddle package is installed
-    
+
     Examples:
         .. code-block:: python
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
修复static流水线报错，由于setup.py和setup.py.in中show()函数中存在空格差异导致
![ca455ed21a7bc7c2242991f43e14b7a8](https://user-images.githubusercontent.com/62429225/209927306-af233213-c390-4c8b-bc8f-20cf5fff7081.png)
![ad84b096f9af2c511807ddf772deeda0](https://user-images.githubusercontent.com/62429225/209927318-778ad469-9c30-47e2-be64-e52d6c346d7d.png)
