### PR TITLE
[ControlFlow][NewExe] set Flag_control_flow_use_new_executor=true by default

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -45,7 +45,7 @@ PADDLE_DEFINE_EXPORTED_bool(new_executor_use_local_scope,
                             "Use local_scope in new executor(especially used "
                             "in UT), can turn off for better performance");
 PADDLE_DEFINE_EXPORTED_bool(control_flow_use_new_executor,
-                            false,
+                            true,
                             "Use new executor in control flow op");
 
 DECLARE_bool(check_nan_inf);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

The support of `InterpreterCore` was added for control flow ops in #45696 and #47573.
These changes  were tested with model `paddlenlp.transformers.InferTransformerModel`. The running scripts comes from [here](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/examples/machine_translation/transformer/predict.py).
Since the test results show that running control flow ops with `InterpreterCore` has no negative effect, we decide to make this a default behavior by set `Flag_control_flow_use_new_executor` 's initial value to `true`.

#### Test Results

##### Speed
| execution time of a step  | Mean             |  Std              |  
|------------------|--------------------|---------------------|
| `InterpreterCore`  | 3.765255368136345  | 0.25985690535277695 | 
| `Executor`     | 3.7777641466323364 | 0.3428938842422705  |   
##### Accuracy
We printed the output `finished_sequence` of every step in both conditions and compared them. 
The output was exactly same no matter which executor was used.
##### Memory Usage
We printed max memory usage during execution of first ten steps:
|          | max_memory_reserved |                    |
|----------|---------------------|--------------------|
| Unit：MB | `InterpreterCore`   | `Executor`         |
| 1        | 26932.67236328125   | 28292.859619140625 |
| 2        | 26932.67236328125   | 28292.859619140625 |
| 3        | 26932.67236328125   | 28292.859619140625 |
| 4        | 26932.67236328125   | 28292.859619140625 |
| 5        | 26932.67236328125   | 28292.859619140625 |
| 6        | 26932.67236328125   | 28292.859619140625 |
| 7        | 26932.67236328125   | 28292.859619140625 |
| 8        | 26932.67236328125   | 28292.859619140625 |
| 9        | 26932.67236328125   | 28292.859619140625 |
| 10       | 26932.67236328125   | 28292.859619140625 |
