### PR TITLE
[PHI]add phi tensor vector array api from fluid

### DIFF
--- a/paddle/fluid/framework/tensor_util.h
+++ b/paddle/fluid/framework/tensor_util.h
@@ -355,7 +355,7 @@ inline void TensorFromVector(const std::vector<bool>& src,
         reinterpret_cast<const platform::NPUDeviceContext&>(ctx).stream());
   }
 #endif
-#ifdef PADDLE_WITH_CUSTOM_DEICE
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
   else if (platform::is_custom_place(dst_place)) {  // NOLINT
     auto stream =
         reinterpret_cast<const platform::CustomDeviceContext&>(ctx).stream();

--- a/paddle/phi/core/tensor_utils.cc
+++ b/paddle/phi/core/tensor_utils.cc
@@ -422,4 +422,449 @@ template void Copy(const OneDNNContext& dev_ctx,
                    bool blocking,
                    DenseTensor* dst);
 #endif
+
+template <typename T>
+void TensorFromVector(const std::vector<T>& src,
+                      const phi::DeviceContext& ctx,
+                      phi::DenseTensor* dst) {
+  auto dst_place = ctx.GetPlace();
+  auto src_ptr = static_cast<const void*>(src.data());
+  phi::CPUPlace src_place;
+  dst->Resize({static_cast<int64_t>(src.size())});
+  ctx.template Alloc<T>(dst);
+  auto dst_ptr = static_cast<void*>(dst->data<T>());
+  auto size = src.size() * sizeof(T);
+
+  if (paddle::platform::is_cpu_place(dst_place)) {
+    paddle::memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
+  }
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  else if (paddle::platform::is_gpu_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place,
+        dst_ptr,
+        src_place,
+        src_ptr,
+        size,
+        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
+  }
+#endif
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+  else if (paddle::platform::is_custom_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place,
+        dst_ptr,
+        src_place,
+        src_ptr,
+        size,
+        reinterpret_cast<const phi::CustomContext&>(ctx).stream());
+  }
+#endif
+#ifdef PADDLE_WITH_XPU
+  else if (paddle::platform::is_xpu_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
+  }
+#endif
+  else {  // NOLINT
+    PADDLE_THROW(phi::errors::Unimplemented(
+        "TensorFromVector on %s is not supported.", dst_place));
+  }
+}
+
+template <>
+void TensorFromVector(const std::vector<bool>& src,
+                      const phi::DeviceContext& ctx,
+                      phi::DenseTensor* dst) {
+  // vector<bool> has no data() member, use array instead.
+  // See details:
+  // https://stackoverflow.com/questions/46115669/why-does-stdvectorbool-have-no-data/46115714
+  bool* array = new bool[src.size()];
+  for (unsigned int i = 0; i < src.size(); i++) {
+    array[i] = static_cast<bool>(src[i]);
+  }
+
+  auto dst_place = ctx.GetPlace();
+  auto src_ptr = static_cast<const void*>(array);
+  phi::CPUPlace src_place{};
+  dst->Resize({static_cast<int64_t>(src.size())});
+  auto dst_ptr = ctx.template Alloc<bool>(dst);
+  auto size = src.size() * sizeof(bool);
+
+  if (paddle::platform::is_cpu_place(dst_place)) {
+    paddle::memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
+  }
+#ifdef PADDLE_WITH_CUDA
+  else if (paddle::platform::is_gpu_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place,
+        dst_ptr,
+        src_place,
+        src_ptr,
+        size,
+        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
+  }
+#endif
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+  else if (paddle::platform::is_custom_place(dst_place)) {  // NOLINT
+    auto stream = reinterpret_cast<const phi::CustomContext&>(ctx).stream();
+    paddle::memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size, stream);
+  }
+#endif
+#ifdef PADDLE_WITH_XPU
+  else if (paddle::platform::is_xpu_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
+  }
+#endif
+  else {  // NOLINT
+    PADDLE_THROW(phi::errors::Unimplemented(
+        "TensorFromVector on %s is not supported.", dst_place));
+  }
+  delete[] array;
+}
+
+template void TensorFromVector<int8_t>(const std::vector<int8_t>& src,
+                                       const phi::DeviceContext& ctx,
+                                       phi::DenseTensor* dst);
+
+template void TensorFromVector<uint8_t>(const std::vector<uint8_t>& src,
+                                        const phi::DeviceContext& ctx,
+                                        phi::DenseTensor* dst);
+
+template void TensorFromVector<int16_t>(const std::vector<int16_t>& src,
+                                        const phi::DeviceContext& ctx,
+                                        phi::DenseTensor* dst);
+
+template void TensorFromVector<int>(const std::vector<int>& src,
+                                    const phi::DeviceContext& ctx,
+                                    phi::DenseTensor* dst);
+
+template void TensorFromVector<int64_t>(const std::vector<int64_t>& src,
+                                        const phi::DeviceContext& ctx,
+                                        phi::DenseTensor* dst);
+
+template void TensorFromVector<float>(const std::vector<float>& src,
+                                      const phi::DeviceContext& ctx,
+                                      phi::DenseTensor* dst);
+
+template void TensorFromVector<double>(const std::vector<double>& src,
+                                       const phi::DeviceContext& ctx,
+                                       phi::DenseTensor* dst);
+
+template void TensorFromVector<phi::dtype::bfloat16>(
+    const std::vector<phi::dtype::bfloat16>& src,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template void TensorFromVector<phi::dtype::float16>(
+    const std::vector<phi::dtype::float16>& src,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template void TensorFromVector<phi::dtype::complex<float>>(
+    const std::vector<phi::dtype::complex<float>>& src,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template void TensorFromVector<phi::dtype::complex<double>>(
+    const std::vector<phi::dtype::complex<double>>& src,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template <typename T>
+void TensorFromArray(const T* src,
+                     const size_t& array_size,
+                     const phi::DeviceContext& ctx,
+                     phi::DenseTensor* dst) {
+  auto dst_place = ctx.GetPlace();
+  auto src_ptr = static_cast<const void*>(src);
+  phi::CPUPlace src_place;
+  dst->Resize({static_cast<int64_t>(array_size)});
+  ctx.template Alloc<T>(dst);
+  auto dst_ptr = static_cast<void*>(dst->data<T>());
+  auto size = array_size * sizeof(T);
+
+  if (paddle::platform::is_cpu_place(dst_place)) {
+    paddle::memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
+  }
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  else if (paddle::platform::is_gpu_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place,
+        dst_ptr,
+        src_place,
+        src_ptr,
+        size,
+        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
+  }
+#endif
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+  else if (paddle::platform::is_custom_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place,
+        dst_ptr,
+        src_place,
+        src_ptr,
+        size,
+        reinterpret_cast<const phi::CustomContext&>(ctx).stream());
+  }
+#endif
+#ifdef PADDLE_WITH_XPU
+  else if (paddle::platform::is_xpu_place(dst_place)) {  // NOLINT
+    paddle::memory::Copy(dst_place, dst_ptr, src_place, src_ptr, size);
+  }
+#endif
+  else {  // NOLINT
+    PADDLE_THROW(phi::errors::Unimplemented(
+        "TensorFromArray on %s is not supported.", dst_place));
+  }
+}
+
+template void TensorFromArray<bool>(const bool* src,
+                                    const size_t& array_size,
+                                    const phi::DeviceContext& ctx,
+                                    phi::DenseTensor* dst);
+
+template void TensorFromArray<int16_t>(const int16_t* src,
+                                       const size_t& array_size,
+                                       const phi::DeviceContext& ctx,
+                                       phi::DenseTensor* dst);
+
+template void TensorFromArray<int>(const int* src,
+                                   const size_t& array_size,
+                                   const phi::DeviceContext& ctx,
+                                   phi::DenseTensor* dst);
+
+template void TensorFromArray<int64_t>(const int64_t* src,
+                                       const size_t& array_size,
+                                       const phi::DeviceContext& ctx,
+                                       phi::DenseTensor* dst);
+
+template void TensorFromArray<float>(const float* src,
+                                     const size_t& array_size,
+                                     const phi::DeviceContext& ctx,
+                                     phi::DenseTensor* dst);
+
+template void TensorFromArray<double>(const double* src,
+                                      const size_t& array_size,
+                                      const phi::DeviceContext& ctx,
+                                      phi::DenseTensor* dst);
+
+template void TensorFromArray<phi::dtype::bfloat16>(
+    const phi::dtype::bfloat16* src,
+    const size_t& array_size,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template void TensorFromArray<phi::dtype::float16>(
+    const phi::dtype::float16* src,
+    const size_t& array_size,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template void TensorFromArray<phi::dtype::complex<float>>(
+    const phi::dtype::complex<float>* src,
+    const size_t& array_size,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template void TensorFromArray<phi::dtype::complex<double>>(
+    const phi::dtype::complex<double>* src,
+    const size_t& array_size,
+    const phi::DeviceContext& ctx,
+    phi::DenseTensor* dst);
+
+template <typename T>
+void TensorToVector(const phi::DenseTensor& src,
+                    const phi::DeviceContext& ctx,
+                    std::vector<T>* dst) {
+  auto src_ptr = static_cast<const void*>(src.data<T>());
+  auto size = src.numel() * sizeof(T);
+
+  phi::CPUPlace dst_place{};
+  dst->resize(src.numel());
+  auto dst_ptr = static_cast<void*>(dst->data());
+
+  if (paddle::platform::is_cpu_place(src.place())) {
+    paddle::memory::Copy(dst_place, dst_ptr, src.place(), src_ptr, size);
+  }
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  else if (paddle::platform::is_gpu_place(src.place())) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place,
+        dst_ptr,
+        src.place(),
+        src_ptr,
+        size,
+        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
+  }
+#endif
+#if defined(PADDLE_WITH_XPU)
+  else if (paddle::platform::is_xpu_place(src.place())) {  // NOLINT
+    paddle::memory::Copy(dst_place, dst_ptr, src.place(), src_ptr, size);
+  }
+#endif
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+  else if (paddle::platform::is_custom_place(src.place())) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place, dst_ptr, src.place(), src_ptr, size, nullptr);
+  }
+#endif
+  else {  // NOLINT
+    PADDLE_THROW(phi::errors::Unimplemented(
+        "TensorToVector on %s is not supported.", src.place()));
+  }
+}
+
+template <>
+void TensorToVector(const phi::DenseTensor& src,
+                    const phi::DeviceContext& ctx,
+                    std::vector<bool>* dst) {
+  auto src_ptr = static_cast<const void*>(src.data<bool>());
+  auto size = src.numel() * sizeof(bool);
+
+  bool* array = new bool[src.numel()];
+
+  phi::CPUPlace dst_place{};
+  dst->resize(src.numel());
+  auto dst_ptr = static_cast<void*>(array);
+
+  if (paddle::platform::is_cpu_place(src.place())) {
+    paddle::memory::Copy(dst_place, dst_ptr, src.place(), src_ptr, size);
+  }
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+  else if (paddle::platform::is_gpu_place(src.place())) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place,
+        dst_ptr,
+        src.place(),
+        src_ptr,
+        size,
+        reinterpret_cast<const phi::GPUContext&>(ctx).stream());
+  }
+#endif
+#if defined(PADDLE_WITH_XPU)
+  else if (paddle::platform::is_xpu_place(src.place())) {  // NOLINT
+    paddle::memory::Copy(dst_place, dst_ptr, src.place(), src_ptr, size);
+  }
+#endif
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+  else if (paddle::platform::is_custom_place(src.place())) {  // NOLINT
+    paddle::memory::Copy(
+        dst_place, dst_ptr, src.place(), src_ptr, size, nullptr);
+  }
+#endif
+  for (unsigned int i = 0; i < src.numel(); i++) {
+    (*dst)[i] = static_cast<bool>(array[i]);
+  }
+  delete[] array;
+}
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<int16_t>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<int>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<int64_t>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<float>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<double>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<phi::dtype::bfloat16>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<phi::dtype::float16>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<phi::dtype::complex<float>>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             const phi::DeviceContext& ctx,
+                             std::vector<phi::dtype::complex<double>>* dst);
+
+template <typename T>
+void TensorToVector(const phi::DenseTensor& src, std::vector<T>* dst) {
+  auto src_ptr = static_cast<const void*>(src.data<T>());
+  auto size = src.numel() * sizeof(T);
+
+  phi::CPUPlace dst_place{};
+  dst->resize(src.numel());
+  auto dst_ptr = static_cast<void*>(dst->data());
+
+  PADDLE_ENFORCE_EQ(
+      paddle::platform::is_cpu_place(src.place()),
+      true,
+      phi::errors::InvalidArgument(
+          "The input tensor should be CPU device, but actually it is in %s.",
+          src.place()));
+
+  paddle::memory::Copy(dst_place, dst_ptr, src.place(), src_ptr, size);
+}
+
+template <>
+void TensorToVector(const phi::DenseTensor& src, std::vector<bool>* dst) {
+  auto src_ptr = static_cast<const void*>(src.data<bool>());
+  auto size = src.numel() * sizeof(bool);
+
+  bool* array = new bool[src.numel()];
+
+  paddle::platform::CPUPlace dst_place{};
+  dst->resize(src.numel());
+  auto dst_ptr = static_cast<void*>(array);
+
+  PADDLE_ENFORCE_EQ(
+      paddle::platform::is_cpu_place(src.place()),
+      true,
+      phi::errors::InvalidArgument(
+          "The input tensor should be CPU device, but actually it is in %s.",
+          src.place()));
+
+  paddle::memory::Copy(dst_place, dst_ptr, src.place(), src_ptr, size);
+
+  for (unsigned int i = 0; i < src.numel(); i++) {
+    (*dst)[i] = static_cast<bool>(array[i]);
+  }
+  delete[] array;
+}
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<int16_t>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<int>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<int64_t>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<float>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<double>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<phi::dtype::bfloat16>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<phi::dtype::float16>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<phi::dtype::complex<float>>* dst);
+
+template void TensorToVector(const phi::DenseTensor& src,
+                             std::vector<phi::dtype::complex<double>>* dst);
+
 }  // namespace phi

