### PR TITLE
[CodeStyle] fix flake8 cannot find the config on Windows

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,16 +13,26 @@ exclude =
     ./python/paddle/fluid/tests/unittests/npu/**,
     ./python/paddle/fluid/tests/unittests/mlu/**
 ignore =
-    E203, # Whitespace before ‘,’, ‘;’, or ‘:’, it is not compatible with black
-    E402, # Module level import not at top of file
-    E501, # Line too long (82 > 79 characters)
-    E721, # Do not compare types, use `isinstance()`
-    E722, # Do not use bare except, specify exception instead
-    E731, # Do not assign a lambda expression, use a def
-    E741, # Do not use variables named ‘l’, ‘O’, or ‘I’
-    F405, # `name` may be undefined, or defined from star imports: `module`
-    F841, # Local variable name is assigned to but never used
-    W503  # Line break before binary operator, it is not compatible with black
+    # Whitespace before ‘,’, ‘;’, or ‘:’, it is not compatible with black
+    E203,
+    # Module level import not at top of file
+    E402,
+    # Line too long (82 > 79 characters)
+    E501,
+    # Do not compare types, use `isinstance()`
+    E721,
+    # Do not use bare except, specify exception instead
+    E722,
+    # Do not assign a lambda expression, use a def
+    E731,
+    # Do not use variables named ‘l’, ‘O’, or ‘I’
+    E741,
+    # `name` may be undefined, or defined from star imports: `module`
+    F405,
+    # Local variable name is assigned to but never used
+    F841,
+    # Line break before binary operator, it is not compatible with black
+    W503
 per-file-ignores =
     # These files need tabs for testing.
     python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py:E101,W191

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,9 +64,10 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
+        args: ["--config=.flake8"]
 -   repo: https://github.com/PyCQA/autoflake
     rev: v1.7.7
     hooks:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

fixes #50982

修复 Windows 下有时会找不到 flake8 配置的问题，并同时升级 flake8 到 5.0.4（无新的存量问题，可以直接升级）
