### PR TITLE
[Paddle Inference] Fix range fp32 input below trt 8.4.

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -357,11 +357,11 @@ struct SimpleOpTypeSetTeller : public Teller {
       if (!with_dynamic_shape) {
         return false;
       }
+#if IS_TRT_VERSION_LT(8400)
       auto* block = desc.Block();
       auto start_var_name = desc.Input("Start")[0];
       auto* start_var_desc = block->FindVar(start_var_name);
       auto start_dtype = start_var_desc->GetDataType();
-#if IS_TRT_VERSION_LT(8400)
       if (start_dtype == framework::proto::VarType::FP32) {
         return false;
       }

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -357,6 +357,15 @@ struct SimpleOpTypeSetTeller : public Teller {
       if (!with_dynamic_shape) {
         return false;
       }
+      auto* block = desc.Block();
+      auto start_var_name = desc.Input("Start")[0];
+      auto* start_var_desc = block->FindVar(start_var_name);
+      auto start_dtype = start_var_desc->GetDataType();
+#if IS_TRT_VERSION_LT(8400)
+      if (start_dtype == framework::proto::VarType::FP32) {
+        return false;
+      }
+#endif
     }
 
     if (op_type == "sign") {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix range fp32 input below trt 8.4.
