### PR TITLE
Adjust OP scheduling order for standalone executor

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -137,7 +137,7 @@ InterpreterCore::InterpreterCore(const platform::Place& place,
     Priority lhs_prority = vec_instruction_[lhs].GetPriority();
     Priority rhs_prority = vec_instruction_[rhs].GetPriority();
     if (lhs_prority == rhs_prority) {
-      return lhs > rhs;
+      return lhs < rhs;
     }
     return lhs_prority > rhs_prority;
   };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
在PR https://github.com/PaddlePaddle/Paddle/pull/49275 支持优先队列调度之前，新执行器对于满足调度要求的OP，会通过插入到双端队列队首的方式进行调度，因而越晚入队的计算OP会越先被调度。在有多个可并发调度的相同优先级计算OP情况下，会优先调度id较大的，实际是按Program中的OP顺序逆序进行调度。
由于双端队列调度的方式只支持2级优先级，因而在支持多级优先级时将双端队列替换成了优先队列。考虑到新执行器第一轮是按Program中顺序调度的，为了尽可能保持和第一轮调度顺序相同，在优先队列中，对于相同优先级的OP，会优先调度id较小的。
这个改动导致手动并行场景下ResNet50 N4C32混合精度训练性能大幅下降。原因是模型中存在以下模式：{OP1, OP2, OP3 -> OP4}。OP1、OP2、OP3为可并发调度的计算OP，在计算流上执行；OP4为通信OP，在通信流上执行。若优先调度OP3，则OP4的通信操作可与OP1和OP2的计算操作overlap。若在OP1和OP2之后再调度OP3，由于OP4和OP3之间存在跨流同步，因而OP4的通信操作和OP1、OP2、OP3的计算操作将变成串行执行，无法overlap。
本PR修改优先级调度的规则，对于相同优先级的OP，恢复成id大的先调度。
![image](https://user-images.githubusercontent.com/17673696/210713050-9e874dc1-719c-4e6d-90b5-5a90688531ea.png)
这种调度顺序的限制是针对具体模式做的，不具有通用性，同优先级的算子逆序调度也并非最优的调度顺序。关于优先级调度，在未来应考虑更合理和完善的设计。