### PR TITLE
[OpAttr]Fix Ignore AttriteTensor in IndicateDataType bug in grad_op

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2716,32 +2716,7 @@ proto::VarType::Type OperatorWithKernel::IndicateDataType(
       static_cast<proto::VarType::Type>(-1);
   proto::VarType::Type data_type = dafault_data_type;
 
-  auto in_name_list = ctx.InNameList();
-  // NOTE(Aurelius84): SupportTensor mechanism will move these Attribues
-  // into OperatorBase.Inputs, so we should filter them while infer
-  // Kernel data type.
-  auto* fwd_op_info = &Info();
-  size_t pos = Type().find("_grad");
-  if (pos != std::string::npos) {
-    fwd_op_info = OpInfoMap::Instance().GetNullable(Type().substr(0, pos));
-  }
-  if (fwd_op_info && fwd_op_info->HasOpProtoAndChecker()) {
-    for (auto& attr : fwd_op_info->Proto().attrs()) {
-      auto it =
-          std::find_if(in_name_list.begin(),
-                       in_name_list.end(),
-                       [&attr](const std::string* name) {
-                         return attr.support_tensor() && *name == attr.name();
-                       });
-      if (it != in_name_list.end()) {
-        VLOG(4) << "Ingore Attribute: " << attr.name()
-                << " in IndicateDataType.";
-        in_name_list.erase(it);
-      }
-    }
-  }
-
-  for (auto* name : in_name_list) {
+  for (auto* name : ctx.InNameList()) {
     if (ctx.InputSize(*name) == 1UL) {
       ParseInputDataType(ctx.InputVar(*name), *name, &data_type);
     } else {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -2717,8 +2717,16 @@ proto::VarType::Type OperatorWithKernel::IndicateDataType(
   proto::VarType::Type data_type = dafault_data_type;
 
   auto in_name_list = ctx.InNameList();
-  if (Info().HasOpProtoAndChecker()) {
-    for (auto& attr : Info().Proto().attrs()) {
+  // NOTE(Aurelius84): SupportTensor mechanism will move these Attribues
+  // into OperatorBase.Inputs, so we should filter them while infer
+  // Kernel data type.
+  auto* fwd_op_info = &Info();
+  size_t pos = Type().find("_grad");
+  if (pos != std::string::npos) {
+    fwd_op_info = OpInfoMap::Instance().GetNullable(Type().substr(0, pos));
+  }
+  if (fwd_op_info && fwd_op_info->HasOpProtoAndChecker()) {
+    for (auto& attr : fwd_op_info->Proto().attrs()) {
       auto it =
           std::find_if(in_name_list.begin(),
                        in_name_list.end(),
@@ -2726,6 +2734,8 @@ proto::VarType::Type OperatorWithKernel::IndicateDataType(
                          return attr.support_tensor() && *name == attr.name();
                        });
       if (it != in_name_list.end()) {
+        VLOG(4) << "Ingore Attribute: " << attr.name()
+                << " in IndicateDataType.";
         in_name_list.erase(it);
       }
     }

--- a/paddle/fluid/operators/pad_op.cc
+++ b/paddle/fluid/operators/pad_op.cc
@@ -30,6 +30,13 @@ class PadOp : public framework::OperatorWithKernel {
     OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "Pad");
     OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "Pad");
   }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(
+        OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace());
+  }
 };
 
 class PadOpMaker : public framework::OpProtoAndCheckerMaker {
@@ -97,6 +104,14 @@ class PadOpGrad : public framework::OperatorWithKernel {
       }
       ctx->SetOutputDim(x_grad_name, dout_dims);
     }
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(OperatorWithKernel::IndicateVarDataType(
+                                       ctx, framework::GradVarName("Out")),
+                                   ctx.GetPlace());
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -187,9 +187,14 @@ class TestPaddingValueTensor3(unittest.TestCase):
             x = paddle.assign(np_x).astype('float32')
             pad_value = paddle.assign([0.0]).astype('float64')
             y = paddle.nn.functional.pad(x, [0, 1, 2, 3], value=pad_value)
+            loss = y.sum()
+            optimize_ops, params_grads = paddle.optimizer.SGD(0.01).minimize(
+                loss
+            )
 
         exe = paddle.static.Executor(paddle.CPUPlace())
-        [pd_out] = exe.run(main_prog, fetch_list=[y])
+        res = exe.run(main_prog, fetch_list=[y] + [g for p, g in params_grads])
+        pd_out = res[0]
         np_out = np.pad(np_x, [(0, 1), (2, 3)], constant_values=0.0)
         np.testing.assert_allclose(pd_out, np_out)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[OpAttr]Fix Ignore AttriteTensor in IndicateDataType bug in grad_op。

统一check了之前升级的OP列表，均已添加GetExpectedKernelType函数