### PR TITLE
[Prim] support use prim flag in shell

### DIFF
--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_softmax_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_softmax_grad.py
@@ -78,7 +78,7 @@ class TestCompositeSoftmax(unittest.TestCase):
 
     def cal_composite_grad(self, inputs):
         paddle.enable_static()
-        core._set_prim_all_enabled(True)
+        core._set_prim_forward_enabled(True)
         startup_program = paddle.static.Program()
         main_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
@@ -109,7 +109,7 @@ class TestCompositeSoftmax(unittest.TestCase):
         exe.run(startup_program)
         res = exe.run(main_program, feed={'x': inputs}, fetch_list=[z])
         paddle.disable_static()
-        core._set_prim_all_enabled(False)
+        core._set_prim_forward_enabled(False)
         return res
 
     def compare_backward(self):
@@ -142,12 +142,13 @@ class TestCompositeSoftmaxPrimBackward(unittest.TestCase):
 
     def setUp(self):
         core._set_prim_backward_enabled(True)
-        self.dtypes = ["float32"]
+        self.dtypes = ["float32", "float64"]
         self.shapes = [[2, 3, 4], [2, 3]]
         self.axes = [-1, 0, 1]
 
     def cal_composite_grad(self, inputs):
         paddle.enable_static()
+        core._set_prim_all_enabled(True)
         startup_program = paddle.static.Program()
         main_program = paddle.static.Program()
         with paddle.static.program_guard(main_program, startup_program):
@@ -164,6 +165,7 @@ class TestCompositeSoftmaxPrimBackward(unittest.TestCase):
         exe.run(startup_program)
         res = exe.run(main_program, feed={'x': inputs}, fetch_list=[z])
         paddle.disable_static()
+        core._set_prim_all_enabled(False)
         return res
 
     def compare_backward(self):

--- a/python/paddle/fluid/tests/unittests/prim/prim/flags/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/prim/prim/flags/CMakeLists.txt
@@ -10,4 +10,5 @@ endforeach()
 
 if(WITH_CINN)
   set_tests_properties(test_prim_flags_case PROPERTIES LABELS "RUN_TYPE=CINN")
+  set_tests_properties(test_prim_flags_case PROPERTIES TIMEOUT 300)
 endif()

--- a/python/paddle/fluid/tests/unittests/prim/prim/flags/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/prim/prim/flags/CMakeLists.txt
@@ -7,3 +7,7 @@ string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${GC_ENVS})
 endforeach()
+
+if(WITH_CINN)
+  set_tests_properties(test_prim_flags_case PROPERTIES LABELS "RUN_TYPE=CINN")
+endif()

--- a/python/paddle/fluid/tests/unittests/prim/prim/flags/test_prim_flags_case.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/flags/test_prim_flags_case.py
@@ -49,17 +49,15 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.flag = None
 
     def reset_env_flag(self):
-        # core.check_and_set_prim_all_enabled()
         os.environ["FLAGS_prim_backward"] = "False"
         os.environ["FLAGS_prim_forward"] = "False"
         if os.getenv("FLAGS_prim_all"):
             del os.environ["FLAGS_prim_all"]
         core.check_and_set_prim_all_enabled()
 
-    def train(self, use_prim):
+    def train(self, use_cinn):
         net = PrimeNet()
-        # core._set_prim_forward_enabled(use_prim)
-        net = apply_to_static(net, use_prim)
+        net = apply_to_static(net, use_cinn)
 
         out = net(self.x)
         loss = paddle.mean(out)
@@ -70,7 +68,6 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         return
 
     def check_prim(self, net):
