### PR TITLE
Add ReduceAbsMax

### DIFF
--- a/paddle/phi/api/yaml/ops.yaml
+++ b/paddle/phi/api/yaml/ops.yaml
@@ -1394,3 +1394,11 @@
   kernel :
     func : where
   backward : where_grad
+
+- op : row_reduce_absmax
+  args : (Tensor x)
+  output : Tensor
+  infer_meta :
+    func : RowReduceAbsMaxInferMeta
+  kernel :
+    func : row_reduce_absmax

--- a/paddle/phi/infermeta/unary.cc
+++ b/paddle/phi/infermeta/unary.cc
@@ -4883,6 +4883,19 @@ void ChannelShuffleInferMeta(const MetaTensor& x,
   out->set_dims(output_dims);
 }
 
+void RowReduceAbsMaxInferMeta(const MetaTensor& x,
+                              MetaTensor* out) {
+  std::vector<int64_t> out_dims_vec;
+  const std::vector<int64_t> x_dims_vec = phi::vectorize(x.dims());
+  out_dims_vec.assign(x_dims_vec.begin(), x_dims_vec.end() - 1);
+  auto out_dims = phi::make_ddim(out_dims_vec);
+  out->set_dims(out_dims);
+  out->share_lod(x);
+  out->set_dtype(x.dtype());
+  out->set_layout(x.layout());
+}
+
+
 }  // namespace phi
 
 PD_REGISTER_INFER_META_FN(flatten, phi::FlattenInferMeta);

--- a/paddle/phi/infermeta/unary.h
+++ b/paddle/phi/infermeta/unary.h
@@ -686,4 +686,7 @@ void UnStackInferMeta(const MetaTensor& x,
                       int num,
                       std::vector<MetaTensor*> outs);
 
