### PR TITLE
Fix Python IndexError of case1: paddle.linalg.lstsq

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
@@ -278,21 +278,32 @@ class LinalgLstsqTestCaseLarge2(LinalgLstsqTestCase):
         self._input_shape_2 = (50, 300)
 
 
-class LinalgLstsqTestAPIError(unittest.TestCase):
-    def test_errors(self):
+class TestLinalgLstsqAPIError(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_api_errors(self):
         def test_x_bad_shape():
-            x = paddle.to_tensor(np.random.random(size=(5)))
-            y = paddle.to_tensor(np.random.random(size=(5, 15)))
+            x = paddle.to_tensor(np.random.random(size=(5)), dtype=np.float32)
+            y = paddle.to_tensor(
+                np.random.random(size=(5, 15)), dtype=np.float32
+            )
             out = paddle.linalg.lstsq(x, y, driver='gelsy')
 
         def test_y_bad_shape():
-            x = paddle.to_tensor(np.random.random(size=(5, 10)))
-            y = paddle.to_tensor(np.random.random(size=(5)))
+            x = paddle.to_tensor(
+                np.random.random(size=(5, 10)), dtype=np.float32
+            )
+            y = paddle.to_tensor(np.random.random(size=(5)), dtype=np.float32)
             out = paddle.linalg.lstsq(x, y, driver='gelsy')
 
         def test_shape_dismatch():
-            x = paddle.to_tensor(np.random.random(size=(5, 10)))
-            y = paddle.to_tensor(np.random.random(size=(4, 15)))
+            x = paddle.to_tensor(
+                np.random.random(size=(5, 10)), dtype=np.float32
+            )
+            y = paddle.to_tensor(
+                np.random.random(size=(4, 15)), dtype=np.float32
+            )
             out = paddle.linalg.lstsq(x, y, driver='gelsy')
 
         self.assertRaises(ValueError, test_x_bad_shape)

--- a/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
+++ b/python/paddle/fluid/tests/unittests/test_linalg_lstsq_op.py
@@ -278,5 +278,27 @@ class LinalgLstsqTestCaseLarge2(LinalgLstsqTestCase):
         self._input_shape_2 = (50, 300)
 
 
+class LinalgLstsqTestAPIError(unittest.TestCase):
+    def test_errors(self):
+        def test_x_bad_shape():
+            x = paddle.to_tensor(np.random.random(size=(5)))
+            y = paddle.to_tensor(np.random.random(size=(5, 15)))
+            out = paddle.linalg.lstsq(x, y, driver='gelsy')
+
+        def test_y_bad_shape():
+            x = paddle.to_tensor(np.random.random(size=(5, 10)))
+            y = paddle.to_tensor(np.random.random(size=(5)))
+            out = paddle.linalg.lstsq(x, y, driver='gelsy')
+
+        def test_shape_dismatch():
+            x = paddle.to_tensor(np.random.random(size=(5, 10)))
+            y = paddle.to_tensor(np.random.random(size=(4, 15)))
+            out = paddle.linalg.lstsq(x, y, driver='gelsy')
+
+        self.assertRaises(ValueError, test_x_bad_shape)
+        self.assertRaises(ValueError, test_y_bad_shape)
+        self.assertRaises(ValueError, test_shape_dismatch)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3171,30 +3171,22 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
     else:
         raise RuntimeError("Only support lstsq api for CPU or CUDA device.")
 
-    if x.dtype == y.dtype and x.dtype in (paddle.float32, paddle.float64):
-        pass
-    else:
+    if not (x.dtype == y.dtype and x.dtype in (paddle.float32, paddle.float64)):
         raise ValueError(
             "Only support x and y have the same dtype such as 'float32' and 'float64'."
         )
 
-    if x.ndim >= 2:
-        pass
-    else:
+    if x.ndim < 2:
         raise ValueError(
             f"The shape of x should be (*, M, N), but received ndim is [{x.ndim} < 2]"
         )
 
-    if y.ndim >= 2:
-        pass
-    else:
+    if y.ndim < 2:
         raise ValueError(
             f"The shape of y should be (*, M, K), but received ndim is [{y.ndim} < 2]"
         )
 
-    if x.shape[-2] == y.shape[-2]:
-        pass
-    else:
+    if x.shape[-2] != y.shape[-2]:
         raise ValueError(
             f"x with shape (*, M = {x.shape[-2]}, N) and y with shape (*, M = {y.shape[-2]}, K) should have same M."
         )

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3178,11 +3178,26 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             "Only support x and y have the same dtype such as 'float32' and 'float64'."
         )
 
-    assert x.ndim >= 2, "the shape of x should be (*, M, N)"
-    assert y.ndim >= 2, "the shape of y should be (*, M, K)"
-    assert (
-        x.shape[-2] == y.shape[-2]
-    ), "x with shape (*, M, N) and y with shape (*, M, K) should have same M."
+    if x.ndim >= 2:
+        pass
+    else:
+        raise ValueError(
+            f"The shape of x should be (*, M, N), but received ndim is [{x.ndim} < 2]"
+        )
+
+    if y.ndim >= 2:
+        pass
+    else:
+        raise ValueError(
+            f"The shape of y should be (*, M, K), but received ndim is [{y.ndim} < 2]"
+        )
+
+    if x.shape[-2] == y.shape[-2]:
+        pass
+    else:
+        raise ValueError(
+            f"x with shape (*, M = {x.shape[-2]}, N) and y with shape (*, M = {y.shape[-2]}, K) should have same M."
+        )
 
     if rcond is None:
         if x.dtype == paddle.float32:

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3178,6 +3178,12 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             "Only support x and y have the same dtype such as 'float32' and 'float64'."
         )
 
+    assert x.ndim >= 2, f'the shape of x should be (*, M, N), but got {x.shape}'
+    assert y.ndim >= 2, f'the shape of y should be (*, M, K), but got {y.shape}'
+    assert (
+        x.shape[-2] == y.shape[-2]
+    ), f'x with shape (*, M({x.shape[-2]}), N({x.shape[-1]})) and y with shape (*, M({y.shape[-2]}), K({y.shape[-1]})) should have same M, but M={x.shape[-2]} in x and {y.shape[-2]} in y.'
+
     if rcond is None:
         if x.dtype == paddle.float32:
             rcond = 1e-7 * max(x.shape[-2], x.shape[-1])

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -3178,11 +3178,11 @@ def lstsq(x, y, rcond=None, driver=None, name=None):
             "Only support x and y have the same dtype such as 'float32' and 'float64'."
         )
 
-    assert x.ndim >= 2, f'the shape of x should be (*, M, N), but got {x.shape}'
-    assert y.ndim >= 2, f'the shape of y should be (*, M, K), but got {y.shape}'
+    assert x.ndim >= 2, "the shape of x should be (*, M, N)"
+    assert y.ndim >= 2, "the shape of y should be (*, M, K)"
     assert (
         x.shape[-2] == y.shape[-2]
-    ), f'x with shape (*, M({x.shape[-2]}), N({x.shape[-1]})) and y with shape (*, M({y.shape[-2]}), K({y.shape[-1]})) should have same M, but M={x.shape[-2]} in x and {y.shape[-2]} in y.'
+    ), "x with shape (*, M, N) and y with shape (*, M, K) should have same M."
 
     if rcond is None:
         if x.dtype == paddle.float32:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
- #49923
- #49927 
<!-- Describe what this PR does -->

### Solution

- 限制 x, y 的 ndim >= 2
- 限制 x.shape[-2] == y.shape[-2]