### PR TITLE
Fix UFA非法地址访问(UFA illegal address access) of case1: paddle.vision.ops.nms

### DIFF
--- a/paddle/phi/kernels/cpu/nms_kernel.cc
+++ b/paddle/phi/kernels/cpu/nms_kernel.cc
@@ -69,6 +69,18 @@ void NMSKernel(const Context& dev_ctx,
                const DenseTensor& boxes,
                float threshold,
                DenseTensor* output) {
+  PADDLE_ENFORCE_EQ(
+      boxes.dims().size(),
+      2,
+      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                   boxes.dims()));
+
+  PADDLE_ENFORCE_EQ(
+      boxes.dims()[1],
+      4,
+      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                   boxes.dims()));
+
   int64_t num_boxes = boxes.dims()[0];
   DenseTensor output_tmp;
   output_tmp.Resize(phi::make_ddim({num_boxes}));

--- a/paddle/phi/kernels/gpu/nms_kernel.cu
+++ b/paddle/phi/kernels/gpu/nms_kernel.cu
@@ -59,6 +59,18 @@ void NMSKernel(const Context& dev_ctx,
                const DenseTensor& boxes,
                float threshold,
                DenseTensor* output) {
+  PADDLE_ENFORCE_EQ(
+      boxes.dims().size(),
+      2,
+      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                   boxes.dims()));
+
+  PADDLE_ENFORCE_EQ(
+      boxes.dims()[1],
+      4,
+      phi::errors::InvalidArgument("The shape [%s] of boxes must be (N, 4).",
+                                   boxes.dims()));
+
   const int64_t num_boxes = boxes.dims()[0];
   const auto blocks_per_line = CeilDivide(num_boxes, threadsPerBlock);
   dim3 block(threadsPerBlock);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
- #49924
- #49927 

### Solution

- 限制 `boxes` 形状为 `[N, 4]`