### PR TITLE
Fix test_conv_bn_fuse_pass_cc on Windows System

### DIFF
--- a/paddle/fluid/framework/ir/conv_bn_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/conv_bn_fuse_pass_tester.cc
@@ -98,7 +98,7 @@ void TestMain(const std::string& conv_type) {
 
 TEST(ConvBNFusePass, conv2d) { TestMain("conv"); }
 
-// TEST(ConvBNFusePass, conv2d_tranpose) { TestMain("conv_transpose"); }
+TEST(ConvBNFusePass, conv2d_tranpose) { TestMain("conv_transpose"); }
 
 }  // namespace ir
 }  // namespace framework

--- a/paddle/fluid/framework/ir/conv_bn_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/conv_bn_fuse_pass_tester.cc
@@ -32,7 +32,11 @@ void AddVarToScope(Scope* param_scope,
                    const DDim& dims) {
   auto* tensor = param_scope->Var(name)->GetMutable<phi::DenseTensor>();
   tensor->Resize(dims);
-  tensor->mutable_data<float>(platform::CPUPlace());
+  auto* data = tensor->mutable_data<float>(platform::CPUPlace());
+  int64_t numel = tensor->numel();
+  for (int64_t i = 0; i < numel; ++i) {
+    data[i] = 0;
+  }
 }
 
 Scope* CreateParamScope() {
@@ -94,7 +98,7 @@ void TestMain(const std::string& conv_type) {
 
 TEST(ConvBNFusePass, conv2d) { TestMain("conv"); }
 
-TEST(ConvBNFusePass, conv2d_tranpose) { TestMain("conv_transpose"); }
+// TEST(ConvBNFusePass, conv2d_tranpose) { TestMain("conv_transpose"); }
 
 }  // namespace ir
 }  // namespace framework


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复`PR-CI-Windows-Inference` 单测`test_conv_bn_fuse_pass_cc`随机出现的如下错误：
<img width="851" alt="image" src="https://user-images.githubusercontent.com/13048366/209942071-7e06ce97-93d6-415f-b790-317b75decc4e.png">

错误原因为Windows系统下tensor调用mutable_data接口分配的初始内存里默认值会有一定随机性，从而导致后续计算出现问题，修复方式为对该块内存进行赋值填充，避免随机默认值的情况出现。
Linux下目前使用mutable_data接口分配的初始内存默认值均为0，因此未出现该错误。