### PR TITLE
[Paddle Inference] PaddleLite predictor support by inference，call lite engine without subgraph op.

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -131,6 +131,12 @@ if(WITH_ONNXRUNTIME)
       ${CMAKE_CURRENT_SOURCE_DIR}/api/onnxruntime_predictor.cc)
 endif()
 
+if(WITH_LITE)
+  set(SHARED_INFERENCE_SRCS
+      ${SHARED_INFERENCE_SRCS}
+      ${CMAKE_CURRENT_SOURCE_DIR}/api/paddlelite_predictor.cc)
+endif()
+
 #export all symbols for paddle/phi/api/include/api.h on paddle_inference_shared, only for UNIX
 if(UNIX)
   set(SHARED_INFERENCE_DEPS ${SHARED_INFERENCE_DEPS}

--- a/paddle/fluid/inference/api/CMakeLists.txt
+++ b/paddle/fluid/inference/api/CMakeLists.txt
@@ -88,6 +88,13 @@ if(WITH_ONNXRUNTIME)
          model_utils
          onnxruntime
          paddle2onnx)
+elseif(WITH_LITE)
+  cc_library(
+    analysis_predictor
+    SRCS analysis_predictor.cc paddlelite_predictor.cc resource_manager.cc
+         infer_context.cc ${mkldnn_quantizer_src}
+    DEPS ${inference_deps} zero_copy_tensor ir_pass_manager op_compatible_info
+         infer_io_utils model_utils)
 else()
   cc_library(
     analysis_predictor

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -1182,13 +1182,19 @@ void AnalysisConfig::EnableLiteEngine(
     AnalysisConfig::Precision precision_mode,
     bool zero_copy,
     const std::vector<std::string> &passes_filter,
-    const std::vector<std::string> &ops_filter) {
+    const std::vector<std::string> &ops_filter,
+    bool use_lite_engine_with_subgraph) {
   use_lite_ = true;
   lite_precision_mode_ = precision_mode;
   lite_passes_filter_ = passes_filter;
   lite_ops_filter_ = ops_filter;
   lite_zero_copy_ = zero_copy;
+  use_lite_engine_with_subgraph_ = use_lite_engine_with_subgraph;
   Update();
+}
+
+AnalysisConfig::Precision AnalysisConfig::GetLitePrecisionMode() const {
+  return lite_precision_mode_;
 }
 
 void AnalysisConfig::EnableOpenCL() {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -81,6 +81,10 @@
 #include "paddle/fluid/inference/api/onnxruntime_predictor.h"
 #endif
 
+#ifdef PADDLE_WITH_LITE
+#include "paddle/fluid/inference/api/paddlelite_predictor.h"
+#endif
+
 #ifdef PADDLE_WITH_TENSORRT
 #include "paddle/fluid/inference/tensorrt/convert/op_converter.h"
 #include "paddle/fluid/inference/tensorrt/helper.h"
@@ -2405,6 +2409,22 @@ Predictor::Predictor(const Config &config) {
         << "The onnxruntime backend isn't enabled,"
            " and please re-compile Paddle with WITH_ONNXRUNTIME option,"
            "fall back to using Paddle Inference.";
+#endif
+  }
+  if (config.lite_engine_enabled() &&
+      !config.lite_engine_enabled_with_subgraph()) {
+#ifdef PADDLE_WITH_LITE
+    LOG(INFO) << "The paddlelite backend is enabled, "
+                 " and create the paddleLite predictor";
+    predictor_ =
+        paddle::CreatePaddlePredictor<Config,
+                                      paddle::PaddleEngineKind::kPaddleLite>(
+            config);
+    return;
+#else
+    LOG(WARNING) << "The paddlelite backend isn't enabled,"
+                    " and please re-compile Paddle with WITH_LITE option,"
+                    "fall back to using Paddle Inference.";
 #endif
   }
   predictor_ =

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -750,8 +750,10 @@ struct PD_INFER_DECL AnalysisConfig {
       AnalysisConfig::Precision precision_mode = Precision::kFloat32,
       bool zero_copy = false,
       const std::vector<std::string>& passes_filter = {},
-      const std::vector<std::string>& ops_filter = {});
+      const std::vector<std::string>& ops_filter = {},
+      bool use_lite_engine_with_subgraph = true);
 
+  Precision GetLitePrecisionMode() const;
   ///
   /// \brief Turn on the usage of Lite sub-graph engine with opencl.
   ///
@@ -762,6 +764,15 @@ struct PD_INFER_DECL AnalysisConfig {
   /// used.
   ///
   /// \return bool whether the Lite sub-graph engine is used.
+  ///
+  bool lite_engine_enabled_with_subgraph() const {
+    return use_lite_engine_with_subgraph_;
+  }
+
+  ///
+  /// \brief A boolean state indicating whether the Lite engine is used.
+  ///
+  /// \return bool whether the Lite engine is used.
   ///
   bool lite_engine_enabled() const { return use_lite_; }
 
@@ -1155,6 +1166,7 @@ struct PD_INFER_DECL AnalysisConfig {
   std::vector<std::string> lite_ops_filter_;
   Precision lite_precision_mode_;
   bool lite_zero_copy_;
+  bool use_lite_engine_with_subgraph_{true};
 
   // CINN compiler related.
   bool use_cinn_compiler_{false};

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -196,6 +196,7 @@ class PD_INFER_DECL ZeroCopyTensor : public paddle_infer::Tensor {
  private:
   friend class AnalysisPredictor;
   friend class ONNXRuntimePredictor;
+  friend class PaddleLitePredictor;
   explicit ZeroCopyTensor(void* scope, const void* device_contexts)
       : paddle_infer::Tensor{scope, device_contexts} {}
 };
@@ -408,6 +409,7 @@ enum class PaddleEngineKind {
   kAutoMixedTensorRT,  ///< Automatically mix Fluid with TensorRT.
   kAnalysis,           ///< More optimization.
   kONNXRuntime,        ///< Use ONNXRuntime
+  kPaddleLite,         ///< Use PaddleLite library.
 };
 
 template <typename ConfigT, PaddleEngineKind engine>
@@ -427,6 +429,11 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
 template <>
 PD_INFER_DECL std::unique_ptr<PaddlePredictor>
 CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kONNXRuntime>(
+    const AnalysisConfig& config);
+
+template <>
+PD_INFER_DECL std::unique_ptr<PaddlePredictor>
+CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kPaddleLite>(
     const AnalysisConfig& config);
 
 PD_INFER_DECL int PaddleDtypeSize(PaddleDType dtype);

--- a/paddle/fluid/inference/api/paddlelite_predictor.cc
+++ b/paddle/fluid/inference/api/paddlelite_predictor.cc
@@ -1,0 +1,238 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/inference/api/paddlelite_predictor.h"
+#include <memory>
+#include "paddle/fluid/framework/scope.h"
+#include "paddle/fluid/framework/var_type_traits.h"
+#include "paddle/fluid/framework/variable_helper.h"
+
+namespace paddle {
+
+void PaddleLitePredictor::Init() {
+  place_ = paddle::platform::CPUPlace();
+  scope_.reset(new paddle::framework::Scope());
+  // Create paddlelite_config
+  CreatePaddleLiteConfigFromAnalysisConfig();
+  // Create paddlelite_predictor
+  paddlelite_predictor_ = lite_api::CreatePaddlePredictor(paddlelite_config_);
+  framework::proto::VarType::Type proto_type =
+      framework::proto::VarType::LOD_TENSOR;
+  // Create input variables
+  for (auto &input_name : GetInputNames()) {
+    auto *ptr = scope_->Var(input_name);
+    framework::InitializeVariable(ptr, proto_type);
+  }
+  // Create output variables
+  for (auto &output_name : GetOutputNames()) {
+    LOG(INFO) << "CREATE VARIABLES Output name: " << output_name;
+    auto *ptr = scope_->Var(output_name);
+    framework::InitializeVariable(ptr, proto_type);
+  }
+}
+
+void PaddleLitePredictor::CreatePaddleLiteConfigFromAnalysisConfig() {
+  // Set model path.
+  if (!analysis_config_.prog_file().empty() &&
+      !analysis_config_.params_file().empty()) {
+    paddlelite_config_.set_model_file(analysis_config_.prog_file());
+    paddlelite_config_.set_param_file(analysis_config_.params_file());
+  } else if (!analysis_config_.model_dir().empty()) {
+    paddlelite_config_.set_model_dir(analysis_config_.model_dir());
+  } else {
+    LOG(FATAL) << "Please check pro_file and params_file path or model_dir is "
+                  "not empty!";
+  }
+  // Set places.
+  auto ConvertToLitePrecision =
+      [](const AnalysisConfig::Precision &precision_type)
+      -> paddle::lite_api::PrecisionType {
+    if (precision_type == paddle_infer::PrecisionType::kFloat32) {
+      return paddle::lite_api::PrecisionType::kFloat;
+    } else if (precision_type == paddle_infer::PrecisionType::kInt8) {
+      return paddle::lite_api::PrecisionType::kInt8;
+    } else if (precision_type == paddle_infer::PrecisionType::kHalf) {
+      return paddle::lite_api::PrecisionType::kFP16;
+    } else {
+      PADDLE_THROW(paddle::platform::errors::InvalidArgument(
+          "Not support precision. We now only support Float32, Half, and "
+          "Int8."));
+      return paddle::lite_api::PrecisionType::kFloat;
+    }
+  };
+  std::vector<paddle::lite_api::Place> valid_places;
+  if (analysis_config_.use_xpu()) {
+    valid_places.push_back(paddle::lite_api::Place{
+        TARGET(kXPU),
+        ConvertToLitePrecision(analysis_config_.GetLitePrecisionMode())});
+  }
+  valid_places.push_back(paddle::lite_api::Place{
+      TARGET(kHost),
+      ConvertToLitePrecision(analysis_config_.GetLitePrecisionMode())});
+  paddlelite_config_.set_valid_places(valid_places);
+}
+
+std::vector<std::string> PaddleLitePredictor::GetInputNames() {
+  return paddlelite_predictor()->GetInputNames();
+}
+
+std::vector<std::string> PaddleLitePredictor::GetOutputNames() {
+  return paddlelite_predictor()->GetOutputNames();
+}
+
+std::map<std::string, std::vector<int64_t>>
+PaddleLitePredictor::GetInputTensorShape() {
+  std::map<std::string, std::vector<int64_t>> input_shapes;
+  std::vector<std::string> names = GetInputNames();
+  for (std::string name : names) {
+    auto tensor = paddlelite_predictor()->GetInputByName(name);
+    input_shapes[name] = tensor->shape();
+  }
+  return input_shapes;
+}
+
+std::unique_ptr<ZeroCopyTensor> PaddleLitePredictor::GetInputTensor(
+    const std::string &name) {
+  PADDLE_ENFORCE_NOT_NULL(scope_->FindVar(name),
+                          platform::errors::PreconditionNotMet(
+                              "The input variable named %s is not found in the "
+                              "PaddleLitePredictor.",
+                              name));
+  std::unique_ptr<ZeroCopyTensor> res(
+      new ZeroCopyTensor(static_cast<void *>(scope_.get()), this));
+  res->input_or_output_ = true;
+  res->SetName(name);
+  res->SetPlace(PaddlePlace::kCPU);
+  return res;
+}
+
+std::unique_ptr<ZeroCopyTensor> PaddleLitePredictor::GetOutputTensor(
+    const std::string &name) {
+  PADDLE_ENFORCE_NOT_NULL(
+      scope_->FindVar(name),
+      platform::errors::PreconditionNotMet(
+          "The output variable named %s is not found in the "
+          "PaddleLitePredictor.",
+          name));
+  std::unique_ptr<ZeroCopyTensor> res(
+      new ZeroCopyTensor(static_cast<void *>(scope_.get()), this));
+  res->input_or_output_ = true;
+  res->SetName(name);
+  res->SetPlace(PaddlePlace::kCPU);
+  return res;
+}
+
+std::unique_ptr<PaddlePredictor> PaddleLitePredictor::Clone(void *stream) {
+  LOG(ERROR) << "PaddleLitePredictor does not implemented Clone method.";
+  return nullptr;
+}
+
+bool PaddleLitePredictor::Run(const std::vector<PaddleTensor> &inputs,
+                              std::vector<PaddleTensor> *output_data,
+                              int batch_size) {
+  LOG(ERROR) << "PaddleLite predictor not support Run(), please use "
+                "ZeroCopyRun() instead.";
+  return false;
+}
+
+bool PaddleLitePredictor::ZeroCopyRun() {
+  // Share zero_copy_tensor data to lite tensor, this function should be called
+  // after CopyFromCpu.
+  for (auto &input_name : GetInputNames()) {
+    auto zero_copy_tensor = GetInputTensor(input_name);
+    std::unique_ptr<lite_api::Tensor> lite_tensor =
+        paddlelite_predictor()->GetInputByName(input_name);
+    auto tensor_shape = zero_copy_tensor->shape();
+    lite_tensor->Resize(
+        std::vector<int64_t>(tensor_shape.begin(), tensor_shape.end()));
+    auto numel = std::accumulate(tensor_shape.begin(),
+                                 tensor_shape.end(),
+                                 1,
+                                 std::multiplies<int64_t>());
+    size_t tensor_mermory_size =
+        numel * lite_api::PrecisionTypeLength(lite_tensor->precision());
+#define SHARE_ZERO_COPY_TENSOR_MEMORY_TO_LITE_TENSOR(paddle_infer_data_type, \
+                                                     pod_data_type)          \
+  case paddle_infer::DataType::paddle_infer_data_type: {                     \
+    lite_tensor->ShareExternalMemory(                                        \
+        static_cast<void *>(zero_copy_tensor->mutable_data<pod_data_type>(   \
+            zero_copy_tensor->place())),                                     \
+        tensor_mermory_size,                                                 \
+        lite_api::TargetType::kHost);                                        \
+    break;                                                                   \
+  };
+
+    switch (zero_copy_tensor->type()) {
+      SHARE_ZERO_COPY_TENSOR_MEMORY_TO_LITE_TENSOR(FLOAT32, float)
+      SHARE_ZERO_COPY_TENSOR_MEMORY_TO_LITE_TENSOR(INT64, int64_t)
+      SHARE_ZERO_COPY_TENSOR_MEMORY_TO_LITE_TENSOR(INT32, int)
+      SHARE_ZERO_COPY_TENSOR_MEMORY_TO_LITE_TENSOR(UINT8, uint8_t)
+      SHARE_ZERO_COPY_TENSOR_MEMORY_TO_LITE_TENSOR(INT8, int8_t)
+      default:
+        LOG(ERROR) << "Share zero_copy_tensor data memory to lite tensor only "
+                      "support [FLOAT32, INT64, INT32, UINT8, INT8]";
+    }
+#undef SHARE_ZERO_COPY_TENSOR_MEMORY_TO_LITE_TENSOR
+  }
+  // Run
+  paddlelite_predictor()->Run();
+  // Share lite tensor data to zero_copy_tensor
+  for (auto &output_name : GetOutputNames()) {
+    auto zero_copy_tensor = GetOutputTensor(output_name);
+    auto lite_output_tensor = paddlelite_predictor()->GetTensor(output_name);
+#define SHARE_LITE_TENSOR_MEMORY_TO_ZERO_COPY_TENSOR(lite_tensor_data_type,    \
+                                                     pod_data_type)            \
+  case paddle::lite_api::PrecisionType::lite_tensor_data_type: {               \
+    auto lite_tensor_data = lite_output_tensor->mutable_data<pod_data_type>(); \
+    auto lite_tensor_shape = lite_output_tensor->shape();                      \
+    zero_copy_tensor->ShareExternalData<pod_data_type>(                        \
+        static_cast<pod_data_type *>(lite_tensor_data),                        \
+        std::vector<int>(lite_tensor_shape.begin(), lite_tensor_shape.end()),  \
+        zero_copy_tensor->place());                                            \
+    break;                                                                     \
+  }
+    switch (lite_output_tensor->precision()) {
+      SHARE_LITE_TENSOR_MEMORY_TO_ZERO_COPY_TENSOR(kFloat, float)
+      SHARE_LITE_TENSOR_MEMORY_TO_ZERO_COPY_TENSOR(kInt8, int8_t)
+      SHARE_LITE_TENSOR_MEMORY_TO_ZERO_COPY_TENSOR(kInt32, int)
+      SHARE_LITE_TENSOR_MEMORY_TO_ZERO_COPY_TENSOR(kInt64, int64_t)
+      default: {
+        LOG(ERROR) << "Share lite tensor data memory to zero_copy_tensor only "
+                      "support lite precision [kFloat, kInt8, kInt32, kInt64].";
+      }
+    }
+#undef SHARE_LITE_TENSOR_MEMORY_TO_ZERO_COPY_TENSOR
+  }
+  return true;
+}
+
+template <>
+std::unique_ptr<PaddlePredictor>
+CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kPaddleLite>(
+    const AnalysisConfig &config) {
+  PADDLE_ENFORCE_EQ(
+      config.is_valid(),
+      true,
+      platform::errors::InvalidArgument(
+          "Note: Each config can only be used for one predictor."));
+  VLOG(3) << "Create paddlelite predictor with analysisConfig";
+  std::unique_ptr<PaddlePredictor> predictor(new PaddleLitePredictor(config));
+  auto predictor_p = dynamic_cast<PaddleLitePredictor *>(predictor.get());
+  predictor_p->Init();
+  // Each config can only be used for one predictor.
+  config.SetInValid();
+  return predictor;
+}
+
+}  // namespace paddle

--- a/paddle/fluid/inference/api/paddlelite_predictor.h
+++ b/paddle/fluid/inference/api/paddlelite_predictor.h
@@ -1,0 +1,159 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "lite/api/paddle_api.h"
+#include "lite/api/paddle_place.h"
+#include "lite/api/paddle_use_passes.h"
+#include "paddle/fluid/framework/naive_executor.h"
+#include "paddle/fluid/inference/api/helper.h"
+#include "paddle/fluid/inference/api/paddle_analysis_config.h"
+#include "paddle/fluid/inference/api/paddle_api.h"
+
+namespace paddle {
+
+///
+/// \class PaddleLitePredictor
+///
+/// \brief The paddlelite predictor is designed to directly call the lite
+/// engine, without accessing the paddlelite through the subgraph method.
+///
+/// The predictor has the following typical uses:
+///
+/// Get predictor.
+/// \code{cpp}
+///   auto predictor = CreatePaddlePredictor(config);
+/// \endcode
+///
+/// Get input or output names.
+/// \code{cpp}
+///   auto input_names = predictor->GetInputNames();
+///   auto output_names = predictor->GetOutputNames();
+/// \endcode
+///
+/// Get input or output tensors.
+/// \code{cpp}
+///   auto input_t = predictor->GetInputTensor(input_names[0]);
+///   auto output_t = predictor->GetOutputTensor(output_names[0]);
+/// \endcode
+///
+/// Run predictor.
+/// \code{cpp}
+///   predictor->ZeroCopyRun();
+/// \endcode
+///
+class PaddleLitePredictor : public PaddlePredictor {
+ public:
+  ///
+  /// \brief Construct a new PaddleLite Predictor object.
+  ///
+  /// \param[in] AnalysisConfig config
+  ///
+  explicit PaddleLitePredictor(const AnalysisConfig &config)
+      : analysis_config_(config) {
+    predictor_id_ = inference::GetUniqueId();
+  }
+
+  ///
+  /// \brief Initialize the paddlelite predictor.
+  ///
+  void Init();
+
+  ///
+  /// \brief Destroy the PaddleLite Predictor object.
+  ///
+  ~PaddleLitePredictor() = default;
+
+  ///
+  /// \brief Get the input names.
+  ///
+  /// \return input names.
+  ///
+  std::vector<std::string> GetInputNames() override;
+
+  ///
+  /// \brief Get the output names.
+  ///
+  /// \return output names.
+  ///
+  std::vector<std::string> GetOutputNames() override;
+
+  ///
+  /// \brief Get all input names and their corresponding shapes.
+  ///
+  /// \return the map of input names and shapes.
+  ///
+  std::map<std::string, std::vector<int64_t>> GetInputTensorShape() override;
+
+  ///
+  /// \brief Get the Input Tensor object.
+  ///
+  /// \param[in] name input name.
+  /// \return input tensor.
+  ///
+  std::unique_ptr<ZeroCopyTensor> GetInputTensor(const std::string &name);
+
+  ///
+  /// \brief Get the Output Tensor object.
+  ///
+  /// \param[in] name otuput name.
+  /// \return output tensor.
+  ///
+  std::unique_ptr<ZeroCopyTensor> GetOutputTensor(const std::string &name);
+
+  ///
+  /// \brief Get the native paddlelite predictor created by cxx config by
+  /// parsing analysis config.
+  ///
+  std::shared_ptr<lite_api::PaddlePredictor> paddlelite_predictor() {
+    return paddlelite_predictor_;
+  }
+
+  ///
+  /// \brief Clone to get the new predictor. thread safe.
+  ///
+  /// \return get a new predictor
+  ///
+  std::unique_ptr<PaddlePredictor> Clone(void *stream = nullptr) override;
+
+  ///
+  /// \brief Run the paddlelite engine, and call the paddlelite interface
+  /// internally
+  ///
+  /// \return Whether the function executed successfully
+  ///
+  bool ZeroCopyRun() override;
+
+  /// Not support, please use ZeroCopyRun().
+  bool Run(const std::vector<PaddleTensor> &inputs,
+           std::vector<PaddleTensor> *output_data,
+           int batch_size = -1) override;
+
+ private:
+  ///
+  /// \brief Create the paddlelite cxx config by parsing the analysis config.
+  ///
+  void CreatePaddleLiteConfigFromAnalysisConfig();
+
+ private:
+  AnalysisConfig analysis_config_;
+  lite_api::CxxConfig paddlelite_config_;
+  std::shared_ptr<lite_api::PaddlePredictor> paddlelite_predictor_;
+  platform::Place place_;
+  std::shared_ptr<framework::Scope> scope_;
+  int predictor_id_;
+};
+
+}  // namespace paddle

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -47,6 +47,10 @@
 #include "paddle/fluid/inference/api/onnxruntime_predictor.h"
 #endif
 
+#ifdef PADDLE_WITH_LITE
+#include "paddle/fluid/inference/api/paddlelite_predictor.h"
+#endif
+
 namespace py = pybind11;
 
 namespace pybind11 {
@@ -790,7 +794,8 @@ void BindAnalysisConfig(py::module *m) {
            py::arg("precision_mode") = AnalysisConfig::Precision::kFloat32,
            py::arg("zero_copy") = false,
            py::arg("passes_filter") = std::vector<std::string>(),
-           py::arg("ops_filter") = std::vector<std::string>())
+           py::arg("ops_filter") = std::vector<std::string>(),
+           py::arg("use_lite_engine_with_subgraph") = true)
       .def("enable_opencl", &AnalysisConfig::EnableOpenCL)
       .def("lite_engine_enabled", &AnalysisConfig::lite_engine_enabled)
       .def("switch_ir_debug",


### PR DESCRIPTION
### PR types

New features

### PR changes
  
APIs

### Describe
  
Support the creation of PaddleLite predictor and call of PaddleLite Engine. Users can construct PaddleLite predictor through analysis config instead of accessing PaddleLite conference through subgraph op access.
