### PR TITLE
[Numpy]Fix NumpyScaler2Tensor dtype error

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_npscaler_to_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_npscaler_to_tensor.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+DTYPE_MAP = {
+    paddle.bool: np.bool_,
+    paddle.int32: np.int32,
+    paddle.int64: np.int64,
+    paddle.float16: np.float16,
+    paddle.float32: np.float32,
+    paddle.float64: np.float64,
+    paddle.complex64: np.complex64,
+}
+
+
+class NumpyScaler2Tensor(unittest.TestCase):
+    def setUp(self):
+        self.dtype = np.float32
+        self.x_np = np.array([1], dtype=self.dtype)[0]
+
+    def test_dynamic_scaler2tensor(self):
+        paddle.disable_static()
+        x = paddle.to_tensor(self.x_np)
+        self.assertEqual(DTYPE_MAP[x.dtype], self.dtype)
+        self.assertEqual(x.numpy(), self.x_np)
+        if self.dtype in [
+            np.bool_
+        ]:  # bool is not supported convert to 0D-Tensor
+            return
+        self.assertEqual(len(x.shape), 0)
+
+    def test_static_scaler2tensor(self):
+        if self.dtype in [np.float16, np.complex64]:
+            return
+        paddle.enable_static()
+        x = paddle.to_tensor(self.x_np)
+        self.assertEqual(DTYPE_MAP[x.dtype], self.dtype)
+        if self.dtype in [
+            np.bool_,
+            np.float64,
+        ]:  # bool is not supported convert to 0D-Tensor and float64 not supported in static mode
+            return
+        self.assertEqual(len(x.shape), 0)
+
+
+class NumpyScaler2TensorBool(NumpyScaler2Tensor):
+    def setUp(self):
+        self.dtype = np.bool_
+        self.x_np = np.array([1], dtype=self.dtype)[0]
+
+
+class NumpyScaler2TensorFloat16(NumpyScaler2Tensor):
+    def setUp(self):
+        self.dtype = np.float16
+        self.x_np = np.array([1], dtype=self.dtype)[0]
+
+
+class NumpyScaler2TensorFloat64(NumpyScaler2Tensor):
+    def setUp(self):
+        self.dtype = np.float64
+        self.x_np = np.array([1], dtype=self.dtype)[0]
+
+
+class NumpyScaler2TensorInt32(NumpyScaler2Tensor):
+    def setUp(self):
+        self.dtype = np.int32
+        self.x_np = np.array([1], dtype=self.dtype)[0]
+
+
+class NumpyScaler2TensorInt64(NumpyScaler2Tensor):
+    def setUp(self):
+        self.dtype = np.int64
+        self.x_np = np.array([1], dtype=self.dtype)[0]
+
+
+class NumpyScaler2TensorComplex64(NumpyScaler2Tensor):
+    def setUp(self):
+        self.dtype = np.complex64
+        self.x_np = np.array([1], dtype=self.dtype)[0]

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -533,6 +533,9 @@ def logspace(start, stop, num, base=10.0, dtype=None, name=None):
 
 def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
 
+    if isinstance(data, np.number):  # Special case for numpy scalars
+        data = np.array(data)
+
     if not isinstance(data, np.ndarray):
 
         def _handle_dtype(data, dtype):
@@ -627,6 +630,8 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
     if isinstance(data, Variable) and (dtype is None or dtype == data.dtype):
         output = data
     else:
+        if isinstance(data, np.number):  # Special case for numpy scalars
+            data = np.array(data)
 
         if not isinstance(data, np.ndarray):
             if np.isscalar(data) and not isinstance(data, str):
@@ -689,6 +694,16 @@ def to_tensor(data, dtype=None, place=None, stop_gradient=True):
 
     If the ``data`` is already a Tensor, copy will be performed and return a new tensor.
     If you only want to change stop_gradient property, please call ``Tensor.stop_gradient = stop_gradient`` directly.
+
+    We use the dtype conversion rules following this:
+               Keep dtype
+    np.number ───────────► paddle.Tensor
+                            (0D-Tensor)
+                   default_dtype
+    Python Number ───────────────► paddle.Tensor
+                                    (1D-Tensor)
+                Keep dtype
+    np.ndarray ───────────► paddle.Tensor
 
     Args:
         data(scalar|tuple|list|ndarray|Tensor): Initial data for the tensor.

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -695,15 +695,17 @@ def to_tensor(data, dtype=None, place=None, stop_gradient=True):
     If the ``data`` is already a Tensor, copy will be performed and return a new tensor.
     If you only want to change stop_gradient property, please call ``Tensor.stop_gradient = stop_gradient`` directly.
 
-    We use the dtype conversion rules following this:
-               Keep dtype
-    np.number ───────────► paddle.Tensor
-                            (0D-Tensor)
-                   default_dtype
-    Python Number ───────────────► paddle.Tensor
-                                    (1D-Tensor)
+    .. code-block:: text
+
+        We use the dtype conversion rules following this:
                 Keep dtype
-    np.ndarray ───────────► paddle.Tensor
+        np.number ───────────► paddle.Tensor
+                                (0D-Tensor)
+                    default_dtype
+        Python Number ───────────────► paddle.Tensor
+                                        (1D-Tensor)
+                    Keep dtype
+        np.ndarray ───────────► paddle.Tensor
 
     Args:
         data(scalar|tuple|list|ndarray|Tensor): Initial data for the tensor.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe

The problem described in the PR fixed issue #48575. 

The `numpy scaler` will be treat as same as `Python Number` (using the `Paddle default dtype`).

After modification, the Number Scaler will hold the dtype, which will be converted to 0D Tensor.

！！！注意：部分模型运行失败的原因和如何修复见 [PR底部评论](https://github.com/PaddlePaddle/Paddle/pull/50018#issuecomment-1420151696) 。