### PR TITLE
Update weight_norm_hook.py

### DIFF
--- a/python/paddle/nn/utils/weight_norm_hook.py
+++ b/python/paddle/nn/utils/weight_norm_hook.py
@@ -232,7 +232,7 @@ def remove_weight_norm(layer, name='weight'):
             # Conv2D(3, 5, kernel_size=[3, 3], data_format=NCHW)
 
             remove_weight_norm(conv)
-            # print(conv.weight_g)
+            print(conv.weight_g)
             # AttributeError: 'Conv2D' object has no attribute 'weight_g'
     """
     for k, hook in layer._forward_pre_hooks.items():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
去掉了代码示例中print(conv.weight_g)前的#

```python
remove_weight_norm(conv)
# print(conv.weight_g)
# AttributeError: 'Conv2D' object has no attribute 'weight_g'
```
改成：
```python
remove_weight_norm(conv)
print(conv.weight_g)
# AttributeError: 'Conv2D' object has no attribute 'weight_g'
```