### PR TITLE
Fix for breaking standalone PyInstaller builds

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -44,14 +44,21 @@ interpreter = sys.executable
 # will be the C++ executable on Windows
 if sys.platform == 'win32' and 'python.exe' not in interpreter:
     interpreter = sys.exec_prefix + os.sep + 'python.exe'
-import_cv2_proc = subprocess.Popen(
-    [interpreter, "-c", "import cv2"],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.PIPE,
-)
-out, err = import_cv2_proc.communicate()
-retcode = import_cv2_proc.poll()
-if retcode != 0:
+try:
+    import_cv2_proc = subprocess.Popen([interpreter, "-c", "import cv2"],
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
+    out, err = import_cv2_proc.communicate()
+    retcode = import_cv2_proc.poll()
+    if retcode != 0:
+        cv2 = None
+    else:
+        try:
+            import cv2
+        except ImportError:
+            cv2 = None
+except FileNotFoundError:
+    # Fix for breaking standalone installations using PyInstaller.
     cv2 = None
 else:
     try:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Currently when importing paddle in a standalone EXE built using pyinstaller, the build will crash as the interpreter path generated in this fix will not resolve to an existing file. It should probably have been wrapped in a try/except in the first place.

related:
-  https://github.com/PaddlePaddle/Paddle/pull/44525
- https://github.com/PaddlePaddle/Paddle/issues/47618#issuecomment-1384761633