### PR TITLE
[inference][ut]update trt workspace size for inference predictor ut

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_inference_predictor.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_inference_predictor.py
@@ -127,7 +127,7 @@ class BackendPaddle:
                         "shape"
                     ][self.args.test_num][0]
                 config.enable_tensorrt_engine(
-                    workspace_size=1 << 33,
+                    workspace_size=1 << 25,
                     precision_mode=precision_mode,
                     max_batch_size=max_batch_size,
                     min_subgraph_size=self.args.subgraph_size,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- use small workspace size for inference predictor ut