### PR TITLE
[CINN] temp fix batch_norm check as inplace op bug

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
@@ -67,13 +67,20 @@ class OpTransInfo {
   std::unordered_set<std::string> GetDenyVarNames(
       const GraphNodeSet& cluster) const;
 
-  static bool IsInplaceOp(const OpDesc& op_desc);
+  std::unordered_set<std::string> GetIgnoreInplaceVarNames(
+      const OpDesc& op_desc) const;
+
+  bool IsInplaceOp(const OpDesc& op_desc,
+                   const std::unordered_set<std::string>& deny_var_names) const;
 
  private:
   DyOpCondT dynamic_op_cond_;
 
   DeParamCondT deny_param_cond_{{"batch_norm", {"ReserveSpace"}},
                                 {"batch_norm_grad", {"ReserveSpace"}}};
+
+  DeParamCondT ignore_inplace_param_cond_{
+      {"batch_norm", {"MeanOut", "VarianceOut"}}};
 
   std::unordered_set<std::string> default_deny_ops_{"feed", "fetch"};
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
【临时方案】
修复`batch_norm`算子由于输出`MeanOut`、`VarianceOut`的变量与输入`Mean`、`Variance`完全一样，被识别成了inplace op，导致`batch_norm`在子图划分的时候被判定为了CINN不支持算子的BUG（https://github.com/PaddlePaddle/Paddle/pull/46843 ），修复后PaddleClas Resnet50子图数目由56减少为6，且精度由不收敛变为收敛：
![image](https://user-images.githubusercontent.com/31386411/211759186-b0127f6f-6ed4-47ad-b3d7-4db44509a906.png)

该问题的根本原因在于CINN不支持inplace操作，且当前对于`batch_norm`的`MeanOut`、`VarianceOut`变量采用的是覆盖操作，而这会导致如下问题，此问题对`batch_norm`的精度是有影响的，亟待解决：
<img width="1341" alt="1c004eef0894a990a0e5b32e4eb3d872" src="https://user-images.githubusercontent.com/31386411/211759329-6d88f840-4cb6-400e-9476-a3976c682484.png">