--- a/paddle/phi/core/tensor_utils.h
+++ b/paddle/phi/core/tensor_utils.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/device_context.h"
 #include "paddle/phi/core/selected_rows.h"
 #include "paddle/phi/core/sparse_coo_tensor.h"
 #include "paddle/phi/core/sparse_csr_tensor.h"
@@ -108,5 +109,21 @@ void Copy(const Context& dev_ctx,
           Place dst_place,
           bool blocking,
           SparseCsrTensor* dst);
+
+template <typename T>
+void TensorFromVector(const std::vector<T>& src,
+                      const phi::DeviceContext& ctx,
+                      phi::DenseTensor* dst);
+
+template <typename T>
+void TensorFromArray(const T* src,
+                     const size_t& array_size,
+                     const phi::DeviceContext& ctx,
+                     phi::DenseTensor* dst);
+
+template <typename T>
+void TensorToVector(const phi::DenseTensor& src,
+                    const phi::DeviceContext& ctx,
+                    std::vector<T>* dst);
 
 }  // namespace phi

--- a/paddle/phi/kernels/assign_kernel.cc
+++ b/paddle/phi/kernels/assign_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/assign_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/utils/optional.h"
@@ -25,7 +24,7 @@ template <typename Context>
 void AssignKernel(const Context& dev_ctx,
                   const DenseTensor& x,
                   DenseTensor* out) {
-  paddle::framework::TensorCopy(x, x.place(), out);
+  phi::Copy(dev_ctx, x, x.place(), false, out);
 }
 
 template <typename Context>
