### PR TITLE
Fix 堆栈溢出 (stack overflow) of case3: paddle.metric.accuracy

### DIFF
--- a/paddle/phi/kernels/cpu/accuracy_kernel.cc
+++ b/paddle/phi/kernels/cpu/accuracy_kernel.cc
@@ -39,8 +39,8 @@ void AccuracyRawKernel(const Context& dev_ctx,
       inference.dims().size(),
       2,
       phi::errors::InvalidArgument(
-          "dimension(Input) of AccuracyOp must be 2, with shape "
-          "[sample_number, class_dim], But received dimension(Input) is %d",
+          "Rank(Input) of AccuracyOp must be 2, with shape "
+          "[sample_number, class_dim], But received rank(Input) is %d",
           inference.dims().size()));
 
   size_t num_samples = inference.dims()[0];
@@ -50,8 +50,8 @@ void AccuracyRawKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(label.dims().size(),
                     0,
                     phi::errors::InvalidArgument(
-                        "dimension(Label) of AccuracyOp must greater than 0, "
-                        "But received dimension(Label) is %d",
+                        "Rank(Label) of AccuracyOp must greater than 0, "
+                        "But received rank(Label) is %d",
                         label.dims().size()));
 
   PADDLE_ENFORCE_GE(

--- a/paddle/phi/kernels/cpu/accuracy_kernel.cc
+++ b/paddle/phi/kernels/cpu/accuracy_kernel.cc
@@ -35,9 +35,32 @@ void AccuracyRawKernel(const Context& dev_ctx,
   const int64_t* indices_data = indices.data<int64_t>();
   const int64_t* label_data = label.data<int64_t>();
 
+  PADDLE_ENFORCE_EQ(
+      inference.dims().size(),
+      2,
+      phi::errors::InvalidArgument(
+          "dimension(Input) of AccuracyOp must be 2, with shape "
+          "[sample_number, class_dim], But received dimension(Input) is %d",
+          inference.dims().size()));
+
   size_t num_samples = inference.dims()[0];
   size_t class_dim = inference.dims()[1];
   *accuracy_data = 0.0f;
+
+  PADDLE_ENFORCE_GT(label.dims().size(),
+                    0,
+                    phi::errors::InvalidArgument(
+                        "dimension(Label) of AccuracyOp must greater than 0, "
+                        "But received dimension(Label) is %d",
+                        label.dims().size()));
+
+  PADDLE_ENFORCE_GE(
+      label.dims()[0],
+      inference.dims()[0],
+      phi::errors::InvalidArgument("num_samples(%d) of Label should less than "
+                                   "or equal to num_samples(%d) of Input",
+                                   label.dims()[0],
+                                   num_samples));
 
   if (num_samples == 0) {
     return;

--- a/paddle/phi/kernels/gpu/accuracy_kernel.cu
+++ b/paddle/phi/kernels/gpu/accuracy_kernel.cu
@@ -86,8 +86,8 @@ void AccuracyRawKernel(const Context& dev_ctx,
       inference.dims().size(),
       2,
       phi::errors::InvalidArgument(
-          "dimension(Input) of AccuracyOp must be 2, with shape "
-          "[sample_number, class_dim], But received dimension(Input) is %d",
+          "Rank(Input) of AccuracyOp must be 2, with shape "
+          "[sample_number, class_dim], But received rank(Input) is %d",
           inference.dims().size()));
 
   int* correct_data = dev_ctx.template Alloc<int>(correct);
@@ -102,8 +102,8 @@ void AccuracyRawKernel(const Context& dev_ctx,
   PADDLE_ENFORCE_GT(label.dims().size(),
                     0,
                     phi::errors::InvalidArgument(
-                        "dimension(Label) of AccuracyOp must greater than 0, "
-                        "But received dimension(Label) is %d",
+                        "Rank(Label) of AccuracyOp must greater than 0, "
+                        "But received rank(Label) is %d",
                         label.dims().size()));
 
   PADDLE_ENFORCE_GE(

--- a/paddle/phi/kernels/gpu/accuracy_kernel.cu
+++ b/paddle/phi/kernels/gpu/accuracy_kernel.cu
@@ -82,6 +82,14 @@ void AccuracyRawKernel(const Context& dev_ctx,
   const int64_t* indices_data = indices.data<int64_t>();
   const int64_t* label_data = label.data<int64_t>();
 
+  PADDLE_ENFORCE_EQ(
+      inference.dims().size(),
+      2,
+      phi::errors::InvalidArgument(
+          "dimension(Input) of AccuracyOp must be 2, with shape "
+          "[sample_number, class_dim], But received dimension(Input) is %d",
+          inference.dims().size()));
+
   int* correct_data = dev_ctx.template Alloc<int>(correct);
   int* total_data = dev_ctx.template Alloc<int>(total);
   T* accuracy_data = dev_ctx.template Alloc<T>(accuracy);
@@ -90,6 +98,21 @@ void AccuracyRawKernel(const Context& dev_ctx,
   size_t infer_width = inference.dims()[1];
   auto stream = dev_ctx.stream();
   phi::backends::gpu::GpuMemsetAsync(accuracy_data, 0, sizeof(T), stream);
+
+  PADDLE_ENFORCE_GT(label.dims().size(),
+                    0,
+                    phi::errors::InvalidArgument(
+                        "dimension(Label) of AccuracyOp must greater than 0, "
+                        "But received dimension(Label) is %d",
+                        label.dims().size()));
+
+  PADDLE_ENFORCE_GE(
+      label.dims()[0],
+      inference.dims()[0],
+      phi::errors::InvalidArgument("num_samples(%d) of Label should less than "
+                                   "or equal to num_samples(%d) of Input",
+                                   label.dims()[0],
+                                   num_samples));
 
   if (num_samples == 0) {
     return;

--- a/python/paddle/fluid/tests/unittests/test_accuracy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_accuracy_op.py
@@ -60,7 +60,7 @@ class TestAccuracyOpFp16(TestAccuracyOp):
 
 
 class TestAccuracyOpError(unittest.TestCase):
-    def test_errors(self):
+    def test_type_errors(self):
         with program_guard(Program(), Program()):
             # The input type of accuracy_op must be Variable.
             x1 = fluid.create_lod_tensor(
@@ -75,15 +75,27 @@ class TestAccuracyOpError(unittest.TestCase):
             x2 = paddle.static.data(name='x2', shape=[-1, 4], dtype="int32")
             self.assertRaises(TypeError, paddle.static.accuracy, x2, label)
             self.assertRaises(TypeError, paddle.metric.accuracy, x2, label)
+
             x3 = paddle.static.data(
                 name='input', shape=[-1, 2], dtype="float16"
             )
             paddle.static.accuracy(input=x3, label=label)
             paddle.metric.accuracy(input=x3, label=label)
 
+    def test_value_errors(self):
+        with program_guard(Program(), Program()):
+            paddle.disable_static()
+
+            # The input rank of accuracy_op must be 2.
+            x3 = paddle.to_tensor([0.1], dtype='float32')
+            label3 = paddle.to_tensor(np.reshape([0], [1, 1]), dtype='int32')
+            with self.assertRaises(ValueError):
+                paddle.metric.accuracy(x3, label3)
+
 
 class TestAccuracyAPI1(unittest.TestCase):
     def setUp(self):
+        paddle.enable_static()
         self.predictions = paddle.static.data(
             shape=[2, 5], name="predictions", dtype="float32"
         )

--- a/python/paddle/fluid/tests/unittests/test_accuracy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_accuracy_op.py
@@ -56,7 +56,6 @@ class TestAccuracyOpFp16(TestAccuracyOp):
         self.dtype = np.float16
 
     def test_check_output(self):
-        self.enable_static()
         self.check_output(atol=1e-3)
 
 

--- a/python/paddle/fluid/tests/unittests/test_accuracy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_accuracy_op.py
@@ -56,6 +56,7 @@ class TestAccuracyOpFp16(TestAccuracyOp):
         self.dtype = np.float16
 
     def test_check_output(self):
+        self.enable_static()
         self.check_output(atol=1e-3)
 
 
@@ -87,15 +88,18 @@ class TestAccuracyOpError(unittest.TestCase):
             paddle.disable_static()
 
             # The input rank of accuracy_op must be 2.
-            x3 = paddle.to_tensor([0.1], dtype='float32')
-            label3 = paddle.to_tensor(np.reshape([0], [1, 1]), dtype='int32')
             with self.assertRaises(ValueError):
+                x3 = paddle.to_tensor([0.1], dtype='float32')
+                label3 = paddle.to_tensor(
+                    np.reshape([0], [1, 1]), dtype='int32'
+                )
                 paddle.metric.accuracy(x3, label3)
+
+            paddle.enable_static()
 
 
 class TestAccuracyAPI1(unittest.TestCase):
     def setUp(self):
-        paddle.enable_static()
         self.predictions = paddle.static.data(
             shape=[2, 5], name="predictions", dtype="float32"
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
- #49925
- #49927 
<!-- Describe what this PR does -->

### Solution

- 限制 input.ndim == 2
- 限制 label.ndim > 0
- 限制 input.shape[0] <= label.shape[0]