### PR TITLE
Remove useless check in slice_impl

### DIFF
--- a/paddle/phi/kernels/impl/slice_kernel_impl.h
+++ b/paddle/phi/kernels/impl/slice_kernel_impl.h
@@ -36,19 +36,8 @@ void SliceCompute(const Context& ctx,
   // Step 1: Get the accurate attribute value of starts and ends
   std::vector<int64_t> starts = starts_t;
   std::vector<int64_t> ends = ends_t;
-  PADDLE_ENFORCE_EQ(
-      starts.size(),
-      axes.size(),
-      phi::errors::InvalidArgument(
-          "The size of starts must be equal to the size of axes."));
-  PADDLE_ENFORCE_EQ(ends.size(),
-                    axes.size(),
-                    phi::errors::InvalidArgument(
-                        "The size of ends must be equal to the size of axes."));
-
   // Step 2: Compute output
   auto in = &input;
-
   auto in_dims = in->dims();
   auto out_dims = out->dims();
   auto slice_dims = out_dims;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- 由于这两个检查，已经在`InferShape`中检验过了，这里直接删除.

https://github.com/PaddlePaddle/Paddle/blob/4e417409ab3613e0d4b3ad249f88be350e6f400a/paddle/phi/infermeta/unary.cc#L3368-L3409
. 