### PR TITLE
fix set_value when source tensor is fp16 dtype and index is scalar tensor

### DIFF
--- a/paddle/phi/ops/compat/set_value_sig.cc
+++ b/paddle/phi/ops/compat/set_value_sig.cc
@@ -194,6 +194,19 @@ KernelSignature SetValueOpArgumentMapping(const ArgumentMappingContext& ctx) {
                                     "shape",
                                     "bool_values"},
                                    {"Out"});
+          } else if (ctx.HasAttr("fp16_values")) {
+            // NOTE(LiuYang):Here any_cast doesn't support fp16 values.
+            return KernelSignature("set_value",
+                                   {"Input"},
+                                   {"StartsTensorList",
+                                    "EndsTensorList",
+                                    "steps",
+                                    "axes",
+                                    "decrease_axes",
+                                    "none_axes",
+                                    "shape",
+                                    "fp16_values"},
+                                   {"Out"});
           }
         }
       } else {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
when code set like the following runs in paddle, it will failed because paddle doesn't support assign when source tensor is fp16 type and index is scalar tensor,.
it's restricted by set_value mechanism and its component will be reconstructed soon, so here we just make minor changes for this program runs correctly 

```
import paddle
cls_targets = paddle.full([3,3],0,dtype="float16")
ix1 = paddle.full([1],1,dtype="int64")
ix2 = paddle.full([1],2,dtype="int64")
cls_targets[ix1,ix2]= 1
print(cls_targets)
```
