### PR TITLE
[Windows] fix compil error on windows for cuda11.6/7/8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,8 +157,14 @@ if(WIN32)
     endforeach()
   endif()
 
-  # NOTE(zhouwei): msvc max/min macro conflict with std::min/max, define NOMINMAX globally
+  # msvc max/min macro conflict with std::min/max, define NOMINMAX globally
   add_definitions("-DNOMINMAX")
+
+  # 1. windows.h define 'small' cause CUDA11.6/11.7/11.8 's cub compile error,
+  # see https://github.com/microsoft/onnxruntime/issues/11227
+  # 2. WIN32_LEAN_AND_MEAN minimize the windows include files, avoid define 'small'
+  add_definitions(-DWIN32_LEAN_AND_MEAN)
+
   # windows build turn off warnings, use parallel compiling.
   foreach(
     flag_var

--- a/cmake/external/cub.cmake
+++ b/cmake/external/cub.cmake
@@ -14,7 +14,7 @@
 
 include(ExternalProject)
 
-# Note(zhouwei): extern_cub  has code __FILE_, If the path of extern_cub is changed,
+# extern_cub  has code __FILE_, If the path of extern_cub is changed,
 # it will effect about 30+ cu files sccache hit and slow compile speed  on windows.
 # Therefore, a fixed CUB_PATH will be input to increase the sccache hit rate.
 set(CUB_PATH
@@ -25,7 +25,7 @@ set(CUB_PREFIX_DIR ${CUB_PATH})
 set(CUB_REPOSITORY ${GIT_URL}/NVlabs/cub.git)
 
 if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6)
-  # cuda_11.6.2_511.65‘s own cub is 1.15.0, which will cause compiling error in windows.
+  # cuda_11.6/11.7/11.8‘s own cub is 1.15.0, which will cause compiling error in windows.
   set(CUB_TAG 1.16.0)
   # cub 1.16.0 is not compitable with current thrust version
   add_definitions(-DTHRUST_IGNORE_CUB_VERSION_CHECK)

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -320,8 +320,7 @@ if(WITH_ONNXRUNTIME)
 endif()
 
 if(WITH_GPU)
-  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0
-     OR (WIN32 AND ${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.6))
+  if(${CMAKE_CUDA_COMPILER_VERSION} LESS 11.0)
     include(external/cub) # download cub
     list(APPEND third_party_deps extern_cub)
   endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

WindowsSDK里某个头文件里宏定义了`small`，与CUDA11.6/11.7/11.8中的cub函数冲突，导致windows编译报错：

报错内容如下：
```
C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\include\cub/device/dispatch/dispatch_segmented_sort.cuh(338): error : invalid combination of type specifiers 

C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\include\cub/device/dispatch/dispatch_segmented_sort.cuh(338): error : expected an identifier 

C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\include\cub/device/dispatch/dispatch_segmented_sort.cuh(379): error : expected a member name 
```
![infoflow 2023-02-02 19-09-54](https://user-images.githubusercontent.com/52485244/216550964-5d8a9ef8-9e42-48df-88ae-ee8039f60650.png)

见Nvidia自带cub头文件该位置，使用了`small`，造成冲突：

![infoflow 2023-02-03 16-35-13](https://user-images.githubusercontent.com/52485244/216551435-615ed4c3-8ac2-4a50-9f01-8f73012e42fc.png)

因此使用宏`DWIN32_LEAN_AND_MEAN` 减少了不常用的windows SDK头文件，避免了宏定义问题，也减少头文件数量的预处理成本。

