### PR TITLE
[CodeStyle][UP005] replace deprecated unittest aliases

### DIFF
--- a/python/paddle/fluid/tests/custom_op/test_check_abi.py
+++ b/python/paddle/fluid/tests/custom_op/test_check_abi.py
@@ -142,7 +142,7 @@ class TestCheckCompiler(TestABIBase):
 class TestRunCMDException(unittest.TestCase):
     def test_exception(self):
         for verbose in [True, False]:
-            with self.assertRaisesRegexp(RuntimeError, "Failed to run command"):
+            with self.assertRaisesRegex(RuntimeError, "Failed to run command"):
                 cmd = "fake cmd"
                 utils.run_cmd(cmd, verbose)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
@@ -396,17 +396,17 @@ class TestErrorWithInitFromStaticMode(unittest.TestCase):
         paddle.enable_static()
 
         net = SimpleNet()
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             RuntimeError, "only available in dynamic mode"
         ):
             net.forward.concrete_program
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             RuntimeError, "only available in dynamic mode"
         ):
             net.forward.inputs
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             RuntimeError, "only available in dynamic mode"
         ):
             net.forward.outputs

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
@@ -357,12 +357,12 @@ class TestErrorWithInitFromStaticMode(unittest.TestCase):
         net = Net()
 
         self.program_translator.enable(True)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             RuntimeError, "only available in dynamic mode"
         ):
             self.program_translator.get_output(net.forward, self.x)
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             RuntimeError, "only available in dynamic mode"
         ):
             self.program_translator.get_program(net.forward, self.x)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_spec_names.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_spec_names.py
@@ -97,7 +97,7 @@ class TestArgsSpecName(unittest.TestCase):
             return name_ids[name]
 
         mode = [to_idx(name) for name in in_names]
-        self.assertEquals(mode, expect_mode)
+        self.assertEqual(mode, expect_mode)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/ir_memory_optimize_net_base.py
+++ b/python/paddle/fluid/tests/unittests/ir_memory_optimize_net_base.py
@@ -140,12 +140,12 @@ class TestIrMemOptBase(BuildIrMemOptBase):
                     self.network
                 )
 
-                self.assertAlmostEquals(
+                self.assertAlmostEqual(
                     np.mean(baseline_last_loss),
                     np.mean(cur_last_loss),
                     delta=1e-6,
                 )
-                self.assertAlmostEquals(
+                self.assertAlmostEqual(
                     np.mean(baseline_first_loss),
                     np.mean(cur_first_loss),
                     delta=1e-6,

--- a/python/paddle/fluid/tests/unittests/mlu/test_tril_triu_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_tril_triu_op_mlu.py
@@ -82,7 +82,7 @@ def case_generator(op_type, Xshape, diagonal, expected):
             paddle.enable_static()
 
             data = fluid.data(shape=Xshape, dtype='float64', name=cls_name)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 eval(expected.split(':')[-1]), errmsg[expected]
             ):
                 getattr(tensor, op_type)(x=data, diagonal=diagonal)

--- a/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_tril_triu_op_npu.py
@@ -83,7 +83,7 @@ def case_generator(op_type, Xshape, diagonal, expected):
             paddle.enable_static()
 
             data = fluid.data(shape=Xshape, dtype='float32', name=cls_name)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 eval(expected.split(':')[-1]), errmsg[expected]
             ):
                 getattr(tensor, op_type)(x=data, diagonal=diagonal)

--- a/python/paddle/fluid/tests/unittests/seresnext_test_base.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_test_base.py
@@ -50,16 +50,16 @@ class TestResnetBase(TestParallelExecutorBase):
 
         if compare_separately:
             for loss in zip(func_1_first_loss, func_2_first_loss):
-                self.assertAlmostEquals(loss[0], loss[1], delta=1e-5)
+                self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
             for loss in zip(func_1_last_loss, func_2_last_loss):
-                self.assertAlmostEquals(loss[0], loss[1], delta=delta2)
+                self.assertAlmostEqual(loss[0], loss[1], delta=delta2)
         else:
             np.testing.assert_allclose(
                 func_1_loss_area, func_2_loss_area, rtol=delta2
             )
-            self.assertAlmostEquals(
+            self.assertAlmostEqual(
                 np.mean(func_1_first_loss), func_2_first_loss[0], delta=1e-5
             )
-            self.assertAlmostEquals(
+            self.assertAlmostEqual(
                 np.mean(func_1_last_loss), func_2_last_loss[0], delta=delta2
             )

--- a/python/paddle/fluid/tests/unittests/test_base_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_base_layer.py
@@ -177,12 +177,12 @@ class TestBuffer(unittest.TestCase):
             net = fluid.Layer()
             var = to_variable(np.zeros([1]))
 
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 TypeError, "name of buffer should be a string"
             ):
                 net.register_buffer(12, var)
 
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 TypeError, "buffer should be a Paddle.Tensor"
             ):
                 if in_dygraph_mode():
@@ -194,18 +194,18 @@ class TestBuffer(unittest.TestCase):
                         "buffer_name", ParamBase([2, 2], 'float32')
                     )
 
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 KeyError, "name of buffer can not contain"
             ):
                 net.register_buffer("buffer.name", var)
 
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 KeyError, "name of buffer can not be empty"
             ):
                 net.register_buffer("", var)
 
             net.attr_name = 10
