### PR TITLE
 Optimize the ernie inference performance on xpu backend.

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1618,7 +1618,7 @@ void OperatorWithKernel::CheckWhetherPreparePhiData(
   }
 }
 
-// When do we need to reset runtime context ?
+// When do we need to reset runtime context?
 // 1. When enable cache runtime context, if the program runs for the first time,
 //   runtime_ctx_.get() == nullptr, we need to create a new runtime context.
 // 2. When enable cache runtime context, if the program is not running for the

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -780,6 +780,7 @@ class OperatorWithKernel : public OperatorBase {
   // used for IndicateOrPromoteVarDataTypes
   phi::DenseTensor* GetTensorFormInputSafely(const ExecutionContext& ctx,
                                              const std::string& name) const;
+  bool NeedResetRuntimeContext(const Scope& scope) const;
 
  protected:
   mutable std::unique_ptr<OpKernelType> kernel_type_;

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -785,13 +785,13 @@ class OperatorWithKernel : public OperatorBase {
   mutable std::unique_ptr<OpKernelType> kernel_type_;
   mutable std::unique_ptr<OpKernelFunc> kernel_func_;
   mutable std::unique_ptr<RuntimeContext> runtime_ctx_;
-  mutable const Scope* pre_scope_ = nullptr;
   mutable bool need_prepare_data_ = true;
   mutable bool need_prepare_phi_data_ = false;
   mutable bool enable_cache_runtime_context_ = false;
   mutable bool all_kernels_must_compute_runtime_shape_ = false;
   mutable std::mutex cache_update_mutex_;
   mutable bool enable_cache_transfer_scope_ = false;
+  mutable Scope* cache_transfer_scope_ = nullptr;
   // NOTE(jiahongyu): Whether fallback to plain kernel after calling
   // GetExpectedKernelType, use this bool flag to solve mkldnn and cudnn hard
   // code

--- a/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.h
+++ b/paddle/fluid/inference/analysis/passes/ir_params_sync_among_devices_pass.h
@@ -46,6 +46,10 @@ class IrParamsSyncAmongDevicesPass : public AnalysisPass {
 #ifdef PADDLE_WITH_CUSTOM_DEVICE
   void CopyParamsToCustomDevice(Argument *argument);
 #endif
+
+#ifdef PADDLE_WITH_XPU
+  void CopyParamsToXpu(Argument *argument);
+#endif
 };
 
 }  // namespace analysis

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1256,6 +1256,18 @@ void AnalysisPredictor::PrepareArgument() {
   }
 #endif
 
+#ifdef PADDLE_WITH_XPU
+  argument_->SetUseXpu(config_.use_xpu_);
+  argument_->SetXpuL3WorkspaceSize(config_.xpu_l3_workspace_size_);
+  argument_->SetXpuLocked(config_.xpu_locked_);
+  argument_->SetXpuAutotune(config_.xpu_autotune_);
+  argument_->SetXpuAutotuneFile(config_.xpu_autotune_file_);
+  argument_->SetXpuPrecision(config_.xpu_precision_);
+  argument_->SetXpuAdaptiveSeqlen(config_.xpu_adaptive_seqlen_);
+  argument_->SetXpuDeviceId(config_.xpu_device_id_);
+  argument_->SetXpuEnableMultiStream(config_.xpu_enable_multi_stream_);
+#endif
+
   auto *pass_builder = config_.pass_builder();
   // TODO(inference): Need to reconstruct the pass_builder, pass should be
   // processed in a single


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Inference 使用 xpu backend 推理增加 cache 机制，优化 ernie 模型，ernie medium 模型性能:
  首次推理时间( 65 ms -> 20 ms)，非首次推理时间( 45.07 ms -> 2.5 ms)
具体改动：

-  修复  operator.cc 中关于 enable_cache_runtime_context 和 prepare_data 的逻辑,

-  删除 pre_scope_ = cur_scope 的判断逻辑，该判断逻辑只应用于 enable_cache_runtime_context_ == true 的场景，判断是否重新生成 runtime_context，所以只需判断 runtime_ctx_.get() == nullptr 即可，因为 enable_cache_runtime_context_ 本身就是要复用 runtime_context，上述判断逻辑多余且非必要。
- 区分 transfer_cache_scope 和 new_scope，new_scope 在 enable_cache_runtime_context_ == true 的场景下，runtime_context 中的 variable 变量会使用 new_scope 中的变量代替，因此需要保证，每次 run 的时候，new_scope 必须存在，不能删除，但是对于 cpu 推理的场景，transfer_cache_scope 是不需要的，所以二者需要区分开。
- 增加重新创建 runtime_context 逻辑:
  -  enable_cache_runtime_context 时，程序第一次运行。
  - enable_cache_runtime_context 时，程序非第一次运行，但是运行时 input shape 或者 layout 发生变化。
