### PR TITLE
【Hackathon 68】Remove utils in phi

### DIFF
--- a/paddle/phi/core/utils/get_data_from_tensor.h
+++ b/paddle/phi/core/utils/get_data_from_tensor.h
@@ -23,23 +23,23 @@ namespace funcs {
 template <typename T = int32_t>
 inline std::vector<T> GetDataFromDenseTensor(const phi::DenseTensor* x) {
   std::vector<T> vec_new_data;
-  if (framework::TransToProtoVarType(x->dtype()) ==
-      framework::proto::VarType::INT32) {
+  if (paddle::framework::TransToProtoVarType(x->dtype()) ==
+      paddle::framework::proto::VarType::INT32) {
     auto* data = x->data<int>();
     phi::DenseTensor cpu_attr_tensor;
-    if (!platform::is_cpu_place(x->place())) {
+    if (!paddle::platform::is_cpu_place(x->place())) {
       paddle::framework::TensorCopySync(
-          *x, platform::CPUPlace(), &cpu_attr_tensor);
+          *x, paddle::platform::CPUPlace(), &cpu_attr_tensor);
       data = cpu_attr_tensor.data<int>();
     }
     vec_new_data = std::vector<T>(data, data + x->numel());
-  } else if (framework::TransToProtoVarType(x->dtype()) ==
-             framework::proto::VarType::INT64) {
+  } else if (paddle::framework::TransToProtoVarType(x->dtype()) ==
+             paddle::framework::proto::VarType::INT64) {
     auto* data = x->data<int64_t>();
     phi::DenseTensor cpu_attr_tensor;
-    if (!platform::is_cpu_place(x->place())) {
+    if (!paddle::platform::is_cpu_place(x->place())) {
       paddle::framework::TensorCopySync(
-          *x, platform::CPUPlace(), &cpu_attr_tensor);
+          *x, paddle::platform::CPUPlace(), &cpu_attr_tensor);
       data = cpu_attr_tensor.data<int64_t>();
     }
     // NOTE: Converting int64 to int32 may cause data overflow.
@@ -47,7 +47,7 @@ inline std::vector<T> GetDataFromDenseTensor(const phi::DenseTensor* x) {
   } else {
     PADDLE_THROW(phi::errors::InvalidArgument(
         "The dtype of Tensor must be int32 or int64, but received: %s",
-        framework::TransToProtoVarType(x->dtype())));
+        paddle::framework::TransToProtoVarType(x->dtype())));
   }
   return vec_new_data;
 }

--- a/paddle/phi/core/utils/get_data_from_tensor.h
+++ b/paddle/phi/core/utils/get_data_from_tensor.h
@@ -18,10 +18,10 @@ limitations under the License. */
 #include <vector>
 
 namespace phi {
-namespace operators {
+namespace funcs {
 
 template <typename T = int32_t>
-inline std::vector<T> GetDataFromTensor(const phi::DenseTensor* x) {
+inline std::vector<T> GetDataFromDenseTensor(const phi::DenseTensor* x) {
   std::vector<T> vec_new_data;
   if (framework::TransToProtoVarType(x->dtype()) ==
       framework::proto::VarType::INT32) {
@@ -52,5 +52,5 @@ inline std::vector<T> GetDataFromTensor(const phi::DenseTensor* x) {
   return vec_new_data;
 }
 
-}  // namespace operators
+}  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/core/utils/get_data_from_tensor.h
+++ b/paddle/phi/core/utils/get_data_from_tensor.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0(the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#pragma once
+#include <paddle/fluid/framework/operator.h>
+
+#include <string>
+#include <vector>
+
+namespace phi {
+namespace operators {
+
+template <typename T = int32_t>
+inline std::vector<T> GetDataFromTensor(const phi::DenseTensor* x) {
+  std::vector<T> vec_new_data;
+  if (framework::TransToProtoVarType(x->dtype()) ==
+      framework::proto::VarType::INT32) {
+    auto* data = x->data<int>();
+    phi::DenseTensor cpu_attr_tensor;
+    if (!platform::is_cpu_place(x->place())) {
+      paddle::framework::TensorCopySync(
+          *x, platform::CPUPlace(), &cpu_attr_tensor);
+      data = cpu_attr_tensor.data<int>();
+    }
+    vec_new_data = std::vector<T>(data, data + x->numel());
+  } else if (framework::TransToProtoVarType(x->dtype()) ==
+             framework::proto::VarType::INT64) {
+    auto* data = x->data<int64_t>();
+    phi::DenseTensor cpu_attr_tensor;
+    if (!platform::is_cpu_place(x->place())) {
+      paddle::framework::TensorCopySync(
+          *x, platform::CPUPlace(), &cpu_attr_tensor);
+      data = cpu_attr_tensor.data<int64_t>();
+    }
+    // NOTE: Converting int64 to int32 may cause data overflow.
+    vec_new_data = std::vector<T>(data, data + x->numel());
+  } else {
+    PADDLE_THROW(phi::errors::InvalidArgument(
+        "The dtype of Tensor must be int32 or int64, but received: %s",
+        framework::TransToProtoVarType(x->dtype())));
+  }
+  return vec_new_data;
+}
+
+}  // namespace operators
+}  // namespace phi

--- a/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
@@ -166,7 +166,7 @@ void RnnGradKernel(const Context& dev_ctx,
   std::vector<int> seq_len_tensor(batch_size, seq_len);
   if (has_seq_length) {
     seq_len_tensor =
-        operators::GetDataFromTensor<int>(sequence_length.get_ptr());
+        phi::funcs::GetDataFromDenseTensor<int>(sequence_length.get_ptr());
   }
 
   for (int i = num_layers - 1; i >= 0; --i) {

--- a/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
@@ -14,8 +14,8 @@
 
 #include "paddle/phi/kernels/rnn_grad_kernel.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
-#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/kernel_registry.h"
+#include "paddle/phi/core/utils/get_data_from_tensor.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/xpu/rnn_util.h"
 
@@ -166,7 +166,7 @@ void RnnGradKernel(const Context& dev_ctx,
   std::vector<int> seq_len_tensor(batch_size, seq_len);
   if (has_seq_length) {
     seq_len_tensor =
-        paddle::experimental::GetDataFromTensor<int>(sequence_length.get_ptr());
+        operators::GetDataFromTensor<int>(sequence_length.get_ptr());
   }
 
   for (int i = num_layers - 1; i >= 0; --i) {

--- a/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/rnn_grad_kernel.h"
-#include "paddle/fluid/operators/utils.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/xpu/rnn_util.h"
@@ -166,7 +166,7 @@ void RnnGradKernel(const Context& dev_ctx,
   std::vector<int> seq_len_tensor(batch_size, seq_len);
   if (has_seq_length) {
     seq_len_tensor =
-        paddle::operators::GetDataFromTensor<int>(sequence_length.get_ptr());
+        paddle::experimental::GetDataFromTensor<int>(sequence_length.get_ptr());
   }
 
   for (int i = num_layers - 1; i >= 0; --i) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/50659#task68
- https://github.com/PaddlePaddle/Paddle/pull/50686
- 由于utils中不仅有phi中依赖的函数，还有其他函数，故仅在phi中增加新文件，不予删除utils中的函数声明
- 由于funcs下有同名函数，为了避免冲突将函数名中Tensor改为DenseTensor

关于utils的函数迁移以及初步测试在本pr进行，其他引用了utils的文件在pr50686修改。

强烈建议reviewer不要同时approve operator.h的修改工作、pr50685、pr50686。因为pr50685和50686依赖于operator.h。