### PR TITLE
[inference] Use output var name to mark the NVTX flag

### DIFF
--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -62,7 +62,8 @@ void NaiveExecutor::Run() {
             << op->DebugStringEx(scope_) << " on scope " << scope_;
     op->SetIsCalledByExecutor(false);
 #ifdef PADDLE_WITH_INFERENCE_NVTX
-    platform::CudaNvtxRangePush(op->Type(), platform::NvtxRangeColor::Green);
+    platform::CudaNvtxRangePush(op->Type() + "|" + op->OutputVars(true).front(),
+                                platform::NvtxRangeColor::Green);
 #endif
 
     // According to reuse table, we share the out tensor's holder.

--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -148,7 +148,9 @@ void TensorRTEngine::FreezeNetwork() {
                           platform::errors::InvalidArgument(
                               "Call InitNetwork first to initialize network."));
   // build engine.
-  infer_builder_->setMaxBatchSize(max_batch_);
+  if (!with_dynamic_shape_) {
+    infer_builder_->setMaxBatchSize(max_batch_);
+  }
 #if IS_TRT_VERSION_GE(8300)
   infer_builder_config_->setMemoryPoolLimit(
       nvinfer1::MemoryPoolType::kWORKSPACE, max_workspace_);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- Use output var name to mark the NVTX flag
<img width="981" alt="d5c8cc749aad5c2d80ac6a9b368d00e3" src="https://user-images.githubusercontent.com/1312389/212638864-5f276cc0-60ed-41b6-8bbf-1f055939f855.png">

- setMaxBatchSize is static shape only. This has no effect for networks created with explicit batch dimension mode. Refer to [TensorRT setMaxBatchSize()](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a61518b4d3baceac8862b4ec3ae5c840e)