### PR TITLE
Fix paddle.var() stop_gradient error

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -182,6 +182,7 @@ def var(x, axis=None, unbiased=True, keepdim=False, name=None):
     if unbiased:
         one_const = paddle.ones([1], x.dtype)
         n = where(n > one_const, n - 1.0, one_const)
+    n.stop_gradient = True
     out /= n
     return out
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
In static graph mode, some branches that do not need gradients are not pruned correctly in `paddle.var()` method. This PR add `n.stop_gradient = True` to avoid this error.