### PR TITLE
disable deprecated ops dygraph tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/sequence/test_sequence_conv.py
+++ b/python/paddle/fluid/tests/unittests/sequence/test_sequence_conv.py
@@ -21,7 +21,7 @@ import numpy as np
 import paddle
 
 sys.path.append("../")
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 def seqconv(
@@ -153,12 +153,16 @@ class TestSeqProject(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
         if self.padding_trainable:
             self.check_grad(
-                set(self.inputs_val), 'Out', max_relative_error=0.05
+                set(self.inputs_val),
+                'Out',
+                max_relative_error=0.05,
+                check_dygraph=False,
             )
 
     def test_check_grad_input(self):
@@ -167,12 +171,16 @@ class TestSeqProject(OpTest):
             'Out',
             max_relative_error=0.05,
             no_grad_set=set(self.inputs_val_no_x),
+            check_dygraph=False,
         )
 
     def test_check_grad_padding_data(self):
         if self.padding_trainable:
             self.check_grad(
-                ['PaddingData'], 'Out', no_grad_set=set(['X', 'Filter'])
+                ['PaddingData'],
+                'Out',
+                no_grad_set=set(['X', 'Filter']),
+                check_dygraph=False,
             )
 
     def test_check_grad_Filter(self):
@@ -181,6 +189,7 @@ class TestSeqProject(OpTest):
             'Out',
             max_relative_error=0.05,
             no_grad_set=set(self.inputs_val_no_f),
+            check_dygraph=False,
         )
 
     def test_check_grad_input_filter(self):
@@ -190,6 +199,7 @@ class TestSeqProject(OpTest):
                 'Out',
                 max_relative_error=0.05,
                 no_grad_set=set(['PaddingData']),
+                check_dygraph=False,
             )
 
     def test_check_grad_padding_input(self):
@@ -199,6 +209,7 @@ class TestSeqProject(OpTest):
                 'Out',
                 max_relative_error=0.05,
                 no_grad_set=set(['Filter']),
+                check_dygraph=False,
             )
 
     def test_check_grad_padding_filter(self):
@@ -208,6 +219,7 @@ class TestSeqProject(OpTest):
                 'Out',
                 max_relative_error=0.05,
                 no_grad_set=set(['X']),
+                check_dygraph=False,
             )
 
     def init_test_case(self):

--- a/python/paddle/fluid/tests/unittests/test_box_decoder_and_assign_op.py
+++ b/python/paddle/fluid/tests/unittests/test_box_decoder_and_assign_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 def box_decoder_and_assign(deltas, weights, boxes, box_score, box_clip):
@@ -62,7 +62,8 @@ def box_decoder_and_assign(deltas, weights, boxes, box_score, box_clip):
 
 class TestBoxDecoderAndAssignOpWithLoD(OpTest):
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def setUp(self):
         self.op_type = "box_decoder_and_assign"

--- a/python/paddle/fluid/tests/unittests/test_chunk_eval_op.py
+++ b/python/paddle/fluid/tests/unittests/test_chunk_eval_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 class Segment:
@@ -222,7 +222,8 @@ class TestChunkEvalOp(OpTest):
         self.set_data()
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 class TestChunkEvalOpWithExclude(TestChunkEvalOp):

--- a/python/paddle/fluid/tests/unittests/test_ctc_align.py
+++ b/python/paddle/fluid/tests/unittests/test_ctc_align.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 import paddle
 
@@ -95,7 +95,8 @@ class TestCTCAlignOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 class TestCTCAlignOpCase1(TestCTCAlignOp):
@@ -161,7 +162,8 @@ class TestCTCAlignPaddingOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 class TestCTCAlignOpCase3(TestCTCAlignPaddingOp):

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -16,7 +16,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 import paddle
 import paddle.fluid.core as core
@@ -268,13 +268,15 @@ class TestDataNormOp(OpTest):
         """
         test check forward, check output
         """
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
         """
         test check backward, check grad
         """
