### PR TITLE
fix op_desc set attr bug of map_op_to_another_pass

### DIFF
--- a/paddle/fluid/framework/ir/map_op_to_another_pass.cc
+++ b/paddle/fluid/framework/ir/map_op_to_another_pass.cc
@@ -57,6 +57,7 @@ void MapOp2AnotherPass::ApplyImpl(ir::Graph* graph) const {
       if (groups > 1) {
 #if CUDNN_VERSION >= 8100
         op_desc->SetType(replaced_map[op_type]);
+        op_desc->RemoveAttr("use_cudnn");
         op_desc->SetAttr("use_cudnn", true);
 #endif
       }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
直接set会产生两份属性，需要先remove再set
// op_desc->RemoveAttr("use_cudnn");
op_desc->SetAttr("use_cudnn", true);
<img width="375" alt="c5da87f220d57d591974fcb7f29ad7e4" src="https://user-images.githubusercontent.com/23653004/217152250-c02eaacd-0be2-4e2b-8456-78f48d6233f8.png">
