### PR TITLE
【Hackathon No.52】为 Paddle dist 算子实现 float16 数据类型支持

### DIFF
--- a/paddle/phi/kernels/dist_grad_kernel.cc
+++ b/paddle/phi/kernels/dist_grad_kernel.cc
@@ -98,6 +98,11 @@ PD_REGISTER_KERNEL(
     dist_grad, CPU, ALL_LAYOUT, phi::DistGradKernel, float, double) {}
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-PD_REGISTER_KERNEL(
-    dist_grad, GPU, ALL_LAYOUT, phi::DistGradKernel, float, double) {}
+PD_REGISTER_KERNEL(dist_grad,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::DistGradKernel,
+                   phi::dtype::float16,
+                   float,
+                   double) {}
 #endif

--- a/paddle/phi/kernels/dist_kernel.cc
+++ b/paddle/phi/kernels/dist_kernel.cc
@@ -33,4 +33,10 @@ void DistKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(dist, CPU, ALL_LAYOUT, phi::DistKernel, float, double) {}
+PD_REGISTER_KERNEL(dist,
+                   CPU,
+                   ALL_LAYOUT,
+                   phi::DistKernel,
+                   phi::dtype::float16,
+                   float,
+                   double) {}

--- a/paddle/phi/kernels/dist_kernel.cc
+++ b/paddle/phi/kernels/dist_kernel.cc
@@ -33,10 +33,4 @@ void DistKernel(const Context& dev_ctx,
 
 }  // namespace phi
 