-        self.check_grad(['X'], 'Y', no_grad_set=set([]))
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_grad(['X'], 'Y', no_grad_set=set([]), check_dygraph=False)
 
 
 class TestDataNormOpWithEnableScaleAndShift(OpTest):
@@ -330,13 +332,15 @@ class TestDataNormOpWithEnableScaleAndShift(OpTest):
         """
         test check forward, check output
         """
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
         """
         test check backward, check grad
         """
-        self.check_grad(['X'], 'Y', no_grad_set=set([]))
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_grad(['X'], 'Y', no_grad_set=set([]), check_dygraph=False)
 
 
 class TestDataNormOpWithoutEnableScaleAndShift(OpTest):
@@ -387,13 +391,15 @@ class TestDataNormOpWithoutEnableScaleAndShift(OpTest):
         """
         test check forward, check output
         """
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
         """
         test check backward, check grad
         """
-        self.check_grad(['X'], 'Y', no_grad_set=set([]))
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_grad(['X'], 'Y', no_grad_set=set([]), check_dygraph=False)
 
 
 class TestDataNormOpWithEnableScaleAndShift_1(OpTest):
@@ -449,13 +455,15 @@ class TestDataNormOpWithEnableScaleAndShift_1(OpTest):
         """
         test check forward, check output
         """
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
         """
         test check backward, check grad
         """
-        self.check_grad(['X'], 'Y', no_grad_set=set([]))
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_grad(['X'], 'Y', no_grad_set=set([]), check_dygraph=False)
 
 
 class TestDataNormOpWithSlotDim(OpTest):
@@ -505,13 +513,15 @@ class TestDataNormOpWithSlotDim(OpTest):
         """
         test check forward, check output
         """
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
         """
         test check backward, check grad
         """
