### PR TITLE
Delete axis of fmin kernel

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -515,7 +515,7 @@
 
 - backward_op : fmin_grad
   forward : fmin(Tensor x, Tensor y) -> Tensor(out)
-  args : (Tensor x, Tensor y, Tensor out_grad, int axis = -1)
+  args : (Tensor x, Tensor y, Tensor out_grad)
   output : Tensor(x_grad), Tensor(y_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta

--- a/paddle/phi/kernels/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_kernel.cc
@@ -131,14 +131,8 @@ PD_REGISTER_KERNEL(fmax_raw,
                    int,
                    int64_t) {}
 
-PD_REGISTER_KERNEL(fmin_raw,
-                   CPU,
-                   ALL_LAYOUT,
-                   phi::FMinRawKernel,
-                   float,
-                   double,
-                   int,
-                   int64_t) {}
+PD_REGISTER_KERNEL(
+    fmin, CPU, ALL_LAYOUT, phi::FMinKernel, float, double, int, int64_t) {}
 
 PD_REGISTER_KERNEL(maximum_raw,
                    CPU,

--- a/paddle/phi/kernels/elementwise_grad_kernel.h
+++ b/paddle/phi/kernels/elementwise_grad_kernel.h
@@ -33,7 +33,6 @@ void ElementwiseFMinGradKernel(const Context& dev_ctx,
                                const DenseTensor& x,
                                const DenseTensor& y,
                                const DenseTensor& out_grad,
-                               int axis,
                                DenseTensor* x_grad,
                                DenseTensor* y_grad);
 

--- a/paddle/phi/kernels/elementwise_kernel.cc
+++ b/paddle/phi/kernels/elementwise_kernel.cc
@@ -118,23 +118,12 @@ void FMaxKernel(const Context& dev_ctx,
   FMaxRawKernel<T, Context>(dev_ctx, x, y, -1, out);
 }
 
-template <typename T, typename Context>
-void FMinKernel(const Context& dev_ctx,
-                const DenseTensor& x,
-                const DenseTensor& y,
-                DenseTensor* out) {
-  FMinRawKernel<T, Context>(dev_ctx, x, y, -1, out);
-}
-
 }  // namespace phi
 using complex64 = ::phi::dtype::complex<float>;
 using complex128 = ::phi::dtype::complex<double>;
 
 PD_REGISTER_KERNEL(
     fmax, CPU, ALL_LAYOUT, phi::FMaxKernel, float, double, int, int64_t) {}
-
-PD_REGISTER_KERNEL(
-    fmin, CPU, ALL_LAYOUT, phi::FMinKernel, float, double, int, int64_t) {}
 
 PD_REGISTER_KERNEL(maximum,
                    CPU,
@@ -236,16 +225,6 @@ PD_REGISTER_KERNEL(fmax,
                    KPS,
                    ALL_LAYOUT,
                    phi::FMaxKernel,
-                   float,
-                   double,
-                   int,
-                   phi::dtype::float16,
-                   int64_t) {}
-
-PD_REGISTER_KERNEL(fmin,
-                   KPS,
-                   ALL_LAYOUT,
-                   phi::FMinKernel,
                    float,
                    double,
                    int,

--- a/paddle/phi/kernels/elementwise_kernel.h
+++ b/paddle/phi/kernels/elementwise_kernel.h
@@ -33,13 +33,6 @@ void FMaxKernel(const Context& dev_ctx,
                 DenseTensor* out);
 
 template <typename T, typename Context>
-void FMinRawKernel(const Context& dev_ctx,
-                   const DenseTensor& x,
-                   const DenseTensor& y,
-                   int axis,
-                   DenseTensor* out);
-
-template <typename T, typename Context>
 void FMinKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const DenseTensor& y,

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -314,13 +314,13 @@ void ElementwiseFMinGradKernel(const Context& dev_ctx,
                                const DenseTensor& x,
                                const DenseTensor& y,
                                const DenseTensor& out_grad,
-                               int axis,
                                DenseTensor* x_grad,
                                DenseTensor* y_grad) {
   funcs::ElementwiseGradPreProcess(out_grad, x_grad);
   auto out = out_grad;  // Fake out, not used
   auto x_dim = x.dims();
   auto y_dim = y.dims();
+  int axis = -1;
   if (x.dims() == y.dims()) {
     funcs::ElemwiseGradComputeNoBroadcast<Context,
                                           T,

--- a/paddle/phi/kernels/impl/elementwise_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_kernel_impl.h
@@ -78,14 +78,13 @@ void FMaxRawKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void FMinRawKernel(const Context& dev_ctx,
-                   const DenseTensor& x,
-                   const DenseTensor& y,
-                   int axis,
-                   DenseTensor* out) {
+void FMinKernel(const Context& dev_ctx,
+                const DenseTensor& x,
+                const DenseTensor& y,
+                DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   funcs::ElementwiseCompute<funcs::FMinFunctor<T>, T, T>(
-      dev_ctx, x, y, axis, funcs::FMinFunctor<T>(), out);
+      dev_ctx, x, y, -1, funcs::FMinFunctor<T>(), out);
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/kps/elementwise_kernel.cu
+++ b/paddle/phi/kernels/kps/elementwise_kernel.cu
@@ -103,10 +103,10 @@ PD_REGISTER_KERNEL(fmax_raw,
                    float16,
                    int64_t) {}
 
-PD_REGISTER_KERNEL(fmin_raw,
+PD_REGISTER_KERNEL(fmin,
                    KPS,
                    ALL_LAYOUT,
-                   phi::FMinRawKernel,
+                   phi::FMinKernel,
                    float,
                    double,
                    int,

--- a/paddle/phi/ops/compat/elementwise_sig.cc
+++ b/paddle/phi/ops/compat/elementwise_sig.cc
@@ -186,13 +186,13 @@ KernelSignature ElementwiseFMaxOpArgumentMapping(
 
 KernelSignature ElementwiseFMinOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
-  return KernelSignature("fmin_raw", {"X", "Y"}, {"axis"}, {"Out"});
+  return KernelSignature("fmin", {"X", "Y"}, {}, {"Out"});
 }
 
 KernelSignature ElementwiseFMaxGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature(
-      "fmax_grad", {"X", "Y", "Out@GRAD"}, {"axis"}, {"X@GRAD", "Y@GRAD"});
+      "fmax_grad", {"X", "Y", "Out@GRAD"}, {}, {"X@GRAD", "Y@GRAD"});
 }
 
 KernelSignature ElementwiseMulDoubleGradOpArgumentMapping(

--- a/paddle/phi/ops/compat/elementwise_sig.cc
+++ b/paddle/phi/ops/compat/elementwise_sig.cc
@@ -162,7 +162,7 @@ KernelSignature ElementwiseDivGradOpArgumentMapping(
 KernelSignature ElementwiseFMinGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature(
-      "fmin_grad", {"X", "Y", "Out@GRAD"}, {"axis"}, {"X@GRAD", "Y@GRAD"});
+      "fmin_grad", {"X", "Y", "Out@GRAD"}, {}, {"X@GRAD", "Y@GRAD"});
 }
 
 KernelSignature ElementwiseDivDoubleGradOpArgumentMapping(
@@ -192,7 +192,7 @@ KernelSignature ElementwiseFMinOpArgumentMapping(
 KernelSignature ElementwiseFMaxGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature(
-      "fmax_grad", {"X", "Y", "Out@GRAD"}, {}, {"X@GRAD", "Y@GRAD"});
+      "fmax_grad", {"X", "Y", "Out@GRAD"}, {"axis"}, {"X@GRAD", "Y@GRAD"});
 }
 
 KernelSignature ElementwiseMulDoubleGradOpArgumentMapping(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
fmin作为elementwise系列算子，由于模板复用在定义时引入了axis参数，但在API使用时从未传入axis参数，因此fmin的kernel在计算时axis值永远为-1，所以理论上可以将axis从fmin的输入参数中去除。

从兼容性的角度考虑：
1. 新版本代码训练模型+新版本代码推理无兼容性问题
2. 旧版本代码训练模型+旧版本代码推理无兼容性问题
3. 旧版本代码训练模型+新版本代码推理：由于旧版本模型保存的axis值都为-1，新版本中Kernel无需读取该属性值且可以正常计算，所以无兼容性问题
4. 新版本代码训练模型+旧版本代码推理：新版本保存的模型中无axis参数，旧版本框架加载时会将axis参数设置为默认值-1，推理计算可以正常进行，所以无兼容性问题

谨慎起见，本次fmin的axis删除将分为两个PR，本PR对Kenrel中的axis进行移除，下一个PR将移除OpMaker定义中的axis参数。