### PR TITLE
Fix 空指针 (Null pointer) of case 2 paddle.linalg.lu_unpack

### DIFF
--- a/paddle/phi/kernels/impl/lu_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_kernel_impl.h
@@ -494,7 +494,8 @@ void Unpack_Pivot(const Context& dev_ctx,
   setter(dev_ctx, P, static_cast<T>(0));
 
   auto batchsize = product(phi::slice_ddim(dims, 0, prank - 1));
-  batchsize = std::max(static_cast<int>(batchsize), 1);
+  if (prank == 1) batchsize = std::max(static_cast<int>(batchsize), 1);
+
   DenseTensor idt;
   for (int i = 0; i < batchsize; i++) {
     arange<Context>(dev_ctx, &idt, h);

--- a/paddle/phi/kernels/impl/lu_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_kernel_impl.h
@@ -408,8 +408,6 @@ struct OneFunctor {
       : output_(output), idtptr_(idtptr), w_(w), dim_(dim) {}
 
   HOSTDEVICE void operator()(size_t idx) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        output_, phi::errors::Fatal("Output of OneFunctor is nullptr."));
     output_[w_ * idtptr_[idx] + idx % dim_] = static_cast<T>(1);
   }
 

--- a/paddle/phi/kernels/impl/lu_unpack_kernel_impl.h
+++ b/paddle/phi/kernels/impl/lu_unpack_kernel_impl.h
@@ -51,6 +51,14 @@ void LUUnpackKernel(const Context& dev_ctx,
 
   if (unpack_pivots) {
     dev_ctx.template Alloc<T>(pmat);
+
+    PADDLE_ENFORCE_EQ(
+        pivots.dtype(),
+        phi::DataType::INT32,
+        phi::errors::InvalidArgument(
+            "The pivots of lu_unpack must be of type int32, but received [%s].",
+            pivots.dtype()));
+
     Unpack_Pivot<Context, T>(dev_ctx, pivots, pmat, m, k);
   }
 }

--- a/python/paddle/fluid/tests/unittests/test_lu_unpack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lu_unpack_op.py
@@ -200,6 +200,19 @@ class TestLU_UnpackOp3(TestLU_UnpackOp):
         self.dtype = "float64"
 
 
+# batchsize = 0
+class TestLU_UnpackOp4(TestLU_UnpackOp):
+    """
+    case 4
+    """
+
+    def config(self):
+        self.x_shape = [10, 12]
+        self.unpack_ludata = True
+        self.unpack_pivots = True
+        self.dtype = "float64"
+
+
 class TestLU_UnpackAPI(unittest.TestCase):
     def setUp(self):
         np.random.seed(2022)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
- #49922 
- #49927 
<!-- Describe what this PR does -->

### Solution

- 在问题直接发生地，`OneFunctor` 限制其写入的指针非空
- 允许 `batchsize` 为 0
- 添加了对 `pivots` 的类型检查