### PR TITLE
Fix Python IndexError of case16: paddle.nn.functional.max_unpool2d/max_unpool3d

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool3d_op.py
@@ -195,6 +195,20 @@ class TestUnpool3DOpException(unittest.TestCase):
             ).astype("int32")
             F.max_unpool3d(data, indices, kernel_size=2, stride=2)
 
+        def x_rank_error():
+            data = paddle.rand(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 27), shape=[1, 1, 3, 3, 3]
+            ).astype("int32")
+            F.max_unpool3d(data, indices, kernel_size=2, stride=2)
+
+        def indices_rank_error():
+            data = paddle.rand(shape=[1, 1, 3, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 27), shape=[1, 3, 3, 3]
+            ).astype("int32")
+            F.max_unpool3d(data, indices, kernel_size=2, stride=2)
+
         def indices_value_error():
             data = paddle.rand(shape=[1, 1, 3, 3, 3])
             indices = paddle.reshape(
@@ -237,6 +251,16 @@ class TestUnpool3DOpException(unittest.TestCase):
             ValueError,
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"The x should have \[N, C, D, H, W\] format",
+            x_rank_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"The indices should have \[N, C, D, H, W\] format",
+            indices_rank_error,
         )
         if not core.is_compiled_with_cuda():
             self.assertRaisesRegex(

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -193,6 +193,20 @@ class TestUnpoolOpException(unittest.TestCase):
             ).astype("int32")
             F.max_unpool2d(data, indices, kernel_size=2, stride=2)
 
+        def x_rank_error():
+            data = paddle.rand(shape=[1, 1, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 9), shape=[1, 1, 3, 3]
+            ).astype("int32")
+            F.max_unpool2d(data, indices, kernel_size=2, stride=2)
+
+        def indices_rank_error():
+            data = paddle.rand(shape=[1, 1, 3, 3])
+            indices = paddle.reshape(
+                paddle.arange(0, 9), shape=[1, 3, 3]
+            ).astype("int32")
+            F.max_unpool2d(data, indices, kernel_size=2, stride=2)
+
         def indices_value_error():
             data = paddle.rand(shape=[1, 1, 3, 3])
             indices = paddle.reshape(
@@ -231,6 +245,16 @@ class TestUnpoolOpException(unittest.TestCase):
             ValueError,
             r"The dimensions of Input\(X\) must equal to",
             indices_size_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"The x should have \[N, C, H, W\] format",
+            x_rank_error,
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            r"The indices should have \[N, C, H, W\] format",
+            indices_rank_error,
         )
         if not core.is_compiled_with_cuda():
             self.assertRaisesRegex(

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -927,6 +927,15 @@ def max_unpool2d(
             # unpool_out shape: [1, 1, 7, 7]
 
     """
+    if x.ndim != 4:
+        raise ValueError(
+            f'The x should have [N, C, H, W] format, but received {x.shape}.'
+        )
+    if indices.ndim != 4:
+        raise ValueError(
+            f'The indices should have [N, C, H, W] format, but received {indices.shape}.'
+        )
+
     kernel_size = utils.convert_to_list(kernel_size, 2, 'pool_size')
     if stride is None:
         stride = kernel_size
@@ -1061,6 +1070,15 @@ def max_unpool3d(
             # unpool_out shape: [1, 1, 4, 4, 6]
 
     """
+    if x.ndim != 5:
+        raise ValueError(
+            f'The x should have [N, C, D, H, W] format, but received {x.shape}.'
+        )
+    if indices.ndim != 5:
+        raise ValueError(
+            f'The indices should have [N, C, D, H, W] format, but received {indices.shape}.'
+        )
+
     kernel_size = utils.convert_to_list(kernel_size, 3, 'pool_size')
     if stride is None:
         stride = kernel_size


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
- #49923
- #49927 

### Solution

- 限制 x.ndim 和 indices.ndim 为对应函数说明中的值