### PR TITLE
[BugFix][NewExe] standaloneExecutor return empty array while setting FLAGS_use_cinn=true

### DIFF
--- a/paddle/fluid/operators/cinn/cinn_launch_op.h
+++ b/paddle/fluid/operators/cinn/cinn_launch_op.h
@@ -142,7 +142,7 @@ class CinnLaunchOpKernel : public framework::OpKernel<T> {
         VLOG(4) << "Execute the runtime program by InterpreterCore";
         auto* interpreter_core = launch_context->InitializeInterpreterCore(
             place, const_cast<framework::Scope*>(&scope));
-        interpreter_core->Run({});
+        interpreter_core->Run({}, false);
       } else {
         platform::RecordEvent record_event_4(
             "Step 4. Execute the runtime graph by PE.");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
While running [tutorials/train_resnet50_with_cinn.py](https://github.com/PaddlePaddle/CINN/blob/develop/tutorials/train_resnet50_with_cinn.py) with command:
`python train_resnet50_with_cinn.py`

The output is:
```
Train step: 0 loss: [array([7.651418], dtype=float32)]
Train step: 1 loss: []
Train step: 2 loss: []
Train step: 3 loss: []
Train step: 4 loss: []
Train step: 5 loss: []
Train step: 6 loss: []
Train step: 7 loss: []
Train step: 8 loss: []
Train step: 9 loss: []
```

This PR fix this problem. The reason is related to the return value of method `Run` of `InterpreterCore`.