### PR TITLE
[Cherry-pick][Paddle Inference] fix mixed precision diff

### DIFF
--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -178,7 +178,7 @@ void AutoMixedPrecisionPass::SetDefaultBlacklist() const {
       "rsqrt",
       "sum",
       "cos_sim",
-      "softmax",
+      "scale",
       "softmax_with_cross_entropy",
       "sigmoid_cross_entropy_with_logits",
       "c_softmax_with_cross_entropy",

--- a/paddle/fluid/inference/tests/api/gpu_ernie_half_test.cc
+++ b/paddle/fluid/inference/tests/api/gpu_ernie_half_test.cc
@@ -164,7 +164,7 @@ TEST(Ernie_gpu_fp16_no_ir, compare_results) {
     }
     float *result = reinterpret_cast<float *>(output.data.data());
     for (size_t j = 0; j < outputs_size; ++j) {
-      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 5e-2);
+      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 8e-3);
     }
   }
 }
@@ -175,8 +175,6 @@ TEST(Ernie_gpu_fp16_with_ir, compare_results) {
   config.SetModel(FLAGS_infer_model);
   config.EnableUseGpu(512, 0, paddle_infer::PrecisionType::kHalf);
   config.SwitchIrOptim(true);
-  // The fc_fuse_pass has diff, which will be repaired later.
-  config.pass_builder()->DeletePass("fc_fuse_pass");
   // There is a problem with the model itself, which has nothing to do with
   // constant_folding_pass.
   config.pass_builder()->DeletePass("constant_folding_pass");
@@ -206,7 +204,7 @@ TEST(Ernie_gpu_fp16_with_ir, compare_results) {
     }
     float *result = reinterpret_cast<float *>(output.data.data());
     for (size_t j = 0; j < outputs_size; ++j) {
-      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 5e-2);
+      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 2e-2);
     }
   }
 }
@@ -243,7 +241,7 @@ TEST(Ernie_gpu_bf16_no_ir, compare_results) {
     }
     float *result = reinterpret_cast<float *>(output.data.data());
     for (size_t j = 0; j < outputs_size; ++j) {
-      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 7e-2);
+      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 1e-2);
     }
   }
 }
@@ -254,8 +252,6 @@ TEST(Ernie_gpu_bf16_with_ir, compare_results) {
   config.SetModel(FLAGS_infer_model);
   config.EnableUseGpu(512, 0, paddle_infer::PrecisionType::kBf16);
   config.SwitchIrOptim(true);
-  // The fc_fuse_pass has diff, which will be repaired later.
-  config.pass_builder()->DeletePass("fc_fuse_pass");
   // There is a problem with the model itself, which has nothing to do with
   // constant_folding_pass.
   config.pass_builder()->DeletePass("constant_folding_pass");
@@ -285,7 +281,7 @@ TEST(Ernie_gpu_bf16_with_ir, compare_results) {
     }
     float *result = reinterpret_cast<float *>(output.data.data());
     for (size_t j = 0; j < outputs_size; ++j) {
-      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 7e-2);
+      EXPECT_NEAR(ref[i * outputs_size + j], result[j], 5e-3);
     }
   }
 }

