### PR TITLE
update xpu.cmake to 20230227

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -7,7 +7,7 @@ set(XPU_PROJECT "extern_xpu")
 set(XPU_API_LIB_NAME "libxpuapi.so")
 set(XPU_RT_LIB_NAME "libxpurt.so")
 
-set(XPU_BASE_DATE "20230220")
+set(XPU_BASE_DATE "20230227")
 set(XPU_XCCL_BASE_VERSION "1.0.10")
 
 if(NOT DEFINED XPU_BASE_URL)


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
更新xpu.cmake日期至20230227，修复pool2d在某个规模下计算出错的问题.
