### PR TITLE
Fix bn performance degradation

### DIFF
--- a/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
@@ -783,7 +783,8 @@ void BatchNormGradRawKernel(const Context &ctx,
     }
     // CUDNN only support small batch size
     bool use_native_nhwc =
-        d_x ? (x_dims.size() == 4 && compute_format == DataLayout::kNHWC)
+        d_x ? (x_dims.size() == 4 && compute_format == DataLayout::kNHWC &&
+               N * H * W * D >= CUDNN_PER_ACTIVATION_THRESHOLD)
             : false;
     const bool use_native_kernel =
         ((x_dims.size() == 2 && N >= CUDNN_PER_ACTIVATION_THRESHOLD) ||

--- a/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_grad_kernel.cu
@@ -784,7 +784,7 @@ void BatchNormGradRawKernel(const Context &ctx,
     // CUDNN only support small batch size
     bool use_native_nhwc =
         d_x ? (x_dims.size() == 4 && compute_format == DataLayout::kNHWC &&
-               N * H * W * D >= CUDNN_PER_ACTIVATION_THRESHOLD)
+               H * W >= CUDNN_SPATIAL_THRESHOLD_EVAL)
             : false;
     const bool use_native_kernel =
         ((x_dims.size() == 2 && N >= CUDNN_PER_ACTIVATION_THRESHOLD) ||


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复 https://github.com/PaddlePaddle/Paddle/pull/48563 导致ResNet50训练性能下降问题。
4维的输入全部走了自定义kernel，在shape不大的时候走cudnn会比较快，因此添加shape大小判断，达到阈值才走自定义kernel。