### PR TITLE
[Paddle-TRT-fix]fix solov2 infer error

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -69,10 +69,14 @@ TRT_DT FluidDataType2TRT(FluidDT type) {
 #if IS_TRT_VERSION_GE(8400)
     case FluidDT::VarType_Type_BOOL:
       return TRT_DT::kBOOL;
+
 #endif
     default:
       PADDLE_THROW(platform::errors::InvalidArgument(
-          "unknown fluid datatype in TRT op converter"));
+          "unsupported datatype in TRT op converter, type: %s. "
+          "Boolean type is supported as TRT input/output "
+          "using TensorRT v8.4+.",
+          VarType_Type_Name(type)));
   }
   return TRT_DT::kINT32;
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复TRT8.0下develop分支solv2 trt推理报错：unknown fluid datatype in TRT op converter
https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-65317/show
解决：
1.tensort8.4：

fp32无问题，fp16有0.00487的max diff，在可接受范围内；
![image](https://user-images.githubusercontent.com/88373061/219049066-b220712e-28f7-459a-95c7-7f4782213c6d.png)

2.tensorrt8.0：

fp32无法通过，fp16无法通过，报上述抛出错误，原因在于trt版本在高于8.4时，才支持将pdmodel的输入输出的bool类型convert到TRT。

![image](https://user-images.githubusercontent.com/88373061/219049118-15374339-7560-4bca-8e78-1517f2031f43.png)

solov2模型是由于equal算子导致trt有的bool类型的output，然后抛出上述错误；将equal算子不进入trt进行测试，这时trt的ouptut就不是bool了，同时使用tensorrt8.0,将不会抛出上述错误，fp16下精度diff为0.00484，可见与tensort8.4几乎一致。

![image](https://user-images.githubusercontent.com/88373061/219049196-8f2a428e-9361-41de-b83d-d0ac56cdf925.png)

3.

在tensorrt8.0版本下，equal算子不作为trt的input/output就可以进入到trt，只有在convert到trt的input/output时不支持，所以不好在equal算子处作修改，不能做到通用。

解决办法：增加新的报错提示，以防混淆，建议升级tensorrt到8.4版本下推理solov2模型
![image](https://user-images.githubusercontent.com/88373061/219049250-3bec100e-8806-4087-b6d8-8bb8b9d1746b.png)

如果tensorrt版本低于8.4，同时有bool类型进入到trt的input/output,会抛出这个错误提示：

![image](https://user-images.githubusercontent.com/88373061/219049290-83be1216-a9be-4553-a15c-dc01a3b2bb0a.png)


