### PR TITLE
fix_StackOverFlow_Case6

### DIFF
--- a/paddle/phi/infermeta/binary.cc
+++ b/paddle/phi/infermeta/binary.cc
@@ -1145,14 +1145,14 @@ void DotInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
                         x_dims.to_str()));
 
   auto y_dims = y.dims();
-  PADDLE_ENFORCE_EQ(
-      true,
-      x_rank == static_cast<size_t>(y_dims.size()),
-      phi::errors::PreconditionNotMet(
-          "ShapeError: The shape of input tensor Y: %s should match with "
-          "input tenosr X: %s",
-          y_dims.to_str(),
-          x_dims.to_str()));
+  auto y_rank = static_cast<size_t>(y_dims.size());
+  PADDLE_ENFORCE_EQ(true,
+                    1 == y_rank || 2 == y_rank,
+                    phi::errors::PreconditionNotMet(
+                        "ShapeError: The dimensions of input tensor Y (%s) "
+                        "should be 1 or 2",
+                        y_dims.to_str()));
+
   bool shape_match = true;
   for (size_t i = 0; i < x_rank; ++i) {
     if (x_dims[i] != y_dims[i]) {

--- a/python/paddle/fluid/tests/unittests/test_lbfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_lbfgs.py
@@ -55,15 +55,13 @@ def test_static_graph_H0(func, x0, H0, dtype='float32'):
     return exe.run(main, feed={'x': x0, 'h': H0}, fetch_list=[Y])
 
 
-def test_static_graph_H1(func, x0, H0, dtype='float32'):
+def test_static_graph_H1(func, x1, H1, dtype='float32'):
     paddle.enable_static()
     main = paddle.static.Program()
     startup = paddle.static.Program()
     with paddle.static.program_guard(main, startup):
-        X = paddle.static.data(name='x', shape=[x0.shape[0]], dtype=dtype)
-        H = paddle.static.data(
-            name='h', shape=[H0.shape[0], H0.shape[1]], dtype=dtype
-        )
+        X = paddle.static.data(name='x', shape=[x1.shape[0]], dtype=dtype)
+        H = paddle.static.data(name='h', shape=[H1.shape[0]], dtype=dtype)
         Y = minimize_lbfgs(
             func,
             X,
@@ -74,7 +72,7 @@ def test_static_graph_H1(func, x0, H0, dtype='float32'):
 
     exe = paddle.static.Executor()
     exe.run(startup)
-    return exe.run(main, feed={'x': x0, 'h': H0}, fetch_list=[Y])
+    return exe.run(main, feed={'x': x1, 'h': H1}, fetch_list=[Y])
 
 
 def test_dynamic_graph(
@@ -191,8 +189,8 @@ class TestLbfgs(unittest.TestCase):
             x = lambda x: paddle.dot(x, x)
             return x
 
-        x3 = np.array([[2.4]]).astype('float32')
-        H3 = np.array([[2.4]]).astype('float32')
+        x3 = np.array([2.4]).astype('float32')
+        H3 = np.array([2.4]).astype('float32')
         results = test_static_graph_H1(func, x3, H3, dtype='float32')
         np.testing.assert_allclose([0.0, 0.0], results[2], rtol=1e-05)
         self.assertTrue(results[0][0])

--- a/python/paddle/fluid/tests/unittests/test_lbfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_lbfgs.py
@@ -55,6 +55,28 @@ def test_static_graph_H0(func, x0, H0, dtype='float32'):
     return exe.run(main, feed={'x': x0, 'h': H0}, fetch_list=[Y])
 
 
+def test_static_graph_H1(func, x0, H0, dtype='float32'):
+    paddle.enable_static()
+    main = paddle.static.Program()
+    startup = paddle.static.Program()
+    with paddle.static.program_guard(main, startup):
+        X = paddle.static.data(name='x', shape=[x0.shape[0]], dtype=dtype)
+        H = paddle.static.data(
+            name='h', shape=[H0.shape[0], H0.shape[1]], dtype=dtype
+        )
+        Y = minimize_lbfgs(
+            func,
+            X,
+            initial_inverse_hessian_estimate=H,
+            tolerance_grad=0.0,
+            dtype=dtype,
+        )
+
+    exe = paddle.static.Executor()
+    exe.run(startup)
+    return exe.run(main, feed={'x': x0, 'h': H0}, fetch_list=[Y])
+
+
 def test_dynamic_graph(
     func, x0, H0=None, line_search_fn='strong_wolfe', dtype='float32'
 ):
@@ -169,10 +191,11 @@ class TestLbfgs(unittest.TestCase):
             x = lambda x: paddle.dot(x, x)
             return x
 
-        x0 = np.array([2.4]).astype('float32')
-        self.assertRaises(
-            ValueError, test_static_graph, func, x0, dtype='float32'
-        )
+        x3 = np.array([[2.4]]).astype('float32')
+        H3 = np.array([[2.4]]).astype('float32')
+        results = test_static_graph_H1(func, x3, dtype='float32')
+        np.testing.assert_allclose([0.0, 0.0], results[2], rtol=1e-05)
+        self.assertTrue(results[0][0])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_lbfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_lbfgs.py
@@ -193,7 +193,7 @@ class TestLbfgs(unittest.TestCase):
 
         x3 = np.array([[2.4]]).astype('float32')
         H3 = np.array([[2.4]]).astype('float32')
-        results = test_static_graph_H1(func, x3, dtype='float32')
+        results = test_static_graph_H1(func, x3, H3, dtype='float32')
         np.testing.assert_allclose([0.0, 0.0], results[2], rtol=1e-05)
         self.assertTrue(results[0][0])
 

--- a/python/paddle/fluid/tests/unittests/test_lbfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_lbfgs.py
@@ -164,6 +164,15 @@ class TestLbfgs(unittest.TestCase):
             ValueError, test_static_graph_H0, func, x2, H0=H1, dtype='float64'
         )
 
+    def test_exceptionOne(self):
+        def func(x):
+            return lambda x: paddle.dot(x, x)
+
+        x0 = np.array([2.4]).astype('float32')
+        self.assertRaises(
+            ValueError, test_static_graph, func, x0, dtype='float32'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_lbfgs.py
+++ b/python/paddle/fluid/tests/unittests/test_lbfgs.py
@@ -166,7 +166,8 @@ class TestLbfgs(unittest.TestCase):
 
     def test_exceptionOne(self):
         def func(x):
-            return lambda x: paddle.dot(x, x)
+            x = lambda x: paddle.dot(x, x)
+            return x
 
         x0 = np.array([2.4]).astype('float32')
         self.assertRaises(

--- a/python/paddle/incubate/optimizer/functional/lbfgs.py
+++ b/python/paddle/incubate/optimizer/functional/lbfgs.py
@@ -103,6 +103,7 @@ def minimize_lbfgs(
         )
 
     op_name = 'minimize_lbfgs'
+    check_input_type(objective_func, 'objective_func', op_name)
     check_input_type(initial_position, 'initial_position', op_name)
 
     if initial_inverse_hessian_estimate is None:

--- a/python/paddle/incubate/optimizer/functional/lbfgs.py
+++ b/python/paddle/incubate/optimizer/functional/lbfgs.py
@@ -103,7 +103,6 @@ def minimize_lbfgs(
         )
 
     op_name = 'minimize_lbfgs'
-    check_input_type(objective_func, 'objective_func', op_name)
     check_input_type(initial_position, 'initial_position', op_name)
 
     if initial_inverse_hessian_estimate is None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/49927
- https://github.com/PaddlePaddle/Paddle/issues/49925
### Solution
Cause original code compare the input x dims size is equal to it's self.
but in code ,when x and y all input x . if x dim is [1,1] ,y is [1], is not equal .
So delete this code. Add code to judge y dim.