@@ -65,15 +64,14 @@ typename std::enable_if<std::is_same<T, bool>::value>::type CopyVectorToTensor(
   for (const auto& val : values) {
     assign_values.emplace_back(val.to<int>());
   }
-  paddle::framework::TensorFromVector(assign_values, dev_ctx, out);
+  phi::TensorFromVector(assign_values, dev_ctx, out);
 
   // use the array to replace to vector
   bool* array_ptr = new T[assign_values.size()];
   for (unsigned int i = 0; i < assign_values.size(); i++) {
     array_ptr[i] = static_cast<T>(assign_values[i]);
   }
-  paddle::framework::TensorFromArray(
-      array_ptr, assign_values.size(), dev_ctx, out);
+  phi::TensorFromArray(array_ptr, assign_values.size(), dev_ctx, out);
   delete[] array_ptr;
 }
 
@@ -87,7 +85,7 @@ typename std::enable_if<!std::is_same<T, bool>::value>::type CopyVectorToTensor(
   for (const auto& val : values) {
     assign_values.emplace_back(val.to<T>());
   }
-  paddle::framework::TensorFromVector(assign_values, dev_ctx, out);
+  phi::TensorFromVector(assign_values, dev_ctx, out);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/cpu/adam_kernel.cc
+++ b/paddle/phi/kernels/cpu/adam_kernel.cc
@@ -16,7 +16,6 @@
 
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/operators/jit/kernels.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -61,7 +60,7 @@ void AdamDenseKernel(const Context& dev_ctx,
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
   // skip_update=true, just copy input to output, and TensorCopy will call

--- a/paddle/phi/kernels/cpu/adamw_kernel.cc
+++ b/paddle/phi/kernels/cpu/adamw_kernel.cc
@@ -16,11 +16,11 @@
 
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/operators/jit/kernels.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/adam_kernel.h"
 #include "paddle/phi/kernels/funcs/adam_functors.h"
 
@@ -61,7 +61,7 @@ void AdamwDenseKernel(const Context& dev_ctx,
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
   VLOG(3) << "Skip update" << skip_update_;

--- a/paddle/phi/kernels/cpu/cross_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_grad_kernel.cc
@@ -14,10 +14,10 @@
 
 #include "paddle/phi/kernels/cross_grad_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 
 namespace phi {
 
@@ -82,9 +82,9 @@ void CrossGradKernel(const Context &dev_ctx,
   }
 
   std::vector<T> input_x_vec, input_y_vec, input_dout_vec;
-  paddle::framework::TensorToVector(input_x, dev_ctx, &input_x_vec);
-  paddle::framework::TensorToVector(input_y, dev_ctx, &input_y_vec);
-  paddle::framework::TensorToVector(input_out_grad, dev_ctx, &input_dout_vec);
+  phi::TensorToVector(input_x, dev_ctx, &input_x_vec);
+  phi::TensorToVector(input_y, dev_ctx, &input_y_vec);
+  phi::TensorToVector(input_out_grad, dev_ctx, &input_dout_vec);
   std::vector<T> out_dx_vec(output_x_grad->numel());
   std::vector<T> out_dy_vec(output_y_grad->numel());
 
@@ -106,8 +106,8 @@ void CrossGradKernel(const Context &dev_ctx,
       }
     }
   }
-  paddle::framework::TensorFromVector(out_dx_vec, dev_ctx, output_x_grad);
-  paddle::framework::TensorFromVector(out_dy_vec, dev_ctx, output_y_grad);
+  phi::TensorFromVector(out_dx_vec, dev_ctx, output_x_grad);
+  phi::TensorFromVector(out_dy_vec, dev_ctx, output_y_grad);
   output_x_grad->Resize(input_x_dims);
   output_y_grad->Resize(input_x_dims);
 }

--- a/paddle/phi/kernels/cpu/cross_kernel.cc
+++ b/paddle/phi/kernels/cpu/cross_kernel.cc
@@ -81,8 +81,8 @@ void CrossKernel(const Context& dev_ctx,
   }
 
   std::vector<T> input_x_vec, input_y_vec;
-  paddle::framework::TensorToVector(input_x, dev_ctx, &input_x_vec);
-  paddle::framework::TensorToVector(input_y, dev_ctx, &input_y_vec);
+  phi::TensorToVector(input_x, dev_ctx, &input_x_vec);
+  phi::TensorToVector(input_y, dev_ctx, &input_y_vec);
   std::vector<T> out_vec(output->numel());
 
   dev_ctx.template Alloc<T>(output);
@@ -100,7 +100,7 @@ void CrossKernel(const Context& dev_ctx,
       }
     }
   }
