### PR TITLE
[inference][trt] Disable ShapeTensor for nearest_interp_v2 when trt version < 8.2

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/nearest_interp_v2_op.cc
@@ -82,6 +82,7 @@ class NearestInterpolateV2OpConverter : public OpConverter {
 
     // Priority: Input(SizeTensor) > attr(out_h/out_w) > attr(scale)
     nvinfer1::ITensor* outsize_tensor = nullptr;
+#if IS_TRT_VERSION_GE(8200)
     if (engine_->with_dynamic_shape() &&
         inputs.find("SizeTensor") != inputs.end()) {
       if (op_desc.Input("SizeTensor").size() >= 2) {
@@ -91,6 +92,7 @@ class NearestInterpolateV2OpConverter : public OpConverter {
             Concat(std::vector<nvinfer1::ITensor*>{outsize_h, outsize_w});
       }
     }
+#endif
 
     if (engine_->with_dynamic_shape()) {
       scales.push_back(1.f);

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -840,12 +840,14 @@ struct SimpleOpTypeSetTeller : public Teller {
           PADDLE_GET_CONST(std::string, desc.GetAttr("interp_method"));
       if (interp_method != "nearest") return false;
 
+#if IS_TRT_VERSION_GE(8200)
       auto resize_inputs = desc.Inputs();
       if (with_dynamic_shape &&
           resize_inputs.find("SizeTensor") != resize_inputs.end() &&
           desc.Input("SizeTensor").size() == 2) {
         return true;
       }
+#endif
 
       auto scale = PADDLE_GET_CONST(std::vector<float>, desc.GetAttr("scale"));
       auto out_h = PADDLE_GET_CONST(int, desc.GetAttr("out_h"));

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_nearest_interp_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_nearest_interp_v2.py
@@ -30,15 +30,11 @@ class TrtConvertNearestInterpV2Test(TrtLayerAutoScanTest):
         def generate_input():
             return np.ones([1, 3, 32, 32]).astype(np.float32)
 
-        def generate_weight():
-            return np.array([64]).astype(np.int32)
-
         ops_config = [
             {
                 "op_type": "nearest_interp_v2",
                 "op_inputs": {
                     "X": ["input_data"],
-                    "SizeTensor": ["size_tensor_data0", "size_tensor_data1"],
                 },
                 "op_outputs": {"Out": ["interp_output_data"]},
                 "op_attrs": {
@@ -58,8 +54,6 @@ class TrtConvertNearestInterpV2Test(TrtLayerAutoScanTest):
         program_config = ProgramConfig(
             ops=ops,
             weights={
-                "size_tensor_data0": TensorConfig(data_gen=generate_weight),
-                "size_tensor_data1": TensorConfig(data_gen=generate_weight),
             },
             inputs={"input_data": TensorConfig(data_gen=generate_input)},
             outputs=["interp_output_data"],
@@ -112,6 +106,100 @@ class TrtConvertNearestInterpV2Test(TrtLayerAutoScanTest):
     def test(self):
         self.run_test()
 
+
+class TrtConvertNearestInterpV2ShapeTensorTest(TrtLayerAutoScanTest):
+    def is_program_valid(self, program_config: ProgramConfig) -> bool:
+        return True
+
+    def sample_program_configs(self):
+        def generate_input():
+            return np.ones([1, 3, 32, 32]).astype(np.float32)
+
+        def generate_weight():
+            return np.array([64]).astype(np.int32)
+
+        ops_config = [
+            {
+                "op_type": "nearest_interp_v2",
+                "op_inputs": {
+                    "X": ["input_data"],
+                    "SizeTensor": ["size_tensor_data0", "size_tensor_data1"],
+                },
+                "op_outputs": {"Out": ["interp_output_data"]},
+                "op_attrs": {
+                    "data_layout": "NCHW",
+                    "interp_method": "nearest",
+                    "align_corners": False,
+                    "align_mode": 1,
+                    "scale": [2.0, 2.0],
+                    "out_d": 0,
+                    "out_h": 0,
+                    "out_w": 0,
+                },
+            }
+        ]
+
+        ops = self.generate_op_config(ops_config)
+        program_config = ProgramConfig(
+            ops=ops,
+            weights={
+                "size_tensor_data0": TensorConfig(data_gen=generate_weight),
+                "size_tensor_data1": TensorConfig(data_gen=generate_weight),
+            },
+            inputs={"input_data": TensorConfig(data_gen=generate_input)},
+            outputs=["interp_output_data"],
+        )
+
+        yield program_config
+
+    def sample_predictor_configs(
+        self, program_config
+    ) -> (paddle_infer.Config, List[int], float):
+        def generate_dynamic_shape(attrs):
+            self.dynamic_shape.min_input_shape = {"input_data": [1, 3, 32, 32]}
+            self.dynamic_shape.max_input_shape = {"input_data": [4, 3, 64, 64]}
+            self.dynamic_shape.opt_input_shape = {"input_data": [1, 3, 64, 64]}
+
+        def clear_dynamic_shape():
+            self.dynamic_shape.min_input_shape = {}
+            self.dynamic_shape.max_input_shape = {}
+            self.dynamic_shape.opt_input_shape = {}
+
+        def generate_trt_nodes_num(attrs, dynamic_shape):
+            if dynamic_shape:
+                ver = paddle_infer.get_trt_compile_version()
+                if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 8200:
+                    return 0, 3
+            return 1, 2
+
+        attrs = [
+            program_config.ops[i].attrs for i in range(len(program_config.ops))
+        ]
+
+        # for static_shape
+        clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False
+        ), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False
+        ), 1e-2
+
+        # for dynamic_shape
+        generate_dynamic_shape(attrs)
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True
+        ), 1e-5
+        self.trt_param.precision = paddle_infer.PrecisionType.Half
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True
+        ), 1e-2
+
+    def test(self):
+        self.run_test()
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_nearest_interp_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_nearest_interp_v2.py
@@ -53,8 +53,7 @@ class TrtConvertNearestInterpV2Test(TrtLayerAutoScanTest):
         ops = self.generate_op_config(ops_config)
         program_config = ProgramConfig(
             ops=ops,
-            weights={
-            },
+            weights={},
             inputs={"input_data": TensorConfig(data_gen=generate_input)},
             outputs=["interp_output_data"],
         )
@@ -200,6 +199,7 @@ class TrtConvertNearestInterpV2ShapeTensorTest(TrtLayerAutoScanTest):
 
     def test(self):
         self.run_test()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_nearest_interp_v2.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_nearest_interp_v2.py
@@ -165,10 +165,6 @@ class TrtConvertNearestInterpV2ShapeTensorTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if dynamic_shape:
-                ver = paddle_infer.get_trt_compile_version()
-                if ver[0] * 1000 + ver[1] * 100 + ver[2] * 10 < 8200:
-                    return 0, 3
             return 1, 2
 
         attrs = [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- Disable ShapeTensor for nearest_interp_v2 when trt version < 8.2