-        self.check_grad(['X'], 'Y', no_grad_set=set([]))
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_grad(['X'], 'Y', no_grad_set=set([]), check_dygraph=False)
 
 
 class TestDataNormOpErrorr(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_detection_map_op.py
+++ b/python/paddle/fluid/tests/unittests/test_detection_map_op.py
@@ -17,7 +17,7 @@ import math
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 class TestDetectionMAPOp(OpTest):
@@ -267,7 +267,8 @@ class TestDetectionMAPOp(OpTest):
         self.set_data()
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 class TestDetectionMAPOpSkipDiff(TestDetectionMAPOp):

--- a/python/paddle/fluid/tests/unittests/test_dropout_nd_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_nd_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 import paddle
 import paddle.fluid as fluid
@@ -109,10 +109,12 @@ class TestDropoutNdOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out')
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_grad(['X'], 'Out', check_dygraph=False)
 
 
 class TestDropoutNdAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 def generate_proposal_labels_in_python(
@@ -339,7 +339,8 @@ class TestGenerateProposalLabelsOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def setUp(self):
         self.op_type = 'generate_proposal_labels'

--- a/python/paddle/fluid/tests/unittests/test_generate_proposals_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_proposals_op.py
@@ -17,7 +17,7 @@ import math
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 from test_anchor_generator_op import anchor_generator_in_python
 
 import paddle
@@ -351,7 +351,8 @@ class TestGenerateProposalsOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def setUp(self):
         self.op_type = "generate_proposals"

--- a/python/paddle/fluid/tests/unittests/test_gru_unit_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gru_unit_op.py
@@ -16,7 +16,7 @@ import math
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 import paddle.fluid as fluid
 
@@ -124,10 +124,13 @@ class TestGRUUnitOp(OpTest):
         self.set_outputs()
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
-        self.check_grad(['Input', 'HiddenPrev', 'Weight'], ['Hidden'])
+        self.check_grad(
+            ['Input', 'HiddenPrev', 'Weight'], ['Hidden'], check_dygraph=False
+        )
 
 
 class TestGRUUnitOpOriginMode(TestGRUUnitOp):
@@ -154,13 +157,19 @@ class TestGRUUnitOpWithBias(TestGRUUnitOp):
         }
 
     def test_check_grad(self):
-        self.check_grad(['Input', 'HiddenPrev', 'Weight', 'Bias'], ['Hidden'])
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_grad(
+            ['Input', 'HiddenPrev', 'Weight', 'Bias'],
+            ['Hidden'],
+            check_dygraph=False,
+        )
 
     def test_check_grad_ingore_input(self):
         self.check_grad(
             ['HiddenPrev', 'Weight', 'Bias'],
             ['Hidden'],
             no_grad_set=set('Input'),
+            check_dygraph=False,
         )
 
 

--- a/python/paddle/fluid/tests/unittests/test_im2sequence_op.py
+++ b/python/paddle/fluid/tests/unittests/test_im2sequence_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from eager_op_test import OpTest, skip_check_grad_ci
 
 
 def get_output_shape(attrs, in_shape, img_real_size):
@@ -207,10 +207,11 @@ class TestBlockExpandOp(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_dygraph=False)
 
 
 class TestBlockExpandOpCase2(TestBlockExpandOp):
@@ -287,7 +288,8 @@ class TestBlockExpandOpCase5(OpTest):
         self.outputs = {'Out': out}
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 class TestBlockExpandOpCase6(TestBlockExpandOpCase5):

--- a/python/paddle/fluid/tests/unittests/test_marker_op.py
+++ b/python/paddle/fluid/tests/unittests/test_marker_op.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-from op_test import OpTest
+from eager_op_test import OpTest
 
 from paddle.distributed.fleet.meta_optimizers.common import OpRole
 
@@ -30,7 +30,8 @@ class TestMarkerOp(OpTest):
         self.outputs = {}
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_mine_hard_examples_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mine_hard_examples_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 class TestMineHardExamplesOp(OpTest):
@@ -41,7 +41,8 @@ class TestMineHardExamplesOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
         return

--- a/python/paddle/fluid/tests/unittests/test_minus_op.py
+++ b/python/paddle/fluid/tests/unittests/test_minus_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 import paddle
 
@@ -30,10 +30,11 @@ class TestMinusOp(OpTest):
         self.outputs = {'Out': (self.inputs['X'] - self.inputs['Y'])}
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_dygraph=False)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mul_op.py
@@ -20,7 +20,7 @@ import numpy as np
 import paddle.fluid.core as core
 
 sys.path.append("..")
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 class TestMulOp(OpTest):
@@ -38,19 +38,28 @@ class TestMulOp(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_dygraph=False)
 
     def test_check_grad_ingore_x(self):
         self.check_grad(
-            ['Y'], 'Out', max_relative_error=0.5, no_grad_set=set("X")
+            ['Y'],
+            'Out',
+            max_relative_error=0.5,
+            no_grad_set=set("X"),
+            check_dygraph=False,
         )
 
     def test_check_grad_ingore_y(self):
         self.check_grad(
-            ['X'], 'Out', max_relative_error=0.5, no_grad_set=set('Y')
+            ['X'],
+            'Out',
+            max_relative_error=0.5,
+            no_grad_set=set('Y'),
+            check_dygraph=False,
         )
 
 
@@ -78,19 +87,27 @@ class TestMulOp2(OpTest):
         pass
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_dygraph=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out')
+        self.check_grad(['X', 'Y'], 'Out', check_dygraph=False)
 
     def test_check_grad_ingore_x(self):
         self.check_grad(
-            ['Y'], 'Out', max_relative_error=0.5, no_grad_set=set('X')
+            ['Y'],
+            'Out',
+            max_relative_error=0.5,
+            no_grad_set=set('X'),
+            check_dygraph=False,
         )
 
     def test_check_grad_ignore_y(self):
         self.check_grad(
-            ['X'], 'Out', max_relative_error=0.5, no_grad_set=set('Y')
+            ['X'],
+            'Out',
+            max_relative_error=0.5,
+            no_grad_set=set('Y'),
+            check_dygraph=False,
         )
 
 
