### PR TITLE
[PrimCinn]Fix some vars are wrongly gc in CINN+InterpreterCore

### DIFF
--- a/paddle/fluid/operators/cinn/cinn_launch_context.cc
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.cc
@@ -108,8 +108,9 @@ CinnLaunchContext::CinnLaunchContext(const framework::ir::Graph& graph,
   // collect variables name list to be skipped in GC
   skip_eager_vars_.reserve(input_var_names.size() + output_var_names.size());
   auto add_skip_var_fn = [&outer_varinfo, this](const std::string& var_name) {
-    // Always consider Input/Output of Graph as skip_gc_vars, because InterpreterCore
-    // has no eager_deletion_op to deal with it.
+    // Always consider Input/Output of Graph as skip_gc_vars, because
+    // InterpreterCore has no eager_deletion_op to deal with it.
+
     VLOG(4) << "Append a skip_gc_var for InterpreterCore:" << var_name;
     skip_gc_vars_.insert(var_name);
     // if a var exists at the outer_varinfo map, that means it will be

--- a/paddle/fluid/operators/cinn/cinn_launch_context.cc
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.cc
@@ -108,12 +108,15 @@ CinnLaunchContext::CinnLaunchContext(const framework::ir::Graph& graph,
   // collect variables name list to be skipped in GC
   skip_eager_vars_.reserve(input_var_names.size() + output_var_names.size());
   auto add_skip_var_fn = [&outer_varinfo, this](const std::string& var_name) {
+    // Always consider Input/Output of Graph as skip_gc_vars, because InterpreterCore
+    // has no eager_deletion_op to deal with it.
+    VLOG(4) << "Append a skip_gc_var for InterpreterCore:" << var_name;
+    skip_gc_vars_.insert(var_name);
     // if a var exists at the outer_varinfo map, that means it will be
     // erased by the following eager_deletion_op of current cinn_launch op
     if (!outer_varinfo.count(var_name)) {
       skip_eager_vars_.emplace_back(var_name);
-      skip_gc_vars_.insert(var_name);
-      VLOG(4) << "Append a skip_gc_var:" << var_name;
+      VLOG(4) << "Append a skip_gc_var for PE:" << var_name;
     }
   };
   std::for_each(

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_grad.py
@@ -90,8 +90,8 @@ class TestAddGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=False)
-        comp_st_cinn_res = self.train(use_prim=True, use_cinn=False)
+        dy_res = self.train(use_prim=False, use_cinn=True)
+        comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_grad.py
@@ -90,7 +90,7 @@ class TestAddGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=True)
+        dy_res = self.train(use_prim=False, use_cinn=False)
         comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_tanh_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_tanh_grad.py
@@ -91,7 +91,7 @@ class TestDivGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=True)
+        dy_res = self.train(use_prim=False, use_cinn=False)
         comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_tanh_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_add_tanh_grad.py
@@ -91,8 +91,8 @@ class TestDivGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=False)
-        comp_st_cinn_res = self.train(use_prim=True, use_cinn=False)
+        dy_res = self.train(use_prim=False, use_cinn=True)
+        comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_div_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_div_grad.py
@@ -90,7 +90,7 @@ class TestDivGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=True)
+        dy_res = self.train(use_prim=False, use_cinn=False)
         comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_div_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_div_grad.py
@@ -90,8 +90,8 @@ class TestDivGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=False)
-        comp_st_cinn_res = self.train(use_prim=True, use_cinn=False)
+        dy_res = self.train(use_prim=False, use_cinn=True)
+        comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sqrt_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sqrt_grad.py
@@ -69,8 +69,8 @@ class TestSqrtGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=False)
-        comp_st_cinn_res = self.train(use_prim=True, use_cinn=False)
+        dy_res = self.train(use_prim=False, use_cinn=True)
+        comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sqrt_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sqrt_grad.py
@@ -69,7 +69,7 @@ class TestSqrtGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=True)
+        dy_res = self.train(use_prim=False, use_cinn=False)
         comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sub_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sub_grad.py
@@ -91,7 +91,7 @@ class TestDivGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=True)
+        dy_res = self.train(use_prim=False, use_cinn=False)
         comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sub_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_sub_grad.py
@@ -91,8 +91,8 @@ class TestDivGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=False)
-        comp_st_cinn_res = self.train(use_prim=True, use_cinn=False)
+        dy_res = self.train(use_prim=False, use_cinn=True)
+        comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_tanh_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_tanh_grad.py
@@ -69,8 +69,8 @@ class TestTanhGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=False)
-        comp_st_cinn_res = self.train(use_prim=True, use_cinn=False)
+        dy_res = self.train(use_prim=False, use_cinn=True)
+        comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):
             np.testing.assert_allclose(

--- a/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_tanh_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/vjp/static/test_comp_tanh_grad.py
@@ -69,7 +69,7 @@ class TestTanhGradComp(unittest.TestCase):
 
     def test_cinn(self):
         paddle.disable_static()
-        dy_res = self.train(use_prim=False, use_cinn=True)
+        dy_res = self.train(use_prim=False, use_cinn=False)
         comp_st_cinn_res = self.train(use_prim=True, use_cinn=True)
 
         for i in range(len(dy_res)):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

修复了组合算子+动转静 在开启cinn时，出现反向 y@Grad 因误GC无数据区的问题。

问题原因：
单测中x_grad有显存是因为产生它的matmul_grad不是走的cinn_launch， y_grad走的是cinn_launch算子，其内部又调用了新执行器执行cinn_sub_graph，但新执行器感知到的skip_gc_vars里没有y_grad。
![680c0d9bb53dacf8587dde15591043a8](https://user-images.githubusercontent.com/9301846/215720516-411bf6f0-1796-4ce8-905a-8c06710f53ac.jpg)
<img width="1004" alt="76b15b7791ed105cc72664fbea2a2416" src="https://user-images.githubusercontent.com/9301846/215720540-2a6b6c93-3282-4ace-8c48-7a84fcaeb086.png">

但cinn 子图里确实把y_grad标记为了fetch输出
<img width="1499" alt="image" src="https://user-images.githubusercontent.com/9301846/215720794-aa6580a1-c6f7-4f6a-a3da-47defc2f83bc.png">

经过进一步分析发现，在CinnLaunchContext构造时，初始化新执行器需要大额skip_gc_vars信息时，错误地用PE的`if (!outer_varinfo.count(var_name))` 做了过滤。
<img width="814" alt="image" src="https://user-images.githubusercontent.com/9301846/215721252-cc1746ca-993e-46f7-8a3e-11d24bace4ae.png">
