### PR TITLE
Fix Python IndexError of case9: paddle.static.nn.deform_conv2d

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_deform_conv2d.py
+++ b/python/paddle/fluid/tests/unittests/test_deform_conv2d.py
@@ -726,5 +726,23 @@ class TestDeformConv2DFunctionalWithGroups(TestDeformConv2DFunctional):
         self.no_bias = False
 
 
+class TestDeformConv2DError(unittest.TestCase):
+    def test_input_error(self):
+        def test_input_rank_error():
+            paddle.enable_static()
+            x = paddle.static.data(name='error_x_1', shape=[0], dtype='float32')
+            offset = paddle.static.data(
+                name='error_offset_1', shape=[0], dtype='float32'
+            )
+            mask = paddle.static.data(
+                name='error_mask_1', shape=[0, 0, 0], dtype='float32'
+            )
+            out = paddle.static.nn.deform_conv2d(
+                x, offset, mask, 0, 0, deformable_groups=0
+            )
+
+        self.assertRaises(ValueError, test_input_rank_error)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -2241,6 +2241,11 @@ def deformable_conv(
         mask, 'mask', (paddle.static.Variable, type(None)), 'deformable_conv'
     )
 
+    if input.ndim != 4:
+        raise ValueError(
+            f'The input should be of [N, C, H, W] format, but received {input.shape}'
+        )
+
     num_channels = input.shape[1]
     assert param_attr is not False, "param_attr should not be False here."
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
- #49923
- #49927 
<!-- Describe what this PR does -->

### Solution

- 限制 input.ndim == 4