+void RowReduceAbsMaxInferMeta(const MetaTensor& x, 
+                              MetaTensor* out);
+
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/row_reduce_absmax_kernel.cu
+++ b/paddle/phi/kernels/gpu/row_reduce_absmax_kernel.cu
@@ -1,0 +1,236 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/phi/common/complex.h"
+#include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/utils/array.h"
+
+namespace phi {
+
+constexpr int32_t WARP_SIZE = 32; 
+constexpr int32_t HALF_WARP = 16; 
+
+template <typename D>
+class PDDataTypeTraits{
+ public:
+  typedef D DataType;
+};
+
+template <>
+class PDDataTypeTraits<phi::dtype::float16> {
+ public:
+  typedef half DataType;
+};
+
+template<typename T>
+struct MaxFunc{
+  __device__ T operator()(T a, T b){
+    return max(a, b); 
+  }
+}; 
+
+template<>
+struct MaxFunc<half>{
+  __device__ half operator()(half a, half b){
+    return __hmax(a, b); 
+  }
+}; 
+
+template<>
+struct MaxFunc<half2>{
+  __device__ half2 operator()(half2 a, half2 b){
+    return __hmax2(a, b); 
+  }
+};
+
+
+template<typename T, int VecSize>
+struct alignas(sizeof(T) * VecSize) Pack {
+  __device__ Pack() {
+    #pragma unroll
+    for(int i = 0; i < VecSize; i++){
+      elem[i] = 0.0f; 
+    }
+  }
+  union {
+    T elem[VecSize];
+  };
+
+  __device__ void pack_abs_max(Pack<T, VecSize> packA){
+    #pragma unroll 
+    for(int i = 0; i < VecSize; i++){
+      elem[i] = max(elem[i], abs(packA.elem[i])); 
+    }
+  }
+};
+
+template <int VecSize>
+struct alignas(sizeof(half) * VecSize) Pack<half, VecSize> {
+  __device__ Pack() {
+    #pragma unroll
+    for(int i = 0; i < VecSize; i++){
+      elem[i] = 0.0f; 
+    }
+  }
+  union {
+    half elem[VecSize];
+    half2 elem[VecSize / 2]; 
+  };
+
+  __device__ void pack_abs_max(Pack<half, VecSize> packA){
+    #pragma unroll 
+    for(int i = 0; i < VecSize; i++){
+      elem[i] = MaxFunc<half>()(elem[i], __habs(packA.elem[i])); 
+    }
+  }
+};
+
+template<typename T, int VecSize>
+__device__ T PackReduceAbsMax(Pack<T, VecSize> pack){
+    T res = 0.0; 
+    #pragma unroll
+    for(int i = 0; i < VecSize; i++){
+      res = MaxFunc<T>()(res, pack.elem[i]); 
+    }
+    return res; 
+}
+
+template <typename T>
+__inline__ __device__ T WarpReduceAbsMax(T val, unsigned lane_mask) {
+  #pragma unroll
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1){
+    val = MaxFunc<T>()(val, __shfl_xor_sync(lane_mask, val, mask, WARP_SIZE));
+  }
+  return val;
+}
+
+template <typename T>
+__inline__ __device__ T BlockReduceAbsMax(T val, unsigned mask) {
+  static __shared__ T smem[WARP_SIZE]; 
+  int32_t lane_id = threadIdx.x & 0x1f; 
+  int32_t warp_id = threadIdx.x >> 5; 
+  val = WarpReduceAbsMax(val, mask); 
+  if(lane_id == 0){
+    smem[warp_id] = val; 
+  }
+  __syncthreads(); 
+  T abs_max_val = (threadIdx.x < blockDim.x / WARP_SIZE) ? smem[threadIdx.x] : static_cast<T>(0.0f); 
+  abs_max_val = WarpReduceAbsMax(abs_max_val, mask); 
+  return abs_max_val; 
+}
+
+template<typename T, int VecSize>
+__global__ void ReduceAbsMaxKernel(const T* x, T* out, int32_t rows, int32_t cols){
+  Pack<T, VecSize> abs_max_pack{}; 
+  Pack<T, VecSize> load_pack{};
+  using LoadType = Pack<T, VecSize>;
+  T local_max_val = 0.0; 
+  for(int row_idx = blockIdx.x; row_idx < rows; row_idx += gridDim.x){
+      for(int col_idx = threadIdx.x * VecSize; col_idx < cols; col_idx += blockDim.x * VecSize){
+          int32_t linear_index = row_idx * cols + col_idx; 
+          const LoadType* x_load = reinterpret_cast<const LoadType*>(x + linear_index);
+          load_pack = *x_load; 
+          // printf("linearidx is: %d, Load pack val is: %f, %f, %f, %f \n", linear_index, load_pack.elem[0], load_pack.elem[1], load_pack.elem[2], load_pack.elem[3]); 
+          abs_max_pack.pack_abs_max(load_pack); 
+          // printf("linearidx is: %d, absmax pack val is: %f, %f, %f, %f \n", linear_index, abs_max_pack.elem[0], abs_max_pack.elem[1], abs_max_pack.elem[2], abs_max_pack.elem[3]); 
+      }
+      local_max_val = PackReduceAbsMax<T, VecSize>(abs_max_pack); 
+      // printf("local max val is: %f \n", local_max_val); 
+      T row_max_val = BlockReduceAbsMax<T>(local_max_val, 0xffffffff); 
+      // printf("row max val is: %f \n", local_max_val); 
+      if(threadIdx.x == 0){
+        // printf("row max val is: %f \n", local_max_val); 
+        out[row_idx] = row_max_val; 
+      }
+  }
+}
+
+// constexpr int32_t BlockSize = 128; 
+// constexpr int32_t BlockSize = 256; 
+constexpr int32_t BlockSize = 512; 
+
+template <typename T, int VecSize>
+bool TryLaunchKernel(const phi::GPUContext& dev_ctx,
+                      const T* x_data, 
+                      T* out_data, 
+                      const int64_t rows, 
+                      const int64_t cols){
+  if((VecSize <= (16 / sizeof(T))) &&
+     (cols % VecSize == 0) &&
+     (reinterpret_cast<uintptr_t>(x_data) % sizeof(T) == 0) &&
+     (reinterpret_cast<uintptr_t>(out_data) % sizeof(T) == 0)){
+    ReduceAbsMaxKernel<T, VecSize><<<rows, BlockSize, 0, dev_ctx.stream()>>>(x_data, out_data, rows, cols);
+    printf("Here is vecsize %d \n", VecSize);  
+    return true; 
+  }
+  return false; 
+}
+
+template <typename T>
+void DispatchVecSize(const phi::GPUContext& ctx,
+                     const T* x_data, 
+                     T* out_data, 
+                     const int64_t rows, 
+                     const int64_t cols) {
+  using Func = bool (*)(const phi::GPUContext& ctx,
+                        const T* x_data, 
+                        T* out_data, 
+                        const int64_t rows, 
+                        const int64_t cols);
+  Func funcs[] = {
+      TryLaunchKernel<T, 8>,  
+      TryLaunchKernel<T, 4>,  
+      TryLaunchKernel<T, 2>,  
+      TryLaunchKernel<T, 1>,  
+  };
+
+  for (int i = 0; i < 4; i++) {
+    if (funcs[i](ctx, x_data, out_data, rows, cols)) {
+      return;
+    }
+  }
+}
+
+template <typename T, typename Context>
+void RowReduceAbsMaxKernel(const Context& dev_ctx,
+                           const DenseTensor& x,
+                           DenseTensor* out) {
+  dev_ctx.template Alloc<T>(out);
+  typedef PDDataTypeTraits<T> traits;
+  typedef typename traits::DataType DataType;
+  auto x_mat_dims = phi::flatten_to_2d(x.dims(), x.dims().size() - 1);
+  const int64_t rows = x_mat_dims[0];
+  const int64_t cols = x_mat_dims[1];
+  const T* x_data = x.data<T>(); 
+  T* out_data = out->data<T>();  
+  DispatchVecSize<DataType>(dev_ctx, 
+                            reinterpret_cast<const DataType*>(x_data), 
+                            reinterpret_cast<DataType*>(out_data), rows, cols); 
+
+//   template <typename T>
+// void DispatchVecSize(const phi::GPUContext& ctx,
+//                      const T* x_data, 
+//                      T* out_data, 
+//                      const int64_t rows, 
+//                      const int64_t cols) 
+}
+
+}  // namespace phi
+
+PD_REGISTER_KERNEL(row_reduce_absmax,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::RowReduceAbsMaxKernel,
+                   phi::dtype::float16,
+                   float) {}

