### PR TITLE
[Update pybind11] update pybind11 TAG, 2.4.3->2.6.0

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -16,7 +16,7 @@ include(ExternalProject)
 
 set(PYBIND_PREFIX_DIR ${THIRD_PARTY_PATH}/pybind)
 set(PYBIND_REPOSITORY ${GIT_URL}/pybind/pybind11.git)
-set(PYBIND_TAG v2.4.3)
+set(PYBIND_TAG v2.6.0)
 
 set(PYBIND_INCLUDE_DIR ${THIRD_PARTY_PATH}/pybind/src/extern_pybind/include)
 include_directories(${PYBIND_INCLUDE_DIR})

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -1081,7 +1081,7 @@ def monkey_patch_varbase():
         # NOTE(zhiqiu): pybind11 will set a default __str__ method of enum class.
         # So, we need to overwrite it to a more readable one.
         # See details in https://github.com/pybind/pybind11/issues/2537.
-        origin = getattr(core.VarDesc.VarType, "__repr__")
+        origin = getattr(core.VarDesc.VarType, "__str__")
 
         def dtype_str(dtype):
             if dtype in _PADDLE_DTYPE_2_NUMPY_DTYPE:
@@ -1094,7 +1094,7 @@ def monkey_patch_varbase():
                 # for example, paddle.fluid.core.VarDesc.VarType.LOD_TENSOR
                 return origin(dtype)
 
-        setattr(core.VarDesc.VarType, "__repr__", dtype_str)
+        setattr(core.VarDesc.VarType, "__str__", dtype_str)
         _already_patch_repr = True
 
     # patch math methods for varbase


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
更新 pybind11 组件至 2.6.0，此 PR 为 [[Cpp Extension] Support Cpp Extension #49893](https://github.com/PaddlePaddle/Paddle/pull/49893) 的前置 PR

升级原因：Windows 环境下 nvcc 编译器编译 2.4.3 版本的 pybind11 会报错 （Ref. https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/7670516/stage/13083653/0?jump=latestJob line 16820）
`2023-01-28 17:56:56 c:\home\workspace\cache\python_venv\lib\site-packages\paddle\include\third_party\pybind11\cast.h(1453): error: expression must be a pointer to a complete object type`

这是由于 2.4.3 版本的 pybind11/cast.h 第 1453 行代码写法不规范，nvcc 编译无法通过，2.6.0 版本的 pybind11 修复了本问题。


Update pybind11 from 2.4.3 to 2.6.0, this PR is the pre-PR of [[Cpp Extension] Support Cpp Extension #49893](https://github.com/PaddlePaddle/Paddle/pull/49893)
Update Reason:
On the windows platform, the nvcc compiler will raise an error when it compiles 2.4.3 pybind11 (Ref. https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/7670516/stage/13083653/0?jump=latestJob line 16820)
`2023-01-28 17:56:56 c:\home\workspace\cache\python_venv\lib\site-packages\paddle\include\third_party\pybind11\cast.h(1453): error: expression must be a pointer to a complete object type`

There is a problem with the code on line 1453 of the 2.4.3 version of the pybind11/cast.h, the 2.6.0 version of pybind11 has fixed this problem.