### PR TITLE
【Hackathon No.45】为 Paddle logical 算子实现 float16 数据类型支持

### DIFF
--- a/paddle/phi/kernels/kps/logical_kernel.cu
+++ b/paddle/phi/kernels/kps/logical_kernel.cu
@@ -69,12 +69,14 @@ PD_REGISTER_KERNEL(logical_or, KPS, ALL_LAYOUT, phi::LogicalOrKernel, int) {}
 PD_REGISTER_KERNEL(logical_not, KPS, ALL_LAYOUT, phi::LogicalNotKernel, int) {}
 PD_REGISTER_KERNEL(logical_xor, KPS, ALL_LAYOUT, phi::LogicalXorKernel, int) {}
 #else
+using float16 = phi::dtype::float16;
 #define REGISTER_LOGICAL_CUDA_KERNEL(logical_and, func_type) \
   PD_REGISTER_KERNEL(logical_and,                            \
                      KPS,                                    \
                      ALL_LAYOUT,                             \
                      phi::Logical##func_type##Kernel,        \
                      float,                                  \
+                     float16,                                \
                      double,                                 \
                      bool,                                   \
                      int64_t,                                \

--- a/python/paddle/fluid/tests/unittests/test_logical_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logical_op.py
@@ -133,7 +133,10 @@ def test(unit_test, use_gpu=False, test_error=False):
             META_DATA = dict(TEST_META_WRONG_SHAPE_DATA)
         for shape_data in META_DATA.values():
             for data_type in SUPPORTED_DTYPES:
-                if not use_gpu and data_type == np.float16:
+                if (
+                    not (paddle.is_compiled_with_cuda() and use_gpu)
+                    and data_type == np.float16
+                ):
                     continue
                 meta_data['x_np'] = np_data_generator(
                     shape_data['x_shape'], dtype=data_type
@@ -187,8 +190,13 @@ def test_type_error(unit_test, use_gpu, type_str_map):
     if use_gpu and paddle.is_compiled_with_cuda():
         place = paddle.CUDAPlace(0)
     for op_data in TEST_META_OP_DATA:
-        if use_gpu and (
-            type_str_map['x'] == np.float16 or type_str_map['y'] == np.float16
+        if (
+            paddle.is_compiled_with_cuda()
+            and use_gpu
+            and (
+                type_str_map['x'] == np.float16
+                or type_str_map['y'] == np.float16
+            )
         ):
             continue
 

--- a/python/paddle/fluid/tests/unittests/test_logical_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logical_op.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 
 import paddle
-from paddle.fluid import core
 from paddle.framework import _non_static_mode
 from paddle.static import Executor, Program, program_guard
 
@@ -134,6 +133,8 @@ def test(unit_test, use_gpu=False, test_error=False):
             META_DATA = dict(TEST_META_WRONG_SHAPE_DATA)
         for shape_data in META_DATA.values():
             for data_type in SUPPORTED_DTYPES:
+                if not use_gpu and data_type == np.float16:
+                    continue
                 meta_data['x_np'] = np_data_generator(
                     shape_data['x_shape'], dtype=data_type
                 )
@@ -186,6 +187,11 @@ def test_type_error(unit_test, use_gpu, type_str_map):
     if use_gpu and paddle.is_compiled_with_cuda():
         place = paddle.CUDAPlace(0)
     for op_data in TEST_META_OP_DATA:
+        if use_gpu and (
+            type_str_map['x'] == np.float16 or type_str_map['y'] == np.float16
+        ):
+            continue
+
         meta_data = dict(op_data)
         binary_op = meta_data['binary_op']
 
@@ -215,7 +221,6 @@ def type_map_factory():
     ]
 
 
-@unittest.skipIf(core.is_compiled_with_cuda(), "core is compiled with CUDA")
 class TestCPU(unittest.TestCase):
     def test(self):
         test(self)

--- a/python/paddle/fluid/tests/unittests/test_logical_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logical_op.py
@@ -26,6 +26,7 @@ SUPPORTED_DTYPES = [
     np.int16,
     np.int32,
     np.int64,
+    np.float16,
     np.float32,
     np.float64,
 ]

--- a/python/paddle/fluid/tests/unittests/test_logical_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logical_op.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 
 import paddle
+from paddle.fluid import core
 from paddle.framework import _non_static_mode
 from paddle.static import Executor, Program, program_guard
 
@@ -214,6 +215,7 @@ def type_map_factory():
     ]
 
 
+@unittest.skipIf(core.is_compiled_with_cuda(), "core is compiled with CUDA")
 class TestCPU(unittest.TestCase):
     def test(self):
         test(self)

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -45,7 +45,16 @@ def _logical_op(op_name, x, y, out=None, name=None, binary_op=True):
         check_variable_and_dtype(
             x,
             "x",
-            ["bool", "int8", "int16", "int32", "int64", "float32", "float64"],
+            [
+                "bool",
+                "int8",
+                "int16",
+                "int32",
+                "int64",
+                "float16",
+                "float32",
+                "float64",
+            ],
             op_name,
         )
         if y is not None:
@@ -58,6 +67,7 @@ def _logical_op(op_name, x, y, out=None, name=None, binary_op=True):
                     "int16",
                     "int32",
                     "int64",
+                    "float16",
                     "float32",
                     "float64",
                 ],