-            with self.assertRaisesRegexp(KeyError, "already exists"):
+            with self.assertRaisesRegex(KeyError, "already exists"):
                 net.register_buffer("attr_name", var)
 
             del net.attr_name
@@ -213,7 +213,7 @@ class TestBuffer(unittest.TestCase):
                 net.attr_name = EagerParamBase([2, 2], 'float32')
             else:
                 net.attr_name = ParamBase([2, 2], 'float32')
-            with self.assertRaisesRegexp(KeyError, "already exists"):
+            with self.assertRaisesRegex(KeyError, "already exists"):
                 net.register_buffer("attr_name", var)
 
     def test_register_buffer_same_name(self):

--- a/python/paddle/fluid/tests/unittests/test_crypto.py
+++ b/python/paddle/fluid/tests/unittests/test_crypto.py
@@ -21,7 +21,7 @@ class CipherUtilsTestCase(unittest.TestCase):
     def test_gen_key(self):
         key1 = CipherUtils.gen_key(256)
         key2 = CipherUtils.gen_key_to_file(256, "paddle_aes_test.keyfile")
-        self.assertNotEquals(key1, key2)
+        self.assertNotEqual(key1, key2)
         key3 = CipherUtils.read_key_from_file("paddle_aes_test.keyfile")
         self.assertEqual(key2, key3)
         self.assertEqual(len(key1), 32)

--- a/python/paddle/fluid/tests/unittests/test_cyclic_cifar_dataset.py
+++ b/python/paddle/fluid/tests/unittests/test_cyclic_cifar_dataset.py
@@ -28,11 +28,11 @@ class TestCifar10(unittest.TestCase):
         read_num = 0
         for data in cyclic_reader():
             read_num += 1
-            self.assertEquals(len(data), 2)
+            self.assertEqual(len(data), 2)
             if read_num == sample_num * 2:
                 break
 
-        self.assertEquals(read_num, sample_num * 2)
+        self.assertEqual(read_num, sample_num * 2)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_dataset_dataloader.py
+++ b/python/paddle/fluid/tests/unittests/test_dataset_dataloader.py
@@ -153,7 +153,7 @@ class DatasetLoaderTestBase(unittest.TestCase):
         for _ in range(EPOCH_NUM):
             has_complete_batch = False
             for batch_id, data in enumerate(dataloader):
-                self.assertEquals(len(places), len(data))
+                self.assertEqual(len(places), len(data))
                 for idx, data_on_each_device in enumerate(data):
                     image = data_on_each_device["image"]
                     label = data_on_each_device["label"]
@@ -166,7 +166,7 @@ class DatasetLoaderTestBase(unittest.TestCase):
                         else:
                             batch_size = BATCH_SIZE
 
-                    self.assertEquals(image.shape()[1:], IMAGE_SHAPE)
+                    self.assertEqual(image.shape()[1:], IMAGE_SHAPE)
                     self.assertTrue(
                         image._place()._equals(places[idx]),
                         msg=get_place_string(image._place())
@@ -174,24 +174,24 @@ class DatasetLoaderTestBase(unittest.TestCase):
                         + get_place_string(places[idx]),
                     )
                     if self.drop_last:
