### PR TITLE
[Paddle C++ API] Remapping input and output tensors after XPU op has fallen back to CPU op

### DIFF
--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -1179,7 +1179,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
     ):
         return None, None, None
 
-    def post_blacklist_remapping(
+    def reset_view_after_fallback(
         self, out_dtype_list, code_indent='', inplace_flag=False
     ):
         return ''
@@ -1232,7 +1232,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 {code_indent}  }}
 {code_indent}  if (kernel_result.has_fallback_cpu) {{
 {fallback_kernel_output_trans}
-{self.post_blacklist_remapping(self.outputs['types'], code_indent, inplace_flag)}
+{self.reset_view_after_fallback(self.outputs['types'], code_indent, inplace_flag)}
 {code_indent}  }}
 {code_indent}  {self.gene_return_code()}"""
 

--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -1195,7 +1195,8 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         for kernel_out in outputs_args:
             fallback_kernel_output_trans += f"""
 {code_indent}    TransDataBackend({kernel_out}, kernel_backend, {kernel_out});"""
-        return f"""
+        return (
+            f"""
 {code_indent}  VLOG(6) << "{self.api} API kernel key: [" << kernel_backend << ", " << kernel_layout << ", "<< kernel_data_type << "]";
 {code_indent}  auto kernel_result = phi::KernelFactory::Instance().SelectKernelOrThrowError(
 {code_indent}      "{kernel_name}", {{kernel_backend, kernel_layout, kernel_data_type}});
@@ -1226,9 +1227,25 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
 {code_indent}    delete kernel_record_event;
 {code_indent}  }}
 {code_indent}  if (kernel_result.has_fallback_cpu) {{
-{fallback_kernel_output_trans}
+{fallback_kernel_output_trans}"""
+            + (
+                f"""
+{code_indent}
+{code_indent}    phi::DenseTensor * mean_subs = static_cast<phi::DenseTensor*>(mean.impl().get());
+{code_indent}    mean_subs->ShareBufferWith(*kernel_out_1);
+{code_indent}
+{code_indent}    phi::DenseTensor * variance_subs = static_cast<phi::DenseTensor*>(variance.impl().get());
+{code_indent}    variance_subs->ShareBufferWith(*kernel_out_2);
+{code_indent}
+{code_indent}
+{code_indent}"""
+                if self.api == "batch_norm"
+                else ""
+            )
+            + f"""
 {code_indent}  }}
 {code_indent}  {self.gene_return_code()}"""
+        )
 
     def get_condition_code(self, kernel_name):
         assert self.kernel['dispatch'][

--- a/paddle/phi/api/yaml/generator/api_gen.py
+++ b/paddle/phi/api/yaml/generator/api_gen.py
@@ -312,7 +312,7 @@ class ForwardAPI(BaseAPI):
 
         return kernel_output, output_names, output_create
 
-    def post_blacklist_remapping(
+    def reset_view_after_fallback(
         self, out_dtype_list, code_indent='', inplace_flag=False
     ):
         remap_code = ''
@@ -326,7 +326,7 @@ class ForwardAPI(BaseAPI):
                 remap_code += f"""
 {code_indent}    phi::DenseTensor * {self.view_map[self.outputs['names'][0]]}_remap = static_cast<phi::DenseTensor*>({self.view_map[self.outputs['names'][0]]}.impl().get());
 {code_indent}    {self.view_map[self.outputs['names'][0]]}_remap->ShareBufferWith(*kernel_out);
-{code_indent}    {self.view_map[self.outputs['names'][0]]}_remap->ShareInplaceVersionCounterWith(*kernel_out);
+{code_indent}    kernel_out->ShareInplaceVersionCounterWith(*{self.view_map[self.outputs['names'][0]]}_remap);
 """
         elif len(out_dtype_list) > 1:
             for i in range(len(out_dtype_list)):
@@ -338,7 +338,7 @@ class ForwardAPI(BaseAPI):
                     remap_code += f"""
 {code_indent}    phi::DenseTensor * {self.view_map[self.outputs['names'][i]]}_remap = static_cast<phi::DenseTensor*>({self.view_map[self.outputs['names'][i]]}.impl().get());
 {code_indent}    {self.view_map[self.outputs['names'][i]]}_remap->ShareBufferWith(*kernel_out_{i});
-{code_indent}    {self.view_map[self.outputs['names'][i]]}_remap->ShareInplaceVersionCounterWith(*kernel_out_{i});
+{code_indent}    kernel_out_{i}->ShareInplaceVersionCounterWith(*{self.view_map[self.outputs['names'][i]]}_remap);
 """
         return remap_code
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
在昆仑2上训练模型时，时常需要通过加黑名单的方法让算子从XPU fallback到CPU上运行以检验XPU算子的精度是否满足要求。但在黑名单方法实际使用过程中发现，与全部算子均在XPU端运算的情况相比，当batch_norm被fallback到CPU后，模型精度会出现大幅下降的现象（0.29->0.013，PaddleClas的ESNet_x0_25训练1个Epoch的结果对比）。原因是batch_norm等算子的某些input tensors和output tensors是需要共享底层的内存空间从而实现input tensor的更新，但在以下XPU fallback到CPU的执行流程中：

XPU端input tensor拷贝到CPU -> CPU端input tensor和CPU端output tensor映射到同一个内存空间 -> 运行算子 -> CPU output tensor重新拷贝到XPU端

只有CPU端的input tensor和output tensor实现了共享内存，而XPU端的input tensor和output tensor没有。因此，本PR修改了代码自动生成组件，让fallback后XPU端的input和output tensors重新共享内存。以batch_norm算子的C++ API为例，修改前的代码为：

```
if(phi::RecordEvent::IsEnabled()){
    kernel_record_event = new phi::RecordEvent("batch_norm compute", phi::TracerEventType::OperatorInner, 1);
}
(*kernel_fn)(*dev_ctx, *input_x, *input_mean, *input_variance, *input_scale, *input_bias, is_test, momentum, epsilon, data_layout, use_global_stats, trainable_statistics, kernel_out_0, kernel_out_1, kernel_out_2, kernel_out_3, kernel_out_4, kernel_out_5);
if(kernel_record_event != nullptr){
    delete kernel_record_event;
}
if (kernel_result.has_fallback_cpu) {

    TransDataBackend(kernel_out_0, kernel_backend, kernel_out_0);
    TransDataBackend(kernel_out_1, kernel_backend, kernel_out_1);
    TransDataBackend(kernel_out_2, kernel_backend, kernel_out_2);
    TransDataBackend(kernel_out_3, kernel_backend, kernel_out_3);
    TransDataBackend(kernel_out_4, kernel_backend, kernel_out_4);
    TransDataBackend(kernel_out_5, kernel_backend, kernel_out_5);
}
```

修改后的代码为：
```
if(phi::RecordEvent::IsEnabled()){
    kernel_record_event = new phi::RecordEvent("batch_norm compute", phi::TracerEventType::OperatorInner, 1);
}
(*kernel_fn)(*dev_ctx, *input_x, *input_mean, *input_variance, *input_scale, *input_bias, is_test, momentum, epsilon, data_layout, use_global_stats, trainable_statistics, kernel_out_0, kernel_out_1, kernel_out_2, kernel_out_3, kernel_out_4, kernel_out_5);
if(kernel_record_event != nullptr){
    delete kernel_record_event;
}
if (kernel_result.has_fallback_cpu) {

    TransDataBackend(kernel_out_0, kernel_backend, kernel_out_0);
    TransDataBackend(kernel_out_1, kernel_backend, kernel_out_1);
    TransDataBackend(kernel_out_2, kernel_backend, kernel_out_2);
    TransDataBackend(kernel_out_3, kernel_backend, kernel_out_3);
    TransDataBackend(kernel_out_4, kernel_backend, kernel_out_4);
    TransDataBackend(kernel_out_5, kernel_backend, kernel_out_5);

    phi::DenseTensor * mean_remap = static_cast<phi::DenseTensor*>(mean.impl().get());
    mean_remap->ShareBufferWith(*kernel_out_1);
    mean_remap->ShareInplaceVersionCounterWith(*kernel_out_1);

    phi::DenseTensor * variance_remap = static_cast<phi::DenseTensor*>(variance.impl().get());
    variance_remap->ShareBufferWith(*kernel_out_2);
    variance_remap->ShareInplaceVersionCounterWith(*kernel_out_2);
}
```

修改后，模型精度从0.013回升到0.25（PaddleClas的ESNet_x0_25训练1个Epoch的结果对比），重新实现了batch_norm fallback前后的对齐。