### PR TITLE
fix a bug calculate_output in eagerChecker

### DIFF
--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -1856,7 +1856,7 @@ class OpTest(unittest.TestCase):
                         ref_eager_dygraph_outs = (
                             self.op_test._calc_python_api_output(place)
                         )
-                        if eager_dygraph_outs is None:
+                        if ref_eager_dygraph_outs is None:
                             self.is_python_api_test = False
                             ref_eager_dygraph_outs = (
                                 self.op_test._calc_dygraph_output(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix a bug calculate_output in eagerChecker，the eager_dygraph_outs needs is produced by the _calc_python_api_output function of fp16, but ref_eager_dygraph_outs which is produced by the _calc_python_api_output function of fp32 should be needed in the branch of is_fp16_compared_with_fp32()