-                        self.assertEquals(image.shape()[0], BATCH_SIZE)
+                        self.assertEqual(image.shape()[0], BATCH_SIZE)
                     else:
                         self.assertTrue(
                             image.shape()[0] == BATCH_SIZE
                             or image.shape()[0] == BATCH_SIZE / 2
                         )
 
-                    self.assertEquals(label.shape()[1:], LABEL_SHAPE)
+                    self.assertEqual(label.shape()[1:], LABEL_SHAPE)
                     self.assertTrue(label._place()._equals(places[idx]))
                     if self.drop_last:
-                        self.assertEquals(label.shape()[0], BATCH_SIZE)
+                        self.assertEqual(label.shape()[0], BATCH_SIZE)
                     else:
                         self.assertTrue(
                             label.shape()[0] == BATCH_SIZE
                             or label.shape()[0] == BATCH_SIZE / 2
                         )
 
-                    self.assertEquals(image.shape()[0], label.shape()[0])
+                    self.assertEqual(image.shape()[0], label.shape()[0])
 
                     if image.shape()[0] == BATCH_SIZE:
                         has_complete_batch = True

--- a/python/paddle/fluid/tests/unittests/test_deprecated_memory_optimize_interfaces.py
+++ b/python/paddle/fluid/tests/unittests/test_deprecated_memory_optimize_interfaces.py
@@ -39,21 +39,21 @@ class DeprecatedMemoryOptimizationInterfaceTest(unittest.TestCase):
 
     def assert_program_equal(self, prog1, prog2):
         block_num = prog1.num_blocks
-        self.assertEquals(block_num, prog2.num_blocks)
+        self.assertEqual(block_num, prog2.num_blocks)
 
         for block_id in range(block_num):
             block1 = prog1.block(block_id)
             block2 = prog2.block(block_id)
-            self.assertEquals(len(block1.ops), len(block2.ops))
+            self.assertEqual(len(block1.ops), len(block2.ops))
             for op1, op2 in zip(block1.ops, block2.ops):
-                self.assertEquals(op1.input_arg_names, op2.input_arg_names)
-                self.assertEquals(op1.output_arg_names, op2.output_arg_names)
+                self.assertEqual(op1.input_arg_names, op2.input_arg_names)
+                self.assertEqual(op1.output_arg_names, op2.output_arg_names)
 
-            self.assertEquals(len(block1.vars), len(block2.vars))
+            self.assertEqual(len(block1.vars), len(block2.vars))
             for var1 in block1.vars.values():
                 self.assertTrue(var1.name in block2.vars)
                 var2 = block2.vars.get(var1.name)
-                self.assertEquals(var1.name, var2.name)
+                self.assertEqual(var1.name, var2.name)
 
     def test_main(self):
         prog1 = self.build_network(False)

--- a/python/paddle/fluid/tests/unittests/test_detach.py
+++ b/python/paddle/fluid/tests/unittests/test_detach.py
@@ -210,7 +210,7 @@ class TestInplace(unittest.TestCase):
             var_d = var_b**2
 
             loss = paddle.nn.functional.relu(var_c + var_d)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 RuntimeError,
                 "received tensor_version:{} != wrapper_version_snapshot:{}".format(
                     1, 0

--- a/python/paddle/fluid/tests/unittests/test_dist_tree_index.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_tree_index.py
@@ -103,8 +103,8 @@ class TestTreeIndex(unittest.TestCase):
             node.id() for node in tree.get_nodes(travel_path_codes)
         ]
 
-        self.assertEquals(travel_path_ids + [travel_ids[-1]], travel_ids)
-        self.assertEquals(travel_path_codes + [travel_codes[-1]], travel_codes)
+        self.assertEqual(travel_path_ids + [travel_ids[-1]], travel_ids)
+        self.assertEqual(travel_path_codes + [travel_codes[-1]], travel_codes)
 
         # get_children
         children_codes = tree.get_children_codes(travel_codes[1], height - 1)

