### PR TITLE
[PHI Decoupling]Remove Profiler header (Part3)

### DIFF
--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -38,10 +38,6 @@ PADDLE_DEFINE_EXPORTED_bool(enable_rpc_profiler,
                             false,
                             "Enable rpc profiler or not.");
 
-DEFINE_bool(enable_record_op_info,
-            false,
-            "enable operator supplement info recorder");
-
 DEFINE_bool(enable_record_memory, false, "enable memory recorder");
 
 namespace paddle {
@@ -109,25 +105,6 @@ RecordOpInfoSupplement::RecordOpInfoSupplement(
   HostEventRecorder<OperatorSupplementOriginEvent>::GetInstance().RecordEvent(
       PosixInNsec(), type, input_shapes, dtypes, attrs, op_id);
 }
-
-RecordOpInfoSupplement::RecordOpInfoSupplement(
-    const std::string &type,
-    const std::vector<std::pair<const char *, std::vector<framework::DDim>>>
-        &input_shapes,
-    const framework::AttributeMap &attrs) {
-  if (FLAGS_enable_host_event_recorder_hook == false) {
-    return;
-  }
-  if (IsEnabled() == false) {
-    return;
-  }
-  std::map<std::string, std::vector<framework::proto::VarType::Type>> dtypes;
-  uint64_t op_id = 0;
-  HostEventRecorder<OperatorSupplementOriginEvent>::GetInstance().RecordEvent(
-      PosixInNsec(), type, input_shapes, dtypes, attrs, op_id);
-}
-
-bool RecordOpInfoSupplement::IsEnabled() { return FLAGS_enable_record_op_info; }
 
 bool RecordMemEvent::IsEnabled() { return FLAGS_enable_record_memory; }
 
@@ -872,10 +849,6 @@ void EnableHostEventRecorder() { FLAGS_enable_host_event_recorder_hook = true; }
 void DisableHostEventRecorder() {
   FLAGS_enable_host_event_recorder_hook = false;
 }
-
-void EnableOpInfoRecorder() { FLAGS_enable_record_op_info = true; }
-
-void DisableOpInfoRecorder() { FLAGS_enable_record_op_info = false; }
 
 void EnableMemoryRecorder() { FLAGS_enable_record_memory = true; }
 

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -214,9 +214,6 @@ void DisableHostEventRecorder();
 void EnableMemoryRecorder();
 void DisableMemoryRecorder();
 
-void EnableOpInfoRecorder();
-void DisableOpInfoRecorder();
-
 // Defined for UT
 std::string PrintHostEvents();
 

--- a/paddle/fluid/platform/profiler/common_event.h
+++ b/paddle/fluid/platform/profiler/common_event.h
@@ -50,27 +50,7 @@ struct OperatorSupplementOriginEvent {
     strncpy(buf, type_name.c_str(), type_name.length() + 1);
     op_type = buf;
   }
-  OperatorSupplementOriginEvent(
-      std::function<void *(size_t)> arena_allocator,
-      uint64_t timestamp_ns,
-      const std::string &type_name,
-      const std::vector<std::pair<const char *, std::vector<framework::DDim>>>
-          &shapes,
-      const std::map<std::string, std::vector<framework::proto::VarType::Type>>
-          &dtypes,
-      const framework::AttributeMap &attributes,
-      uint64_t op_id)
-      : timestamp_ns(timestamp_ns),
-        dtypes(dtypes),
-        attributes(attributes),
-        op_id(op_id) {
-    auto buf = static_cast<char *>(arena_allocator(type_name.length() + 1));
-    strncpy(buf, type_name.c_str(), type_name.length() + 1);
-    op_type = buf;
-    for (auto it = shapes.begin(); it != shapes.end(); it++) {
-      input_shapes[std::string((*it).first)] = (*it).second;
-    }
-  }
+
   uint64_t timestamp_ns;
   const char *op_type = nullptr;  // not owned, designed for performance
   // input shapes

--- a/paddle/fluid/platform/profiler/supplement_tracing.h
+++ b/paddle/fluid/platform/profiler/supplement_tracing.h
@@ -21,6 +21,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/shape_inference.h"
 #include "paddle/fluid/framework/type_defs.h"
 #include "paddle/fluid/platform/profiler/trace_event.h"
+#include "paddle/phi/api/profiler/supplement_tracing.h"
 #include "paddle/phi/core/compat/arg_map_context.h"
 
 namespace paddle {
@@ -30,10 +31,8 @@ class RuntimeContext;
 }
 namespace platform {
 
-class RecordOpInfoSupplement {
+class RecordOpInfoSupplement : public phi::RecordOpInfoSupplement {
  public:
-  static bool IsEnabled();
-
   /**
    * @param type:  Operator type name.
    * @param attrs: Attribute map of op.
@@ -55,15 +54,6 @@ class RecordOpInfoSupplement {
                                   const framework::AttributeMap& attrs,
                                   const framework::InferShapeContext& shape_ctx,
                                   const phi::KernelSignature& kernel_signature);
-
-  /**
-   *
-   */
-  explicit RecordOpInfoSupplement(
-      const std::string& type,
-      const std::vector<std::pair<const char*, std::vector<framework::DDim>>>&
-          input_shapes,
-      const framework::AttributeMap& attrs);
 };
 
 }  // namespace platform

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2452,8 +2452,8 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("load_profiler_result", &paddle::platform::LoadProfilerResult);
   m.def("enable_memory_recorder", &paddle::platform::EnableMemoryRecorder);
   m.def("disable_memory_recorder", &paddle::platform::DisableMemoryRecorder);
-  m.def("enable_op_info_recorder", &paddle::platform::EnableOpInfoRecorder);
-  m.def("disable_op_info_recorder", &paddle::platform::DisableOpInfoRecorder);
+  m.def("enable_op_info_recorder", &phi::EnableOpInfoRecorder);
+  m.def("disable_op_info_recorder", &phi::DisableOpInfoRecorder);
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
   m.def("set_cublas_switch", platform::SetAllowTF32Cublas);

--- a/paddle/phi/api/profiler/common_event.h
+++ b/paddle/phi/api/profiler/common_event.h
@@ -104,4 +104,31 @@ struct CommonMemEvent {
   uint64_t peak_reserved;
 };
 
+struct OperatorSupplementOriginEvent {
+ public:
+  OperatorSupplementOriginEvent(
+      std::function<void *(size_t)> arena_allocator,
+      uint64_t timestamp_ns,
+      const std::string &type_name,
+      const std::vector<std::pair<const char *, std::vector<DDim>>> &shapes,
+      const AttributeMap &attributes,
+      uint64_t op_id)
+      : timestamp_ns(timestamp_ns), attributes(attributes), op_id(op_id) {
+    auto buf = static_cast<char *>(arena_allocator(type_name.length() + 1));
+    strncpy(buf, type_name.c_str(), type_name.length() + 1);
+    op_type = buf;
+    for (auto it = shapes.begin(); it != shapes.end(); it++) {
+      input_shapes[std::string((*it).first)] = (*it).second;
+    }
+  }
+  uint64_t timestamp_ns;
+  const char *op_type = nullptr;  // not owned, designed for performance
+  // input shapes
+  std::map<std::string, std::vector<DDim>> input_shapes;
+  // op attributes
+  AttributeMap attributes;
+  // op id
+  uint64_t op_id;
+};
+
 }  // namespace phi

--- a/paddle/phi/api/profiler/common_event.h
+++ b/paddle/phi/api/profiler/common_event.h
@@ -20,6 +20,7 @@
 
 #include "paddle/phi/api/profiler/event.h"  // import EventRole, TODO(TIEXING): remove later
 #include "paddle/phi/api/profiler/trace_event.h"
+#include "paddle/phi/core/attribute.h"
 #include "paddle/phi/core/ddim.h"
 
 namespace phi {

--- a/paddle/phi/api/profiler/profiler.h
+++ b/paddle/phi/api/profiler/profiler.h
@@ -26,6 +26,7 @@ limitations under the License. */
 #include "gflags/gflags.h"
 
 #include "paddle/phi/api/profiler/event_tracing.h"
+#include "paddle/phi/api/profiler/supplement_tracing.h"
 
 DECLARE_bool(enable_host_event_recorder_hook);
 
@@ -87,5 +88,8 @@ Event* PushEvent(const std::string& name,
 void PopEvent(const std::string& name,
               const EventRole role,
               const std::string attr = "none");
+
+void EnableOpInfoRecorder();
+void DisableOpInfoRecorder();
 
 }  // namespace phi

--- a/paddle/phi/api/profiler/supplement_tracing.h
+++ b/paddle/phi/api/profiler/supplement_tracing.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <utility>
+
+#include "paddle/phi/core/attribute.h"
+#include "paddle/phi/core/ddim.h"
+
+namespace phi {
+
+class RecordOpInfoSupplement {
+ public:
+  static bool IsEnabled();
+
+  RecordOpInfoSupplement() = default;
+
+  explicit RecordOpInfoSupplement(
+      const std::string& type,
+      const std::vector<std::pair<const char*, std::vector<DDim>>>&
+          input_shapes,
+      const AttributeMap& attrs);
+};
+
+}  // namespace phi

--- a/paddle/phi/api/yaml/generator/api_base.py
+++ b/paddle/phi/api/yaml/generator/api_base.py
@@ -886,7 +886,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         input_tensor_code = (
             input_tensor_code
             + f"""
-{code_indent}  if(platform::RecordOpInfoSupplement::IsEnabled()){{"""
+{code_indent}  if(phi::RecordOpInfoSupplement::IsEnabled()){{"""
         )
         single_tensor_names = []
         list_tensor_names = []
@@ -1030,7 +1030,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
             )
 
         input_tensor_code += f"""
-{code_indent}     framework::AttributeMap attrs;"""
+{code_indent}     phi::AttributeMap attrs;"""
 
         for attr_name in self.attrs['names']:
             if 'IntArray' in self.attrs['attr_info'][attr_name][0]:
@@ -1096,7 +1096,7 @@ PADDLE_API {self.get_return_type(inplace_flag=True)} {api_func_name}({self.get_d
         input_tensor_code = (
             input_tensor_code
             + f"""
-{code_indent}     platform::RecordOpInfoSupplement("{self.api}", input_shapes, attrs);
+{code_indent}     phi::RecordOpInfoSupplement("{self.api}", input_shapes, attrs);
 {code_indent}  }}"""
         )
         kernel_args = ["*dev_ctx"]

--- a/paddle/phi/api/yaml/generator/api_gen.py
+++ b/paddle/phi/api/yaml/generator/api_gen.py
@@ -344,7 +344,7 @@ def source_include(header_file_path):
 #include "paddle/phi/infermeta/ternary.h"
 
 #include "paddle/phi/api/profiler/event_tracing.h"
-#include "paddle/fluid/platform/profiler/supplement_tracing.h"
+#include "paddle/phi/api/profiler/supplement_tracing.h"
 
 DECLARE_bool(conv2d_disable_cudnn);
 DECLARE_int32(low_precision_op_list);

--- a/paddle/phi/api/yaml/generator/backward_api_gen.py
+++ b/paddle/phi/api/yaml/generator/backward_api_gen.py
@@ -287,7 +287,7 @@ def source_include(header_file_path):
 #include "paddle/phi/infermeta/unary.h"
 
 #include "paddle/phi/api/profiler/event_tracing.h"
-#include "paddle/fluid/platform/profiler/supplement_tracing.h"
+#include "paddle/phi/api/profiler/supplement_tracing.h"
 
 DECLARE_bool(conv2d_disable_cudnn);
 DECLARE_int32(low_precision_op_list);

--- a/paddle/phi/api/yaml/generator/intermediate_api_gen.py
+++ b/paddle/phi/api/yaml/generator/intermediate_api_gen.py
@@ -53,7 +53,7 @@ def source_include(header_file_path):
 #include "paddle/phi/infermeta/sparse/multiary.h"
 
 #include "paddle/phi/api/profiler/event_tracing.h"
-#include "paddle/fluid/platform/profiler/supplement_tracing.h"
+#include "paddle/phi/api/profiler/supplement_tracing.h"
 
 DECLARE_int32(low_precision_op_list);
 """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
迁移Profiler组件并移除对"paddle/fluid/platform/profiler/supplement_tracing.h"的依赖