### PR TITLE
[XPU] fix clip op unit test.

### DIFF
--- a/python/paddle/fluid/tests/unittests/xpu/test_clip_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_clip_op_xpu.py
@@ -134,12 +134,6 @@ class TestClipOpError(unittest.TestCase):
                 paddle.clip(x=input_data, min=-1.0, max=1.0)
 
             self.assertRaises(TypeError, test_Variable)
-
-            def test_dtype():
-                x2 = fluid.layers.data(name='x2', shape=[1], dtype='int32')
-                paddle.clip(x=x2, min=-1.0, max=1.0)
-
-            self.assertRaises(TypeError, test_dtype)
         paddle.disable_static()
 
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
在PR https://github.com/PaddlePaddle/Paddle/pull/48946 中，删掉了单测`test_clip_op.py`里面的部分代码，但是没有同步删除XPU单测`test_clip_op_xpu.py`里面的相应位置，导致单测跑不过。
本PR修复了此问题。
