### PR TITLE
[PHI] Delete onednn kernel of feed

### DIFF
--- a/paddle/fluid/operators/controlflow/feed_op.cc
+++ b/paddle/fluid/operators/controlflow/feed_op.cc
@@ -208,27 +208,6 @@ PD_REGISTER_GENERAL_KERNEL(
     paddle::operators::FeedStringsKernel<phi::CPUContext>,
     ALL_DTYPE) {}
 
-#if defined(PADDLE_WITH_MKLDNN)
-PD_REGISTER_GENERAL_KERNEL(
-    feed_dense_tensor,
-    OneDNN,
-    ALL_LAYOUT,
-    paddle::operators::FeedDenseTensorKernel<phi::OneDNNContext>,
-    ALL_DTYPE) {}
-PD_REGISTER_GENERAL_KERNEL(
-    feed_sparse_coo_tensor,
-    OneDNN,
-    ALL_LAYOUT,
-    paddle::operators::FeedSparseCooTensorKernel<phi::OneDNNContext>,
-    ALL_DTYPE) {}
-PD_REGISTER_GENERAL_KERNEL(
-    feed_strings,
-    OneDNN,
-    ALL_LAYOUT,
-    paddle::operators::FeedStringsKernel<phi::OneDNNContext>,
-    ALL_DTYPE) {}
-#endif
-
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 PD_REGISTER_GENERAL_KERNEL(
     feed_dense_tensor,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
onednn kernel的选择需要通过use_mkldnn属性进行控制，feed算未定义use_mkldnn属性，理论上feed算子的onednn kernel不会被选到并执行，因此本PR中将删除feed算子注册的onednn kernel。
