### PR TITLE
[bug fix] fix fp16 dtype checking for argmax op

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_arg_min_max_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_arg_min_max_v2_op.py
@@ -366,5 +366,17 @@ class TestArgMinMaxOpError(unittest.TestCase):
             self.assertRaises(ValueError, test_argmin_dtype_type)
 
 
+class TestArgMaxOpFp16(unittest.TestCase):
+    def test_fp16(self):
+        paddle.enable_static()
+        x_np = np.random.random((10, 16)).astype('float16')
+        x = paddle.static.data(shape=[10, 16], name='x', dtype='float16')
+        out = paddle.argmax(x)
+        exe = paddle.static.Executor()
+        exe.run(paddle.static.default_startup_program())
+        out = exe.run(feed={'x': x_np}, fetch_list=[out])
+        paddle.disable_static()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_arg_min_max_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_arg_min_max_v2_op.py
@@ -368,14 +368,15 @@ class TestArgMinMaxOpError(unittest.TestCase):
 
 class TestArgMaxOpFp16(unittest.TestCase):
     def test_fp16(self):
-        paddle.enable_static()
         x_np = np.random.random((10, 16)).astype('float16')
-        x = paddle.static.data(shape=[10, 16], name='x', dtype='float16')
-        out = paddle.argmax(x)
-        exe = paddle.static.Executor()
-        exe.run(paddle.static.default_startup_program())
-        out = exe.run(feed={'x': x_np}, fetch_list=[out])
-        paddle.disable_static()
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data(shape=[10, 16], name='x', dtype='float16')
+            out = paddle.argmax(x)
+            if core.is_compiled_with_cuda():
+                place = paddle.CUDAPlace(0)
+                exe = paddle.static.Executor(place)
+                exe.run(paddle.static.default_startup_program())
+                out = exe.run(feed={'x': x_np}, fetch_list=[out])
 
 
 if __name__ == '__main__':

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -127,7 +127,7 @@ def argmax(x, axis=None, keepdim=False, dtype="int64", name=None):
     element along the provided axis.
 
     Args:
-        x(Tensor): An input N-D Tensor with type float32, float64, int16,
+        x(Tensor): An input N-D Tensor with type float16, float32, float64, int16,
             int32, int64, uint8.
         axis(int, optional): Axis to compute indices along. The effective range
             is [-R, R), where R is x.ndim. when axis < 0, it works the same way

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -185,7 +185,15 @@ def argmax(x, axis=None, keepdim=False, dtype="int64", name=None):
         check_variable_and_dtype(
             x,
             'x',
-            ['float32', 'float64', 'int16', 'int32', 'int64', 'uint8'],
+            [
+                'float16',
+                'float32',
+                'float64',
+                'int16',
+                'int32',
+                'int64',
+                'uint8',
+            ],
             'paddle.argmax',
         )
         check_dtype(var_dtype, 'dtype', ['int32', 'int64'], 'argmin')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> APIs

### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/50832 case1

**问题描述**：在静态图模式下，输入为FP16类型时，argmax会报TypeError。

```
import paddle
import numpy as np

paddle.enable_static()

x_np = np.random.random((10, 16)).astype('float16')
x = paddle.static.data(shape=[10, 16], name='x', dtype='float16')
out = paddle.argmax(x)

exe = paddle.static.Executor()
exe.run(paddle.static.default_startup_program())
out = exe.run(feed={'x': x_np},
            fetch_list=[out])
```
报错：
```
Traceback (most recent call last):
  File "test_argmax.py", line 8, in <module>
    out = paddle.argmax(x)
  File "/usr/local/lib/python3.7/dist-packages/paddle/tensor/search.py", line 201, in argmax
    'paddle.argmax',
  File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/data_feeder.py", line 115, in check_variable_and_dtype
    check_dtype(input.dtype, input_name, expected_dtype, op_name, extra_message)
  File "/usr/local/lib/python3.7/dist-packages/paddle/fluid/data_feeder.py", line 191, in check_dtype
    extra_message,
TypeError: The data type of 'x' in paddle.argmax must be ['float32', 'float64', 'int16', 'int32', 'int64', 'uint8'], but received float16.
```
**修复方案**：
- 在argmax API静态图模式下的类型检查中增加fp16支持，并且修改API doc
- 修复对应的API中文文档：https://github.com/PaddlePaddle/docs/pull/5654