### PR TITLE
[Don't merge][Type Hints] move `Tensor` defination to `tensor.py`

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: define the basic tensor classes
-from .. import fluid, framework
+from paddle import Tensor
 
-if fluid.framework._in_eager_mode_:
-    Tensor = framework.core.eager.Tensor
-else:
-    from .framework import VarBase as Tensor  # noqa: F401
-
-Tensor.__qualname__ = 'Tensor'  # noqa: F401
+x = Tensor()
+x.foo

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -55,12 +55,7 @@ from .framework.dtype import bool  # noqa: F401
 from .framework.dtype import complex64  # noqa: F401
 from .framework.dtype import complex128  # noqa: F401
 
-if fluid.framework._in_eager_mode_:
-    Tensor = framework.core.eager.Tensor
-else:
-    from .framework import VarBase as Tensor  # noqa: F401
-
-Tensor.__qualname__ = 'Tensor'  # noqa: F401
+from .tensor.tensor import Tensor
 import paddle.distributed  # noqa: F401
 import paddle.sysconfig  # noqa: F401
 import paddle.distribution  # noqa: F401

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -24,9 +24,9 @@ except ImportError:
     )
 
 from .batch import batch  # noqa: F401
+from .tensor.tensor import Tensor
 from .framework import monkey_patch_variable
 from .framework import monkey_patch_math_varbase
-from .tensor.tensor import Tensor
 
 monkey_patch_variable()
 monkey_patch_math_varbase()

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -55,7 +55,6 @@ from .framework.dtype import bool  # noqa: F401
 from .framework.dtype import complex64  # noqa: F401
 from .framework.dtype import complex128  # noqa: F401
 
-from .tensor.tensor import Tensor
 import paddle.distributed  # noqa: F401
 import paddle.sysconfig  # noqa: F401
 import paddle.distribution  # noqa: F401
@@ -82,6 +81,7 @@ import paddle.geometric  # noqa: F401
 import paddle.sparse  # noqa: F401
 import paddle.quantization  # noqa: F401
 
+from .tensor.tensor import Tensor
 from .tensor.attribute import is_complex  # noqa: F401
 from .tensor.attribute import is_integer  # noqa: F401
 from .tensor.attribute import rank  # noqa: F401

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -26,6 +26,7 @@ except ImportError:
 from .batch import batch  # noqa: F401
 from .framework import monkey_patch_variable
 from .framework import monkey_patch_math_varbase
+from .tensor.tensor import Tensor
 
 monkey_patch_variable()
 monkey_patch_math_varbase()
@@ -81,7 +82,6 @@ import paddle.geometric  # noqa: F401
 import paddle.sparse  # noqa: F401
 import paddle.quantization  # noqa: F401
 
-from .tensor.tensor import Tensor
 from .tensor.attribute import is_complex  # noqa: F401
 from .tensor.attribute import is_integer  # noqa: F401
 from .tensor.attribute import rank  # noqa: F401

--- a/python/paddle/distributed/fleet/recompute/recompute_hybrid.py
+++ b/python/paddle/distributed/fleet/recompute/recompute_hybrid.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import paddle
+from paddle import Tensor
 from paddle.autograd import PyLayer
 from paddle.fluid import core, framework
 
@@ -213,7 +214,7 @@ class _HPRecomputeFunction(PyLayer):
                     detached_inputs = detach_variable(tuple(inputs))
                     outputs = ctx.run_function(*detached_inputs, **ctx.kwargs)
 
-            if isinstance(outputs, (core.VarBase, core.eager.Tensor)):
+            if isinstance(outputs, Tensor):
                 outputs = (outputs,)
             assert len(outputs) == len(args)
 
@@ -222,7 +223,7 @@ class _HPRecomputeFunction(PyLayer):
 
             for i in range(len(outputs)):
                 if (
-                    isinstance(outputs[i], (core.VarBase, core.eager.Tensor))
+                    isinstance(outputs[i], Tensor)
                     and not outputs[i].stop_gradient
                 ):
                     forward_outputs_with_grad.append(outputs[i])
@@ -238,7 +239,7 @@ class _HPRecomputeFunction(PyLayer):
             grads = tuple(
                 inp._grad_ivar()
                 for inp in detached_inputs
-                if isinstance(inp, (core.VarBase, core.eager.Tensor))
+                if isinstance(inp, Tensor)
             )
             return grads
 

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -47,7 +47,9 @@ from ..data_feeder import (
 )
 from ..backward import _infer_var_data_type_shape_
 import paddle
