### PR TITLE
Add transpose_qkv_wb flags to the fused_attention_op.

### DIFF
--- a/paddle/fluid/operators/fused/fused_attention_op.cc
+++ b/paddle/fluid/operators/fused/fused_attention_op.cc
@@ -108,10 +108,17 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
                    "FusedAttentionOp");
     OP_INOUT_CHECK(ctx->HasOutput("Y"), "Output", "Y", "FusedAttentionOp");
 
+    int num_heads = ctx->Attrs().Get<int>("num_heads");
+    bool transpose_qkv_wb = ctx->Attrs().Get<bool>("transpose_qkv_wb");
+
     // x: qkv's input [batch_size, seq_len, dim_embed]
+    // if transpose_qkv_wb is False
     // y: qkv's weight: [3, num_head, dim_head, dim_embed]
+    // if transpose_qkv_wb is True
+    // y: qkv's weight: [dim_embed, 3 * dim_embed]
     auto x_dim = ctx->GetInputDim("X");
     auto y_dim = ctx->GetInputDim("QKVW");
+    int dim_head;
     PADDLE_ENFORCE_EQ(
         x_dim.size(),
         3,
@@ -120,32 +127,66 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
                                           "but received dimensions of"
                                           "Input is [%d]",
                                           x_dim.size()));
-    PADDLE_ENFORCE_EQ(y_dim.size(),
-                      4,
-                      platform::errors::InvalidArgument(
-                          "The dimensions of qkv_weight must be 4"
-                          "(3, num_head, dim_head, dim_embed),"
-                          "but received dimensions of"
-                          "Input is [%d]",
-                          y_dim.size()));
-    PADDLE_ENFORCE_EQ(x_dim[2],
-                      y_dim[3],
-                      platform::errors::InvalidArgument(
-                          "ShapeError: the dimension of x_dim[2] and y_dim[3]"
-                          "must be equal. But received: the shape "
-                          "of input x = [%s], and the shape of "
-                          "input qkv_weight = [%s]",
-                          x_dim,
-                          y_dim));
-
-    if (ctx->Attrs().Get<int>("ring_id") == -1) {
-      PADDLE_ENFORCE_EQ(y_dim[1] * y_dim[2],
-                        y_dim[3],
+    if (!transpose_qkv_wb) {
+      PADDLE_ENFORCE_EQ(y_dim.size(),
+                        4,
                         platform::errors::InvalidArgument(
                             "The dimensions of qkv_weight must be 4"
                             "(3, num_head, dim_head, dim_embed),"
-                            "and must satisfy the limitations: "
-                            "(num_head * dim_head == dim_embed)"));
+                            "but received dimensions of"
+                            "Input is [%d]",
+                            y_dim.size()));
+      PADDLE_ENFORCE_EQ(x_dim[2],
+                        y_dim[3],
+                        platform::errors::InvalidArgument(
+                            "ShapeError: the dimension of x_dim[2] and y_dim[3]"
+                            "must be equal. But received: the shape "
+                            "of input x = [%s], and the shape of "
+                            "input qkv_weight = [%s]",
+                            x_dim,
+                            y_dim));
+
+      if (ctx->Attrs().Get<int>("ring_id") == -1) {
+        PADDLE_ENFORCE_EQ(y_dim[1] * y_dim[2],
+                          y_dim[3],
+                          platform::errors::InvalidArgument(
+                              "The dimensions of qkv_weight must be 4"
+                              "(3, num_head, dim_head, dim_embed),"
+                              "and must satisfy the limitations: "
+                              "(num_head * dim_head == dim_embed)"));
+      }
+    } else {
+      PADDLE_ENFORCE_GT(num_heads,
+                        0,
+                        platform::errors::InvalidArgument(
+                            "num_heads must be provided and greater than 0 if "
+                            "enable transpose_qkv_wb"));
+      dim_head = y_dim[0] / num_heads;
+      PADDLE_ENFORCE_EQ(y_dim.size(),
+                        2,
+                        platform::errors::InvalidArgument(
+                            "The dimensions of qkv_weight must be 2 if enable"
+                            "transpose_qkv_wb: (dim_embed, 3 * dim_embed),"
+                            "but received dimensions of"
+                            "Input is [%d]",
+                            y_dim.size()));
+      PADDLE_ENFORCE_EQ(x_dim[2],
+                        y_dim[0],
+                        platform::errors::InvalidArgument(
+                            "ShapeError: the dimension of x_dim[2] and y_dim[0]"
+                            "must be equal. But received: the shape "
+                            "of input x = [%s], and the shape of "
+                            "input qkv_weight = [%s]",
+                            x_dim,
+                            y_dim));
+
+      if (ctx->Attrs().Get<int>("ring_id") == -1) {
+        PADDLE_ENFORCE_EQ(y_dim[0] * 3,
+                          y_dim[1],
+                          platform::errors::InvalidArgument(
+                              "The dimensions of qkv_weight must be 2"
+                              "(dim_embed, 3 * dim_embed)."));
+      }
     }
 
     if (ctx->Attrs().Get<bool>("pre_layer_norm") == true) {
@@ -157,17 +198,31 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
       ctx->SetOutputDim("Ln2Variance", {x_dim[0] * x_dim[1]});
       ctx->SetOutputDim("BiasDropoutResidualOut", ctx->GetInputDim("X"));
     }
