### PR TITLE
[XPU] update xpu.cmake to 20230110

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -10,7 +10,7 @@ set(XPU_RT_LIB_NAME "libxpurt.so")
 if(NOT DEFINED XPU_BASE_URL)
   set(XPU_BASE_URL_WITHOUT_DATE
       "https://baidu-kunlun-product.su.bcebos.com/KL-SDK/klsdk-dev")
-  set(XPU_BASE_URL "${XPU_BASE_URL_WITHOUT_DATE}/20230102")
+  set(XPU_BASE_URL "${XPU_BASE_URL_WITHOUT_DATE}/20230110")
 else()
   set(XPU_BASE_URL "${XPU_BASE_URL}")
 endif()


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
更新xpu.cmake到20230110。
重点解决20230105时候XDNN修复的transpose算子的速度问题。