-
         ops = [
             op.type
             for op in net.forward.program_cache.last()[-1][-1]
@@ -98,10 +95,9 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.reset_env_flag()
         os.environ["FLAGS_prim_all"] = "True"
         self.flag = "cinn_prim_all"
-        # breakpoint()
         plat = platform.system()
         if plat == "Linux":
-            _ = self.train(use_prim=True)
+            _ = self.train(use_cinn=True)
         else:
             pass
 
@@ -112,7 +108,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.flag = "prim_all"
         plat = platform.system()
         if plat == "Linux":
-            _ = self.train(use_prim=False)
+            _ = self.train(use_cinn=False)
         else:
             pass
 
@@ -125,7 +121,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.flag = "cinn_prim_forward"
         plat = platform.system()
         if plat == "Linux":
-            _ = self.train(use_prim=True)
+            _ = self.train(use_cinn=True)
         else:
             pass
 
@@ -136,7 +132,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.flag = "prim_forward"
         plat = platform.system()
         if plat == "Linux":
-            _ = self.train(use_prim=False)
+            _ = self.train(use_cinn=False)
         else:
             pass
 
@@ -147,7 +143,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.flag = "cinn_prim_backward"
         plat = platform.system()
         if plat == "Linux":
-            _ = self.train(use_prim=True)
+            _ = self.train(use_cinn=True)
         else:
             pass
 
@@ -158,7 +154,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.flag = "prim_backward"
         plat = platform.system()
         if plat == "Linux":
-            _ = self.train(use_prim=False)
+            _ = self.train(use_cinn=False)
         else:
             pass
 
@@ -168,7 +164,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
         self.flag = "cinn"
         plat = platform.system()
         if plat == "Linux":
-            _ = self.train(use_prim=True)
+            _ = self.train(use_cinn=True)
         else:
             pass
 

--- a/python/paddle/fluid/tests/unittests/prim/prim/flags/test_prim_flags_case.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/flags/test_prim_flags_case.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import platform
+import unittest
+
+import numpy as np
+
+import paddle
+import paddle.nn.functional as F
+from paddle.fluid import core
+
+
+def apply_to_static(net, use_cinn):
+    build_strategy = paddle.static.BuildStrategy()
+    build_strategy.build_cinn_pass = use_cinn
+    return paddle.jit.to_static(net, build_strategy=build_strategy)
+
+
+class PrimeNet(paddle.nn.Layer):
+    def __init__(self):
+        super(PrimeNet, self).__init__()
+
+    def forward(self, x):
+        out = F.softmax(x)
+        res = paddle.exp(out)
+        return res
+
+
+class TestPrimForward(unittest.TestCase):
+    """
+    This case only tests prim_forward + to_static + cinn. Thus we need to
+    set this flag as False to avoid prim_backward.
+    core.set_prim_backward(False)
+    """
+
+    def setUp(self):
+        self.x = paddle.randn([2, 4])
+        self.x.stop_gradient = False
+
+    def train(self, use_prim):
+        net = PrimeNet()
+        sgd = paddle.optimizer.SGD(
+            learning_rate=0.1, parameters=net.parameters()
+        )
+        core._set_prim_forward_enabled(use_prim)
+        if use_prim:
+            net = apply_to_static(net, use_prim)
+
+        res = []
+        for _ in range(10):
+            out = net(self.x)
+            loss = paddle.mean(out)
+            loss.backward()
+            sgd.step()
+            sgd.clear_grad()
+
+            res.append(out.numpy())
+
+        self.check_prim(net, use_prim)
+
+        return res
+
+    def check_prim(self, net, use_prim):
+        if not use_prim:
+            return
+        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        # Ensure that softmax is splitted into small ops
+        self.assertTrue('softmax' not in fwd_ops)
+
+    def _test_cinn_prim_forward(self):
+        dy_res = self.train(use_prim=False)
+        cinn_res = self.train(use_prim=True)
+
+        for i in range(len(dy_res)):
+            np.testing.assert_allclose(
+                cinn_res[i], dy_res[i], rtol=1e-7, atol=1e-7
+            )
+
+
+class TestPrimForwardAndBackward(unittest.TestCase):
+    """
+    Test PrimeNet with @to_static + prim forward + prim backward + cinn v.s Dygraph
+    """
+
+    def setUp(self):
+        paddle.seed(2022)
+        self.x = paddle.randn([2, 4])
+        self.x.stop_gradient = False
+
+    def train(self, use_prim):
+        net = PrimeNet()
+        core._set_prim_forward_enabled(use_prim)
+        if use_prim:
+            net = apply_to_static(net, False)
+
+        out = net(self.x)
+        loss = paddle.mean(out)
+        loss.backward()
+
+        self.check_prim(net, use_prim)
+        breakpoint()
+
+        return
+
+    def check_prim(self, net, use_prim):
+        if not use_prim:
+            return
+        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        ops = [
+            op.type
+            for op in net.forward.program_cache.last()[-1][-1]
+            .train_program.block(0)
+            .ops
+        ]
+        print(ops)
+        breakpoint()
+        # Ensure that softmax is splitted into small ops
+        self.assertTrue('softmax' not in fwd_ops)
+
+    def test_cinn_prim(self):
+        plat = platform.system()
+        if plat == "Linux":
+            # dy_res = self.train(use_prim=False)
+            cinn_res = self.train(use_prim=True)
+        else:
+            pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -571,9 +571,8 @@ class PartialProgramLayer:
                 targets.append(program.global_block().var(out.name))
 
         if targets:
-            if self._build_strategy.build_cinn_pass:
-                # TODO(Jiabin): Change this to True if we need this to be default option
-                core.check_and_set_prim_all_enabled()
+            # TODO(CZ): later when use cinn, set_prim_all_enabled and check_and_set_prim_all_enabled will be set at else branch.
+            core.check_and_set_prim_all_enabled()
             backward.gradients(targets=targets, inputs=[])
 
         start_idx = len(main_program.block(0).ops) + len(self._outputs.tolist())

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1140,9 +1140,8 @@ class ProgramCache:
         enable_prim = cache_key.kwargs['build_strategy'].build_cinn_pass
         # NOTE(xiongkun): Need a global FLAGS to enable/disable fallback
         enable_fallback = enable_prim
-        if enable_prim:
-            # TODO(Jiabin): Change this to True if we need this to be default option
-            core.check_and_set_prim_all_enabled()
+        # TODO(CZ): later when use cinn, set_prim_all_enabled and check_and_set_prim_all_enabled will be set at else branch.
+        core.check_and_set_prim_all_enabled()
         try:
             concrete_program = ConcreteProgram.from_func_spec(
                 func_spec=cache_key.function_spec,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
 New features

### PR changes
Others

### Describe
improvement of usability:
User can control decomposing forward and backward ops respectively by set environment variable in shell. When user needs debug project, not any code need be modified. 

Currently following modes are supported:
1. cinn + prim forward + prim backward
2. prim forward + prim backward
3. cinn + prim forward
4. only prim forward
5. cinn + prim_backward
6. only prim backward
7. only cinn

