### PR TITLE
[Paddle Inference] add unitest for zero_copy_tensor with bool type

### DIFF
--- a/paddle/fluid/inference/api/paddle_infer_contrib.cc
+++ b/paddle/fluid/inference/api/paddle_infer_contrib.cc
@@ -89,6 +89,12 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
                           cb,
                           cb_params);
         break;
+      case PaddleDType::BOOL:
+        src.CopyToCpuImpl(dst.mutable_data<bool>(PlaceType::kCPU),
+                          exec_stream,
+                          cb,
+                          cb_params);
+        break;
       case PaddleDType::FLOAT16:
         src.CopyToCpuImpl(
             dst.mutable_data<paddle::platform::float16>(PlaceType::kCPU),
@@ -98,7 +104,7 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
         break;
       default:
         PADDLE_THROW(paddle::platform::errors::Unimplemented(
-            "Only INT32, INT64, UINT8, INT8, FLOAT16 and "
+            "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16 and "
             "FLOAT32 is supported in Tensor. Others not implements"));
     }
     // gpu => gpu or cpu => gpu
@@ -142,6 +148,11 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
         src_data = static_cast<void*>(src.data<int8_t>(&src_place, &data_size));
         data_len = data_size * sizeof(int8_t);
         break;
+      case PaddleDType::BOOL:
+        dst_data = static_cast<void*>(dst.mutable_data<bool>(PlaceType::kGPU));
+        src_data = static_cast<void*>(src.data<bool>(&src_place, &data_size));
+        data_len = data_size * sizeof(bool);
+        break;
       case PaddleDType::FLOAT16:
         dst_data = static_cast<void*>(
             dst.mutable_data<paddle::platform::float16>(PlaceType::kGPU));
@@ -151,7 +162,7 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
         break;
       default:
         PADDLE_THROW(paddle::platform::errors::Unimplemented(
-            "Only INT32, INT64, UINT8, INT8, FLOAT16 and "
+            "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16 and "
             "FLOAT32 is supported in Tensor. Others not implements"));
     }
 

--- a/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
+++ b/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstring>
 #include <numeric>
 
@@ -246,11 +247,11 @@ TEST(CopyTensor, bool_cpu_to_cpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kCPU, static_cast<void *>(&scope));
 
