### PR TITLE
[CINN] fix build_cinn_pass collect inplace var bug

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.cc
@@ -163,9 +163,14 @@ std::unordered_set<std::string> OpTransInfo::GetDenyVarNames(
 }
 
 std::unordered_set<std::string> OpTransInfo::GetInplaceVarNames(
-    const GraphNodeSet& cluster_inputs, const GraphNodeSet& cluster_outputs) {
+    const GraphNodeSet& cluster_internals,
+    const GraphNodeSet& cluster_inputs,
+    const GraphNodeSet& cluster_outputs) {
   std::unordered_set<std::string> all_inputs, all_outputs;
 
+  for (auto* var : cluster_internals) {
+    all_inputs.insert(var->Name());
+  }
   for (auto* var : cluster_inputs) {
     all_inputs.insert(var->Name());
   }
@@ -478,7 +483,8 @@ std::unique_ptr<Graph> CreateNewSubGraph(const GraphNodeSet& cluster,
   subgraph->GetOrInit<Name2VarInfoMap>(kMemOptVarInfoFromMainGraph);
 
   auto inplace_var_names = std::make_unique<std::unordered_set<std::string>>(
-      OpTransInfo::GetInplaceVarNames(cluster_inputs, cluster_outputs));
+      OpTransInfo::GetInplaceVarNames(
+          cluster_internals, cluster_inputs, cluster_outputs));
   VLOG_IF(4, !inplace_var_names->empty())
       << "Inplace var in cluster are: " << GetDebugInfo(*inplace_var_names);
   subgraph->Set<std::unordered_set<std::string>>(kInplaceVarNames,

--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
@@ -69,7 +69,9 @@ class OpTransInfo {
       const GraphNodeSet& cluster) const;
 
   static std::unordered_set<std::string> GetInplaceVarNames(
-      const GraphNodeSet& cluster_inputs, const GraphNodeSet& cluster_outputs);
+      const GraphNodeSet& cluster_internals,
+      const GraphNodeSet& cluster_inputs,
+      const GraphNodeSet& cluster_outputs);
 
  private:
   DyOpCondT dynamic_op_cond_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
`BuildCinnPass`中只统计cluster中输入输出相同的变量会导致，某个变量是cluster中某个op的输入但同时也是cluster输出时，该变量在CINN中会加上`@InplaceOut`后缀，但Paddle侧仍按照不带`@InplaceOut`后缀来查找，从而报错。本PR改为取`cluster_internals+cluster_inputs`和`cluster_outputs`交集的方式来判断变量是否inplace。