### PR TITLE
fix protobuf import pyext._message error

### DIFF
--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -22,6 +22,12 @@ from paddle.distributed.fleet.utils.log_util import logger
 from paddle.fluid.framework import _global_flags
 from paddle.fluid.wrapped_decorator import wrap_decorator
 
+protobuf_version = google.protobuf.__version__
+if protobuf_version >= "4.21.0":
+    import google._upb._message as _message
+else:
+    import google.protobuf.pyext._message as _message
+
 __all__ = []
 
 non_auto_func_called = True
@@ -2497,7 +2503,7 @@ class DistributedStrategy:
                             for ff in config_fields:
                                 if isinstance(
                                     getattr(my_configs, ff.name),
-                                    google.protobuf.pyext._message.RepeatedScalarContainer,
+                                    _message.RepeatedScalarContainer,
                                 ):
                                     values = getattr(my_configs, ff.name)
                                     for i, v in enumerate(values):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
python端，protobuf从3.20到4.21的主要版本中，语法发生了变化。一些低版本的protobuf属性在高版本中换了位置或被弃用,其中_message方法的临界版本是4.21.0
![a305a364f00f04dbef1e186f2e19c089](https://user-images.githubusercontent.com/62429225/219579012-11a3a0b6-21e6-4ef9-b3b2-1bb72f351328.png)

