### PR TITLE
Refine munmap freq for RefcountedMemoryMapAllocation

### DIFF
--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -207,7 +207,7 @@ void RefcountedMemoryMapAllocation::close() {
   } else {
     if (FLAGS_use_shm_cache &&
         MemoryMapAllocationPool::Instance().BufferSize() <
-            FLAGS_memory_map_allocation_pool_max_size) {
+            static_cast<size_t>(FLAGS_memory_map_allocation_pool_max_size)) {
       MemoryMapAllocationPool::Instance().Insert(
           MemoryMap(flags_, map_size_ - mmap_alignment, ipc_name_, map_ptr_));
     } else {

--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -368,7 +368,7 @@ void MemoryMapAllocationPool::RemoveById(int id) {
 int MemoryMapAllocationPool::GetAndUse(const MemoryMap &memory_map) {
   std::lock_guard<std::mutex> guard(mtx_);
   VLOG(4) << " GetAndUse from: " << this;
-  for (auto idx = 0; idx < memory_map_allocations_.size(); idx++) {
+  for (size_t idx = 0; idx < memory_map_allocations_.size(); idx++) {
     if (memory_map_allocations_.at(idx) == memory_map) {
       VLOG(4) << "** match at: " << idx;
       memory_map_allocations_.at(idx).is_using_ = true;
@@ -381,7 +381,7 @@ int MemoryMapAllocationPool::GetAndUse(const MemoryMap &memory_map) {
 int MemoryMapAllocationPool::GetAndReset(const MemoryMap &memory_map) {
   std::lock_guard<std::mutex> guard(mtx_);
   VLOG(4) << " GetAndReset from: " << this;
-  for (auto idx = 0; idx < memory_map_allocations_.size(); idx++) {
+  for (size_t idx = 0; idx < memory_map_allocations_.size(); idx++) {
     if (memory_map_allocations_.at(idx) == memory_map) {
       VLOG(4) << "** match at: " << idx;
       memory_map_allocations_.at(idx).is_using_ = false;

--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -208,7 +208,7 @@ void RefcountedMemoryMapAllocation::close() {
             << MemoryMapAllocationPool::Instance().BufferSize()
             << ", max size is: " << FLAGS_memory_map_allocation_pool_max_size;
     if (MemoryMapAllocationPool::Instance().BufferSize() <
-            FLAGS_memory_map_allocation_pool_max_size &&
+            static_cast<size_t>(FLAGS_memory_map_allocation_pool_max_size) &&
         FLAGS_use_shm_cache) {
       MemoryMapAllocationPool::Instance().Insert(MemoryMap(
           flags_, map_size_ - mmap_alignment, false, ipc_name_, map_ptr_, fd_));
@@ -355,16 +355,6 @@ void MemoryMapAllocationPool::Insert(const MemoryMap &memory_map) {
   std::lock_guard<std::mutex> guard(mtx_);
   memory_map_allocations_.push_back(memory_map);
   VLOG(4) << this << " intset a new shm";
-  VLOG(4) << "===================================";
-  for (auto idx = 0; idx < memory_map_allocations_.size(); idx++) {
-    VLOG(4) << idx << "(flags: " << memory_map_allocations_.at(idx).flags_
-            << ", data_size:" << memory_map_allocations_.at(idx).data_size_
-            << ", is_using: " << memory_map_allocations_.at(idx).is_using_
-            << ",file_name: " << memory_map_allocations_.at(idx).file_name_
-            << ",mmap_ptr: " << memory_map_allocations_.at(idx).mmap_ptr_
-            << ",fd: " << memory_map_allocations_.at(idx).fd_ << ")";
-  }
-  VLOG(4) << "===================================";
 }
 
 void MemoryMapAllocationPool::RemoveById(int id) {
@@ -378,16 +368,6 @@ void MemoryMapAllocationPool::RemoveById(int id) {
 int MemoryMapAllocationPool::GetAndUse(const MemoryMap &memory_map) {
   std::lock_guard<std::mutex> guard(mtx_);
   VLOG(4) << " GetAndUse from: " << this;
-  VLOG(4) << "===================================";
-  for (auto idx = 0; idx < memory_map_allocations_.size(); idx++) {
-    VLOG(4) << idx << "(flags: " << memory_map_allocations_.at(idx).flags_
-            << ", data_size:" << memory_map_allocations_.at(idx).data_size_
-            << ", is_using: " << memory_map_allocations_.at(idx).is_using_
-            << ",file_name: " << memory_map_allocations_.at(idx).file_name_
-            << ",mmap_ptr: " << memory_map_allocations_.at(idx).mmap_ptr_
-            << ",fd: " << memory_map_allocations_.at(idx).fd_ << ")";
-  }
-  VLOG(4) << "===================================";
   for (auto idx = 0; idx < memory_map_allocations_.size(); idx++) {
     if (memory_map_allocations_.at(idx) == memory_map) {
       VLOG(4) << "** match at: " << idx;
@@ -420,16 +400,6 @@ void MemoryMapAllocationPool::ResetById(int id) {
   std::lock_guard<std::mutex> guard(mtx_);
   memory_map_allocations_.at(id).is_using_ = false;
   VLOG(4) << this << " set " << id << " can use";
-  VLOG(4) << "===================================";
-  for (auto idx = 0; idx < memory_map_allocations_.size(); idx++) {
-    VLOG(4) << idx << "(flags: " << memory_map_allocations_.at(idx).flags_
-            << ", data_size:" << memory_map_allocations_.at(idx).data_size_
-            << ", is_using: " << memory_map_allocations_.at(idx).is_using_
-            << ",file_name: " << memory_map_allocations_.at(idx).file_name_
-            << ",mmap_ptr: " << memory_map_allocations_.at(idx).mmap_ptr_
-            << ",fd: " << memory_map_allocations_.at(idx).fd_ << ")";
-  }
-  VLOG(4) << "===================================";
 }
 
 void MemoryMapAllocationPool::Clear() {

--- a/paddle/fluid/memory/allocation/mmap_allocator.cc
+++ b/paddle/fluid/memory/allocation/mmap_allocator.cc
@@ -357,7 +357,7 @@ int MemoryMapAllocationPool::FindFromCache(const int &flag,
                                            const std::string &file_name,
                                            bool check_refcount) {
   std::lock_guard<std::mutex> guard(mtx_);
-  for (auto idx = 0; idx < memory_map_allocations_.size(); idx++) {
+  for (size_t idx = 0; idx < memory_map_allocations_.size(); idx++) {
     if (memory_map_allocations_.at(idx).flags_ == flag &&
         memory_map_allocations_.at(idx).data_size_ == data_size) {
       if (file_name == "" ||

--- a/paddle/fluid/memory/allocation/mmap_allocator.h
+++ b/paddle/fluid/memory/allocation/mmap_allocator.h
@@ -163,28 +163,17 @@ class MemoryMap {
  public:
   explicit MemoryMap(int flags,
                      size_t data_size,
-                     bool is_using,
                      std::string file_name,
-                     void *mmap_ptr,
-                     int fd)
+                     void *mmap_ptr)
       : flags_(flags),
         data_size_(data_size),
-        is_using_(is_using),
         file_name_(file_name),
-        mmap_ptr_(mmap_ptr),
-        fd_(fd) {}
+        mmap_ptr_(mmap_ptr) {}
 
   int flags_ = 0;
   size_t data_size_ = 0;
-  bool is_using_ = false;
   std::string file_name_;
   void *mmap_ptr_ = nullptr;
-  int fd_ = -1;
-
-  bool operator==(const MemoryMap &other) {
-    return (flags_ == other.flags_) && (data_size_ == other.data_size_) &&
-           (is_using_ == other.is_using_);
-  }
 };
 
 class MemoryMapAllocationPool {
@@ -193,15 +182,12 @@ class MemoryMapAllocationPool {
 
   void Insert(const MemoryMap &memory_map);
 
-  void RemoveById(int id);
-
-  int GetAndUse(const MemoryMap &memory_map);
-
-  int GetAndReset(const MemoryMap &memory_map);
+  int FindFromCache(const int &flag,
+                    const size_t &data_size,
+                    const std::string &file_name = "",
+                    bool check_refcount = true);
 
   const MemoryMap &GetById(int id);
-
-  void ResetById(int id);
 
   size_t BufferSize() { return memory_map_allocations_.size(); }
 

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -627,6 +627,11 @@ void BindImperative(py::module *m_ptr) {
 
   m.def("_cleanup_mmap_fds",
         []() { memory::allocation::MemoryMapFdSet::Instance().Clear(); });
+
+  m.def("_set_max_memory_map_allocation_pool_size", [](int32_t size) {
+    memory::allocation::MemoryMapAllocationPool::Instance().SetMaxPoolSize(
+        size);
+  });
 #endif
 
   m.def("start_imperative_gperf_profiler",

--- a/paddle/fluid/pybind/tensor.cc
+++ b/paddle/fluid/pybind/tensor.cc
@@ -913,7 +913,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                std::string handle = memory::allocation::GetIPCName();
                int find_id = -1;
                if (FLAGS_use_shm_cache) {
-                 find_id = memory::allocation::MemoryMapAllocationPool::Instance().GetAndUse(memory::allocation::MemoryMap(flags, data_size, false, "", nullptr, -1)); // NOLINT
+                 find_id = memory::allocation::MemoryMapAllocationPool::Instance().FindFromCache(flags, data_size); // NOLINT
                }
                if (find_id != -1) {
                  handle = memory::allocation::MemoryMapAllocationPool::Instance().GetById(find_id).file_name_; // NOLINT
@@ -971,7 +971,7 @@ void BindTensor(pybind11::module &m) {  // NOLINT
                          memory::allocation::MAPPED_NOCREATE;
              int find_id = -1;
              if (FLAGS_use_shm_cache) {
-               find_id = memory::allocation::MemoryMapAllocationPool::Instance().GetAndUse(memory::allocation::MemoryMap(flags, size, false, ipc_name, nullptr, -1)); // NOLINT
+               find_id = memory::allocation::MemoryMapAllocationPool::Instance().FindFromCache(flags, size, ipc_name, /*check_refcount*/ false); // NOLINT
              }
              auto shared_holder =
                  memory::allocation::AllocateRefcountedMemoryMapAllocation(

--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -1182,6 +1182,15 @@ PADDLE_DEFINE_EXPORTED_bool(trt_ibuilder_cache,
                             false,
                             "Add a persistent ibuilder.");
 
+/**
+ * mmap_allocator related FLAG
+ * Name: use_shm_cache
+ * Since Version: 2.5.0
+ * Value Range: bool, default=true
+ * Example:
+ * Note: . If True, mmap_allocator will cache shm file to decrease munmap
+ * operation.
+ */
 PADDLE_DEFINE_EXPORTED_bool(use_shm_cache,
                             true,
-                            "Use shm cache in dataloader.");
+                            "Use shm cache in mmap_allocator.");

--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -1181,3 +1181,7 @@ PADDLE_DEFINE_EXPORTED_int32(cudnn_cache_saturation_count, 1, "");
 PADDLE_DEFINE_EXPORTED_bool(trt_ibuilder_cache,
                             false,
                             "Add a persistent ibuilder.");
+
+PADDLE_DEFINE_EXPORTED_bool(use_shm_cache,
+                            true,
+                            "Use shm cache in dataloader.");

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -317,6 +317,7 @@ try:
         from .libpaddle import _array_to_share_memory_tensor
         from .libpaddle import _cleanup_mmap_fds
         from .libpaddle import _remove_tensor_list_mmap_fds
+        from .libpaddle import _set_max_memory_map_allocation_pool_size
 except Exception as e:
     if has_paddle_dy_lib:
         sys.stderr.write(

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -411,19 +411,15 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         # MemoryMapAllocationPool is used to cache and reuse shm, thus reducing munmap in dataloader.
         # For more details, please see: paddle/fluid/memory/allocation/mmap_allocator.h
         try:
-            self._worker_shm_buffer_size = (
-                (2 + 1) * len(self._dataset[0])
-                if len(self._dataset[0]) < 5
-                else 0
-            )
+            self._worker_shm_buffer_size = (2 + 1) * len(self._dataset[0])
         except:
             self._worker_shm_buffer_size = 0
             warnings.warn(
                 "Setting the shm cache buffer size to 0, equivalent to not using the shm cache policy."
             )
         self._main_thread_shm_buffer_size = (
-            self._worker_shm_buffer_size
-        ) * self._num_workers
+            (self._worker_shm_buffer_size) * 2 * self._num_workers
+        )
 
         # init workers and indices queues and put 2 indices in each indices queue
         self._init_workers()

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -409,7 +409,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         # Note:zhangbo, shm_buffer_size is used for MemoryMapAllocationPool.
         # MemoryMapAllocationPool is used to cache and reuse shm, thus reducing munmap in dataloader.
         # For more details, please see: paddle/fluid/memory/allocation/mmap_allocator.h
-        self._worker_shm_buffer_size = (2 + 1) * len(self._dataset[0])
+        self._worker_shm_buffer_size = (2 + 1) * 2
         self._main_thread_shm_buffer_size = (
             self._worker_shm_buffer_size
         ) * self._num_workers

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -411,7 +411,11 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         # MemoryMapAllocationPool is used to cache and reuse shm, thus reducing munmap in dataloader.
         # For more details, please see: paddle/fluid/memory/allocation/mmap_allocator.h
         try:
-            self._worker_shm_buffer_size = (2 + 1) * len(self._dataset[0])
+            self._worker_shm_buffer_size = (
+                (2 + 1) * len(self._dataset[0])
+                if len(self._dataset[0]) < 5
+                else 0
+            )
         except:
             self._worker_shm_buffer_size = 0
             warnings.warn(

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -406,6 +406,14 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
 
         self._base_seed = np.random.randint(low=0, high=sys.maxsize)
 
+        # Note:zhangbo, shm_buffer_size is used for MemoryMapAllocationPool.
+        # MemoryMapAllocationPool is used to cache and reuse shm, thus reducing munmap in dataloader.
+        # For more details, please see: paddle/fluid/memory/allocation/mmap_allocator.h
+        self._worker_shm_buffer_size = (2 + 1) * len(self._dataset[0])
+        self._main_thread_shm_buffer_size = (
+            self._worker_shm_buffer_size
+        ) * self._num_workers
+
         # init workers and indices queues and put 2 indices in each indices queue
         self._init_workers()
         for _ in range(self._outstanding_capacity):
@@ -450,6 +458,7 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
                     self._num_workers,
                     self._use_shared_memory,
                     self._base_seed,
+                    self._worker_shm_buffer_size,
                 ),
             )
             worker.daemon = True
@@ -480,6 +489,9 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
         # if only 1 place, do not need to keep order
         self._blocking_queue = core.init_lod_tensor_blocking_queue(
             core.Variable(), self._outstanding_capacity, len(self._places) > 1
+        )
+        core._set_max_memory_map_allocation_pool_size(
+            self._main_thread_shm_buffer_size
         )
         self._reader = core.create_py_reader(
             self._blocking_queue,

--- a/python/paddle/fluid/dataloader/worker.py
+++ b/python/paddle/fluid/dataloader/worker.py
@@ -275,6 +275,7 @@ def _worker_loop(
     num_workers,
     use_shared_memory,
     base_seed,
+    shm_cahce_size=0,
 ):
     try:
         # NOTE: [ mmap files clear ] When the child process exits unexpectedly,
@@ -285,6 +286,8 @@ def _worker_loop(
 
         # set signal handler
         core._set_process_signal_handler()
+
+        core._set_max_memory_map_allocation_pool_size(shm_cahce_size)
 
         # set different numpy seed for each worker
         try:


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
APIs

### Describe
#### 1. 问题：
动转静训练场景下，dataloader的子线程会阻塞训练主线程，原因是：**RefcountedMemoryMapAllocation的close函数中munmap(shm_mmap_ptr)指令会阻塞本进程其他线程**。本PR设计一种shm复用方案来消除训练过程中的munmap，由此解决该问题。

#### 2. 方案：
为 _share_filename、_new_share_file 进程构造 shm 缓存池，存储 shm_file -> data_size -> mmap_ptr；
- _share_filename 进程根据 data_size 从缓存中查找是否存在可用 shm，有可用：获取该 shm 及 mmap_ptr 使用；没有可用：创建新 shm，做 mmap(shm)。而后，根据 shm、mmap_ptr 构造 RefcountedMemoryMapAllocation
- _new_share_filename 进程根据 shm 查找是否已在缓存中，已经存在：获取该 shm 的 mmap_ptr 使用；没有存在：做 mmap(shm)。而后，根据 shm、mmap_ptr 构造 RefcountedMemoryMapAllocation
当 RefcountedMemoryMapAllocation 引用计数减为 0，做析构的同时，将 shm->mmap_ptr->data_size 加入缓存池。

shm 前 64 位用于存储该文件的引用计数，_share_filename 将使用的 shm 引用计数 +1，close 的时候 -1；同样 _new_share_filename 将使用的 shm 引用计数 +1，close 的时候 -1。在复用缓存中的 shm 时，会先判断 shm 的引用计数是否为 0，如果不为 0 说明该 shm 还处于使用中，无法复用，创建新 shm。

![图片](https://user-images.githubusercontent.com/82555433/212585757-e6af813c-2d78-49fa-ac41-7cfc0cb8c3b5.png)


#### 3. 性能测试：
A100平台对MobileNetV1、V2模型进行测试：
![图片](https://user-images.githubusercontent.com/82555433/212522123-7aab2a69-6117-44bc-bb03-2590702e302b.png)
timeline分析，优化后，复用 shm、不再频繁执行munmap，由此提升性能
![图片](https://user-images.githubusercontent.com/82555433/212522255-0896c470-6d6c-4e0a-99fb-812f0c2aa672.png)

#### 4. 控制FLAG
- FLAGS_use_shm_cache：bool，控制是否使用 shm 复用策略，默认为 true.
