### PR TITLE
fix get_single_test_cov.py bug

### DIFF
--- a/tools/get_single_test_cov.py
+++ b/tools/get_single_test_cov.py
@@ -167,22 +167,31 @@ def getBaseFnda(rootPath, test):
 def getCovinfo(rootPath, test):
     ut_map_path = '%s/build/ut_map/%s' % (rootPath, test)
     print("start get fluid ===>")
-    cmd_fluid = 'lcov --capture -d ./paddle/fluid/ -o ./paddle/fluid/coverage_fluid.info --rc lcov_branch_coverage=0'
+    cmd_fluid = (
+        'cd %s lcov --capture -d ./paddle/fluid/ -o ./paddle/fluid/coverage_fluid.info --rc lcov_branch_coverage=0'
+        % ut_map_path
+    )
     p_fluid = subprocess.Popen(cmd_fluid, shell=True, stdout=subprocess.DEVNULL)
 
     print("start get phi ===>")
-    cmd_phi = 'lcov --capture -d ./paddle/phi -o ./paddle/phi/coverage_phi.info --rc lcov_branch_coverage=0'
+    cmd_phi = (
+        'cd %s lcov --capture -d ./paddle/phi -o ./paddle/phi/coverage_phi.info --rc lcov_branch_coverage=0'
+        % ut_map_path
+    )
     p_phi = subprocess.Popen(cmd_phi, shell=True, stdout=subprocess.DEVNULL)
 
     print("start get utils ===>")
-    cmd_utils = 'lcov --capture -d ./paddle/utils -o ./paddle/utils/coverage_utils.info --rc lcov_branch_coverage=0'
+    cmd_utils = (
+        'cd %s lcov --capture -d ./paddle/utils -o ./paddle/utils/coverage_utils.info --rc lcov_branch_coverage=0'
+        % ut_map_path
+    )
     p_utils = subprocess.Popen(cmd_utils, shell=True, stdout=subprocess.DEVNULL)
 
-    print("start wiat fluid ===>")
+    print("start wait fluid ===>")
     p_fluid.wait()
-    print("start wiat phi ===>")
+    print("start wait phi ===>")
     p_phi.wait()
-    print("start wiat utils ===>")
+    print("start wait utils ===>")
     p_utils.wait()
     print("end wait...")
     os.system(

--- a/tools/get_single_test_cov.py
+++ b/tools/get_single_test_cov.py
@@ -168,21 +168,21 @@ def getCovinfo(rootPath, test):
     ut_map_path = '%s/build/ut_map/%s' % (rootPath, test)
     print("start get fluid ===>")
     cmd_fluid = (
-        'cd %s lcov --capture -d ./paddle/fluid/ -o ./paddle/fluid/coverage_fluid.info --rc lcov_branch_coverage=0'
+        'cd %s && lcov --capture -d ./paddle/fluid/ -o ./paddle/fluid/coverage_fluid.info --rc lcov_branch_coverage=0'
         % ut_map_path
     )
     p_fluid = subprocess.Popen(cmd_fluid, shell=True, stdout=subprocess.DEVNULL)
 
     print("start get phi ===>")
     cmd_phi = (
-        'cd %s lcov --capture -d ./paddle/phi -o ./paddle/phi/coverage_phi.info --rc lcov_branch_coverage=0'
+        'cd %s && lcov --capture -d ./paddle/phi -o ./paddle/phi/coverage_phi.info --rc lcov_branch_coverage=0'
         % ut_map_path
     )
     p_phi = subprocess.Popen(cmd_phi, shell=True, stdout=subprocess.DEVNULL)
 
     print("start get utils ===>")
     cmd_utils = (
-        'cd %s lcov --capture -d ./paddle/utils -o ./paddle/utils/coverage_utils.info --rc lcov_branch_coverage=0'
+        'cd %s && lcov --capture -d ./paddle/utils -o ./paddle/utils/coverage_utils.info --rc lcov_branch_coverage=0'
         % ut_map_path
     )
     p_utils = subprocess.Popen(cmd_utils, shell=True, stdout=subprocess.DEVNULL)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
BUg fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
根据精准测试日志错误，修复get_single_test_cov.py上存在的bug，原因是路径的问题，将covera_utils.info存到了build/paddle/utils/coverage_utils.info，而不是存到/paddle/build/ut_map/simple_precision_test/paddle/utils/coverage_utils.info
<img width="964" alt="image" src="https://user-images.githubusercontent.com/62429225/210160977-557da389-6824-472c-936d-78a1446c69fb.png">
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/62429225/210160995-c8c23036-fe53-4782-b042-bd04ef7783a7.png">

