### PR TITLE
[Extension Operants] Extension supports tensor operants

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -42,7 +42,10 @@ set(PYBIND_DEPS
     auto_parallel
     jit_layer
     jit_property
-    prim_utils)
+    prim_utils
+    operants_manager
+    phi_tensor_operants
+    static_tensor_operants)
 
 if(WITH_PSCORE)
   set(PYBIND_DEPS ${PYBIND_DEPS} ps_service)
@@ -498,10 +501,7 @@ if(WITH_PYTHON)
     list(APPEND PYBIND_DEPS custom_operator)
     list(APPEND PYBIND_DEPS custom_operator_node)
     list(APPEND PYBIND_DEPS tensor_api)
-    list(APPEND PYBIND_DEPS operants_manager)
     list(APPEND PYBIND_DEPS eager_tensor_operants)
-    list(APPEND PYBIND_DEPS static_tensor_operants)
-    list(APPEND PYBIND_DEPS phi_tensor_operants)
     list(APPEND PYBIND_DEPS pybind_util)
   endif()
 

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -499,15 +499,18 @@ static PyObject* eager_api_jit_function_call(PyObject* self,
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
-static PyObject* eager_api_init_eager_and_static_tensor_operants(
-    PyObject* self, PyObject* args, PyObject* kwargs) {
+static PyObject* eager_api_init_tensor_operants(PyObject* self,
+                                                PyObject* args,
+                                                PyObject* kwargs) {
   EAGER_TRY
 
   paddle::OperantsManager::Instance().eager_operants.reset(
       new paddle::prim::EagerTensorOperants());
   paddle::OperantsManager::Instance().static_operants.reset(
       new paddle::prim::StaticTensorOperants());
-  VLOG(4) << "Initialize eager and static tensor operants successfully";
+  paddle::OperantsManager::Instance().phi_operants.reset(
+      new paddle::operants::PhiTensorOperants());
+  VLOG(4) << "Initialize tensor operants successfully";
 
   RETURN_PY_NONE
   EAGER_CATCH_AND_THROW_RETURN_NULL
@@ -1123,9 +1126,8 @@ PyMethodDef variable_functions[] = {
      (PyCFunction)(void (*)(void))eager_api_run_custom_op,
      METH_VARARGS | METH_KEYWORDS,
      NULL},
-    {"_init_eager_and_static_tensor_operants",
-     (PyCFunction)(void (*)(
-         void))eager_api_init_eager_and_static_tensor_operants,
+    {"_init_tensor_operants",
+     (PyCFunction)(void (*)(void))eager_api_init_tensor_operants,
      METH_VARARGS | METH_KEYWORDS,
      NULL},
     {"tensor_copy",

--- a/paddle/fluid/pybind/eager_functions.cc
+++ b/paddle/fluid/pybind/eager_functions.cc
@@ -40,8 +40,6 @@ typedef SSIZE_T ssize_t;
 #include "paddle/fluid/platform/device/gpu/gpu_info.h"
 #include "paddle/fluid/platform/dynload/dynamic_loader.h"
 #include "paddle/fluid/platform/enforce.h"
-#include "paddle/fluid/prim/utils/eager/eager_tensor_operants.h"
-#include "paddle/fluid/prim/utils/static/static_tensor_operants.h"
 #include "paddle/fluid/pybind/eager.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/fluid/pybind/exception.h"
@@ -496,23 +494,6 @@ static PyObject* eager_api_jit_function_call(PyObject* self,
     outs = (*function)(ins);
   }
   return ToPyObject(outs);
-  EAGER_CATCH_AND_THROW_RETURN_NULL
-}
-
-static PyObject* eager_api_init_tensor_operants(PyObject* self,
-                                                PyObject* args,
-                                                PyObject* kwargs) {
-  EAGER_TRY
-
-  paddle::OperantsManager::Instance().eager_operants.reset(
-      new paddle::prim::EagerTensorOperants());
-  paddle::OperantsManager::Instance().static_operants.reset(
-      new paddle::prim::StaticTensorOperants());
-  paddle::OperantsManager::Instance().phi_operants.reset(
-      new paddle::operants::PhiTensorOperants());
-  VLOG(4) << "Initialize tensor operants successfully";
-
-  RETURN_PY_NONE
   EAGER_CATCH_AND_THROW_RETURN_NULL
 }
 
@@ -1124,10 +1105,6 @@ PyMethodDef variable_functions[] = {
      NULL},
     {"_run_custom_op",
      (PyCFunction)(void (*)(void))eager_api_run_custom_op,
-     METH_VARARGS | METH_KEYWORDS,
-     NULL},
-    {"_init_tensor_operants",
-     (PyCFunction)(void (*)(void))eager_api_init_tensor_operants,
      METH_VARARGS | METH_KEYWORDS,
      NULL},
     {"tensor_copy",

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -196,8 +196,12 @@ limitations under the License. */
 
 #include "paddle/fluid/eager/api/utils/global_utils.h"
 #include "paddle/fluid/imperative/layout_autotune.h"
+#include "paddle/fluid/prim/utils/eager/eager_tensor_operants.h"
+#include "paddle/fluid/prim/utils/static/static_tensor_operants.h"
 #include "paddle/fluid/pybind/eager_utils.h"
 #include "paddle/phi/api/ext/op_meta_info.h"
+#include "paddle/phi/api/include/operants_manager.h"
+#include "paddle/phi/api/include/tensor_operants.h"
 #include "paddle/phi/kernels/autotune/cache.h"
 #include "paddle/phi/kernels/autotune/switch_autotune.h"
 #include "pybind11/stl.h"
@@ -1859,6 +1863,15 @@ All parameter, weight, gradient are variables in Paddle.
   });
   m.def("init_default_kernel_signatures",
         []() { framework::InitDefaultKernelSignatureMap(); });
+  m.def("init_tensor_operants", []() {
+    paddle::OperantsManager::Instance().eager_operants.reset(
+        new paddle::prim::EagerTensorOperants());
+    paddle::OperantsManager::Instance().static_operants.reset(
+        new paddle::prim::StaticTensorOperants());
+    paddle::OperantsManager::Instance().phi_operants.reset(
+        new paddle::operants::PhiTensorOperants());
+    VLOG(4) << "Initialize tensor operants successfully";
+  });
   m.def("is_compiled_with_avx", IsCompiledWithAVX);
   m.def("is_compiled_with_cuda", IsCompiledWithCUDA);
   m.def("is_compiled_with_ascend", IsCompiledWithAscend);

--- a/paddle/utils/CMakeLists.txt
+++ b/paddle/utils/CMakeLists.txt
@@ -17,5 +17,5 @@ if(NOT ((NOT WITH_PYTHON) AND ON_INFER))
   cc_library(
     pybind_util
     SRCS pybind.cc
-    DEPS phi_tensor_raw)
+    DEPS phi_tensor_raw flags)
 endif()

--- a/paddle/utils/pybind.cc
+++ b/paddle/utils/pybind.cc
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 #include "paddle/utils/pybind.h"
+
+#include "gflags/gflags.h"
 #include "paddle/phi/core/enforce.h"
 
+DECLARE_string(tensor_operants_mode);
 namespace paddle {
 namespace pybind {
 
@@ -65,6 +68,8 @@ PyObject* ToPyObject(const paddle::experimental::Tensor& value,
   }
   return obj;
 }
+
+void SwitchTensorOperantsMode() { FLAGS_tensor_operants_mode = "phi"; }
 
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/utils/pybind.cc
+++ b/paddle/utils/pybind.cc
@@ -69,7 +69,7 @@ PyObject* ToPyObject(const paddle::experimental::Tensor& value,
   return obj;
 }
 
-void SwitchTensorOperantsMode() { FLAGS_tensor_operants_mode = "phi"; }
+void EnableTensorOperantsToPhiMode() { FLAGS_tensor_operants_mode = "phi"; }
 
 }  // namespace pybind
 }  // namespace paddle

--- a/paddle/utils/pybind.h
+++ b/paddle/utils/pybind.h
@@ -46,6 +46,9 @@ paddle::experimental::Tensor CastPyArg2Tensor(PyObject* obj, ssize_t arg_pos);
 PyObject* ToPyObject(const paddle::experimental::Tensor& value,
                      bool return_py_none_if_not_initialize = false);
 
+// Internal use only, switch tensor_operants_mode to phi
+void SwitchTensorOperantsMode();
+
 }  // namespace pybind
 }  // namespace paddle
 
