### PR TITLE
【PRIM】Support custom_vjp for reducing video memory

### DIFF
--- a/paddle/fluid/framework/op_info.h
+++ b/paddle/fluid/framework/op_info.h
@@ -91,6 +91,8 @@ class OpInfo {
   // some ops don't have grad_op_maker, add check before use GradOpMaker()
   bool HasGradOpMaker() const { return grad_op_maker_ != nullptr; }
 
+  bool HasCompGradOpMaker() const { return grad_comp_op_maker_ != nullptr; }
+
   bool HasNonEmptyGradOpMaker() const {
     return grad_op_maker_ != nullptr && !use_empty_grad_op_desc_maker_;
   }

--- a/paddle/fluid/operators/cast_op.cc
+++ b/paddle/fluid/operators/cast_op.cc
@@ -27,6 +27,7 @@ limitations under the License. */
 #include "paddle/fluid/prim/api/composite_backward/composite_backward_api.h"
 #include "paddle/fluid/prim/utils/static/composite_grad_desc_maker.h"
 #include "paddle/fluid/prim/utils/static/desc_tensor.h"
+#include "paddle/phi/core/utils/data_type.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -944,6 +944,7 @@ void maximum_grad(const Tensor& x,
   }
 }
 
+template <typename T>
 void dropout_grad(const Tensor& mask,
                   const Tensor& out_grad,
                   const Scalar& p,

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -944,5 +944,32 @@ void maximum_grad(const Tensor& x,
   }
 }
 
+void dropout_grad(const Tensor& mask,
+                  const Tensor& out_grad,
+                  const Scalar& p,
+                  bool is_test,
+                  const std::string& mode,
+                  Tensor* x_grad) {
+  if (!x_grad) return;
+  if (is_test) {
+    if (mode == "unscale_in_train") {
+      by_pass<T>(out_grad, x_grad);
+    } else {
+      set_output<T>(out_grad * (1.0 - p.to<float>()), x_grad);
+    }
+  } else {
+    if (mode == "unscale_in_train") {
+      if (p.to<float>() == 1.0f) {
+        set_output<T>(out_grad * 0.0, x_grad);
+      } else {
+        set_output<T>(
+            out_grad * cast<T>(mask, out_grad.dtype()) / (1.0 - p.to<float>()),
+            x_grad);
+      }
+    } else {
+      set_output<T>(out_grad * cast<T>(mask, out_grad.dtype()), x_grad);
+    }
+  }
+}
 }  // namespace prim
 }  // namespace paddle