--- a/paddle/phi/kernels/row_reduce_absmax_kernel.h
+++ b/paddle/phi/kernels/row_reduce_absmax_kernel.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/phi/core/dense_tensor.h"
+
+namespace phi {
+    
+template <typename T, typename Context>
+void RowReduceAbsMaxKernel(const Context& dev_ctx,
+                           const DenseTensor& x,
+                           DenseTensor* out);
+
+}  // namespace phi

--- a/python/paddle/incubate/nn/functional/__init__.py
+++ b/python/paddle/incubate/nn/functional/__init__.py
@@ -18,6 +18,7 @@ from .fused_transformer import fused_multi_transformer
 from .fused_matmul_bias import fused_matmul_bias, fused_linear
 from .fused_transformer import fused_bias_dropout_residual_layer_norm
 from .fused_ec_moe import fused_ec_moe
+from .row_reduce_absmax import row_reduce_absmax
 
 __all__ = [
     'fused_multi_head_attention',
@@ -27,4 +28,5 @@ __all__ = [
     'fused_linear',
     'fused_bias_dropout_residual_layer_norm',
     'fused_ec_moe',
+    'row_reduce_absmax', 
 ]

--- a/python/paddle/incubate/nn/functional/row_reduce_absmax.py
+++ b/python/paddle/incubate/nn/functional/row_reduce_absmax.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from paddle import _C_ops
+from paddle.fluid.framework import in_dygraph_mode
+from paddle.fluid.layer_helper import LayerHelper
+
+def row_reduce_absmax(x):
+    if in_dygraph_mode():
+        return _C_ops.row_reduce_absmax(x)
+
+    helper = LayerHelper('row_reduce_absmax', **locals())
+    out = helper.create_variable_for_type_inference(dtype=x.dtype)
+    helper.append_op(
+        type='row_reduce_absmax',
+        inputs={'X': x},
+        outputs={'Out': out},
+    )
+    return out


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe
Add reduce AbsMax

### usage
```python
import paddle 
import numpy as np 

batch = 8
hidden = 12288
dtype = paddle.float16
np.random.seed(0)

for seq_len in [300, 1000, 2000]: 
    x = paddle.to_tensor(np.random.uniform(-0.01, 0.01, (batch, seq_len, hidden)), dtype=dtype)
    naive_out = paddle.max(paddle.abs(x), axis=-1)
    zzk_out = paddle.incubate.nn.functional.row_reduce_absmax(x)
    print("Is it equal?: ", np.allclose(naive_out.numpy(), zzk_out.numpy(), atol=1e-4, rtol=1e-4))
```

### Benchmark
dtype = paddle.float16
A100 80G

| | Paddle Reduce | RowReduce |
|----|-----|-----|
| 2400 * 12288  | 53.57us | 36.16us |
| 8000 * 12288  | 136.9us | 105.7us |
| 2400 * 12288  | 260.38us | 209.8us |