### PR TITLE
Cache for cublaslt descriptor

### DIFF
--- a/paddle/phi/kernels/autotune/cache_base.h
+++ b/paddle/phi/kernels/autotune/cache_base.h
@@ -60,10 +60,6 @@ size_t GenKey(Args&&... args) {
   return seed;
 }
 
-struct MatmulHashValueType {
-  uint64_t data[8];
-};
-
 struct MatmulCacheKey {
  public:
   MatmulCacheKey() {}
@@ -79,7 +75,7 @@ struct MatmulCacheKey {
                  static_cast<int64_t>(dtype));
   }
   size_t GetKey() const { return key; }
-  size_t GetSubKey(int64_t idx) const { return GenKey(key, idx); }
+  size_t GenSubKey(int64_t idx) const { return GenKey(key, idx); }
 
  private:
   size_t key;
@@ -249,22 +245,22 @@ class MatmulAlgorithmsCache : public AlgorithmsCache<KeyT, AlgorithmT> {
     return ret;
   }
 
-  void SetSubKey(const KeyT& sub_key, const MatmulHashValueType* algo) {
+  void SetSubKey(const KeyT& sub_key, void* algo) {
     std::lock_guard<std::mutex> lock(*(this->cache_mutex_));
-    sub_hash_[sub_key] = *algo;
+    sub_hash_[sub_key] = algo;
   }
 
-  MatmulHashValueType* GetSubAlgo(const KeyT& sub_key) {
+  void* GetSubKey(const KeyT& sub_key) {
     std::lock_guard<std::mutex> lock(*(this->cache_mutex_));
     PADDLE_ENFORCE_NE(
         sub_hash_.find(sub_key),
         sub_hash_.end(),
         phi::errors::PreconditionNotMet("The key does not exist."));
-    return &(sub_hash_[sub_key]);
+    return sub_hash_[sub_key];
   }
 
  private:
-  std::unordered_map<KeyT, MatmulHashValueType> sub_hash_;
+  std::unordered_map<KeyT, void*> sub_hash_;
 };
 
 }  // namespace autotune

--- a/paddle/phi/kernels/autotune/cache_base.h
+++ b/paddle/phi/kernels/autotune/cache_base.h
@@ -254,7 +254,7 @@ class MatmulAlgorithmsCache : public AlgorithmsCache<KeyT, AlgorithmT> {
     sub_hash_[sub_key] = *algo;
   }
 
-  MatmulHashValueType* GetSubKey(const KeyT& sub_key) {
+  MatmulHashValueType* GetSubAlgo(const KeyT& sub_key) {
     std::lock_guard<std::mutex> lock(*(this->cache_mutex_));
     PADDLE_ENFORCE_NE(
         sub_hash_.find(sub_key),

--- a/paddle/phi/kernels/funcs/blas/blaslt_impl.cu.h
+++ b/paddle/phi/kernels/funcs/blas/blaslt_impl.cu.h
@@ -82,8 +82,7 @@ struct MatmulDescriptor {
     }
   }
 
-  // As far as concerned, x_desc, y_desc, op_desc are all
-  // allocated in heap memory.
+  // x_desc, y_desc, op_desc are all allocated in heap memory.
   template <typename T>
   void Create(const int M,
               const int N,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
- Feature :

Everytime cublaslt create op descriptor `x_dec, y_desc, out_desc, op_desc, algo `, heap memory is needed. However, heap memory allocation and free cost much host time, apparently affect performance of Matmul OP execution. Feature in this PR, is just cache the heap memory that allocated for the 1st time, and decrease the host time cost while this op executing.

- Performance :  

PaddleHelix alphafold model trainning performance increase about 1.7%, from 3.22s/step to 3.16s/step.


- Other : 

Op descriptor creation relies on heap memory, a better memory management will be needed for heap memory cache.