### PR TITLE
[Paddle Inference] Add ci flags for a persistent IBuilder.

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -26,8 +26,6 @@ limitations under the License. */
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/phi/common/data_type.h"
 
-DECLARE_bool(trt_ibuilder_cache);
-
 namespace paddle {
 namespace inference {
 namespace tensorrt {
@@ -65,13 +63,6 @@ void TensorRTEngine::Weight::SetDataType(phi::DataType type) {
 }
 
 void TensorRTEngine::InitNetwork() {
-  if (FLAGS_trt_ibuilder_cache) {
-    holder.reset(createInferBuilder(&NaiveLogger::Global()), [](auto *ptr) {
-      if (ptr) {
-        ptr->destroy();
-      }
-    });
-  }
   freshDeviceId();
   infer_builder_.reset(createInferBuilder(&logger_));
 

--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -26,6 +26,8 @@ limitations under the License. */
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/phi/common/data_type.h"
 
+DECLARE_bool(trt_ibuilder_cache);
+
 namespace paddle {
 namespace inference {
 namespace tensorrt {
@@ -63,6 +65,13 @@ void TensorRTEngine::Weight::SetDataType(phi::DataType type) {
 }
 
 void TensorRTEngine::InitNetwork() {
+  if (FLAGS_trt_ibuilder_cache) {
+    holder.reset(createInferBuilder(&NaiveLogger::Global()), [](auto *ptr) {
+      if (ptr) {
+        ptr->destroy();
+      }
+    });
+  }
   freshDeviceId();
   infer_builder_.reset(createInferBuilder(&logger_));
 

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -857,12 +857,14 @@ class TRTEngineManager {
   // createInferBuilder loads trt kernels and take a few second
   // But as long as one IBuilder lives, trt kernel will not be unloaded
   // Hence, a persistent IBuilder to avoid TensorRT unload/reload kernels
+#ifdef PADDLE_WITH_TESTING
   std::unique_ptr<nvinfer1::IBuilder, std::function<void(nvinfer1::IBuilder*)>>
       holder{createInferBuilder(&NaiveLogger::Global()), [](auto* ptr) {
                if (ptr) {
                  ptr->destroy();
                }
              }};
+#endif
 };
 
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -43,6 +43,7 @@ limitations under the License. */
 #include "paddle/utils/any.h"
 
 DECLARE_bool(trt_ibuilder_cache);
+
 namespace paddle {
 namespace inference {
 namespace tensorrt {

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -42,6 +42,7 @@ limitations under the License. */
 #include "paddle/phi/core/stream.h"
 #include "paddle/utils/any.h"
 
+DECLARE_bool(trt_ibuilder_cache);
 namespace paddle {
 namespace inference {
 namespace tensorrt {
@@ -857,14 +858,15 @@ class TRTEngineManager {
   // createInferBuilder loads trt kernels and take a few second
   // But as long as one IBuilder lives, trt kernel will not be unloaded
   // Hence, a persistent IBuilder to avoid TensorRT unload/reload kernels
-#ifdef PADDLE_WITH_TESTING
-  std::unique_ptr<nvinfer1::IBuilder, std::function<void(nvinfer1::IBuilder*)>>
-      holder{createInferBuilder(&NaiveLogger::Global()), [](auto* ptr) {
-               if (ptr) {
-                 ptr->destroy();
-               }
-             }};
-#endif
+  if (FLAGS_trt_ibuilder_cache) {
+    std::unique_ptr<nvinfer1::IBuilder,
+                    std::function<void(nvinfer1::IBuilder*)>>
+        holder{createInferBuilder(&NaiveLogger::Global()), [](auto* ptr) {
+                 if (ptr) {
+                   ptr->destroy();
+                 }
+               }};
+  }
 };
 
 }  // namespace tensorrt

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -95,6 +95,17 @@ static std::tuple<int, int, int> GetTrtCompileVersion() {
       NV_TENSORRT_MAJOR, NV_TENSORRT_MINOR, NV_TENSORRT_PATCH};
 }
 
+template <typename T>
+struct Destroyer {
+  void operator()(T* x) {
+    if (x) {
+      x->destroy();
+    }
+  }
+};
+template <typename T>
+using infer_ptr = std::unique_ptr<T, Destroyer<T>>;
+
 // A logger for create TensorRT infer builder.
 class NaiveLogger : public nvinfer1::ILogger {
  public:

--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -1165,3 +1165,16 @@ PADDLE_DEFINE_EXPORTED_bool(enable_cudnn_frontend, false, "");
  */
 PADDLE_DEFINE_EXPORTED_int32(cudnn_cache_saturation_count, 1, "");
 #endif  // PADDLE_WITH_CUDNN_FRONTEND
+
+/**
+ * CI related FLAG
+ * Name: trt_ibuilder_cache
+ * Since Version: 2.5.0
+ * Value Range: bool, default=false
+ * Example:
+ * Note: If True, a persistent IBuilder is added to avoid TensorRT unload/reload
+ * kernels.
+ */
+PADDLE_DEFINE_EXPORTED_bool(trt_ibuilder_cache,
+                            false,
+                            "Add a persistent ibuilder.");

--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -1172,8 +1172,8 @@ PADDLE_DEFINE_EXPORTED_int32(cudnn_cache_saturation_count, 1, "");
  * Since Version: 2.5.0
  * Value Range: bool, default=false
  * Example:
- * Note: If True, a persistent IBuilder is added to avoid TensorRT unload/reload
- * kernels.
+ * Note: This FLAG is only enabled when CI is running. If True, a persistent
+ * IBuilder is added to avoid TensorRT unload/reload kernels.
  */
 PADDLE_DEFINE_EXPORTED_bool(trt_ibuilder_cache,
                             false,

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1403,6 +1403,7 @@ EOF
 set -x
         # set trt_convert ut to run 15% cases.
         export TEST_NUM_PERCENT_CASES=0.15
+        export FLAGS_trt_ibuilder_cache=1
         precison_cases=""
         bash $PADDLE_ROOT/tools/check_added_ut.sh
         if [ ${PRECISION_TEST:-OFF} == "ON" ]; then
@@ -2547,6 +2548,7 @@ EOF
 set -x
         # set trt_convert ut to run 15% cases.
         export TEST_NUM_PERCENT_CASES=0.15
+        export FLAGS_trt_ibuilder_cache=1
         precison_cases=""
         bash $PADDLE_ROOT/tools/check_added_ut.sh
         #check change of pr_unnitests and dev_unnitests


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add ci flags for a persistent IBuilder.
- 增加了 FLAGS_trt_ibuilder_cache 来判断是否预先产生 a persistent IBuilder，仅用于 CI