### PR TITLE
jit layer support multi thread and fix predictor clone

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -2229,7 +2229,7 @@ std::unique_ptr<PaddlePredictor> AnalysisPredictor::Clone(void *stream) {
   auto *x = new AnalysisPredictor(config_);
   x->status_is_cloned_ = true;
   x->root_predictor_id_ = this->root_predictor_id_;
-  x->config_.apply_optim_ = false; 
+  x->config_.apply_optim_ = false;
   if (config_.use_external_stream_ && stream == nullptr) {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "config has been configured to use external stream, but the Clone "

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1085,6 +1085,7 @@ bool AnalysisPredictor::GetFetch(std::vector<PaddleTensor> *outputs,
 }
 
 void AnalysisPredictor::PrepareArgument() {
+  VLOG(3) << "AnalysisPredictor::PrepareArgument";
   // Init std::unique_ptr argument_.
   argument_.reset(new Argument);
   argument_->SetUseGPU(config_.use_gpu());
@@ -2223,10 +2224,12 @@ AnalysisPredictor::~AnalysisPredictor() {
 }
 
 std::unique_ptr<PaddlePredictor> AnalysisPredictor::Clone(void *stream) {
+  VLOG(3) << "AnalysisPredictor::Clone";
   std::lock_guard<std::mutex> lk(clone_mutex_);
   auto *x = new AnalysisPredictor(config_);
   x->status_is_cloned_ = true;
   x->root_predictor_id_ = this->root_predictor_id_;
+  x->config_.apply_optim_ = false; 
   if (config_.use_external_stream_ && stream == nullptr) {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "config has been configured to use external stream, but the Clone "

--- a/paddle/fluid/jit/compilation_unit.cc
+++ b/paddle/fluid/jit/compilation_unit.cc
@@ -38,5 +38,13 @@ void CompilationUnit::SetEngine(const std::string &name,
 
 const jit::EngineMap &CompilationUnit::EngineMap() const { return engine_map_; }
 
+std::shared_ptr<CompilationUnit> CompilationUnit::Clone(void *stream) {
+  auto x = std::make_shared<CompilationUnit>();
+  for( auto& it : engine_map_) {
+    x->SetEngine(it.first, std::move(it.second->Clone(stream)));
+  }
+  return x;
+}
+
 }  // namespace jit
 }  // namespace paddle

--- a/paddle/fluid/jit/compilation_unit.cc
+++ b/paddle/fluid/jit/compilation_unit.cc
@@ -40,7 +40,7 @@ const jit::EngineMap &CompilationUnit::EngineMap() const { return engine_map_; }
 
 std::shared_ptr<CompilationUnit> CompilationUnit::Clone(void *stream) {
   auto x = std::make_shared<CompilationUnit>();
-  for( auto& it : engine_map_) {
+  for (auto &it : engine_map_) {
     x->SetEngine(it.first, std::move(it.second->Clone(stream)));
   }
   return x;

--- a/paddle/fluid/jit/compilation_unit.h
+++ b/paddle/fluid/jit/compilation_unit.h
@@ -36,6 +36,8 @@ class CompilationUnit {
 
   const jit::EngineMap &EngineMap() const;
 
+  std::shared_ptr<CompilationUnit> Clone(void *stream = nullptr);
+
  private:
   jit::EngineMap engine_map_;
 };

--- a/paddle/fluid/jit/engine/base_engine.h
+++ b/paddle/fluid/jit/engine/base_engine.h
@@ -29,6 +29,8 @@ class BaseEngine {
 
   virtual std::vector<Tensor> operator()(const std::vector<Tensor> &inputs) = 0;
 
+  virtual std::unique_ptr<BaseEngine> Clone(void *stream = nullptr) = 0;
+
   virtual ~BaseEngine() {}
 };
 

--- a/paddle/fluid/jit/engine/interpreter_engine.cc
+++ b/paddle/fluid/jit/engine/interpreter_engine.cc
@@ -28,14 +28,14 @@ namespace jit {
 InterpreterEngine::InterpreterEngine(const std::shared_ptr<FunctionInfo> &info,
                                      const VariableMap &params_dict,
                                      const phi::Place &place)
-    : info_(info), place_(place) {
+    : info_(info), params_dict_(params_dict), place_(place) {
   info_->RemoveDescFeedFetch();
   PADDLE_ENFORCE_GT(
       static_cast<int64_t>(info_->ProgramDesc().Block(0).OpSize()),
       0,
       platform::errors::PreconditionNotMet(
           "There is no operator in ProgramDesc."));
-  utils::ShareParamsIntoScope(info_->ParamNames(), params_dict, &scope_);
+  utils::ShareParamsIntoScope(info_->ParamNames(), params_dict_, &scope_);
   VLOG(6) << framework::GenScopeTreeDebugInfo(&scope_);
   CreateInterpreterCore();
 }
@@ -96,6 +96,11 @@ std::vector<DenseTensor> InterpreterEngine::operator()(
 
 const std::shared_ptr<FunctionInfo> &InterpreterEngine::Info() const {
   return info_;
+}
+
+std::unique_ptr<BaseEngine> InterpreterEngine::Clone(void *stream) {
+  auto *x = new InterpreterEngine(info_, params_dict_, place_);
+  return std::unique_ptr<BaseEngine>(x);
 }
 
 }  // namespace jit

--- a/paddle/fluid/jit/engine/interpreter_engine.cc
+++ b/paddle/fluid/jit/engine/interpreter_engine.cc
@@ -100,7 +100,7 @@ const std::shared_ptr<FunctionInfo> &InterpreterEngine::Info() const {
 
 std::unique_ptr<BaseEngine> InterpreterEngine::Clone(void *stream) {
   auto *x = new InterpreterEngine(info_, params_dict_, place_);
-  return std::unique_ptr<BaseEngine>(x);
+  return std::make_unique<BaseEngine>(*x);
 }
 
 }  // namespace jit

--- a/paddle/fluid/jit/engine/interpreter_engine.cc
+++ b/paddle/fluid/jit/engine/interpreter_engine.cc
@@ -100,7 +100,7 @@ const std::shared_ptr<FunctionInfo> &InterpreterEngine::Info() const {
 
 std::unique_ptr<BaseEngine> InterpreterEngine::Clone(void *stream) {
   auto *x = new InterpreterEngine(info_, params_dict_, place_);
-  return std::make_unique<BaseEngine>(*x);
+  return std::unique_ptr<BaseEngine>(x);
 }
 
 }  // namespace jit

--- a/paddle/fluid/jit/engine/interpreter_engine.h
+++ b/paddle/fluid/jit/engine/interpreter_engine.h
@@ -49,8 +49,11 @@ class InterpreterEngine : public BaseEngine {
 
   const std::shared_ptr<FunctionInfo> &Info() const;
 
+  std::unique_ptr<BaseEngine> Clone(void *stream = nullptr) override;
+
  private:
   std::shared_ptr<FunctionInfo> info_;
+  VariableMap params_dict_;
   framework::Scope scope_;
   phi::Place place_;
   std::shared_ptr<framework::InterpreterCore> inner_interpreter_;

--- a/paddle/fluid/jit/engine/interpreter_engine.h
+++ b/paddle/fluid/jit/engine/interpreter_engine.h
@@ -43,9 +43,10 @@ class InterpreterEngine : public BaseEngine {
 
   void CreateInterpreterCore();
 
-  std::vector<Tensor> operator()(const std::vector<Tensor> &inputs);
+  std::vector<Tensor> operator()(const std::vector<Tensor> &inputs) override;
 
-  std::vector<DenseTensor> operator()(const std::vector<DenseTensor> &inputs);
+  std::vector<DenseTensor> operator()(
+      const std::vector<DenseTensor> &inputs) override;
 
   const std::shared_ptr<FunctionInfo> &Info() const;
 

--- a/paddle/fluid/jit/engine/predictor_engine.cc
+++ b/paddle/fluid/jit/engine/predictor_engine.cc
@@ -55,15 +55,16 @@ PredictorEngine::PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
       scope_, std::make_shared<framework::ProgramDesc>(info_->ProgramDesc()));
 }
 
-PredictorEngine::PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
-                                 const std::shared_ptr<framework::Scope> &scope,
-                                 const phi::Place &place,
-                                 const std::shared_ptr<PaddlePredictor> &predictor){
-   info_ = info;
-   scope_ = scope;
-   place_ = place;
-   predictor_ = std::dynamic_pointer_cast<AnalysisPredictor, PaddlePredictor>(predictor);
-}
+PredictorEngine::PredictorEngine(
+    const std::shared_ptr<FunctionInfo> &info,
+    const std::shared_ptr<framework::Scope> &scope,
+    const phi::Place &place,
+    const std::shared_ptr<PaddlePredictor> &predictor)
+    : info_(info),
+      scope_(scope),
+      place_(place),
+      predictor_(std::dynamic_pointer_cast<AnalysisPredictor, PaddlePredictor>(
+          predictor)) {}
 
 std::vector<Tensor> PredictorEngine::operator()(
     const std::vector<Tensor> &inputs) {
@@ -199,7 +200,8 @@ static bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
 }
 
 std::unique_ptr<BaseEngine> PredictorEngine::Clone(void *stream) {
-  auto *x = new PredictorEngine(info_, scope_, place_, std::move(predictor_->Clone()));
+  auto *x = new PredictorEngine(
+      info_, scope_, place_, std::move(predictor_->Clone()));
   return std::unique_ptr<BaseEngine>(x);
 }
 

--- a/paddle/fluid/jit/engine/predictor_engine.cc
+++ b/paddle/fluid/jit/engine/predictor_engine.cc
@@ -55,6 +55,16 @@ PredictorEngine::PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
       scope_, std::make_shared<framework::ProgramDesc>(info_->ProgramDesc()));
 }
 
+PredictorEngine::PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
+                                 const std::shared_ptr<framework::Scope> &scope,
+                                 const phi::Place &place,
+                                 const std::shared_ptr<PaddlePredictor> &predictor){
+   info_ = info;
+   scope_ = scope;
+   place_ = place;
+   predictor_ = predictor;
+}
+
 std::vector<Tensor> PredictorEngine::operator()(
     const std::vector<Tensor> &inputs) {
   auto dense_tensors = utils::ToDenseTensors(inputs);
@@ -186,6 +196,11 @@ static bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
         "The analysis predictor supports CPU, GPU and XPU now."));
   }
   return true;
+}
+
+std::unique_ptr<BaseEngine> PredictorEngine::Clone(void *stream) {
+  auto *x = new PredictorEngine(info_, scope_, place_, std::move(predictor_->Clone()));
+  return std::unique_ptr<BaseEngine>(x);
 }
 
 }  // namespace jit

