### PR TITLE
[Dy2St]Fix param and out grad names in dy2st for high order grad

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_func.h
+++ b/paddle/fluid/eager/to_static/run_program_op_func.h
@@ -80,16 +80,10 @@ inline void run_program_ad_func(
       trace_backward, &p_autograd_x, &p_autograd_params);
 
   if (require_any_grad) {
-    std::vector<std::string> out_names;
-    for (auto& t : deref_out) {
-      out_names.emplace_back(t.name());
-    }
-
     egr::EagerUtils::PassStopGradient(false, &p_autograd_outs);
     // Create GradOpNode (1 means [out_grad], 2 means [x_grad, paramx_grad])
     auto grad_node = std::make_shared<GradNodeRunProgram>(1, 2);
 
-    grad_node->SetFwdOutNames(out_names);
     // Set Attributes
     grad_node->SetAttrMap(attrs);
     // Set TensorWrappers

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -799,7 +799,6 @@ class GradNodeRunProgram : public egr::GradNodeBase {
                           "The hooked_grads[0].size() and "
                           "out_grad_names.size() should be equal."));
     for (size_t i = 0; i < out_grad_names.size(); ++i) {
-      VLOG(1) << "out_grad_names[i]: " << out_grad_names[i];
       hooked_grads[0][i].set_name(out_grad_names[i]);
     }
     RunProgramGradAPI(x_,

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -792,13 +792,16 @@ class GradNodeRunProgram : public egr::GradNodeBase {
       }
     }
 
+    auto out_grad_names =
+        PADDLE_GET_CONST(std::vector<std::string>, attrs_.at("out_grad_names"));
     PADDLE_ENFORCE_EQ(hooked_grads[0].size(),
-                      fwd_out_names_.size(),
+                      out_grad_names.size(),
                       paddle::platform::errors::InvalidArgument(
                           "The hooked_grads[0].size() and "
                           "fwd_out_names_.size() should be equal."));
