### PR TITLE
Remove redundant cpu computation in slice compute

### DIFF
--- a/paddle/phi/kernels/impl/slice_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slice_kernel_impl.h
@@ -53,7 +53,7 @@ void SliceCompute(const Context& ctx,
     }
   }
 
-  funcs::CheckAndUpdateSliceAttrs<int64_t>(in_dims, axes, &starts, &ends);
+  funcs::UpdateSliceAttrs<int64_t>(in_dims, axes, &starts, &ends);
   slice_dims = funcs::GetSliceDims<int64_t>(
       in_dims, axes, starts, ends, nullptr, nullptr);
   out_dims = funcs::GetDecreasedDims<int64_t>(slice_dims, decrease_axis);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
Reduce redundant cpu computation in SliceCompute
Since InferShape have made checks thus here only UpdateSliceAttrs 