### PR TITLE
throw error for fallback cpu of inplace op

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -7,7 +7,7 @@ set(XPU_PROJECT "extern_xpu")
 set(XPU_API_LIB_NAME "libxpuapi.so")
 set(XPU_RT_LIB_NAME "libxpurt.so")
 
-set(XPU_BASE_DATE "20230119")
+set(XPU_BASE_DATE "20230127")
 set(XPU_XCCL_BASE_VERSION "1.0.7")
 
 if(NOT DEFINED XPU_BASE_URL)

--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -1195,6 +1195,10 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         for kernel_out in outputs_args:
             fallback_kernel_output_trans += f"""
 {code_indent}    TransDataBackend({kernel_out}, kernel_backend, {kernel_out});"""
+        if inplace_flag:
+            fallback_kernel_output_trans += f"""
+{code_indent}  if (kernel_backend == Backend::XPU)
+{code_indent}    PADDLE_THROW(phi::errors::Unimplemented("The fallback_cpu function for inplace update is unimplemented, please implement api {self.api}_ for backend XPU"));"""
         return f"""
 {code_indent}  VLOG(6) << "{self.api} API kernel key: [" << kernel_backend << ", " << kernel_layout << ", "<< kernel_data_type << "]";
 {code_indent}  auto kernel_result = phi::KernelFactory::Instance().SelectKernelOrThrowError(


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
对于inplace op的语义要求更新操作直接作用在输入的tensor上，但是如果op没有实现需要fallback到cpu，再通过transdatabackend把数据拷贝到异构设备上，就会新分配一块设备显存，而不是直接作用于原来的地址，因此这种case需要抛出错误。