@@ -104,13 +121,17 @@ class TestFP16MulOp1(TestMulOp):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, atol=1e-1)
+            self.check_output_with_place(place, atol=1e-1, check_dygraph=False)
 
     def test_check_grad_normal(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
             self.check_grad_with_place(
-                place, ['X', 'Y'], 'Out', max_relative_error=0.5
+                place,
+                ['X', 'Y'],
+                'Out',
+                max_relative_error=0.5,
+                check_dygraph=False,
             )
 
     def test_check_grad_ingore_x(self):
@@ -122,6 +143,7 @@ class TestFP16MulOp1(TestMulOp):
                 'Out',
                 max_relative_error=0.5,
                 no_grad_set=set("X"),
+                check_dygraph=False,
             )
 
     def test_check_grad_ingore_y(self):
@@ -133,6 +155,7 @@ class TestFP16MulOp1(TestMulOp):
                 'Out',
                 max_relative_error=0.5,
                 no_grad_set=set('Y'),
+                check_dygraph=False,
             )
 
 
@@ -146,13 +169,17 @@ class TestFP16MulOp2(TestMulOp2):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, atol=2e-1)
+            self.check_output_with_place(place, atol=2e-1, check_dygraph=False)
 
     def test_check_grad_normal(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
             self.check_grad_with_place(
-                place, ['X', 'Y'], 'Out', max_relative_error=0.9
+                place,
+                ['X', 'Y'],
+                'Out',
+                max_relative_error=0.9,
+                check_dygraph=False,
             )
 
     def test_check_grad_ingore_x(self):
@@ -164,6 +191,7 @@ class TestFP16MulOp2(TestMulOp2):
                 'Out',
                 max_relative_error=0.5,
                 no_grad_set=set("X"),
+                check_dygraph=False,
             )
 
     def test_check_grad_ingore_y(self):
@@ -175,6 +203,7 @@ class TestFP16MulOp2(TestMulOp2):
                 'Out',
                 max_relative_error=0.9,
                 no_grad_set=set('Y'),
+                check_dygraph=False,
             )
 
 

--- a/python/paddle/fluid/tests/unittests/test_positive_negative_pair_op.py
+++ b/python/paddle/fluid/tests/unittests/test_positive_negative_pair_op.py
@@ -16,7 +16,7 @@ import itertools
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 def py_pnpair_op(score, label, query, column=-1, weight=None):
@@ -75,7 +75,8 @@ class TestPositiveNegativePairOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 class TestPositiveNegativePairOpAccumulateWeight(OpTest):
@@ -123,7 +124,7 @@ class TestPositiveNegativePairOpAccumulateWeight(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_dygraph=False)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_target_assign_op.py
+++ b/python/paddle/fluid/tests/unittests/test_target_assign_op.py
@@ -16,7 +16,7 @@ import random
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 
 def gen_match_and_neg_indices(num_prior, gt_lod, neg_lod):