-    // [batch_size, seq_len, 3, num_head, head_size]
-    ctx->SetOutputDim("QKVOut",
-                      {x_dim[0], x_dim[1], y_dim[0], y_dim[1], y_dim[2]});
 
-    if (ctx->HasInput("QKVBias")) {
-      ctx->SetOutputDim("QKVBiasOut",
+    if (!transpose_qkv_wb) {
+      // [batch_size, seq_len, 3, num_head, head_size]
+      ctx->SetOutputDim("QKVOut",
                         {x_dim[0], x_dim[1], y_dim[0], y_dim[1], y_dim[2]});
+
+      if (ctx->HasInput("QKVBias")) {
+        ctx->SetOutputDim("QKVBiasOut",
+                          {x_dim[0], x_dim[1], y_dim[0], y_dim[1], y_dim[2]});
+      }
+      // [3, batch_size, num_head, seq_len, head_size]
+      ctx->SetOutputDim("TransposeOut2",
+                        {y_dim[0], x_dim[0], y_dim[1], x_dim[1], y_dim[2]});
+    } else {
+      // [batch_size, seq_len, 3, num_head, head_size]
+      ctx->SetOutputDim("QKVOut", {x_dim[0], x_dim[1], 3, num_heads, dim_head});
+
+      if (ctx->HasInput("QKVBias")) {
+        ctx->SetOutputDim("QKVBiasOut",
+                          {x_dim[0], x_dim[1], 3, num_heads, dim_head});
+      }
+      // [3, batch_size, num_head, seq_len, head_size]
+      ctx->SetOutputDim("TransposeOut2",
+                        {3, x_dim[0], num_heads, x_dim[1], dim_head});
     }
-    // [3, batch_size, num_head, seq_len, head_size]
-    ctx->SetOutputDim("TransposeOut2",
-                      {y_dim[0], x_dim[0], y_dim[1], x_dim[1], y_dim[2]});
 
     // cache_seq_len + seq_len if cache else seq_len
     auto out_seq_len = x_dim[1];
@@ -192,13 +247,23 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
                             "batch size %d, but got %d",
                             x_dim[0],
                             c_dim[1]));  // batch_size
-      PADDLE_ENFORCE_EQ(c_dim[2],
-                        y_dim[1],
-                        paddle::platform::errors::InvalidArgument(
-                            "The third dim of CacheKV must be equal with num "
-                            "head %d, but got %d",
-                            y_dim[1],
-                            c_dim[2]));  // num_head
+      if (!transpose_qkv_wb) {
+        PADDLE_ENFORCE_EQ(c_dim[2],
+                          y_dim[1],
+                          paddle::platform::errors::InvalidArgument(
+                              "The third dim of CacheKV must be equal with num "
+                              "head %d, but got %d",
+                              y_dim[1],
+                              c_dim[2]));  // num_head
+      } else {
+        PADDLE_ENFORCE_EQ(c_dim[2],
+                          num_heads,
+                          paddle::platform::errors::InvalidArgument(
+                              "The third dim of CacheKV must be equal with num "
+                              "head %d, but got %d",
+                              num_heads,
+                              c_dim[2]));  // num_head
+      }
       // In compile stage, input seq_len can be -1, in that case
       // c_dim[3] may < 0 in while
       if (ctx->IsRuntime()) {
@@ -209,13 +274,25 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
                 "The forth dim of CacheKV must be greater than 0, but got %d",
                 c_dim[3]));  // cache_seq_len
       }
-      PADDLE_ENFORCE_EQ(c_dim[4],
-                        y_dim[2],
-                        paddle::platform::errors::InvalidArgument(
-                            "The fifth dim of CacheKV must be equal with head "
-                            "size %d, but got %d",
-                            y_dim[2],
-                            c_dim[4]));  // head_size
+      if (!transpose_qkv_wb) {
+        PADDLE_ENFORCE_EQ(
+            c_dim[4],
+            y_dim[2],
+            paddle::platform::errors::InvalidArgument(
+                "The fifth dim of CacheKV must be equal with head "
+                "size %d, but got %d",
+                y_dim[2],
+                c_dim[4]));  // head_size
+      } else {
+        PADDLE_ENFORCE_EQ(
+            c_dim[4],
+            dim_head,
+            paddle::platform::errors::InvalidArgument(
+                "The fifth dim of CacheKV must be equal with head "
+                "size %d, but got %d",
+                dim_head,
+                c_dim[4]));  // head_size
+      }
 
       out_seq_len += c_dim[3];
       // [3, batch_size, num_head, cache_seq_len + seq_len, head_size]
