### PR TITLE
Fix errors for test_standalone_custom_stream

### DIFF
--- a/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_custom_stream.py
+++ b/python/paddle/fluid/tests/unittests/standalone_executor/test_standalone_custom_stream.py
@@ -50,10 +50,10 @@ class TestCustomStream(unittest.TestCase):
         ops = prog.global_block().ops
         for op_index in op_index_for_stream1:
             ops[op_index].dist_attr.execution_stream = "s1"
-            ops[op_index].dist_attr.stream_priority = -1
+            ops[op_index].dist_attr.stream_priority = 0
         for op_index in op_index_for_stream2:
             ops[op_index].dist_attr.execution_stream = "s2"
-            ops[op_index].dist_attr.stream_priority = -2
+            ops[op_index].dist_attr.stream_priority = -1
 
     def run_program(self, apply_custom_stream=False):
         paddle.seed(2022)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
单测`test_standalone_custom_stream`中为GPU自定义流设置了优先级-1和-2，这要求GPU设备能支持三级优先级（0，-1和-2），但在Windows CI少部分较低配的测试GPU上，只支持两级优先级（0和-1），运行此单测会触发报错拦截。
本PR将此单测设置的优先级从-1和-2改为0和-1，这样在所有GPU上都能成功运行。
当前CUDA的流优先级功能仅为静态图内部临时支持和使用，因而不涉及对外暴露API的相关改动。关于流优先级的定义范围，Stream相关API后续计划会重新梳理和统一抽象不同异构设备下的流概念以及优先级设计，并对现有的对外API进行对应改造。