### PR TITLE
make FLAGS_gemm_use_half_precision_compute_type=false by default

### DIFF
--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -156,7 +156,7 @@ PADDLE_DEFINE_EXPORTED_bool(
     false,
     "Whether to use fp16 compute type when the input and output is fp16, "
     "faster but it may loss precision in most case. If true, the compute "
-    "type will be set to fp32. Default is true.");
+    "type will be set to fp16. Default is false.");
 
 /**
  * CUDA related FLAG

--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -146,14 +146,14 @@ PADDLE_DEFINE_EXPORTED_bool(
  * CUDA related related FLAG
  * Name: FLAGS_gemm_use_half_precision_compute_type
  * Since Version: 2.4
- * Value Range: bool, default=true
+ * Value Range: bool, default=false
  * Example:
  * Note: whether to use fp16 compute type when the input and output is fp16,
  * faster but it may loss precision.
  */
 PADDLE_DEFINE_EXPORTED_bool(
     gemm_use_half_precision_compute_type,
-    true,
+    false,
     "Whether to use fp16 compute type when the input and output is fp16, "
     "faster but it may loss precision in most case. If true, the compute "
     "type will be set to fp32. Default is true.");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Make `FLAGS_gemm_use_half_precision_compute_type=false` by default. It would improve the performance of the ViT models and make FP16 models convergence better.