--- a/paddle/fluid/jit/engine/predictor_engine.cc
+++ b/paddle/fluid/jit/engine/predictor_engine.cc
@@ -62,7 +62,7 @@ PredictorEngine::PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
    info_ = info;
    scope_ = scope;
    place_ = place;
-   predictor_ = predictor;
+   predictor_ = std::dynamic_pointer_cast<AnalysisPredictor, PaddlePredictor>(predictor);
 }
 
 std::vector<Tensor> PredictorEngine::operator()(

--- a/paddle/fluid/jit/engine/predictor_engine.cc
+++ b/paddle/fluid/jit/engine/predictor_engine.cc
@@ -201,7 +201,7 @@ static bool PaddleTensorToDenseTensor(const PaddleTensor &pt,
 
 std::unique_ptr<BaseEngine> PredictorEngine::Clone(void *stream) {
   auto *x = new PredictorEngine(
-      info_, scope_, place_, std::move(predictor_->Clone()));
+      info_, scope_, place_, std::move(predictor_->Clone(stream)));
   return std::unique_ptr<BaseEngine>(x);
 }
 

--- a/paddle/fluid/jit/engine/predictor_engine.h
+++ b/paddle/fluid/jit/engine/predictor_engine.h
@@ -36,7 +36,7 @@ class PredictorEngine : public BaseEngine {
 
   PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
                   const std::shared_ptr<framework::Scope> &scope,
-                  const phi::Place &place, 
+                  const phi::Place &place,
                   const std::shared_ptr<PaddlePredictor> &predictor);
 
   ~PredictorEngine() noexcept {}

--- a/paddle/fluid/jit/engine/predictor_engine.h
+++ b/paddle/fluid/jit/engine/predictor_engine.h
@@ -33,11 +33,18 @@ class PredictorEngine : public BaseEngine {
                   const VariableMap &params_dict,
                   const phi::Place &place);
 
+  PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
+                  const std::shared_ptr<framework::Scope> &scope,
+                  const phi::Place &place, 
+                  const std::shared_ptr<AnalysisPredictor> &predictor);
+
   ~PredictorEngine() noexcept {}
 
   std::vector<Tensor> operator()(const std::vector<Tensor> &inputs);
 
   std::vector<DenseTensor> operator()(const std::vector<DenseTensor> &inputs);
