### PR TITLE
[XPU] add logical_not op.

### DIFF
--- a/paddle/phi/backends/xpu/xpu2_op_list.cc
+++ b/paddle/phi/backends/xpu/xpu2_op_list.cc
@@ -360,6 +360,7 @@ XPUOpMap& get_kl2_ops() {
       {"log_grad", XPUKernelSet({phi::DataType::FLOAT32})},
       {"log_softmax", XPUKernelSet({phi::DataType::FLOAT32})},
       {"log_softmax_grad", XPUKernelSet({phi::DataType::FLOAT32})},
+      {"logical_not", XPUKernelSet({phi::DataType::BOOL})},
       {"lookup_table_v2_grad", XPUKernelSet({phi::DataType::FLOAT32})},
       {"lookup_table_v2", XPUKernelSet({phi::DataType::FLOAT32})},
       {"masked_select",

--- a/paddle/phi/kernels/xpu/logical_kernel.cc
+++ b/paddle/phi/kernels/xpu/logical_kernel.cc
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/logical_kernel.h"
+
+#include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+namespace phi {
+
+template <typename T, typename Context>
+void LogicalNotKernel(const Context& ctx,
+                      const DenseTensor& x,
+                      DenseTensor* out) {
+  ctx.template Alloc<T>(out);
+  int r =
+      xpu::logical_not(ctx.x_context(), x.data<T>(), out->data<T>(), x.numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "logical_not");
+}
+}  // namespace phi
+
+PD_REGISTER_KERNEL(logical_not, XPU, ALL_LAYOUT, phi::LogicalNotKernel, bool) {}

--- a/python/paddle/fluid/tests/unittests/xpu/get_test_cover_info.py
+++ b/python/paddle/fluid/tests/unittests/xpu/get_test_cover_info.py
@@ -228,7 +228,8 @@ def get_xpu_op_support_types(op_name, dev_id=0):
         op_name_type = op_name + "_" + stype
         if op_name_type in ops:
             support_types.append(stype)
-
+    if len(support_types) == 0:
+        print("WARNING: support_types is EMPTY for op", op_name)
     return support_types
 
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_logical_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_logical_op_xpu.py
@@ -46,6 +46,11 @@ class XPUTestLogicalAnd(XPUOpTestWrapper):
         def set_case(self):
             self.op_type = 'logical_and'
 
+            # special range for bool dtype
+            if self.dtype == np.dtype(np.bool):
+                self.low = 0
+                self.high = 2
+
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype
             )
@@ -62,7 +67,7 @@ class XPUTestLogicalAnd(XPUOpTestWrapper):
             self.outputs = {'Out': out}
 
         def init_case(self):
-            self.dtype = np.int32
+            self.dtype = self.in_type
             self.x_shape = [2, 3, 4, 5]
             self.y_shape = [2, 3, 4, 5]
             self.low = -100
@@ -76,7 +81,7 @@ class XPUTestLogicalAnd(XPUOpTestWrapper):
 
     class XPUTestLogicalAndCase1(XPUTestLogicalAndBase):
         def init_case(self):
-            self.dtype = np.int32
+            self.dtype = self.in_type
             self.x_shape = [4, 5]
             self.y_shape = [2, 3, 4, 5]
             self.low = -100
@@ -102,6 +107,11 @@ class XPUTestLogicalOr(XPUOpTestWrapper):
         def set_case(self):
             self.op_type = 'logical_or'
 
+            # special range for bool dtype
+            if self.dtype == np.dtype(np.bool):
+                self.low = 0
+                self.high = 2
+
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype
             )
@@ -118,7 +128,7 @@ class XPUTestLogicalOr(XPUOpTestWrapper):
             self.outputs = {'Out': out}
 
         def init_case(self):
-            self.dtype = np.int32
+            self.dtype = self.in_type
             self.x_shape = [2, 3, 4, 5]
             self.y_shape = [2, 3, 4, 5]
             self.low = -100
@@ -132,7 +142,7 @@ class XPUTestLogicalOr(XPUOpTestWrapper):
 
     class XPUTestLogicalOrCase1(XPUTestLogicalOrBase):
         def init_case(self):
-            self.dtype = np.int32
+            self.dtype = self.in_type
             self.x_shape = [4, 5]
             self.y_shape = [2, 3, 4, 5]
             self.low = -100
@@ -158,6 +168,11 @@ class XPUTestLogicalXor(XPUOpTestWrapper):
         def set_case(self):
             self.op_type = 'logical_xor'
 
+            # special range for bool dtype
+            if self.dtype == np.dtype(np.bool):
+                self.low = 0
+                self.high = 2
+
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype
             )
@@ -174,7 +189,7 @@ class XPUTestLogicalXor(XPUOpTestWrapper):
             self.outputs = {'Out': out}
 
         def init_case(self):
-            self.dtype = np.int64
+            self.dtype = self.in_type
             self.x_shape = [2, 3, 4, 5]
             self.y_shape = [2, 3, 4, 5]
             self.low = -100
@@ -188,7 +203,7 @@ class XPUTestLogicalXor(XPUOpTestWrapper):
 
     class XPUTestLogicalXorCase1(XPUTestLogicalXorBase):
         def init_case(self):
-            self.dtype = np.int32
+            self.dtype = self.in_type
             self.x_shape = [4, 5]
             self.y_shape = [2, 3, 4, 5]
             self.low = -100
@@ -214,6 +229,11 @@ class XPUTestLogicalNot(XPUOpTestWrapper):
         def set_case(self):
             self.op_type = 'logical_not'
 
+            # special range for bool dtype
+            if self.dtype == np.dtype(np.bool):
+                self.low = 0
+                self.high = 2
+
             x = np.random.randint(
                 self.low, self.high, self.x_shape, dtype=self.dtype
             )
@@ -224,7 +244,7 @@ class XPUTestLogicalNot(XPUOpTestWrapper):
             self.outputs = {'Out': out}
 
         def init_case(self):
-            self.dtype = np.int32
+            self.dtype = self.in_type
             self.x_shape = [2, 3, 4, 5]
             self.low = -100
             self.high = 100


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
添加`logical_not`的XPU算子。
其它逻辑运算，例如`logical_and`、`logical_or`、`logical_xor`，已有XPU单测但是没有对应的算子实现，暂时先放着不管，只改了单测的数据类型。
另外修改了一下`get_xpu_op_support_types`函数，如果获得的类型列表为空则打印一个WARNING信息出来，便于找到“有单测但是缺实现”的算子。