--- a/python/paddle/fluid/tests/unittests/test_egr_python_api.py
+++ b/python/paddle/fluid/tests/unittests/test_egr_python_api.py
@@ -75,12 +75,12 @@ class EagerScaleTestCase(unittest.TestCase):
 
         out_eager = core.eager.scale(data_eager, 1.0, 0.9, True, True)
         self.assertIsNone(data_eager.grad)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             AssertionError, "The type of grad_tensor must be paddle.Tensor"
         ):
             out_eager.backward(grad_data, False)
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             AssertionError,
             "Tensor shape not match, Tensor of grad_tensor /*",
         ):
@@ -265,17 +265,17 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         zero_dim_param = EagerParamBase(shape=[], dtype="float32")
         self.assertEqual(zero_dim_param.shape, [])
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "The shape of Parameter should not be None"
         ):
             eager_param = EagerParamBase(shape=None, dtype="float32")
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "The dtype of Parameter should not be None"
         ):
             eager_param = EagerParamBase(shape=[1, 1], dtype=None)
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError,
             "Each dimension of shape for Parameter must be greater than 0, but received /*",
         ):
@@ -285,7 +285,7 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         self.assertTrue(eager_param.trainable)
         eager_param.trainable = False
         self.assertFalse(eager_param.trainable)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "The type of trainable MUST be bool, but the type is /*"
         ):
             eager_param.trainable = "False"
@@ -296,7 +296,7 @@ class EagerVariablePropertiesAndMethodsTestCase(unittest.TestCase):
         self.assertTrue(eager_param_2.trainable)
         eager_param_2.trainable = False
         self.assertFalse(eager_param_2.trainable)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "The type of trainable MUST be bool, but the type is /*"
         ):
             eager_param_2.trainable = "False"

--- a/python/paddle/fluid/tests/unittests/test_fuse_all_reduce_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_all_reduce_pass.py
@@ -79,9 +79,9 @@ class TestFuseAllReduceOpsBase(TestParallelExecutorBase):
         )
 
         for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
         for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
 
     def optimizer(self, learning_rate=1e-3):
         optimizer = fluid.optimizer.SGD(

--- a/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
@@ -75,9 +75,9 @@ class TestMNIST(TestParallelExecutorBase):
         )
 
         for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
         for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
 
     def test_simple_fc_with_fuse_op(self):
         self._compare_fuse_elewise_add_act_ops(simple_fc_net, DeviceType.CUDA)

