### PR TITLE
Fix 空指针 (Null pointer) of case 17 paddle.flip

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_flip.py
+++ b/python/paddle/fluid/tests/unittests/test_flip.py
@@ -198,6 +198,17 @@ class TestFlipTripleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+class TestFlipError(unittest.TestCase):
+    def test_axis(self):
+        paddle.enable_static()
+
+        def test_axis_rank():
+            input = fluid.data(name='input', dtype='float32', shape=[2, 3])
+            output = paddle.flip(input, axis=[[0]])
+
+        self.assertRaises(ValueError, test_axis_rank)
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1329,6 +1329,8 @@ def flip(x, axis, name=None):
     if isinstance(axis, int):
         axis = [axis]
 
+    assert np.array(axis).ndim == 1
+
     if in_dygraph_mode():
         return _C_ops.flip(x, axis)
     else:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1329,7 +1329,8 @@ def flip(x, axis, name=None):
     if isinstance(axis, int):
         axis = [axis]
 
-    assert np.array(axis).ndim == 1
+    if np.array(axis).ndim != 1:
+        raise ValueError('The axis of flip must be a list, tuple or int.')
 
     if in_dygraph_mode():
         return _C_ops.flip(x, axis)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
- #49922 
- #49927 
<!-- Describe what this PR does -->

### Solution

要求 `flip` 的 `axis` 必须为 `int` 或维度为 `1`（`tuple`|`list`|`tensor`)。