-  paddle::framework::TensorFromVector(out_vec, dev_ctx, output);
+  phi::TensorFromVector(out_vec, dev_ctx, output);
   output->Resize(input_x_dims);
 }
 

--- a/paddle/phi/kernels/cpu/index_sample_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_sample_grad_kernel.cc
@@ -14,10 +14,10 @@
 
 #include "paddle/phi/kernels/index_sample_grad_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/core/utils/data_type.h"
 namespace phi {
 template <typename T, typename Context, typename IndexT = int>
@@ -27,8 +27,8 @@ void IndexSampleGradInner(const Context& context,
                           DenseTensor* x_grad) {
   std::vector<T> out_grad_vec;
   std::vector<IndexT> index_vec;
-  paddle::framework::TensorToVector(out_grad, context, &out_grad_vec);
-  paddle::framework::TensorToVector(index, context, &index_vec);
+  phi::TensorToVector(out_grad, context, &out_grad_vec);
+  phi::TensorToVector(index, context, &index_vec);
 
   auto index_dims = index.dims();
   auto x_grad_dims = x_grad->dims();
@@ -63,7 +63,7 @@ void IndexSampleGradInner(const Context& context,
     x_grad_vec[v_i] += out_grad_vec[i];
   }
   context.template Alloc<T>(x_grad);
-  paddle::framework::TensorFromVector(x_grad_vec, context, x_grad);
+  phi::TensorFromVector(x_grad_vec, context, x_grad);
   x_grad->Resize(x_grad_dims);
 }
 

--- a/paddle/phi/kernels/cpu/index_sample_kernel.cc
+++ b/paddle/phi/kernels/cpu/index_sample_kernel.cc
@@ -21,10 +21,10 @@
 #include <utility>
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/core/utils/data_type.h"
 namespace phi {
 template <typename T, typename Context, typename IndexT = int>
@@ -42,8 +42,8 @@ void IndexSampleInner(const Context &context,
 
   std::vector<T> input_vec;
   std::vector<IndexT> index_vec;
-  paddle::framework::TensorToVector(input, context, &input_vec);
-  paddle::framework::TensorToVector<IndexT>(index, context, &index_vec);
+  phi::TensorToVector(input, context, &input_vec);
+  phi::TensorToVector<IndexT>(index, context, &index_vec);
 
   std::vector<T> res(index_ids_num);
   for (int i = 0; i < index_ids_num; i++) {
@@ -76,7 +76,7 @@ void IndexSampleInner(const Context &context,
 
   auto ddim = phi::make_ddim({batch_size, index_length});
   context.template Alloc<T>(output);
-  paddle::framework::TensorFromVector(res, context, output);
+  phi::TensorFromVector(res, context, output);
   output->Resize(ddim);
 }
 

--- a/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/repeat_interleave_grad_kernel.cc
@@ -94,7 +94,7 @@ void RepeatInterleaveGradKernel(const Context& ctx,
     std::fill_n(index_vec.begin() + i * repeats, repeats, i);
   }
   index.Resize(phi::make_ddim({index_size}));
-  paddle::framework::TensorFromVector<int>(index_vec, &index);
+  phi::TensorFromVector<int>(index_vec, ctx, &index);
   const DenseTensor index_copy = index;
   IndexSelectGradInner<Context, T, int>(ctx, out_grad, index_copy, x_grad, dim);
 }

--- a/paddle/phi/kernels/cpu/roll_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/roll_grad_kernel.cc
@@ -14,8 +14,8 @@
 
 #include "paddle/phi/kernels/roll_grad_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/cpu/roll_kernel_impl.h"
 
 namespace phi {
@@ -28,7 +28,7 @@ void RollGradKernel(const Context& dev_ctx,
                     const std::vector<int64_t>& axis,
                     DenseTensor* x_grad) {
   std::vector<T> out_vec;
-  paddle::framework::TensorToVector(out_grad, dev_ctx, &out_vec);
+  phi::TensorToVector(out_grad, dev_ctx, &out_vec);
 
   auto shifts_data = shifts.GetData();
   size_t nums = shifts_data.size();
@@ -46,7 +46,7 @@ void RollGradKernel(const Context& dev_ctx,
   }
 
   dev_ctx.template Alloc<T>(x_grad);
-  paddle::framework::TensorFromVector(out_vec, dev_ctx, x_grad);
+  phi::TensorFromVector(out_vec, dev_ctx, x_grad);
   x_grad->Resize(out_grad.dims());
 }
 

--- a/paddle/phi/kernels/cpu/roll_kernel.cc
+++ b/paddle/phi/kernels/cpu/roll_kernel.cc
@@ -14,10 +14,10 @@
 
 #include "paddle/phi/kernels/roll_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/common/complex.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/cpu/roll_kernel_impl.h"
 
 namespace phi {
@@ -29,7 +29,7 @@ void RollKernel(const Context& dev_ctx,
                 const std::vector<int64_t>& axis,
                 DenseTensor* out) {
   std::vector<T> out_vec;
-  paddle::framework::TensorToVector(x, dev_ctx, &out_vec);
+  phi::TensorToVector(x, dev_ctx, &out_vec);
 
   auto shifts_data = shifts.GetData();
   size_t nums = shifts_data.size();
@@ -57,7 +57,7 @@ void RollKernel(const Context& dev_ctx,
     ShiftAlongDim(out_vec.data(), input_dim, dims[i], shifts_data[i]);
   }
   dev_ctx.template Alloc<T>(out);
-  paddle::framework::TensorFromVector(out_vec, dev_ctx, out);
+  phi::TensorFromVector(out_vec, dev_ctx, out);
   out->Resize(x.dims());
 }
 

--- a/paddle/phi/kernels/cpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/cpu/unique_consecutive_functor.h
@@ -14,9 +14,8 @@
 
 #pragma once
 
-#include "paddle/fluid/framework/tensor_util.h"
-
 #include "paddle/phi/core/dense_tensor.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/funcs/unique_functor.h"
@@ -210,10 +209,10 @@ static void UniqueConsecutiveDim(const Context& context,
   phi::funcs::TransCompute<Context, InT>(
       out_trans.dims().size(), context, out_trans, out, permute);
   if (return_inverse) {
-    paddle::framework::TensorFromVector(inverse_vec, context, inverse);
+    phi::TensorFromVector(inverse_vec, context, inverse);
   }
   if (return_counts) {
-    paddle::framework::TensorFromVector(counts_vec, context, count);
+    phi::TensorFromVector(counts_vec, context, count);
   }
 }
 

--- a/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.h
+++ b/paddle/phi/kernels/funcs/repeat_tensor2index_tensor.h
@@ -42,7 +42,7 @@ void RepeatsTensor2IndexTensor(const Context& ctx,
   }
   index->Resize(phi::make_ddim({index_size}));
 
-  paddle::framework::TensorFromVector<RepeatsT>(index_vec, ctx, index);
+  phi::TensorFromVector<RepeatsT>(index_vec, ctx, index);
 }
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/funcs/unique_functor.h
+++ b/paddle/phi/kernels/funcs/unique_functor.h
@@ -312,15 +312,15 @@ static void UniqueDim(const Context& context,
       out_trans.dims().size(), context, out_trans, out, permute);
 
   if (return_inverse) {
-    paddle::framework::TensorFromVector(inverse_vec, context, index);
+    phi::TensorFromVector(inverse_vec, context, index);
   }
 
   if (return_counts) {
-    paddle::framework::TensorFromVector(counts_vec, context, count);
+    phi::TensorFromVector(counts_vec, context, count);
   }
 
   if (return_index) {
-    paddle::framework::TensorFromVector(indices_vec, context, indices);
+    phi::TensorFromVector(indices_vec, context, indices);
   }
 }
 

--- a/paddle/phi/kernels/gpu/adam_kernel.cu
+++ b/paddle/phi/kernels/gpu/adam_kernel.cu
@@ -18,7 +18,6 @@
 
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/float16.h"
@@ -162,7 +161,7 @@ void AdamDenseKernel(const Context& dev_ctx,
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
   // skip_update=true, just copy input to output, and TensorCopy will call

--- a/paddle/phi/kernels/gpu/adamw_kernel.cu
+++ b/paddle/phi/kernels/gpu/adamw_kernel.cu
@@ -18,7 +18,6 @@
 
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/bfloat16.h"
@@ -181,7 +180,7 @@ void AdamwDenseKernel(const Context& dev_ctx,
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
 

--- a/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
+++ b/paddle/phi/kernels/gpu/class_center_sample_kernel.cu
@@ -31,6 +31,7 @@ namespace cub = hipcub;
 
 #include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/tensor_utils.h"
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
 #include "paddle/fluid/distributed/collective/process_group.h"
@@ -344,8 +345,7 @@ void ClassCenterSampleKernel(const Context& dev_ctx,
   std::vector<T> shard_dim_vec(nranks + 1, 0);
   shard_dim_vec[rank + 1] = num_classes;
   DenseTensor num_classes_per_device;
-  paddle::framework::TensorFromVector(
-      shard_dim_vec, dev_ctx, &num_classes_per_device);
+  phi::TensorFromVector(shard_dim_vec, dev_ctx, &num_classes_per_device);
   T* num_classes_per_device_ptr = num_classes_per_device.data<T>();
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)

--- a/paddle/phi/kernels/gpu/diagonal_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/diagonal_grad_kernel.cu
@@ -14,9 +14,9 @@
 
 #include "paddle/phi/kernels/diagonal_grad_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/diagonal.h"
 
 namespace phi {
@@ -38,8 +38,7 @@ void DiagonalGradKernel(const Context& dev_ctx,
 
   std::vector<int64_t> res_dout = vectorize(phi::stride(dout->dims()));
   DenseTensor dout_stride_tensor;
-  paddle::framework::TensorFromVector<int64_t>(
-      res_dout, dev_ctx, &dout_stride_tensor);
+  phi::TensorFromVector<int64_t>(res_dout, dev_ctx, &dout_stride_tensor);
   int64_t* dout_stride = dout_stride_tensor.data<int64_t>();
 
   auto* dx = in_grad;
@@ -49,8 +48,7 @@ void DiagonalGradKernel(const Context& dev_ctx,
 
   std::vector<int64_t> res_dx = vectorize(phi::stride(dx->dims()));
   DenseTensor dx_stride_tensor;
-  paddle::framework::TensorFromVector<int64_t>(
-      res_dx, dev_ctx, &dx_stride_tensor);
+  phi::TensorFromVector<int64_t>(res_dx, dev_ctx, &dx_stride_tensor);
   int64_t* dx_stride = dx_stride_tensor.data<int64_t>();
 
   const int64_t offset_ = offset;

--- a/paddle/phi/kernels/gpu/diagonal_kernel.cu
+++ b/paddle/phi/kernels/gpu/diagonal_kernel.cu
@@ -14,9 +14,9 @@
 
 #include "paddle/phi/kernels/diagonal_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/gpu/gpu_primitives.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/diagonal.h"
 
 namespace phi {
@@ -35,8 +35,7 @@ void DiagonalKernel(const Context& dev_ctx,
 
   std::vector<int64_t> res_in = vectorize(phi::stride(input->dims()));
   DenseTensor input_stride_tensor;
-  paddle::framework::TensorFromVector<int64_t>(
-      res_in, dev_ctx, &input_stride_tensor);
+  phi::TensorFromVector<int64_t>(res_in, dev_ctx, &input_stride_tensor);
   int64_t* input_stride = input_stride_tensor.data<int64_t>();
 
   auto* output = out;
@@ -46,8 +45,7 @@ void DiagonalKernel(const Context& dev_ctx,
 
   std::vector<int64_t> res_out = vectorize(phi::stride(output->dims()));
   DenseTensor output_stride_tensor;
-  paddle::framework::TensorFromVector<int64_t>(
-      res_out, dev_ctx, &output_stride_tensor);
+  phi::TensorFromVector<int64_t>(res_out, dev_ctx, &output_stride_tensor);
   int64_t* output_stride = output_stride_tensor.data<int64_t>();
 
   const int64_t offset_ = offset;

--- a/paddle/phi/kernels/gpu/margin_cross_entropy_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/margin_cross_entropy_grad_kernel.cu
@@ -62,13 +62,12 @@ void GetClassInterval(const gpuStream_t& stream,
   std::vector<int> shard_dim_vec(nranks + 1, 0);
   shard_dim_vec[rank + 1] = D;
   if (nranks <= 1) {
-    paddle::framework::TensorFromVector(shard_dim_vec, dev_ctx, class_interval);
+    phi::TensorFromVector(shard_dim_vec, dev_ctx, class_interval);
     return;
   }
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
   DenseTensor num_classes_per_device;
-  paddle::framework::TensorFromVector(
-      shard_dim_vec, dev_ctx, &num_classes_per_device);
+  phi::TensorFromVector(shard_dim_vec, dev_ctx, &num_classes_per_device);
   int* num_classes_per_device_ptr = num_classes_per_device.data<int>();
 
   auto map = paddle::distributed::ProcessGroupMapFromGid::getInstance();

--- a/paddle/phi/kernels/gpu/margin_cross_entropy_kernel.cu
+++ b/paddle/phi/kernels/gpu/margin_cross_entropy_kernel.cu
@@ -57,14 +57,13 @@ void GetClassInterval(const gpuStream_t& stream,
   std::vector<int> shard_dim_vec(nranks + 1, 0);
   shard_dim_vec[rank + 1] = D;
   if (nranks <= 1) {
-    paddle::framework::TensorFromVector(shard_dim_vec, dev_ctx, class_interval);
+    phi::TensorFromVector(shard_dim_vec, dev_ctx, class_interval);
     return;
   }
 
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
   DenseTensor num_classes_per_device;
-  paddle::framework::TensorFromVector(
-      shard_dim_vec, dev_ctx, &num_classes_per_device);
+  phi::TensorFromVector(shard_dim_vec, dev_ctx, &num_classes_per_device);
   int* num_classes_per_device_ptr = num_classes_per_device.data<int>();
 
   auto map = paddle::distributed::ProcessGroupMapFromGid::getInstance();

--- a/paddle/phi/kernels/gpu/prior_box_kernel.cu
+++ b/paddle/phi/kernels/gpu/prior_box_kernel.cu
@@ -17,10 +17,10 @@
 #include <algorithm>
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 
 namespace phi {
 
@@ -160,15 +160,15 @@ void PriorBoxKernel(const Context& ctx,
   ctx.template Alloc<T>(var);
 
   DenseTensor r;
-  paddle::framework::TensorFromVector(new_aspect_ratios, ctx, &r);
+  phi::TensorFromVector(new_aspect_ratios, ctx, &r);
 
   DenseTensor min;
-  paddle::framework::TensorFromVector(min_sizes, ctx, &min);
+  phi::TensorFromVector(min_sizes, ctx, &min);
 
   T* max_data = nullptr;
   DenseTensor max;
   if (max_sizes.size() > 0) {
-    paddle::framework::TensorFromVector(max_sizes, ctx, &max);
+    phi::TensorFromVector(max_sizes, ctx, &max);
     max_data = max.data<T>();
   }
 
@@ -189,7 +189,7 @@ void PriorBoxKernel(const Context& ctx,
                                              min_max_aspect_ratios_order);
 
   DenseTensor v;
-  paddle::framework::TensorFromVector(variances, ctx, &v);
+  phi::TensorFromVector(variances, ctx, &v);
   grid = (box_num * 4 + block - 1) / block;
   SetVariance<T><<<grid, block, 0, stream>>>(
       var->data<T>(), v.data<T>(), variances.size(), box_num * 4);

--- a/paddle/phi/kernels/gpu/unique_consecutive_functor.h
+++ b/paddle/phi/kernels/gpu/unique_consecutive_functor.h
@@ -24,8 +24,6 @@
 #include <iostream>
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
-
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/funcs/concat_and_split_functor.h"
@@ -293,8 +291,8 @@ void IndexSelect(const Context& context,
 
   std::vector<InT> input_vec;
   std::vector<IndexT> index_vec;
-  paddle::framework::TensorToVector(input, context, &input_vec);
-  paddle::framework::TensorToVector(index, context, &index_vec);
+  phi::TensorToVector(input, context, &input_vec);
+  phi::TensorToVector(index, context, &index_vec);
   std::vector<InT> out_vec(output->numel());
 
   for (int i = 0; i < index_size; i++) {
@@ -331,7 +329,7 @@ void IndexSelect(const Context& context,
     }
   }
   context.template Alloc<InT>(output);
-  paddle::framework::TensorFromVector(out_vec, context, output);
+  phi::TensorFromVector(out_vec, context, output);
   output->Resize(output_dim);
 }
 

--- a/paddle/phi/kernels/gpu/unique_kernel.cu
+++ b/paddle/phi/kernels/gpu/unique_kernel.cu
@@ -25,7 +25,6 @@
 #include <iostream>
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"  // TensorToVector()
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -126,8 +125,8 @@ void IndexSelect(const Context& context,
 
   std::vector<InT> input_vec;
   std::vector<IndexT> index_vec;
-  paddle::framework::TensorToVector(input, context, &input_vec);
-  paddle::framework::TensorToVector(index, context, &index_vec);
+  phi::TensorToVector(input, context, &input_vec);
+  phi::TensorToVector(index, context, &index_vec);
   std::vector<InT> out_vec(output->numel());
 
   for (int i = 0; i < index_size; i++) {
@@ -164,7 +163,7 @@ void IndexSelect(const Context& context,
     }
   }
   context.template Alloc<IndexT>(output);
-  paddle::framework::TensorFromVector(out_vec, context, output);
+  phi::TensorFromVector(out_vec, context, output);
   output->Resize(output_dim);
 }
 

--- a/paddle/phi/kernels/impl/determinant_kernel_impl.h
+++ b/paddle/phi/kernels/impl/determinant_kernel_impl.h
@@ -20,8 +20,8 @@
 #include <cmath>
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/determinant_kernel.h"
 
 namespace phi {
@@ -71,7 +71,7 @@ struct DeterminantFunctor {
                   DenseTensor* output) {
     std::vector<T> input_vec;
     std::vector<T> output_vec;
-    paddle::framework::TensorToVector(input, dev_ctx, &input_vec);
+    phi::TensorToVector(input, dev_ctx, &input_vec);
     for (int64_t i = 0; i < batch_count; ++i) {  // maybe can be parallel
       auto begin_iter = input_vec.begin() + i * rank * rank;
       auto end_iter = input_vec.begin() + (i + 1) * rank * rank;
@@ -85,7 +85,7 @@ struct DeterminantFunctor {
       }
       output_vec.push_back(matrix.determinant());
     }
-    paddle::framework::TensorFromVector(output_vec, output);
+    phi::TensorFromVector(output_vec, dev_ctx, output);
   }
 };
 

--- a/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_grad_kernel_impl.h
@@ -205,7 +205,7 @@ void RepeatInterleaveGradKernel(const Context& ctx,
     std::fill_n(index_vec.begin() + i * repeats, repeats, i);
   }
   index.Resize(phi::make_ddim({index_size}));
-  paddle::framework::TensorFromVector<int>(index_vec, ctx, &index);
+  phi::TensorFromVector<int>(index_vec, ctx, &index);
 
   const int* index_data = index.data<int>();
   int64_t index_nums = index.numel();

--- a/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
+++ b/paddle/phi/kernels/impl/repeat_interleave_kernel_impl.h
@@ -75,7 +75,7 @@ void RepeatInterleaveKernel(const Context& ctx,
   index.Resize(phi::make_ddim({index_size}));
   if (place == cpu_place) {
     DenseTensor x_copy = x;
-    paddle::framework::TensorFromVector<int>(index_vec, &index);
+    phi::TensorFromVector<int>(index_vec, ctx, &index);
 
     auto output_dim = phi::vectorize(x.dims());
     output_dim[dim] = index_size;
@@ -85,7 +85,7 @@ void RepeatInterleaveKernel(const Context& ctx,
   } else {
     auto stride_dim = phi::stride(input_dim);
     int64_t stride = stride_dim[dim];
-    paddle::framework::TensorFromVector<int>(index_vec, ctx, &index);
+    phi::TensorFromVector<int>(index_vec, ctx, &index);
     auto stream = ctx.stream();
     auto output_dim = phi::vectorize(x.dims());
     output_dim[dim] = index_size;

--- a/paddle/phi/kernels/impl/set_value_kernel_impl.h
+++ b/paddle/phi/kernels/impl/set_value_kernel_impl.h
@@ -316,7 +316,7 @@ void SetValueKernel(const Context& dev_ctx,
     assgin_values.push_back(val.to<T>());
   }
   DenseTensor value_tensor = Empty<T>(dev_ctx, shape);
-  paddle::framework::TensorFromVector(assgin_values, dev_ctx, &value_tensor);
+  phi::TensorFromVector(assgin_values, dev_ctx, &value_tensor);
   value_tensor.Resize(phi::make_ddim(shape));
 
   SetTensorValueKernel<T, Context>(dev_ctx,

--- a/paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slogdeterminant_kernel_impl.h
@@ -18,8 +18,8 @@
 #include <cmath>
 #include <vector>
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/core/enforce.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/impl/determinant_kernel_impl.h"
 #include "paddle/phi/kernels/slogdeterminant_kernel.h"
 
@@ -41,7 +41,7 @@ struct SlogDeterminantFunctor {
     std::vector<T> sign_vec;
     std::vector<T> log_vec;
     std::vector<T> output_vec;
-    paddle::framework::TensorToVector(input, dev_ctx, &input_vec);
+    phi::TensorToVector(input, dev_ctx, &input_vec);
     for (int64_t i = 0; i < batch_count; ++i) {  // maybe can be parallel
       auto begin_iter = input_vec.begin() + i * rank * rank;
       auto end_iter = input_vec.begin() + (i + 1) * rank * rank;
@@ -65,7 +65,7 @@ struct SlogDeterminantFunctor {
     // merge sign_vec and log_vec as final output_vec
     output_vec.insert(output_vec.end(), sign_vec.begin(), sign_vec.end());
     output_vec.insert(output_vec.end(), log_vec.begin(), log_vec.end());
-    paddle::framework::TensorFromVector(output_vec, output);
+    phi::TensorFromVector(output_vec, dev_ctx, output);
   }
 };
 

--- a/paddle/phi/kernels/selected_rows/cpu/adam_kernel.cc
+++ b/paddle/phi/kernels/selected_rows/cpu/adam_kernel.cc
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/selected_rows/adam_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -60,7 +59,7 @@ void AdamDenseParamSparseGradKernel(
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
   // skip_update=true, just copy input to output, and TensorCopy will call

--- a/paddle/phi/kernels/selected_rows/cpu/adamw_kernel.cc
+++ b/paddle/phi/kernels/selected_rows/cpu/adamw_kernel.cc
@@ -14,10 +14,10 @@
 
 #include "paddle/phi/kernels/selected_rows/adamw_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/common/float16.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/tensor_utils.h"
 #include "paddle/phi/kernels/adam_kernel.h"
 #include "paddle/phi/kernels/funcs/adam_functors.h"
 #include "paddle/phi/kernels/selected_rows/adam_kernel.h"
@@ -61,7 +61,7 @@ void AdamwDenseParamSparseGradKernel(
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
   VLOG(3) << "Skip update" << skip_update_;

--- a/paddle/phi/kernels/selected_rows/gpu/adam_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/adam_kernel.cu
@@ -14,7 +14,6 @@
 
 #include "paddle/phi/kernels/selected_rows/adam_kernel.h"
 
-#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/float16.h"
@@ -129,7 +128,7 @@ void AdamDenseParamSparseGradKernel(
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
   // skip_update=true, just copy input to output, and TensorCopy will call

--- a/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
+++ b/paddle/phi/kernels/selected_rows/gpu/adamw_kernel.cu
@@ -146,7 +146,7 @@ void AdamwDenseParamSparseGradKernel(
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
 

--- a/paddle/phi/kernels/selected_rows/xpu/adam_kernel.cc
+++ b/paddle/phi/kernels/selected_rows/xpu/adam_kernel.cc
@@ -156,7 +156,7 @@ void AdamDenseParamSparseGradKernel(
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
 

--- a/paddle/phi/kernels/xpu/adam_kernel.cc
+++ b/paddle/phi/kernels/xpu/adam_kernel.cc
@@ -124,7 +124,7 @@ void AdamDenseKernel(const Context& dev_ctx,
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
 

--- a/paddle/phi/kernels/xpu/adamw_kernel.cc
+++ b/paddle/phi/kernels/xpu/adamw_kernel.cc
@@ -20,8 +20,6 @@
 #include "paddle/phi/backends/xpu/xpu_context.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/core/tensor_utils.h"
-// for TensorToVector
-#include "paddle/fluid/framework/tensor_util.h"
 
 namespace phi {
 
@@ -61,7 +59,7 @@ void AdamwDenseKernel(const Context& dev_ctx,
         errors::InvalidArgument("Input(SkipUpdate) size must be 1, but get %d",
                                 skip_update->numel()));
     std::vector<bool> skip_update_vec;
-    paddle::framework::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
+    phi::TensorToVector(*skip_update, dev_ctx, &skip_update_vec);
     skip_update_ = skip_update_vec[0];
   }
   if (skip_update_) {

--- a/paddle/phi/kernels/xpu/set_value_kernel.cc
+++ b/paddle/phi/kernels/xpu/set_value_kernel.cc
@@ -365,7 +365,7 @@ void SetValueKernel(const Context& dev_ctx,
     assgin_values.push_back(val.to<T>());
   }
   DenseTensor value_tensor = Empty<T>(dev_ctx, shape);
-  paddle::framework::TensorFromVector(assgin_values, dev_ctx, &value_tensor);
+  phi::TensorFromVector(assgin_values, dev_ctx, &value_tensor);
   value_tensor.Resize(phi::make_ddim(shape));
 
   SetTensorValueKernel<T, Context>(dev_ctx,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
PHI算子解藕代码
将TensorFromVector和TensorFromArray和TensorToVector从fluild的tensor_utils
移植到[paddle/phi/core/tensor_utils.cc](https://github.com/PaddlePaddle/Paddle/compare/develop...engineer1109:assignphi?expand=1#diff-34b30fd87d30ae6e12457e2cdb3c7d8aa608f790e9abd6a2614ca3528617d4e5)

对[paddle/phi/kernels/assign_kernel.cc](https://github.com/PaddlePaddle/Paddle/compare/develop...engineer1109:assignphi?expand=1#diff-b081b0257b5d3bf09388ddf0d6ad747b3b7d4dcb320f1d7349717bf74d0c44ef)实现fluid头文件解藕
全部的PHI算子相关部分解藕

[paddle/fluid/framework/tensor_util.h](https://github.com/PaddlePaddle/Paddle/pull/49885/files#diff-43d0a25d0b7a9677070c5989c96ff8d8f2ccecd2a2e47bb99b3060f95726a9ae)
有一个宏拼写错误 PADDLE_WITH_CUSTOM_DEICE  改为PADDLE_WITH_CUSTOM_DEVICE