--- a/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
@@ -71,9 +71,9 @@ class TestFuseOptimizationOps(TestParallelExecutorBase):
         )
 
         for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
         for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
 
     def _decorate_compare_fused_optimizer_ops(
         self, model, use_device, optimizer

--- a/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
@@ -119,9 +119,9 @@ class TestMNIST(TestParallelExecutorBase):
         )
 
         for loss in zip(not_fuse_op_first_loss, fuse_op_first_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
         for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
 
     def test_simple_depthwise_with_fuse_op(self):
         self._compare(simple_depthwise_net, DeviceType.CUDA)

--- a/python/paddle/fluid/tests/unittests/test_global_var_getter_setter.py
+++ b/python/paddle/fluid/tests/unittests/test_global_var_getter_setter.py
@@ -55,7 +55,7 @@ class TestGlobalVarGetterSetter(unittest.TestCase):
         self.assertFalse(name in g)
         self.assertFalse(name in g.keys())
         self.assertIsNone(g.get(name, None))
-        self.assertEquals(g.get(name, -1), -1)
+        self.assertEqual(g.get(name, -1), -1)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_exception.py
@@ -37,7 +37,7 @@ class TestDygraphDataLoaderWithException(unittest.TestCase):
 
     def test_not_capacity(self):
         with fluid.dygraph.guard():
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 ValueError, "Please give value to capacity."
             ):
                 fluid.io.DataLoader.from_generator()

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -53,7 +53,7 @@ class TestInplace(unittest.TestCase):
             var_d = var_b**2
 
             loss = paddle.nn.functional.relu(var_c + var_d)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 RuntimeError,
                 "received tensor_version:{} != wrapper_version_snapshot:{}".format(
                     1, 0
@@ -161,7 +161,7 @@ class TestDygraphInplace(unittest.TestCase):
             self.inplace_api_processing(var_b)
 
             loss = paddle.nn.functional.relu(var_c)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 RuntimeError,
                 "received tensor_version:{} != wrapper_version_snapshot:{}".format(
                     1, 0

--- a/python/paddle/fluid/tests/unittests/test_io_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_io_save_load.py
@@ -76,7 +76,7 @@ class TestSaveInferenceModelAPIError(unittest.TestCase):
 
         exe = fluid.Executor(fluid.CPUPlace())
         exe.run(start_prog)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "not involved in the target_vars calculation"
         ):
             fluid.io.save_inference_model(

--- a/python/paddle/fluid/tests/unittests/test_optimizer_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_grad.py
@@ -251,7 +251,7 @@ class TestOptimizer(unittest.TestCase):
 )
 class TestSGDOptimizer(TestOptimizer):
     def test_optimizer_multiblock_except(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError, "var param_y not in this block"
         ):
             self._check_grads(use_bf16=True)

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_mnist.py
@@ -174,12 +174,12 @@ class TestMNIST(TestParallelExecutorBase):
             use_parallel_executor=True,
         )
 
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             np.mean(parallel_first_loss),
             single_first_loss,
             delta=1e-6,
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             np.mean(parallel_last_loss), single_last_loss, delta=1e-6
         )
 

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_pg.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_pg.py
@@ -70,12 +70,12 @@ class TestMNIST(TestParallelExecutorBase):
             use_parallel_executor=True,
         )
 
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             np.mean(parallel_first_loss),
             single_first_loss,
             delta=1e-6,
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             np.mean(parallel_last_loss), single_last_loss, delta=1e-6
         )
 

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_cpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_cpu.py
@@ -49,9 +49,9 @@ class TestResnetWithReduceBase(TestParallelExecutorBase):
         )
 
         for loss in zip(all_reduce_first_loss, reduce_first_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-5)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
         for loss in zip(all_reduce_last_loss, reduce_last_loss):
-            self.assertAlmostEquals(loss[0], loss[1], delta=loss[0] * delta2)
+            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
 
         if not use_device:
             return
@@ -87,19 +87,19 @@ class TestResnetWithReduceBase(TestParallelExecutorBase):
         )
 
         for loss in zip(all_reduce_first_loss, all_reduce_first_loss_seq):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-5)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
         for loss in zip(all_reduce_last_loss, all_reduce_last_loss_seq):
-            self.assertAlmostEquals(loss[0], loss[1], delta=loss[0] * delta2)
+            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
 
         for loss in zip(reduce_first_loss, reduce_first_loss_seq):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-5)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
         for loss in zip(reduce_last_loss, reduce_last_loss_seq):
-            self.assertAlmostEquals(loss[0], loss[1], delta=loss[0] * delta2)
+            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
 
         for loss in zip(all_reduce_first_loss_seq, reduce_first_loss_seq):
-            self.assertAlmostEquals(loss[0], loss[1], delta=1e-5)
+            self.assertAlmostEqual(loss[0], loss[1], delta=1e-5)
         for loss in zip(all_reduce_last_loss_seq, reduce_last_loss_seq):
-            self.assertAlmostEquals(loss[0], loss[1], delta=loss[0] * delta2)
+            self.assertAlmostEqual(loss[0], loss[1], delta=loss[0] * delta2)
 
 
 class TestResnetWithReduceCPU(TestResnetWithReduceBase):

--- a/python/paddle/fluid/tests/unittests/test_pylayer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pylayer_op.py
@@ -440,7 +440,7 @@ class TestPyLayer(unittest.TestCase):
         data.stop_gradient = False
         layer = Layer()
         z = layer(data)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             RuntimeError,
             "received tensor_version:{} != wrapper_version_snapshot:{}".format(
                 1, 0

--- a/python/paddle/fluid/tests/unittests/test_scope.py
+++ b/python/paddle/fluid/tests/unittests/test_scope.py
@@ -52,7 +52,7 @@ class TestScope(unittest.TestCase):
         scope = paddle_c.Scope()
         # Delete the scope.
         scope._remove_from_pool()
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             Exception, "Deleting a nonexistent scope is not allowed*"
         ):
             # It is not allowed to delete a nonexistent scope.

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -899,7 +899,7 @@ class TestSetValueValueShape5(TestSetValueApi):
 # 4. Test error
 class TestError(TestSetValueBase):
     def _value_type_error(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError,
             "Only support to assign an integer, float, numpy.ndarray or paddle.Tensor",
         ):
