### PR TITLE
[Paddle Inference] fix gflags from environment not activated (C++)

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <tuple>
 
+#include "paddle/fluid/inference/api/helper.h"
 #include "paddle/fluid/inference/api/paddle_analysis_config.h"
 #include "paddle/fluid/inference/api/paddle_pass_builder.h"
 #include "paddle/fluid/inference/utils/table_printer.h"
@@ -39,6 +40,12 @@ struct MkldnnQuantizerConfig;
 extern const std::vector<std::string> kTRTSubgraphPasses;
 extern const std::vector<std::string> kDlnneSubgraphPasses;
 extern const std::vector<std::string> kLiteSubgraphPasses;
+
+AnalysisConfig::AnalysisConfig() {
+  // NOTE(liuyuanle): Why put the following code here?
+  // ref to https://github.com/PaddlePaddle/Paddle/pull/50864
+  inference::InitGflagsFromEnv();
+}
 
 PassStrategy *AnalysisConfig::pass_builder() const {
   if (!pass_builder_.get()) {

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1497,32 +1497,6 @@ CreatePaddlePredictor<AnalysisConfig, PaddleEngineKind::kAnalysis>(
         if (std::getenv("FLAGS_initial_cpu_memory_in_mb") == nullptr) {
           SetGflag("initial_cpu_memory_in_mb", "0");
         }
-
-        // support set gflags from environment.
-        std::vector<std::string> gflags;
-        const phi::ExportedFlagInfoMap &env_map = phi::GetExportedFlagInfoMap();
-        std::ostringstream os;
-        for (auto &pair : env_map) {
-          os << pair.second.name << ",";
-        }
-        std::string tryfromenv_str = os.str();
-        if (!tryfromenv_str.empty()) {
-          tryfromenv_str.pop_back();
-          tryfromenv_str = "--tryfromenv=" + tryfromenv_str;
-          gflags.push_back(tryfromenv_str);
-        }
-        if (framework::InitGflags(gflags)) {
-          VLOG(3)
-              << "The following gpu analysis configurations only take effect "
-                 "for the first predictor: ";
-          for (const auto &gflag : gflags) {
-            VLOG(3) << gflag;
-          }
-        } else {
-          LOG(WARNING) << "The one-time configuration of analysis predictor "
-                          "failed, which may be due to native predictor called "
-                          "first and its configurations taken effect.";
-        }
       });
 
       if (config.thread_local_stream_enabled() &&

--- a/paddle/fluid/inference/api/helper.cc
+++ b/paddle/fluid/inference/api/helper.cc
@@ -16,6 +16,7 @@
 
 #include "paddle/fluid/framework/custom_operator.h"
 #include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/platform/init.h"
 #include "paddle/phi/api/ext/op_meta_info.h"
 
 namespace paddle {
@@ -57,6 +58,23 @@ void RegisterAllCustomOperator() {
                    "Therefore, we will not repeat the registration here.";
     }
   }
+}
+
+void InitGflagsFromEnv() {
+  // support set gflags from environment.
+  std::vector<std::string> gflags;
+  const phi::ExportedFlagInfoMap &env_map = phi::GetExportedFlagInfoMap();
+  std::ostringstream os;
+  for (auto &pair : env_map) {
+    os << pair.second.name << ",";
+  }
+  std::string tryfromenv_str = os.str();
+  if (!tryfromenv_str.empty()) {
+    tryfromenv_str.pop_back();
+    tryfromenv_str = "--tryfromenv=" + tryfromenv_str;
+    gflags.push_back(tryfromenv_str);
+  }
+  framework::InitGflags(gflags);
 }
 
 }  // namespace inference

--- a/paddle/fluid/inference/api/helper.h
+++ b/paddle/fluid/inference/api/helper.h
@@ -432,6 +432,8 @@ static bool IsFileExists(const std::string &path) {
 
 void RegisterAllCustomOperator();
 
+void InitGflagsFromEnv();
+
 static inline double ToMegaBytes(size_t bytes) {
   return static_cast<double>(bytes) / (1 << 20);
 }

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -138,7 +138,7 @@ struct DistConfig {
 /// and loading it into AnalysisPredictor.
 ///
 struct PD_INFER_DECL AnalysisConfig {
-  AnalysisConfig() = default;
+  AnalysisConfig();
   ///
   /// \brief Construct a new AnalysisConfig from another
   /// AnalysisConfig.

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -85,7 +85,6 @@ namespace framework {
 
 std::once_flag gflags_init_flag;
 std::once_flag glog_init_flag;
-std::once_flag npu_init_flag;
 std::once_flag memory_method_init_flag;
 
 bool InitGflags(std::vector<std::string> args) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

此PR修复C++端读取环境变量中的“FLAGS_”不生效问题。

在此PR之前不会生效的“FLAGS_”，如FLAGS_gpu_memory_limit_mb [issue](https://github.com/PaddlePaddle/Paddle/issues/50724)、FLAGS_call_stack_level等。

有以下几点说明：

1. 为什么Python端总是可以生效？
这是因为Python端的ParseCommandLineFlags调用在import paddle时就发生了，这意味着会在所有paddle代码中试图使用“FLAGS_”之前，因此当ParseCommandLineFlags调用之后，所有“FLAGS_”都会生效。

2. 为什么C++端会出现不生效的情况？
首先准确的说应该是”部分“不生效。这不生效的一部分“FLAGS_”是由于C++端的ParseCommandLineFlags调用原本是在CreatPredictor调用中发生的，然而，在此之前已经有许多地方使用了“FLAGS_”，如Config配置过程中。然而ParseCommandLineFlags此时还并未被调用，因此没来得及从环境变量中读取。

综上，本PR将ParseCommandLineFlags的调用尽可能地提前，想到了两个方案：

1. 将其放在单例中，这样在进入mian函数之前，可以调用来从环境变量中读取。但是似乎行不通，会发生段错误，可能是由于完成这项工作所需的资源初始化顺序（在main函数之前）无法保证？

2. 在main函数之后或静态变量的初始化中，将其尽可能的往前放，本人能想到的就是Config初始化阶段了，这也是本PR采用的方法。

如果您有更好的建议，请在本PR下留言，感谢～。