### PR TITLE
[WIP][Paddle Inference] make conv2d_fusion_cutlass and conv2d_fusion sig same

### DIFF
--- a/paddle/phi/kernels/fusion/cutlass/conv2d_fusion.cu
+++ b/paddle/phi/kernels/fusion/cutlass/conv2d_fusion.cu
@@ -29,12 +29,16 @@ void Conv2dFusionKernel(const Context& ctx,
                         const std::vector<int>& strides,
                         const std::vector<int>& paddings,
                         const std::string& padding_algorithm,
-                        int groups,
                         const std::vector<int>& dilations,
+                        int groups,
                         const std::string& data_format,
                         const std::string& activation,
+                        bool exhaustive_search,
+                        const std::vector<int>& channels,
+                        int user_workspace_size,
                         float fuse_alpha,
-                        DenseTensor* output) {
+                        DenseTensor* output,
+                        std::vector<DenseTensor*> outs) {
   ctx.template Alloc<T>(output);
   auto in_dims = x.dims();
   auto filter_dims = filter.dims();

--- a/paddle/phi/kernels/fusion/gpu/conv_fusion_kernel.cu
+++ b/paddle/phi/kernels/fusion/gpu/conv_fusion_kernel.cu
@@ -374,6 +374,7 @@ void ConvFusionKernel(const Context& ctx,
                       bool exhaustive_search,
                       const std::vector<int>& channels,
                       int user_workspace_size,
+                      float fuse_alpha,
                       DenseTensor* output,
                       std::vector<DenseTensor*> outs) {
   auto handle = ctx.cudnn_handle();

--- a/paddle/phi/ops/compat/conv2d_sig.cc
+++ b/paddle/phi/ops/compat/conv2d_sig.cc
@@ -53,24 +53,9 @@ KernelSignature Conv2dDoubleGradOpArgumentMapping(
                          {"DInput", "DFilter", "DDOutput"});
 }
 
-KernelSignature Conv2dFusionArgumentMapping(const ArgumentMappingContext& ctx) {
-  return KernelSignature("conv2d_fusion_cutlass",
-                         {"Input", "Filter", "Bias", "ResidualData"},
-                         {"strides",
-                          "paddings",
-                          "padding_algorithm",
-                          "groups",
-                          "dilations",
-                          "data_format",
-                          "activation",
-                          "fuse_alpha"},
-                         {"Output"});
-}
 }  // namespace phi
 
 PD_REGISTER_ARG_MAPPING_FN(conv2d, phi::Conv2dOpArgumentMapping);
-PD_REGISTER_ARG_MAPPING_FN(conv2d_fusion_cutlass,
-                           phi::Conv2dFusionArgumentMapping);
 PD_REGISTER_ARG_MAPPING_FN(conv2d_grad, phi::Conv2dGradOpArgumentMapping);
 PD_REGISTER_ARG_MAPPING_FN(conv2d_grad_grad,
                            phi::Conv2dDoubleGradOpArgumentMapping);

--- a/paddle/phi/ops/compat/conv_fusion_sig.cc
+++ b/paddle/phi/ops/compat/conv_fusion_sig.cc
@@ -30,6 +30,7 @@ KernelSignature ConvFusionOpArgumentMapping(const ArgumentMappingContext& ctx) {
                              "exhaustive_search",
                              "split_channels",
                              "workspace_size_MB",
+                             "fuse_alpha",
                          },
                          {"Output", "Outputs"});
 }

--- a/paddle/phi/ops/compat/conv_fusion_sig.cc
+++ b/paddle/phi/ops/compat/conv_fusion_sig.cc
@@ -37,3 +37,5 @@ KernelSignature ConvFusionOpArgumentMapping(const ArgumentMappingContext& ctx) {
 }  // namespace phi
 
 PD_REGISTER_ARG_MAPPING_FN(conv2d_fusion, phi::ConvFusionOpArgumentMapping);
+PD_REGISTER_ARG_MAPPING_FN(conv2d_fusion_cutlass,
+                           phi::ConvFusionOpArgumentMapping);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 让 conv2d_fusion_cutlass 和 conv2d_fusion 共享一个签名。
- 这个暂时先不合入，等CUTLASS后端加入的pr合入后，再合入此pr！！