### PR TITLE
[Paddle Inference] Support tensorrt timing cache 

### DIFF
--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -231,6 +231,7 @@ struct Argument {
                       TensorRtUseStaticEngine,
                       bool);
   DECL_ARGUMENT_FIELD(tensorrt_use_calib_mode, TensorRtUseCalibMode, bool);
+  DECL_ARGUMENT_FIELD(tensorrt_use_timing_cache, TensorRtUseTimingCache, bool);
   DECL_ARGUMENT_FIELD(tensorrt_use_varseqlen, TensorRtUseOSS, bool);
   DECL_ARGUMENT_FIELD(tensorrt_with_interleaved, TensorRtWithInterleaved, bool);
   DECL_ARGUMENT_FIELD(tensorrt_transformer_posid,

--- a/paddle/fluid/inference/analysis/helper.h
+++ b/paddle/fluid/inference/analysis/helper.h
@@ -247,12 +247,28 @@ static std::string GetTrtEngineSerializedData(
   return "";
 }
 
-static void SaveTrtEngineSerializedDataToFile(
-    const std::string &trt_serialized_path,
-    const std::string &engine_serialized_data) {
-  std::ofstream outfile(trt_serialized_path, std::ios::binary);
-  outfile << engine_serialized_data;
+static void SaveSerializedDataToFile(const std::string &path,
+                                     const std::string &data) {
+  std::ofstream outfile(path, std::ios::binary);
+  outfile << data;
   outfile.close();
+}
+
+static std::string GetTrtTimingCacheSerializedData(
+    const std::string &timing_cache_dir) {
+  std::string timing_cache_file = timing_cache_dir + "/paddle_trt_timing.cache";
+  if (FileExists(timing_cache_file)) {
+    VLOG(3) << "Trt timing chache file: " << timing_cache_file
+            << "is found here";
+    std::ifstream infile(timing_cache_file, std::ios::binary);
+    std::stringstream buffer;
+    buffer << infile.rdbuf();
+    std::string trt_timing_cache_data(buffer.str());
+    return trt_timing_cache_data;
+  } else {
+    VLOG(3) << "Trt timing chache file does not exist";
+    return "";
+  }
 }
 
 }  // namespace analysis

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -154,8 +154,10 @@ void IRPassManager::CreatePasses(Argument *argument,
       pass->Set("program",
                 new framework::ProgramDesc *(&argument->main_program()));
       pass->Set("predictor_id", new int(argument->predictor_id()));
+
       bool use_calib_mode = argument->tensorrt_use_calib_mode();
       pass->Set("use_calib_mode", new bool(use_calib_mode));
+
       pass->Set("precision_mode",
                 new AnalysisConfig::Precision(precision_mode));
       pass->Set("context_memory_sharing",
@@ -222,6 +224,9 @@ void IRPassManager::CreatePasses(Argument *argument,
       // not run fp16.
       pass->Set("disable_trt_plugin_fp16",
                 new bool(argument->disable_trt_plugin_fp16()));
+
+      bool use_timing_cache = argument->tensorrt_use_timing_cache();
+      pass->Set("use_timing_cache", new bool(use_timing_cache));
     } else if (pass_name == "dlnne_subgraph_pass") {
       auto precision_mode = argument->dlnne_precision_mode();
       pass->Set("min_subgraph_size",

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -647,6 +647,7 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
     trt_timing_cache_data =
         std::string((const char *)serialized_timing_cache_data->data(),
                     serialized_timing_cache_data->size());
+
     SaveSerializedDataToFile(timing_cache_dir + "/paddle_trt_timing.cache",
                              trt_timing_cache_data);
   }

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -424,6 +424,7 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   CP_MEMBER(trt_dla_core_);
   CP_MEMBER(trt_use_static_engine_);
   CP_MEMBER(trt_use_calib_mode_);
+  CP_MEMBER(trt_use_timing_cache_)
   CP_MEMBER(trt_use_varseqlen_);
   CP_MEMBER(trt_with_interleaved_);
   CP_MEMBER(tensorrt_transformer_posid_);
@@ -725,6 +726,15 @@ void AnalysisConfig::EnableTensorRtEngine(
   trt_use_calib_mode_ = use_calib_mode;
 
   Update();
+#else
+  PADDLE_THROW(platform::errors::PreconditionNotMet(
+      "To use Paddle-TensorRT, please compile with TENSORRT first."));
+#endif
+}
+
+void AnalysisConfig::EnableTensorRTTimingCache(bool use_timing_cache) {
+#ifdef PADDLE_WITH_TENSORRT
+  trt_use_timing_cache_ = use_timing_cache;
 #else
   PADDLE_THROW(platform::errors::PreconditionNotMet(
       "To use Paddle-TensorRT, please compile with TENSORRT first."));
@@ -1171,6 +1181,10 @@ bool AnalysisConfig::trt_engine_memory_sharing() const {
   return trt_engine_memory_sharing_;
 }
 
+bool AnalysisConfig::trt_use_timing_cache() const {
+  return trt_use_timing_cache_;
+}
+
 void AnalysisConfig::SetModelBuffer(const char *prog_buffer,
                                     size_t prog_buffer_size,
                                     const char *param_buffer,
@@ -1313,6 +1327,8 @@ std::string AnalysisConfig::Summary() {
                     trt_use_static_engine_ ? "true" : "false"});
       os.InsertRow(
           {"tensorrt_use_calib_mode", trt_use_calib_mode_ ? "true" : "false"});
+      os.InsertRow({"tensorrt_use_timing_cache",
+                    trt_use_timing_cache_ ? "true" : "false"});
 
       // dynamic_shape
       os.InsertRow({"tensorrt_enable_dynamic_shape",

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1139,6 +1139,7 @@ void AnalysisPredictor::PrepareArgument() {
         config_.trt_allow_build_at_runtime());
     argument_->SetTensorRtUseInspector(config_.trt_use_inspector_);
     argument_->SetTrtEngineMemorySharing(config_.trt_engine_memory_sharing());
+    argument_->SetTensorRtUseTimingCache(config_.trt_use_timing_cache());
   }
 
   if (config_.dlnne_enabled()) {

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -600,6 +600,17 @@ struct PD_INFER_DECL AnalysisConfig {
   void EnableTensorRTMemoryOptim(bool engine_memory_sharing = true,
                                  int sharing_identifier = 0);
   ///
+  /// \brief Turn on the TensorRT timing cache
+  ///
+  /// \param use_timing_cache Whether to enable TensorRT timing cache
+  ///
+  void EnableTensorRTTimingCache(bool use_timing_cache = true);
+  ///
+  /// \brief A boolean state telling whether the tensorrt engine timing cache
+  /// is activated.
+  ///
+  bool trt_use_timing_cache() const;
+  ///
   /// \brief A boolean state telling whether the tensorrt engine memory sharing
   /// is activated.
   ///
@@ -1097,6 +1108,7 @@ struct PD_INFER_DECL AnalysisConfig {
   Precision tensorrt_precision_mode_{Precision::kFloat32};
   bool trt_use_static_engine_{false};
   bool trt_use_calib_mode_{true};
+  bool trt_use_timing_cache_{false};
   bool trt_use_varseqlen_{false};
   bool trt_with_interleaved_{false};
   std::string tensorrt_transformer_posid_{""};

--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -313,6 +313,13 @@ void TensorRTEngine::FreezeNetwork() {
         nvinfer1::ProfilingVerbosity::kDETAILED);
   }
 #endif
+#if IS_TRT_VERSION_GE(8250)
+  if (use_timing_cache_) {
+    infer_timing_cache_.reset(infer_builder_config_->createTimingCache(
+        timing_cache_data_.data(), timing_cache_data_.size()));
+    infer_builder_config_->setTimingCache(*infer_timing_cache_.get(), false);
+  }
+#endif
 
 #if IS_TRT_VERSION_LT(8000)
   infer_engine_.reset(infer_builder_->buildEngineWithConfig(

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -358,6 +358,7 @@ class TensorRTEngine {
             "The TensorRT Timing Cache must be not null when serializing"));
     return infer_timing_cache_->serialize();
 #endif
+    return nullptr;
   }
 
   void Deserialize(const std::string& engine_serialized_data);

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -399,7 +399,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
             std::string trt_engine_serialized_data =
                 std::string((const char *)serialized_engine_data->data(),
                             serialized_engine_data->size());
-            inference::analysis::SaveTrtEngineSerializedDataToFile(
+            inference::analysis::SaveSerializedDataToFile(
                 inference::analysis::GetTrtEngineSerializedPath(
                     model_opt_cache_dir_, engine_key_),
                 trt_engine_serialized_data);

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -770,6 +770,9 @@ void BindAnalysisConfig(py::module *m) {
            &AnalysisConfig::EnableTensorRTMemoryOptim,
            py::arg("engine_memory_sharing") = true,
            py::arg("sharing_identifier") = 0)
+      .def("enable_tensorrt_timing_cache",
+           &AnalysisConfig::EnableTensorRTTimingCache,
+           py::arg("use_timing_cache") = true)
       .def("tensorrt_precision_mode", &AnalysisConfig::tensorrt_precision_mode)
       .def("set_trt_dynamic_shape_info",
            &AnalysisConfig::SetTRTDynamicShapeInfo,

--- a/python/paddle/fluid/tests/unittests/ir/inference/inference_pass_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/inference_pass_test.py
@@ -109,6 +109,7 @@ class InferencePassTest(unittest.TestCase):
         config.switch_specify_input_names(True)
         config.switch_ir_optim(True)
         config.switch_use_feed_fetch_ops(False)
+        config.enable_tensorrt_timing_cache(True)
         if use_gpu:
             config.enable_use_gpu(100, 0)
             if use_trt:

--- a/python/paddle/fluid/tests/unittests/ir/inference/quant_dequant_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/quant_dequant_test.py
@@ -177,6 +177,7 @@ class QuantDequantTest(unittest.TestCase):
         config.switch_specify_input_names(True)
         config.switch_ir_optim(True)
         config.switch_use_feed_fetch_ops(False)
+        config.enable_tensorrt_timing_cache(True)
         if use_gpu:
             config.enable_use_gpu(100, 0)
             if use_trt:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
**Background:** Some inference unittests spend more time after trt version is updated, which is because more tactics is provided in engine building with later trt version. In order to speed up engine generation process, timing cache can be used. [[Reference]](https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-825/developer-guide/index.html#builder-layer-timing)

**Method:**   
1. Add API _EnableTensorRTTimingCache_ to enable timing cache function.
2. If TimingCache is enabled, file "/tmp/paddle_trt_timing.cache" will be loaded and parsed, trt engine can use tactic timing info contained in this file to skip some tuning steps.
3. After building engine, new cache generated by trt will be saved to "/tmp/paddle_trt_timing.cache".

**Test:** 
<div data-slate-node="element" class="mp-table-container" style="box-sizing: border-box; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); -webkit-print-color-adjust: exact; margin: 1px 0px; overflow: auto hidden; padding-bottom: 8px; padding-top: 32px; position: relative; padding-left: 0px;">

ut_name | 8.4 without HEURISTIC | 8.5 with HEURISTIC | Timing cache 第一次运行 | Timing cache 第二次运行
-- | -- | -- | -- | --
test_trt_matmul_quant_dequant | 297 sec | 290 sec | 232.67 sec | 88.89sec
test_trt_matmul | - | 90.28 sec | 87.95 sec | 87.9 sec

</div><div class="mp-table-serialize-flag" style="box-sizing: border-box; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); -webkit-print-color-adjust: exact;"><br style="box-sizing: border-box; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); color: rgb(51, 51, 51); font-family: &quot;PingFang SC&quot;, &quot;Helvetica Neue&quot;, &quot;Hiragino Sans GB&quot;, &quot;Microsoft YaHei&quot;, Arial, SimSun, sans-serif; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">