### PR TITLE
fix ninja compilation for cinn

### DIFF
--- a/cmake/external/cinn.cmake
+++ b/cmake/external/cinn.cmake
@@ -40,7 +40,12 @@ set(CINN_OPTIONAL_ARGS
     -DWITH_MKLDNN=${WITH_MKL}
     -DPUBLISH_LIBS=ON
     -DWITH_TESTING=ON)
-set(CINN_BUILD_COMMAND $(MAKE) cinnapi -j)
+set(CINN_BUILD_COMMAND ${CMAKE_COMMAND} --build . --target cinnapi -j)
+set(CINN_BINARY_DIR ${CINN_PREFIX_DIR}/src/external_cinn-build)
+set(CINN_LIB_NAME "libcinnapi.so")
+set(CINN_LIB_LOCATION "${CINN_BINARY_DIR}/dist/cinn/lib")
+set(CINN_LIB "${CINN_LIB_LOCATION}/${CINN_LIB_NAME}")
+
 ExternalProject_Add(
   external_cinn
   ${EXTERNAL_PROJECT_LOG_ARGS}
@@ -49,11 +54,12 @@ ExternalProject_Add(
   PREFIX ${CINN_PREFIX_DIR}
   BUILD_COMMAND ${CINN_BUILD_COMMAND}
   INSTALL_COMMAND ""
-  CMAKE_ARGS ${CINN_OPTIONAL_ARGS})
+  CMAKE_ARGS ${CINN_OPTIONAL_ARGS}
+  CMAKE_GENERATOR "Unix Makefiles"
+  BUILD_BYPRODUCTS ${CINN_LIB})
 
 ExternalProject_Get_Property(external_cinn BINARY_DIR)
 ExternalProject_Get_Property(external_cinn SOURCE_DIR)
-set(CINN_BINARY_DIR ${BINARY_DIR})
 set(CINN_SOURCE_DIR ${SOURCE_DIR})
 
 message(STATUS "CINN BINARY_DIR: ${CINN_BINARY_DIR}")
@@ -79,8 +85,6 @@ include_directories(${LLVM_INCLUDE_DIR})
 # Put external_cinn and dependencies together as a lib
 ######################################################
 
-set(CINN_LIB_NAME "libcinnapi.so")
-set(CINN_LIB_LOCATION "${CINN_BINARY_DIR}/dist/cinn/lib")
 set(CINN_INCLUDE_DIR "${CINN_BINARY_DIR}/dist/cinn/include")
 
 add_library(cinn SHARED IMPORTED GLOBAL)

--- a/setup.py
+++ b/setup.py
@@ -591,8 +591,8 @@ def options_process(args, build_options):
 
 
 def get_cmake_generator():
-    if os.getenv("CMAKE_GENERATOR"):
-        cmake_generator = os.getenv("CMAKE_GENERATOR")
+    if os.getenv("GENERATOR"):
+        cmake_generator = os.getenv("GENERATOR")
     else:
         cmake_generator = "Unix Makefiles"
     return cmake_generator
@@ -628,7 +628,7 @@ def cmake_run(build_path):
                 "XPU_SDK_ROOT",
                 "MSVC_STATIC_CRT",
                 "NEW_RELEASE_ALL",
-                "CMAKE_GENERATOR",
+                "GENERATOR",
             )
         }
     )
@@ -647,10 +647,13 @@ def cmake_run(build_path):
             elif option_key == 'PYTHON_INCLUDE_DIR':
                 key = option_key + ':PATH'
                 print(key)
+            elif option_key == 'GENERATOR':
+                key = 'CMAKE_' + option_key
             else:
                 key = other_options[option_key]
             if key not in paddle_build_options:
                 paddle_build_options[key] = option_value
+
     options_process(args, paddle_build_options)
     print("args:", args)
     with cd(build_path):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix ninja compilation for cinn

- `CMAKE_GENERAROR`  is a built-in enviroment of CMAKE, and it affects all projects, including the third_party of paddle and the third_party of third_pary. Some third_parties are not supported ninja yet, so we can not use `CMAKE_GENERAROR` by to enable all.
- Update `cinn.cmake` to support ninja.