### PR TITLE
[dy2static] support fallback for whole graph. (stage 1)

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fallback.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fallback.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+def support_func(x):
+    return 2 * x
+
+
+def unsupport_func(x):
+    x = 2 * x
+    t = x.numpy()
+    t = np.ones(t)
+    return paddle.to_tensor(t)
+
+
+class SuppportNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return support_func(x)
+
+
+class UnsuppportNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return unsupport_func(x)
+
+
+class TestFallback(unittest.TestCase):
+    def setUp(self):
+        self.x = paddle.to_tensor(2).astype('int')
+
+    def tearDown(self):
+        pass
+
+    def test_case_support(self):
+        output = paddle.jit.to_static(support_func)(self.x)
+        np.testing.assert_allclose(output.numpy(), 4)
+
+    def test_case_func_fallback(self):
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = True
+        output = paddle.jit.to_static(
+            unsupport_func, build_strategy=build_strategy
+        )(self.x)
+        np.testing.assert_allclose(output.numpy(), unsupport_func(self.x))
+
+    def test_case_net_fallback(self):
+        s_net = SuppportNet()
+        u_net = UnsuppportNet()
+        np.testing.assert_allclose(
+            paddle.jit.to_static(s_net)(self.x).numpy(), 4
+        )
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = True
+        np.testing.assert_allclose(
+            paddle.jit.to_static(u_net, build_strategy=build_strategy)(
+                self.x
+            ).numpy(),
+            u_net(self.x).numpy(),
+        )
+
+    def test_case_net_error(self):
+        s_net = SuppportNet()
+        u_net = UnsuppportNet()
+        np.testing.assert_allclose(
+            paddle.jit.to_static(s_net)(self.x).numpy(), 4
+        )
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = False
+        with self.assertRaises(TypeError):
+            np.testing.assert_allclose(
+                paddle.jit.to_static(u_net, build_strategy=build_strategy)(
+                    self.x
+                ).numpy(),
+                u_net(self.x).numpy(),
+            )
+
+    def test_case_save_error(self):
+        """
+        test the save will raise error.
+        """
+        u_net = UnsuppportNet()
+        u_net = paddle.jit.to_static(
+            u_net, input_spec=[paddle.static.InputSpec(name='x', shape=[1])]
+        )
+        with self.assertRaises(TypeError):
+            paddle.jit.save(u_net, path="model")
+
+    def test_case_flag(self):
+        """
+        test the flags is working. TODO: add a global flags.
+        """
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fallback.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fallback.py
@@ -109,6 +109,7 @@ class TestFallback(unittest.TestCase):
         )
         u_net.eval()
         np.testing.assert_allclose(u_net(self.x).numpy(), [1, 1])
+        assert u_net.training is False, "Training must be false."
 
     def test_case_save_error(self):
         """

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fallback.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fallback.py
@@ -109,6 +109,18 @@ class TestFallback(unittest.TestCase):
         with self.assertRaises(TypeError):
             paddle.jit.save(u_net, path="model")
 
+    def test_case_save_error_2(self):
+        """
+        test the save will raise error.
+        """
+        u_net = UnsuppportNet()
+        build_strategy = paddle.static.BuildStrategy()
+        build_strategy.build_cinn_pass = True
+        u_net = paddle.jit.to_static(u_net, build_strategy=build_strategy)
+        u_net(self.x)
+        with self.assertRaises(RuntimeError):
+            print(u_net.forward.main_program)
+
     def test_case_flag(self):
         """
         test the flags is working. TODO: add a global flags.

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1097,9 +1097,8 @@ class FallbackProgramLayer(object):
     def __getattr__(self, key):
         if key not in self.__slots__:
             raise RuntimeError(
-                "There raises a exception while dy2static and you are in fallback mode. \n"
-                "You can't get attribute for a fallback program layer. Check dy2static.error file "
-                "and fix unsupported gramma."
+                "There raises a exception after applying `@paddle.jit.to_static()` and already switch into fallback mode. \n"
+                "You can't get attribute for a fallback program layer. Please check `to_static.error` file for detail."
             )
         elif key in ['training']:
             if self._instance is not None:
@@ -1111,9 +1110,8 @@ class FallbackProgramLayer(object):
     def __setattr__(self, key, value):
         if key not in self.__slots__:
             raise RuntimeError(
-                "There raises a exception while dy2static and you are in fallback mode. \n"
-                "You can't get attribute for a fallback program layer. Check dy2static.error file "
-                "and fix unsupported gramma."
+                "There raises a exception after applying `@paddle.jit.to_static()` and already switch into fallback mode. \n"
+                "You can't get attribute for a fallback program layer. Please check `to_static.error` file for detail."
             )
         elif key in ['training']:
             if self._instance is not None:
