### PR TITLE
Reduce time cost of BuildOpHappensBefore

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
@@ -40,7 +40,13 @@ class DependencyBuilder {
 
   const std::map<size_t, std::set<size_t>>& OpDownstreamMap() const;
 
-  bool OpHappensBefore(size_t prior_op_idx, size_t posterior_op_idx) const;
+  bool OpHappensBefore(size_t prior_op_idx, size_t posterior_op_idx) const {
+    PADDLE_ENFORCE_GE(
+        op_happens_before_.size(),
+        0,
+        phi::errors::Unavailable("op_happen_before is not yet built"));
+    return op_happens_before_.at(prior_op_idx).at(posterior_op_idx);
+  }
 
  private:
   void AddDependencyForCoalesceTensorOp();
@@ -61,13 +67,19 @@ class DependencyBuilder {
 
   // op_behind_map_ is the mapping from op to its posterior-op set, that is to
   // say, op_behind_map_[i] == {a, b, c} means op[a], op[b] and op[c] depend on
-  // op[i] directly or indirectly
+  // op[i] directly or indirectly. op_before_map_ is the revered mapping of
+  // op_behind_map.
+  std::map<size_t, std::set<size_t>> op_before_map_;
   std::map<size_t, std::set<size_t>> op_behind_map_;
 
   // op_downstream_map_ is the mapping from op to its downstream-op set, that is
   // to say, op_downstream_map_[i] == {a, b, c} means op[a], op[b] and op[c]
   // depend on op[i] directly
   std::map<size_t, std::set<size_t>> op_downstream_map_;
+
+  // op_happens_before_ is a matrix form of op_before_map_ and op_behind_map_,
+  // it is used to speed up the query.
+  std::vector<std::vector<bool>> op_happens_before_;
 };
 
 }  // namespace interpreter

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
@@ -65,20 +65,20 @@ class DependencyBuilder {
   const std::vector<Instruction>* instructions_;  // not_own
   size_t op_num_;
 
-  // op_behind_map_ is the mapping from op to its posterior-op set, that is to
-  // say, op_behind_map_[i] == {a, b, c} means op[a], op[b] and op[c] depend on
-  // op[i] directly or indirectly. op_before_map_ is the revered mapping of
-  // op_behind_map.
-  std::map<size_t, std::set<size_t>> op_before_map_;
-  std::map<size_t, std::set<size_t>> op_behind_map_;
+  // ops_behind_ is the adjacency list about op to its posterior-ops, that is to
+  // say, op_behind_[i] == {a, b, c} means op[a], op[b] and op[c] depend on
+  // op[i] directly or indirectly. ops_before_ is the revered adjacency list of
+  // ops_behind_.
+  std::vector<std::vector<size_t>> ops_before_;
+  std::vector<std::vector<size_t>> ops_behind_;
 
   // op_downstream_map_ is the mapping from op to its downstream-op set, that is
   // to say, op_downstream_map_[i] == {a, b, c} means op[a], op[b] and op[c]
-  // depend on op[i] directly
+  // depend on op[i] directly.
   std::map<size_t, std::set<size_t>> op_downstream_map_;
 
-  // op_happens_before_ is a matrix form of op_before_map_ and op_behind_map_,
-  // it is used to speed up the query.
+  // op_happens_before_ is a matrix form of ops_before_ and ops_behind_, it is
+  // used to speed up the query.
   std::vector<std::vector<bool>> op_happens_before_;
 };
 

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
@@ -61,12 +61,14 @@ class DependencyBuilder {
   const std::vector<Instruction>* instructions_;  // not_own
   size_t op_num_;
 
-  // op_happens_before_[i][j] == true means op[i] happens before op[j]
-  std::vector<std::vector<bool>> op_happens_before_;
+  // op_behind_map_ is the mapping from op to its posterior-op set, that is to
+  // say, op_behind_map_[i] == {a, b, c} means op[a], op[b] and op[c] depend on
+  // op[i] directly or indirectly
+  std::map<size_t, std::set<size_t>> op_behind_map_;
 
   // op_downstream_map_ is the mapping from op to its downstream-op set, that is
   // to say, op_downstream_map_[i] == {a, b, c} means op[a], op[b] and op[c]
-  // should be dispatched after op[i]
+  // depend on op[i] directly
   std::map<size_t, std::set<size_t>> op_downstream_map_;
 };
 

