### PR TITLE
[CodeStyle] update flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,8 +6,6 @@ exclude =
     # https://github.com/PaddlePaddle/Paddle/pull/46290#discussion_r976392010
     ./python/paddle/fluid/[!t]**,
     ./python/paddle/fluid/tra**,
-    # Exclude auto-generated files
-    *_pb2.py,
     # Exclude third-party libraries
     ./python/paddle/utils/gast/**,
     # Exclude files that will be removed in the future, see more at

--- a/.flake8
+++ b/.flake8
@@ -13,26 +13,16 @@ exclude =
     ./python/paddle/fluid/tests/unittests/npu/**,
     ./python/paddle/fluid/tests/unittests/mlu/**
 ignore =
-    # Whitespace before ‘,’, ‘;’, or ‘:’, it's not compatible with black
-    E203,
-    # Module level import not at top of file
-    E402,
-    # Line too long (82 > 79 characters)
-    E501,
-    # Do not compare types, use `isinstance()`
-    E721,
-    # Do not use bare except, specify exception instead
-    E722,
-    # Do not assign a lambda expression, use a def
-    E731,
-    # Do not use variables named ‘l’, ‘O’, or ‘I’
-    E741,
-    # `name` may be undefined, or defined from star imports: `module`
-    F405,
-    # Local variable name is assigned to but never used
-    F841,
-    # Line break before binary operator, it's not compatible with black
-    W503
+    E203, # Whitespace before ‘,’, ‘;’, or ‘:’, it is not compatible with black
+    E402, # Module level import not at top of file
+    E501, # Line too long (82 > 79 characters)
+    E721, # Do not compare types, use `isinstance()`
+    E722, # Do not use bare except, specify exception instead
+    E731, # Do not assign a lambda expression, use a def
+    E741, # Do not use variables named ‘l’, ‘O’, or ‘I’
+    F405, # `name` may be undefined, or defined from star imports: `module`
+    F841, # Local variable name is assigned to but never used
+    W503  # Line break before binary operator, it is not compatible with black
 per-file-ignores =
     # These files need tabs for testing.
     python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py:E101,W191

--- a/.flake8
+++ b/.flake8
@@ -15,17 +15,25 @@ exclude =
     ./python/paddle/fluid/tests/unittests/npu/**,
     ./python/paddle/fluid/tests/unittests/mlu/**
 ignore =
-    # E, see https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+    # Whitespace before ‘,’, ‘;’, or ‘:’, it's not compatible with black
     E203,
+    # Module level import not at top of file
     E402,
+    # Line too long (82 > 79 characters)
     E501,
-    E721,E722,E731,E741,
-
-    # F, see https://flake8.pycqa.org/en/latest/user/error-codes.html
+    # Do not compare types, use `isinstance()`
+    E721,
+    # Do not use bare except, specify exception instead
+    E722,
+    # Do not assign a lambda expression, use a def
+    E731,
+    # Do not use variables named ‘l’, ‘O’, or ‘I’
+    E741,
+    # `name` may be undefined, or defined from star imports: `module`
     F405,
+    # Local variable name is assigned to but never used
     F841,
-
-    # W, see https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+    # Line break before binary operator, it's not compatible with black
     W503
 per-file-ignores =
     # These files need tabs for testing.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ exclude: |
         paddle/fluid/framework/fleet/heter_ps/cudf/.+|
         paddle/fluid/distributed/ps/thirdparty/round_robin.h|
         python/paddle/utils/gast/.+|
-        .+_pb2\.py|
         python/paddle/fluid/tests/unittests/npu/.+|
         python/paddle/fluid/tests/unittests/mlu/.+
     )$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ extend_skip_glob = [
     # see .flake8 for more details
     "python/paddle/fluid/[!t]**",
     "python/paddle/fluid/tra**",
-    "*_pb2.py",
     "python/paddle/utils/gast/**",
     "python/paddle/fluid/tests/unittests/npu/**",
     "python/paddle/fluid/tests/unittests/mlu/**",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

更新 flake8 配置的样式，增加剩余不太方便修复错误码的说明（10个），其中 2 个（E203、W503）与 black 不兼容，在使用 black 的项目中基本都会被 ignore 掉，其余 8 个会在下面说明下原因。

此外移除配置中 ignore 项目里的 `_pb2` 后缀，因为现在代码库已经没有 `_pb2` 后缀的文件了（`ps_pb2.py` 已经在 #50040 被移除，修改为从 proto 自动生成）

### Related links

- #46039