### PR TITLE
add tensor numel check for float

### DIFF
--- a/paddle/fluid/pybind/op_function_common.cc
+++ b/paddle/fluid/pybind/op_function_common.cc
@@ -92,7 +92,8 @@ bool PyObject_CheckFloatOrToFloat(PyObject** obj) {
   // sometimes users provide PyLong or numpy.int64 but attr is float
   if (PyFloat_Check(*obj) || PyLong_Check(*obj) ||
       PyObject_IsInstance(*obj, (PyObject*)g_varbase_pytype) ||  // NOLINT
-      PyObject_IsInstance(*obj, (PyObject*)p_tensor_type)) {     // NOLINT
+      (PyObject_IsInstance(*obj, (PyObject*)p_tensor_type) &&    // NOLINT
+       (((TensorObject*)(*obj))->tensor.numel() == 1))) {        // NOLINT
     return true;
   }
   if (std::string(((PyTypeObject*)(*obj)->ob_type)->tp_name)  // NOLINT


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
参考 #50028 ，添加了 `PyObject_CheckFloatOrToFloat` 时对 `Tensor` 类型的检查。