-PD_REGISTER_KERNEL(dist,
-                   CPU,
-                   ALL_LAYOUT,
-                   phi::DistKernel,
-                   phi::dtype::float16,
-                   float,
-                   double) {}
+PD_REGISTER_KERNEL(dist, CPU, ALL_LAYOUT, phi::DistKernel, float, double) {}

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -172,7 +172,7 @@ struct KeyValuePair<half> {
 template <typename T>
 __inline__ __device__ T WarpReduceSum(T val, unsigned lane_mask) {
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
-    val += CudaShuffleXorSync(lane_mask, val, mask);
+    val += phi::backends::gpu::CudaShuffleXorSync(lane_mask, val, mask);
   return val;
 }
 
@@ -241,7 +241,8 @@ __inline__ __device__ T BlockReduceSumV2(T *val) {
 template <typename T>
 __inline__ __device__ T WarpReduceMax(T val, unsigned lane_mask) {
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
-    val = std::max(val, CudaShuffleXorSync(lane_mask, val, mask));
+    val = std::max(
+        val, phi::backends::gpu::CudaShuffleXorSync(lane_mask, val, mask));
   return val;
 }
 
@@ -259,7 +260,8 @@ __inline__ __device__ T WarpReduceMaxV2(T *val) {
 template <typename T>
 __inline__ __device__ T WarpReduceMin(T val, unsigned lane_mask) {
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
-    val = std::min(val, CudaShuffleXorSync(lane_mask, val, mask, warpSize));
+    val = std::min(
+        val, phi::backends::gpu::CudaShuffleXorSync(lane_mask, val, mask));
   return val;
 }
 

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -199,7 +199,7 @@ __inline__ __device__ phi::dtype::float16 WarpReduceSum(phi::dtype::float16 val,
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
     val_ret += __shfl_xor_sync(lane_mask, val_ret, mask, warpSize);
 #else
-  val_ret = static_cast<float>(val);
+  float val_ret = static_cast<float>(val);
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
     val_ret += __shfl_xor(val_ret, mask, warpSize);
 #endif

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -24,6 +24,7 @@ limitations under the License. */
 #include <algorithm>
 
 #include "paddle/phi/backends/gpu/gpu_device_function.h"
+#include "paddle/phi/common/data_type.h"
 
 namespace phi {
 namespace funcs {
@@ -302,7 +303,7 @@ __inline__ __device__ T BlockReduceMax(T val, unsigned mask) {
 
   // align block_span to warpSize
   int block_span = (blockDim.x + warpSize - 1) >> 5;
-  val = (lane < block_span) ? shared[lane] : (T)-1e10f;
+  val = (lane < block_span) ? shared[lane] : std::numeric_limits<T>::min();
   val = WarpReduceMax(val, mask);
 
   return val;
@@ -350,7 +351,7 @@ __inline__ __device__ T BlockReduceMin(T val, unsigned mask) {
 
   // align block_span to warpSize
   int block_span = (blockDim.x + warpSize - 1) >> 5;
-  val = (lane < block_span) ? shared[lane] : (T)1e10f;
+  val = (lane < block_span) ? shared[lane] : std::numeric_limits<T>::max();
   val = WarpReduceMin(val, mask);
 
   return val;

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -194,14 +194,15 @@ __inline__ __device__ T WarpReduceSum(T val, unsigned lane_mask) {
 template <>
 __inline__ __device__ phi::dtype::float16 WarpReduceSum(phi::dtype::float16 val,
                                                         unsigned lane_mask) {
-  __half val_half = val.to_half();
-  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val_half += __shfl_xor_sync(lane_mask, val_half, mask, warpSize);
+  __half val_ret = val.to_half();
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
+    val_ret += __shfl_xor_sync(lane_mask, val_ret, mask, warpSize);
 #else
-    val_half += __shfl_xor(val_half, mask, warpSize);
+  val_ret = static_cast<float>(val);
+  val_ret += __shfl_xor(val_ret, mask, warpSize);
 #endif
-  return phi::dtype::float16(val_half);
+  return static_cast<phi::dtype::float16>(val_ret);
 }
 
 /* Calculate the sum of all elements in a block */
@@ -280,15 +281,16 @@ __inline__ __device__ T WarpReduceMax(T val, unsigned lane_mask) {
 template <>
 __inline__ __device__ phi::dtype::float16 WarpReduceMax(phi::dtype::float16 val,
                                                         unsigned lane_mask) {
-  __half val_half = val.to_half();
-  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val_half =
-        max(val_half, __shfl_xor_sync(lane_mask, val_half, mask, warpSize));
+  __half val_ret = val.to_half();
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
+    val_ret = max(val_ret, __shfl_xor_sync(lane_mask, val_ret, mask, warpSize));
 #else
-    val_half = max(val_half, __shfl_xor(val_half, mask, warpSize));
+  float val_ret = static_cast<float>(val);
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
+    val_ret = max(val_ret, __shfl_xor(val_ret, mask, warpSize));
 #endif
-  return phi::dtype::float16(val_half);
+  return static_cast<phi::dtype::float16>(val_ret);
 }
 
 template <typename T, int NUM>
@@ -316,15 +318,16 @@ __inline__ __device__ T WarpReduceMin(T val, unsigned lane_mask) {
 template <>
 __inline__ __device__ phi::dtype::float16 WarpReduceMin(phi::dtype::float16 val,
                                                         unsigned lane_mask) {
-  __half val_half = val.to_half();
-  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val_half =
-        min(val_half, __shfl_xor_sync(lane_mask, val_half, mask, warpSize));
+  __half val_ret = val.to_half();
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
+    val_ret = min(val_ret, __shfl_xor_sync(lane_mask, val_ret, mask, warpSize));
 #else
-    val_half = min(val_half, __shfl_xor(val_half, mask, warpSize));
+  float val_ret = static_cast<float>(val);
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
+    val_ret = min(val_ret, __shfl_xor(val_ret, mask, warpSize));
 #endif
-  return phi::dtype::float16(val_half);
+  return static_cast<phi::dtype::float16>(val_ret);
 }
 
 /* Calculate the minimum of all elements in a warp when actual quantity of

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -200,7 +200,8 @@ __inline__ __device__ phi::dtype::float16 WarpReduceSum(phi::dtype::float16 val,
     val_ret += __shfl_xor_sync(lane_mask, val_ret, mask, warpSize);
 #else
   val_ret = static_cast<float>(val);
-  val_ret += __shfl_xor(val_ret, mask, warpSize);
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
+    val_ret += __shfl_xor(val_ret, mask, warpSize);
 #endif
   return static_cast<phi::dtype::float16>(val_ret);
 }

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -30,16 +30,6 @@ namespace phi {
 namespace funcs {
 
 template <typename T>
-__device__ T max(T a, T b) {
-  return a > b ? a : b;
-}
-
-template <typename T>
-__device__ T min(T a, T b) {
-  return a < b ? a : b;
-}
-
-template <typename T>
 __device__ __forceinline__ T FromFloat(float a);
 
 template <typename T>
@@ -272,9 +262,9 @@ template <typename T>
 __inline__ __device__ T WarpReduceMax(T val, unsigned lane_mask) {
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val = max(val, __shfl_xor_sync(lane_mask, val, mask, warpSize));
+    val = std::max(val, __shfl_xor_sync(lane_mask, val, mask, warpSize));
 #else
-    val = max(val, __shfl_xor(val, mask, warpSize));
+    val = std::max(val, __shfl_xor(val, mask, warpSize));
 #endif
   return val;
 }
@@ -285,11 +275,12 @@ __inline__ __device__ phi::dtype::float16 WarpReduceMax(phi::dtype::float16 val,
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
   __half val_ret = val.to_half();
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
-    val_ret = max(val_ret, __shfl_xor_sync(lane_mask, val_ret, mask, warpSize));
+    val_ret =
+        std::max(val_ret, __shfl_xor_sync(lane_mask, val_ret, mask, warpSize));
 #else
   float val_ret = static_cast<float>(val);
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
-    val_ret = max(val_ret, __shfl_xor(val_ret, mask, warpSize));
+    val_ret = std::max(val_ret, __shfl_xor(val_ret, mask, warpSize));
 #endif
   return static_cast<phi::dtype::float16>(val_ret);
 }
@@ -309,9 +300,9 @@ template <typename T>
 __inline__ __device__ T WarpReduceMin(T val, unsigned lane_mask) {
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val = min(val, __shfl_xor_sync(lane_mask, val, mask, warpSize));
+    val = std::min(val, __shfl_xor_sync(lane_mask, val, mask, warpSize));
 #else
-    val = min(val, __shfl_xor(val, mask, warpSize));
+    val = std::min(val, __shfl_xor(val, mask, warpSize));
 #endif
   return val;
 }
@@ -322,11 +313,12 @@ __inline__ __device__ phi::dtype::float16 WarpReduceMin(phi::dtype::float16 val,
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
   __half val_ret = val.to_half();
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
-    val_ret = min(val_ret, __shfl_xor_sync(lane_mask, val_ret, mask, warpSize));
+    val_ret =
+        std::min(val_ret, __shfl_xor_sync(lane_mask, val_ret, mask, warpSize));
 #else
   float val_ret = static_cast<float>(val);
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
-    val_ret = min(val_ret, __shfl_xor(val_ret, mask, warpSize));
+    val_ret = std::min(val_ret, __shfl_xor(val_ret, mask, warpSize));
 #endif
   return static_cast<phi::dtype::float16>(val_ret);
 }
@@ -368,7 +360,7 @@ __inline__ __device__ T BlockReduceMax(T val, unsigned mask) {
 
   // align block_span to warpSize
   int block_span = (blockDim.x + warpSize - 1) >> 5;
-  val = (lane < block_span) ? shared[lane] : T(-1e10f);
+  val = (lane < block_span) ? shared[lane] : (T)-1e10f;
   val = WarpReduceMax(val, mask);
 
   return val;
@@ -416,7 +408,7 @@ __inline__ __device__ T BlockReduceMin(T val, unsigned mask) {
 
   // align block_span to warpSize
   int block_span = (blockDim.x + warpSize - 1) >> 5;
-  val = (lane < block_span) ? shared[lane] : T(1e10f);
+  val = (lane < block_span) ? shared[lane] : (T)1e10f;
   val = WarpReduceMin(val, mask);
 
   return val;

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -184,13 +184,14 @@ __inline__ __device__ T WarpReduceSum(T val, unsigned lane_mask) {
 template <>
 __inline__ __device__ phi::dtype::float16 WarpReduceSum(phi::dtype::float16 val,
                                                         unsigned lane_mask) {
+  __half val_half = val.to_half();
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val += __shfl_xor_sync(lane_mask, val.to_half(), mask, warpSize);
+    val_half += __shfl_xor_sync(lane_mask, val_half, mask, warpSize);
 #else
-    val += __shfl_xor(val.to_half(), mask, warpSize);
+    val_half += __shfl_xor(val_half, mask, warpSize);
 #endif
-  return phi::dtype::float16(val);
+  return phi::dtype::float16(val_half);
 }
 
 /* Calculate the sum of all elements in a block */
@@ -269,13 +270,15 @@ __inline__ __device__ T WarpReduceMax(T val, unsigned lane_mask) {
 template <>
 __inline__ __device__ phi::dtype::float16 WarpReduceMax(phi::dtype::float16 val,
                                                         unsigned lane_mask) {
+  __half val_half = val.to_half();
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val = max(val, __shfl_xor_sync(lane_mask, val.to_half(), mask, warpSize));
+    val_half =
+        max(val_half, __shfl_xor_sync(lane_mask, val_half, mask, warpSize));
 #else
-    val = max(val, __shfl_xor(val.to_half(), mask, warpSize));
+    val_half = max(val_half, __shfl_xor(val_half, mask, warpSize));
 #endif
-  return phi::dtype::float16(val);
+  return phi::dtype::float16(val_half);
 }
 
 template <typename T, int NUM>
@@ -303,13 +306,15 @@ __inline__ __device__ T WarpReduceMin(T val, unsigned lane_mask) {
 template <>
 __inline__ __device__ phi::dtype::float16 WarpReduceMin(phi::dtype::float16 val,
                                                         unsigned lane_mask) {
+  __half val_half = val.to_half();
   for (int mask = HALF_WARP; mask > 0; mask >>= 1)
 #if defined(PADDLE_WITH_CUDA) && (__CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000)
-    val = min(val, __shfl_xor_sync(lane_mask, val.to_half(), mask, warpSize));
+    val_half =
+        min(val_half, __shfl_xor_sync(lane_mask, val_half, mask, warpSize));
 #else
-    val = min(val, __shfl_xor(val.to_half(), mask, warpSize));
+    val_half = min(val_half, __shfl_xor(val_half, mask, warpSize));
 #endif
-  return phi::dtype::float16(val);
+  return phi::dtype::float16(val_half);
 }
 
 /* Calculate the minimum of all elements in a warp when actual quantity of

--- a/paddle/phi/kernels/funcs/math_cuda_utils.h
+++ b/paddle/phi/kernels/funcs/math_cuda_utils.h
@@ -30,6 +30,16 @@ namespace phi {
 namespace funcs {
 
 template <typename T>
+__device__ T max(T a, T b) {
+  return a > b ? a : b;
+}
+
+template <typename T>
+__device__ T min(T a, T b) {
+  return a < b ? a : b;
+}
+
+template <typename T>
 __device__ __forceinline__ T FromFloat(float a);
 
 template <typename T>

--- a/paddle/phi/kernels/gpu/dist_kernel.cu
+++ b/paddle/phi/kernels/gpu/dist_kernel.cu
@@ -136,12 +136,13 @@ void DistKernel(const Context& dev_ctx,
       ReduceSumWithSubtract<T, MT>
           <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
               x_ptr, y_ptr, i_ptr, n, ZeroOrderFunctor<T, MT>());
-      phi::funcs::ReduceKernel<MT, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
-          dev_ctx,
-          intermediate,
-          out,
-          kps::IdentityFunctor<MT, T>(),
-          reduce_axis);
+      phi::funcs::
+          ReduceKernel<MT, T, kps::AddFunctor, kps::IdentityFunctor<MT, T>>(
+              dev_ctx,
+              intermediate,
+              out,
+              kps::IdentityFunctor<MT, T>(),
+              reduce_axis);
 
     } else if (p == INFINITY) {
       T* i_ptr = dev_ctx.template Alloc<T>(&intermediate);
@@ -167,7 +168,7 @@ void DistKernel(const Context& dev_ctx,
           <<<config.block_per_grid.x, config.thread_per_block.x, 0, stream>>>(
               x_ptr, y_ptr, i_ptr, n, OtherOrderFunctor<T, MT>(p_order));
       phi::funcs::
-          ReduceKernel<MT, MT, kps::AddFunctor, kps::IdentityFunctor<T>>(
+          ReduceKernel<MT, MT, kps::AddFunctor, kps::IdentityFunctor<MT>>(
               dev_ctx,
               intermediate,
               out,

--- a/python/paddle/fluid/tests/unittests/test_dist_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_op.py
@@ -158,40 +158,40 @@ class TestDistOpCase5(TestDistOp):
         self.p = 1.5
 
 
-class TestDistOpWithFP16(TestDistOp):
+class TestDistFP16Op(OpTest):
     def init_data_type(self):
         self.data_type = 'float16'
 
 
-class TestDistOpWithFP16Case1(TestDistOpWithFP16):
+class TestDistFP16OpCase1(TestDistFP16Op):
     def init_case(self):
         self.x_shape = (3, 5, 5, 6)
         self.y_shape = (5, 5, 6)
         self.p = 1.0
 
 
-class TestDistOpWithFP16Case2(TestDistOpWithFP16):
+class TestDistFP16OpCase2(TestDistFP16Op):
     def init_case(self):
         self.x_shape = (10, 10)
         self.y_shape = (4, 10, 10)
         self.p = 2.0
 
 
-class TestDistOpWithFP16Case3(TestDistOpWithFP16):
+class TestDistFP16OpCase3(TestDistFP16Op):
     def init_case(self):
         self.x_shape = (15, 10)
         self.y_shape = (15, 10)
         self.p = float("inf")
 
 
-class TestDistOpWithFP16Case4(TestDistOpWithFP16):
+class TestDistFP16OpCase4(TestDistFP16Op):
     def init_case(self):
         self.x_shape = (2, 3, 4, 5, 8)
         self.y_shape = (3, 1, 5, 8)
         self.p = float("-inf")
 
 
-class TestDistOpWithFP16Case5(TestDistOpWithFP16):
+class TestDistFP16OpCase5(TestDistFP16Op):
     def init_case(self):
         self.x_shape = (4, 1, 4, 8)
         self.y_shape = (2, 2, 1, 4, 4, 8)
@@ -240,11 +240,6 @@ class TestDistAPI(unittest.TestCase):
         c = paddle.dist(a, b, 2)
         c.backward()
         paddle.enable_static()
-
-
-class TestDistAPIWithFP16(unittest.TestCase):
-    def init_data_type(self):
-        self.data_type = 'float16'
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_dist_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_op.py
@@ -158,6 +158,46 @@ class TestDistOpCase5(TestDistOp):
         self.p = 1.5
 
 
+class TestDistOpWithFP16(TestDistOp):
+    def init_data_type(self):
+        self.data_type = 'float16'
+
+
+class TestDistOpWithFP16Case1(TestDistOpWithFP16):
+    def init_case(self):
+        self.x_shape = (3, 5, 5, 6)
+        self.y_shape = (5, 5, 6)
+        self.p = 1.0
+
+
+class TestDistOpWithFP16Case2(TestDistOpWithFP16):
+    def init_case(self):
+        self.x_shape = (10, 10)
+        self.y_shape = (4, 10, 10)
+        self.p = 2.0
+
+
+class TestDistOpWithFP16Case3(TestDistOpWithFP16):
+    def init_case(self):
+        self.x_shape = (15, 10)
+        self.y_shape = (15, 10)
+        self.p = float("inf")
+
+
+class TestDistOpWithFP16Case4(TestDistOpWithFP16):
+    def init_case(self):
+        self.x_shape = (2, 3, 4, 5, 8)
+        self.y_shape = (3, 1, 5, 8)
+        self.p = float("-inf")
+
+
+class TestDistOpWithFP16Case5(TestDistOpWithFP16):
+    def init_case(self):
+        self.x_shape = (4, 1, 4, 8)
+        self.y_shape = (2, 2, 1, 4, 4, 8)
+        self.p = 1.5
+
+
 class TestDistAPI(unittest.TestCase):
     def init_data_type(self):
         self.data_type = (
@@ -200,6 +240,11 @@ class TestDistAPI(unittest.TestCase):
         c = paddle.dist(a, b, 2)
         c.backward()
         paddle.enable_static()
+
+
+class TestDistAPIWithFP16(unittest.TestCase):
+    def init_data_type(self):
+        self.data_type = 'float16'
 
 
 if __name__ == '__main__':

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -675,8 +675,8 @@ def dist(x, y, p=2, name=None):
         ||z||_{p}=(\sum_{i=1}^{m}|z_i|^p)^{\\frac{1}{p}}
 
     Args:
-        x (Tensor): 1-D to 6-D Tensor, its data type is float32 or float64.
-        y (Tensor): 1-D to 6-D Tensor, its data type is float32 or float64.
+        x (Tensor): 1-D to 6-D Tensor, its data type is float16, float32 or float64.
+        y (Tensor): 1-D to 6-D Tensor, its data type is flaot16, float32 or float64.
         p (float, optional): The norm to be computed, its data type is float32 or float64. Default: 2.
         name (str, optional): The default value is `None`. Normally there is no need for
             user to set this property. For more information, please refer to :ref:`api_guide_Name`.
@@ -706,8 +706,12 @@ def dist(x, y, p=2, name=None):
     if in_dygraph_mode():
         return _C_ops.dist(x, y, p)
 
-    check_variable_and_dtype(x, 'dtype', ['float32', 'float64'], 'dist')
-    check_variable_and_dtype(y, 'dtype', ['float32', 'float64'], 'dist')
+    check_variable_and_dtype(
+        x, 'dtype', ['float16', 'float32', 'float64'], 'dist'
+    )
+    check_variable_and_dtype(
+        y, 'dtype', ['float16', 'float32', 'float64'], 'dist'
+    )
     check_type(p, 'p', (float, int), 'dist')
     helper = LayerHelper("dist", **locals())
     out = helper.create_variable_for_type_inference(x.dtype)

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -676,7 +676,7 @@ def dist(x, y, p=2, name=None):
 
     Args:
         x (Tensor): 1-D to 6-D Tensor, its data type is float16, float32 or float64.
-        y (Tensor): 1-D to 6-D Tensor, its data type is flaot16, float32 or float64.
+        y (Tensor): 1-D to 6-D Tensor, its data type is float16, float32 or float64.
         p (float, optional): The norm to be computed, its data type is float32 or float64. Default: 2.
         name (str, optional): The default value is `None`. Normally there is no need for
             user to set this property. For more information, please refer to :ref:`api_guide_Name`.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Description
<!-- Describe what you’ve done -->
任务：https://github.com/PaddlePaddle/Paddle/issues/50658#task52

中文文档： https://github.com/PaddlePaddle/docs/pull/5740

OP Performance:
| OP| shape |p| fp32| fp16|
|---|---|---|---|---|
|dist_forward| [1000,1000]|2|0.05938422923185387|0.050949320501210746|
|dist_backward|[1000,1000]|2|0.11299653929107042| 0.08545359786675902|
|dist_forward| [1000,1000]|inf| 0.0472954341343471| 0.044048319057542445|
|dist_backward|[1000,1000]|inf| 0.09125203502421475 |0.08334651285288286|
|dist_forward| [1000,1000]|0| 0.04742607778432417| 0.045565683014538824 |
|dist_backward|[1000,1000]|0|  0.08797159000318877|0.08200139415507414|

[used AI Studio]