--- a/paddle/fluid/operators/fused/fused_fc_elementwise_layernorm_op.cu
+++ b/paddle/fluid/operators/fused/fused_fc_elementwise_layernorm_op.cu
@@ -223,13 +223,7 @@ __global__ void InplaceAddReluAddLayerNormKernel(const float16* y_data,
 
       // For layer_norm, reduce to calculate mean and std
       sum_i += static_cast<float>(tmp_3);
-#if defined(PADDLE_WITH_CUDA) && __CUDA_ARCH__ >= 530
-      square_sum_i += static_cast<float>(__hmul(tmp_3, tmp_3));
-#elif defined(PADDLE_WITH_CUDA)
       square_sum_i += static_cast<float>(tmp_3) * static_cast<float>(tmp_3);
-#else
-      square_sum_i += static_cast<float>(tmp_3 * tmp_3);
-#endif
     }
     auto pair = BlockReduce(temp_storage)
                     .Reduce(PairForLayerNorm<float>(sum_i, square_sum_i),
@@ -282,9 +276,9 @@ __global__ void InplaceAddReluAddLayerNormKernel(const float16* y_data,
       half tmp_0 = __hdiv(__hsub(save_ptr[save_index], mean_i), std_i);
       half tmp_1 = scale ? __hmul(scale[j], tmp_0) : tmp_0;
 #else
-      half tmp_0 = static_cast<float>(static_cast<float>(save_ptr[save_index]) +
-                                      static_cast<float>(mean_i) /
-                                          static_cast<float>(std_i));
+      half tmp_0 = static_cast<half>(static_cast<float>(save_ptr[save_index]) -
+                                     static_cast<float>(mean_i) /
+                                         static_cast<float>(std_i));
       half tmp_1 = scale ? static_cast<half>(static_cast<float>(scale[j]) *
                                              static_cast<float>(tmp_0))
                          : tmp_0;

--- a/paddle/phi/kernels/funcs/fc_functor.cu
+++ b/paddle/phi/kernels/funcs/fc_functor.cu
@@ -149,9 +149,7 @@ __global__ void bias_relu_v2(const int num,
 #if __CUDA_ARCH__ >= 800
       packed_val = __hmax2(__half2(0, 0), packed_val);
 #elif __CUDA_ARCH__ >= 530
-      half zero = 0.0f;
-      packed_val.x = __hmul(packed_val.x > zero, packed_val.x);
-      packed_val.y = __hmul(packed_val.y > zero, packed_val.y);
+      packed_val = __hmul2(__hgt2(packed_val, __half2(0, 0)), packed_val);
 #else
       packed_val.x = static_cast<int>(static_cast<float>(packed_val.x) > 0) *
                      static_cast<float>(packed_val.x);

--- a/paddle/phi/kernels/funcs/fc_functor.cu
+++ b/paddle/phi/kernels/funcs/fc_functor.cu
@@ -149,12 +149,13 @@ __global__ void bias_relu_v2(const int num,
 #if __CUDA_ARCH__ >= 800
       packed_val = __hmax2(__half2(0, 0), packed_val);
 #elif __CUDA_ARCH__ >= 530
-      packed_val = __hmul2(__hgt2(__half2(0, 0), packed_val), packed_val);
+      half zero = 0.0f;
+      packed_val.x = __hmul(packed_val.x > zero, dpacked_val.x);
+      packed_val.y = __hmul(packed_val.y > zero, dpacked_val.y);
 #else
-      packed_val.x = static_cast<int>(static_cast<float>(packed_val.x) > 0) *
-                     static_cast<float>(packed_val.x);
-      packed_val.y = static_cast<int>(static_cast<float>(packed_val.y) > 0) *
-                     static_cast<float>(packed_val.y);
+      half zero = 0.0f;
+      packed_val.x = static_cast<half>(packed_val.x > zero) * packed_val.x;
+      packed_val.y = static_cast<half>(packed_val.y > zero) * packed_val.y;
 #endif
     }
     data[tid] = packed_val;

--- a/paddle/phi/kernels/funcs/fc_functor.cu
+++ b/paddle/phi/kernels/funcs/fc_functor.cu
@@ -150,12 +150,13 @@ __global__ void bias_relu_v2(const int num,
       packed_val = __hmax2(__half2(0, 0), packed_val);
 #elif __CUDA_ARCH__ >= 530
       half zero = 0.0f;
-      packed_val.x = __hmul(packed_val.x > zero, dpacked_val.x);
-      packed_val.y = __hmul(packed_val.y > zero, dpacked_val.y);
+      packed_val.x = __hmul(packed_val.x > zero, packed_val.x);
+      packed_val.y = __hmul(packed_val.y > zero, packed_val.y);
 #else
-      half zero = 0.0f;
-      packed_val.x = static_cast<half>(packed_val.x > zero) * packed_val.x;
-      packed_val.y = static_cast<half>(packed_val.y > zero) * packed_val.y;
+      packed_val.x = static_cast<int>(static_cast<float>(packed_val.x) > 0) *
+                     static_cast<float>(packed_val.x);
+      packed_val.y = static_cast<int>(static_cast<float>(packed_val.y) > 0) *
+                     static_cast<float>(packed_val.y);
 #endif
     }
     data[tid] = packed_val;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- scale op的scale和bias属性值可能会影响float16计算精度，handle it in amp pass.
- fused_fc_elementwise_layernorm kernel的float16计算有精度问题，fix it.
- fc_kernel的float16计算有精度问题，fix it.
- 避免amp pass插入冗余的cast op并修复一些函数和变量命名不当问题。
- 将一些无精度问题的op移除黑名单。
- 将gpu_ernie_half_test之前由于fc kernel的精度问题而禁用的fc_fuse_pass开启并修改绝对误差容忍值。