-from paddle import _C_ops, _legacy_C_ops, Tensor
+from paddle import _C_ops, _legacy_C_ops
+
+Tensor = core.eager.Tensor
 
 __all__ = [
     'Switch',

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -47,7 +47,7 @@ from ..data_feeder import (
 )
 from ..backward import _infer_var_data_type_shape_
 import paddle
-from paddle import _C_ops, _legacy_C_ops
+from paddle import _C_ops, _legacy_C_ops, Tensor
 
 __all__ = [
     'Switch',
@@ -1054,7 +1054,7 @@ def assign_skip_lod_tensor_array(input, output):
                 return True
         return False
 
-    if not isinstance(input, (Variable, core.VarBase)):
+    if not isinstance(input, (Variable, Tensor)):
         if isinstance(output, Variable) and isinstance(
             input, support_ret_buildin_type
         ):

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -27,6 +27,7 @@ import threading
 from typing import Any
 
 import paddle
+from paddle import Tensor
 from paddle.fluid import core, dygraph
 from paddle.fluid.compiler import (
     BuildStrategy,
@@ -363,7 +364,7 @@ class _SaveLoadConfig:
                 % type(input)
             )
             for var in spec:
-                if not isinstance(var, core.VarBase):
+                if not isinstance(var, Tensor):
                     raise TypeError(
                         "The element in config `output_spec` list should be 'Variable', but received element's type is %s."
                         % type(var)
@@ -946,7 +947,7 @@ def save(layer, path, input_spec=None, **configs):
         for var in flatten(input_spec):
             if isinstance(var, paddle.static.InputSpec):
                 inner_input_spec.append(var)
-            elif isinstance(var, (core.VarBase, core.eager.Tensor, Variable)):
+            elif isinstance(var, (Tensor, Variable)):
                 inner_input_spec.append(
                     paddle.static.InputSpec.from_tensor(var)
                 )

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -27,7 +27,6 @@ import threading
 from typing import Any
 
 import paddle
-from paddle import Tensor
 from paddle.fluid import core, dygraph
 from paddle.fluid.compiler import (
     BuildStrategy,
@@ -74,6 +73,8 @@ from paddle.fluid.framework import (
 )
 from paddle.fluid.framework import dygraph_only, _non_static_mode
 from paddle.fluid.wrapped_decorator import wrap_decorator
+
+Tensor = core.eager.Tensor
 
 __all__ = []
 

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -15,21 +15,14 @@
 # TODO: define logic functions of a tensor
 
 import paddle
-
-from ..fluid.data_feeder import check_type, check_variable_and_dtype
-from ..fluid.framework import _in_eager_mode_
-from ..static import Variable
-from .layer_function_generator import templatedoc
-
-if _in_eager_mode_:
-    Tensor = paddle.fluid.framework.core.eager.Tensor
-else:
-    from ..framework import VarBase as Tensor
-
 from paddle import _C_ops
 from paddle.tensor.creation import full
 
+from ..fluid.data_feeder import check_type, check_variable_and_dtype
 from ..framework import LayerHelper, in_dygraph_mode
+from ..static import Variable
+from .layer_function_generator import templatedoc
+from .tensor import Tensor
 
 __all__ = []
 

--- a/python/paddle/tensor/tensor.py
+++ b/python/paddle/tensor/tensor.py
@@ -19,7 +19,7 @@ The basic tensor classes
 from .. import fluid
 
 if fluid.framework._in_eager_mode_:
-    from ..framework.core.eager import Tensor
+    from ..fluid.core.eager import Tensor
 else:
     from ..framework import VarBase as Tensor
 

--- a/python/paddle/tensor/tensor.py
+++ b/python/paddle/tensor/tensor.py
@@ -12,12 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: define the basic tensor classes
-from .. import fluid, framework
+"""
+The basic tensor classes
+"""
+
+from .. import fluid
 
 if fluid.framework._in_eager_mode_:
-    Tensor = framework.core.eager.Tensor
+    from ..framework.core.eager import Tensor
 else:
-    from .framework import VarBase as Tensor  # noqa: F401
+    from ..framework import VarBase as Tensor
 
-Tensor.__qualname__ = 'Tensor'  # noqa: F401
+Tensor.__qualname__ = 'Tensor'

--- a/python/paddle/tensor/tensor.py
+++ b/python/paddle/tensor/tensor.py
@@ -19,7 +19,7 @@ The basic tensor classes
 from .. import fluid
 
 if fluid.framework._in_eager_mode_:
-    from ..fluid.core.eager import Tensor
+    Tensor = fluid.core.eager.Tensor
 else:
     from ..framework import VarBase as Tensor
 

--- a/python/paddle/tensor/tensor.pyi
+++ b/python/paddle/tensor/tensor.pyi
@@ -1,0 +1,4 @@
+class Tensor:
+    def foo() -> int:
+        """Docstring"""
+        ...

--- a/python/paddle/tensor/tensor.pyi
+++ b/python/paddle/tensor/tensor.pyi
@@ -1,4 +1,4 @@
 class Tensor:
     def foo() -> int:
-        """Docstring"""
+        """Document for Tensor.foo"""
         ...


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

将原来散落在 `python/paddle/__init__.py`、`python/paddle/tensor/logic.py` 等位置的 Tensor 处理统一放到 `python/paddle/tensor/tensor.py`，这样就可以在 `python/paddle/tensor/tensor.pyi` 添加更详细的 Tensor 属性方法了，这使得新的类型提示方案只需要添加一个 `tensor.pyi` 即可，不需要任何其他的改动（如添加 `if TYPE_CHECKING: from .tensor_proxy import Tensor`），经验证，这也是支持 Docstring 的（PyCharm、VS Code pylance 均已验证）

本 PR 验证该重构在运行时没有影响

相对于原来的方案，只需要将扩展名从 `.py` 改成 `.pyi` 即可，比如 #49053 脚本仍然是可用的（虽然新的 RFC 已经不用那个方案了）

```bash
# 改个输出路径即可
python tools/gen_tensor_proxy.py -o python/paddle/tensor/tensor.pyi
# 此时试一下应该 IDE 的提示功能都正常了～
```