### PR TITLE
patch for bool tensor indexing with shape -1

### DIFF
--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -321,14 +321,19 @@ def get_value_for_bool_tensor(var, item):
             "the dims of bool index except to be equal or less "
             "than {}, but received {}.".format(len(var.shape), len(item.shape))
         )
-    for i, dim_len in enumerate(item.shape):
-        if dim_len != var.shape[i]:
+    i = 0
+    item_shape = item.shape
+    while i < len(item.shape):
+        dim_len = item_shape[i]
+        if dim_len != -1 and var.shape[i] != -1 and dim_len != var.shape[i]:
             raise IndexError(
                 "The dimension of bool index doesn't match indexed array along "
                 "dimension {}, the target dimension is {}, but received {}.".format(
                     i, var.shape[i], dim_len
                 )
             )
+        i += 1
+    empty_shape = [0] + list(var.shape[i:])
 
     def idx_not_empty(var, item):
         from ..tensor import gather_nd
@@ -336,15 +341,12 @@ def get_value_for_bool_tensor(var, item):
         bool_2_idx = paddle.nonzero(item == True)
         return gather_nd(var, bool_2_idx)
 
-    def idx_empty(var):
-        var_shape = list(var.shape)
-        var_shape[0] = 0
-        return paddle.empty(var_shape, dtype=var.dtype)
-
     from paddle.static.nn import cond
 
     return cond(
-        item.any(), lambda: idx_not_empty(var, item), lambda: idx_empty(var)
+        item.any(),
+        lambda: idx_not_empty(var, item),
+        lambda: paddle.empty(empty_shape, var.dtype),
     )
 
 
@@ -849,7 +851,7 @@ def set_value_for_bool_tensor(var, item, value):
             "than {}, but received {}.".format(len(var.shape), len(item.shape))
         )
     for i, dim_len in enumerate(item.shape):
-        if dim_len != var.shape[i]:
+        if dim_len != -1 and var.shape[i] != -1 and dim_len != var.shape[i]:
             raise IndexError(
                 "The dimension of bool index doesn't match indexed array along "
                 "dimension {}, the target dimension is {}, but received {}.".format(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
This PR is a patch, which is to support bool tensor indexing with shape -1.

```python
import paddle

paddle.enable_static()
x = paddle.static.data(name='x', shape=[-1, 1, -1], dtype='float32')
index = paddle.static.data(name='index', shape=[-1, 1, -1], dtype='bool')
a = paddle.static.data(name="a", shape=[-1, ])
# getitem for bool tensor
out = x[index]

# setitem for bool tensor
x[index] = a
```

**Note1**:  A incompatible change will be introduced by this PR. However, it is consistent with Numpy.
```python
x = paddle.rand((2,3,4))
index = x < 0   # all elements are False
x[index].shape 

# before this PR :  [0, 3, 4]
# After this PR: [0]

index = index[:, :, 0]  # shape of index is [2, 3]
x[index].shape 
# before this PR :  [0, 3, 4]
# After this PR: [0, 4]
```

**Note2**: This PR is just a patch, which cannot completely solve indexing problem. The indexing of Paddle still needs to be re-designed. The following case are still not be supported.
```python
# when length of index is less than x, and the later part of x.shape contains -1
x = paddle.static.data(name='x', shape=[-1, 1, -1], dtype='float32')
index = paddle.static.data(name='index', shape=[-1, 1], dtype='bool')
x[index] = a   # will raise a error
```