### PR TITLE
Apply all passes to all subgraphs

### DIFF
--- a/paddle/fluid/framework/ir/pass.cc
+++ b/paddle/fluid/framework/ir/pass.cc
@@ -38,19 +38,6 @@ namespace ir {
 
 static const char kParamScopeAttr[] = "__param_scope__";
 
-static const std::vector<std::string> support_subgraph_passes = {
-    "simplify_with_basic_ops_pass",
-    "fused_multi_transformer_encoder_pass",
-    "fused_multi_transformer_decoder_pass",
-    "fused_multi_transformer_encoder_fuse_qkv_pass",
-    "fused_multi_transformer_decoder_fuse_qkv_pass",
-    "multi_devices_fused_multi_transformer_encoder_fuse_qkv_pass",
-    "multi_devices_fused_multi_transformer_decoder_fuse_qkv_pass",
-    "fuse_multi_transformer_layer_pass",
-    "delete_quant_dequant_linear_op_pass",
-    "delete_weight_dequant_linear_op_pass",
-};
-
 Graph *Pass::Apply(Graph *graph) const {
   VLOG(10) << "start to apply pass " << Type() << " to graph";
   CheckPrevPass();
@@ -85,34 +72,33 @@ Graph *Pass::Apply(Graph *graph) const {
     graph->Set<PassRecorder>(kPassRecorder, new PassRecorder);
   }
   graph->Get<PassRecorder>(kPassRecorder).insert(Type());
+  if (this->Has("apply_to_subgraph")) {
+    if (graph->IsMainGraph()) {
+      for (size_t i = 1; i < graph->SubGraphsSize(); i++) {
+        auto *sub_graph = graph->GetSubGraph(i);
+        if (!sub_graph->Has(framework::ir::kParamScopeAttr)) {
+          sub_graph->SetNotOwned<Scope>(
+              framework::ir::kParamScopeAttr,
+              &graph->Get<Scope>(framework::ir::kParamScopeAttr));
+        }
 
-  if (graph->IsMainGraph() && std::count(support_subgraph_passes.begin(),
-                                         support_subgraph_passes.end(),
-                                         Type())) {
-    for (size_t i = 1; i < graph->SubGraphsSize(); i++) {
-      auto *sub_graph = graph->GetSubGraph(i);
-      if (!sub_graph->Has(framework::ir::kParamScopeAttr)) {
-        sub_graph->SetNotOwned<Scope>(
-            framework::ir::kParamScopeAttr,
-            &graph->Get<Scope>(framework::ir::kParamScopeAttr));
+        ApplyImpl(sub_graph);
+        PADDLE_ENFORCE_EQ(
+            HasCircle(*sub_graph),
+            false,
+            platform::errors::InvalidArgument(
+                "Illegal pass %s. Generated graph shouldn't contain cycle.",
+                Type()));
+        PADDLE_ENFORCE_EQ(
+            VarDescIsConsistency(*sub_graph),
+            true,
+            platform::errors::InvalidArgument(
+                "The VarDescs of persistable variable are not consistency."));
+        if (!sub_graph->Has(kPassRecorder)) {
+          sub_graph->Set<PassRecorder>(kPassRecorder, new PassRecorder);
+        }
+        sub_graph->Get<PassRecorder>(kPassRecorder).insert(Type());
       }
-
-      ApplyImpl(sub_graph);
-      PADDLE_ENFORCE_EQ(
-          HasCircle(*sub_graph),
-          false,
-          platform::errors::InvalidArgument(
-              "Illegal pass %s. Generated graph shouldn't contain cycle.",
-              Type()));
-      PADDLE_ENFORCE_EQ(
-          VarDescIsConsistency(*sub_graph),
-          true,
-          platform::errors::InvalidArgument(
-              "The VarDescs of persistable variable are not consistency."));
-      if (!sub_graph->Has(kPassRecorder)) {
-        sub_graph->Set<PassRecorder>(kPassRecorder, new PassRecorder);
-      }
-      sub_graph->Get<PassRecorder>(kPassRecorder).insert(Type());
     }
   }
   applied_ = true;

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -51,6 +51,8 @@ void IRPassManager::CreatePasses(Argument *argument,
 
   for (const std::string &pass_name : passes) {
     auto pass = framework::ir::PassRegistry::Instance().Get(pass_name);
+    if (!argument->use_gpu() && pass_name != "graph_viz_pass")
+      pass->Set<bool>("apply_to_subgraph", new bool(true));
     pass->Set("use_varseqlen", new bool(argument->tensorrt_use_varseqlen()));
     pass->Set("use_cutlass", new bool(argument->use_cutlass()));
     pass->Set("with_interleaved",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
Others

### Describe
期望模型优化期间，所有的优化 ir_pass 都能作用于子图。
由于训练等其他 pass 与推理优化 pass 公用一个 Pass 基类，而推理优化 pass 全部由 inference::ir_pass_manager 创建管理，
因此 ir_pass_manager 在创建模型所需的 ir_pass 过程中，给这些 ir_pass 增加一个属性 “apply_the_pass_to_subgraph”。

在 pass 基类中判断这个属性，若有这个属性，即对所有的子图也做优化。

这样做能够控制所有参与主 block 优化的 pass 也参与子 block 优化，而对其他不参与优化的推理pass或者训练 pass 不造成影响。
