### PR TITLE
sequence_mask fix: when the bug when the input length is an empty tensor

### DIFF
--- a/paddle/fluid/operators/sequence_ops/sequence_mask_op_npu.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_mask_op_npu.cc
@@ -48,10 +48,14 @@ class SequenceMaskNPUKernel : public framework::OpKernel<T> {
 
     if (maxlen < 0) {
       auto x_numel = x->numel();
-      std::vector<T> x_vec;
-      framework::TensorToVector(*x, dev_ctx, &x_vec);
-      auto x_data = x_vec.data();
-      maxlen = static_cast<int>(*std::max_element(x_data, x_data + x_numel));
+      if (x_numel == 0) {
+        maxlen = 0;
+      } else {
+        std::vector<T> x_vec;
+        framework::TensorToVector(*x, dev_ctx, &x_vec);
+        auto x_data = x_vec.data();
+        maxlen = static_cast<int>(*std::max_element(x_data, x_data + x_numel));
+      }
     }
     auto y_dim = phi::vectorize<int>(x->dims());
     y_dim.push_back(maxlen);

--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_mask.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_mask.py
@@ -17,6 +17,7 @@ import unittest
 
 import numpy as np
 
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.framework import (
     Program,
@@ -169,6 +170,15 @@ class TestSequenceMaskOpError(unittest.TestCase):
                 fluid.layers.sequence_mask(input_data, maxlen=4)
 
             self.assertRaises(TypeError, test_Variable)
+
+
+class TestSequenceMaskWithEmptyTensor(unittest.TestCase):
+    def test_empty(self):
+        paddle.disable_static()
+        lengths = paddle.to_tensor(np.array([], dtype=np.int64))
+        mask = paddle.nn.functional.sequence_mask(lengths)
+        self.assertEqual(list(mask.shape), [0, 0])
+        paddle.enable_static()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
sequence_mask fix: when the input length is an empty tensor, the kernel tries to dereference illegal sentinel iterator