--- a/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
+++ b/paddle/fluid/framework/new_executor/interpreter/dependency_builder.h
@@ -53,8 +53,6 @@ class DependencyBuilder {
 
   void BuildDownstreamMap();
 
-  void BuildOpHappensBefore();
-
   void ShrinkDownstreamMap();
 
   bool is_build_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization
### PR changes
Others

### Describe
<!-- Describe what this PR does -->
**【相关背景】**
PR https://github.com/PaddlePaddle/Paddle/pull/41471 为新执行器在预分析阶段引入了存储依赖图上结点可达关系的矩阵`op_happens_before_`，用于辅助对存储OP依赖关系的`op_downstream_map_`进行剪枝。**`op_happens_before_`的构建需要对网络做n次BFS遍历，时间复杂度为O(n^2+nm))**，其中n为OP数量，m为未经剪枝的数据依赖边数量。
在PR https://github.com/PaddlePaddle/Paddle/pull/48809 支持跨step多流同步后，多流的依赖同步需要拼接两个step的网络结构进行分析，这使得模型中的OP和依赖边数量都成倍增加，进一步增大了新执行器预分析阶段的时间开销。
虽然实际训练时图依赖关系的构建只需要在预分析阶段执行一次，但在网络较大时，较长的预处理时间仍是不可接受的。当前**自动并行场景下GPT 10B模型新执行器进行一次预分析所需时间超过10小时；手动数据并行`transformer_base_bs4096_amp_fp16`单机八卡训练切换成新执行器后，预分析阶段op_happens_before_的计算也耗费了极长的时间，导致CE监控触发模型运行超时失败报警。**

**【具体工作】**
本PR将新执行器依赖剪枝逻辑从**构建完整的数据依赖边 -> 根据数据依赖边n次BFS构建可达矩阵 -> 根据可达矩阵裁剪数据依赖边**更改为在构建数据依赖时**实时维护和更新可达矩阵，并在添加依赖时提前判断并跳过冗余依赖**。
在具体的可达矩阵计算方法上，不会再通过n次BFS来计算`op_happens_before`，而是在每次加依赖边时进行实时更新。当添加依赖边a->b时：

- 查询所有b的可达结点c，将其添加到a的可达列表中

- 查询所有可达a的结点c，将b添加到c的可达列表中

为了高效查询以上两种情况中的c，额外维护两个邻接表`ops_before_`和`op_behind_`，分别存储`可达结点i的结点列表`以及`结点i的可达结点列表`，通过空间换时间的方式降低代码复杂度。

基于新的算法，添加依赖边时实时跳过冗余依赖，只在加实际依赖边时更新邻接表，总的时间复杂度为O(m')，其中m’为剪枝后的数据依赖边数量。每个结点i最坏情况下会被通过所有`可达i的结点列表`以及`i的可达结点列表`各查询一次，这两个结点列表的总数不超过网络总的结点数n，假设平均可达结点数为k，则总的查询复杂度为O(kn)。整个算法计算可达关系的复杂度为O（kn + m + m'），通常情况下m >> m'，因而**时间复杂度为O(kn + m)。另外，由于剪枝操作的存在，k通常情况下是远小于n的**。

**【优化效果】**
基于本PR的修改，计算可达矩阵的**时间复杂度从O(n^2+nm))降低为O(kn + m)*，同时依赖关系`op_downstream_map_`的构建也**省去了先添加再剪掉冗余边的操作开销**。
对于transformer_base_bs4096_amp_fp16模型，在跨step多流拼接两倍网络的情况下:
n = 6391
m = 16407
m' = 7772
优化前最大计算量：n^2+n*m = 145702018
优化后即使k按打满n计，最大计算量：n^2 + m= 40861288
从亿级降低到千万级，由于k在实际网络中至少能比n小一个数量级，因而**实际的计算量至少可以优化到百万级**。
实测本PR优化后transformer_base_bs4096_amp_fp16模型可在感知较小的时间开销内完成一轮预分析，且前后依赖分析结果逐一对比完全一致。
对于自动并行GPT 10B模型，优化效果未实测，后续由@JZ-LIANG 进行验证。