### PR TITLE
[Fix deprecation warning in test] int => int32

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_one_hot.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_one_hot.py
@@ -59,7 +59,7 @@ class TrtConvertOneHotTest(TrtLayerAutoScanTest):
                         },
                         "op_outputs": {"Out": ["output_data"]},
                         "op_attrs": dics[0],
-                        "outputs_dtype": {"output_data": np.int},
+                        "outputs_dtype": {"output_data": np.int32},
                     },
                 ]
                 ops = self.generate_op_config(ops_config)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
fix np.int to np.int32

[升级飞桨代码中使用Numpy 1.20 数据类型的用法](#49949)