### PR TITLE
[PHI Decoupling]fix custom plugin include headers error

### DIFF
--- a/paddle/phi/core/tensor_utils.h
+++ b/paddle/phi/core/tensor_utils.h
@@ -14,17 +14,12 @@ limitations under the License. */
 
 #pragma once
 
-#include "paddle/phi/backends/all_context.h"
-#include "paddle/phi/backends/cpu/cpu_context.h"
-#include "paddle/phi/common/place.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/device_context.h"
 #include "paddle/phi/core/selected_rows.h"
 #include "paddle/phi/core/sparse_coo_tensor.h"
 #include "paddle/phi/core/sparse_csr_tensor.h"
 #include "paddle/phi/core/tensor_meta.h"
-#include "paddle/phi/core/utils/data_type.h"
-
 namespace phi {
 
 class DenseTensorUtils {
@@ -149,35 +144,6 @@ inline T GetValue(const Context& dev_ctx, const DenseTensor& x) {
 }
 
 template <typename T = int32_t>
-inline std::vector<T> GetVectorFromTensor(const phi::DenseTensor* x) {
-  std::vector<T> vec_new_data;
-  if (phi::TransToProtoVarType(x->dtype()) == ProtoDataType::INT32) {
-    auto* data = x->data<int>();
-    phi::DenseTensor cpu_attr_tensor;
-    if (!paddle::platform::is_cpu_place(x->place())) {
-      phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
-      auto dev_ctx = pool.Get(x->place());
-      phi::Copy(*dev_ctx, *x, CPUPlace(), true, &cpu_attr_tensor);
-      data = cpu_attr_tensor.data<int>();
-    }
-    vec_new_data = std::vector<T>(data, data + x->numel());
-  } else if (phi::TransToProtoVarType(x->dtype()) == ProtoDataType::INT64) {
-    auto* data = x->data<int64_t>();
-    phi::DenseTensor cpu_attr_tensor;
-    if (!paddle::platform::is_cpu_place(x->place())) {
-      phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
-      auto dev_ctx = pool.Get(x->place());
-      phi::Copy(*dev_ctx, *x, CPUPlace(), true, &cpu_attr_tensor);
-      data = cpu_attr_tensor.data<int64_t>();
-    }
-    // NOTE: Converting int64 to int32 may cause data overflow.
-    vec_new_data = std::vector<T>(data, data + x->numel());
-  } else {
-    PADDLE_THROW(phi::errors::InvalidArgument(
-        "The dtype of Tensor must be int32 or int64, but received: %s",
-        phi::TransToProtoVarType(x->dtype())));
-  }
-  return vec_new_data;
-}
+std::vector<T> GetVectorFromTensor(const phi::DenseTensor* x);
 
 }  // namespace phi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复PHI解藕算子的一个隐蔽错误
https://github.com/PaddlePaddle/Paddle/commit/6c181d1d8c503db3200f23f7bd8b9c7493e2eb24

phi::GetVectorFromTensor 直接inline暴露在外，会在custom plugin开发时引起头文件引用错误

```
[build] ../third_party/paddle/include/paddle/phi/core/tensor_utils.h: In function ‘std::vector<_RealType> phi::GetVectorFromTensor(const phi::DenseTensor*)’:
[build] ../third_party/paddle/include/paddle/phi/core/tensor_utils.h:157:28: error: ‘is_cpu_place’ is not a member of ‘paddle::platform’
[build] 157 | if (!paddle::platform::is_cpu_place(x->place())) {
[build] | ^~~~~~~~~~~~
[build] ../third_party/paddle/include/paddle/phi/core/tensor_utils.h:158:12: error: ‘DeviceContextPool’ is not a member of ‘phi’; did you mean ‘DeviceContext’?
[build] 158 | phi::DeviceContextPool& pool = phi::DeviceContextPool::Instance();
[build] | ^~~~~~~~~~~~~~~~~
[build] | DeviceContext
```
在#include "paddle/phi/extension.h"的时候
paddle::platform::is_cpu_place  这个是目前不可见的，改为phi::AllocationType::CPU进行判断

另外在device_context.h进行了如下定义
#define PADDLE_WITH_CUSTOM_KERNEL 1
```
#ifndef PADDLE_WITH_CUSTOM_KERNEL
// TODO(wilber): DeviceContextPool nees include fluid file.
#include "paddle/fluid/platform/device_context.h"

namespace phi {
using DeviceContextPool = paddle::platform::DeviceContextPool;
} // namespace phi
#endif
```
在custom plugin开发时禁止引用DeviceContextPool，变为不可见。

这个PR将GetVectorFromTensor 将实现改入到tensor_utils.cc中，避免custom plugin遇到头文件错误问题。

另外删除多加的头文件