### PR TITLE
[Bug fix] Fix kaiming initializer div zero

### DIFF
--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -772,6 +772,15 @@ class MSRAInitializer(Initializer):
         assert isinstance(block, framework.Block)
         f_in, f_out = self._compute_fans(var)
 
+        if fan_in == 0:
+            if self._fan_in is None:
+                raise ValueError(
+                    "The in_features of the Tensor contain zero, can not initialize the Tensor."
+                )
+            else:
+                raise ValueError(
+                    "fan_in should not be zero, can not initialize the Tensor."
+                )
         # If fan_in is passed, use it
         fan_in = f_in if self._fan_in is None else self._fan_in
 

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -772,6 +772,9 @@ class MSRAInitializer(Initializer):
         assert isinstance(block, framework.Block)
         f_in, f_out = self._compute_fans(var)
 
+        # If fan_in is passed, use it
+        fan_in = f_in if self._fan_in is None else self._fan_in
+
         if fan_in == 0:
             if self._fan_in is None:
                 raise ValueError(
@@ -781,8 +784,6 @@ class MSRAInitializer(Initializer):
                 raise ValueError(
                     "fan_in should not be zero, can not initialize the Tensor."
                 )
-        # If fan_in is passed, use it
-        fan_in = f_in if self._fan_in is None else self._fan_in
 
         if self._seed == 0:
             self._seed = block.program.random_seed

--- a/python/paddle/fluid/tests/unittests/test_initializer.py
+++ b/python/paddle/fluid/tests/unittests/test_initializer.py
@@ -1176,6 +1176,22 @@ class TestDiracInitializer3(TestDiracInitializer1):
             paddle.nn.Conv2D(5, 9, (3, 3), weight_attr=self.weight_attr)
 
 
+class TestKaimingUniform(unittest.TestCase):
+    def func_kaiminguniform_initializer_fan_in_zero(self):
+        paddle.enable_static()
+        x = paddle.static.data(name='x', shape=[1, 0, 0], dtype='float32')
+
+        kaiming = paddle.nn.initializer.KaimingUniform(0)
+        param_attr = paddle.ParamAttr(initializer=kaiming)
+
+        paddle.static.nn.prelu(x, 'all', param_attr=param_attr)
+
+    def test_type_error(self):
+        self.assertRaises(
+            ValueError, self.func_kaiminguniform_initializer_fan_in_zero
+        )
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
KaimingUniform初始化器，在如下代码下会发生除0问题：
`paddle.nn.initializer.KaimingUniform` has `divide by 0` problem in following case:
```
import paddle
import numpy as np

paddle.enable_static()
x = paddle.static.data(name='x', shape=[1, 0, 0], dtype='float32')

kaiming = paddle.nn.initializer.KaimingUniform(0)
param_attr = paddle.ParamAttr(initializer=kaiming)

paddle.static.nn.prelu(x, 'all', param_attr=param_attr)
```

- 原因：这个初始化器，默认是使用Tensor shape的一个维度作为fan_in的，也可以由用户指定fan_in的值。但均不能为0。
- 解决方案：对这两种情况添加检查、报错。同时为这种场景添加单测case。
- Reason: This initializer uses one dimension of Tensor shape as `fan_in` by default,  besides, users can also specify the value of `fan_in`. But both of them can not be 0.
- Solution: Add parameter check, error reporting, and unit-test for these two scenarios.