+
+  std::unique_ptr<BaseEngine> Clone(void *stream = nullptr) override;
 
  private:
   std::shared_ptr<FunctionInfo> info_;

--- a/paddle/fluid/jit/engine/predictor_engine.h
+++ b/paddle/fluid/jit/engine/predictor_engine.h
@@ -41,9 +41,10 @@ class PredictorEngine : public BaseEngine {
 
   ~PredictorEngine() noexcept {}
 
-  std::vector<Tensor> operator()(const std::vector<Tensor> &inputs);
+  std::vector<Tensor> operator()(const std::vector<Tensor> &inputs) override;
 
-  std::vector<DenseTensor> operator()(const std::vector<DenseTensor> &inputs);
+  std::vector<DenseTensor> operator()(
+      const std::vector<DenseTensor> &inputs) override;
 
   std::unique_ptr<BaseEngine> Clone(void *stream = nullptr) override;
 

--- a/paddle/fluid/jit/engine/predictor_engine.h
+++ b/paddle/fluid/jit/engine/predictor_engine.h
@@ -20,6 +20,7 @@
 
 namespace paddle {
 class AnalysisPredictor;
+class PaddlePredictor;
 
 namespace framework {
 class Scope;
@@ -36,7 +37,7 @@ class PredictorEngine : public BaseEngine {
   PredictorEngine(const std::shared_ptr<FunctionInfo> &info,
                   const std::shared_ptr<framework::Scope> &scope,
                   const phi::Place &place, 
-                  const std::shared_ptr<AnalysisPredictor> &predictor);
+                  const std::shared_ptr<PaddlePredictor> &predictor);
 
   ~PredictorEngine() noexcept {}
 

--- a/paddle/fluid/jit/layer.cc
+++ b/paddle/fluid/jit/layer.cc
@@ -30,7 +30,10 @@ Layer::Layer(const VariableMap& params_map,
              const VariableMap& attrs_map,
              const FunctionInfoMap& info_map,
              const phi::Place& place)
-    : params_map_(params_map), attrs_map_(attrs_map), info_map_(info_map), place_(place) {
+    : params_map_(params_map),
+      attrs_map_(attrs_map),
+      info_map_(info_map),
+      place_(place) {
   unit_.reset(new CompilationUnit());
 }
 
@@ -94,9 +97,9 @@ PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<int>)
 PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<float>)
 PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<std::string>)
 
-
-std::shared_ptr<Layer> Layer::Clone(void *stream) {
-  std::shared_ptr<Layer> x = std::make_shared<Layer>(params_map_, attrs_map_, info_map_, place_);
+std::shared_ptr<Layer> Layer::Clone(void* stream) {
+  std::shared_ptr<Layer> x =
+      std::make_shared<Layer>(params_map_, attrs_map_, info_map_, place_);
   x->unit_ = unit_->Clone(stream);
   return x;
 }

--- a/paddle/fluid/jit/layer.cc
+++ b/paddle/fluid/jit/layer.cc
@@ -95,9 +95,10 @@ PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<float>)
 PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<std::string>)
 
 
