### PR TITLE
Update the style of print for low precision op list

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2551,8 +2551,10 @@ All parameter, weight, gradient are variables in Paddle.
     for (auto iter = list_op.begin(); iter != list_op.end(); iter++) {
       auto op_name = (iter->first).c_str();
       auto counts = iter->second;
-      op_list[op_name] = std::to_string(counts.low_precision_called_) + "," +
-                         std::to_string(counts.high_precision_called_);
+      op_list[op_name] = std::to_string(counts.fp16_called_) + "," +
+                         std::to_string(counts.bf16_called_) + "," +
+                         std::to_string(counts.fp32_called_) + "," +
+                         std::to_string(counts.other_called_);
     }
     return op_list;
   });

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2073,7 +2073,7 @@ All parameter, weight, gradient are variables in Paddle.
           [](const gpuDeviceProp &prop) { return prop.integrated; })
       .def("__repr__", [](const gpuDeviceProp &prop) {
         std::stringstream ostr;
-        ostr << "_gpuDeviceProperties(name='" << prop.name
+        ostr << "_gpuDeticeProperties(name='" << prop.name
              << "', major=" << prop.major << ", minor=" << prop.minor
              << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";
@@ -2546,7 +2546,15 @@ All parameter, weight, gradient are variables in Paddle.
         [] { return phi::autotune::AutoTuneStatus::Instance().Update(); });
 
   m.def("get_low_precision_op_list", [] {
-    return phi::KernelFactory::Instance().GetLowPrecisionKernelList();
+    py::dict op_list;
+    auto list_op = phi::KernelFactory::Instance().GetLowPrecisionKernelList();
+    for (auto iter = list_op.begin(); iter != list_op.end(); iter++) {
+      auto op_name = (iter->first).c_str();
+      auto counts = iter->second;
+      op_list[op_name] = std::to_string(counts.low_precision_called_) + "," +
+                         std::to_string(counts.high_precision_called_);
+    }
+    return op_list;
   });
 
   m.def("autotune_status", [] {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2073,7 +2073,7 @@ All parameter, weight, gradient are variables in Paddle.
           [](const gpuDeviceProp &prop) { return prop.integrated; })
       .def("__repr__", [](const gpuDeviceProp &prop) {
         std::stringstream ostr;
-        ostr << "_gpuDeticeProperties(name='" << prop.name
+        ostr << "_gpuDeviceProperties(name='" << prop.name
              << "', major=" << prop.major << ", minor=" << prop.minor
              << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
              << "MB, multi_processor_count=" << prop.multiProcessorCount << ")";

--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -110,7 +110,7 @@ bool KernelFactory::HasKernel(const std::string& kernel_name,
 void KernelFactory::AddToLowPrecisionKernelList(
     const std::string& name,
     const paddle::experimental::DataType& kernel_key_type) {
-  if (FLAGS_low_precision_op_list) {
+  if (FLAGS_low_precision_op_list >= 1) {
     auto op_name = phi::TransToFluidOpName(name);
     if (op_name.find("_grad") != std::string::npos) {
       return;  // only record forward api

--- a/paddle/phi/core/kernel_factory.cc
+++ b/paddle/phi/core/kernel_factory.cc
@@ -120,13 +120,14 @@ void KernelFactory::AddToLowPrecisionKernelList(
       auto count = OpCount();
       low_precision_kernels_[op_name] = count;
     }
-    bool is_low_precision =
-        (kernel_key_type == paddle::experimental::DataType::FLOAT16 ||
-         kernel_key_type == paddle::experimental::DataType::BFLOAT16);
-    if (is_low_precision) {
-      low_precision_kernels_[op_name].low_precision_called_ += 1;
+    if (kernel_key_type == paddle::experimental::DataType::FLOAT16) {
+      low_precision_kernels_[op_name].fp16_called_ += 1;
+    } else if (kernel_key_type == paddle::experimental::DataType::BFLOAT16) {
+      low_precision_kernels_[op_name].bf16_called_ += 1;
     } else if (kernel_key_type == paddle::experimental::DataType::FLOAT32) {
-      low_precision_kernels_[op_name].high_precision_called_ += 1;
+      low_precision_kernels_[op_name].fp32_called_ += 1;
+    } else {
+      low_precision_kernels_[op_name].other_called_ += 1;
     }
   }
 }

--- a/paddle/phi/core/kernel_factory.h
+++ b/paddle/phi/core/kernel_factory.h
@@ -34,6 +34,15 @@ namespace phi {
 
 using DataType = paddle::experimental::DataType;
 
+struct OpCount {
+  OpCount() {
+    low_precision_called_ = 0;
+    high_precision_called_ = 0;
+  }
+  int low_precision_called_;
+  int high_precision_called_;
+};
+
 /**
  * [ Naming considerations ]
  *
@@ -309,7 +318,7 @@ class KernelFactory {
       const std::string& name,
       const paddle::experimental::DataType& kernel_key_type);
 
-  std::map<const std::string, int> GetLowPrecisionKernelList();
+  std::map<const std::string, OpCount> GetLowPrecisionKernelList();
 
  private:
   KernelFactory() = default;
@@ -317,7 +326,7 @@ class KernelFactory {
   KernelNameMap kernels_;
 
   // Get the low precision kernel list of current module.
-  std::map<const std::string, int> low_precision_kernels_;
+  std::map<const std::string, OpCount> low_precision_kernels_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const KernelKey& kernel_key) {

--- a/paddle/phi/core/kernel_factory.h
+++ b/paddle/phi/core/kernel_factory.h
@@ -36,11 +36,15 @@ using DataType = paddle::experimental::DataType;
 
 struct OpCount {
   OpCount() {
-    low_precision_called_ = 0;
-    high_precision_called_ = 0;
+    fp16_called_ = 0;
+    bf16_called_ = 0;
+    fp32_called_ = 0;
+    other_called_ = 0;
   }
-  int low_precision_called_;
-  int high_precision_called_;
+  int fp16_called_;
+  int bf16_called_;
+  int fp32_called_;
+  int other_called_;
 };
 
 /**

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -97,21 +97,21 @@ _g_amp_state_ = None
 def low_precision_op_list():
     if os.getenv("FLAGS_low_precision_op_list") is not None:
         level = int(os.getenv("FLAGS_low_precision_op_list"))
-        if level == 0:
-            return
-        if level == 1:
-            print('<{:-^60}>'.format(" low precision op list "))
-        else:
-            print('<{:-^60}>'.format(" op list "))
+        print('<{:-^80}>'.format(" op list "))
         op_list = paddle.fluid.core.get_low_precision_op_list()
         op_count = 0
         print(
-            '<{:-^40}'.format(" op_name "), '|', '{:-^17}>'.format(" op count ")
+            '<{:-^40}'.format(" op_name "),
+            '|',
+            '{:-^17}'.format("FP16/BF16 Calls"),
+            '|',
+            '{:-^17}>'.format('FP32 Calls'),
         )
         for x in op_list:
-            print('  %-40s|  %-15d' % (x, op_list[x]))
+            called = op_list[x].split(",")
+            print('  %-40s|  %-17s|  %-17s' % (x, called[0], called[1]))
             op_count += 1
-        print('<{:-^60}>'.format(" op count: " + str(op_count) + " "))
+        print('<{:-^80}>'.format(" op count: " + str(op_count) + " "))
 
 
 def amp_state():

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -97,21 +97,29 @@ _g_amp_state_ = None
 def low_precision_op_list():
     if os.getenv("FLAGS_low_precision_op_list") is not None:
         level = int(os.getenv("FLAGS_low_precision_op_list"))
-        print('<{:-^80}>'.format(" op list "))
+        print('<{:-^120}>'.format(" op list "))
         op_list = paddle.fluid.core.get_low_precision_op_list()
         op_count = 0
         print(
-            '<{:-^40}'.format(" op_name "),
+            '<{:-^40}'.format(" Op Name "),
             '|',
-            '{:-^17}'.format("FP16/BF16 Calls"),
+            '{:-^17}'.format("FP16 Calls"),
             '|',
-            '{:-^17}>'.format('FP32 Calls'),
+            '{:-^17}'.format("BF16 Calls"),
+            '|',
+            '{:-^17}'.format('FP32 Calls'),
+            '|',
+            '{:-^17}>'.format('Other Calls'),
         )
         for x in op_list:
+            # fp16, bf16, fp32, other
             called = op_list[x].split(",")
-            print('  %-40s|  %-17s|  %-17s' % (x, called[0], called[1]))
+            print(
+                '  %-40s|  %-17s|  %-17s|  %-17s|  %-17s'
+                % (x, called[0], called[1], called[2], called[3])
+            )
             op_count += 1
-        print('<{:-^80}>'.format(" op count: " + str(op_count) + " "))
+        print('<{:-^120}>'.format(" op count: " + str(op_count) + " "))
 
 
 def amp_state():

--- a/python/paddle/fluid/tests/unittests/test_low_precision_list.py
+++ b/python/paddle/fluid/tests/unittests/test_low_precision_list.py
@@ -36,9 +36,14 @@ class TestAMPList(unittest.TestCase):
 
         conv2d_called = op_list['conv2d'].split(',')
         add_called = op_list['elementwise_add'].split(',')
+        add_num = 0
+        conv_num = 0
+        for i in range(4):
+            add_num += int(add_called[i])
+            conv_num += int(add_called[i])
 
-        self.assertTrue(int(conv2d_called[0]) + int(conv2d_called[1]) == 1)
-        self.assertTrue(int(add_called[0]) + int(add_called[1]) == 1)
+        self.assertTrue(conv_num == 1)
+        self.assertTrue(add_num == 1)
 
         if conv.dtype == "float16":
             self.assertTrue(int(conv2d_called[0]) == 1)

--- a/python/paddle/fluid/tests/unittests/test_low_precision_list.py
+++ b/python/paddle/fluid/tests/unittests/test_low_precision_list.py
@@ -30,12 +30,19 @@ class TestAMPList(unittest.TestCase):
             c = a + b
         paddle.amp.low_precision_op_list()
         op_list = paddle.fluid.core.get_low_precision_op_list()
-        if conv.dtype == paddle.float16:
-            self.assertTrue('elementwise_add' in op_list)
-            self.assertTrue('conv2d' in op_list)
-            self.assertTrue(2 == len(op_list))
-        else:
-            self.assertTrue(0 == len(op_list))
+
+        self.assertTrue('elementwise_add' in op_list)
+        self.assertTrue('conv2d' in op_list)
+
+        conv2d_called = op_list['conv2d'].split(',')
+        add_called = op_list['elementwise_add'].split(',')
+
+        self.assertTrue(int(conv2d_called[0]) + int(conv2d_called[1]) == 1)
+        self.assertTrue(int(add_called[0]) + int(add_called[1]) == 1)
+
+        if conv.dtype == "float16":
+            self.assertTrue(int(conv2d_called[0]) == 1)
+            self.assertTrue(int(add_called[0]) == 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
重新修改低精度算子列表打印格式：
功能说明：默认打印当前模型的所有算子列表，并统计FP16,BF16 ,FP32的算子调用次数，其他类型不进行区分统计在Other Calls中
<img width="993" alt="image" src="https://user-images.githubusercontent.com/51102941/211272327-595ca3c3-1c21-478f-8c5a-81b472a221cb.png">
<img width="992" alt="image" src="https://user-images.githubusercontent.com/51102941/211272138-29c32feb-9669-48b9-97fa-74534a27b1db.png">