--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
@@ -952,13 +952,13 @@ void dropout_grad(const Tensor& mask,
                   Tensor* x_grad) {
   if (!x_grad) return;
   if (is_test) {
-    if (mode == "unscale_in_train") {
+    if (mode == "upscale_in_train") {
       by_pass<T>(out_grad, x_grad);
     } else {
       set_output<T>(out_grad * (1.0 - p.to<float>()), x_grad);
     }
   } else {
-    if (mode == "unscale_in_train") {
+    if (mode == "upscale_in_train") {
       if (p.to<float>() == 1.0f) {
         set_output<T>(out_grad * 0.0, x_grad);
       } else {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1472,6 +1472,9 @@ All parameter, weight, gradient are variables in Paddle.
               [](std::unique_ptr<OpDesc> &p) { return p.release(); });
           return std::make_pair(grad_op_desc_ptrs, grad_to_var);
         });
+  m.def("has_comp_grad_op_maker", [](const std::string op_type) {
+    return framework::OpInfoMap::Instance().Get(op_type).HasCompGradOpMaker();
+  });
   m.def("has_grad_op_maker", [](const std::string op_type) {
     return framework::OpInfoMap::Instance().Get(op_type).HasGradOpMaker();
   });

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -446,6 +446,10 @@ def __sync_stat_with_flag(flag):
         )
 
 
+def _is_all_prim_enabled():
+    return _is_fwd_prim_enabled() and _is_bwd_prim_enabled()
+
+
 # Alert!!! This method is only for test coveraget, user should never use it directly, this may cause serious system errors.
 def _test_use_sync(value):
     __sync_stat_with_flag(value)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3751,7 +3751,6 @@ class Block:
         self.vars = collections.OrderedDict()  # var_name --> var
         self.ops = list()  # operator list
         self.program = program
-        self.removed_vars = collections.OrderedDict()
 
     def __str__(self):
         return self._to_readable_code()

--- a/python/paddle/fluid/tests/unittests/autograd/test_primapi.py
+++ b/python/paddle/fluid/tests/unittests/autograd/test_primapi.py
@@ -1045,13 +1045,13 @@ class TestToPrim(unittest.TestCase):
         core._set_prim_forward_enabled(False)
         paddle.disable_static()
 
-    @param.parameterized((('dropout',),))
+    @param.parameterized.expand((({'dropout'},),))
     def test_exclude(self, exclude):
         program = paddle.static.Program()
         with paddle.static.program_guard(program):
             x = paddle.rand((1,))
             y = paddle.nn.functional.dropout(x)
-        primapi.to_prim(program, exclude)
+        primapi.to_prim(program.blocks, exclude)
         ops = tuple(op.type for op in program.block(0).ops)
         self.assertTrue(all(tuple(op in ops for op in exclude)))
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim.py
@@ -77,7 +77,12 @@ class TestPrimForward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
-        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        fwd_ops = [
+            op.type
+            for op in net.forward.get_concrete_program(self.x)[1]
+            .train_program.block(0)
+            .ops
+        ]
         # Ensure that softmax is splitted into small ops
         self.assertTrue('softmax' not in fwd_ops)
 
@@ -128,7 +133,12 @@ class TestPrimForwardAndBackward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
-        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        fwd_ops = [
+            op.type
+            for op in net.forward.get_concrete_program(self.x)[1]
+            .train_program.block(0)
+            .ops
+        ]
         all_ops = [
             op.type
             for op in net.forward.program_cache.last()[-1][-1]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim.py
@@ -77,6 +77,8 @@ class TestPrimForward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
+        # Please use PartialProgramLayer(second output parameter of get_concrete_program) rather than
+        # main_program here, as main_program is original program before to_prim.
         fwd_ops = [
             op.type
             for op in net.forward.get_concrete_program(self.x)[1]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_gelu.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_gelu.py
@@ -77,6 +77,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
             net = apply_to_static(net, use_prim)
 
         res = []
+        self.x = data
         for _ in range(10):
             out = net(data)
             loss = paddle.mean(out)
@@ -92,7 +93,12 @@ class TestPrimForwardAndBackward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
-        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        fwd_ops = [
+            op.type
+            for op in net.forward.get_concrete_program(self.x)[1]
+            .train_program.block(0)
+            .ops
+        ]
         # Ensure that gelu is splitted into small ops
         self.assertTrue('gelu' not in fwd_ops)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_gelu.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_gelu.py
@@ -93,6 +93,8 @@ class TestPrimForwardAndBackward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
+        # Please use PartialProgramLayer(second output parameter of get_concrete_program) rather than
+        # main_program here, as main_program is original program before to_prim.
         fwd_ops = [
             op.type
             for op in net.forward.get_concrete_program(self.x)[1]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_layer_norm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_layer_norm.py
@@ -89,7 +89,14 @@ class TestPrimForward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
-        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        fwd_ops = [
+            op.type
+            for op in net.forward.get_concrete_program(self.x, self.w, self.b)[
+                1
+            ]
+            .train_program.block(0)
+            .ops
+        ]
         # Ensure that layer_norm is splitted into small ops
         self.assertTrue('layer_norm' not in fwd_ops)
 
@@ -150,7 +157,14 @@ class TestPrimForwardAndBackward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
-        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        fwd_ops = [
+            op.type
+            for op in net.forward.get_concrete_program(self.x, self.w, self.b)[
+                1
+            ]
+            .train_program.block(0)
+            .ops
+        ]
         # Ensure that layer_norm is splitted into small ops
         self.assertTrue('layer_norm' not in fwd_ops)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_layer_norm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_layer_norm.py
@@ -89,6 +89,8 @@ class TestPrimForward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
+        # Please use PartialProgramLayer(second output parameter of get_concrete_program) rather than
+        # main_program here, as main_program is original program before to_prim.
         fwd_ops = [
             op.type
             for op in net.forward.get_concrete_program(self.x, self.w, self.b)[

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_mean.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_mean.py
@@ -83,6 +83,7 @@ class TestPrimForward(unittest.TestCase):
             net = apply_to_static(net, use_prim)
 
         res = []
+        self.x = data
         for _ in range(10):
             out = net(data)
             loss = paddle.mean(out, axis, keep_dim)
@@ -99,7 +100,12 @@ class TestPrimForward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
-        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        fwd_ops = [
+            op.type
+            for op in net.forward.get_concrete_program(self.x)[1]
+            .train_program.block(0)
+            .ops
+        ]
         # Ensure that reduce_mean is splitted into small ops
         self.assertTrue('reduce_mean' not in fwd_ops)
 
@@ -150,6 +156,7 @@ class TestPrimForwardAndBackward(unittest.TestCase):
             net = apply_to_static(net, use_prim)
 
         res = []
+        self.x = data
         for _ in range(10):
             out = net(data)
             loss = paddle.mean(out, axis, keep_dim)
@@ -166,7 +173,12 @@ class TestPrimForwardAndBackward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
-        fwd_ops = [op.type for op in net.forward.main_program.block(0).ops]
+        fwd_ops = [
+            op.type
+            for op in net.forward.get_concrete_program(self.x)[1]
+            .train_program.block(0)
+            .ops
+        ]
         # Ensure that reduce_mean is splitted into small ops
         self.assertTrue('reduce_mean' not in fwd_ops)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_mean.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cinn_prim_mean.py
@@ -100,6 +100,8 @@ class TestPrimForward(unittest.TestCase):
     def check_prim(self, net, use_prim):
         if not use_prim:
             return
+        # Please use PartialProgramLayer(second output parameter of get_concrete_program) rather than
+        # main_program here, as main_program is original program before to_prim.
         fwd_ops = [
             op.type
             for op in net.forward.get_concrete_program(self.x)[1]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program_hook.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program_hook.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+from paddle.fluid import core
+from paddle.jit.dy2static import partial_program, program_translator
+
+
+class TestPartiaProgramLayerHook(unittest.TestCase):
+    def setUp(self):
+        self._hook = partial_program.PartialProgramLayerHook()
+
+    def test_before_append_backward(self):
+        self.assertIsNone(self._hook.before_append_backward(None))
+
+    def test_after_append_backward(self):
+        self.assertIsNone(self._hook.after_append_backward(None, 0))
+
+    def test_after_infer(self):
+        self.assertIsNone(self._hook.after_infer(None))
+
+
+class TestPrimHook(unittest.TestCase):
+    def setUp(self):
+        core._set_prim_all_enabled(False)
+
+        def f():
+            return paddle.nn.functional.dropout(paddle.rand((1,)))
+
+        concrete_program, partial_program = paddle.jit.to_static(
+            f
+        ).get_concrete_program()
+        self._hook = program_translator.PrimHooker(
+            concrete_program.main_program
+        )
+        self._forward = partial_program.forward_program
+        self._whole = partial_program._train_program
+
+        core._set_prim_all_enabled(True)
+
+    def tearDown(self):
+        core._set_prim_all_enabled(False)
+
+    def test_before_append_backward(self):
+        self._hook.before_append_backward(self._forward)
+        self.assertNotIn(
+            'dropout', tuple(op.type for op in self._forward.blocks[0].ops)
+        )
+
+    def test_after_append_backward(self):
+        self._hook.after_append_backward(self._whole, 0)
+        self.assertNotIn(
+            'dropout_grad', tuple(op.type for op in self._whole.blocks[0].ops)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm.py
@@ -244,22 +244,22 @@ class TestCompositeBatchNorm(unittest.TestCase):
             atol=attrs.get_atol("forward"),
         )
 
-    def test_forward(self):
-        for i in self.training:
-            for j in self.dtypes:
-                for m in self.momentum:
-                    attrs.set_training(i)
-                    attrs.set_dtype(j)
-                    attrs.set_momentum(m)
-                    self.compare_forward()
+    # def test_forward(self):
+    #     for i in self.training:
+    #         for j in self.dtypes:
+    #             for m in self.momentum:
+    #                 attrs.set_training(i)
+    #                 attrs.set_dtype(j)
+    #                 attrs.set_momentum(m)
+    #                 self.compare_forward()
 
-        for n in self.shapes:
-            for s in self.data_formats:
-                for t in self.use_global_stats:
-                    attrs.set_shape(n)
-                    attrs.set_data_format(s)
-                    attrs.set_use_global_stats(t)
-                    self.compare_forward()
+    #     for n in self.shapes:
+    #         for s in self.data_formats:
+    #             for t in self.use_global_stats:
+    #                 attrs.set_shape(n)
+    #                 attrs.set_data_format(s)
+    #                 attrs.set_use_global_stats(t)
+    #                 self.compare_forward()
 
 
 def apply_to_static(net, use_cinn):

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm.py
@@ -21,6 +21,7 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 from paddle.fluid import core, framework
+from paddle.incubate.autograd import primapi
 from paddle.nn import BatchNorm
 from paddle.tensor import ones  # noqa: F401
 from paddle.tensor import zeros  # noqa: F401
@@ -183,7 +184,7 @@ class TestCompositeBatchNorm(unittest.TestCase):
                 attrs.use_global_stats,
             )
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
         exe = paddle.static.Executor()
         exe.run(startup_program)

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm.py
@@ -244,22 +244,22 @@ class TestCompositeBatchNorm(unittest.TestCase):
             atol=attrs.get_atol("forward"),
         )
 
-    # def test_forward(self):
-    #     for i in self.training:
-    #         for j in self.dtypes:
-    #             for m in self.momentum:
-    #                 attrs.set_training(i)
-    #                 attrs.set_dtype(j)
-    #                 attrs.set_momentum(m)
-    #                 self.compare_forward()
+    def test_forward(self):
+        for i in self.training:
+            for j in self.dtypes:
+                for m in self.momentum:
+                    attrs.set_training(i)
+                    attrs.set_dtype(j)
+                    attrs.set_momentum(m)
+                    self.compare_forward()
 
-    #     for n in self.shapes:
-    #         for s in self.data_formats:
-    #             for t in self.use_global_stats:
-    #                 attrs.set_shape(n)
-    #                 attrs.set_data_format(s)
-    #                 attrs.set_use_global_stats(t)
-    #                 self.compare_forward()
+        for n in self.shapes:
+            for s in self.data_formats:
+                for t in self.use_global_stats:
+                    attrs.set_shape(n)
+                    attrs.set_data_format(s)
+                    attrs.set_use_global_stats(t)
+                    self.compare_forward()
 
 
 def apply_to_static(net, use_cinn):

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_batch_norm_grad.py
@@ -20,6 +20,7 @@ from utils import SUB_TOLERANCE
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 np.random.seed(2023)
 
@@ -190,7 +191,7 @@ class TestCompositeBatchNorm(unittest.TestCase):
                 attrs.use_global_stats,
             )
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             z = paddle.static.gradients([y], [x1])
 

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_dropout.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_dropout.py
@@ -164,11 +164,13 @@ class TestCompositeDropout(unittest.TestCase):
             return fwd, rev, mp
 
         core._set_prim_forward_enabled(False)
+        core._set_prim_backward_enabled(False)
         desired_fwd, desired_rev, _ = dropout(
             self.x, self.p, self.is_test, self.mode, self.seed
         )
 
         core._set_prim_forward_enabled(True)
+        core._set_prim_backward_enabled(False)
         actual_fwd, actual_rev, prog = dropout(
             self.x, self.p, self.is_test, self.mode, self.seed
         )
@@ -188,6 +190,23 @@ class TestCompositeDropout(unittest.TestCase):
             atol=0,
         )
 
+        core._set_prim_forward_enabled(False)
+        core._set_prim_backward_enabled(True)
+        actual_fwd, actual_rev, _ = dropout(
+            self.x, self.p, self.is_test, self.mode, self.seed
+        )
+        np.testing.assert_allclose(
+            actual_fwd.sum(),
+            desired_fwd.sum(),
+            rtol=1e-2,  # mean of uniform distribution, scale for avoid random failed
+            atol=0,
+        )
+        np.testing.assert_allclose(
+            actual_rev.sum(),
+            desired_rev.sum(),
+            rtol=1e-2,  # mean of uniform distribution, scale for avoid random failed
+            atol=0,
+        )
         core._set_prim_all_enabled(True)
         actual_fwd, actual_rev, _ = dropout(
             self.x, self.p, self.is_test, self.mode, self.seed

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_dropout.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_dropout.py
@@ -19,6 +19,7 @@ import parameterized as param
 
 import paddle
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 np.random.seed(2023)
 
@@ -154,7 +155,7 @@ class TestCompositeDropout(unittest.TestCase):
                     input_, p, training=(not is_test), mode=mode
                 )
                 if core._is_fwd_prim_enabled():
-                    paddle.incubate.autograd.to_prim(mp.blocks)
+                    primapi.to_prim(mp.blocks)
                 grad = paddle.static.gradients(output, input_)[0]
             exe = paddle.static.Executor(self.place)
             exe.run(sp)

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_gelu.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_gelu.py
@@ -22,6 +22,7 @@ np.random.seed(2013)
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 def generate_data(shape, dtype="float32"):
@@ -89,7 +90,7 @@ class TestCompositeGelu(unittest.TestCase):
             # Ensure that gelu in original block
             self.assertTrue('gelu' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that gelu is splitted into small ops

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_gelu_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_gelu_grad.py
@@ -22,6 +22,7 @@ np.random.seed(2013)
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 def generate_data(shape, dtype="float32"):
@@ -97,7 +98,7 @@ class TestCompositeGelu(unittest.TestCase):
             # Ensure that gelu in original block
             self.assertTrue('gelu' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that gelu is splitted into small ops
@@ -164,7 +165,7 @@ class TestCompositeGeluPrimBackward(unittest.TestCase):
             x.stop_gradient = False
             y = fn(x)
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
             z = paddle.static.gradients([y], x)
 
         exe = paddle.static.Executor()

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_layer_norm.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_layer_norm.py
@@ -20,6 +20,7 @@ from utils import SUB_TOLERANCE
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 def generate_data(shape1, shape2, shape3, dtype="float32"):
@@ -98,7 +99,7 @@ class TestCompositelayer_norm(unittest.TestCase):
             # Ensure that layer_norm in original block
             self.assertTrue('layer_norm' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that layer_norm is splitted into small ops
@@ -137,7 +138,7 @@ class TestCompositelayer_norm(unittest.TestCase):
             # Ensure that layer_norm in original block
             self.assertTrue('layer_norm' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that layer_norm is splitted into small ops

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_layer_norm_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_layer_norm_grad.py
@@ -22,6 +22,7 @@ from utils import SUB_TOLERANCE
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 TOLERANCE_NUMPY = {
     "float32": {"rtol": 2e-5, "atol": 2e-5},
@@ -196,7 +197,7 @@ class TestCompositelayer_norm(unittest.TestCase):
             # Ensure that layer_norm in original block
             self.assertTrue('layer_norm' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that layer_norm is splitted into small ops
@@ -242,7 +243,7 @@ class TestCompositelayer_norm(unittest.TestCase):
             # Ensure that layer_norm in original block
             self.assertTrue('layer_norm' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that layer_norm is splitted into small ops
@@ -341,7 +342,7 @@ class TestCompositelayer_normPrimBackward(unittest.TestCase):
             y = fn(x, norm_shape, w, b)
 
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
             z = paddle.static.gradients([y], x)
 
         exe = paddle.static.Executor()
@@ -374,7 +375,7 @@ class TestCompositelayer_normPrimBackward(unittest.TestCase):
             y = fn(x, norm_shape, weight, bias)
 
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
             z = paddle.static.gradients([y], x)
 
         exe = paddle.static.Executor()
@@ -480,7 +481,7 @@ class TestCompositeNumpylayer_norm(unittest.TestCase):
             # Ensure that layer_norm in original block
             self.assertTrue('layer_norm' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that layer_norm is splitted into small ops
@@ -532,7 +533,7 @@ class TestCompositeNumpylayer_norm(unittest.TestCase):
             )
 
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
             z = paddle.static.gradients([y], x)
 
         exe = paddle.static.Executor()

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_mean.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_mean.py
@@ -20,6 +20,7 @@ from utils import TOLERANCE
 import paddle
 import paddle.tensor as tensor
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 def generate_data(shape, dtype="float32"):
@@ -93,7 +94,7 @@ class TestCompositeMean(unittest.TestCase):
             # Ensure that reduce_mean in original block
             self.assertTrue('reduce_mean' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that reduce_mean is splitted into small ops

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_mean_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_mean_grad.py
@@ -20,6 +20,7 @@ from utils import TOLERANCE
 import paddle
 import paddle.tensor as tensor
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 def generate_data(shape, dtype="float32"):
@@ -99,7 +100,7 @@ class TestCompositeMean(unittest.TestCase):
             # Ensure that reduce_mean in original block
             self.assertTrue('reduce_mean' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that reduce_mean is splitted into small ops
@@ -173,7 +174,7 @@ class TestCompositeMeanPrimBackward(unittest.TestCase):
             x.stop_gradient = False
             y = fn(x)
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
             z = paddle.static.gradients([y], x)
 
         exe = paddle.static.Executor()

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_softmax.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_softmax.py
@@ -20,6 +20,7 @@ from utils import TOLERANCE
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 def generate_data(shape, dtype="float32"):
@@ -87,7 +88,7 @@ class TestCompositeSoftmax(unittest.TestCase):
             # Ensure that softmax in original block
             self.assertTrue('softmax' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that softmax is splitted into small ops

--- a/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_softmax_grad.py
+++ b/python/paddle/fluid/tests/unittests/prim/composite_ops/test_composite_softmax_grad.py
@@ -20,6 +20,7 @@ from utils import TOLERANCE
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 def generate_data(shape, dtype="float32"):
@@ -93,7 +94,7 @@ class TestCompositeSoftmax(unittest.TestCase):
             # Ensure that softmax in original block
             self.assertTrue('softmax' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that softmax is splitted into small ops
@@ -158,7 +159,7 @@ class TestCompositeSoftmaxPrimBackward(unittest.TestCase):
             x.stop_gradient = False
             y = fn(x)
             blocks = main_program.blocks
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
             z = paddle.static.gradients([y], x)
 
         exe = paddle.static.Executor()

--- a/python/paddle/fluid/tests/unittests/prim/prim/flags/test_prim_flags.py
+++ b/python/paddle/fluid/tests/unittests/prim/prim/flags/test_prim_flags.py
@@ -20,6 +20,7 @@ import numpy as np
 import paddle
 import paddle.nn.functional as F
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 
 class TestPrimFlags(unittest.TestCase):
@@ -64,6 +65,12 @@ class TestPrimFlags(unittest.TestCase):
         with self.assertRaises(TypeError):
             core._test_use_sync("aaaa")
 
+        core._set_prim_all_enabled(True)
+        self.assertTrue(core._is_all_prim_enabled())
+
+        core._set_prim_all_enabled(False)
+        self.assertFalse(core._is_all_prim_enabled())
+
 
 class TestPrimBlacklistFlags(unittest.TestCase):
     def not_in_blacklist(self):
@@ -83,7 +90,7 @@ class TestPrimBlacklistFlags(unittest.TestCase):
             # Ensure that softmax in original block
             self.assertTrue('softmax' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that softmax is splitted into small ops
@@ -113,7 +120,7 @@ class TestPrimBlacklistFlags(unittest.TestCase):
             # Ensure that softmax in original block
             self.assertTrue('softmax' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that softmax is splitted into small ops

--- a/python/paddle/fluid/tests/unittests/prim/process/test_copy_op.py
+++ b/python/paddle/fluid/tests/unittests/prim/process/test_copy_op.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import paddle
 from paddle.fluid import core
+from paddle.incubate.autograd import primapi
 
 paddle.framework.random._manual_program_seed(2023)
 
@@ -49,7 +50,7 @@ class TestCompositeCopyOp(unittest.TestCase):
             # Ensure that dropout in original block
             self.assertTrue('dropout' in fwd_ops)
 
-            paddle.incubate.autograd.to_prim(blocks)
+            primapi.to_prim(blocks)
 
             fwd_ops_new = [op.type for op in blocks[0].ops]
             # Ensure that dropout is not splitted into small ops

--- a/python/paddle/fluid/tests/unittests/prim/test_comp_custom_vjp.py
+++ b/python/paddle/fluid/tests/unittests/prim/test_comp_custom_vjp.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+import paddle
+from paddle.fluid import core
+
+
+class TestCustomVJP(unittest.TestCase):
+    def setUp(self):
+        def func():
+            x = paddle.rand((1,))
+            x.stop_gradient = False
+            return paddle.nn.functional.dropout(x)
+
+        self.f = func
+        self.ops_fwd_enable_bwd_disable = (
+            'uniform_random',
+            'uniform_random',
+            'fill_constant',
+            'greater_equal',
+            'cast',
+            'elementwise_mul',
+            'scale',
+            'cast',
+            'fill_any_like',
+            'scale',
+            'elementwise_mul_grad',
+        )
+        self.ops_fwd_disable_bwd_enable = (
+            'uniform_random',
+            'dropout',
+            'fill_any_like',
+            'cast',
+            'elementwise_mul',
+            'fill_constant',
+            'elementwise_div',
+        )
+        self.ops_all_enable = (
+            'uniform_random',
+            'uniform_random',
+            'fill_constant',
+            'greater_equal',
+            'cast',
+            'elementwise_mul',
+            'scale',
+            'cast',
+            'fill_constant',
+            'cast',
+            'elementwise_mul',
+            'fill_constant',
+            'elementwise_div',
+        )
+
+    def test_enable_prim_fwd(self):
+        core._set_prim_forward_enabled(True)
+        core._set_prim_backward_enabled(False)
+        self.assertEqual(
+            self.ops_fwd_enable_bwd_disable,
+            tuple(
+                op.type
+                for op in paddle.jit.to_static(self.f)
+                .get_concrete_program()[1]
+                ._train_program.block(0)
+                .ops
+            ),
+        )
+        core._set_prim_forward_enabled(False)
+        core._set_prim_backward_enabled(False)
+
+    def test_enable_prim_bwd(self):
+        core._set_prim_forward_enabled(False)
+        core._set_prim_backward_enabled(True)
+        self.assertEqual(
+            self.ops_fwd_disable_bwd_enable,
+            tuple(
+                op.type
+                for op in paddle.jit.to_static(self.f)
+                .get_concrete_program()[1]
+                ._train_program.block(0)
+                .ops
+            ),
+        )
+        core._set_prim_forward_enabled(False)
+        core._set_prim_backward_enabled(False)
+
+    def test_enable_prim_all(self):
+        core._set_prim_all_enabled(True)
+        self.assertEqual(
+            self.ops_all_enable,
+            tuple(
+                op.type
+                for op in paddle.jit.to_static(self.f)
+                .get_concrete_program()[1]
+                ._train_program.block(0)
+                .ops
+            ),
+        )
+        core._set_prim_all_enabled(False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/prim/test_comp_custom_vjp.py
+++ b/python/paddle/fluid/tests/unittests/prim/test_comp_custom_vjp.py
@@ -56,7 +56,7 @@ class TestCustomVJP(unittest.TestCase):
             'elementwise_mul',
             'scale',
             'cast',
-            'fill_constant',
+            'fill_any_like',
             'cast',
             'elementwise_mul',
             'fill_constant',

--- a/python/paddle/fluid/tests/unittests/prim_op_test.py
+++ b/python/paddle/fluid/tests/unittests/prim_op_test.py
@@ -22,6 +22,7 @@ import numpy as np
 import paddle
 import paddle.fluid.core as core
 from paddle.fluid.framework import _dygraph_tracer, in_dygraph_mode
+from paddle.incubate.autograd import primapi
 from paddle.jit.dy2static.utils import parse_arg_and_kwargs
 
 
@@ -588,7 +589,7 @@ class PrimForwardChecker:
                 args, len(inputs_sig)
             )
             ret = flatten(_as_list(self.python_api(*args)))
-            paddle.incubate.autograd.to_prim(main_program.blocks)
+            primapi.to_prim(main_program.blocks)
         exe = paddle.static.Executor(self.place)
         exe.run(startup_program)
         ret = exe.run(main_program, feed=feed, fetch_list=ret)
@@ -1018,7 +1019,7 @@ class PrimGradChecker(PrimForwardChecker):
             outputs_dict = self.get_output_dict(
                 self.outputs, fw_outs, outputs_sig
             )
-            paddle.incubate.autograd.to_prim(main_program.blocks)
+            primapi.to_prim(main_program.blocks)
             ys = []
             if isinstance(self.output_names, list):
                 for output_name in self.output_names:

--- a/python/paddle/incubate/autograd/__init__.py
+++ b/python/paddle/incubate/autograd/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .functional import Hessian, Jacobian, jvp, vjp
-from .primapi import forward_grad, grad, to_prim
+from .primapi import forward_grad, grad
 from .primx import prim2orig
 from .utils import disable_prim, enable_prim, prim_enabled
 
@@ -25,5 +25,4 @@ __all__ = [  # noqa
     'disable_prim',
     'forward_grad',
     'grad',
-    'to_prim',
 ]

--- a/python/paddle/incubate/autograd/primapi.py
+++ b/python/paddle/incubate/autograd/primapi.py
@@ -239,6 +239,11 @@ def to_prim(blocks, exclude=frozenset()):
         raise TypeError(
             f"Expect block or sequence of blocks, but got {type(blocks)}."
         )
+    if not isinstance(exclude, (set, frozenset)):
+        raise TypeError(
+            f'Expected type of exclude is set|frozenset, but got {type(exclude)}.'
+        )
+
     with framework.program_guard(main_program):
         logging.debug("Lowering composite forward ops begin...")
         primx._lower_composite(

--- a/python/paddle/incubate/autograd/primapi.py
+++ b/python/paddle/incubate/autograd/primapi.py
@@ -226,7 +226,7 @@ def to_prim(blocks, exclude=frozenset()):
     if not core._is_fwd_prim_enabled():
         return
     if isinstance(blocks, paddle.fluid.framework.Block):
-        logging.debug("Atomize composite op to primitive ops begin.")
+        logging.info("Atomize composite op to primitive ops begin.")
         main_program = blocks.program
     elif isinstance(blocks, typing.Sequence):
         for item in blocks:
@@ -245,9 +245,9 @@ def to_prim(blocks, exclude=frozenset()):
         )
 
     with framework.program_guard(main_program):
-        logging.debug("Lowering composite forward ops begin...")
+        print("Lowering composite forward ops begin...")
         primx._lower_composite(
             blocks, prim_config["forward_blacklist"] | exclude
         )
         replace_ops = prim_config["composite_ops_record"]
-        logging.debug(f"Lowering composite forward ops finish: {replace_ops}")
+        print(f"Lowering composite forward ops finish: {replace_ops}")

--- a/python/paddle/incubate/autograd/primapi.py
+++ b/python/paddle/incubate/autograd/primapi.py
@@ -217,11 +217,18 @@ def grad(outputs, inputs, grad_outputs=None):
 
 
 @framework.static_only
-def to_prim(blocks, exclude=frozenset()):
+def to_prim(blocks, blacklist=frozenset(), whitelist=frozenset()):
     """Search nonbasic ops which have be registered composite rules and replace them with primitive ops.
+    The operators in blacklist will be excluded from program when lowering into primitives, and only the
+    operators in whitelist will be lowering. The priority of blacklist is higher than whitelist, it means
+    an operator both in blacklist and whitelist will not be lowering.
+
+    The finally set that will be lowering is:
+        (blocks.ops & ops have decomposite rule & whitelist) - blacklist
 
     Args:
-        exclude(frozenset): The Operators that will be exclude in lowering.
+        blacklist(frozenset): The Operators that will be exclude when lowering into primitives.
+        whitelist(frozenset): Only the operators in whitelist will be lowering into primitives.
     """
     if not core._is_fwd_prim_enabled():
         return
@@ -239,15 +246,28 @@ def to_prim(blocks, exclude=frozenset()):
         raise TypeError(
             f"Expect block or sequence of blocks, but got {type(blocks)}."
         )
-    if not isinstance(exclude, (set, frozenset)):
+    if not isinstance(blacklist, (set, frozenset)):
         raise TypeError(
-            f'Expected type of exclude is set|frozenset, but got {type(exclude)}.'
+            f'Expected type of blacklisst is set|frozenset, but got {type(blacklist)}.'
         )
+    if not isinstance(whitelist, (set, frozenset)):
+        raise TypeError(
+            f'Expected type of whiltelist is set|frozenset, but got {type(whitelist)}.'
+        )
+
+    blacklist = prim_config["forward_blacklist"] | blacklist
 
     with framework.program_guard(main_program):
         print("Lowering composite forward ops begin...")
-        primx._lower_composite(
-            blocks, prim_config["forward_blacklist"] | exclude
-        )
+
+        if len(blacklist) > 0 and len(whitelist) > 0:
+            filter_ = lambda x: x.type in whitelist and x.type not in blacklist
+        elif len(blacklist) > 0 and len(whitelist) == 0:
+            filter_ = lambda x: x.type not in blacklist
+        elif len(blacklist) == 0 and len(whitelist) > 0:
+            filter_ = lambda x: x.type in whitelist
+        else:
+            filter_ = lambda x: True
+        primx._lower_composite(blocks, filter_)
         replace_ops = prim_config["composite_ops_record"]
         print(f"Lowering composite forward ops finish: {replace_ops}")

--- a/python/paddle/incubate/autograd/primx.py
+++ b/python/paddle/incubate/autograd/primx.py
@@ -550,7 +550,7 @@ def _lower(block, reverse, blacklist):
     block._sync_with_cpp()
 
 
-def _lower_composite(block, blacklist=[]):
+def _lower_composite(block, blacklist=frozenset()):
     # Some functions which are only used in _lower.
     def bind(args, to_bind, value_table):
         for i in range(len(args)):

--- a/python/paddle/incubate/autograd/primx.py
+++ b/python/paddle/incubate/autograd/primx.py
@@ -645,36 +645,9 @@ def _lower_composite(block, blacklist=frozenset()):
                     else:
                         none_vars_to_remove.add(orig_out.name)
             else:
-<<<<<<< HEAD
-                inputs = {}
-                for i in range(len(op.input_names)):
-                    inputs[op.input_names[i]] = bind_name(
-                        op.input(op.input_names[i]), to_bind
-                    )
-
-                outputs = {}
-                for i in range(len(op.output_names)):
-                    outputs[op.output_names[i]] = op.output(op.output_names[i])
-
-                from paddle.fluid.dygraph.base import param_guard
-
-                new_op_desc = block.desc.append_op()
-                new_op_desc.copy_from(op.desc)
-                with param_guard(inputs), param_guard(outputs):
-                    op = Operator(
-                        block=block,
-                        desc=new_op_desc,
-                        type=op.type,
-                        inputs=inputs,
-                        outputs=outputs,
-                        attrs=None,
-                    )
-                block.ops.append(op)
-=======
                 op_desc = block.desc.append_op()
                 op_desc.copy_from(op.desc)
                 block._sync_with_cpp()
->>>>>>> [prim] enable dygraph_to_static to support custom_vjp
 
         # Step3: Do some post-processing work
         for op_idx in reversed(ops_to_remove):

--- a/python/paddle/incubate/autograd/primx.py
+++ b/python/paddle/incubate/autograd/primx.py
@@ -645,6 +645,7 @@ def _lower_composite(block, blacklist=frozenset()):
                     else:
                         none_vars_to_remove.add(orig_out.name)
             else:
+<<<<<<< HEAD
                 inputs = {}
                 for i in range(len(op.input_names)):
                     inputs[op.input_names[i]] = bind_name(
@@ -669,6 +670,11 @@ def _lower_composite(block, blacklist=frozenset()):
                         attrs=None,
                     )
                 block.ops.append(op)
+=======
+                op_desc = block.desc.append_op()
+                op_desc.copy_from(op.desc)
+                block._sync_with_cpp()
+>>>>>>> [prim] enable dygraph_to_static to support custom_vjp
 
         # Step3: Do some post-processing work
         for op_idx in reversed(ops_to_remove):

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -195,7 +195,7 @@ class PartialProgramLayer:
         # Set default mode to train
         self.training = True
         self._infer_info = ProgramInfo()
-        self._backward_start_index_map = {}
+        self._forward_end_index_map = {}
 
         custom_white_list, custom_black_list = None, None
         tracer = framework._dygraph_tracer()
@@ -314,7 +314,10 @@ class PartialProgramLayer:
     @switch_to_static_graph
     def _create_forward_backward_train_program(self):
         whole_program = self._train_program
-        _, forward_end_op_index = self._infer_info('fp32', self._create_program)
+        # _, forward_end_op_index = self._infer_info('fp32', self._create_program)
+        forward_end_op_index = self._forward_end_index_map[
+            _hash_with_id(whole_program, self)
+        ]
         assert forward_end_op_index >= 0
 
         return self._get_forward_backward_program_form(
@@ -642,15 +645,16 @@ class PartialProgramLayer:
         if targets:
             # TODO(CZ): later when use cinn, set_prim_all_enabled and check_and_set_prim_all_enabled will be set at else branch.
             core.check_and_set_prim_all_enabled()
+            start_idx = len(program.block(0).ops) + len(self._outputs.tolist())
             backward.gradients(targets=targets, inputs=[])
-            start_idx = (
-                len(main_program.block(0).ops) + len(self._outputs.tolist()) + 1
-            )
+
             if self._hooker:
                 program, start_idx = self._hooker.after_append_backward(
                     self, program, start_idx
                 )
-                # self._backward_start_index_map[self._hash_with_id(program, self)]
+            self._forward_end_index_map[
+                _hash_with_id(program, self)
+            ] = start_idx - len(self._outputs.tolist())
             # TODO: prim make this complicate
             self.prepare_gradient_aggregation(start_idx, main_program, program)
 
@@ -732,10 +736,6 @@ class PartialProgramLayer:
             'program_id',
             self.program_id,
         ]
-
-        print(self.forward_program)
-        print(self.backward_program)
-        print(self.program_id)
 
         if self.training:
             # NOTE: In the case of higher-order gradient, the names of the parameter grads may be like
@@ -1155,5 +1155,5 @@ def add_build_strategy_for(
         if hasattr(compiled_program._program, 'lr_sheduler'):
             builded_program.lr_sheduler = compiled_program._program.lr_sheduler
     else:
-        builded_program = program
+        builded_program = paddle.static.Program()
     return builded_program

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -143,6 +143,19 @@ class ProgramInfo:
         return self.programs[key], self.op_size[key]
 
 
+class PartialProgramLayerHook:
+    def before_append_backward(self, partial_program_layer, forward_program):
+        ...
+
+    def after_append_backward(
+        self, partial_program_layer, whole_program, backward_start_idx
+    ):
+        ...
+
+    def after_infer(self, partial_program_layer, infer_program):
+        ...
+
+
 class PartialProgramLayer:
     """
     PartialProgramLayer wraps all the ops from layers decorated by `@to_static`
@@ -182,6 +195,7 @@ class PartialProgramLayer:
         # Set default mode to train
         self.training = True
         self._infer_info = ProgramInfo()
+        self._backward_start_index_map = {}
 
         custom_white_list, custom_black_list = None, None
         tracer = framework._dygraph_tracer()
@@ -195,6 +209,7 @@ class PartialProgramLayer:
 
         # program_id -> list(scope)
         self._scope_cache = {}
+        self._hooker = None
 
     def __call__(self, inputs):
         """
@@ -217,6 +232,9 @@ class PartialProgramLayer:
         )
         restored_nest_out = self._restore_out(out_vars)
         return self._remove_no_value(restored_nest_out)
+
+    def set_hooker(self, hooker):
+        self._hooker = hooker
 
     def _get_scope(self, program_id=None, use_scope_cache=False):
         if use_scope_cache:
@@ -242,7 +260,12 @@ class PartialProgramLayer:
     @switch_to_static_graph
     def _create_program(self, is_infer_mode=False):
         if is_infer_mode:
-            return self._origin_main_program.clone(for_test=is_infer_mode)
+            infer_program = self._origin_main_program.clone(
+                for_test=is_infer_mode
+            )
+            if self._hooker:
+                infer_program = self._hooker.after_infer(self, infer_program)
+            return infer_program
         else:
             train_program = self._append_backward_desc(
                 self._origin_main_program
@@ -609,6 +632,8 @@ class PartialProgramLayer:
     def _append_backward_desc(self, main_program):
         # make sure all status of is_test are False in train mode.
         program = _change_is_test_status(main_program.clone(), is_test=False)
+        if self._hooker:
+            program = self._hooker.before_append_backward(self, program)
         targets = []
         for out in self._outputs.tolist():
             if isinstance(out, framework.Variable):
@@ -618,10 +643,16 @@ class PartialProgramLayer:
             # TODO(CZ): later when use cinn, set_prim_all_enabled and check_and_set_prim_all_enabled will be set at else branch.
             core.check_and_set_prim_all_enabled()
             backward.gradients(targets=targets, inputs=[])
-
-        start_idx = len(main_program.block(0).ops) + len(self._outputs.tolist())
-
-        self.prepare_gradient_aggregation(start_idx, main_program, program)
+            start_idx = (
+                len(main_program.block(0).ops) + len(self._outputs.tolist()) + 1
+            )
+            if self._hooker:
+                program, start_idx = self._hooker.after_append_backward(
+                    self, program, start_idx
+                )
+                # self._backward_start_index_map[self._hash_with_id(program, self)]
+            # TODO: prim make this complicate
+            self.prepare_gradient_aggregation(start_idx, main_program, program)
 
         return program
 
@@ -701,6 +732,11 @@ class PartialProgramLayer:
             'program_id',
             self.program_id,
         ]
+
+        print(self.forward_program)
+        print(self.backward_program)
+        print(self.program_id)
+
         if self.training:
             # NOTE: In the case of higher-order gradient, the names of the parameter grads may be like
             # `grad/grad/grad/linear_0.w_0@GRAD` instead of simply `linear_0.w_0@GRAD`, so we get

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -144,15 +144,13 @@ class ProgramInfo:
 
 
 class PartialProgramLayerHook:
-    def before_append_backward(self, partial_program_layer, forward_program):
+    def before_append_backward(self, forward_program):
         ...
 
-    def after_append_backward(
-        self, partial_program_layer, whole_program, backward_start_idx
-    ):
+    def after_append_backward(self, whole_program, backward_start_idx):
         ...
 
-    def after_infer(self, partial_program_layer, infer_program):
+    def after_infer(self, infer_program):
         ...
 
 
@@ -264,7 +262,7 @@ class PartialProgramLayer:
                 for_test=is_infer_mode
             )
             if self._hooker:
-                infer_program = self._hooker.after_infer(self, infer_program)
+                infer_program = self._hooker.after_infer(infer_program)
             return infer_program
         else:
             train_program = self._append_backward_desc(
@@ -298,11 +296,9 @@ class PartialProgramLayer:
                 pure_fp16_program, self._amp_list, use_fp16_guard=False
             )
 
-        core.check_and_set_prim_all_enabled()
-        from paddle.incubate.autograd.primapi import to_prim
-
-        to_prim(pure_fp16_program.blocks)
         if is_infer_mode:
+            if self._hooker:
+                pure_fp16_program = self._hooker.after_infer(pure_fp16_program)
             return pure_fp16_program
         else:
             train_pure_fp16_program = self._append_backward_desc(
@@ -314,7 +310,6 @@ class PartialProgramLayer:
     @switch_to_static_graph
     def _create_forward_backward_train_program(self):
         whole_program = self._train_program
-        # _, forward_end_op_index = self._infer_info('fp32', self._create_program)
         forward_end_op_index = self.get_forward_end_op_idx(whole_program)
         assert forward_end_op_index >= 0
 
@@ -437,7 +432,9 @@ class PartialProgramLayer:
         return _param_grad_names(self._train_program.desc, self._params)
 
     def get_forward_end_op_idx(self, program):
-        return self._forward_end_index_map[_hash_with_id(program, self)]
+        return self._forward_end_index_map[
+            paddle.utils._hash_with_id(program, self)
+        ]
 
     @LazyInitialized
     def _out_grad_names(self):
@@ -637,7 +634,7 @@ class PartialProgramLayer:
         # make sure all status of is_test are False in train mode.
         program = _change_is_test_status(main_program.clone(), is_test=False)
         if self._hooker:
-            program = self._hooker.before_append_backward(self, program)
+            program = self._hooker.before_append_backward(program)
         targets = []
         for out in self._outputs.tolist():
             if isinstance(out, framework.Variable):
@@ -652,12 +649,14 @@ class PartialProgramLayer:
 
             if self._hooker:
                 program, start_idx = self._hooker.after_append_backward(
-                    self, program, start_idx
+                    program, start_idx
                 )
-            self.prepare_gradient_aggregation(start_idx, main_program, program)
+            self.prepare_gradient_aggregation(
+                start_idx + 1, main_program, program
+            )
 
         self._forward_end_index_map[
-            _hash_with_id(program, self)
+            paddle.utils._hash_with_id(program, self)
         ] = start_idx - len(self._outputs.tolist())
         return program
 

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1226,7 +1226,6 @@ class ProgramCache:
             partial_program.set_hooker(PrimHooker())
         return concrete_program, partial_program
 
-
     def __getitem__(self, item):
         if not isinstance(item, CacheKey):
             raise ValueError(

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -19,7 +19,7 @@ import threading
 import warnings
 import weakref
 
-from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
+from paddle.amp.auto_cast import _in_amp_guard
 from paddle.fluid import _non_static_mode, core, framework
 from paddle.fluid.data_feeder import check_type
 from paddle.fluid.dygraph import layers
@@ -194,7 +194,7 @@ class CacheKey:
         input_args_with_spec,
         input_kwargs_with_spec,
         class_instance,
-        **kwargs
+        **kwargs,
     ):
         """
         Initializes a cache key.
@@ -568,7 +568,7 @@ class StaticFunction:
             self._class_instance,
             **self._kwargs,
             with_hook=with_hook,
-            is_train=is_train
+            is_train=is_train,
         )
 
         # 3. check whether hit the cache or build a new program for the input arguments
@@ -674,7 +674,7 @@ class StaticFunction:
                 concrete_program, _ = self.get_concrete_program(
                     *desired_input_spec,
                     with_hook=with_hook,
-                    is_train=self._is_train_mode()
+                    is_train=self._is_train_mode(),
                 )
                 return concrete_program
             else:
@@ -946,7 +946,7 @@ class ConcreteProgram:
         function,
         main_program,
         startup_program=None,
-        **kwargs
+        **kwargs,
     ):
         self.inputs = inputs
         self.outputs = outputs
@@ -1049,7 +1049,7 @@ class ConcreteProgram:
             function=dygraph_function,
             main_program=main_program,
             startup_program=startup_program,
-            **kwargs
+            **kwargs,
         )
 
 
@@ -1152,7 +1152,7 @@ class ProgramCache:
                 input_spec=cache_key.input_args_with_spec,
                 input_kwargs_spec=cache_key.input_kwargs_with_spec,
                 class_instance=cache_key.class_instance,
-                **cache_key.kwargs
+                **cache_key.kwargs,
             )
         except Exception as e:
             if enable_fallback:
@@ -1182,48 +1182,11 @@ class ProgramCache:
                         )
                     )
 
-        class PrimHooker(PartialProgramLayerHook):
-            def __init__(self):
-                self.custom_vjps = set()
-                if core._is_fwd_prim_enabled() and core._is_bwd_prim_enabled():
-                    self.custom_vjps = {
-                        op.type
-                        for op in concrete_program.main_program.block(0).ops
-                        if core.has_comp_grad_op_maker(op.type)
-                    }
-
-            def before_append_backward(
-                self, partial_program_layer, forward_program
-            ):
-                if core._is_fwd_prim_enabled():
-                    to_prim(forward_program.block(0), self.custom_vjps)
-                return forward_program
-
-            def after_append_backward(
-                self, partial_program_layer, whole_program, backward_start_idx
-            ):
-                backward_length = (
-                    len(whole_program.block(0).ops) - backward_start_idx
-                )
-                if core._is_fwd_prim_enabled() and len(self.custom_vjps) != 0:
-                    to_prim(whole_program.block(0))
-                new_start_index = (
-                    len(whole_program.block(0).ops) - backward_length
-                )
-                return whole_program, new_start_index
-
-            def after_infer(self, partial_program_layer, infer_program):
-                if core._is_fwd_prim_enabled():
-                    to_prim(infer_program.block(0))
-                return infer_program
-
         partial_program = partial_program_from(concrete_program)
-        if (
-            core._is_fwd_prim_enabled()
-            and not _in_amp_guard()
-            and not _in_pure_fp16_guard()
-        ):
-            partial_program.set_hooker(PrimHooker())
+        if core._is_fwd_prim_enabled() and not _in_amp_guard():
+            partial_program.set_hooker(
+                PrimHooker(concrete_program.main_program)
+            )
         return concrete_program, partial_program
 
     def __getitem__(self, item):
@@ -1277,6 +1240,38 @@ class ProgramCache:
 
     def clear(self):
         self._caches = collections.OrderedDict()
+
+
+class PrimHooker(PartialProgramLayerHook):
+    def __init__(self, original_program):
+        if len(original_program.blocks) > 1:
+            raise ValueError(
+                'The primitive mode only support one block currently.'
+            )
+        self.custom_vjps = set()
+        if core._is_all_prim_enabled():
+            self.custom_vjps = {
+                op.type
+                for op in original_program.block(0).ops
+                if core.has_comp_grad_op_maker(op.type)
+            }
+
+    def before_append_backward(self, forward_program):
+        if core._is_fwd_prim_enabled():
+            _to_prim(forward_program.blocks, blacklist=self.custom_vjps)
+        return forward_program
+
+    def after_append_backward(self, whole_program, backward_start_idx):
+        backward_length = len(whole_program.block(0).ops) - backward_start_idx
+        if core._is_fwd_prim_enabled() and len(self.custom_vjps) != 0:
+            _to_prim(whole_program.blocks, whitelist=self.custom_vjps)
+        new_start_index = len(whole_program.block(0).ops) - backward_length
+        return whole_program, new_start_index
+
+    def after_infer(self, infer_program):
+        if core._is_fwd_prim_enabled():
+            _to_prim(infer_program.block(0))
+        return infer_program
 
 
 class ProgramTranslator:
@@ -1696,8 +1691,9 @@ def enable_to_static(enable_to_static_bool):
 
 
 @switch_to_static_graph
-def to_prim(blocks, exclude=frozenset()):
+def _to_prim(blocks, blacklist=frozenset(), whitelist=frozenset()):
+    """Swith to static graph and call to_prim."""
     # TODO(Aurelius84): Fix this cycle import problem
     from paddle.incubate.autograd import primapi
 
-    primapi.to_prim(blocks, exclude)
+    primapi.to_prim(blocks, blacklist=blacklist, whitelist=whitelist)

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -1218,7 +1218,11 @@ class ProgramCache:
                 return infer_program
 
         partial_program = partial_program_from(concrete_program)
-        if not _in_amp_guard() and not _in_pure_fp16_guard():
+        if (
+            core._is_fwd_prim_enabled()
+            and not _in_amp_guard()
+            and not _in_pure_fp16_guard()
+        ):
             partial_program.set_hooker(PrimHooker())
         return concrete_program, partial_program
 

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -956,13 +956,6 @@ class ConcreteProgram:
         self.function = function
         self.kwargs = kwargs
 
-    @switch_to_static_graph
-    def _to_prim(self):
-        # TODO(Aurelius84): Fix this cycle import problem
-        from paddle.incubate.autograd.primapi import to_prim
-
-        to_prim(self.main_program.blocks)
-
     @staticmethod
     @switch_to_static_graph
     def from_func_spec(
@@ -1188,10 +1181,29 @@ class ProgramCache:
                             var.name, var.shape
                         )
                     )
-        if not _in_amp_guard() and not _in_pure_fp16_guard():
-            concrete_program._to_prim()
 
-        return concrete_program, partial_program_from(concrete_program)
+        custom_vjps = set()
+        if core._is_fwd_prim_enabled() and core._is_bwd_prim_enabled():
+            custom_vjps = {
+                op.type
+                for op in concrete_program.main_program.block(0).ops
+                if core.has_comp_grad_op_maker(op.type)
+            }
+
+        if core._is_fwd_prim_enabled():
+            if not _in_amp_guard() and not _in_pure_fp16_guard():
+                _to_prim(
+                    concrete_program.main_program.blocks, exclude=custom_vjps
+                )
+
+        partial_program = partial_program_from(concrete_program)
+
+        if core._is_fwd_prim_enabled() and len(custom_vjps) != 0:
+            if not _in_amp_guard() and not _in_pure_fp16_guard():
+                _to_prim(partial_program.forward_program.blocks)
+
+        return concrete_program, partial_program
+
 
     def __getitem__(self, item):
         if not isinstance(item, CacheKey):
@@ -1660,3 +1672,11 @@ def enable_to_static(enable_to_static_bool):
     )
     _program_trans = ProgramTranslator()
     _program_trans.enable(enable_to_static_bool)
+
+
+@switch_to_static_graph
+def _to_prim(blocks, exclude=frozenset()):
+    # TODO(Aurelius84): Fix this cycle import problem
+    from paddle.incubate.autograd import primapi
+
+    primapi.to_prim(blocks, exclude=exclude)

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -1542,7 +1542,7 @@ def _out_grad_names(program_desc, fwd_end_op_index, out_size):
         min(fwd_end_op_index + out_size, program_desc.block(0).op_size()),
     ):
         op = program_desc.block(0).op(i)
-        if op.type() in ['fill_any_like', "fill_constant"]:
+        if op.type() == 'fill_any_like':
             var_name = op.output('Out')[0]
             names.append(var_name)
     return names

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -1542,7 +1542,7 @@ def _out_grad_names(program_desc, fwd_end_op_index, out_size):
         min(fwd_end_op_index + out_size, program_desc.block(0).op_size()),
     ):
         op = program_desc.block(0).op(i)
-        if op.type() == 'fill_any_like':
+        if op.type() in ['fill_any_like', "fill_constant"]:
             var_name = op.output('Out')[0]
             names.append(var_name)
     return names


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-66975
- Add new CustomVJP feature. When forward and backward are both decomposite, run backward decomposite firstly.
- Enable dy2st to support CustomVJP . @2742195759
- Fix _lower_composite bugs when op is not register in decomposite rules.
- Fix cast prim api and vjp rules DataType and VarType mapping error.
- Delete to_prim from autograd __all__ list and supoort blacklist/whitelist feature.