### PR TITLE
Remove redundant UTs for interptercore

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -1243,17 +1243,6 @@ if(WITH_CINN AND WITH_TESTING)
   )
 endif()
 
-py_test_modules(
-  test_add_reader_dependency_for_interpretercore MODULES
-  test_add_reader_dependency ENVS FLAGS_CONVERT_GRAPH_TO_PROGRAM=true)
-
-set_tests_properties(test_add_reader_dependency_for_interpretercore
-                     PROPERTIES TIMEOUT 120)
-
-py_test_modules(
-  test_eager_deletion_padding_rnn_for_interpretercore MODULES
-  test_eager_deletion_padding_rnn ENVS FLAGS_CONVERT_GRAPH_TO_PROGRAM=true)
-
 # ExecutionStrategy is deprecated in standalone executor
 set_tests_properties(test_parallel_executor_dry_run
                      PROPERTIES ENVIRONMENT "FLAGS_USE_STANDALONE_EXECUTOR=0")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
清理冗余单测`test_add_reader_dependency_for_interpretercore`和`test_eager_deletion_padding_rnn_for_interpretercore`，这两个单测用于在新执行器未切换之前临时测试，切换后旧执行器的对应相同单测也切换成测新执行器，这两个单测不再需要。