### PR TITLE
[CINN] fix inplace internal var cannot found in scope when only input fused bug

### DIFF
--- a/paddle/fluid/operators/cinn/cinn_launch_context.cc
+++ b/paddle/fluid/operators/cinn/cinn_launch_context.cc
@@ -235,6 +235,9 @@ std::unordered_set<std::string> CinnLaunchContext::ExtractInternalVarNames(
       remain_var_names.erase(var_name + InplaceOutSuffix);
     }
   };
+
+  VLOG(1) << "Input var list: " << string::join_strings(input_var_names, ", ");
+  VLOG(1) << "Ouput var list: " << string::join_strings(output_var_names, ", ");
   std::for_each(
       input_var_names.begin(), input_var_names.end(), exclude_names_fn);
   std::for_each(
@@ -474,6 +477,8 @@ framework::InterpreterCore* CinnLaunchContext::InitializeInterpreterCore(
                "interpreter_core_: "
             << interpreter_core_.get() << "; scope: " << scope
             << "; cached_scope_: " << cached_scope_;
+    VLOG(1) << "Internal var list: "
+            << string::join_strings(internal_var_names_, ", ");
     for (auto&& var_name : internal_var_names_) {
       auto* var = scope->FindVar(var_name);
       if (var != nullptr) {
@@ -506,8 +511,7 @@ std::string CinnLaunchContext::RedirectVarName(const std::string& var_name) {
   }
   std::string remove_suffix_name = var_name.substr(0, pos);
   if (!inplace_var_names_.count(remove_suffix_name)) {
-    LOG(WARNING) << "Variable:" << remove_suffix_name
-                 << " was not marked as inplaced by Paddle, but CINN does";
+    return var_name;
   }
   VLOG(4) << "Inplaced variable:" << var_name << " redirect to "
           << remove_suffix_name;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复由于inplace输入输出变量都是internal，输出变量带`@InplaceOut`后缀，而输入变量由于被fused掉了导致paddle scope中找不到不带后缀的变量而报错：
![image](https://user-images.githubusercontent.com/31386411/216555014-c2697311-f679-4584-b48c-7489844222dc.png)
