### PR TITLE
[with_data_parallel][part6.2] remove with_data_parallel in fleet

### DIFF
--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -1465,7 +1465,7 @@ class Fleet:
 
                 compiled_program = compiler.CompiledProgram(
                     self.origin_main_program
-                ).with_data_parallel(loss_name=loss.name, share_vars_from=None)
+                )
                 loss.block.program._graph = compiled_program
                 return self.user_defined_optimizer.minimize(
                     loss,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The api `with_data_parallel` will be removed after paddle2.5. So its references should be removed at same time.
The `with_data_parallel` here does nothing so simply removed it.

#### Others
Pcard-67004