### PR TITLE
【Zero-Dim】unique_consecutive support 0d tensor

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4504,7 +4504,6 @@ void UniqueConsecutiveInferMeta(const MetaTensor& x,
   }
 
   if (axis.empty()) {
-    out->set_dims({-1});
     out->set_dtype(x.dtype());
     if (return_inverse) {
       index->set_dims({phi::product(in_dims)});

--- a/paddle/phi/kernels/cpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/cpu/unique_consecutive_functor.h
@@ -57,13 +57,14 @@ static void UniqueConsecutiveFlattenedTensor(const Context& context,
     *q = in.numel() - last;
     counts_vec.resize(output_size);
   }
-  out_vec.resize(output_size);
-
   if (output_size != 1) {
+    out_vec.resize(output_size);
     out->Resize(phi::make_ddim({output_size}));
   }
   auto* out_data = context.template Alloc<InT>(out);
-  std::copy(out_vec.begin(), out_vec.end(), out_data);
+  if (output_size != 1) {
+    std::copy(out_vec.begin(), out_vec.end(), out_data);
+  }
 
   if (return_inverse) {
     inverse->Resize(phi::make_ddim({in.numel()}));

--- a/paddle/phi/kernels/cpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/cpu/unique_consecutive_functor.h
@@ -59,7 +59,9 @@ static void UniqueConsecutiveFlattenedTensor(const Context& context,
   }
   out_vec.resize(output_size);
 
-  out->Resize(phi::make_ddim({output_size}));
+  if (output_size != 1) {
+    out->Resize(phi::make_ddim({output_size}));
+  }
   auto* out_data = context.template Alloc<InT>(out);
   std::copy(out_vec.begin(), out_vec.end(), out_data);
 

--- a/paddle/phi/kernels/gpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/gpu/unique_consecutive_functor.h
@@ -74,7 +74,9 @@ static void UniqueConsecutiveFlattenedCUDATensor(const Context& context,
           thrust::device, out_data, out_data + num_input, range_data_ptr, equal)
           .first -
       out_data;
-  out->Resize(phi::make_ddim({num_out}));
+  if (num_out != 1) {
+    out->Resize(phi::make_ddim({num_out}));
+  }
 
   // 2. Calculate inverse index: 'inverse'
   if (return_inverse) {

--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -1503,6 +1503,12 @@ class TestNoBackwardAPI(unittest.TestCase):
         self.assertEqual(one_hot_label.shape, [4])
         self.assertEqual(one_hot_label.numpy()[2], 1)
 
+    def test_unique_consecutive(self):
+        x = paddle.full([], 1.0, 'float32')
+        x.stop_gradient = True
+        out = paddle.unique_consecutive(x)
+        self.assertEqual(out.shape, [])
+
 
 class TestNoBackwardAPIStatic(unittest.TestCase):
     def setUp(self):
@@ -1704,6 +1710,14 @@ class TestNoBackwardAPIStatic(unittest.TestCase):
 
         self.assertEqual(res[0].shape, (4,))
         self.assertEqual(res[0][2], 1)
+
+    def test_unique_consecutive(self):
+        x = paddle.full(shape=[], fill_value=1.0, dtype='float32')
+        unique_consecutive_out = paddle.unique_consecutive(x)
+        prog = paddle.static.default_main_program()
+        self.exe.run(paddle.fluid.default_startup_program())
+        res = self.exe.run(prog, fetch_list=[unique_consecutive_out])
+        self.assertEqual(res[0].shape, ())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
paddle.unique_consecutive 支持 0D-tensor，其输出为 1D-tensor