### PR TITLE
[Dy2St]Fix func.__self__ problem in FunctionSpec

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
@@ -338,8 +338,10 @@ class ListWithCondNet(paddle.nn.Layer):
     def __init__(self):
         super().__init__()
 
+    # Add *args to test function.__self__ in FunctionSpec.
+    # DO NOT remove *args.
     @paddle.jit.to_static
-    def forward(self, x, index):
+    def forward(self, x, index, *args):
         y = paddle.nn.functional.relu(x)
         a = []
 

--- a/python/paddle/jit/dy2static/function_spec.py
+++ b/python/paddle/jit/dy2static/function_spec.py
@@ -54,7 +54,7 @@ class FunctionSpec:
         # parse *args
         self.varargs_name = parse_varargs_name(function)
         if self.varargs_name is not None and isinstance(
-            function.__self__, TranslatedLayer
+            getattr(function, '__self__', None), TranslatedLayer
         ):
             self._arg_names += function.__self__._input_args_names
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dy2St]Fix func.__self__ problem in FunctionSpec

问题描述：

```python

class Net:
     # ...
   
    @to_static   # <---- 这里会被解释执行，因为此时没有实例化，所以to_static获取的forward是 function类型，而非bound method
    def forward(self, ....):
         # ....

```