### PR TITLE
[Bug Fix] Fix NLP-Bert model performance loss

### DIFF
--- a/paddle/fluid/framework/op_kernel_type.h
+++ b/paddle/fluid/framework/op_kernel_type.h
@@ -16,10 +16,12 @@ limitations under the License. */
 
 #include <string>
 
+#include "glog/logging.h"
 #include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/framework/library_type.h"
 #include "paddle/fluid/platform/place.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
 #include "paddle/phi/core/kernel_factory.h"
 
@@ -131,10 +133,31 @@ inline bool backends_are_same_class(const phi::Backend& l,
   return phi::TransToPhiPlace(l) == phi::TransToPhiPlace(r);
 }
 
-inline bool NeedTransform(const phi::KernelKey& l, const phi::KernelKey& r) {
-  return !backends_are_same_class(l.backend(), r.backend()) ||
-         NeedTransformDataType(l, r) ||
-         NeedTransformLayout(l.layout(), r.layout());
+inline bool NeedTransformBackend(const phi::Backend& type_for_var_backend,
+                                 const phi::Backend& expected_backend,
+                                 const phi::DenseTensor& tensor) {
+  // NOTE(jiahongyu): KernelKey does not hold place information, so we need to
+  // explicitly transform CUDAPinnedPlace->CUDAPlace
+  if (type_for_var_backend != phi::Backend::ALL_BACKEND &&
+      paddle::platform::is_cuda_pinned_place(tensor.place()) &&
+      expected_backend != phi::Backend::CPU) {
+    VLOG(3) << "Transform Variable " << tensor.name() << " from "
+            << tensor.place() << " to "
+            << phi::TransToPhiPlace(expected_backend);
+    return true;
+  }
+  return !backends_are_same_class(type_for_var_backend, expected_backend);
+}
+
+inline bool NeedTransform(const phi::KernelKey& kernel_type_for_var,
+                          const phi::KernelKey& expected_kernel_key,
+                          const phi::DenseTensor& tensor) {
+  return NeedTransformBackend(kernel_type_for_var.backend(),
+                              expected_kernel_key.backend(),
+                              tensor) ||
+         NeedTransformDataType(kernel_type_for_var, expected_kernel_key) ||
+         NeedTransformLayout(kernel_type_for_var.layout(),
+                             expected_kernel_key.layout());
 }
 
 }  // namespace framework

--- a/paddle/fluid/framework/op_kernel_type.h
+++ b/paddle/fluid/framework/op_kernel_type.h
@@ -16,13 +16,13 @@ limitations under the License. */
 
 #include <string>
 
-#include "glog/logging.h"
 #include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/framework/library_type.h"
 #include "paddle/fluid/platform/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
+#include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_factory.h"
 
 namespace paddle {

--- a/paddle/fluid/imperative/prepared_operator.h
+++ b/paddle/fluid/imperative/prepared_operator.h
@@ -87,8 +87,8 @@ std::shared_ptr<NameVarMap<VarType>> PrepareData(
       if (tensor && tensor->IsInitialized() && (tensor->memory_size() != 0)) {
         auto kernel_type_for_var = op.GetKernelTypeForVar(
             name_pair.first, *tensor, expected_kernel_key);
-        if (!framework::NeedTransform(kernel_type_for_var,
-                                      expected_kernel_key)) {
+        if (!framework::NeedTransform(
+                kernel_type_for_var, expected_kernel_key, *tensor)) {
           continue;
         } else {
           VLOG(3) << "Transform Variable " << GetNameFromVar(template_var)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe

KernelKey 不持有 place 信息，当 Tensor 位于 `CUDAPinnedPlace` 而 `expected_kernel_key = GPU` 时，不会将 Tensor 拷贝到 GPU 上，本 PR 修复此问题。

`KernelKey` does not hold place information, so we need to explicitly transform `CUDAPinnedPlace->CUDAPlace`

**Local performance test(V100):**

- The performance of one commit before(723ceed92de80d59221ccf8054718e6a11a5cbb9): 159.369, 160.813, 161.979
- After error-commit(4383494f012b6613aa65496e7892ae3f0052ddd9) merging this PR: 162.316, 162.194, 161.428
