### PR TITLE
fix zero bug  of case18: paddle.logsumexp

### DIFF
--- a/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
+++ b/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
@@ -36,6 +36,7 @@ struct LogsumexpFunctor {
   void operator()(const Context& place, X* x, Y* y, const Dim& dim) {
     using MT = typename phi::dtype::MPTypeTrait<T>::Type;
     auto x_dim = x->dimensions();
+
     auto t_dim = x_dim;
     for (int i = 0; i < static_cast<int>(dim.size()); i++) {
       t_dim[dim[i]] = 1;
@@ -70,7 +71,13 @@ void LogsumexpKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
 
   reduce_all = recompute_reduce_all(x, axis, reduce_all);
-
+  auto x_dim = x.dims();
+  for (int i = 0; i < x_dim.size(); i++) {
+    PADDLE_ENFORCE_LT(0,
+                      x_dim[i],
+                      errors::InvalidArgument(
+                          "The dims of Input(X) should be greater than 0."));
+  }
   if (reduce_all) {
     // Flatten and reduce 1-D tensor
     auto input = phi::EigenVector<T>::Flatten(x);

--- a/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
+++ b/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
@@ -36,7 +36,6 @@ struct LogsumexpFunctor {
   void operator()(const Context& place, X* x, Y* y, const Dim& dim) {
     using MT = typename phi::dtype::MPTypeTrait<T>::Type;
     auto x_dim = x->dimensions();
-
     auto t_dim = x_dim;
     for (int i = 0; i < static_cast<int>(dim.size()); i++) {
       t_dim[dim[i]] = 1;

--- a/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
+++ b/paddle/phi/kernels/impl/logsumexp_kernel_impl.h
@@ -70,6 +70,7 @@ void LogsumexpKernel(const Context& dev_ctx,
   dev_ctx.template Alloc<T>(out);
 
   reduce_all = recompute_reduce_all(x, axis, reduce_all);
+
   auto x_dim = x.dims();
   for (int i = 0; i < x_dim.size(); i++) {
     PADDLE_ENFORCE_LT(0,

--- a/python/paddle/fluid/tests/unittests/test_logsumexp.py
+++ b/python/paddle/fluid/tests/unittests/test_logsumexp.py
@@ -238,7 +238,7 @@ class TestLogsumexpAPI(unittest.TestCase):
         paddle.enable_static()
 
 
-#Test logsumexp bug
+# Test logsumexp bug
 class TestLogZeroError(unittest.TestCase):
     def test_errors(self):
         with paddle.fluid.dygraph.guard():
@@ -248,7 +248,7 @@ class TestLogZeroError(unittest.TestCase):
                 x = paddle.to_tensor(
                     np.reshape(array, [0, 0, 0]), dtype='float32'
                 )
-                paddle.logsumexp(x,axis=1)
+                paddle.logsumexp(x, axis=1)
 
             self.assertRaises(ValueError, test_0_size)
 

--- a/python/paddle/fluid/tests/unittests/test_logsumexp.py
+++ b/python/paddle/fluid/tests/unittests/test_logsumexp.py
@@ -238,5 +238,20 @@ class TestLogsumexpAPI(unittest.TestCase):
         paddle.enable_static()
 
 
+#Test logsumexp bug
+class TestLogZeroError(unittest.TestCase):
+    def test_errors(self):
+        with paddle.fluid.dygraph.guard():
+
+            def test_0_size():
+                array = np.array([], dtype=np.float32)
+                x = paddle.to_tensor(
+                    np.reshape(array, [0, 0, 0]), dtype='float32'
+                )
+                paddle.logsumexp(x,axis=1)
+
+            self.assertRaises(ValueError, test_0_size)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
`paddle.logsumexp`在如下代码会报错:
`import paddle
import numpy as np
array = np.array([], dtype=np.float32)
x = paddle.to_tensor(np.reshape(array, [0] * 3), dtype='float32')
paddle.logsumexp(x, axis=0)`
原因:问题在于没有对输入进行检查, 输入的size不能为0
解决方案: 在c++代码中添加检查,并增加相应的单测代码.
#49927 
#49919

