### PR TITLE
Not use shm cache default for mmap_allocator

### DIFF
--- a/paddle/phi/core/flags.cc
+++ b/paddle/phi/core/flags.cc
@@ -1198,11 +1198,11 @@ PADDLE_DEFINE_EXPORTED_bool(trt_ibuilder_cache,
  * mmap_allocator related FLAG
  * Name: use_shm_cache
  * Since Version: 2.5.0
- * Value Range: bool, default=true
+ * Value Range: bool, default=false
  * Example:
  * Note: . If True, mmap_allocator will cache shm file to decrease munmap
  * operation.
  */
 PADDLE_DEFINE_EXPORTED_bool(use_shm_cache,
-                            true,
+                            false,
                             "Use shm cache in mmap_allocator.");


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
[PR46961](https://github.com/PaddlePaddle/Paddle/pull/49691) 为 mmap_allocator 开发了 shm 复用的方案以解决 munmap 阻塞训练线程导致的性能问题。
针对迭代器类型dataset、或者每轮训练数据规模不一致的场景，该方案可能存在问题，因此设置开关 FLAGS_use_shm_cache 默认为false。
