### PR TITLE
Fix UFA非法地址访问(UFA illegal address access) of case3: paddle.crop

### DIFF
--- a/paddle/phi/kernels/impl/crop_kernel_impl.h
+++ b/paddle/phi/kernels/impl/crop_kernel_impl.h
@@ -121,17 +121,6 @@ void CropTensorFunction(const Context& dev_ctx,
                           offsets_vec[i],
                           shape_vec[i],
                           i));
-
-    PADDLE_ENFORCE_GE(offsets_vec[i] + shape_vec[i],
-                      0,
-                      errors::InvalidArgument(
-                          "The sum of the %uth elements of "
-                          "offsets (%d) and shape (%d) of Op(crop_tensor) "
-                          "should be greater than or "
-                          "equal to 0.",
-                          i,
-                          offsets_vec[i],
-                          shape_vec[i]));
   }
 
   auto x_tensor = EigenTensor<T, D>::From(x);

--- a/paddle/phi/kernels/impl/crop_kernel_impl.h
+++ b/paddle/phi/kernels/impl/crop_kernel_impl.h
@@ -100,6 +100,16 @@ void CropTensorFunction(const Context& dev_ctx,
   out->Resize(out_dims);
   dev_ctx.template Alloc<T>(out);
   for (size_t i = 0; i < offsets_vec.size(); ++i) {
+    PADDLE_ENFORCE_GE(
+        offsets_vec[i],
+        0,
+        errors::InvalidArgument("The offsets (%d) of the %uth elements of"
+                                " Op(crop_tensor) "
+                                "should be greater than or "
+                                "equal to 0.",
+                                offsets_vec[i],
+                                i));
+
     PADDLE_ENFORCE_LE(offsets_vec[i] + shape_vec[i],
                       x_dims[i],
                       errors::InvalidArgument(
@@ -111,6 +121,17 @@ void CropTensorFunction(const Context& dev_ctx,
                           offsets_vec[i],
                           shape_vec[i],
                           i));
+
+    PADDLE_ENFORCE_GE(offsets_vec[i] + shape_vec[i],
+                      0,
+                      errors::InvalidArgument(
+                          "The sum of the %uth elements of "
+                          "offsets (%d) and shape (%d) of Op(crop_tensor) "
+                          "should be greater than or "
+                          "equal to 0.",
+                          i,
+                          offsets_vec[i],
+                          shape_vec[i]));
   }
 
   auto x_tensor = EigenTensor<T, D>::From(x);

--- a/python/paddle/fluid/tests/unittests/test_crop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_crop_op.py
@@ -149,6 +149,13 @@ class TestCropNoneShape(unittest.TestCase):
         self.assertEqual(crop.shape, (3, 6, 6))
 
 
+class TestCropError(unittest.TestCase):
+    def test_neg_offset_error(self):
+        with self.assertRaises(ValueError):
+            x = fluid.data(name='input2', shape=[1], dtype="float32")
+            out = paddle.crop(x, offsets=[-1])
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
- #49924
- #49927 

### Solution

- 添加了对 offset 的下限检查
- 添加了对 offset+shape 的下限检查