-std::shared_ptr<Layer> Layer::Clone(void *stream=nullptr) {
+std::shared_ptr<Layer> Layer::Clone(void *stream) {
   std::shared_ptr<Layer> x = std::make_shared<Layer>(params_map_, attrs_map_, info_map_, place_);
   x->unit_ = unit_->Clone(stream);
+  return x;
 }
 
 }  // namespace jit

--- a/paddle/fluid/jit/layer.cc
+++ b/paddle/fluid/jit/layer.cc
@@ -30,7 +30,7 @@ Layer::Layer(const VariableMap& params_map,
              const VariableMap& attrs_map,
              const FunctionInfoMap& info_map,
              const phi::Place& place)
-    : params_map_(params_map), attrs_map_(attrs_map), info_map_(info_map) {
+    : params_map_(params_map), attrs_map_(attrs_map), info_map_(info_map), place_(place) {
   unit_.reset(new CompilationUnit());
 }
 
@@ -93,6 +93,12 @@ PD_SPECIALZE_ATTRIBUTE_TYPE(framework::String)
 PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<int>)
 PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<float>)
 PD_SPECIALZE_ATTRIBUTE_TYPE(std::vector<std::string>)
+
+
+std::shared_ptr<Layer> Layer::Clone(void *stream=nullptr) {
+  std::shared_ptr<Layer> x = std::make_shared<Layer>(params_map_, attrs_map_, info_map_, place_);
+  x->unit_ = unit_->Clone(stream);
+}
 
 }  // namespace jit
 }  // namespace paddle

