### PR TITLE
[Fix Compile Error] Fix operants_manager.cc compile error

### DIFF
--- a/paddle/phi/api/lib/CMakeLists.txt
+++ b/paddle/phi/api/lib/CMakeLists.txt
@@ -319,4 +319,4 @@ cc_library(
 cc_library(
   operants_manager
   SRCS operants_manager.cc
-  DEPS flags)
+  DEPS phi_enforce)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Fix `operants_manager.cc` compile error in `paddle/phi/api/lib/CMakeLists.txt`