### PR TITLE
[CINN] BuildCinnPass collect inplace var from all cluster instead op

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
@@ -69,7 +69,7 @@ class OpTransInfo {
       const GraphNodeSet& cluster) const;
 
   static std::unordered_set<std::string> GetInplaceVarNames(
-      const GraphNodeSet& cluster);
+      const GraphNodeSet& cluster_inputs, const GraphNodeSet& cluster_outputs);
 
  private:
   DyOpCondT dynamic_op_cond_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
之前CINN `build_cinn_pass`收集inplace变量的方式是判断单个op的输入输出中是否含有相同变量，但在基础算子体系中，该方法不再适用。原因在于大算子（如`batch_norm`）被拆分后，inplace变量不再在同一个算子中了。本PR改为收集cluster输入输出中是否含有相同变量。 