### PR TITLE
2.4:modify cmake file for cuda11.8 compile

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -317,8 +317,8 @@ if(WITH_ONNXRUNTIME)
 endif()
 
 if(WITH_GPU)
-  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0 OR ${CMAKE_CUDA_COMPILER_VERSION}
-                                                 GREATER_EQUAL 11.6)
+  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0
+     OR (WIN32 AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6))
     include(external/cub) # download cub
     list(APPEND third_party_deps extern_cub)
   endif()

--- a/paddle/fluid/operators/fused/CMakeLists.txt
+++ b/paddle/fluid/operators/fused/CMakeLists.txt
@@ -68,6 +68,7 @@ if(WITH_GPU OR WITH_ROCM)
   op_library(yolo_box_head_op)
   op_library(yolo_box_post_op)
   op_library(fused_embedding_eltwise_layernorm_op DEPS bert_encoder_functor)
+  op_library(fused_gate_attention_op)
   # fusion_group
   if(NOT APPLE AND NOT WIN32)
     op_library(fusion_group_op DEPS device_code)

--- a/paddle/fluid/operators/fused/CMakeLists.txt
+++ b/paddle/fluid/operators/fused/CMakeLists.txt
@@ -68,7 +68,7 @@ if(WITH_GPU OR WITH_ROCM)
   op_library(yolo_box_head_op)
   op_library(yolo_box_post_op)
   op_library(fused_embedding_eltwise_layernorm_op)
-  op_library(fused_gate_attention_op)
+  op_library(fused_embedding_eltwise_layernorm_op DEPS bert_encoder_functor)
   # fusion_group
   if(NOT APPLE AND NOT WIN32)
     op_library(fusion_group_op DEPS device_code)

--- a/paddle/fluid/operators/fused/CMakeLists.txt
+++ b/paddle/fluid/operators/fused/CMakeLists.txt
@@ -67,7 +67,6 @@ if(WITH_GPU OR WITH_ROCM)
   op_library(skip_layernorm_op)
   op_library(yolo_box_head_op)
   op_library(yolo_box_post_op)
-  op_library(fused_embedding_eltwise_layernorm_op)
   op_library(fused_embedding_eltwise_layernorm_op DEPS bert_encoder_functor)
   # fusion_group
   if(NOT APPLE AND NOT WIN32)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
For Linux, cuda11.6 and above do not need to include(external/cub).