### PR TITLE
[CINN] Try fix cinn not support inplace bug

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/cinn_compiler.cc
+++ b/paddle/fluid/framework/paddle2cinn/cinn_compiler.cc
@@ -285,7 +285,7 @@ std::unique_ptr<CinnCompiledObject> CinnCompiler::CompileGraph(
   GraphCompiler::CompileOptions options;
   options.with_instantiate_variables = false;
   if (!FLAGS_enable_pe_launch_cinn) {
-    options.with_buffer_handle_instruction_inserted = true;
+    options.with_buffer_handle_instruction_inserted = false;
   }
   std::unique_ptr<AutoTuner> auto_tuner;
   if (FLAGS_enable_cinn_auto_tune) {

--- a/paddle/fluid/operators/cinn/cinn_launch_context.h
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.h
@@ -129,7 +129,8 @@ class CinnLaunchContext {
   void InitializeArguments();
 
   // Assign tensor buffer to input or output variables
-  void AssignExternalVariable(const std::string& var_name);
+  void AssignExternalVariable(const std::string& var_name,
+                              bool is_input = true);
 
   // Assign tensor buffer to internal variables
   void AssignInternalVariable(const std::string& var_name);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
尝试修复CINN由于`batch_norm`算子存在inplace变量`Mean -> MeanOut`、`Variance -> VarianceOut`导致`batch_norm`的输入`Mean`、`Variance`由于映射被覆盖导致计算时为随机值的Bug。