### PR TITLE
add silu composite rule

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -256,6 +256,9 @@ class TestSigmoidBF16_ZeroDim(TestSigmoidBF16):
 class TestSilu(TestActivation):
     def setUp(self):
         self.op_type = "silu"
+        self.prim_op_type = "comp"
+        self.enable_cinn = False
+        self.python_api = paddle.nn.functional.silu
         self.init_dtype()
         self.init_shape()
 
@@ -272,7 +275,7 @@ class TestSilu(TestActivation):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', check_prim=True)
 
 
 class TestSilu_ZeroDim(TestSilu):

--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -283,6 +283,36 @@ class TestSilu_ZeroDim(TestSilu):
         self.shape = []
 
 
+class TestSiluFP16(TestActivation):
+    def setUp(self):
+        self.op_type = "silu"
+        self.prim_op_type = "comp"
+        self.enable_cinn = False
+        self.only_prim = True
+        self.python_api = paddle.nn.functional.silu
+        self.init_dtype()
+        self.init_shape()
+
+        np.random.seed(1024)
+        x = np.random.uniform(-1, 1, self.shape).astype(self.dtype)
+        out = x / (np.exp(-x) + 1)
+
+        self.inputs = {'X': x}
+        self.outputs = {'Out': out}
+
+    def init_dtype(self):
+        self.dtype = np.float16
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out', check_prim=True)
+
+    def test_check_output(self):
+        check_eager = False
+        if hasattr(self, 'check_eager'):
+            check_eager = self.check_eager
+        self.check_output(check_eager=check_eager, check_prim=True)
+
+
 class TestSiluAPI(unittest.TestCase):
     # test paddle.nn.Silu, paddle.nn.functional.silu
     def setUp(self):
@@ -3533,6 +3563,7 @@ create_test_act_fp16_class(TestActivation)
 create_test_act_fp16_class(TestExpm1)
 create_test_act_fp16_class(TestSigmoid)
 create_test_act_fp16_class(TestSilu)
+create_test_act_fp16_class(TestSiluFP16)
 create_test_act_fp16_class(TestLogSigmoid)
 create_test_act_fp16_class(TestTanh)
 create_test_act_fp16_class(TestTanhshrink)

--- a/python/paddle/incubate/autograd/composite_rules.py
+++ b/python/paddle/incubate/autograd/composite_rules.py
@@ -227,8 +227,10 @@ def bernoulli(shape, dtype, p, seed=0):
 
 @REGISTER_COMPOSITE('silu')
 def silu_composite(x):
-    """define composite rule of op silu"""
-    # res = x / (1 + exp(-x))
+    """
+    define composite rule of op silu
+    res = x / (1 + exp(-x))
+    """
     sum_temp = 1 + exp(-x)
     res = x / sum_temp
     return res

--- a/python/paddle/incubate/autograd/composite_rules.py
+++ b/python/paddle/incubate/autograd/composite_rules.py
@@ -223,3 +223,12 @@ def bernoulli(shape, dtype, p, seed=0):
         ),
         dtype,
     )
+
+
+@REGISTER_COMPOSITE('silu')
+def silu_composite(x):
+    """define composite rule of op silu"""
+    # res = x / (1 + exp(-x))
+    sum_temp = 1 + exp(-x)
+    res = x / sum_temp
+    return res


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
add silu composite rule
CINN报错，已禁用
forward prim enabled: I0223 11:50:57.502880 12847 build_cinn_pass.cc:682] --- [build_cinn_pass] detected 1 cinn supported subgraphs
I0223 11:50:57.504834 12847 build_cinn_pass.cc:682] --- [build_cinn_pass] detected 1 cinn supported subgraphs
F0223 11:50:57.672315 12847 nvrtc_util.cc:115] Check failed: compile_res == NVRTC_SUCCESS (6 vs. 0) default_program(4): catastrophic error: cannot open source file "float16.h"