### PR TITLE
【Hackathon 68】Remove utils in phi

### DIFF
--- a/paddle/phi/kernels/cpu/rnn_functor.h
+++ b/paddle/phi/kernels/cpu/rnn_functor.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "paddle/fluid/operators/utils.h"
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/generator.h"
 #include "paddle/phi/core/tensor_utils.h"
@@ -48,7 +48,7 @@ void CreateMaskMatrix(const CPUContext& dev_ctx,
                       const bool& is_reverse,
                       int* min_seq_len) {
   const auto& seq_len_vec =
-      paddle::operators::GetDataFromTensor<int>(sequence_length);
+      paddle::experimental::GetDataFromTensor<int>(sequence_length);
   const int table_width = mask_matrix->dims()[0];
   DenseTensor temp =
       Empty<T>(dev_ctx, {mask_matrix->dims()[1], mask_matrix->dims()[0]});

--- a/paddle/phi/kernels/gpu/rnn_grad_kernel.cu.cc
+++ b/paddle/phi/kernels/gpu/rnn_grad_kernel.cu.cc
@@ -14,8 +14,8 @@
 
 #include "paddle/phi/kernels/rnn_grad_kernel.h"
 
-#include "paddle/fluid/operators/utils.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/empty_kernel.h"
 #include "paddle/phi/kernels/full_kernel.h"
@@ -224,7 +224,7 @@ void RnnGradKernel(const Context &dev_ctx,
   std::vector<int> SequenceLength;
   if (has_seq_length) {
     SequenceLength =
-        paddle::operators::GetDataFromTensor<int>(sequence_length.get_ptr());
+        paddle::experimental::GetDataFromTensor<int>(sequence_length.get_ptr());
   }
 
   auto input_dims = x.dims();

--- a/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
+++ b/paddle/phi/kernels/gpu/rnn_kernel.cu.cc
@@ -14,8 +14,8 @@
 
 #include "paddle/phi/kernels/rnn_kernel.h"
 
-#include "paddle/fluid/operators/utils.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/generator.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/empty_kernel.h"
@@ -206,7 +206,7 @@ void RnnKernel(const Context &dev_ctx,
   std::vector<int> SequenceLength;
   if (has_seq_length) {
     SequenceLength =
-        paddle::operators::GetDataFromTensor<int>(sequence_length.get_ptr());
+        paddle::experimental::GetDataFromTensor<int>(sequence_length.get_ptr());
   }
 
   auto handle = dev_ctx.cudnn_handle();

--- a/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/rnn_grad_kernel.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/rnn_grad_kernel.h"
-#include "paddle/fluid/operators/utils.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/xpu/rnn_util.h"
@@ -166,7 +166,7 @@ void RnnGradKernel(const Context& dev_ctx,
   std::vector<int> seq_len_tensor(batch_size, seq_len);
   if (has_seq_length) {
     seq_len_tensor =
-        paddle::operators::GetDataFromTensor<int>(sequence_length.get_ptr());
+        paddle::experimental::GetDataFromTensor<int>(sequence_length.get_ptr());
   }
 
   for (int i = num_layers - 1; i >= 0; --i) {

--- a/paddle/phi/kernels/xpu/rnn_kernel.cc
+++ b/paddle/phi/kernels/xpu/rnn_kernel.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/rnn_kernel.h"
-#include "paddle/fluid/operators/utils.h"
 #include "paddle/phi/backends/xpu/enforce_xpu.h"
+#include "paddle/phi/common/scalar.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/math_function.h"
 #include "paddle/phi/kernels/xpu/rnn_util.h"
@@ -120,7 +120,7 @@ void RnnKernel(const Context& dev_ctx,
 
   if (has_seq_length) {
     seq_len_tensor =
-        paddle::operators::GetDataFromTensor<int>(sequence_length.get_ptr());
+        paddle::experimental::GetDataFromTensor<int>(sequence_length.get_ptr());
   }
 
   int state_offset = pre_state[0]->dims()[1] * pre_state[0]->dims()[2];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/50659#task68
- https://github.com/PaddlePaddle/Paddle/pull/50685

关于utils的函数迁移以及初步测试在pr50685进行，其他引用了utils的文件在本pr修改。

强烈建议reviewer不要同时approve operator.h的修改工作、pr50685、pr50686。因为pr50685和50686依赖于operator.h。