### PR TITLE
Fix failed tests while analyzing coverage rate in precise_test ci

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1867,6 +1867,7 @@ function precise_card_test_single {
         find paddle/phi -name '*.gcno'|xargs -I {} cp --parents {} ut_map/$case
         find paddle/utils -name '*.gcno'|xargs -I {} cp --parents {} ut_map/$case
         find paddle/fluid -name '*.gcno'|xargs -I {} cp --parents {} ut_map/$case
+        wait;
         python ${PADDLE_ROOT}/tools/get_single_test_cov.py ${PADDLE_ROOT} $case &
 
         # python

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -401,7 +401,7 @@ set_paddle_lib_path()
 # else:
 # # # _set_prim_all_enabled > FLAGS_prim_all == check_and_set_prim_all_enabled == _set_prim_backward_enabled == _set_prim_backward_enabled > FLAGS_prim_forward == FLAGS_prim_backward
 def __sync_stat_with_flag(flag):
-    if flag is "FLAGS_prim_forward":
+    if flag == "FLAGS_prim_forward":
         flag_value = os.getenv("FLAGS_prim_forward")
         assert flag_value is not None
         flag_value = flag_value.lower()
@@ -412,7 +412,7 @@ def __sync_stat_with_flag(flag):
         else:
             raise TypeError(f"flag {flag} should be true or false.")
         print("forward prim enabled: ", bool(_is_fwd_prim_enabled()))
-    elif flag is "FLAGS_prim_backward":
+    elif flag == "FLAGS_prim_backward":
         flag_value = os.getenv("FLAGS_prim_backward")
         assert flag_value is not None
         flag_value = flag_value.lower()
@@ -423,7 +423,7 @@ def __sync_stat_with_flag(flag):
         else:
             raise TypeError(f"flag {flag} should be true or false.")
         print("backward prim enabled: ", bool(_is_bwd_prim_enabled()))
-    elif flag is "FLAGS_prim_all":
+    elif flag == "FLAGS_prim_all":
         flag_value = os.getenv("FLAGS_prim_all")
         assert flag_value is not None
         flag_value = flag_value.lower()

--- a/tools/get_single_test_cov.py
+++ b/tools/get_single_test_cov.py
@@ -83,9 +83,14 @@ def analysisFNDAFile(rootPath, test):
     if os.path.isfile(related_ut_map_file) and os.path.isfile(
         notrelated_ut_map_file
     ):
-        print("make related.txt and not_related.txt succesfully")
+        print(
+            "make %s and %s succesfully"
+            % (related_ut_map_file, related_ut_map_file)
+        )
     else:
-        print("make related.txt and not_related.txt failed")
+        print(
+            "make %s and %s failed" % (related_ut_map_file, related_ut_map_file)
+        )
         return
 
     fn_filename = '%s/build/ut_map/%s/fnda.tmp' % (rootPath, test)
@@ -203,7 +208,7 @@ def getCovinfo(rootPath, test):
     )
     if (
         os.path.exists(coverage_utils_info_path)
-        and os.path.getsize(coverage_utils_info_path) != 0
+        and os.path.getsize(coverage_utils_info_path) > 4
     ):
         os.system(
             'cd %s && lcov -a paddle/fluid/coverage_fluid.info -a paddle/phi/coverage_phi.info -a paddle/utils/coverage_utils.info -o coverage.info --rc lcov_branch_coverage=0 > /dev/null 2>&1'
@@ -217,10 +222,13 @@ def getCovinfo(rootPath, test):
     coverage_info_path = ut_map_path + '/coverage.info'
     file_size = os.path.getsize(coverage_info_path)
     if file_size == 0:
-        print("coverage.info is empty,collect coverage rate failed")
+        print(
+            "coverage.info of %s is empty,collect coverage rate failed"
+            % ut_map_path
+        )
         return
     else:
-        print("get coverage.info succesfully")
+        print("get coverage.info of %s succesfully" % ut_map_path)
     os.system(
         "cd %s && lcov --extract coverage.info '/paddle/paddle/phi/*' '/paddle/paddle/utils/*' '/paddle/paddle/fluid/*' '/paddle/build/*' -o coverage.info.tmp --rc lcov_branch_coverage=0 > /dev/null 2>&1"
         % ut_map_path


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
1 修复精准测试中大量warning的问题
<img width="769" alt="image" src="https://user-images.githubusercontent.com/62429225/218442928-197b1974-0b23-4a87-9223-512277dd193c.png">
2 修复精准测试流水线某些单测没有gcda文件却进行覆盖率分析
3 打印信息更加详细便于分析那个单测出现问题
4 test_conv_elementwise_add_mkldnn_fuse_pass和test_params_quantization_mkldnn_pass执行完成之后，且分析覆盖率时会生成coverage_utils.info且次文件大小不为0，字节数为4，但是coverage_utils.info里面只有一行TN：，故locv -a合并的时候会报错