@@ -59,6 +62,7 @@ struct type_caster<paddle::experimental::Tensor> {
                        _("paddle::experimental::Tensor"));
 
   bool load(handle src, bool) {
+    paddle::pybind::SwitchTensorOperantsMode();
     PyObject* obj = src.ptr();
     if (paddle::pybind::PyCheckTensor(obj)) {
       value = paddle::pybind::CastPyArg2Tensor(obj, 0);

--- a/paddle/utils/pybind.h
+++ b/paddle/utils/pybind.h
@@ -47,7 +47,7 @@ PyObject* ToPyObject(const paddle::experimental::Tensor& value,
                      bool return_py_none_if_not_initialize = false);
 
 // Internal use only, switch tensor_operants_mode to phi
-void SwitchTensorOperantsMode();
+void EnableTensorOperantsToPhiMode();
 
 }  // namespace pybind
 }  // namespace paddle
@@ -62,7 +62,7 @@ struct type_caster<paddle::experimental::Tensor> {
                        _("paddle::experimental::Tensor"));
 
   bool load(handle src, bool) {
-    paddle::pybind::SwitchTensorOperantsMode();
+    paddle::pybind::EnableTensorOperantsToPhiMode();
     PyObject* obj = src.ptr();
     if (paddle::pybind::PyCheckTensor(obj)) {
       value = paddle::pybind::CastPyArg2Tensor(obj, 0);

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -231,7 +231,7 @@ def __bootstrap__():
         core.init_glog(sys.argv[0])
     # don't init_p2p when in unittest to save time.
     core.init_devices()
-    core.eager._init_tensor_operants()
+    core.init_tensor_operants()
     core.init_default_kernel_signatures()
     core.init_memory_method()
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -231,7 +231,7 @@ def __bootstrap__():
         core.init_glog(sys.argv[0])
     # don't init_p2p when in unittest to save time.
     core.init_devices()
-    core.eager._init_eager_and_static_tensor_operants()
+    core.eager._init_tensor_operants()
     core.init_default_kernel_signatures()
     core.init_memory_method()
 

--- a/python/paddle/fluid/tests/cpp_extension/custom_extension.cc
+++ b/python/paddle/fluid/tests/cpp_extension/custom_extension.cc
@@ -21,7 +21,7 @@
 paddle::Tensor custom_sub(paddle::Tensor x, paddle::Tensor y);
 
 paddle::Tensor custom_add(const paddle::Tensor& x, const paddle::Tensor& y) {
-  return paddle::add(paddle::exp(x), paddle::exp(y));
+  return x.exp() + y.exp();
 }
 
 paddle::Tensor nullable_tensor(bool return_none = false) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
Others

### Describe
1. After we support C++ Extension and tensor operants overloading, users can use tensor operants in Extension, this PR supports such a mechanism.

2. Unbind init_tensor_operants with eager, making the init process of fluid more concise.

Notice: Extension operants use `phi` mode, which enables C++ API without backward.

Relevant PRs:
- https://github.com/PaddlePaddle/Paddle/pull/49893
- https://github.com/PaddlePaddle/Paddle/pull/50731
- https://github.com/PaddlePaddle/Paddle/pull/50563

