### PR TITLE
[Fix bug] Fix distributed custom_device bug

### DIFF
--- a/paddle/phi/api/lib/kernel_dispatch.cc
+++ b/paddle/phi/api/lib/kernel_dispatch.cc
@@ -22,6 +22,9 @@ limitations under the License. */
 #include "paddle/phi/core/compat/convert_utils.h"
 #include "paddle/phi/core/string_tensor_utils.h"
 #include "paddle/phi/core/tensor_utils.h"
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+#include "paddle/phi/backends/device_manager.h"
+#endif
 
 namespace paddle {
 namespace experimental {
@@ -54,6 +57,11 @@ bool HasAllocation(const phi::TensorBase& t) {
 
 BackendSet GetTensorBackendSet(const phi::TensorBase& t) {
   if (HasAllocation(t) && t.place().GetType() != AllocationType::UNDEFINED) {
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+    if (t.place().GetType() == AllocationType::CUSTOM) {
+      phi::DeviceManager::SetDevice(t.place());
+    }
+#endif
     phi::Backend backend_key = phi::TransToPhiBackend(t.place());
     BackendSet backend_set(backend_key);
     if (backend_key == Backend::GPU && phi::DenseTensor::classof(&t) &&


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
**Background**
The user found a problem when using the custom C++ operator. The place returned by the tensor was inconsistent with the set place when the tensor was created through paddle::empty.
**Bug Fix**
SetDevice when parsing TensorBase, so that C++ API could find the correct device under distributed custom devices scenario.


**背景**
用户在使用自定义C++算子的时候发现一个问题，通过paddle::empty创建一个tensor，该tensor返回的place与设定的place不一致。
**解决方案**
分布式自定义设备场景下，phi 内没有正确设置 device 的 place，因此会报错。当 phi 解析 TensorBase 时调用 SetDevice 函数，解决此 bug