### PR TITLE
[Fix bug]修复DataLoader中存在的内存泄露问题

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -567,7 +567,7 @@ class DataLoader(object):
             return _DataLoaderIterMultiProcess(self)
 
     def __call__(self):
-        return self.__iter__
+        return self
 
     @staticmethod
     def from_generator(feed_list=None,

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -567,7 +567,7 @@ class DataLoader(object):
             return _DataLoaderIterMultiProcess(self)
 
     def __call__(self):
-        return self.__iter__()
+        return self.__iter__
 
     @staticmethod
     def from_generator(feed_list=None,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
APIs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
社区成员反馈使用DataLoader时遇到内存泄露问题，在调用loader对象时，若添加了()则会引起内存泄露。通过源码可查看到我们在构建DataLoader的`__call__`方法时返回的是`self.__iter__()`而非`self`这使得loader在被类似`for i in loader()`方式调用后返回的并不是`paddle.fluid.reader.DataLoader`对象，而是`paddle.fluid.dataloader.dataloader_iter._DataLoaderIterSingleProcess`对象。  
更改源码的`__call__`方法，即可解决该问题。

查询Pytorch相关代码，Pytorch并未设置__call__方法，无相关代码参考。

<img width="714" alt="图片" src="https://user-images.githubusercontent.com/46156734/215302227-7de91597-61cb-4f90-beeb-f7c854828d55.png">


```
# loader与loader()返回的对象不同

import numpy as np
from paddle.io import Dataset, DataLoader

class TDataset(Dataset):
    def __init__(self):
        super(TDataset, self).__init__()
        self.data = [1, 2, 3]

    def __getitem__(self, idx):
        return [self.data[idx]]

    def __len__(self):
        return 3


dataset = TDataset()
loader = DataLoader(dataset, batch_size=1)

print(loader)
print(loader())
```

可复现内存泄露的issue参考：[https://github.com/PaddlePaddle/Paddle/issues/40734](https://github.com/PaddlePaddle/Paddle/issues/40734)