### PR TITLE
[Fix Compile Error] Fix compile error of operants_manager.cc

### DIFF
--- a/paddle/phi/core/CMakeLists.txt
+++ b/paddle/phi/core/CMakeLists.txt
@@ -117,7 +117,7 @@ cc_library(
 cc_library(
   operants_manager
   SRCS operants_manager.cc
-  DEPS flags)
+  DEPS phi_enforce)
 
 cc_library(
   mixed_vector


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Why `flags -> phi_enforce`?

`phi_enforce` depends on `external_error_proto` if `WITH_GPU`

<img width="1365" alt="image" src="https://user-images.githubusercontent.com/17810795/218364313-0e8999bf-d58a-490b-810a-949c1234851b.png">

