### PR TITLE
[Executor]remove StandaloneExecutor unsuported case: data_parallel and FLAGS_enable_parallel_graph

### DIFF
--- a/python/paddle/fluid/compiler.py
+++ b/python/paddle/fluid/compiler.py
@@ -324,6 +324,8 @@ class CompiledProgram:
         if self._places is not None:
             if not isinstance(self._places, (list, tuple)):
                 self._places = [self._places]
+        if len(self._places) > 1:
+            raise NotImplementedError("NewExe not supported")
 
         return self
 

--- a/python/paddle/fluid/compiler.py
+++ b/python/paddle/fluid/compiler.py
@@ -324,7 +324,7 @@ class CompiledProgram:
         if self._places is not None:
             if not isinstance(self._places, (list, tuple)):
                 self._places = [self._places]
-        if len(self._places) > 1:
+        if self._places is not None and len(self._places) > 1:
             raise NotImplementedError("NewExe not supported")
 
         return self

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1731,37 +1731,7 @@ class Executor:
                     else program._graph
                 )
 
-                # Unsupported case 1: data parallel
-                if (
-                    compiled_program._is_data_parallel
-                    and len(
-                        compiled_program._get_places(
-                            place, compiled_program._places
-                        )
-                    )
-                    != 1
-                ):
-                    warnings.warn(
-                        "Standalone executor is not used for data parallel",
-                        UserWarning,
-                    )
-                    return False
-
-                # Unsupported case 2: parallel graph
-                if core.globals()['FLAGS_enable_parallel_graph'] in [
-                    1,
-                    '1',
-                    True,
-                    'True',
-                    'true',
-                ]:
-                    warnings.warn(
-                        "Standalone executor is not used for parallel graph",
-                        UserWarning,
-                    )
-                    return False
-
-                # Unsupported case 3: inference
+                # Unsupported case 1: inference
                 if compiled_program._is_inference:
                     warnings.warn(
                         "Standalone executor is not used for inference",
@@ -1769,7 +1739,7 @@ class Executor:
                     )
                     return False
 
-                # Unsupported case 4: async mode
+                # Unsupported case 2: async mode
                 if (
                     compiled_program._build_strategy is not None
                     and compiled_program._build_strategy.async_mode
@@ -1780,7 +1750,7 @@ class Executor:
                     )
                     return False
 
-                # Unsupported case 5: CUDA Graph
+                # Unsupported case 3: CUDA Graph
                 if (
                     compiled_program._build_strategy is not None
                     and compiled_program._build_strategy.allow_cuda_graph_capture


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. when using `with_data_parallel` to  do a multi-card training, use `StandaloneExecutor` instead of `ParallelExecutor`
2. remove `FLAGS_enable_parallel_graph` since it's only used for `ParallelExecutor`