### PR TITLE
[Zero-Dim] support input 0D for gcd and lcm

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_zero_dim_tensor.py
@@ -282,6 +282,8 @@ binary_int_api_list = [
     paddle.bitwise_and,
     paddle.bitwise_or,
     paddle.bitwise_xor,
+    paddle.gcd,
+    paddle.lcm,
 ]
 
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4432,15 +4432,19 @@ def gcd(x, y, name=None):
     y = paddle.broadcast_to(y, shape)
     x = paddle.abs(x)
     y = paddle.abs(y)
+    # TODO(zhouwei25): Support 0D for not_equal tensor with scalar
+    zero = paddle.full([], 0)
 
     def _gcd_cond_fn(x, y):
-        return paddle.any(y != 0)
+        # return paddle.any(y != 0)
+        return paddle.any(y != zero)
 
     def _gcd_body_fn(x, y):
         # paddle.mod will raise an error when any element of y is 0. To avoid
         # that, we change those zeros to ones. Their values don't matter because
         # they won't be used.
-        y_not_equal_0 = y != 0
+        # y_not_equal_0 = y != 0
+        y_not_equal_0 = y != zero
         y_safe = paddle.where(y_not_equal_0, y, paddle.ones(y.shape, y.dtype))
         x, y = (
             paddle.where(y_not_equal_0, y, x),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
add zero-dim unit test for gcd and lcm