### PR TITLE
[Deprecate API] add deprecated decorator for paddle.utils.profiler

### DIFF
--- a/python/paddle/utils/profiler.py
+++ b/python/paddle/utils/profiler.py
@@ -19,6 +19,7 @@ from ..fluid import core
 from ..fluid.profiler import cuda_profiler  # noqa: F401
 from ..fluid.profiler import profiler  # noqa: F401
 from ..fluid.profiler import reset_profiler, start_profiler, stop_profiler
+from .deprecated import deprecated
 
 __all__ = [  # noqa
     'Profiler',
@@ -32,6 +33,12 @@ __all__ = [  # noqa
 ]
 
 
+@deprecated(
+    since="2.4.2",
+    update_to="paddle.profiler.Profiler",
+    level=1,
+    reason="Please use new profiler tool, this profiler tool is no longer maintained.",
+)
 class ProfilerOptions:
     def __init__(self, options=None):
         self.options = {
@@ -72,6 +79,12 @@ class ProfilerOptions:
 _current_profiler = None
 
 
+@deprecated(
+    since="2.4.2",
+    update_to="paddle.profiler.Profiler",
+    level=1,
+    reason="Please use new profiler tool, this profiler tool is no longer maintained.",
+)
 class Profiler:
     def __init__(self, enabled=True, options=None):
         if options is not None:
@@ -146,6 +159,12 @@ class Profiler:
                 self.stop()
 
 
+@deprecated(
+    since="2.4.2",
+    update_to="paddle.profiler.Profiler",
+    level=1,
+    reason="Please use new profiler tool, this profiler tool is no longer maintained.",
+)
 def get_profiler():
     global _current_profiler
     if _current_profiler is None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
#### Motivation：
- The APIs `paddle.utils.profiler` is `paddle.fluid.profiler` essentially, if we delete the code of `paddle.fluid.profiler`, `paddle.utils.profiler` will not work.  So the `paddle.utils.profiler` need to be deprecated, then we can remove the code of `paddle.fluid.profiler`.
- From version 2.3, there is a new profiler `paddle.profiler`, which is more comprehensive.  As outdated APIs, `paddle.utils.profiler` can be removed. 
- There are **8** public APIs need to be deprecated，**5** of them have already been marked at `2.3.0`, we need to mark the remaining **3** APIs. Then these APIs can be removed together in the next release version of PaddlePaddle.

#### What Is This PR Doing:
This PR adds deprecated decorator for following 3 public APIs:
```
paddle.utils.profiler.ProfilerOptions
paddle.utils.profiler.Profiler
paddle.utils.profiler.get_profiler
```
#### What to Do Next
- From version `2.4.2`, these APIs will be marked as `deprecated`. Users can still use them, however, we strongly recommend using the new API `paddle.profiler`
- From version `2.5.0`, these APIs will be removed.
