### PR TITLE
force use np.uint8 for cv2 lut

### DIFF
--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -440,7 +440,7 @@ def adjust_brightness(img, brightness_factor):
     if _is_pil_image(img):
         return F_pil.adjust_brightness(img, brightness_factor)
     elif _is_numpy_image(img):
-        return F_cv2.adjust_brightness(img.astype(np.uint8) brightness_factor)
+        return F_cv2.adjust_brightness(img.astype(np.uint8), brightness_factor)
     else:
         return F_t.adjust_brightness(img, brightness_factor)
 

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -440,7 +440,7 @@ def adjust_brightness(img, brightness_factor):
     if _is_pil_image(img):
         return F_pil.adjust_brightness(img, brightness_factor)
     elif _is_numpy_image(img):
-        return F_cv2.adjust_brightness(img, brightness_factor)
+        return F_cv2.adjust_brightness(img.astype(np.uint8) brightness_factor)
     else:
         return F_t.adjust_brightness(img, brightness_factor)
 


### PR DESCRIPTION
### PR types
Others
### PR changes
Others 
### Describe
force use np.uint8 for cv2 lut 
as mentioned in https://github.com/PaddlePaddle/Paddle/issues/50215 we must use uint8 for cv2.LUT