### PR TITLE
Expand mixed_precision to custom device

### DIFF
--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -200,13 +200,19 @@ void AutoMixedPrecisionPass::Init(Graph* graph) const {
   if (enable_gpu_mixed) {
     backend_ = phi::Backend::GPU;
   } else if (enable_custom_device_mixed) {
-    // transform Backend::CUSTOM to actual backend.
-    // Here, we only consider one custom backend.
+// transform Backend::CUSTOM to actual backend.
+// Here, we only consider one custom backend.
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
     auto device_type = phi::DeviceManager::GetAllCustomDeviceTypes()[0];
     backend_ = static_cast<phi::Backend>(
         static_cast<size_t>(phi::Backend::NUM_BACKENDS) +
         phi::CustomRegisteredDeviceMap::Instance()
             .GetOrRegisterGlobalDeviceTypeId(device_type));
+#else
+    PADDLE_THROW(paddle::platform::errors::Unavailable(
+        "Paddle is not compiled with CustomDevice. "
+        "Cannot enable custom_device_mixed."));
+#endif
   }
   skip_pass_ = !enable_gpu_mixed && !enable_custom_device_mixed;
 

--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -184,7 +184,10 @@ void AutoMixedPrecisionPass::SetDefaultBlacklist() const {
 
 void AutoMixedPrecisionPass::Init(Graph* graph) const {
   bool enable_gpu_mixed = Get<bool>("enable_gpu_mixed");
-  bool enable_custom_device_mixed = Get<bool>("enable_custom_device_mixed");
+  bool enable_custom_device_mixed = false;
+  if (Has("enable_custom_device_mixed")) {
+    enable_custom_device_mixed = Get<bool>("enable_custom_device_mixed");
+  }
   if (enable_gpu_mixed) {
     backend_ = phi::Backend::GPU;
   }

--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -22,6 +22,9 @@
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/errors.h"
+#ifdef PADDLE_WITH_CUSTOM_DEVICE
+#include "paddle/phi/backends/device_manager.h"
+#endif
 
 namespace paddle {
 namespace framework {
@@ -44,15 +47,14 @@ bool PhiKernelSupportPrecision(
   return phi::KernelFactory::Instance().HasKernel(op_type, kernel_key);
 }
 
-bool GpuKernelSupportPrecision(
+bool KernelSupportPrecision(
     const std::string& op_type,
+    phi::Backend backend,
     phi::DataType precision,
     phi::DataLayout layout = phi::DataLayout::ALL_LAYOUT) {
   auto phi_op_type = phi::TransToPhiKernelName(op_type);
-  bool support = PhiKernelSupportPrecision(
-      phi_op_type, phi::Backend::GPU, precision, layout);
-  support |= PhiKernelSupportPrecision(
-      phi_op_type, phi::Backend::GPUDNN, precision, layout);
+  bool support =
+      PhiKernelSupportPrecision(phi_op_type, backend, precision, layout);
 
   if (!support) {
     const auto& all_kernels = framework::OperatorWithKernel::AllOpKernels();
@@ -146,12 +148,7 @@ bool OpSupportPrecision(const std::string& op_type,
                         const std::unordered_set<std::string>& black_list) {
   bool support = false;
   if (black_list.count(op_type) == 0) {
-    if (backend == phi::Backend::GPU) {
-      support = GpuKernelSupportPrecision(op_type, precision);
-    } else {
-      PADDLE_THROW(paddle::platform::errors::InvalidArgument(
-          "Now, only support backend of GPU."));
-    }
+    support = KernelSupportPrecision(op_type, backend, precision);
   }
   return support;
 }
@@ -183,11 +180,21 @@ void AutoMixedPrecisionPass::SetDefaultBlacklist() const {
 
 void AutoMixedPrecisionPass::Init(Graph* graph) const {
   bool enable_gpu_mixed = Get<bool>("enable_gpu_mixed");
+  bool enable_custom_device_mixed = Get<bool>("enable_custom_device_mixed");
   if (enable_gpu_mixed) {
     backend_ = phi::Backend::GPU;
   }
 
-  skip_pass_ = !enable_gpu_mixed;
+  if (enable_custom_device_mixed) {
+    // transform Backend::CUSTOM to actual backend.
+    // Here, we only consider one custom backend.
+    auto device_type = phi::DeviceManager::GetAllCustomDeviceTypes()[0];
+    backend_ = static_cast<phi::Backend>(
+        static_cast<size_t>(phi::Backend::NUM_BACKENDS) +
+        phi::CustomRegisteredDeviceMap::Instance()
+            .GetOrRegisterGlobalDeviceTypeId(device_type));
+  }
+  skip_pass_ = !enable_gpu_mixed && !enable_custom_device_mixed;
 
   low_precision_ = static_cast<phi::DataType>(Get<int>("mixed_precision_mode"));
 
@@ -466,8 +473,8 @@ void AutoMixedPrecisionPass::UpdateOpPrecision() const {
         // when op_1 only support cpu kernel. if op_2's intput var is op_1's
         // output var, then op_2 should not run at low precision.
         if (GetOpOriginalType(op_type) != "feed" &&
-            !GpuKernelSupportPrecision(GetOpOriginalType(op_type),
-                                       phi::DataType::FLOAT32)) {
+            !KernelSupportPrecision(
+                GetOpOriginalType(op_type), backend_, phi::DataType::FLOAT32)) {
           for (auto* out_var_node : op_node->outputs) {
             CHECK_EQ(out_var_node->IsVar(), true);
             if (out_var_node->Var()->Persistable()) continue;

--- a/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
+++ b/paddle/fluid/framework/ir/auto_mixed_precision_pass.cc
@@ -53,9 +53,13 @@ bool KernelSupportPrecision(
     phi::DataType precision,
     phi::DataLayout layout = phi::DataLayout::ALL_LAYOUT) {
   auto phi_op_type = phi::TransToPhiKernelName(op_type);
+
   bool support =
       PhiKernelSupportPrecision(phi_op_type, backend, precision, layout);
-
+  if (backend == phi::Backend::GPU) {
+    support |= PhiKernelSupportPrecision(
+        phi_op_type, phi::Backend::GPUDNN, precision, layout);
+  }
   if (!support) {
     const auto& all_kernels = framework::OperatorWithKernel::AllOpKernels();
     auto it = all_kernels.find(op_type);

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -145,6 +145,8 @@ phi::Backend ConvertBackend(paddle_infer::PlaceType backend) {
       return phi::Backend::CPU;
     case paddle_infer::PlaceType::kIPU:
       return phi::Backend::IPU;
+    case paddle_infer::PlaceType::kCUSTOM:
+      return phi::Backend::CUSTOM;
     default:
       PADDLE_THROW(paddle::platform::errors::InvalidArgument(
           "Paddle Inference not support backend, we now only support GPU, XPU, "

--- a/paddle/phi/common/backend.h
+++ b/paddle/phi/common/backend.h
@@ -59,6 +59,9 @@ enum class Backend : uint8_t {
   // paddle kernel primitives backend
   KPS,
 
+  // custom device reference
+  CUSTOM,
+
   // end of backend types
   NUM_BACKENDS,
 
@@ -207,7 +210,7 @@ inline std::string BackendToString(const Backend& backend) {
       return "KPS";
     case Backend::IPU:
       return "IPU";
-    default:
+    default: {
       size_t device_type_id_ = static_cast<size_t>(backend) -
                                static_cast<size_t>(Backend::NUM_BACKENDS);
       std::string device_type =
@@ -219,6 +222,7 @@ inline std::string BackendToString(const Backend& backend) {
         PD_THROW(
             "Invalid enum backend type `", static_cast<int>(backend), "`.");
       }
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
APIs

### Describe
Expand ConvertToMixedPrecision to all backend and change the input arg `backend`from `phi::PlaceType` to `const char*` to support custom device.