### PR TITLE
【Hackathon 4th No.54】为 Paddle allclose、isclose 算子实现 float16 数据类型支持

### DIFF
--- a/paddle/phi/kernels/gpu/allclose_kernel.cu
+++ b/paddle/phi/kernels/gpu/allclose_kernel.cu
@@ -15,7 +15,7 @@
 #include "paddle/phi/kernels/allclose_kernel.h"
 
 #include "glog/logging.h"
-
+#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/enforce.h"
 #include "paddle/phi/core/kernel_registry.h"
 
@@ -92,7 +92,12 @@ void AllCloseKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(
-    allclose, GPU, ALL_LAYOUT, phi::AllCloseKernel, float, double) {
+PD_REGISTER_KERNEL(allclose,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::AllCloseKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {
   kernel->OutputAt(0).SetDataType(phi::DataType::BOOL);
 }

--- a/paddle/phi/kernels/gpu/isclose_kernel.cu
+++ b/paddle/phi/kernels/gpu/isclose_kernel.cu
@@ -13,10 +13,15 @@
 // limitations under the License.
 
 #include "paddle/phi/kernels/isclose_kernel.h"
-
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/impl/isclose_kernel_impl.h"
 
-PD_REGISTER_KERNEL(
-    isclose, GPU, ALL_LAYOUT, phi::IscloseKernel, float, double) {}
+PD_REGISTER_KERNEL(isclose,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::IscloseKernel,
+                   float,
+                   double,
+                   phi::dtype::float16) {}

--- a/paddle/phi/kernels/impl/isclose_kernel_impl.h
+++ b/paddle/phi/kernels/impl/isclose_kernel_impl.h
@@ -18,6 +18,7 @@
 
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/data_type.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -109,14 +110,16 @@ __global__ void IscloseCUDAKernel(const T* in_data,
                                   bool* out_data) {
   unsigned int idx = threadIdx.x + blockIdx.x * blockDim.x;
   bool val;
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   for (int i = idx; i < num; i += blockDim.x * gridDim.x) {
-    const T a = in_data[i], b = other_data[i];
+    const MPType a = static_cast<MPType>(in_data[i]),
+                 b = static_cast<MPType>(other_data[i]);
     if (isnan(a) || isnan(b)) {
       val = equal_nan && isnan(a) == isnan(b);
     } else {
-      T left = (a > b ? a - b : b - a);
-      T right = atol + (b > 0 ? rtol * b : (-rtol) * b);
-      T diff = (left > right ? left - right : right - left);
+      MPType left = (a > b ? a - b : b - a);
+      MPType right = atol + (b > 0 ? rtol * b : (-rtol) * b);
+      MPType diff = (left > right ? left - right : right - left);
       val = a == b || left <= right || diff <= 1e-15;
     }
     out_data[i] = val;

--- a/python/paddle/fluid/tests/unittests/test_allclose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_allclose_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+import paddle.fluid.core as core
 
 
 class TestAllcloseOp(OpTest):
@@ -97,6 +98,9 @@ class TestAllcloseOpSmallNum(TestAllcloseOp):
         self.equal_nan = False
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
 class TestAllcloseOpSmallNumFP16(TestAllcloseOp):
     def set_args(self):
         self.input = np.array([10000.0, 1e-08]).astype("float16")
@@ -179,6 +183,9 @@ class TestAllcloseError(unittest.TestCase):
         self.assertRaises(TypeError, test_equal_nan)
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
 class TestAllcloseOpFloat16(TestAllcloseOp):
     def set_args(self):
         self.input = np.array([10.1]).astype("float16")

--- a/python/paddle/fluid/tests/unittests/test_allclose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_allclose_op.py
@@ -143,16 +143,6 @@ class TestAllcloseDygraph(unittest.TestCase):
 
 class TestAllcloseError(unittest.TestCase):
     def test_input_dtype(self):
-        def test_x_dtype():
-            with paddle.static.program_guard(
-                paddle.static.Program(), paddle.static.Program()
-            ):
-                x = paddle.fluid.data(name='x', shape=[10, 10], dtype='float16')
-                y = paddle.fluid.data(name='y', shape=[10, 10], dtype='float64')
-                result = paddle.allclose(x, y)
-
-        self.assertRaises(TypeError, test_x_dtype)
-
         def test_y_dtype():
             with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/test_allclose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_allclose_op.py
@@ -97,6 +97,15 @@ class TestAllcloseOpSmallNum(TestAllcloseOp):
         self.equal_nan = False
 
 
+class TestAllcloseOpSmallNumFP16(TestAllcloseOp):
+    def set_args(self):
+        self.input = np.array([10000.0, 1e-08]).astype("float16")
+        self.other = np.array([10000.1, 1e-09]).astype("float16")
+        self.rtol = np.array([1e-05]).astype("float64")
+        self.atol = np.array([1e-08]).astype("float64")
+        self.equal_nan = False
+
+
 class TestAllcloseOpNanFalse(TestAllcloseOp):
     def set_args(self):
         self.input = np.array([1.0, float('nan')]).astype("float32")
@@ -168,6 +177,15 @@ class TestAllcloseError(unittest.TestCase):
             result = paddle.allclose(x, y, equal_nan=1)
 
         self.assertRaises(TypeError, test_equal_nan)
+
+
+class TestAllcloseOpFloat16(TestAllcloseOp):
+    def set_args(self):
+        self.input = np.array([10.1]).astype("float16")
+        self.other = np.array([10]).astype("float16")
+        self.rtol = np.array([0.01]).astype("float64")
+        self.atol = np.array([0]).astype("float64")
+        self.equal_nan = False
 
 
 class TestAllcloseOpFloat32(TestAllcloseOp):

--- a/python/paddle/fluid/tests/unittests/test_isclose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_isclose_op.py
@@ -175,16 +175,6 @@ class TestIscloseError(unittest.TestCase):
     def test_input_dtype(self):
         paddle.enable_static()
 
-        def test_x_dtype():
-            with paddle.static.program_guard(
-                paddle.static.Program(), paddle.static.Program()
-            ):
-                x = paddle.fluid.data(name='x', shape=[10, 10], dtype='float16')
-                y = paddle.fluid.data(name='y', shape=[10, 10], dtype='float64')
-                result = paddle.isclose(x, y)
-
-        self.assertRaises(TypeError, test_x_dtype)
-
         def test_y_dtype():
             with paddle.static.program_guard(
                 paddle.static.Program(), paddle.static.Program()

--- a/python/paddle/fluid/tests/unittests/test_isclose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_isclose_op.py
@@ -18,6 +18,7 @@ import numpy as np
 from op_test import OpTest
 
 import paddle
+import paddle.fluid.core as core
 
 
 class TestIscloseOp(OpTest):
@@ -98,6 +99,9 @@ class TestIscloseOpSmallNum(TestIscloseOp):
         self.equal_nan = False
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
 class TestIscloseOpSmallNumFP16(TestIscloseOp):
     def set_args(self):
         self.input = np.array([10000.0, 1e-08]).astype("float16")
@@ -212,6 +216,9 @@ class TestIscloseError(unittest.TestCase):
         self.assertRaises(TypeError, test_equal_nan)
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(), "core is not compiled with CUDA"
+)
 class TestIscloseOpFloat16(TestIscloseOp):
     def set_args(self):
         self.input = np.array([10.1]).astype("float16")

--- a/python/paddle/fluid/tests/unittests/test_isclose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_isclose_op.py
@@ -98,6 +98,15 @@ class TestIscloseOpSmallNum(TestIscloseOp):
         self.equal_nan = False
 
 
+class TestIscloseOpSmallNumFP16(TestIscloseOp):
+    def set_args(self):
+        self.input = np.array([10000.0, 1e-08]).astype("float16")
+        self.other = np.array([10000.1, 1e-09]).astype("float16")
+        self.rtol = np.array([1e-05]).astype("float64")
+        self.atol = np.array([1e-08]).astype("float64")
+        self.equal_nan = False
+
+
 class TestIscloseOpNanFalse(TestIscloseOp):
     def set_args(self):
         self.input = np.array([1.0, float('nan')]).astype("float32")
@@ -201,6 +210,15 @@ class TestIscloseError(unittest.TestCase):
             result = paddle.isclose(x, y, equal_nan=1)
 
         self.assertRaises(TypeError, test_equal_nan)
+
+
+class TestIscloseOpFloat16(TestIscloseOp):
+    def set_args(self):
+        self.input = np.array([10.1]).astype("float16")
+        self.other = np.array([10]).astype("float16")
+        self.rtol = np.array([0.01]).astype("float64")
+        self.atol = np.array([0]).astype("float64")
+        self.equal_nan = False
 
 
 class TestIscloseOpFloat32(TestIscloseOp):

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -362,8 +362,8 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
     two tensors are elementwise equal within a tolerance.
 
     Args:
-        x(Tensor): The input tensor, it's data type should be float32, float64..
-        y(Tensor): The input tensor, it's data type should be float32, float64..
+        x(Tensor): The input tensor, it's data type should be float16, float32, float64..
+        y(Tensor): The input tensor, it's data type should be float16, float32, float64..
         rtol(rtoltype, optional): The relative tolerance. Default: :math:`1e-5` .
         atol(atoltype, optional): The absolute tolerance. Default: :math:`1e-8` .
         equal_nan(equalnantype, optional): ${equal_nan_comment}.
@@ -402,8 +402,12 @@ def allclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
     if in_dygraph_mode():
         return _C_ops.allclose(x, y, rtol, atol, equal_nan)
     else:
-        check_variable_and_dtype(x, "input", ['float32', 'float64'], 'allclose')
-        check_variable_and_dtype(y, "input", ['float32', 'float64'], 'allclose')
+        check_variable_and_dtype(
+            x, "input", ['float16,', 'float32', 'float64'], 'allclose'
+        )
+        check_variable_and_dtype(
+            y, "input", ['float16,', 'float32', 'float64'], 'allclose'
+        )
         check_type(rtol, 'rtol', float, 'allclose')
         check_type(atol, 'atol', float, 'allclose')
         check_type(equal_nan, 'equal_nan', bool, 'allclose')
@@ -990,8 +994,8 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
     two tensors are elementwise equal within a tolerance.
 
     Args:
-        x(Tensor): The input tensor, it's data type should be float32, float64.
-        y(Tensor): The input tensor, it's data type should be float32, float64.
+        x(Tensor): The input tensor, it's data type should be float16, float32, float64.
+        y(Tensor): The input tensor, it's data type should be float16, float32, float64.
         rtol(rtoltype, optional): The relative tolerance. Default: :math:`1e-5` .
         atol(atoltype, optional): The absolute tolerance. Default: :math:`1e-8` .
         equal_nan(equalnantype, optional): If :math:`True` , then two :math:`NaNs` will be compared as equal. Default: :math:`False` .
@@ -1028,8 +1032,12 @@ def isclose(x, y, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
     if in_dygraph_mode():
         return _C_ops.isclose(x, y, rtol, atol, equal_nan)
     else:
-        check_variable_and_dtype(x, "input", ['float32', 'float64'], 'isclose')
-        check_variable_and_dtype(y, "input", ['float32', 'float64'], 'isclose')
+        check_variable_and_dtype(
+            x, "input", ['float16', 'float32', 'float64'], 'isclose'
+        )
+        check_variable_and_dtype(
+            y, "input", ['float16', 'float32', 'float64'], 'isclose'
+        )
         check_type(rtol, 'rtol', float, 'isclose')
         check_type(atol, 'atol', float, 'isclose')
         check_type(equal_nan, 'equal_nan', bool, 'isclose')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe

<table class="tg">
<thead>
  <tr>
    <th class="tg-5ioy" colspan="2">allclose</th>
    <th class="tg-5ioy" colspan="2">before</th>
    <th class="tg-5ioy" colspan="2">after</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td class="tg-5ioy">Case No.</td>
    <td class="tg-5ioy">input_shape</td>
    <td class="tg-5ioy">fp32(ms)</td>
    <td class="tg-5ioy">fp16(ms)</td>
    <td class="tg-5ioy">fp32(ms)</td>
    <td class="tg-5ioy">fp16(ms)</td>
  </tr>
  <tr>
    <td class="tg-5ioy">0</td>
    <td class="tg-5ioy">[16,10,100]</td>
    <td class="tg-5ioy">3.9588</td>
    <td class="tg-5ioy">3.923</td>
    <td class="tg-5ioy">4.0632</td>
    <td class="tg-5ioy">4.5353</td>
  </tr>
  <tr>
    <td class="tg-5ioy">1</td>
    <td class="tg-5ioy">[16, 256, 10, 10]</td>
    <td class="tg-5ioy">11.5456</td>
    <td class="tg-5ioy">9.1728</td>
    <td class="tg-5ioy">9.0451</td>
    <td class="tg-5ioy">6.6540</td>
  </tr>
  <tr>
    <td class="tg-5ioy">2</td>
    <td class="tg-5ioy">[100,100,100]</td>
    <td class="tg-5ioy">18.3031</td>
    <td class="tg-5ioy">17.8495</td>
    <td class="tg-5ioy">11.3204</td>
    <td class="tg-5ioy">10.9800</td>
  </tr>
</tbody>
</table>

<table>
<thead>
  <tr>
    <th colspan="2">isclose</th>
    <th colspan="2">before</th>
    <th colspan="2">after</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>Case No.</td>
    <td>input_shape</td>
    <td>fp32(ms)</td>
    <td>fp16(ms)</td>
    <td>fp32(ms)</td>
    <td>fp16(ms)</td>
  </tr>
  <tr>
    <td>0</td>
    <td>[1700971,1]</td>
    <td>12.2054</td>
    <td>11.5510</td>
    <td>11.6839</td>
    <td>12.3301</td>
  </tr>
  <tr>
    <td>1</td>
    <td>[17009,100]</td>
    <td>13.7947</td>
    <td>13.3367</td>
    <td>12.0218</td>
    <td>12.5707</td>
  </tr>
</tbody>
</table>

### 优化思路

- 将输入 `tensor` 的元素加载到共享内存中，然后在共享内存上进行比较。这种方法将减少全局内存访问次数，从而提高访问效率。(但是对于小数量可能反而会增加线程同步的开销，导致性能下降)
- 输入 `tensor` 只读。添加 `__restrict__` 关键字，编译器就可以更好地对代码进行优化
