### PR TITLE
fix div 0 error in conv1_transpose

### DIFF
--- a/paddle/phi/kernels/funcs/concat_and_split_functor.cc
+++ b/paddle/phi/kernels/funcs/concat_and_split_functor.cc
@@ -37,6 +37,11 @@ struct ConcatFunctor<phi::CPUContext, T> {
     }
     int64_t out_rows = rows, out_cols = 0;
 
+    PADDLE_ENFORCE_NE(
+        rows,
+        0,
+        phi::errors::InvalidArgument("The input size should not be 0."));
+
     std::vector<int64_t> input_cols(input.size());
     for (size_t i = 0; i < num; ++i) {
       int64_t t_cols = input[i].numel() / rows;

--- a/python/paddle/fluid/tests/unittests/test_functional_conv1d_transpose.py
+++ b/python/paddle/fluid/tests/unittests/test_functional_conv1d_transpose.py
@@ -82,5 +82,17 @@ class TestFunctionalConv1DErrorCase2(TestFunctionalConv1DError):
         self.data_format = "NCL"
 
 
+class TestFunctionalConv1DErrorCase3(TestFunctionalConv1DError):
+    def setUp(self):
+        self.input = np.random.randn(6, 0, 6)
+        self.filter = np.random.randn(6, 0, 0)
+        self.bias = None
+        self.padding = 0
+        self.stride = 1
+        self.dilation = 1
+        self.groups = 1
+        self.data_format = "NCL"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
related issues
- https://github.com/PaddlePaddle/Paddle/issues/49919
- https://github.com/PaddlePaddle/Paddle/issues/49927
### Notes
由于Conv3d的单测一直写的有点问题，暂时只提conv1d_transpose的单测