### PR TITLE
Set waiterType of kGpuSync to kCUDA

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
@@ -431,8 +431,7 @@ void StreamAnalyzer::ShrinkEventInfo(
 
 platform::DeviceType StreamAnalyzer::GetWaiterType(
     const Instruction& instr) const {
-  if (instr.KernelType() == OpFuncType::kCpuSync ||
-      instr.KernelType() == OpFuncType::kGpuSync) {
+  if (instr.KernelType() == OpFuncType::kCpuSync) {
     return platform::kCPU;
   } else {
     if (platform::is_xpu_place(place_)) {

--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -858,8 +858,6 @@ void InterpreterCore::RunOperator(const Instruction& instr_node) {
                                        : var_scope_.GetMutableScope();
   VLOG(4) << "Start run " << place << " " << op->DebugStringEx(local_scope);
 
-  SetDeviceId(place);
-
 #ifdef PADDLE_WITH_ASCEND_CL
   if (platform::is_npu_place(place)) {
     // NOTE(wangxi): nan/inf cannot be detected on NPU by checking the
@@ -988,6 +986,8 @@ void InterpreterCore::RunInstruction(const Instruction& instr_node) {
   auto* op = instr_node.OpBase();
   platform::RecordEvent instruction_event(
       op->Type(), platform::TracerEventType::Operator, 1);
+
+  SetDeviceId(instr_node.DeviceContext().GetPlace());
 
   try {
     instr_node.WaitEvent(place_);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
PR https://github.com/PaddlePaddle/Paddle/pull/48758 将kGpuSync类型算子的waiterType从kCUDA修改成kCPU，这导致ResNet50_bs128_fp16 N4C32手动数据并行训练性能下降约3%。原因是相比cudaEventWait，memcpy操作使用cudaEventSynchronize在CPU端的同步开销更大。
本PR将kGpuSync类型算子的waiterType恢复成kCUDA，以避免ResNet50_bs128_fp16性能下降的问题。本PR修改后，ResNet50_bs128_fp16 N4C32手动数据并行IPS从35600提升到36644 samples/sec（+3%）。
另，之前的改动可避免memcpy_d2h跨线程cudaEventWait导致的CUDA Error(2)错误，但并没有实际修复跨线程同步会出现CUDA Error的问题。经排查，跨线程cudaError是因PR https://github.com/PaddlePaddle/Paddle/pull/48370 在开发trace mode时引入，原本多流同步的操作（WaitEvent）应在线程设置DeviceId之后再进行，该PR改动导致在未设置DeviceId时即开始执行WaitEvent操作，从而触发Cuda Error错误。本PR对此问题一并进行了修复。