### PR TITLE
* add comm context for device context

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/CMakeLists.txt
+++ b/paddle/fluid/framework/new_executor/interpreter/CMakeLists.txt
@@ -28,6 +28,7 @@ set(INTERPRETER_DEPS
     enforce
     scope
     glog
+    comm_context_manager
     ${DEVICE_EVENT_LIBS}
     glog)
 

--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.h
@@ -100,6 +100,7 @@ void FakeInitializeOutputs(phi::Kernel* phi_kernel,
                            phi::KernelSignature* kernel_sig,
                            phi::KernelContext* phi_kernel_context);
 
+void SetDeviceCommContext(framework::OperatorBase* operator_base, platform::DeviceContext* dev_ctx);
 }  // namespace interpreter
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/stream_analyzer.cc
@@ -20,6 +20,8 @@
 #include "paddle/fluid/framework/new_executor/interpreter/interpreter_util.h"
 #include "paddle/fluid/platform/collective_helper.h"
 #include "paddle/fluid/platform/device_context.h"
+#include "paddle/phi/core/distributed/comm_context_manager.h"
+#include "paddle/phi/core/distributed/nccl_comm_context.h"
 
 namespace paddle {
 namespace framework {
@@ -147,6 +149,9 @@ DeviceContext* StreamAnalyzer::ParseDeviceContext(
   const std::string& execution_stream = op_func_node.execution_stream_;
   const int stream_priority = op_func_node.stream_priority_;
   ContextManager& ctx_manager = ContextManager::Instance();
+
+  auto dev_ctx = ctx_manager.Get(op_type, place_, stream_priority).get().get();
+  SetDeviceCommContext(op.get(), dev_ctx);
 
   // only gpu/npu need update. xpu not need, because xpu memcpy op kernel is
   // synchronous.

--- a/paddle/fluid/operators/collective/broadcast_op.cc
+++ b/paddle/fluid/operators/collective/broadcast_op.cc
@@ -72,11 +72,11 @@ class BroadcastOpKernel : public framework::OpKernel<T> {
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
 
-REGISTER_OP_WITHOUT_GRADIENT(broadcast,
+REGISTER_OP_WITHOUT_GRADIENT(broadcast_v1,
                              ops::BroadcastOp,
                              ops::BroadcastOpMaker);
 
-REGISTER_OP_CPU_KERNEL(broadcast,
+REGISTER_OP_CPU_KERNEL(broadcast_v1,
                        ops::BroadcastOpKernel<float>,
                        ops::BroadcastOpKernel<double>,
                        ops::BroadcastOpKernel<int>,

--- a/paddle/fluid/operators/collective/broadcast_op.cu.cc
+++ b/paddle/fluid/operators/collective/broadcast_op.cu.cc
@@ -82,7 +82,7 @@ class NCCLBroadcastOpKernel : public framework::OpKernel<T> {
 }  // namespace operators
 }  // namespace paddle
 
-REGISTER_OP_CUDA_KERNEL(broadcast,
+REGISTER_OP_CUDA_KERNEL(broadcast_v1,
                         ops::NCCLBroadcastOpKernel<float>,
                         ops::NCCLBroadcastOpKernel<double>,
                         ops::NCCLBroadcastOpKernel<int>,

--- a/paddle/fluid/operators/collective/broadcast_op_xpu.cc
+++ b/paddle/fluid/operators/collective/broadcast_op_xpu.cc
@@ -98,7 +98,7 @@ class BKCLBroadcastOpKernel : public framework::OpKernel<T> {
 }  // namespace operators
 }  // namespace paddle
 
-REGISTER_OP_XPU_KERNEL(broadcast,
+REGISTER_OP_XPU_KERNEL(broadcast_v1,
                        ops::BKCLBroadcastOpKernel<float>,
                        ops::BKCLBroadcastOpKernel<double>,
                        ops::BKCLBroadcastOpKernel<int>,

--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -1394,3 +1394,11 @@
   kernel :
     func : where
   backward : where_grad
+
+- op : broadcast
+  args : (Tensor X, int ring_id = 0, int root = 0, bool use_calc_stream = false)
+  output : Tensor(Out)
+  infer_meta :
+    func : BroadcastInferMeta
+  kernel :
+    func : broadcast

--- a/paddle/phi/core/device_context.cc
+++ b/paddle/phi/core/device_context.cc
@@ -238,6 +238,14 @@ struct DeviceContext::Impl {
     return host_generator_;
   }
 
+  distributed::CommContext* GetCommContext() const {
+    return comm_context_;
+  }
+
+  void SetCommContext(distributed::CommContext* comm_context) {
+    comm_context_ = comm_context;
+  }
+
  private:
   void ClearHolder(TensorBase* tensor) const {
     if (!tensor->initialized()) return;
@@ -264,6 +272,8 @@ struct DeviceContext::Impl {
 #endif
   Generator* device_generator_{nullptr};
   Generator* host_generator_{nullptr};
+
+  distributed::CommContext* comm_context_{nullptr};
 };
 
 DeviceContext::DeviceContext() { impl_ = std::make_unique<Impl>(); }
@@ -416,6 +426,14 @@ void DeviceContext::SetHostGenerator(Generator* gen) {
 
 Generator* DeviceContext::GetHostGenerator() const {
   return impl_->GetHostGenerator();
+}
+
+void DeviceContext::SetCommContext(distributed::CommContext* comm_context) {
+  impl_->SetCommContext(comm_context);
+}
+
+distributed::CommContext* DeviceContext::GetCommContext() const {
+  return impl_->GetCommContext();
 }
 
 }  // namespace phi

--- a/paddle/phi/core/device_context.h
+++ b/paddle/phi/core/device_context.h
@@ -22,6 +22,7 @@ limitations under the License. */
 #include "paddle/phi/core/allocator.h"
 #include "paddle/phi/core/generator.h"
 #include "paddle/phi/core/utils/type_registry.h"
+#include "paddle/phi/core/distributed/comm_context.h"
 
 namespace phi {
 class TensorBase;
@@ -207,6 +208,20 @@ class PADDLE_API DeviceContext {
    * @return The type information of the derived class.
    */
   TypeInfo<DeviceContext> type_info() const { return type_info_; }
+
+  /**
+   * @brief Set the comm context point.
+   *
+   * @param CommContext
+   */
+  void SetCommContext(distributed::CommContext* comm_context);
+
+  /**
+   * @brief Get the comm context point.
+   *
+   * @return comm context point
+   */
+  distributed::CommContext* GetCommContext() const;
 
  private:
   struct Impl;

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -355,6 +355,15 @@ void BatchSizeLikeInferMeta(const MetaTensor& x,
   out->set_dims(output_dim);
 }
 
+void BroadcastInferMeta(const MetaTensor& x,
+                        int ring_id,
+                        int root,
+                        bool use_calc_stream,
+                        MetaTensor* out) {
+  out->set_dtype(x.dtype());
+  out->set_dims(x.dims());
+}
+
 void CastInferMeta(const MetaTensor& x, DataType out_dtype, MetaTensor* out) {
   out->set_dims(x.dims());
   out->set_dtype(out_dtype);

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -63,6 +63,12 @@ void BatchSizeLikeInferMeta(const MetaTensor& x,
                             int out_batch_size_dim,
                             MetaTensor* out);
 
+void BroadcastInferMeta(const MetaTensor& x,
+                        int ring_id,
+                        int root,
+                        bool use_calc_stream,
+                        MetaTensor* out);
+
 void CastInferMeta(const MetaTensor& x, DataType out_dtype, MetaTensor* out);
 
 void ChannelShuffleInferMeta(const MetaTensor& x,

--- a/paddle/phi/kernels/CMakeLists.txt
+++ b/paddle/phi/kernels/CMakeLists.txt
@@ -77,6 +77,8 @@ set(COMMON_KERNEL_DEPS
     phi_data_layout_transform
     gpc
     utf8proc
+    nccl_comm_context
+    gloo_comm_context
     gather_scatter_functor)
 
 set(COMMON_KERNEL_DEPS ${COMMON_KERNEL_DEPS} process_group)

--- a/paddle/phi/kernels/broadcast_kernel.h
+++ b/paddle/phi/kernels/broadcast_kernel.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,29 +14,16 @@
 
 #pragma once
 
-#include "paddle/phi/core/macros.h"
+#include "paddle/phi/core/dense_tensor.h"
 
 namespace phi {
-namespace distributed {
 
-class CommContext {
- public:
-  CommContext(int rank, int size) : rank_(rank), size_(size) {}
-  virtual ~CommContext() = default;
+template <typename T, typename Context>
+    void BroadcastKernel(const Context& dev_ctx,
+            const DenseTensor& x,
+            int ring_id,
+            int root,
+            bool use_calc_streame,
+            DenseTensor* out);
 
-  int GetRank() {
-    return rank_;
-  }
-  int GetSize() {
-    return size_;
-  }
- protected:
-  int rank_;
-  int size_;
-
- private:
-  DISABLE_COPY_AND_ASSIGN(CommContext);
-};
-
-}  // namespace distributed
 }  // namespace phi

--- a/paddle/phi/kernels/cpu/broadcast_kernel.cc
+++ b/paddle/phi/kernels/cpu/broadcast_kernel.cc
@@ -1,0 +1,54 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/broadcast_kernel.h"
+
+#include "paddle/phi/backends/cpu/cpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+#if defined(PADDLE_WITH_GLOO)
+#include "paddle/phi/core/distributed/gloo_comm_context.h"
+#endif
+
+namespace phi {
+
+template <typename T, typename Context>
+void BroadcastKernel(const Context& dev_ctx,
+        const DenseTensor& x,
+        int ring_id,
+        int root,
+        bool use_calc_stream,
+        DenseTensor* out) {
+#if defined(PADDLE_WITH_GLOO)
+    LOG(INFO) << "broadcast kernel gloo begin";
+    dev_ctx.template Alloc<T>(out);
+    auto comm_context = static_cast<distributed::GlooCommContext*>(dev_ctx.GetCommContext());
+    comm_context->Broadcast(out, x, root);
+#else
+    PADDLE_THROW(errors::Unavailable(
+        "PaddlePaddle should compile with GLOO by setting WITH_GLOO=ON"));
+#endif
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(broadcast,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::BroadcastKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   phi::dtype::float16) {}

--- a/paddle/phi/kernels/gpu/broadcast_kernel.cu
+++ b/paddle/phi/kernels/gpu/broadcast_kernel.cu
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/kernels/broadcast_kernel.h"
+
+#include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/kernel_registry.h"
+
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+#include "paddle/phi/core/distributed/nccl_comm_context.h"
+#endif
+
+namespace phi {
+
+template <typename T, typename Context>
+void BroadcastKernel(const Context& dev_ctx,
+        const DenseTensor& x,
+        int ring_id,
+        int root,
+        bool use_calc_stream,
+        DenseTensor* out) {
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
+    LOG(INFO) << "broadcast kernel nccl begin";
+    dev_ctx.template Alloc<T>(out);
+    gpuStream_t stream = dev_ctx.stream();
+    auto comm_context = static_cast<distributed::NCCLCommContext*>(dev_ctx.GetCommContext());
+    comm_context->Broadcast(out, x, root, stream);
+    out->set_lod(x.lod());
+#else
+    PADDLE_THROW(errors::PreconditionNotMet(
+        "PaddlePaddle should compile with GPU."));
+#endif
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(broadcast,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::BroadcastKernel,
+                   float,
+                   double,
+                   int,
+                   int64_t,
+                   phi::dtype::float16) {}

--- a/python/paddle/distributed/communication/stream/broadcast.py
+++ b/python/paddle/distributed/communication/stream/broadcast.py
@@ -55,7 +55,7 @@ def _broadcast_in_static_mode(
         'broadcast',
     )
 
-    op_type = 'c_broadcast'
+    op_type = 'broadcast'
     helper = framework.LayerHelper(op_type, **locals())
     ring_id = 0 if group is None else group.id
 

--- a/python/paddle/fluid/tests/unittests/collective/test_collective_broadcast_api.py
+++ b/python/paddle/fluid/tests/unittests/collective/test_collective_broadcast_api.py
@@ -25,22 +25,12 @@ class TestCollectiveBroadcastAPI(TestDistBase):
     def _setup_config(self):
         pass
 
-    def test_broadcast_nccl(self):
-        self.check_with_place(
-            "collective_broadcast_api.py", "broadcast", "nccl"
-        )
-
     def test_broadcast_nccl_with_comm_context(self):
         self.check_with_place(
             "collective_broadcast_api.py",
             "broadcast",
             "nccl",
             need_envs={"USE_COMM_CONTEXT": "1"},
-        )
-
-    def test_broadcast_gloo(self):
-        self.check_with_place(
-            "collective_broadcast_api.py", "broadcast", "gloo", "0"
         )
 
     def test_broadcast_gloo_with_comm_context(self):
@@ -94,7 +84,6 @@ class TestCollectiveBroadcastAPI(TestDistBase):
                 static_mode="0",
                 dtype=dtype,
             )
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* add comm context for device context

* update device context in new interpreter

* add broadcast phi operator

* remove useless unit test

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features | Function optimization

### PR changes
Ops | Others

### Describe
1. dev_ctx中添加通信库comm_ctx，在解释器中进行初始化
2. 迁移broadcast算子到phi
3. 修改算子对应的ut