@@ -135,7 +135,8 @@ class TestTargetAssginFloatType(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
 
 class TestTargetAssginIntType(OpTest):
@@ -182,7 +183,7 @@ class TestTargetAssginIntType(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(check_dygraph=False)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
@@ -15,7 +15,7 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest
+from eager_op_test import OpTest
 
 import paddle.fluid.core as core
 
@@ -144,8 +144,6 @@ class TestTrilinearInterpOp(OpTest):
         self.init_test_case()
         self.op_type = "trilinear_interp"
         # NOTE(dev): some AsDispensible input is not used under imperative mode.
-        # Skip check_eager while found them in Inputs.
-        self.check_eager = True
         input_np = np.random.random(self.input_shape).astype("float32")
 
         if self.data_layout == "NCDHW":
@@ -180,10 +178,8 @@ class TestTrilinearInterpOp(OpTest):
         self.inputs = {'X': input_np}
         if self.out_size is not None:
             self.inputs['OutSize'] = self.out_size
-            self.check_eager = False
         if self.actual_shape is not None:
             self.inputs['OutSize'] = self.actual_shape
-            self.check_eager = False
         # c++ end treat NCDHW the same way as NCHW
         if self.data_layout == 'NCDHW':
             data_layout = 'NCHW'
@@ -202,12 +198,11 @@ class TestTrilinearInterpOp(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_eager=self.check_eager)
+        # NODE(yjjiang11): This op will be deprecated.
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'], 'Out', in_place=True, check_eager=self.check_eager
-        )
+        self.check_grad(['X'], 'Out', in_place=True, check_dygraph=False)
 
     def init_test_case(self):
         self.interp_method = 'trilinear'
@@ -353,7 +348,6 @@ class TestTrilinearInterpOpUint8(OpTest):
         self.actual_shape = None
         self.init_test_case()
         self.op_type = "trilinear_interp"
-        self.check_eager = True
         input_np = np.random.randint(
             low=0, high=256, size=self.input_shape
         ).astype("uint8")
@@ -380,7 +374,6 @@ class TestTrilinearInterpOpUint8(OpTest):
         self.inputs = {'X': input_np}
         if self.out_size is not None:
             self.inputs['OutSize'] = self.out_size
-            self.check_eager = False
 
         self.attrs = {
             'out_d': self.out_d,
@@ -395,7 +388,7 @@ class TestTrilinearInterpOpUint8(OpTest):
 
     def test_check_output(self):
         self.check_output_with_place(
-            place=core.CPUPlace(), atol=1, check_eager=self.check_eager
+            place=core.CPUPlace(), atol=1, check_dygraph=False
         )
 
     def init_test_case(self):
@@ -506,7 +499,6 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
         self.actual_shape = None
         self.init_test_case()
         self.op_type = "trilinear_interp"
-        self.check_eager = True
         self.shape_by_1Dtensor = False
         self.scale_by_1Dtensor = False
         self.attrs = {
@@ -532,7 +524,6 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
 
         if self.shape_by_1Dtensor:
             self.inputs['OutSize'] = self.out_size
-            self.check_eager = False
         elif self.out_size is not None:
             size_tensor = []
             for index, ele in enumerate(self.out_size):
@@ -540,7 +531,6 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
                     ("x" + str(index), np.ones((1)).astype('int32') * ele)
                 )
             self.inputs['SizeTensor'] = size_tensor
-            self.check_eager = False
 
         self.attrs['out_d'] = self.out_d
         self.attrs['out_h'] = self.out_h
@@ -558,12 +548,10 @@ class TestTrilinearInterpOp_attr_tensor(OpTest):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(check_eager=self.check_eager)
+        self.check_output(check_dygraph=False)
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'], 'Out', in_place=True, check_eager=self.check_eager
-        )
+        self.check_grad(['X'], 'Out', in_place=True, check_dygraph=False)
 
     def init_test_case(self):
         self.interp_method = 'trilinear'


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
**背景**：
    支持老动态图退场工作，统一动态图测试开关，对使用了 OpTest 的测例进行老动态图到新动态图测试迁移

**工作节奏**：

1.  【已完成】基于op_test.py 创建eager_op_test.py文件, 去除老动态图测试代码，仅保留新动态图测试代码
2. 对老动态图测试进行新动态图迁移，修复失败的测例
3. 将eager_op_test.py 替换当前的op_test.py

**迁移规则**：

* 若是测试代码中有check_eager = False 则表示此前不支持新动态图测试，需要分析原因，调通新动态图测试
* 若是测试代码中有check_dygraph=False 则表示此前不支持老动态图测试，需要分析原因，调通新动态图测试
* 若是既没有显示设置check_eager和check_dygraph 则表示此前支持老动态图测试不支持新动态图测试，需要添加python_api，调通测试

**本次迁移算子如下**
   因为不同原因而长期废弃的算子可以不测动态图，不同原因如下(参考算子2022.9版本梳理统计表）
* 废弃v1版本：trilinear_interp
* fluid专用：target_assign、mul 、mine_hard_example、 im2sequence 、gru_unit 、generate_proposal_labels 、detection_map 、 ctc_align、 chunk_eval 、box_decoder_and_assign
* 仅静态图使用算子：sequence_conv 、data_norm
* 未被用到的算子：positive_negative_pair、minus、marker 、dropout_nd 