### PR TITLE
Fix slice error in static mode

### DIFF
--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -337,9 +337,7 @@ def get_value_for_bool_tensor(var, item):
         return gather_nd(var, bool_2_idx)
 
     def idx_empty(var):
-        var_shape = list(var.shape)
-        var_shape[0] = 0
-        return paddle.empty(var_shape, dtype=var.dtype)
+        return paddle.empty([0], dtype=var.dtype)
 
     from paddle.static.nn import cond
 
@@ -849,7 +847,7 @@ def set_value_for_bool_tensor(var, item, value):
             "than {}, but received {}.".format(len(var.shape), len(item.shape))
         )
     for i, dim_len in enumerate(item.shape):
-        if dim_len != var.shape[i]:
+        if dim_len != -1 and var.shape[i] != -1 and dim_len != var.shape[i]:
             raise IndexError(
                 "The dimension of bool index doesn't match indexed array along "
                 "dimension {}, the target dimension is {}, but received {}.".format(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复静态图下下面两个slice报错的case
```python
# case1
import paddle

paddle.enable_static()
x = paddle.static.data(name='x', shape=[-1, 1, -1], dtype='float32')
index = paddle.static.data(name='index', shape=[-1, 1, -1], dtype='bool')
out = x[index]

# case2
paddle.enable_static()
x = paddle.static.data(name="x", shape=[-1, -1, -1])
index = paddle.static.data(name="index", shape=[-1, 1, -1], dtype='bool')
a = paddle.static.data(name="a", shape=[-1, ])
# breakpoint()
x[index] = a
print(x)
```