@@ -223,26 +300,50 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
                         {c_dim[0], c_dim[1], c_dim[2], out_seq_len, c_dim[4]});
     }
 
-    // [batch, num_head, seq_len, out_seq_len]
-    ctx->SetOutputDim("QKOut", {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
+    if (!transpose_qkv_wb) {
+      // [batch, num_head, seq_len, out_seq_len]
+      ctx->SetOutputDim("QKOut", {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
 
-    if (ctx->HasInput("SrcMask")) {
-      ctx->SetOutputDim("SrcMaskOut",
+      if (ctx->HasInput("SrcMask")) {
+        ctx->SetOutputDim("SrcMaskOut",
+                          {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
+      }
+      // the same as QKOut's shape.
+      ctx->SetOutputDim("AttnDropoutOut",
                         {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
-    }
-    // the same as QKOut's shape.
-    ctx->SetOutputDim("AttnDropoutOut",
-                      {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
-    if (ctx->Attrs().Get<bool>("is_test") == false) {
-      ctx->SetOutputDim("AttnDropoutMaskOut",
+      if (ctx->Attrs().Get<bool>("is_test") == false) {
+        ctx->SetOutputDim("AttnDropoutMaskOut",
+                          {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
+      }
+      ctx->SetOutputDim("SoftmaxOut",
                         {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
+      // [batch_size, num_heads, seq_len, head_dim]
+      ctx->SetOutputDim("QKTVOut", {x_dim[0], y_dim[1], x_dim[1], y_dim[2]});
+      // [batch_size, seq_len, number of heads*head size]
+      ctx->SetOutputDim("FMHAOut", {x_dim[0], x_dim[1], y_dim[1], y_dim[2]});
+    } else {
+      // [batch, num_head, seq_len, out_seq_len]
+      ctx->SetOutputDim("QKOut", {x_dim[0], num_heads, x_dim[1], out_seq_len});
+
+      if (ctx->HasInput("SrcMask")) {
+        ctx->SetOutputDim("SrcMaskOut",
+                          {x_dim[0], num_heads, x_dim[1], out_seq_len});
+      }
+      // the same as QKOut's shape.
+      ctx->SetOutputDim("AttnDropoutOut",
+                        {x_dim[0], num_heads, x_dim[1], out_seq_len});
+      if (ctx->Attrs().Get<bool>("is_test") == false) {
+        ctx->SetOutputDim("AttnDropoutMaskOut",
+                          {x_dim[0], num_heads, x_dim[1], out_seq_len});
+      }
+      ctx->SetOutputDim("SoftmaxOut",
+                        {x_dim[0], num_heads, x_dim[1], out_seq_len});
+      // [batch_size, num_heads, seq_len, head_dim]
+      ctx->SetOutputDim("QKTVOut", {x_dim[0], num_heads, x_dim[1], dim_head});
+      // [batch_size, seq_len, number of heads*head size]
+      ctx->SetOutputDim("FMHAOut", {x_dim[0], x_dim[1], num_heads, dim_head});
     }
-    ctx->SetOutputDim("SoftmaxOut",
-                      {x_dim[0], y_dim[1], x_dim[1], out_seq_len});
-    // [batch_size, num_heads, seq_len, head_dim]
-    ctx->SetOutputDim("QKTVOut", {x_dim[0], y_dim[1], x_dim[1], y_dim[2]});
-    // [batch_size, seq_len, number of heads*head size]
-    ctx->SetOutputDim("FMHAOut", {x_dim[0], x_dim[1], y_dim[1], y_dim[2]});
+
     ctx->SetOutputDim("OutLinearOut", ctx->GetInputDim("X"));
 
     if (ctx->Attrs().Get<bool>("is_test") == false) {

--- a/paddle/fluid/operators/fused/fused_attention_op.cc
+++ b/paddle/fluid/operators/fused/fused_attention_op.cc
@@ -132,9 +132,8 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
                         4,
                         platform::errors::InvalidArgument(
                             "The dimensions of qkv_weight must be 4"
-                            "(3, num_head, dim_head, dim_embed),"
-                            "but received dimensions of"
-                            "Input is [%d]",
+                            "(3, num_head, dim_head, dim_embed), but received"
+                            "dimensions of Input is [%d]",
                             y_dim.size()));
       PADDLE_ENFORCE_EQ(x_dim[2],
                         y_dim[3],

--- a/paddle/fluid/operators/fused/fused_attention_op.cc
+++ b/paddle/fluid/operators/fused/fused_attention_op.cc
@@ -131,9 +131,9 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
       PADDLE_ENFORCE_EQ(y_dim.size(),
                         4,
                         platform::errors::InvalidArgument(
-                            "The dimensions of qkv_weight must be 4"
-                            "(3, num_head, dim_head, dim_embed), but received"
-                            "dimensions of Input is [%d]",
+                            "The dimensions of qkv_weight must be 4 if not"
+                            "enable transpose_qkv_wb: (3, num_head, dim_head, "
+                            "dim_embed), but received [%d]",
                             y_dim.size()));
       PADDLE_ENFORCE_EQ(x_dim[2],
                         y_dim[3],

--- a/paddle/fluid/operators/fused/fused_attention_op.cc
+++ b/paddle/fluid/operators/fused/fused_attention_op.cc
@@ -315,6 +315,11 @@ class FusedAttentionOpMaker : public framework::OpProtoAndCheckerMaker {
     AddOutput("CacheKVOut", "The udpated cache KV.");
     AddOutput("Y", "Result after attention.");
 
+    AddAttr<int>("num_heads", "The number head for multi_head_attention.")
+        .SetDefault(-1);
+    AddAttr<bool>("transpose_qkv_wb",
+                  "The qkv_w shape is (h, 3h), do transpose to it.")
+        .SetDefault(false);
     AddAttr<bool>("pre_layer_norm",
                   "if true, the attention op uses pre_layer_norm architecure, "
                   "else, uses post_layer_norm architecuture. "

--- a/paddle/fluid/operators/fused/fused_attention_op.cc
+++ b/paddle/fluid/operators/fused/fused_attention_op.cc
@@ -211,12 +211,13 @@ class FusedAttentionOp : public framework::OperatorWithKernel {
       ctx->SetOutputDim("TransposeOut2",
                         {y_dim[0], x_dim[0], y_dim[1], x_dim[1], y_dim[2]});
     } else {
-      // [batch_size, seq_len, 3, num_head, head_size]
-      ctx->SetOutputDim("QKVOut", {x_dim[0], x_dim[1], 3, num_heads, dim_head});
+      // [batch_size, seq_len, 3 * hidden_size]
+      ctx->SetOutputDim("QKVOut",
+                        {x_dim[0], x_dim[1], 3 * num_heads * dim_head});
 
       if (ctx->HasInput("QKVBias")) {
         ctx->SetOutputDim("QKVBiasOut",
-                          {x_dim[0], x_dim[1], 3, num_heads, dim_head});
+                          {x_dim[0], x_dim[1], 3 * num_heads * dim_head});
       }
       // [3, batch_size, num_head, seq_len, head_size]
       ctx->SetOutputDim("TransposeOut2",

--- a/paddle/fluid/operators/fused/fused_attention_op.cu
+++ b/paddle/fluid/operators/fused/fused_attention_op.cu
@@ -196,7 +196,7 @@ class FusedAttentionOpKernel : public framework::OpKernel<T> {
       // do transpose to qkv weight
       std::vector<int> perm = {1, 2, 3, 0};
       phi::funcs::TransposeGPUKernelDriver<T>(
-          ctx.cuda_device_context(), *qkv_weight, perm, &qkvw_transpose_out);
+          ctx.cuda_device_context(), qkv_weight_tmp, perm, &qkvw_transpose_out);
     }
     const phi::DenseTensor *qkv_weight_real_ptr =
         transpose_qkv_wb ? &qkvw_transpose_out : qkv_weight;
@@ -801,7 +801,7 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
     }
     const phi::DenseTensor *qkv_weight_real_ptr =
         transpose_qkv_wb ? &qkvw_transpose_out : qkv_weight;
-    const phi::Densetensor *d_qkv_weight_real_ptr =
+    phi::DenseTensor *d_qkv_weight_real_ptr =
         transpose_qkv_wb ? &d_qkvw_transpose_out : d_qkv_weight;
 
     if (pre_layer_norm) {
@@ -878,7 +878,7 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
     if (transpose_qkv_wb && d_qkv_weight != nullptr) {
       std::vector<int> perm = {3, 0, 1, 2};
       phi::funcs::TransposeGPUKernelDriver<T>(
-          ctx.cuda_device_context(), *d_qkvw_transpose_out, perm, d_qkv_weight);
+          ctx.cuda_device_context(), d_qkvw_transpose_out, perm, d_qkv_weight);
       d_qkv_weight->Resize({dim_embed, 3 * dim_embed});
     }
     if (transpose_qkv_wb && d_qkv_bias != nullptr) {

--- a/paddle/fluid/operators/fused/fused_attention_op.cu
+++ b/paddle/fluid/operators/fused/fused_attention_op.cu
@@ -726,7 +726,7 @@ class FusedAttentionGradKernel : public framework::OpKernel<T> {
       if (compute_bias) {
         d_qkv_bias_out->Resize({batch_size, max_seq_len, 3 * hidden_size});
       } else {
-        d_qkv_out->resize({batch_size, max_seq_len, 3 * hidden_size});
+        d_qkv_out->Resize({batch_size, max_seq_len, 3 * hidden_size});
       }
     }
 

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
@@ -287,8 +287,9 @@ class TestFusedAttentionOp(OpTest):
             k_proj_weight = k_proj_weight.numpy()
             v_proj_weight = v_proj_weight.numpy()
 
+        concatenate_axis = 1 if self.transpose_qkv_wb else 0
         qkv_weight = np.concatenate(
-            (q_proj_weight, k_proj_weight, v_proj_weight)
+            (q_proj_weight, k_proj_weight, v_proj_weight), axis=concatenate_axis
         )
         if not self.transpose_qkv_wb:
             qkv_weight = qkv_weight.reshape(

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
@@ -103,6 +103,7 @@ class TestFusedAttentionOp(OpTest):
             self.query_length,
             self.query_length,
         )
+        self.transpose_qkv_wb = False
 
     def generate_input_data(self):
         self.query = np.random.rand(
@@ -265,7 +266,8 @@ class TestFusedAttentionOp(OpTest):
             qkv_bias = np.concatenate(
                 (q_proj_bias.numpy(), k_proj_bias.numpy(), v_proj_bias.numpy())
             )
-            qkv_bias = qkv_bias.reshape((3, self.num_heads, self.head_dim))
+            if not self.transpose_qkv_wb:
+                qkv_bias = qkv_bias.reshape((3, self.num_heads, self.head_dim))
             qkv_bias_tensor = paddle.to_tensor(qkv_bias, stop_gradient=False)
             out_linear_bias = paddle.to_tensor(
                 self.out_proj.bias, stop_gradient=False
@@ -276,15 +278,22 @@ class TestFusedAttentionOp(OpTest):
         ln2_scale = paddle.to_tensor(self.norm2.weight, stop_gradient=False)
         ln2_bias = paddle.to_tensor(self.norm2.bias, stop_gradient=False)
 
-        q_proj_weight = q_proj_weight.numpy().transpose((1, 0))
-        k_proj_weight = k_proj_weight.numpy().transpose((1, 0))
-        v_proj_weight = v_proj_weight.numpy().transpose((1, 0))
+        if not self.transpose_qkv_wb:
+            q_proj_weight = q_proj_weight.numpy().transpose((1, 0))
+            k_proj_weight = k_proj_weight.numpy().transpose((1, 0))
+            v_proj_weight = v_proj_weight.numpy().transpose((1, 0))
+        else:
+            q_proj_weight = q_proj_weight.numpy()
+            k_proj_weight = k_proj_weight.numpy()
+            v_proj_weight = v_proj_weight.numpy()
+
         qkv_weight = np.concatenate(
             (q_proj_weight, k_proj_weight, v_proj_weight)
         )
-        qkv_weight = qkv_weight.reshape(
-            (3, self.num_heads, self.head_dim, self.embed_dim)
-        )
+        if not self.transpose_qkv_wb:
+            qkv_weight = qkv_weight.reshape(
+                (3, self.num_heads, self.head_dim, self.embed_dim)
+            )
 
         x = paddle.to_tensor(self.query, stop_gradient=False)
         cache_kv = None
@@ -317,6 +326,8 @@ class TestFusedAttentionOp(OpTest):
             self.dropout_prob,
             self.attn_dropout_prob,
             ln2_epsilon,
+            num_heads=self.num_heads,
+            transpose_qkv_wb=self.transpose_qkv_wb,
         )
 
         if self.has_cache_kv:
@@ -342,6 +353,12 @@ class TestFusedAttentionOpBiasIsNone(TestFusedAttentionOp):
     def config(self):
         super().config()
         self.bias_attr = False
+
+
+class TestFusedAttentionOpTransposeQKVWB(TestFusedAttentionOp):
+    def config(self):
+        super().config()
+        self.transpose_qkv_wb = True
 
 
 class TestFusedAttentionOpPreLn(TestFusedAttentionOp):

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op.py
@@ -356,10 +356,17 @@ class TestFusedAttentionOpBiasIsNone(TestFusedAttentionOp):
         self.bias_attr = False
 
 
-class TestFusedAttentionOpTransposeQKVWB(TestFusedAttentionOp):
+class TestFusedAttentionAPITransposeWAndB(TestFusedAttentionOp):
     def config(self):
         super().config()
         self.transpose_qkv_wb = True
+
+
+class TestFusedAttentionAPITransposeWAndBWithoutBias(TestFusedAttentionOp):
+    def config(self):
+        super().config()
+        self.transpose_qkv_wb = True
+        self.bias_attr = False
 
 
 class TestFusedAttentionOpPreLn(TestFusedAttentionOp):

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op_api.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op_api.py
@@ -111,8 +111,9 @@ def compute_reference(
     else:
         assert len(qkv_weight.shape) == 2
         assert qkv_weight.shape[0] * 3 == qkv_weight.shape[1]
-        assert len(qkv_bias.shape) == 1
-        assert qkv_bias.shape[0] == qkv_weight.shape[1]
+        if qkv_bias is not None:
+            assert len(qkv_bias.shape) == 1
+            assert qkv_bias.shape[0] == qkv_weight.shape[1]
 
     if pre_layer_norm:
         ln_out = ln_out.reshape(batch_size * seq_len, embed_dim)
@@ -604,6 +605,14 @@ class TestFusedAttentionAPIBiasIsNone(TestFusedAttentionAPI):
 class TestFusedAttentionAPITransposeWAndB(TestFusedAttentionAPI):
     def setTransposeWAndB(self):
         self.transpose_qkv_wb = True
+
+
+class TestFusedAttentionAPITransposeWAndBWithoutBias(TestFusedAttentionAPI):
+    def setTransposeWAndB(self):
+        self.transpose_qkv_wb = True
+
+    def setBiasAttr(self):
+        self.bias_attr = False
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_fused_attention_op_api.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_attention_op_api.py
@@ -81,6 +81,8 @@ def compute_reference(
     qkv_bias,
     out_linear_weight,
     out_linear_bias,
+    num_head,
+    transpose_qkv_wb,
 ):
     batch_size = query.shape[0]
     seq_len = query.shape[1]
@@ -93,19 +95,25 @@ def compute_reference(
     if pre_layer_norm:
         ln_out = layer_norm(query, True, has_bias, ln_scale, ln_bias)
 
-    num_head = qkv_weight.shape[1]
-    head_dim = qkv_weight.shape[2]
-    # embed_dim, 3, num_heads, self.head_dim
-    qkv_weight = qkv_weight.transpose((3, 0, 1, 2))
-    qkv_weight = qkv_weight.reshape(
-        qkv_weight.shape[0],
-        qkv_weight.shape[1] * qkv_weight.shape[2] * qkv_weight.shape[3],
-    )
-
-    if qkv_bias is not None:
-        qkv_bias = qkv_bias.reshape(
-            qkv_bias.shape[0] * qkv_bias.shape[1] * qkv_bias.shape[2]
+    head_dim = embed_dim // num_head
+    if not transpose_qkv_wb:
+        # embed_dim, 3, num_heads, self.head_dim
+        qkv_weight = qkv_weight.transpose((3, 0, 1, 2))
+        qkv_weight = qkv_weight.reshape(
+            qkv_weight.shape[0],
+            qkv_weight.shape[1] * qkv_weight.shape[2] * qkv_weight.shape[3],
         )
+
+        if qkv_bias is not None:
+            qkv_bias = qkv_bias.reshape(
+                qkv_bias.shape[0] * qkv_bias.shape[1] * qkv_bias.shape[2]
+            )
+    else:
+        assert len(qkv_weight.shape) == 2
+        assert qkv_weight.shape[0] * 3 == qkv_weight.shape[1]
+        assert len(qkv_bias.shape) == 1
+        assert qkv_bias.shape[0] == qkv_weight.shape[1]
+
     if pre_layer_norm:
         ln_out = ln_out.reshape(batch_size * seq_len, embed_dim)
         qkv = fc(ln_out, qkv_weight)
@@ -189,6 +197,7 @@ class TestFusedAttentionAPI(unittest.TestCase):
         self.setPreLn()
         self.setAttnMask()
         self.setBiasAttr()
+        self.setTransposeWAndB()
         self.config()
         self.generate_input_data()
 
@@ -208,6 +217,9 @@ class TestFusedAttentionAPI(unittest.TestCase):
 
     def setBiasAttr(self):
         self.bias_attr = None
+
+    def setTransposeWAndB(self):
+        self.transpose_qkv_wb = False
 
     def setPreLn(self):
         self.pre_layer_norm = False
@@ -284,6 +296,7 @@ class TestFusedAttentionAPI(unittest.TestCase):
             self.bias_attr,
             self.weight_attr,
             self.bias_attr,
+            transpose_qkv_wb=self.transpose_qkv_wb,
         )
         if self.bias_attr is not False:
             qkv_bias = np.random.random(fused_attn.qkv_bias.shape).astype(
@@ -323,6 +336,8 @@ class TestFusedAttentionAPI(unittest.TestCase):
             fused_attn_qkv_bias,
             fused_attn.linear_weight.numpy(),
             fused_attn_linear_bias,
+            num_head=self.num_heads,
+            transpose_qkv_wb=self.transpose_qkv_wb,
         )
         np.testing.assert_allclose(
             ref_out, out.numpy(), rtol=self.rtol, atol=self.atol
@@ -346,6 +361,7 @@ class TestFusedAttentionAPI(unittest.TestCase):
             self.bias_attr,
             self.weight_attr,
             self.bias_attr,
+            transpose_qkv_wb=self.transpose_qkv_wb,
         )
 
         x = paddle.static.data(
@@ -562,6 +578,8 @@ class TestFusedAttentionAPI(unittest.TestCase):
             qkv_bias,
             linear_weight,
             linear_bias,
+            num_head=self.num_heads,
+            transpose_qkv_wb=self.transpose_qkv_wb,
         )
         np.testing.assert_allclose(ref_out, out, rtol=self.rtol, atol=self.atol)
 
@@ -581,6 +599,11 @@ class TestFusedAttentionAPINoneAttnMask(TestFusedAttentionAPI):
 class TestFusedAttentionAPIBiasIsNone(TestFusedAttentionAPI):
     def setBiasAttr(self):
         self.bias_attr = False
+
+
+class TestFusedAttentionAPITransposeWAndB(TestFusedAttentionAPI):
+    def setTransposeWAndB(self):
+        self.transpose_qkv_wb = True
 
 
 if __name__ == "__main__":

--- a/python/paddle/incubate/nn/functional/fused_transformer.py
+++ b/python/paddle/incubate/nn/functional/fused_transformer.py
@@ -482,6 +482,8 @@ def fused_multi_head_attention(
     mode='upscale_in_train',
     ring_id=-1,
     add_residual=True,
+    num_heads=-1,
+    transpose_qkv_wb=False,
     name=None,
 ):
     r"""
@@ -567,6 +569,8 @@ def fused_multi_head_attention(
                                   - inference: out = input * (1.0 - p)
         ring_id (int, optional): For distributed forward in mp, only support NCCL and forward. Default is -1, means not using mp
         add_residual (bool, optional): Whether add residual at the end. Default is True.
+        num_heads (int, optional): If enable transpose_qkv_wb, should provide the num_heads. Default is -1, means not transpose qkv wb.
+        transpose_qkv_wb (bool, optional): Whether transpose the qkv_weight and qkv_bias in the op. Only support GPU for now. Default is false, means not transpose qkv wb.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -617,21 +621,48 @@ def fused_multi_head_attention(
         # pre_ln_mean, pre_ln_variance, pre_ln_out, qkv_out, qkv_bias_out, transpose_out, qk_out,
         # qktv_out, softmax_out, attn_dropout_mask_out, attn_dropout_out, attn_mask_out, fmha_out,
         # linear_out, dropout_mask_out, ln_mean_out, ln_var_out, bias_dropout_residual_out, final_out
-        assert (
-            len(qkv_weight.shape) == 4
-        ), "The dims of the shape of qkv_weight should be 4."
-        assert (
-            qkv_weight.shape[0] == 3
-        ), "The shape of qkv_weight should be [3, num_head, head_dim, embed_dim]."
-        assert (
-            qkv_weight.shape[3] == x.shape[2]
-        ), "The 3rd dim of qkv_weight and 2nd dim of x should be the same, i.e., embed_dim."
-        if ring_id == -1:
-            # under mp, the num head will be split, this equation will not hold
+        if not transpose_qkv_wb:
             assert (
-                qkv_weight.shape[1] * qkv_weight.shape[2] == qkv_weight.shape[3]
-            ), "embed_dim must be divisible by num_heads."
-
+                len(qkv_weight.shape) == 4
+            ), "The dims of the shape of qkv_weight should be 4."
+            assert (
+                qkv_weight.shape[0] == 3
+            ), "The shape of qkv_weight should be [3, num_head, head_dim, embed_dim]."
+            assert (
+                qkv_weight.shape[3] == x.shape[2]
+            ), "The 3rd dim of qkv_weight and 2nd dim of x should be the same, i.e., embed_dim."
+            if ring_id == -1:
+                # under mp, the num head will be split, this equation will not hold
+                assert (
+                    qkv_weight.shape[1] * qkv_weight.shape[2]
+                    == qkv_weight.shape[3]
+                ), "embed_dim must be divisible by num_heads."
+        else:
+            assert (
+                num_heads > 0
+            ), "When enable transpose_qkv_wb, the num_heads should be provided and greater than 0."
+            assert len(qkv_weight.shape) == 2, (
+                "When enable transpose_qkv_wb, the dims of the shape of qkv_weight "
+                "should be 2 when enable transpose_qkv_wb."
+            )
+            if ring_id == -1:
+                # under mp, the num head will be split, this equation will not hold
+                assert qkv_weight.shape[1] == 3 * qkv_weight.shape[0], (
+                    "When enable transpose_qkv_wb, the shape of qkv_weight should be "
+                    "[embed_dim, 3 * embed_dim] when enable transpose_qkv_wb."
+                )
+            assert qkv_weight.shape[0] == x.shape[2], (
+                "When enable transpose_qkv_wb, the 1st dim of qkv_weight and 2nd dim of x "
+                "should be the same, i.e., embed_dim."
+            )
+            if qkv_bias is not None:
+                assert (
+                    len(qkv_bias.shape) == 1
+                ), "When enable transpose_qkv_wb, the dims of the shape of qkv_bias should be 1."
+                assert qkv_bias.shape[0] == qkv_weight.shape[1], (
+                    "When enable transpose_qkv_wb, the 1st dim of qkv_bias and 2nd dim of "
+                    "qkv_weight should be the same, i.e., embed_dim."
+                )
         (
             _,
             _,
@@ -665,6 +696,10 @@ def fused_multi_head_attention(
             linear_bias,
             ln_scale,
             ln_bias,
+            'num_heads',
+            num_heads,
+            'transpose_qkv_wb',
+            transpose_qkv_wb,
             'pre_layer_norm',
             pre_layer_norm,
             'epsilon',
@@ -754,6 +789,8 @@ def fused_multi_head_attention(
             'dropout_implementation': mode,
             'add_residual': add_residual,
             'ring_id': ring_id,
+            'num_heads': num_heads,
+            'transpose_qkv_wb': transpose_qkv_wb,
         }
 
         # set outputs

--- a/python/paddle/incubate/nn/layer/fused_transformer.py
+++ b/python/paddle/incubate/nn/layer/fused_transformer.py
@@ -321,16 +321,16 @@ class FusedMultiHeadAttention(Layer):
 
         # tensor model parallel
         assert num_heads % nranks == 0
-        num_heads = num_heads // nranks
+        self.num_heads = num_heads // nranks
 
         self.transpose_qkv_wb = transpose_qkv_wb
         if self.transpose_qkv_wb:
             # For tensor model parallel, use num_head * head_dim to compute the real shape.
-            qkv_wight_shape = [embed_dim, 3 * num_heads * self.head_dim]
-            qkv_bias_shape = [3 * num_heads * self.head_dim]
+            qkv_wight_shape = [embed_dim, 3 * self.num_heads * self.head_dim]
+            qkv_bias_shape = [3 * self.num_heads * self.head_dim]
         else:
-            qkv_wight_shape = [3, num_heads, self.head_dim, embed_dim]
-            qkv_bias_shape = [3, num_heads, self.head_dim]
+            qkv_wight_shape = [3, self.num_heads, self.head_dim, embed_dim]
+            qkv_bias_shape = [3, self.num_heads, self.head_dim]
 
         self.qkv_weight = self.create_parameter(
             shape=qkv_wight_shape,
@@ -345,7 +345,7 @@ class FusedMultiHeadAttention(Layer):
             is_bias=True,
         )
         self.linear_weight = self.create_parameter(
-            shape=[num_heads * self.head_dim, embed_dim],
+            shape=[self.num_heads * self.head_dim, embed_dim],
             attr=linear_weight_attr,
             dtype=self._dtype,
             is_bias=False,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Add transpose_qkv_wb flags to the fused_attention_op, which enable the op accepts a qkv weight in the shape of [h, 3h] and accepts a qkv bias in the shape of [3h]. This is mainly to facilitate the development of FusedAttentionPass.

#### Op changes
`fused_attention op`
Add two attributes:
- `num_heads`, int, default value is -1. The number head for multi_head_attention, which must be provided when enable transpose_qkv_wb.
-  `transpose_qkv_wb`, bool, default value is False. Enable the qkv_w shape is (h, 3h), do transpose to it.

#### API changes
`paddle.incubate.nn.FusedMultiHeadAttention`
Add one new parameter:
- `transpose_qkv_wb` (bool, optional): Support input qkv matmul weight shape as [hidden_size, 3 * hidden_size] and qkv matmul bias shape as [3 * hidden_size]. Will transpose the weight to [3, num_head, head_dim, hidden_size] and transpose bias to [3, num_head, hidden_size] in the fused_attention_op. Only support for GPU for now. The default value is False, which is not do transpose to qkv_w and qkv_b.

`paddle.incubate.nn.functional.fused_multi_head_attention`
Add two new paramters:
- `num_heads` (int, optional): If enable transpose_qkv_wb, should provide the num_heads. Default is -1, means not transpose qkv wb.
- `transpose_qkv_wb` (bool, optional): Whether transpose the qkv_weight and qkv_bias in the op. Only support GPU for now. Default is false, means not transpose qkv wb.
