### PR TITLE
Fix div 0 error of case10: paddle.nn.functional.max_pool2d/max_pool3d

### DIFF
--- a/paddle/phi/kernels/funcs/pooling.h
+++ b/paddle/phi/kernels/funcs/pooling.h
@@ -371,6 +371,13 @@ inline int PoolOutputSize(int input_size,
                           int padding_2,
                           int stride,
                           bool ceil_mode) {
+  PADDLE_ENFORCE_NE(
+      stride,
+      0,
+      phi::errors::InvalidArgument(
+          "The stride of PoolOutputSize shall not be 0, but received %d.",
+          stride));
+
   int output_size;
   if (!ceil_mode) {
     output_size =

--- a/python/paddle/fluid/tests/unittests/test_pool1d_api.py
+++ b/python/paddle/fluid/tests/unittests/test_pool1d_api.py
@@ -429,6 +429,16 @@ class TestPool1DError_API(unittest.TestCase):
 
         self.assertRaises(ValueError, run_zero_stride)
 
+        def run_zero_tuple_stride():
+            with fluid.dygraph.guard():
+                array = np.array([1], dtype=np.float32)
+                x = paddle.to_tensor(
+                    np.reshape(array, [1, 1, 1]), dtype='float32'
+                )
+                out = F.max_pool1d(x, 1, stride=(0))
+
+        self.assertRaises(ValueError, run_zero_tuple_stride)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_pool2d_api.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_api.py
@@ -609,6 +609,18 @@ class TestPool2DError_API(unittest.TestCase):
 
         self.assertRaises(ValueError, run_zero_stride)
 
+        def run_zero_tuple_stride():
+            with fluid.dygraph.guard():
+                array = np.array([1], dtype=np.float32)
+                x = paddle.to_tensor(
+                    np.reshape(array, [1, 1, 1, 1]), dtype='float32'
+                )
+                out = max_pool2d(
+                    x, 1, stride=(0, 0), return_mask=False, data_format='NHWC'
+                )
+
+        self.assertRaises(ValueError, run_zero_tuple_stride)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_pool3d_api.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_api.py
@@ -575,6 +575,16 @@ class TestPool3DError_API(unittest.TestCase):
 
         self.assertRaises(ValueError, run_zero_stride)
 
+        def run_zero_tuple_stride():
+            with fluid.dygraph.guard():
+                array = np.array([1], dtype=np.float32)
+                x = paddle.to_tensor(
+                    np.reshape(array, [1, 1, 1, 1, 1]), dtype='float32'
+                )
+                out = max_pool3d(x, 1, stride=(0, 0, 0), ceil_mode=False)
+
+        self.assertRaises(ValueError, run_zero_tuple_stride)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
- #49919
- #49927 

### Solution

- 限制 stride != 0