### PR TITLE
Fix 空指针 (Null pointer) of case 14 paddle.atan2

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -142,6 +142,17 @@ void KLDivInferMeta(const MetaTensor& x,
 }
 
 void Atan2InferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
+  auto x_dims = x.dims();
+  auto y_dims = y.dims();
+
+  PADDLE_ENFORCE_LE(
+      x_dims[0],
+      y_dims[0],
+      phi::errors::InvalidArgument("The count (%d) of elements of X shall not "
+                                   "greater than count (%d) of elements of Y.",
+                                   x_dims[0],
+                                   y_dims[0]));
+
   out->share_meta(x);
   if (x.dtype() == DataType::INT32 || x.dtype() == DataType::INT64 ||
       y.dtype() == DataType::INT32 || y.dtype() == DataType::INT64) {

--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -145,13 +145,22 @@ void Atan2InferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
   auto x_dims = x.dims();
   auto y_dims = y.dims();
 
-  PADDLE_ENFORCE_LE(
-      x_dims[0],
-      y_dims[0],
-      phi::errors::InvalidArgument("The count (%d) of elements of X shall not "
-                                   "greater than count (%d) of elements of Y.",
-                                   x_dims[0],
-                                   y_dims[0]));
+  PADDLE_ENFORCE_EQ(
+      x_dims.size(),
+      y_dims.size(),
+      phi::errors::InvalidArgument("The rank (%d) of X shall be same as "
+                                   "rank (%d) of Y.",
+                                   x_dims.size(),
+                                   y_dims.size()));
+
+  if (x_dims.size() > 0)
+    PADDLE_ENFORCE_LE(x_dims[0],
+                      y_dims[0],
+                      phi::errors::InvalidArgument(
+                          "The count (%d) of elements of X shall not "
+                          "greater than count (%d) of elements of Y.",
+                          x_dims[0],
+                          y_dims[0]));
 
   out->share_meta(x);
   if (x.dtype() == DataType::INT32 || x.dtype() == DataType::INT64 ||

--- a/paddle/phi/kernels/impl/atan2_kernel_impl.h
+++ b/paddle/phi/kernels/impl/atan2_kernel_impl.h
@@ -77,6 +77,14 @@ void Atan2Kernel(const Context& ctx,
   auto x_data = x.data<T>();
   auto y_data = y.data<T>();
 
+  PADDLE_ENFORCE_LE(
+      numel,
+      y.numel(),
+      phi::errors::InvalidArgument("The count (%d) of elements of X shall not "
+                                   "greater than count (%d) of elements of Y.",
+                                   numel,
+                                   y.numel()));
+
   auto* out_data = ctx.template Alloc<typename Atan2Out<T>::type>(
       out, size_t(x.numel() * sizeof(typename Atan2Out<T>::type)));
 

--- a/python/paddle/fluid/tests/unittests/test_atan2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_atan2_op.py
@@ -130,6 +130,18 @@ class TestAtan2API(unittest.TestCase):
             run(place)
 
 
+class TestAtan2Error(unittest.TestCase):
+    def test_mismatch(self):
+        paddle.enable_static()
+
+        def test_mismatch_numel():
+            X = paddle.fluid.data('X', (1,), dtype=np.float64)
+            Y = paddle.fluid.data('Y', (0,), dtype=np.float64)
+            out = paddle.atan2(X, Y)
+
+        self.assertRaises(ValueError, test_mismatch_numel)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
- #49922
- #49927 
<!-- Describe what this PR does -->

### Solution

限制 `x` 的每个变量都在 `y` 中有对应值（`x.numel() <= y.numel()`）