### PR TITLE
fix npu save_combine

### DIFF
--- a/paddle/fluid/operators/save_combine_op.h
+++ b/paddle/fluid/operators/save_combine_op.h
@@ -195,45 +195,52 @@ class SaveCombineOpKernel : public framework::OpKernel<T> {
     platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
     auto& dev_ctx = *pool.Get(place);
 
-    for (size_t i = 0; i < inp_var_names.size(); i++) {
-      PADDLE_ENFORCE_NOT_NULL(
-          inp_vars[i],
-          platform::errors::InvalidArgument("Cannot find variable %s to save.",
-                                            inp_var_names[i]));
-      PADDLE_ENFORCE_EQ(
-          inp_vars[i]->IsType<phi::DenseTensor>() ||
-              inp_vars[i]->IsType<framework::Vocab>(),
-          true,
-          platform::errors::InvalidArgument(
-              "SaveCombine operator only supports saving "
-              "phi::DenseTensor or Vocab variable, %s has wrong type.",
-              inp_var_names[i]));
-
-      if (inp_vars.size() > 0 && inp_vars[0]->IsType<phi::DenseTensor>()) {
-        std::vector<const phi::DenseTensor*> x(inp_vars.size());
-        for (size_t i = 0; i < inp_vars.size(); i++) {
-          x[i] = (&(inp_vars[i]->Get<phi::DenseTensor>()));
-        }
-        SaveCombineTensorKernel<T>(dev_ctx,
-                                   x,
-                                   filename,
-                                   overwrite,
-                                   save_as_fp16,
-                                   save_to_memory,
-                                   output);
-      } else {
-        std::vector<const phi::ExtendedTensor*> x(inp_vars.size());
-        for (size_t i = 0; i < inp_vars.size(); i++) {
-          x[i] = (&(inp_vars[i]->Get<framework::Vocab>()));
-        }
-        SaveCombineVocabKernel<T>(dev_ctx,
-                                  x,
-                                  filename,
-                                  overwrite,
-                                  save_as_fp16,
-                                  save_to_memory,
-                                  output);
+    if (inp_vars.size() > 0 && inp_vars[0]->IsType<phi::DenseTensor>()) {
+      std::vector<const phi::DenseTensor*> x(inp_vars.size());
+      for (size_t i = 0; i < inp_vars.size(); i++) {
+        PADDLE_ENFORCE_NOT_NULL(
+            inp_vars[i],
+            platform::errors::InvalidArgument(
+                "Cannot find variable %s to save.", inp_var_names[i]));
+        PADDLE_ENFORCE_EQ(
+            inp_vars[i]->IsType<phi::DenseTensor>(),
+            true,
+            platform::errors::InvalidArgument(
+                "SaveCombine operator only supports saving "
+                "phi::DenseTensor or Vocab variable, %s has wrong type.",
+                inp_var_names[i]));
+        x[i] = (&(inp_vars[i]->Get<phi::DenseTensor>()));
       }
+      SaveCombineTensorKernel<T>(dev_ctx,
+                                 x,
+                                 filename,
+                                 overwrite,
+                                 save_as_fp16,
+                                 save_to_memory,
+                                 output);
+    } else {
+      std::vector<const phi::ExtendedTensor*> x(inp_vars.size());
+      for (size_t i = 0; i < inp_vars.size(); i++) {
+        PADDLE_ENFORCE_NOT_NULL(
+            inp_vars[i],
+            platform::errors::InvalidArgument(
+                "Cannot find variable %s to save.", inp_var_names[i]));
+        PADDLE_ENFORCE_EQ(
+            inp_vars[i]->IsType<framework::Vocab>(),
+            true,
+            platform::errors::InvalidArgument(
+                "SaveCombine operator only supports saving "
+                "phi::DenseTensor or Vocab variable, %s has wrong type.",
+                inp_var_names[i]));
+        x[i] = (&(inp_vars[i]->Get<framework::Vocab>()));
+      }
+      SaveCombineVocabKernel<T>(dev_ctx,
+                                x,
+                                filename,
+                                overwrite,
+                                save_as_fp16,
+                                save_to_memory,
+                                output);
     }
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes 

### PR changes
OPs 

### Describe
修复save_combine op逻辑，fluid下的执行逻辑目前只有npu可以执行到
原本代码存在两重嵌套，导致npu的save_model异常缓慢，会重复执行400多次（数量是由inp_vars的大小决定的）

修改前save_combine_op time:
![image](https://user-images.githubusercontent.com/45005871/218670479-d6a289a8-6681-4c44-bd09-d2c194bf5006.png)
![image](https://user-images.githubusercontent.com/45005871/218670515-f6701157-6114-4db8-8841-dba584a065cc.png)

修改后save_combine_op time:
![image](https://user-images.githubusercontent.com/45005871/218670330-c7d72ea2-23c7-45d4-9b2a-eb88b750747a.png)
