### PR TITLE
[Paddle-TRT] allow plugin fall back to fp16 when int8

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -161,7 +161,6 @@ void TensorRTEngine::FreezeNetwork() {
   if (enable_fp16) {
     bool support_fp16 = infer_builder_->platformHasFastFp16();
     infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kFP16);
-    with_fp16_ = true;
     if (!support_fp16) {
       LOG(INFO) << "You specify FP16 mode, but the hardware do not support "
                    "FP16 speed up, use FP32 instead.";
@@ -174,10 +173,8 @@ void TensorRTEngine::FreezeNetwork() {
   if (enable_int8) {
     if (!use_dla_) {
       infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kFP16);
-      with_fp16_ = true;
     }
     infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kINT8);
-    with_int8_ = true;
 
     if (calibrator_) {
       infer_builder_config_->setInt8Calibrator(calibrator_);

--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -161,6 +161,7 @@ void TensorRTEngine::FreezeNetwork() {
   if (enable_fp16) {
     bool support_fp16 = infer_builder_->platformHasFastFp16();
     infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kFP16);
+    with_fp16_ = true;
     if (!support_fp16) {
       LOG(INFO) << "You specify FP16 mode, but the hardware do not support "
                    "FP16 speed up, use FP32 instead.";
@@ -173,8 +174,10 @@ void TensorRTEngine::FreezeNetwork() {
   if (enable_int8) {
     if (!use_dla_) {
       infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kFP16);
+      with_fp16_ = true;
     }
     infer_builder_config_->setFlag(nvinfer1::BuilderFlag::kINT8);
+    with_int8_ = true;
 
     if (calibrator_) {
       infer_builder_config_->setInt8Calibrator(calibrator_);

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -356,15 +356,13 @@ class TensorRTEngine {
   int GetRuntimeBatch();
 
   bool WithFp16() {
-    bool enable_fp16 = (precision_ == AnalysisConfig::Precision::kHalf);
     bool support_fp16 = infer_builder_->platformHasFastFp16();
-    return enable_fp16 && support_fp16;
+    return with_fp16_ && support_fp16;
   }
 
   bool WithInt8() {
-    bool enable_int8 = (precision_ == AnalysisConfig::Precision::kInt8);
     bool support_int8 = infer_builder_->platformHasFastInt8();
-    return enable_int8 && support_int8;
+    return with_int8_ && support_int8;
   }
 
   int GetDeviceId() { return device_id_; }
@@ -671,6 +669,8 @@ class TensorRTEngine {
   ShapeMapType max_shape_tensor_;
   ShapeMapType optim_shape_tensor_;
   bool disable_trt_plugin_fp16_{false};
+  bool with_fp16_{false};
+  bool with_int8_{false};
   phi::DataType model_precision_{phi::DataType::FLOAT32};
   bool use_varseqlen_{false};
   bool use_dla_{false};

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -358,7 +358,8 @@ class TensorRTEngine {
   bool WithFp16() {
     bool enable_fp16 = (precision_ == AnalysisConfig::Precision::kHalf);
     bool support_fp16 = infer_builder_->platformHasFastFp16();
-    return (enable_fp16 || WithInt8()) && support_fp16;
+    bool fall_back_fp16 = WithInt8() && !use_dla_;
+    return (enable_fp16 || fall_back_fp16) && support_fp16;
   }
 
   bool WithInt8() {

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -356,13 +356,15 @@ class TensorRTEngine {
   int GetRuntimeBatch();
 
   bool WithFp16() {
+    bool enable_fp16 = (precision_ == AnalysisConfig::Precision::kHalf);
     bool support_fp16 = infer_builder_->platformHasFastFp16();
-    return with_fp16_ && support_fp16;
+    return (enable_fp16 || WithInt8()) && support_fp16;
   }
 
   bool WithInt8() {
+    bool enable_int8 = (precision_ == AnalysisConfig::Precision::kInt8);
     bool support_int8 = infer_builder_->platformHasFastInt8();
-    return with_int8_ && support_int8;
+    return enable_int8 && support_int8;
   }
 
   int GetDeviceId() { return device_id_; }
@@ -669,8 +671,6 @@ class TensorRTEngine {
   ShapeMapType max_shape_tensor_;
   ShapeMapType optim_shape_tensor_;
   bool disable_trt_plugin_fp16_{false};
-  bool with_fp16_{false};
-  bool with_int8_{false};
   phi::DataType model_precision_{phi::DataType::FLOAT32};
   bool use_varseqlen_{false};
   bool use_dla_{false};

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -358,6 +358,7 @@ class TensorRTEngine {
   bool WithFp16() {
     bool enable_fp16 = (precision_ == AnalysisConfig::Precision::kHalf);
     bool support_fp16 = infer_builder_->platformHasFastFp16();
+    // below is consistent with setFlag in engine.cc
     bool fall_back_fp16 = WithInt8() && !use_dla_;
     return (enable_fp16 || fall_back_fp16) && support_fp16;
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 对于某些plugin，开启int8精度的时候，这些plugin会回退到fp32，现将其更正为可以回退到fp16.