### PR TITLE
[CodeStyle][UP019] update deprecated type annotation in `python/paddle/jit/api.py`

### DIFF
--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -16,13 +16,15 @@
 # Temporary disable isort to avoid circular import
 # This can be removed after the circular import is resolved
 # isort: skip_file
+from __future__ import annotations
+
 import os
 import pickle
 import warnings
 from collections import OrderedDict
 import inspect
 import threading
-from typing import Text, Tuple, Any, List
+from typing import Any
 
 import paddle
 from paddle.fluid import core, dygraph
@@ -705,12 +707,12 @@ def _run_save_pre_hooks(func):
     return wrapper
 
 
-def _save_property(filename: Text, property_vals: List[Tuple[Any, Text]]):
+def _save_property(filename: str, property_vals: list[tuple[Any, str]]):
     """class property serialization.
 
     Args:
-        filename (Text): *.meta
-        property_vals (List[Tuple): class property.
+        filename (str): *.meta
+        property_vals (list[tuple[Any, str]]): class property.
     """
 
     def set_property(meta, key, val):

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -13,15 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
-import inspect
+# Temporary disable isort to avoid circular import
+# This can be removed after the circular import is resolved
+# isort: skip_file
 import os
 import pickle
-import threading
 import warnings
 from collections import OrderedDict
-from typing import Any
+import inspect
+import threading
+from typing import Text, Tuple, Any, List
 
 import paddle
 from paddle.fluid import core, dygraph
@@ -31,42 +32,45 @@ from paddle.fluid.compiler import (
     ExecutionStrategy,
 )
 from paddle.fluid.data_feeder import check_type
+from paddle.fluid.layers.utils import flatten, pack_sequence_as
 from paddle.fluid.dygraph.base import (
     program_desc_tracing_guard,
     switch_to_static_graph,
 )
-from paddle.fluid.dygraph.layers import Layer
-from paddle.fluid.executor import Executor, scope_guard
-from paddle.fluid.framework import (
-    Block,
-    EagerParamBase,
-    ParamBase,
-    Parameter,
-    Program,
-    Variable,
-    _current_expected_place,
-    _dygraph_guard,
-    _dygraph_tracer,
-    _non_static_mode,
-    dygraph_only,
-)
-from paddle.fluid.layers.utils import flatten, pack_sequence_as
-from paddle.fluid.wrapped_decorator import wrap_decorator
-from paddle.jit.translated_layer import (
-    INFER_MODEL_SUFFIX,
-    INFER_PARAMS_INFO_SUFFIX,
-    INFER_PARAMS_SUFFIX,
-    INFER_PROPERTY_SUFFIX,
-    TranslatedLayer,
-)
-
 from .dy2static import logging_utils
-from .dy2static.convert_call_func import CONVERSION_OPTIONS, ConversionOptions
+from .dy2static.convert_call_func import (
+    ConversionOptions,
+    CONVERSION_OPTIONS,
+)
 from .dy2static.program_translator import (
     ProgramTranslator,
     StaticFunction,
     unwrap_decorators,
 )
+from paddle.jit.translated_layer import (
+    TranslatedLayer,
+    INFER_MODEL_SUFFIX,
+    INFER_PARAMS_SUFFIX,
+    INFER_PARAMS_INFO_SUFFIX,
+    INFER_PROPERTY_SUFFIX,
+)
+from paddle.fluid.dygraph.layers import Layer
+from paddle.fluid.executor import Executor, scope_guard
+from paddle.fluid.framework import (
+    Block,
+    ParamBase,
+    Program,
+    Variable,
+    Parameter,
+    EagerParamBase,
+)
+from paddle.fluid.framework import (
+    _current_expected_place,
+    _dygraph_guard,
+    _dygraph_tracer,
+)
+from paddle.fluid.framework import dygraph_only, _non_static_mode
+from paddle.fluid.wrapped_decorator import wrap_decorator
 
 __all__ = []
 
@@ -701,12 +705,12 @@ def _run_save_pre_hooks(func):
     return wrapper
 
 
-def _save_property(filename: str, property_vals: list[tuple[Any, str]]):
+def _save_property(filename: Text, property_vals: List[Tuple[Any, Text]]):
     """class property serialization.
 
     Args:
-        filename (str): *.meta
-        property_vals (list[tuple[Any, str]]): class property.
+        filename (Text): *.meta
+        property_vals (List[Tuple): class property.
     """
 
     def set_property(meta, key, val):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

- ~~#48637 中使用 isort 时由于循环依赖原因无法直接 sort，目前相关文件都已经删除或移出 fluid（于 #48709、#49065、#48841），因此现在可以 sort 了~~ 仍然有 `paddle.jit.translated_layer` -> `paddle.jit.dy2static` -> `paddle.jit.translated_layer` 的循环依赖关系，这个 PR 先不修改这个了
- ruff 实现的 pyupgrade 规则 UP019（`typing.Text` is deprecated, use `str`[^1]）只有 `python/paddle/jit/api.py` 有存量，因此本 PR ~~一起~~改一下

## Related links

- #46837

[^1]: 可参考 [typing.Text doc](https://docs.python.org/3/library/typing.html#typing.Text)，于 Python3 `typing.Text` 只是 `str` 的一个 alias，已经弃用，将会在未来版本移除（虽然具体版本未定）