### PR TITLE
修改hapi.model的fit, evaluate和predict接口，以暴露dataloader的collate_fn参数

### DIFF
--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1752,7 +1752,7 @@ class Model:
                 Dataloader, this parameter will be ignored. Default: 0.
             collate_fn(callable, optional): function to generate mini-batch data by merging
                 the sample list, None for only stack each fields of sample in axis
-                0(same as :attr::`np.stack(..., axis=0)`). Default None
+                0(same as :attr::`np.stack(..., axis=0)`). Default: None.
             callbacks (Callback|None, optional): A list of `Callback` instances to apply
                 during training. If None, :ref:`api_paddle_callbacks_ProgBarLogger` and
                 :ref:`api_paddle_callbacks_ModelCheckpoint` are automatically inserted. Default: None.
@@ -1981,7 +1981,7 @@ class Model:
                 this parameter will be ignored. Default: 0.
             collate_fn(callable, optional): function to generate mini-batch data by merging
                 the sample list, None for only stack each fields of sample in axis
-                0(same as :attr::`np.stack(..., axis=0)`). Default None
+                0(same as :attr::`np.stack(..., axis=0)`). Default: None.
             callbacks (Callback|None, optional): A list of `Callback` instances to apply
                 during training. If None, `ProgBarLogger` and `ModelCheckpoint`
                 are automatically inserted. Default: None.
@@ -2091,7 +2091,7 @@ class Model:
                 this argument will be ignored. Default: 0.
             collate_fn(callable, optional): function to generate mini-batch data by merging
                 the sample list, None for only stack each fields of sample in axis
-                0(same as :attr::`np.stack(..., axis=0)`). Default None
+                0(same as :attr::`np.stack(..., axis=0)`). Default: None.
             stack_outputs (bool, optional): Whether stack output field like a batch, as for an output
                 field of a sample is in shape [X, Y], test_data contains N samples, predict
                 output field will be in shape [N, X, Y] if stack_output is True, and will

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1707,6 +1707,7 @@ class Model:
         drop_last=False,
         shuffle=True,
         num_workers=0,
+        collate_fn=None,
         callbacks=None,
         accumulate_grad_batches=1,
         num_iters=None,
@@ -1749,6 +1750,9 @@ class Model:
                 subprocess used and loading data in main process.
                 When train_data and eval_data are both the instance of
                 Dataloader, this parameter will be ignored. Default: 0.
+            collate_fn(callable, optional): function to generate mini-batch data by merging
+                the sample list, None for only stack each fields of sample in axis
+                0(same as :attr::`np.stack(..., axis=0)`). Default None
             callbacks (Callback|None, optional): A list of `Callback` instances to apply
                 during training. If None, :ref:`api_paddle_callbacks_ProgBarLogger` and
                 :ref:`api_paddle_callbacks_ModelCheckpoint` are automatically inserted. Default: None.
@@ -1871,6 +1875,7 @@ class Model:
                 places=self._place,
                 num_workers=num_workers,
                 return_list=True,
+                collate_fn=collate_fn,
             )
         else:
             train_loader = train_data
@@ -1885,6 +1890,7 @@ class Model:
                 places=self._place,
                 num_workers=num_workers,
                 return_list=True,
+                collate_fn=collate_fn,
             )
         elif eval_data is not None:
             eval_loader = eval_data
@@ -1951,6 +1957,7 @@ class Model:
         log_freq=10,
         verbose=2,
         num_workers=0,
+        collate_fn=None,
         callbacks=None,
         num_iters=None,
     ):
@@ -1972,6 +1979,9 @@ class Model:
                 0 for no subprocess used and loading data in main process. When
                 train_data and eval_data are both the instance of Dataloader,
                 this parameter will be ignored. Default: 0.
+            collate_fn(callable, optional): function to generate mini-batch data by merging
+                the sample list, None for only stack each fields of sample in axis
+                0(same as :attr::`np.stack(..., axis=0)`). Default None
             callbacks (Callback|None, optional): A list of `Callback` instances to apply
                 during training. If None, `ProgBarLogger` and `ModelCheckpoint`
                 are automatically inserted. Default: None.
@@ -2016,6 +2026,7 @@ class Model:
                 places=self._place,
                 num_workers=num_workers,
                 return_list=True,
+                collate_fn=collate_fn,
             )
         else:
             eval_loader = eval_data
@@ -2061,6 +2072,7 @@ class Model:
         test_data,
         batch_size=1,
         num_workers=0,
+        collate_fn=None,
         stack_outputs=False,
         verbose=1,
         callbacks=None,
@@ -2077,6 +2089,9 @@ class Model:
             num_workers (int, optional): The number of subprocess to load data, 0 for no subprocess
                 used and loading data in main process. When test_data is the instance of Dataloader,
                 this argument will be ignored. Default: 0.
+            collate_fn(callable, optional): function to generate mini-batch data by merging
+                the sample list, None for only stack each fields of sample in axis
+                0(same as :attr::`np.stack(..., axis=0)`). Default None
             stack_outputs (bool, optional): Whether stack output field like a batch, as for an output
                 field of a sample is in shape [X, Y], test_data contains N samples, predict
                 output field will be in shape [N, X, Y] if stack_output is True, and will
@@ -2144,6 +2159,7 @@ class Model:
                 places=self._place,
                 num_workers=num_workers,
                 return_list=True,
+                collate_fn=collate_fn,
             )
         else:
             test_loader = test_data


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
修改hapi.model的fit, evaluate和predict接口，以暴露dataloader的collate_fn参数