-    for (size_t i = 0; i < fwd_out_names_.size(); ++i) {
-      hooked_grads[0][i].set_name(fwd_out_names_[i] + "@GRAD");
+    for (size_t i = 0; i < out_grad_names.size(); ++i) {
+      VLOG(1) << "out_grad_names[i]: " << out_grad_names[i];
+      hooked_grads[0][i].set_name(out_grad_names[i]);
     }
     RunProgramGradAPI(x_,
                       params_,

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -21,7 +21,6 @@
 #include "paddle/fluid/operators/run_program_op.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/profiler/event_tracing.h"
-#include "paddle/utils/string/string_helper.h"
 
 namespace details {
 using Tensor = paddle::experimental::Tensor;

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -797,7 +797,7 @@ class GradNodeRunProgram : public egr::GradNodeBase {
                       out_grad_names.size(),
                       paddle::platform::errors::InvalidArgument(
                           "The hooked_grads[0].size() and "
-                          "fwd_out_names_.size() should be equal."));
+                          "out_grad_names.size() should be equal."));
     for (size_t i = 0; i < out_grad_names.size(); ++i) {
       VLOG(1) << "out_grad_names[i]: " << out_grad_names[i];
       hooked_grads[0][i].set_name(out_grad_names[i]);
@@ -830,10 +830,6 @@ class GradNodeRunProgram : public egr::GradNodeBase {
 
   void SetStepScope(const std::vector<paddle::framework::Scope *> &scopes) {
     step_scope_ = scopes;
-  }
-
-  void SetFwdOutNames(std::vector<std::string> out_names) {
-    fwd_out_names_ = out_names;
   }
 
  protected:
@@ -891,8 +887,6 @@ class GradNodeRunProgram : public egr::GradNodeBase {
   std::vector<paddle::experimental::Tensor> x_;
   std::vector<paddle::experimental::Tensor> params_;
   std::vector<paddle::framework::Scope *> step_scope_;
-
-  std::vector<std::string> fwd_out_names_;
 
   // Attribute Map
   paddle::framework::AttributeMap attrs_;

--- a/paddle/fluid/operators/run_program_op.cc
+++ b/paddle/fluid/operators/run_program_op.cc
@@ -132,7 +132,7 @@ class RunProgramOpMaker : public framework::OpProtoAndCheckerMaker {
         .SetDefault(nullptr);
     AddAttr<std::vector<std::string>>("param_grad_names",
                                       "std::vector<std::string>"
-                                      "param_grad_names.")
+                                      "The names of parameter gradients.")
         .SetDefault({});
     AddComment(R"DOC(
 RunProgram operator.

--- a/paddle/fluid/operators/run_program_op.cc
+++ b/paddle/fluid/operators/run_program_op.cc
@@ -134,6 +134,10 @@ class RunProgramOpMaker : public framework::OpProtoAndCheckerMaker {
                                       "std::vector<std::string>"
                                       "The names of parameter gradients.")
         .SetDefault({});
+    AddAttr<std::vector<std::string>>("out_grad_names",
+                                      "std::vector<std::string>"
+                                      "The names of output gradients.")
+        .SetDefault({});
     AddComment(R"DOC(
 RunProgram operator.
 

--- a/paddle/fluid/operators/run_program_op.cc
+++ b/paddle/fluid/operators/run_program_op.cc
@@ -130,6 +130,10 @@ class RunProgramOpMaker : public framework::OpProtoAndCheckerMaker {
                         "(BlockDesc *)"
                         "The global block of executed backward program desc.")
         .SetDefault(nullptr);
+    AddAttr<std::vector<std::string>>("param_grad_names",
+                                      "std::vector<std::string>"
+                                      "param_grad_names.")
+        .SetDefault({});
     AddComment(R"DOC(
 RunProgram operator.
 

--- a/python/paddle/fluid/tests/unittests/test_eager_run_program.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_run_program.py
@@ -135,6 +135,10 @@ class TestRunProgram(unittest.TestCase):
             False,
             'program_id',
             _hash_with_id(program),
+            'param_grad_names',
+            ['Fake_var@GRAD'],
+            'out_grad_names',
+            [out.name + '@GRAD'],
         ]
 
         use_interpretorcore = (

--- a/python/paddle/fluid/tests/unittests/test_run_program_op.py
+++ b/python/paddle/fluid/tests/unittests/test_run_program_op.py
@@ -262,6 +262,15 @@ class RunProgramOpTest(unittest.TestCase):
                     )
                 )
 
+            self.attrs.extend(
+                (
+                    'param_grad_names',
+                    [p.name + '@GRAD' for p in inputs['Params']],
+                    'out_grad_names',
+                    [out.name + '@GRAD' for out in outputs['Out']],
+                )
+            )
+
             _legacy_C_ops.run_program(
                 inputs['X'],
                 inputs['Params'],
@@ -304,6 +313,15 @@ class RunProgramOpTest(unittest.TestCase):
                         backward_program_desc.block(0),
                     )
                 )
+
+            self.attrs.extend(
+                (
+                    'param_grad_names',
+                    [p.name + '@GRAD' for p in inputs['Params']],
+                    'out_grad_names',
+                    [out.name + '@GRAD' for out in outputs['Out']],
+                )
+            )
 
             _legacy_C_ops.run_program(
                 inputs['X'],

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -427,7 +427,10 @@ class PartialProgramLayer:
         fwd_end_op_index = self._get_end_op_index()
         for i in range(
             fwd_end_op_index + 1,
-            fwd_end_op_index + 2 * len(self._outputs.var_ids),
+            min(
+                fwd_end_op_index + 2 * len(self._outputs.var_ids),
+                len(self.program.block(0).ops),
+            ),
             2,
         ):
             op = self.program.block(0).ops[i]

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -643,9 +643,9 @@ class PartialProgramLayer:
             self.program_id,
         ]
         if self.training:
-            # NOTE: In the case of higher-order gradient, the name of the parameter grad may be like
+            # NOTE: In the case of higher-order gradient, the names of the parameter grads may be like
             # `grad/grad/grad/linear_0.w_0@GRAD` instead of simply `linear_0.w_0@GRAD`, so we get
-            # the correct name of the parameter grad from program.
+            # the correct names of the parameter grads from program. And out grads are similar to above.
             attrs.extend(
                 (
                     'param_grad_names',

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -251,7 +251,7 @@ class PartialProgramLayer:
 
     @switch_to_static_graph
     def _create_forward_backward_train_program(self):
-        whole_program = self._create_program()
+        whole_program = self._train_program
         forward_end_op_index = self._infer_program.desc.block(0).op_size()
         return self._get_forward_backward_program_form(
             whole_program, forward_end_op_index
@@ -259,7 +259,7 @@ class PartialProgramLayer:
 
     @switch_to_static_graph
     def _create_forward_backward_train_amp_program(self):
-        whole_program = self._create_amp_program()
+        whole_program = self._train_amp_program
         forward_end_op_index = self._infer_amp_program.desc.block(0).op_size()
         return self._get_forward_backward_program_form(
             whole_program, forward_end_op_index
@@ -267,7 +267,7 @@ class PartialProgramLayer:
 
     @switch_to_static_graph
     def _create_forward_backward_train_pure_fp16_program(self):
-        whole_program = self._create_pure_fp16_program()
+        whole_program = self._train_pure_fp16_program
         forward_end_op_index = self._infer_pure_fp16_program.desc.block(
             0
         ).op_size()
@@ -409,9 +409,9 @@ class PartialProgramLayer:
         # the param grad name can be set correctly in the run_program.
         for param in self._params:
             candidate = [
-                var.name
-                for var in self.backward_program.list_vars()
-                if var.name.endswith(param.name + '@GRAD')
+                var_name
+                for var_name in self.backward_program.block(0).vars.keys()
+                if var_name.endswith(param.name + '@GRAD')
             ]
             if candidate:
                 names.append(
@@ -428,7 +428,7 @@ class PartialProgramLayer:
         for i in range(
             fwd_end_op_index + 1,
             fwd_end_op_index + 2 * len(self._outputs.var_ids),
-            step=2,
+            2,
         ):
             op = self.program.block(0).ops[i]
             if op.type == 'fill_constant':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
科学计算场景下，param_grad name不再是简单的`linear_0.w_0@GRAD`的形式，而有可能是
`grad/grad/grad/linear_0.w_0@GRAD`这样的名字；同样的out_grad name也不再是简单的`linear_7.tmp_1@GRAD`，而有可能是`linear_7.tmp_1@GRAD_0`。
这个PR对科学计算场景高阶微分的情况进行了支持，不再简单的通过前向`name+@GRAD`的方式拼接para/out_grad 的name，而是在program中拿到准确的para/out_grad name