### PR TITLE
adjust ptq mnist test's timeout

### DIFF
--- a/python/paddle/static/quantization/tests/CMakeLists.txt
+++ b/python/paddle/static/quantization/tests/CMakeLists.txt
@@ -532,7 +532,7 @@ if(NOT WIN32)
   set_tests_properties(test_post_training_quantization_resnet50
                        PROPERTIES TIMEOUT 600 LABELS "RUN_TYPE=NIGHTLY")
   set_tests_properties(test_post_training_quantization_mnist PROPERTIES TIMEOUT
-                                                                        120)
+                                                                        150)
   set_tests_properties(test_post_training_quantization_while PROPERTIES TIMEOUT
                                                                         120)
   set_tests_properties(test_imperative_ptq PROPERTIES TIMEOUT 120)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Adjust the execution time of mnist test to prevent timeout.