--- a/paddle/fluid/jit/layer.h
+++ b/paddle/fluid/jit/layer.h
@@ -67,7 +67,7 @@ class Layer {
 
   std::vector<std::string> FunctionNames() const;
 
-  std::shared_ptr<Layer> Clone(void *stream=nullptr);
+  std::shared_ptr<Layer> Clone(void* stream = nullptr);
 
  private:
   VariableMap params_map_;

--- a/paddle/fluid/jit/layer.h
+++ b/paddle/fluid/jit/layer.h
@@ -67,10 +67,13 @@ class Layer {
 
   std::vector<std::string> FunctionNames() const;
 
+  std::shared_ptr<Layer> Clone(void *stream=nullptr);
+
  private:
   VariableMap params_map_;
   VariableMap attrs_map_;
   FunctionInfoMap info_map_;
+  phi::Place place_;
   std::shared_ptr<CompilationUnit> unit_;
 };
 

--- a/paddle/fluid/jit/layer_test.cc
+++ b/paddle/fluid/jit/layer_test.cc
@@ -119,7 +119,6 @@ TEST(CpuLayerTest, Construct) {
   EXPECT_NEAR(out_data[0], pow(1.41562390, 2.0), 1e-6);
 }
 
-
 TEST(CpuLayerTest, Clone) {
   auto place = phi::CPUPlace();
   std::string path = "./multi_program_load/export";
@@ -173,7 +172,6 @@ TEST(GpuLayerTest, Construct) {
   out_data = cpu_tensor.data<float>();
   EXPECT_NEAR(out_data[0], sqrt(1.41562390), 1e-6);
 }
-
 
 TEST(GpuLayerTest, Clone) {
   auto place = phi::GPUPlace();

--- a/paddle/fluid/jit/layer_test.cc
+++ b/paddle/fluid/jit/layer_test.cc
@@ -20,6 +20,7 @@
 
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/variable.h"
+#include "paddle/fluid/platform/timer.h"
 #include "paddle/phi/api/include/api.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
@@ -78,7 +79,11 @@ TEST(CpuLayerTest, Function) {
 TEST(CpuLayerTest, Construct) {
   auto place = phi::CPUPlace();
   std::string path = "./multi_program_load/export";
+  paddle::platform::Timer timer;
+  timer.Start();
   auto layer = jit::Load(path, place);
+  timer.Pause();
+  std::cout << "jit::Load coast" << timer.ElapsedMS() << std::endl;
 
   float fbias = layer.Attribute<float>("fbias");
   EXPECT_FLOAT_EQ(fbias, 1.4);
@@ -122,9 +127,19 @@ TEST(CpuLayerTest, Construct) {
 TEST(CpuLayerTest, Clone) {
   auto place = phi::CPUPlace();
   std::string path = "./multi_program_load/export";
-  auto layer = jit::Load(path, place);
 
+  paddle::platform::Timer timer;
+  timer.Start();
+  auto layer = jit::Load(path, place);
+  timer.Pause();
+  std::cout << "jit::Load cost " << timer.ElapsedMS() << " ms" << std::endl;
+
+  timer.Start();
   auto layer2 = layer.Clone();
+  timer.Pause();
+  std::cout << "jit::Layer::Clone cost " << timer.ElapsedMS() << " ms"
+            << std::endl;
+
   float fbias = layer2->Attribute<float>("fbias");
   EXPECT_FLOAT_EQ(fbias, 1.4);
 

--- a/paddle/fluid/jit/layer_test.cc
+++ b/paddle/fluid/jit/layer_test.cc
@@ -117,6 +117,12 @@ TEST(CpuLayerTest, Construct) {
       paddle::experimental::pow(outs[0], paddle::experimental::Scalar(2));
   out_data = pow_out.data<float>();
   EXPECT_NEAR(out_data[0], pow(1.41562390, 2.0), 1e-6);
+
+  auto layer2 = layer.Clone();
+  {
+  float fbias = layer2->Attribute<float>("fbias");
+  EXPECT_FLOAT_EQ(fbias, 1.4);
+  }
 }
 
 #if defined(PADDLE_WITH_CUDA)
@@ -146,6 +152,16 @@ TEST(GpuLayerTest, Construct) {
   cpu_tensor = paddle::experimental::copy_to(sqrt_out, phi::CPUPlace(), true);
   out_data = cpu_tensor.data<float>();
   EXPECT_NEAR(out_data[0], sqrt(1.41562390), 1e-6);
+
+  auto layer2 = layer.Clone();
+  {
+    auto outs = layer2->forward(inputs);
+    auto gpu_tensor = outs[0];
+    auto cpu_tensor =
+        paddle::experimental::copy_to(gpu_tensor, phi::CPUPlace(), true);
+    auto out_data = cpu_tensor.data<float>();
+    EXPECT_NEAR(out_data[0], 0.02194316, 1e-6);
+  }
 }
 #endif
 

--- a/paddle/fluid/jit/serializer.cc
+++ b/paddle/fluid/jit/serializer.cc
@@ -30,8 +30,10 @@ DECLARE_string(jit_engine_type);
 
 namespace paddle {
 namespace jit {
+
 using FunctionInfoMap =
     std::unordered_map<std::string, std::shared_ptr<FunctionInfo>>;
+
 Layer Deserializer::operator()(const std::string& path,
                                const phi::Place& place) {
   const auto& pdmodel_paths = utils::PdmodelFilePaths(path);

--- a/paddle/fluid/jit/serializer.cc
+++ b/paddle/fluid/jit/serializer.cc
@@ -58,8 +58,6 @@ Layer Deserializer::operator()(const std::string& path,
 
   VariableMap params_dict;
   VariableMap attrs_dict;
-  // auto params_dict = std::make_shared<VariableMap>();
-  // auto attrs_dict = std::make_shared<VariableMap>();
   ReadTensorData(path + PDPARAMS_SUFFIX, param_names_set, place, &params_dict);
 
   if (utils::FileExists(path + PROPERTY_SUFFIX)) {

--- a/paddle/fluid/jit/serializer.cc
+++ b/paddle/fluid/jit/serializer.cc
@@ -58,6 +58,8 @@ Layer Deserializer::operator()(const std::string& path,
 
   VariableMap params_dict;
   VariableMap attrs_dict;
+  // auto params_dict = std::make_shared<VariableMap>();
+  // auto attrs_dict = std::make_shared<VariableMap>();
   ReadTensorData(path + PDPARAMS_SUFFIX, param_names_set, place, &params_dict);
 
   if (utils::FileExists(path + PROPERTY_SUFFIX)) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
* jit layer 支持 Clone，用于多线程中使用。
* fix predictor clone, which not need optimizer graph

收益：
* 满足多实例推理需求。
* clone从内存中加载模型，避免从外存中加载，节约 （n-1) 倍的时间，n为实例个数。
* clone 相比 init 快 44.13%

![image](https://user-images.githubusercontent.com/3038472/215939638-691faabf-6160-44fa-87ed-c9f47a959e56.png)