@@ -908,7 +908,7 @@ class TestError(TestSetValueBase):
             x[0] = value
 
     def _dtype_error(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             TypeError,
             "When assign a numpy.ndarray, integer or float to a paddle.Tensor, ",
         ):
@@ -916,17 +916,17 @@ class TestError(TestSetValueBase):
             y[0] = 1
 
     def _step_error(self):
-        with self.assertRaisesRegexp(ValueError, "step can not be 0"):
+        with self.assertRaisesRegex(ValueError, "step can not be 0"):
             x = paddle.ones(shape=self.shape, dtype=self.dtype)
             x[0:1:0] = self.value
 
     def _ellipsis_error(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             IndexError, "An index can only have a single ellipsis"
         ):
             x = paddle.ones(shape=self.shape, dtype=self.dtype)
             x[..., ...] = self.value
-        with self.assertRaisesRegexp(ValueError, "the start or end is None"):
+        with self.assertRaisesRegex(ValueError, "the start or end is None"):
             x = paddle.ones(shape=self.shape, dtype=self.dtype)
             one = paddle.ones([1])
             x[::one] = self.value

--- a/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
@@ -79,7 +79,7 @@ def case_generator(op_type, Xshape, diagonal, expected):
             paddle.enable_static()
 
             data = fluid.data(shape=Xshape, dtype='float64', name=cls_name)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 eval(expected.split(':')[-1]), errmsg[expected]
             ):
                 getattr(tensor, op_type)(x=data, diagonal=diagonal)

--- a/python/paddle/fluid/tests/unittests/test_view_op_reuse_allocation.py
+++ b/python/paddle/fluid/tests/unittests/test_view_op_reuse_allocation.py
@@ -78,7 +78,7 @@ class TestDygraphViewReuseAllocation(unittest.TestCase):
             view_var_b[0] = 2.0  # var_b is modified inplace
 
             loss = paddle.nn.functional.relu(var_c)
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                 RuntimeError,
                 "received tensor_version:{} != wrapper_version_snapshot:{}".format(
                     1, 0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others


### Describe
<!-- Describe what this PR does -->

清理一些 unittest 模块弃用的 API 别名，相关 API 已经分别在 Python 3.1、3.2、3.5 弃用了[^1]，将会在 Python 3.12 移除[^2]

| Deprecated alias | Method Name | Deprecated in |
| -- | -- | -- |
| failUnless | assertTrue() | 3.1 |
| failIf | assertFalse() | 3.1 |
| failUnlessEqual | assertEqual() | 3.1 |
| failIfEqual | assertNotEqual() | 3.1 |
| failUnlessAlmostEqual | assertAlmostEqual() | 3.1 |
| failIfAlmostEqual | assertNotAlmostEqual() | 3.1 |
| failUnlessRaises | assertRaises() | 3.1 |
| assert_ | assertTrue() | 3.2 |
| assertEquals | assertEqual() | 3.2 |
| assertNotEquals | assertNotEqual() | 3.2 |
| assertAlmostEquals | assertAlmostEqual() | 3.2 |
| assertNotAlmostEquals | assertNotAlmostEqual() | 3.2 |
| assertRegexpMatches | assertRegex() | 3.2 |
| assertRaisesRegexp | assertRaisesRegex() | 3.2 |
| assertNotRegexpMatches | assertNotRegex() | 3.5 |

清理所使用的命令：

```bash
ruff --select=UP005 . --fix
```

### Related links

- #46837

[^1]: [unittest — Unit testing framework - Deprecated aliases](https://docs.python.org/3/library/unittest.html#deprecated-aliases)
[^2]: [What’s New In Python 3.11 - Pending Removal in Python 3.12](https://docs.python.org/3/whatsnew/3.11.html#pending-removal-in-python-3-12)