### PR TITLE
Fix Python IndexError of case4: paddle.optimizer.lr.PiecewiseDecay

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
@@ -728,6 +728,12 @@ class TestLRScheduler(unittest.TestCase):
                 step_size_down=-1,
                 scale_mode='test',
             )
+        # check empty boundaries
+        with self.assertRaises(ValueError):
+            paddle.optimizer.lr.PiecewiseDecay(boundaries=[], values=[])
+        # check non-empty boundaries but empty values
+        with self.assertRaises(ValueError):
+            paddle.optimizer.lr.PiecewiseDecay(boundaries=[100, 200], values=[])
 
         func_api_kwargs = [
             (

--- a/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_lr_scheduler.py
@@ -734,6 +734,11 @@ class TestLRScheduler(unittest.TestCase):
         # check non-empty boundaries but empty values
         with self.assertRaises(ValueError):
             paddle.optimizer.lr.PiecewiseDecay(boundaries=[100, 200], values=[])
+        # check boundaries and values has same length
+        with self.assertRaises(ValueError):
+            paddle.optimizer.lr.PiecewiseDecay(
+                boundaries=[100, 200], values=[0.5, 0.1]
+            )
 
         func_api_kwargs = [
             (

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -391,9 +391,9 @@ class PiecewiseDecay(LRScheduler):
         if len(boundaries) == 0:
             raise ValueError('The boundaries cannot be empty.')
 
-        if len(values) < len(boundaries):
+        if len(values) <= len(boundaries):
             raise ValueError(
-                f'The length ({len(values)}) of values should >= length ({len(boundaries)}) of boundaries.'
+                f'The values have one more element than boundaries, but received len(values) [{len(values)}] < len(boundaries) + 1 [{len(boundaries) + 1}].'
             )
 
         self.boundaries = boundaries

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -388,14 +388,10 @@ class PiecewiseDecay(LRScheduler):
     """
 
     def __init__(self, boundaries, values, last_epoch=-1, verbose=False):
-        if len(boundaries) > 0:
-            pass
-        else:
+        if len(boundaries) == 0:
             raise ValueError('The boundaries cannot be empty.')
 
-        if len(values) >= len(boundaries):
-            pass
-        else:
+        if len(values) < len(boundaries):
             raise ValueError(
                 f'The length ({len(values)}) of values should >= length ({len(boundaries)}) of boundaries.'
             )

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -388,6 +388,12 @@ class PiecewiseDecay(LRScheduler):
     """
 
     def __init__(self, boundaries, values, last_epoch=-1, verbose=False):
+        assert len(boundaries) != 0, 'boundaries cannot be empty.'
+        assert len(values) != 0, 'values cannot be empty.'
+        assert len(values) >= len(
+            boundaries
+        ), 'len(values) should >= len(boundaries)'
+
         self.boundaries = boundaries
         self.values = values
         super().__init__(last_epoch=last_epoch, verbose=verbose)

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -388,11 +388,17 @@ class PiecewiseDecay(LRScheduler):
     """
 
     def __init__(self, boundaries, values, last_epoch=-1, verbose=False):
-        assert len(boundaries) != 0, 'boundaries cannot be empty.'
-        assert len(values) != 0, 'values cannot be empty.'
-        assert len(values) >= len(
-            boundaries
-        ), 'len(values) should >= len(boundaries)'
+        if len(boundaries) > 0:
+            pass
+        else:
+            raise ValueError('The boundaries cannot be empty.')
+
+        if len(values) >= len(boundaries):
+            pass
+        else:
+            raise ValueError(
+                f'The length ({len(values)}) of values should >= length ({len(boundaries)}) of boundaries.'
+            )
 
         self.boundaries = boundaries
         self.values = values

--- a/python/paddle/tests/test_callback_reduce_lr_on_plateau.py
+++ b/python/paddle/tests/test_callback_reduce_lr_on_plateau.py
@@ -88,7 +88,7 @@ class TestReduceLROnPlateau(unittest.TestCase):
 
         optim = paddle.optimizer.Adam(
             learning_rate=paddle.optimizer.lr.PiecewiseDecay(
-                [0.001, 0.0001], [5, 10]
+                [0.001, 0.0001, 0.0001], [5, 10]
             ),
             parameters=net.parameters(),
         )

--- a/python/paddle/tests/test_callback_reduce_lr_on_plateau.py
+++ b/python/paddle/tests/test_callback_reduce_lr_on_plateau.py
@@ -88,7 +88,7 @@ class TestReduceLROnPlateau(unittest.TestCase):
 
         optim = paddle.optimizer.Adam(
             learning_rate=paddle.optimizer.lr.PiecewiseDecay(
-                [0.001, 0.0001, 0.0001], [5, 10]
+                [0.001, 0.0001], [5, 10, 10]
             ),
             parameters=net.parameters(),
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
- #49923
- #49927 
<!-- Describe what this PR does -->

### Solution

- 限制 boundaries 和 values 非空