### PR TITLE
[FleetExecutor]Fix gc bug and start interceptor

### DIFF
--- a/paddle/fluid/distributed/fleet_executor/start_interceptor.cc
+++ b/paddle/fluid/distributed/fleet_executor/start_interceptor.cc
@@ -68,14 +68,15 @@ void StartInterceptor::SendDataReadyToDownStream() {
   }
   if (finish_count_ == batch_size_) {
     for (int64_t i = 0; i < batch_size_; ++i) {
+      int64_t scope_id = step_ % node_->max_run_times();
       for (auto& outs : out_buffs_) {
         auto down_id = outs.first;
         InterceptorMessage ready_msg;
         ready_msg.set_message_type(DATA_IS_READY);
-        ready_msg.set_scope_idx(step_);
+        ready_msg.set_scope_idx(scope_id);
         VLOG(3) << "StartInterceptor " << interceptor_id_
                 << " Send data_is_ready msg to " << down_id
-                << " in scope: " << step_;
+                << " in scope: " << scope_id;
         Send(down_id, ready_msg);
       }
       step_++;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复多轮运行start interceptor步数累计的bug，while block里的var复用显存，只在while执行完成后统一释放。
后续可以优化成只保留计算条件变量的var。