### PR TITLE
[Save/Load]Fix backward op's error when use jit.load

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2773,6 +2773,9 @@ class OpProtoHolder:
 
         return custom_op_names
 
+    def has_op_proto(self, type):
+        return type in self.op_proto_map
+
     @staticmethod
     def generated_op_attr_names():
         return {

--- a/python/paddle/jit/translated_layer.py
+++ b/python/paddle/jit/translated_layer.py
@@ -563,6 +563,11 @@ class _ProgramHolder:
                         op.desc.set_output("ReserveSpace", [reserve_space.name])
                     continue
 
+                # There are some situations that users will add backward op in Forward
+                # function of Layer. And because backward op doesn't have proto. So, we
+                # should skip it when we meet it.
+                if op.type.endswith("_grad"):
+                    continue
                 proto = OpProtoHolder.instance().get_op_proto(op.type)
                 has_create_intermediate_out = False
                 for output_proto in proto.outputs:

--- a/python/paddle/jit/translated_layer.py
+++ b/python/paddle/jit/translated_layer.py
@@ -566,7 +566,7 @@ class _ProgramHolder:
                 # There are some situations that users will add backward op in Forward
                 # function of Layer. And because backward op doesn't have proto. So, we
                 # should skip it when we meet it.
-                if op.type.endswith("_grad"):
+                if not OpProtoHolder.instance().has_op_proto(op.type):
                     continue
                 proto = OpProtoHolder.instance().get_op_proto(op.type)
                 has_create_intermediate_out = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
科学计算场景下，需要在Forward方法中添加反向算子。jit.load会先遍历一遍前向算子进行intermediate变量处理，处理过程使用proto来获取输入输出信息，由于反向算子没有proto，在这个过程中会报错，该PR对反向算子的处理进行跳过以解决此问题