### PR TITLE
fix div 0 error of fftfreq

### DIFF
--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -1275,6 +1275,8 @@ def fftfreq(n, d=1.0, dtype=None, name=None):
             #  Tensor(shape=[5], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
             #           [ 0.        ,  0.40000001,  0.80000001, -0.80000001, -0.40000001])
     """
+    if d == 0:
+        raise ValueError("d should not be 0.")
 
     dtype = paddle.framework.get_default_dtype()
     val = 1.0 / (n * d)

--- a/python/paddle/fft.py
+++ b/python/paddle/fft.py
@@ -1275,8 +1275,8 @@ def fftfreq(n, d=1.0, dtype=None, name=None):
             #  Tensor(shape=[5], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
             #           [ 0.        ,  0.40000001,  0.80000001, -0.80000001, -0.40000001])
     """
-    if d == 0:
-        raise ValueError("d should not be 0.")
+    if d * n == 0:
+        raise ValueError("d or n should not be 0.")
 
     dtype = paddle.framework.get_default_dtype()
     val = 1.0 / (n * d)

--- a/python/paddle/fluid/tests/unittests/fft/test_fft.py
+++ b/python/paddle/fluid/tests/unittests/fft/test_fft.py
@@ -1827,6 +1827,21 @@ class TestFftFreq(unittest.TestCase):
 @parameterize(
     (TEST_CASE_NAME, 'n', 'd', 'dtype'),
     [
+        ('test_with_d0', 20, 0, 'float32'),
+    ],
+)
+class TestFftFreqException(unittest.TestCase):
+    def test_fftfreq2(self):
+        """Test fftfreq with d = 0"""
+        with paddle.fluid.dygraph.guard(self.place):
+            with self.assertRaises(self.expect_exception):
+                paddle.fft.fftfreq(self.n, self.d, self.dtype)
+
+
+@place(DEVICES)
+@parameterize(
+    (TEST_CASE_NAME, 'n', 'd', 'dtype'),
+    [
         ('test_without_d', 20, 1, 'float32'),
         ('test_with_d', 20, 0.5, 'float32'),
     ],

--- a/python/paddle/fluid/tests/unittests/fft/test_fft.py
+++ b/python/paddle/fluid/tests/unittests/fft/test_fft.py
@@ -1825,9 +1825,9 @@ class TestFftFreq(unittest.TestCase):
 
 @place(DEVICES)
 @parameterize(
-    (TEST_CASE_NAME, 'n', 'd', 'dtype'),
+    (TEST_CASE_NAME, 'n', 'd', 'dtype', 'expect_exception'),
     [
-        ('test_with_d0', 20, 0, 'float32'),
+        ('test_with_d0', 20, 0, 'float32', ValueError),
     ],
 )
 class TestFftFreqException(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/fft/test_fft.py
+++ b/python/paddle/fluid/tests/unittests/fft/test_fft.py
@@ -1827,7 +1827,9 @@ class TestFftFreq(unittest.TestCase):
 @parameterize(
     (TEST_CASE_NAME, 'n', 'd', 'dtype', 'expect_exception'),
     [
-        ('test_with_d0', 20, 0, 'float32', ValueError),
+        ('test_with_0_0', 0, 0, 'float32', ValueError),
+        ('test_with_n_0', 20, 0, 'float32', ValueError),
+        ('test_with_0_d', 0, 20, 'float32', ValueError),
     ],
 )
 class TestFftFreqException(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/49919
- https://github.com/PaddlePaddle/Paddle/issues/49927

### 解决思路
- 错误：输入参数的计算结果做除数，除数不能为0，报错
- 解决：
  - 在计算前增加数值检查，如果为0抛出错误和修改提
  - 增加单测，分别设计不同的参数输入组合，验证0除报错语句是否能够执行