-  std::vector<bool> data_src(6, true);
+  std::array<bool, 6> data_src{true};
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::vector<bool> data_dst(4, false);
+  std::array<bool, 4> data_dst{false};
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -260,7 +261,7 @@ TEST(CopyTensor, bool_cpu_to_cpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::vector<bool> data_check(6, false);
+  std::array<bool, 6> data_check{false};
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {
@@ -275,11 +276,11 @@ TEST(CopyTensor, bool_gpu_to_gpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kGPU, static_cast<void *>(&scope));
 
-  std::vector<bool> data_src(6, true);
+  std::array<bool, 6> data_src{true};
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::vector<bool> data_dst(4, false);
+  std::array<bool, 4> data_dst{false};
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -289,7 +290,7 @@ TEST(CopyTensor, bool_gpu_to_gpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::vector<bool> data_check(6, false);
+  std::array<bool, 6> data_check{false};
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {
@@ -304,11 +305,11 @@ TEST(CopyTensor, bool_gpu_to_cpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kCPU, static_cast<void *>(&scope));
 
-  std::vector<bool> data_src(6, true);
+  std::array<bool, 6> data_src{true};
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::vector<bool> data_dst(4, false);
+  std::array<bool, 4> data_dst{false};
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -318,7 +319,7 @@ TEST(CopyTensor, bool_gpu_to_cpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::vector<bool> data_check(6, false);
+  std::array<bool, 6> data_check{false};
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {
@@ -333,11 +334,11 @@ TEST(CopyTensor, bool_cpu_to_gpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kGPU, static_cast<void *>(&scope));
 
-  std::vector<bool> data_src(6, true);
+  std::array<bool, 6> data_src{true};
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::vector<bool> data_dst(4, false);
+  std::array<bool, 4> data_dst{false};
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -347,7 +348,7 @@ TEST(CopyTensor, bool_cpu_to_gpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::vector<bool> data_check(6, false);
+  std::array<bool, 6> data_check{false};
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {

--- a/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
+++ b/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
@@ -247,11 +247,13 @@ TEST(CopyTensor, bool_cpu_to_cpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kCPU, static_cast<void *>(&scope));
 
-  std::array<bool, 6> data_src{true};
+  std::array<bool, 6> data_src;
+  data_src.fill(true);
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::array<bool, 4> data_dst{false};
+  std::array<bool, 4> data_dst;
+  data_dst.fill(false);
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -261,7 +263,8 @@ TEST(CopyTensor, bool_cpu_to_cpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::array<bool, 6> data_check{false};
+  std::array<bool, 6> data_check;
+  data_check.fill(false);
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {
@@ -276,11 +279,13 @@ TEST(CopyTensor, bool_gpu_to_gpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kGPU, static_cast<void *>(&scope));
 
-  std::array<bool, 6> data_src{true};
+  std::array<bool, 6> data_src;
+  data_src.fill(true);
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::array<bool, 4> data_dst{false};
+  std::array<bool, 4> data_dst;
+  data_dst.fill(false);
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -290,7 +295,8 @@ TEST(CopyTensor, bool_gpu_to_gpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::array<bool, 6> data_check{false};
+  std::array<bool, 6> data_check;
+  data_check.fill(false);
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {
@@ -305,11 +311,13 @@ TEST(CopyTensor, bool_gpu_to_cpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kCPU, static_cast<void *>(&scope));
 
-  std::array<bool, 6> data_src{true};
+  std::array<bool, 6> data_src;
+  data_src.fill(true);
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::array<bool, 4> data_dst{false};
+  std::array<bool, 4> data_dst;
+  data_dst.fill(false);
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -319,7 +327,8 @@ TEST(CopyTensor, bool_gpu_to_cpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::array<bool, 6> data_check{false};
+  std::array<bool, 6> data_check;
+  data_check.fill(false);
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {
@@ -334,11 +343,13 @@ TEST(CopyTensor, bool_cpu_to_gpu) {
   auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_dst", PlaceType::kGPU, static_cast<void *>(&scope));
 
-  std::array<bool, 6> data_src{true};
+  std::array<bool, 6> data_src;
+  data_src.fill(true);
   tensor_src->Reshape({2, 3});
   tensor_src->CopyFromCpu(data_src.data());
 
-  std::array<bool, 4> data_dst{false};
+  std::array<bool, 4> data_dst;
+  data_dst.fill(false);
   tensor_dst->Reshape({2, 2});
   tensor_dst->CopyFromCpu(data_dst.data());
 
@@ -349,6 +360,7 @@ TEST(CopyTensor, bool_cpu_to_gpu) {
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
   std::array<bool, 6> data_check{false};
+  data_check.fill(false);
   tensor_dst->CopyToCpu<bool>(data_check.data());
 
   for (int i = 0; i < 6; i++) {

--- a/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
+++ b/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
@@ -207,30 +207,155 @@ static void test_copy_tensor(PlaceType src_place, PlaceType dst_place) {
 TEST(CopyTensor, float32) {
   test_copy_tensor<float>(PlaceType::kCPU, PlaceType::kCPU);
   test_copy_tensor<float>(PlaceType::kCPU, PlaceType::kGPU);
+  test_copy_tensor<float>(PlaceType::kGPU, PlaceType::kCPU);
   test_copy_tensor<float>(PlaceType::kGPU, PlaceType::kGPU);
 }
 
 TEST(CopyTensor, int32) {
   test_copy_tensor<int32_t>(PlaceType::kCPU, PlaceType::kCPU);
+  test_copy_tensor<int32_t>(PlaceType::kCPU, PlaceType::kGPU);
+  test_copy_tensor<int32_t>(PlaceType::kGPU, PlaceType::kCPU);
   test_copy_tensor<int32_t>(PlaceType::kGPU, PlaceType::kGPU);
 }
 
 TEST(CopyTensor, int64) {
   test_copy_tensor<int64_t>(PlaceType::kCPU, PlaceType::kCPU);
+  test_copy_tensor<int64_t>(PlaceType::kCPU, PlaceType::kGPU);
+  test_copy_tensor<int64_t>(PlaceType::kGPU, PlaceType::kCPU);
   test_copy_tensor<int64_t>(PlaceType::kGPU, PlaceType::kGPU);
 }
 
 TEST(CopyTensor, int8) {
   test_copy_tensor<int8_t>(PlaceType::kCPU, PlaceType::kCPU);
+  test_copy_tensor<int8_t>(PlaceType::kCPU, PlaceType::kGPU);
+  test_copy_tensor<int8_t>(PlaceType::kGPU, PlaceType::kCPU);
   test_copy_tensor<int8_t>(PlaceType::kGPU, PlaceType::kGPU);
 }
 
 TEST(CopyTensor, uint8) {
   test_copy_tensor<uint8_t>(PlaceType::kCPU, PlaceType::kCPU);
+  test_copy_tensor<uint8_t>(PlaceType::kCPU, PlaceType::kGPU);
+  test_copy_tensor<uint8_t>(PlaceType::kGPU, PlaceType::kCPU);
   test_copy_tensor<uint8_t>(PlaceType::kGPU, PlaceType::kGPU);
 }
 
-TEST(CopyTensor, float16) {
+TEST(CopyTensor, bool_cpu_to_cpu) {
+  paddle::framework::Scope scope;
+  auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_src", PlaceType::kCPU, static_cast<void *>(&scope));
+  auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_dst", PlaceType::kCPU, static_cast<void *>(&scope));
+
+  std::vector<bool> data_src(6, true);
+  tensor_src->Reshape({2, 3});
+  tensor_src->CopyFromCpu(data_src.data());
+
+  std::vector<bool> data_dst(4, false);
+  tensor_dst->Reshape({2, 2});
+  tensor_dst->CopyFromCpu(data_dst.data());
+
+  paddle_infer::contrib::TensorUtils::CopyTensor(tensor_dst.get(), *tensor_src);
+
+  EXPECT_EQ(tensor_dst->shape().size(), (size_t)2);
+  EXPECT_EQ(tensor_dst->shape()[0], 2);
+  EXPECT_EQ(tensor_dst->shape()[1], 3);
+
+  std::vector<bool> data_check(6, false);
+  tensor_dst->CopyToCpu<bool>(data_check.data());
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_TRUE(data_check[i] == true);
+  }
+}
+
+TEST(CopyTensor, bool_gpu_to_gpu) {
+  paddle::framework::Scope scope;
+  auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_src", PlaceType::kGPU, static_cast<void *>(&scope));
+  auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_dst", PlaceType::kGPU, static_cast<void *>(&scope));
+
+  std::vector<bool> data_src(6, true);
+  tensor_src->Reshape({2, 3});
+  tensor_src->CopyFromCpu(data_src.data());
+
+  std::vector<bool> data_dst(4, false);
+  tensor_dst->Reshape({2, 2});
+  tensor_dst->CopyFromCpu(data_dst.data());
+
+  paddle_infer::contrib::TensorUtils::CopyTensor(tensor_dst.get(), *tensor_src);
+
+  EXPECT_EQ(tensor_dst->shape().size(), (size_t)2);
+  EXPECT_EQ(tensor_dst->shape()[0], 2);
+  EXPECT_EQ(tensor_dst->shape()[1], 3);
+
+  std::vector<bool> data_check(6, false);
+  tensor_dst->CopyToCpu<bool>(data_check.data());
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_TRUE(data_check[i] == true);
+  }
+}
+
+TEST(CopyTensor, bool_gpu_to_cpu) {
+  paddle::framework::Scope scope;
+  auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_src", PlaceType::kGPU, static_cast<void *>(&scope));
+  auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_dst", PlaceType::kCPU, static_cast<void *>(&scope));
+
+  std::vector<bool> data_src(6, true);
+  tensor_src->Reshape({2, 3});
+  tensor_src->CopyFromCpu(data_src.data());
+
+  std::vector<bool> data_dst(4, false);
+  tensor_dst->Reshape({2, 2});
+  tensor_dst->CopyFromCpu(data_dst.data());
+
+  paddle_infer::contrib::TensorUtils::CopyTensor(tensor_dst.get(), *tensor_src);
+
+  EXPECT_EQ(tensor_dst->shape().size(), (size_t)2);
+  EXPECT_EQ(tensor_dst->shape()[0], 2);
+  EXPECT_EQ(tensor_dst->shape()[1], 3);
+
+  std::vector<bool> data_check(6, false);
+  tensor_dst->CopyToCpu<bool>(data_check.data());
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_TRUE(data_check[i] == true);
+  }
+}
+
+TEST(CopyTensor, bool_cpu_to_gpu) {
+  paddle::framework::Scope scope;
+  auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_src", PlaceType::kCPU, static_cast<void *>(&scope));
+  auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_dst", PlaceType::kGPU, static_cast<void *>(&scope));
+
+  std::vector<bool> data_src(6, true);
+  tensor_src->Reshape({2, 3});
+  tensor_src->CopyFromCpu(data_src.data());
+
+  std::vector<bool> data_dst(4, false);
+  tensor_dst->Reshape({2, 2});
+  tensor_dst->CopyFromCpu(data_dst.data());
+
+  paddle_infer::contrib::TensorUtils::CopyTensor(tensor_dst.get(), *tensor_src);
+
+  EXPECT_EQ(tensor_dst->shape().size(), (size_t)2);
+  EXPECT_EQ(tensor_dst->shape()[0], 2);
+  EXPECT_EQ(tensor_dst->shape()[1], 3);
+
+  std::vector<bool> data_check(6, false);
+  tensor_dst->CopyToCpu<bool>(data_check.data());
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_TRUE(data_check[i] == true);
+  }
+}
+
+TEST(CopyTensor, float16_cpu_to_cpu) {
   paddle::framework::Scope scope;
   auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_src", PlaceType::kCPU, static_cast<void *>(&scope));
@@ -252,7 +377,7 @@ TEST(CopyTensor, float16) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::vector<float16> data_check(6, float16(1.0));
+  std::vector<float16> data_check(6, float16(2.0));
   tensor_dst->CopyToCpu<float16>(data_check.data());
 
   for (int i = 0; i < 6; i++) {
@@ -260,7 +385,7 @@ TEST(CopyTensor, float16) {
   }
 }
 
-TEST(CopyTensor, float16_gpu) {
+TEST(CopyTensor, float16_gpu_to_gpu) {
   paddle::framework::Scope scope;
   auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
       "tensor_src", PlaceType::kGPU, static_cast<void *>(&scope));
@@ -282,7 +407,67 @@ TEST(CopyTensor, float16_gpu) {
   EXPECT_EQ(tensor_dst->shape()[0], 2);
   EXPECT_EQ(tensor_dst->shape()[1], 3);
 
-  std::vector<float16> data_check(6, float16(1.0));
+  std::vector<float16> data_check(6, float16(2.0));
+  tensor_dst->CopyToCpu<float16>(data_check.data());
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_TRUE(data_check[i] == float16(1.0));
+  }
+}
+
+TEST(CopyTensor, float16_cpu_to_gpu) {
+  paddle::framework::Scope scope;
+  auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_src", PlaceType::kCPU, static_cast<void *>(&scope));
+  auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_dst", PlaceType::kGPU, static_cast<void *>(&scope));
+
+  using paddle::platform::float16;
+  std::vector<float16> data_src(6, float16(1.0));
+  tensor_src->Reshape({2, 3});
+  tensor_src->CopyFromCpu(data_src.data());
+
+  std::vector<float16> data_dst(4, float16(2.0));
+  tensor_dst->Reshape({2, 2});
+  tensor_dst->CopyFromCpu(data_dst.data());
+
+  paddle_infer::contrib::TensorUtils::CopyTensor(tensor_dst.get(), *tensor_src);
+
+  EXPECT_EQ(tensor_dst->shape().size(), (size_t)2);
+  EXPECT_EQ(tensor_dst->shape()[0], 2);
+  EXPECT_EQ(tensor_dst->shape()[1], 3);
+
+  std::vector<float16> data_check(6, float16(2.0));
+  tensor_dst->CopyToCpu<float16>(data_check.data());
+
+  for (int i = 0; i < 6; i++) {
+    EXPECT_TRUE(data_check[i] == float16(1.0));
+  }
+}
+
+TEST(CopyTensor, float16_gpu_to_cpu) {
+  paddle::framework::Scope scope;
+  auto tensor_src = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_src", PlaceType::kGPU, static_cast<void *>(&scope));
+  auto tensor_dst = paddle_infer::InferApiTesterUtils::CreateInferTensorForTest(
+      "tensor_dst", PlaceType::kCPU, static_cast<void *>(&scope));
+
+  using paddle::platform::float16;
+  std::vector<float16> data_src(6, float16(1.0));
+  tensor_src->Reshape({2, 3});
+  tensor_src->CopyFromCpu(data_src.data());
+
+  std::vector<float16> data_dst(4, float16(2.0));
+  tensor_dst->Reshape({2, 2});
+  tensor_dst->CopyFromCpu(data_dst.data());
+
+  paddle_infer::contrib::TensorUtils::CopyTensor(tensor_dst.get(), *tensor_src);
+
+  EXPECT_EQ(tensor_dst->shape().size(), (size_t)2);
+  EXPECT_EQ(tensor_dst->shape()[0], 2);
+  EXPECT_EQ(tensor_dst->shape()[1], 3);
+
+  std::vector<float16> data_check(6, float16(2.0));
   tensor_dst->CopyToCpu<float16>(data_check.data());
 
   for (int i = 0; i < 6; i++) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- add unitest for zero_copy_tensor with bool type.
- enhance unitest for other data type.