@@ -105,8 +115,8 @@ def logical_and(x, y, out=None, name=None):
         .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
 
     Args:
-        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
-        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
+        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
+        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
         out(Tensor, optional): The ``Tensor`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor`` will be created to save the output.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
@@ -147,8 +157,8 @@ def logical_or(x, y, out=None, name=None):
         .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
 
     Args:
-        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
-        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
+        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
+        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
         out(Tensor): The ``Variable`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor`` will be created to save the output.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
@@ -191,8 +201,8 @@ def logical_xor(x, y, out=None, name=None):
         .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
 
     Args:
-        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
-        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float32, float64.
+        x (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
+        y (Tensor): the input tensor, it's data type should be one of bool, int8, int16, in32, in64, float16, float32, float64.
         out(Tensor): The ``Tensor`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor`` will be created to save the output.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
@@ -237,7 +247,7 @@ def logical_not(x, out=None, name=None):
         .. _Introduction to Tensor: ../../guides/beginner/tensor_en.html#chapter5-broadcasting-of-tensor
 
     Args:
-        x(Tensor):  Operand of logical_not operator. Must be a Tensor of type bool, int8, int16, in32, in64, float32, or float64.
+        x(Tensor):  Operand of logical_not operator. Must be a Tensor of type bool, int8, int16, in32, in64, float16, float32, or float64.
         out(Tensor): The ``Tensor`` that specifies the output of the operator, which can be any ``Tensor`` that has been created in the program. The default value is None, and a new ``Tensor` will be created to save the output.
         name(str|None): The default value is None. Normally there is no need for users to set this property. For more information, please refer to :ref:`api_guide_Name`.
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
性能数据（op benchmark）
<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">
<head>

<meta name=Generator content="Microsoft Excel">

</head>
<body>
<!--StartFragment-->


op | shape_x | shape_y | fp32 | fp16
-- | -- | -- | -- | --
logical_and | 16, 3, 224, 224 | 16, 3, 224, 224 | 0.045765419 | 0.033781723
  | 16, 102400 | 16, 102400 | 0.036889436 | 0.028767634
  | 128, 128 | 128, 128 | 0.017890638 | 0.017675818
logical_or | 16, 3, 224, 224 | 16, 3, 224, 224 | 0.045839135 | 0.033784886
  | 16, 102400 | 16, 102400 | 0.037104986 | 0.028587117
  | 128, 128 | 128, 128 | 0.017838575 | 0.017863147
logical_xor | 16, 3, 224, 224 | 16, 3, 224, 224 | 0.045718952 | 0.03373039
  | 16, 102400 | 16, 102400 | 0.036929578 | 0.028795612
  | 128, 128 | 128, 128 | 0.01771596 | 0.017614511
logical_not | 16, 3, 224, 224 | none | 0.036817181 | 0.030557233
  | 16, 102400 | none | 0.031756382 | 0.02452792
  | 128, 128 | none | 0.022468275 | 0.022301382


<!--EndFragment-->
</body>

</html>

























































































