### PR TITLE
Fix UFA非法地址访问(UFA illegal address access) of case4: paddle.unbind

### DIFF
--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4235,12 +4235,12 @@ void UnbindInferMeta(const MetaTensor& x,
   PADDLE_ENFORCE_GE(
       axis,
       -in_dims.size(),
-      phi::error::InvalidArgument(
+      phi::errors::InvalidArgument(
           "axis must be in range(%d, %d).", -in_dims.size(), in_dims.size()));
   PADDLE_ENFORCE_LT(
       axis,
       in_dims.size(),
-      phi::error::InvalidArgument(
+      phi::errors::InvalidArgument(
           "axis must be in range(%d, %d).", -in_dims.size(), in_dims.size()));
 
   axis = axis < 0 ? in_dims.size() + axis : axis;

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4231,7 +4231,20 @@ void UnbindInferMeta(const MetaTensor& x,
                      std::vector<MetaTensor*> outs) {
   auto in_dims = x.dims();
   std::vector<int> out_dim;
+
+  PADDLE_ENFORCE_GE(
+      axis,
+      -in_dims.size(),
+      phi::error::InvalidArgument(
+          "axis must be in range(%d, %d).", -in_dims.size(), in_dims.size()));
+  PADDLE_ENFORCE_LT(
+      axis,
+      in_dims.size(),
+      phi::error::InvalidArgument(
+          "axis must be in range(%d, %d).", -in_dims.size(), in_dims.size()));
+
   axis = axis < 0 ? in_dims.size() + axis : axis;
+
   for (int i = 0; i < in_dims.size(); ++i) {
     if (i != axis) out_dim.push_back(in_dims[i]);
   }

--- a/python/paddle/fluid/tests/unittests/test_unbind_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unbind_op.py
@@ -25,6 +25,7 @@ from paddle.fluid import Program, program_guard
 
 class TestUnbind(unittest.TestCase):
     def test_unbind(self):
+        paddle.enable_static()
 
         x_1 = fluid.data(shape=[2, 3], dtype='float32', name='x_1')
         [out_0, out_1] = tensor.unbind(input=x_1, axis=0)
@@ -59,6 +60,7 @@ class TestUnbind(unittest.TestCase):
 
 class TestLayersUnbind(unittest.TestCase):
     def test_layers_unbind(self):
+        paddle.enable_static()
 
         x_1 = fluid.data(shape=[2, 3], dtype='float32', name='x_1')
         [out_0, out_1] = paddle.unbind(input=x_1, axis=0)

--- a/python/paddle/fluid/tests/unittests/test_unbind_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unbind_op.py
@@ -216,6 +216,11 @@ class TestUnbindAxisError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_table_Variable)
 
+            def test_invalid_axis():
+                tensor.unbind(input=x, axis=2)
+
+            self.assertRaises(ValueError, test_invalid_axis)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2751,9 +2751,6 @@ def unbind(input, axis=0):
             # x2.shape [3, 5]
             # x3.shape [3, 5]
     """
-    if isinstance(axis, np.generic):
-        axis = axis.item()
-
     if not isinstance(axis, (int)):
         raise TypeError(
             "The type of 'axis'  must be int, but received %s." % (type(axis))

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2751,20 +2751,22 @@ def unbind(input, axis=0):
             # x2.shape [3, 5]
             # x3.shape [3, 5]
     """
-    assert axis in range(
-        -input.ndim, input.ndim
-    ), f'The axis must in range({-input.ndim}, {input.ndim})'
+    if isinstance(axis, np.generic):
+        axis = axis.item()
+
+    if not isinstance(axis, (int)):
+        raise TypeError(
+            "The type of 'axis'  must be int, but received %s." % (type(axis))
+        )
+
+    if axis not in range(-input.ndim, input.ndim):
+        raise ValueError(
+            f'The axis must in range({-input.ndim}, {input.ndim}).'
+        )
 
     if in_dygraph_mode():
         return _C_ops.unbind(input, axis)
     else:
-        if not isinstance(axis, (int)):
-            raise TypeError(
-                "The type of 'axis'  must be int, but received %s."
-                % (type(axis))
-            )
-        if isinstance(axis, np.generic):
-            axis = np.asscalar(axis)
         input_shape = input.shape
         axis_ = axis if axis >= 0 else len(input_shape) + axis
         num = input_shape[axis_]

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2751,6 +2751,10 @@ def unbind(input, axis=0):
             # x2.shape [3, 5]
             # x3.shape [3, 5]
     """
+    assert axis in range(
+        -input.ndim, input.ndim
+    ), f'The axis must in range({-input.ndim}, {input.ndim})'
+
     if in_dygraph_mode():
         return _C_ops.unbind(input, axis)
     else:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -2764,6 +2764,8 @@ def unbind(input, axis=0):
     if in_dygraph_mode():
         return _C_ops.unbind(input, axis)
     else:
+        if isinstance(axis, np.generic):
+            axis = np.asscalar(axis)
         input_shape = input.shape
         axis_ = axis if axis >= 0 else len(input_shape) + axis
         num = input_shape[axis_]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
- #49924
- #49927 

### Solution

- 在 Python 端添加了对 axis 的检查
- 更新单元测试使适配新版本 Paddle
- 在 inferMeta 中添加对 axis 范围的检查