### PR TITLE
Fix 空指针 (Null pointer) of case 17 paddle.flip

### DIFF
--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -30,6 +30,7 @@
 #include "paddle/fluid/imperative/tracer.h"
 #include "paddle/fluid/imperative/type_defs.h"
 #include "paddle/fluid/operators/ops_extra_info.h"
+#include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/imperative.h"
 #include "paddle/phi/common/complex.h"
 
@@ -70,7 +71,8 @@ bool PyObject_CheckLongOrToLong(PyObject** obj) {
   if ((PyLong_Check(*obj) && !PyBool_Check(*obj)) ||
       PyObject_IsInstance(*obj, (PyObject*)g_vartype_pytype) ||  // NOLINT
       PyObject_IsInstance(*obj, (PyObject*)g_varbase_pytype) ||  // NOLINT
-      PyObject_IsInstance(*obj, (PyObject*)p_tensor_type)) {     // NOLINT
+      (PyObject_IsInstance(*obj, (PyObject*)p_tensor_type) &&    // NOLINT
+       (((TensorObject*)(*obj))->tensor.numel() == 1))) {        // NOLINT
     return true;
   }
 

--- a/python/paddle/fluid/tests/unittests/test_flip.py
+++ b/python/paddle/fluid/tests/unittests/test_flip.py
@@ -198,6 +198,23 @@ class TestFlipTripleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+class TestFlipError(unittest.TestCase):
+    def test_axis(self):
+        paddle.enable_static()
+
+        def test_axis_rank():
+            input = fluid.data(name='input', dtype='float32', shape=[2, 3])
+            output = paddle.flip(input, axis=[[0]])
+
+        self.assertRaises(TypeError, test_axis_rank)
+
+        def test_axis_rank2():
+            input = fluid.data(name='input', dtype='float32', shape=[2, 3])
+            output = paddle.flip(input, axis=[[0, 0], [1, 1]])
+
+        self.assertRaises(TypeError, test_axis_rank2)
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
- #49922 
- #49927 
<!-- Describe what this PR does -->

### Solution

在 `paddle/fluid/pybind/op_function_common.cc` 中的 `CastPyArg2Ints` 函数里，对 `PyLong_AsLong` 操作的返回值进行检查，并根据 Python 文档的 [PyLong_AsLong](https://docs.python.org/3/c-api/long.html?highlight=pylong_aslong#c.PyLong_AsLong) 部分，当其返回值为 -1 且 `PyErr_Occurred()` 不为 `NULL` 时，进行报错：输入值类型错误。

> long PyLong_AsLong([PyObject](https://docs.python.org/3/c-api/structures.html#c.PyObject) *obj)
> Part of the [Stable ABI](https://docs.python.org/3/c-api/stable.html#stable).
> Return a C long representation of obj. If obj is not an instance of [PyLongObject](https://docs.python.org/3/c-api/long.html?highlight=pylong_aslong#c.PyLongObject), first call its __index__() method (if present) to convert it to a [PyLongObject](https://docs.python.org/3/c-api/long.html?highlight=pylong_aslong#c.PyLongObject).
>
> Raise [OverflowError](https://docs.python.org/3/library/exceptions.html#OverflowError) if the value of obj is out of range for a long.
>
> Returns -1 on error. Use [PyErr_Occurred()](https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Occurred) to disambiguate.