### PR TITLE
fix QuantWeightPass error in sub graph

### DIFF
--- a/python/paddle/static/quantization/quantization_pass.py
+++ b/python/paddle/static/quantization/quantization_pass.py
@@ -3226,11 +3226,15 @@ class QuantWeightPass:
                     self._quantized_ops[x_node.name()] = quant_weight_node
 
                 for next_op_node in out_node.outputs:
-                    graph.update_input_link(
-                        out_node,
-                        self._quantized_ops[x_node.name()],
-                        next_op_node,
-                    )
+                    if (
+                        self._quantized_ops[x_node.name()].node
+                        in graph.graph.nodes()
+                    ):
+                        graph.update_input_link(
+                            out_node,
+                            self._quantized_ops[x_node.name()],
+                            next_op_node,
+                        )
                 graph.safe_remove_nodes(_op)
         self._remove_unused_var_nodes(graph)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix QuantWeightPass error in sub graph.
```shell
File "/usr/local/lib/python3.7/site-packages/paddle/quantization/imperative/qat.py", line 587, in save_quantized_model
    quant_weight_pass.apply(sub_graph)
  File "/usr/local/lib/python3.7/site-packages/paddle/static/quantization/quantization_pass.py", line 3235, in apply
    next_op_node,
  File "/usr/local/lib/python3.7/site-packages/paddle/fluid/framework.py", line 5034, in update_input_link
    ), 'The three arguments(old_input_node&new_input_node&op_node) must be in the graph nodes.'
AssertionError: The three arguments(old_input_node&new_input_node&op_node) must be in the graph nodes.
```