@@ -1128,7 +1126,7 @@ class ProgramCache:
     Wrapper class for the program functions defined by dygraph function.
     """
 
-    dy2static_error_file = "dy2static.error"
+    dy2static_error_file = "to_static.error"
 
     def __init__(self):
         # {hash_id : (concrete_program, partial_layer)}
@@ -1140,7 +1138,7 @@ class ProgramCache:
     def _build_once(self, cache_key):
         # TODO(Aurelius84): Need a gloabl FLAGS to enable/disable to_prim
         enable_prim = cache_key.kwargs['build_strategy'].build_cinn_pass
-        # NOTE(xiongkun): Need a global FLAGS to enable/disable to_prim
+        # NOTE(xiongkun): Need a global FLAGS to enable/disable fallback
         enable_fallback = enable_prim
         if enable_prim:
             # TODO(Jiabin): Change this to True if we need this to be default option
@@ -1156,9 +1154,9 @@ class ProgramCache:
         except Exception as e:
             if enable_fallback:
                 warnings.warn(
-                    "Exception is thrown while performing dygraph to static. FallBack to dygraph mode training.\n"
-                    "1. You can check `dy2static.error` file in current work directory to see what is going wrong.\n"
-                    "2. In fallback mode, you can only do training, can't save or get program."
+                    "Exception is thrown while applying @paddle.jit.to_static. It will fallback into dygraph mode for training.\n"
+                    "1. You can check `to_static.error` file in current workspace directory for detail.\n"
+                    "2. In fallback mode, you can only do training, can't call paddle.jit.save(). Please modify model code according `to_static.error` firstly"
                 )
                 # TODO(xiongkun) change different file name to avoid overwrite.
                 with open(self.dy2static_error_file, "w") as fp:

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1092,10 +1092,7 @@ class FallbackProgramLayer(object):
         self._dy_func = dy_func
 
     def __call__(self, inputs):
-        if self._instance is None:
-            return self._dy_func(*inputs)
-        else:
-            return self._dy_func(*inputs)
+        return self._dy_func(*inputs)
 
     def __getattr__(self, key):
         if key not in self.__slots__:

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1098,7 +1098,7 @@ class FallbackProgramLayer(object):
         if key not in self.__slots__:
             raise RuntimeError(
                 "There raises a exception while dy2static and you are in fallback mode. \n"
-                "You can't get attribute for a fallback program layer. Check dy2static.error file"
+                "You can't get attribute for a fallback program layer. Check dy2static.error file "
                 "and fix unsupported gramma."
             )
         elif key in ['training']:
@@ -1112,7 +1112,7 @@ class FallbackProgramLayer(object):
         if key not in self.__slots__:
             raise RuntimeError(
                 "There raises a exception while dy2static and you are in fallback mode. \n"
-                "You can't get attribute for a fallback program layer. Check dy2static.error file"
+                "You can't get attribute for a fallback program layer. Check dy2static.error file "
                 "and fix unsupported gramma."
             )
         elif key in ['training']:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
动转静整图Fallback机制：
给动转静添加了整图Fallback机制。如果在动转静过程中出现了语法错误、用户无法识别语法会进行fallback到动态图下执行。整个过程不修改任何的用户用法，除了会报 warning 之外，不会有任何的影响。

#### 开启方法： 

build_strategy 中传入 build_strategy.build_cinn_pass=True 就会默认开启。（TODO：后续会添加一个独立的开关进行启动）

#### 运行截图：报warning

如果出现了动转静失败，同时开启了上述的pass，那么就会抛出一个warning，如下：
![image](https://user-images.githubusercontent.com/16025309/215684914-e68b9c75-47d9-4ddf-9652-2aa6b8e20ee7.png)

#### 错误日志

如果报错，那么warning中会提示在 dy2static.error 文件中可以查看不支持的语法：例如：
![image](https://user-images.githubusercontent.com/16025309/215685064-bfb6a3ba-9b43-4e06-95ee-68f459aeb4d4.png)
可以看到上述的错误是因为调用了numpy函数，用户可以通过修改代码，或者是反馈来解决模型问题，当模型问题修复之后，就不会出现warning了。

#### 设计架构：

![image](https://user-images.githubusercontent.com/16025309/215685204-feac565d-af31-4203-bab4-562f424bf9da.png)

#### 局限性
当前只是支持整图fallback，所以整个模型都会到动态图下执行。因此无法进行 jit.save、jit.load 等用法，同时也不支持获取 program。如果使用了上述的不支持方法，会有 Exception 抛出，并拦截提示。（用户友好）
比如调用了如下代码：
```
print(u_net.forward.main_program)
```
如果 u_net 不支持动转静，那么会报如下错误：
![image](https://user-images.githubusercontent.com/16025309/215689516-8b633953-13b5-4881-8473-37cc21a4ba0e.png)