### PR TITLE
[IR] Type system stage4: Add some built-in types and type conversion methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ option(WITH_CUDNN_FRONTEND
        "Compile with CUDNN Frontend API support (experimental)" OFF)
 option(WITH_CUDNN_DSO "Compile PaddlePaddle with cuDNN dynamic-link libraries"
        OFF)
-option(WITH_NEWIR "Compile PaddlePaddle with NEWIR" OFF)
+option(WITH_NEWIR "Compile PaddlePaddle with NEWIR" ON)
 
 if(WITH_RECORD_BUILDTIME)
   set_property(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ option(WITH_CUDNN_FRONTEND
        "Compile with CUDNN Frontend API support (experimental)" OFF)
 option(WITH_CUDNN_DSO "Compile PaddlePaddle with cuDNN dynamic-link libraries"
        OFF)
-option(WITH_NEWIR "Compile PaddlePaddle with NEWIR" ON)
+option(WITH_NEWIR "Compile PaddlePaddle with NEWIR" OFF)
 
 if(WITH_RECORD_BUILDTIME)
   set_property(

--- a/paddle/ir/builtin_type.cc
+++ b/paddle/ir/builtin_type.cc
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/ir/builtin_type.h"
+
+namespace ir {
+ir::Type DenseTensorType::dtype() { return storage()->dtype_; }
+
+ir::DenseTensorTypeStorage::Dim DenseTensorType::dim() {
+  return storage()->dims_;
+}
+
+ir::DenseTensorTypeStorage::DataLayout DenseTensorType::data_layout() {
+  return storage()->layout_;
+}
+
+ir::DenseTensorTypeStorage::LoD DenseTensorType::lod() {
+  return storage()->lod_;
+}
+
+size_t DenseTensorType::offset() { return storage()->offset_; }
+}  // namespace ir

--- a/paddle/ir/builtin_type.cc
+++ b/paddle/ir/builtin_type.cc
@@ -15,19 +15,19 @@
 #include "paddle/ir/builtin_type.h"
 
 namespace ir {
-ir::Type DenseTensorType::dtype() { return storage()->dtype_; }
+ir::Type& DenseTensorType::dtype() { return storage()->dtype_; }
 
-ir::DenseTensorTypeStorage::Dim DenseTensorType::dim() {
+ir::DenseTensorTypeStorage::Dim& DenseTensorType::dim() {
   return storage()->dims_;
 }
 
-ir::DenseTensorTypeStorage::DataLayout DenseTensorType::data_layout() {
+ir::DenseTensorTypeStorage::DataLayout& DenseTensorType::data_layout() {
   return storage()->layout_;
 }
 
-ir::DenseTensorTypeStorage::LoD DenseTensorType::lod() {
+ir::DenseTensorTypeStorage::LoD& DenseTensorType::lod() {
   return storage()->lod_;
 }
 
-size_t DenseTensorType::offset() { return storage()->offset_; }
+size_t& DenseTensorType::offset() { return storage()->offset_; }
 }  // namespace ir

--- a/paddle/ir/builtin_type.cc
+++ b/paddle/ir/builtin_type.cc
@@ -15,19 +15,20 @@
 #include "paddle/ir/builtin_type.h"
 
 namespace ir {
-ir::Type& DenseTensorType::dtype() { return storage()->dtype_; }
+const ir::Type& DenseTensorType::dtype() const { return storage()->dtype_; }
 
-ir::DenseTensorTypeStorage::Dim& DenseTensorType::dim() {
+const ir::DenseTensorTypeStorage::Dim& DenseTensorType::dim() const {
   return storage()->dims_;
 }
 
-ir::DenseTensorTypeStorage::DataLayout& DenseTensorType::data_layout() {
+const ir::DenseTensorTypeStorage::DataLayout& DenseTensorType::data_layout()
+    const {
   return storage()->layout_;
 }
 
-ir::DenseTensorTypeStorage::LoD& DenseTensorType::lod() {
+const ir::DenseTensorTypeStorage::LoD& DenseTensorType::lod() const {
   return storage()->lod_;
 }
 
-size_t& DenseTensorType::offset() { return storage()->offset_; }
+const size_t& DenseTensorType::offset() const { return storage()->offset_; }
 }  // namespace ir

--- a/paddle/ir/builtin_type.h
+++ b/paddle/ir/builtin_type.h
@@ -20,14 +20,22 @@
 namespace ir {
 ///
 /// \brief This macro is used to get a list of all built-in types in this file.
+/// The built-in Dialect will use this macro to quickly register all built-in
+/// types.
 ///
 #define GET_BUILT_IN_TYPE_LIST                                      \
   ir::Float16Type, ir::Float32Type, ir::Float64Type, ir::Int16Type, \
       ir::Int32Type, ir::Int64Type, ir::DenseTensorType
 
 ///
-/// \brief Definitions of built-in type classes. The built-in type object get
-/// method is as follows:
+/// \brief Define built-in parameterless types. Please add the necessary
+/// interface functions for built-in types through the macro
+/// DECLARE_TYPE_UTILITY_FUNCTOR. NOTE(zhangbo9674): If you need to directly
+/// cache the object of this built-in type in IrContext, please overload the get
+/// method, and construct and cache the object in IrContext. For the specific
+/// implementation method, please refer to Float16Type.
+///
+/// The built-in type object get method is as follows:
 /// \code{cpp}
 ///   ir::IrContext *ctx = ir::IrContext::Instance();
 ///   Type fp32 = Float32Type::get(ctx);
@@ -87,6 +95,9 @@ class Int64Type : public ir::Type {
   static Int64Type get(ir::IrContext *context);
 };
 
+///
+/// \brief Define built-in parameteric types.
+///
 class DenseTensorType : public ir::Type {
  public:
   using Type::Type;

--- a/paddle/ir/builtin_type.h
+++ b/paddle/ir/builtin_type.h
@@ -105,6 +105,16 @@ class DenseTensorType : public ir::Type {
   using Type::Type;
 
   DECLARE_TYPE_UTILITY_FUNCTOR(DenseTensorType, DenseTensorTypeStorage);
+
+  ir::Type dtype();
+
+  ir::DenseTensorTypeStorage::Dim dim();
+
+  ir::DenseTensorTypeStorage::DataLayout data_layout();
+
+  ir::DenseTensorTypeStorage::LoD lod();
+
+  size_t offset();
 };
 
 }  // namespace ir

--- a/paddle/ir/builtin_type.h
+++ b/paddle/ir/builtin_type.h
@@ -14,13 +14,16 @@
 
 #pragma once
 
+#include "paddle/ir/builtin_type_storage.h"
 #include "paddle/ir/type.h"
 
 namespace ir {
 ///
 /// \brief This macro is used to get a list of all built-in types in this file.
 ///
-#define GET_BUILT_IN_TYPE_LIST ir::Float32Type, ir::Int32Type
+#define GET_BUILT_IN_TYPE_LIST                                      \
+  ir::Float16Type, ir::Float32Type, ir::Float64Type, ir::Int16Type, \
+      ir::Int32Type, ir::Int64Type, ir::DenseTensorType
 
 ///
 /// \brief Definitions of built-in type classes. The built-in type object get
@@ -30,6 +33,15 @@ namespace ir {
 ///   Type fp32 = Float32Type::get(ctx);
 /// \endcode
 ///
+class Float16Type : public ir::Type {
+ public:
+  using Type::Type;
+
+  DECLARE_TYPE_UTILITY_FUNCTOR(Float16Type, ir::TypeStorage);
+
+  static Float16Type get(ir::IrContext *context);
+};
+
 class Float32Type : public ir::Type {
  public:
   using Type::Type;
@@ -39,6 +51,24 @@ class Float32Type : public ir::Type {
   static Float32Type get(ir::IrContext *context);
 };
 
+class Float64Type : public ir::Type {
+ public:
+  using Type::Type;
+
+  DECLARE_TYPE_UTILITY_FUNCTOR(Float64Type, ir::TypeStorage);
+
+  static Float64Type get(ir::IrContext *context);
+};
+
+class Int16Type : public ir::Type {
+ public:
+  using Type::Type;
+
+  DECLARE_TYPE_UTILITY_FUNCTOR(Int16Type, ir::TypeStorage);
+
+  static Int16Type get(ir::IrContext *context);
+};
+
 class Int32Type : public ir::Type {
  public:
   using Type::Type;
@@ -46,6 +76,22 @@ class Int32Type : public ir::Type {
   DECLARE_TYPE_UTILITY_FUNCTOR(Int32Type, ir::TypeStorage);
 
   static Int32Type get(ir::IrContext *context);
+};
+
+class Int64Type : public ir::Type {
+ public:
+  using Type::Type;
+
+  DECLARE_TYPE_UTILITY_FUNCTOR(Int64Type, ir::TypeStorage);
+
+  static Int64Type get(ir::IrContext *context);
+};
+
+class DenseTensorType : public ir::Type {
+ public:
+  using Type::Type;
+
+  DECLARE_TYPE_UTILITY_FUNCTOR(DenseTensorType, DenseTensorTypeStorage);
 };
 
 }  // namespace ir

--- a/paddle/ir/builtin_type.h
+++ b/paddle/ir/builtin_type.h
@@ -106,15 +106,15 @@ class DenseTensorType : public ir::Type {
 
   DECLARE_TYPE_UTILITY_FUNCTOR(DenseTensorType, DenseTensorTypeStorage);
 
-  ir::Type &dtype();
+  const ir::Type &dtype() const;
 
-  ir::DenseTensorTypeStorage::Dim &dim();
+  const ir::DenseTensorTypeStorage::Dim &dim() const;
 
-  ir::DenseTensorTypeStorage::DataLayout &data_layout();
+  const ir::DenseTensorTypeStorage::DataLayout &data_layout() const;
 
-  ir::DenseTensorTypeStorage::LoD &lod();
+  const ir::DenseTensorTypeStorage::LoD &lod() const;
 
-  size_t &offset();
+  const size_t &offset() const;
 };
 
 }  // namespace ir

--- a/paddle/ir/builtin_type.h
+++ b/paddle/ir/builtin_type.h
@@ -30,7 +30,9 @@ namespace ir {
 ///
 /// \brief Define built-in parameterless types. Please add the necessary
 /// interface functions for built-in types through the macro
-/// DECLARE_TYPE_UTILITY_FUNCTOR. NOTE(zhangbo9674): If you need to directly
+/// DECLARE_TYPE_UTILITY_FUNCTOR.
+///
+/// NOTE(zhangbo9674): If you need to directly
 /// cache the object of this built-in type in IrContext, please overload the get
 /// method, and construct and cache the object in IrContext. For the specific
 /// implementation method, please refer to Float16Type.

--- a/paddle/ir/builtin_type.h
+++ b/paddle/ir/builtin_type.h
@@ -106,15 +106,15 @@ class DenseTensorType : public ir::Type {
 
   DECLARE_TYPE_UTILITY_FUNCTOR(DenseTensorType, DenseTensorTypeStorage);
 
-  ir::Type dtype();
+  ir::Type &dtype();
 
-  ir::DenseTensorTypeStorage::Dim dim();
+  ir::DenseTensorTypeStorage::Dim &dim();
 
-  ir::DenseTensorTypeStorage::DataLayout data_layout();
+  ir::DenseTensorTypeStorage::DataLayout &data_layout();
 
-  ir::DenseTensorTypeStorage::LoD lod();
+  ir::DenseTensorTypeStorage::LoD &lod();
 
-  size_t offset();
+  size_t &offset();
 };
 
 }  // namespace ir

--- a/paddle/ir/builtin_type_storage.h
+++ b/paddle/ir/builtin_type_storage.h
@@ -89,9 +89,10 @@ enum class DataLayout {
 };
 
 ///
-/// \brief Define Parameteric TypeStorage for DenseTensorType. Derived
-/// TypeStorage need to declare ParamKey, define Construction method, define
-/// HashValue method, and overload operator==.
+/// \brief Define Parameteric TypeStorage for DenseTensorType.
+/// NOTE(zhangbo9674): The derived TypeStorage class needs to implement the
+/// following methods: (1)declare ParamKey, (2)define Construction method,
+/// (3)define HashValue method, (4)overload operator==.
 ///
 struct DenseTensorTypeStorage : public ir::TypeStorage {
   using Dim = std::vector<int64_t>;

--- a/paddle/ir/builtin_type_storage.h
+++ b/paddle/ir/builtin_type_storage.h
@@ -33,21 +33,6 @@ struct hash<std::vector<T>> {
   }
 };
 
-///
-/// \brief Enable hashing std::vector<std::vector<T> instances.
-///
-template <typename T>
-struct hash<std::vector<std::vector<T>>> {
-  std::size_t operator()(const std::vector<std::vector<T>> &lod) const {
-    std::size_t seed = 0;
-    for (size_t i = 0; i < lod.size(); ++i) {
-      seed ^= std::hash<std::vector<T>>()(lod[i]) + 0x9e3779b9 + (seed << 6) +
-              (seed >> 2);
-    }
-    return seed;
-  }
-};
-
 }  // namespace std
 
 namespace ir {
@@ -65,8 +50,6 @@ struct DenseTensorTypeStorage : public ir::TypeStorage {
   ///
   enum class DataLayout : unsigned int {
     UNDEFINED = 0,
-    // TODO(chenweihang): keep ANY for compatibility, remove it later
-    ANY = UNDEFINED,
     NHWC,
     NCHW,
     NCDHW,
@@ -83,14 +66,6 @@ struct DenseTensorTypeStorage : public ir::TypeStorage {
 
     // Note: Unify phi DataLayout and fluid::framework::DataLayout,
     // for compatible with fluid DataLayout, here need prefix `k`
-
-    // Note: The original `kAnyLayout (enum value 2)` is a strange design.
-    // `kAnyLayout` originally cannot represent any kind of Layout,
-    // at the same time, it can also represent any Layout.
-    // Strictly, it means "default" or "undefined" layout,
-    // and should not be mixed with other meaningful layouts
-
-    kAnyLayout = ANY,
     kNHWC = NHWC,
     kNCHW = NCHW,
     kMKLDNN = ONEDNN,  // all layouts supported by ONEDNN internally

--- a/paddle/ir/builtin_type_storage.h
+++ b/paddle/ir/builtin_type_storage.h
@@ -90,6 +90,7 @@ enum class DataLayout {
 
 ///
 /// \brief Define Parameteric TypeStorage for DenseTensorType.
+///
 /// NOTE(zhangbo9674): The derived TypeStorage class needs to implement the
 /// following methods: (1)declare ParamKey, (2)define Construction method,
 /// (3)define HashValue method, (4)overload operator==.

--- a/paddle/ir/builtin_type_storage.h
+++ b/paddle/ir/builtin_type_storage.h
@@ -1,0 +1,174 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/ir/type.h"
+
+namespace std {
+///
+/// \brief Enable hashing std::vector<T> instances.
+///
+template <typename T>
+struct hash<std::vector<T>> {
+  std::size_t operator()(const std::vector<T> &dim) const {
+    std::size_t seed = 0;
+    for (size_t i = 0; i < dim.size(); ++i) {
+      seed ^= std::hash<T>()(dim[i]) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+    return seed;
+  }
+};
+
+///
+/// \brief Enable hashing std::vector<std::vector<T> instances.
+///
+template <typename T>
+struct hash<std::vector<std::vector<T>>> {
+  std::size_t operator()(const std::vector<std::vector<T>> &lod) const {
+    std::size_t seed = 0;
+    for (size_t i = 0; i < lod.size(); ++i) {
+      seed ^= std::hash<std::vector<T>>()(lod[i]) + 0x9e3779b9 + (seed << 6) +
+              (seed >> 2);
+    }
+    return seed;
+  }
+};
+
+}  // namespace std
+
+namespace ir {
+///
+/// \brief It is consistent with the DataLayout defined by Phi operator library.
+/// See the file for details: paddle/phi/common/layout.h.
+///
+enum class DataLayout {
+  UNDEFINED = 0,
+  // TODO(chenweihang): keep ANY for compatibility, remove it later
+  ANY = UNDEFINED,
+  NHWC,
+  NCHW,
+  NCDHW,
+  NDHWC,
+  ONEDNN,
+  SPARSE_COO,
+  SPARSE_CSR,
+  PSTRING_UNION,
+
+  NUM_DATA_LAYOUTS,
+
+  // See Note [ Why we need ALL in basic kernel key member? ]
+  ALL_LAYOUT = UNDEFINED,
+
+  // Note: Unify phi DataLayout and fluid::framework::DataLayout,
+  // for compatible with fluid DataLayout, here need prefix `k`
+
+  // Note: The original `kAnyLayout (enum value 2)` is a strange design.
+  // `kAnyLayout` originally cannot represent any kind of Layout,
+  // at the same time, it can also represent any Layout.
+  // Strictly, it means "default" or "undefined" layout,
+  // and should not be mixed with other meaningful layouts
+
+  kAnyLayout = ANY,
+  kNHWC = NHWC,
+  kNCHW = NCHW,
+  kMKLDNN = ONEDNN,  // all layouts supported by ONEDNN internally
+  kNDHWC = NDHWC,
+  kNCDHW = NCDHW,
+};
+
+///
+/// \brief Define Parameteric TypeStorage for DenseTensorType. Derived
+/// TypeStorage need to declare ParamKey, define Construction method, define
+/// HashValue method, and overload operator==.
+///
+struct DenseTensorTypeStorage : public ir::TypeStorage {
+  using Dim = std::vector<int64_t>;
+
+  using LoD = std::vector<std::vector<size_t>>;
+
+  ///
+  /// \brief Declare ParamKey according to parameter type.
+  ///
+  using ParamKey = std::tuple<ir::Type, Dim, DataLayout, LoD, size_t>;
+
+  DenseTensorTypeStorage(
+      ir::Type dtype, Dim dims, DataLayout layout, LoD lod, size_t offset)
+      : dtype_(dtype),
+        dims_(dims),
+        layout_(layout),
+        lod_(lod),
+        offset_(offset) {}
+
+  ///
+  /// \brief Each derived TypeStorage must define a Construc method, which
+  /// StorageManager uses to construct a derived TypeStorage.
+  ///
+  static DenseTensorTypeStorage *Construct(ParamKey key) {
+    return new DenseTensorTypeStorage(std::get<0>(key),
+                                      std::get<1>(key),
+                                      std::get<2>(key),
+                                      std::get<3>(key),
+                                      std::get<4>(key));
+  }
+
+  ///
+  /// \brief Each derived TypeStorage must provide a HashValue method.
+  ///
+  static std::size_t HashValue(const ParamKey &key) {
+    std::size_t hash_value = 0;
+    // hash dtype
+    hash_value =
+        hash_combine(hash_value, std::hash<ir::Type>()(std::get<0>(key)));
+    // hash dims
+    hash_value = hash_combine(hash_value, std::hash<Dim>()(std::get<1>(key)));
+    // hash layout
+    hash_value =
+        hash_combine(hash_value, std::hash<DataLayout>()(std::get<2>(key)));
+    // hash lod
+    hash_value = hash_combine(hash_value, std::hash<LoD>()(std::get<3>(key)));
+    // hash offset
+    hash_value =
+        hash_combine(hash_value, std::hash<size_t>()(std::get<4>(key)));
+    return hash_value;
+  }
+
+  ///
+  /// \brief Each derived TypeStorage needs to overload operator==.
+  ///
+  bool operator==(const ParamKey &key) const {
+    return ParamKey(dtype_, dims_, layout_, lod_, offset_) == key;
+  }
+
+  ParamKey GetAsKey() const {
+    return ParamKey(dtype_, dims_, layout_, lod_, offset_);
+  }
+
+  ///
+  /// \brief DenseTensorTypeStorage include five parameters: dims, dtype,
+  /// layout, lod, offset.
+  ///
+  ir::Type dtype_;
+  Dim dims_;
+  DataLayout layout_;
+  LoD lod_;
+  size_t offset_;
+
+ private:
+  static std::size_t hash_combine(std::size_t lhs, std::size_t rhs) {
+    return lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
+  }
+};
+
+}  // namespace ir

--- a/paddle/ir/cast_utils.h
+++ b/paddle/ir/cast_utils.h
@@ -82,33 +82,33 @@ inline bool isa(const From &Val) {
 /// \brief Derive cast return type by template parameter From and To.
 ///
 template <typename To, typename From>
-struct DeriveRettyWrap {
-  typedef To &return_type;
+struct ReturnTypeDuductionWrap {
+  typedef To &type;
 };
 
 template <typename To, typename From>
-struct DeriveRettyWrap<To, const From> {
-  typedef const To &return_type;
+struct ReturnTypeDuductionWrap<To, const From> {
+  typedef const To &type;
 };
 
 template <typename To, typename From>
-struct DeriveRettyWrap<To, From *> {
-  typedef To *return_type;
+struct ReturnTypeDuductionWrap<To, From *> {
+  typedef To *type;
 };
 
 template <typename To, typename From>
-struct DeriveRettyWrap<To, const From *> {
-  typedef const To *return_type;
+struct ReturnTypeDuductionWrap<To, const From *> {
+  typedef const To *type;
 };
 
 template <typename To, typename From>
-struct DeriveRettyWrap<To, const From *const> {
-  typedef const To *return_type;
+struct ReturnTypeDuductionWrap<To, const From *const> {
+  typedef const To *type;
 };
 
 template <typename To, typename From>
-struct DeriveRetty {
-  typedef typename DeriveRettyWrap<To, From>::return_type return_type;
+struct ReturnTypeDuduction {
+  typedef typename ReturnTypeDuductionWrap<To, From>::type type;
 };
 
 ///
@@ -117,15 +117,15 @@ struct DeriveRetty {
 template <typename To, typename From>
 struct cast_impl {
   // This _is_ a simple type, just cast it.
-  static typename DeriveRetty<To, From>::return_type call(const From &Val) {
-    typename DeriveRetty<To, From>::return_type ret =
-        (typename DeriveRetty<To, From>::return_type) const_cast<From &>(Val);
+  static typename ReturnTypeDuduction<To, From>::type call(const From &Val) {
+    typename ReturnTypeDuduction<To, From>::type ret =
+        (typename ReturnTypeDuduction<To, From>::type) const_cast<From &>(Val);
     return ret;
   }
 };
 
 template <typename To, typename From>
-inline typename DeriveRetty<To, From>::return_type cast(From &Val) {  // NOLINT
+inline typename ReturnTypeDuduction<To, From>::type cast(From &Val) {  // NOLINT
   if (!isa<To>(Val)) {
     throw("cast<To>() argument of incompatible type!");
   }
@@ -133,7 +133,7 @@ inline typename DeriveRetty<To, From>::return_type cast(From &Val) {  // NOLINT
 }
 
 template <typename To, typename From>
-inline typename DeriveRetty<To, From *>::return_type cast(From *Val) {
+inline typename ReturnTypeDuduction<To, From *>::type cast(From *Val) {
   if (!isa<To>(Val)) {
     throw("cast<To>() argument of incompatible type!");
   }
@@ -144,13 +144,13 @@ inline typename DeriveRetty<To, From *>::return_type cast(From *Val) {
 /// \brief dyn_cast From to To.
 ///
 template <typename To, typename From>
-inline std::decay_t<typename DeriveRetty<To, From>::return_type> dyn_cast(
+inline std::decay_t<typename ReturnTypeDuduction<To, From>::type> dyn_cast(
     From &Val) {  // NOLINT
   return isa<To>(Val) ? cast<To>(Val) : nullptr;
 }
 
 template <typename To, typename From>
-inline typename DeriveRetty<To, From *>::return_type dyn_cast(From *Val) {
+inline typename ReturnTypeDuduction<To, From *>::type dyn_cast(From *Val) {
   return isa<To>(Val) ? cast<To>(Val) : nullptr;
 }
 

--- a/paddle/ir/cast_utils.h
+++ b/paddle/ir/cast_utils.h
@@ -120,7 +120,7 @@ template <class To, class From>
 inline typename cast_type_deduction<To, From>::return_type dyn_cast_impl(
     From &Val) {  // NOLINT
   if (!isa<To>(Val)) {
-    throw("dyn_cast_impl<To>() argument of incompatible type!");
+    return nullptr;
   }
   return cast_value<To, From>::call(Val);
 }
@@ -129,7 +129,7 @@ template <class To, class From>
 inline typename cast_type_deduction<To, From *>::return_type dyn_cast_impl(
     From *Val) {
   if (!isa<To>(Val)) {
-    throw("dyn_cast_impl<To>() argument of incompatible type!");
+    return nullptr;
   }
   return cast_value<To, From *>::call(Val);
 }

--- a/paddle/ir/cast_utils.h
+++ b/paddle/ir/cast_utils.h
@@ -33,7 +33,7 @@ struct isa_impl<
 ///
 /// \brief The template function actually called by isa.
 ///
-template <typename Target, typename From>
+template <typename Target, typename From, typename Enable = void>
 struct isa_wrap {
   static inline bool call(const From &Val) {
     return isa_impl<Target, From>::call(Val);
@@ -52,42 +52,17 @@ struct isa_wrap<Target, const From> {
 };
 
 template <typename Target, typename From>
-struct isa_wrap<Target, From *> {
-  static inline bool call(const From *Val) {
+struct isa_wrap<
+    Target,
+    From,
+    typename std::enable_if_t<std::is_pointer<std::decay_t<From>>::value>> {
+  static inline bool call(
+      std::remove_pointer_t<std::decay_t<From>> const *Val) {
     if (Val == nullptr) {
       throw("isa<> used on a null pointer");
     }
-    return isa_impl<Target, From>::call(*Val);
-  }
-};
-
-template <typename Target, typename From>
-struct isa_wrap<Target, From *const> {
-  static inline bool call(const From *Val) {
-    if (Val == nullptr) {
-      throw("isa<> used on a null pointer");
-    }
-    return isa_impl<Target, From>::call(*Val);
-  }
-};
-
-template <typename Target, typename From>
-struct isa_wrap<Target, const From *> {
-  static inline bool call(const From *Val) {
-    if (Val == nullptr) {
-      throw("isa<> used on a null pointer");
-    }
-    return isa_impl<Target, From>::call(*Val);
-  }
-};
-
-template <typename Target, typename From>
-struct isa_wrap<Target, const From *const> {
-  static inline bool call(const From *Val) {
-    if (Val == nullptr) {
-      throw("isa<> used on a null pointer");
-    }
-    return isa_impl<Target, From>::call(*Val);
+    return isa_impl<Target, std::remove_pointer_t<std::decay_t<From>>>::call(
+        *Val);
   }
 };
 

--- a/paddle/ir/cast_utils.h
+++ b/paddle/ir/cast_utils.h
@@ -19,7 +19,7 @@
 namespace ir {
 template <typename Target, typename From, typename Enabler = void>
 struct isa_impl {
-  static inline bool doit(const From &Val) { return Target::classof(Val); }
+  static inline bool call(const From &Val) { return Target::classof(Val); }
 };
 
 template <typename Target, typename From>
@@ -27,69 +27,77 @@ struct isa_impl<
     Target,
     From,
     typename std::enable_if<std::is_base_of<Target, From>::value>::type> {
-  static inline bool doit(const From &) { return true; }
+  static inline bool call(const From &) { return true; }
 };
 
+///
+/// \brief The template function actually called by isa.
+///
 template <typename Target, typename From>
 struct isa_wrap {
-  static inline bool doit(const From &Val) {
-    return isa_impl<Target, From>::doit(Val);
+  static inline bool call(const From &Val) {
+    return isa_impl<Target, From>::call(Val);
   }
 };
 
+///
+/// \brief typequalified specialization of the isa_wrap template parameter From.
+/// Specialized types include: const T, T*, const T*, T* const, const T* const.
+///
 template <typename Target, typename From>
 struct isa_wrap<Target, const From> {
-  static inline bool doit(const From &Val) {
-    return isa_impl<Target, From>::doit(Val);
+  static inline bool call(const From &Val) {
+    return isa_impl<Target, From>::call(Val);
   }
 };
 
 template <typename Target, typename From>
 struct isa_wrap<Target, From *> {
-  static inline bool doit(const From *Val) {
+  static inline bool call(const From *Val) {
     if (Val == nullptr) {
       throw("isa<> used on a null pointer");
     }
-    return isa_impl<Target, From>::doit(*Val);
+    return isa_impl<Target, From>::call(*Val);
   }
 };
 
 template <typename Target, typename From>
 struct isa_wrap<Target, From *const> {
-  static inline bool doit(const From *Val) {
+  static inline bool call(const From *Val) {
     if (Val == nullptr) {
       throw("isa<> used on a null pointer");
     }
-    return isa_impl<Target, From>::doit(*Val);
+    return isa_impl<Target, From>::call(*Val);
   }
 };
 
 template <typename Target, typename From>
 struct isa_wrap<Target, const From *> {
-  static inline bool doit(const From *Val) {
+  static inline bool call(const From *Val) {
     if (Val == nullptr) {
       throw("isa<> used on a null pointer");
     }
-    return isa_impl<Target, From>::doit(*Val);
+    return isa_impl<Target, From>::call(*Val);
   }
 };
 
 template <typename Target, typename From>
 struct isa_wrap<Target, const From *const> {
-  static inline bool doit(const From *Val) {
+  static inline bool call(const From *Val) {
     if (Val == nullptr) {
       throw("isa<> used on a null pointer");
     }
-    return isa_impl<Target, From>::doit(*Val);
+    return isa_impl<Target, From>::call(*Val);
   }
 };
 
 ///
-/// \brief isa func: if (isa<Type>(value)) { ... }.
+/// \brief isa template function, used to determine whether the value is a
+/// Target type. Using method: if (isa<Target_Type>(value)) { ... }.
 ///
 template <class Target, class From>
 inline bool isa(const From &Val) {
-  return isa_wrap<typename std::remove_pointer<Target>::type, From>::doit(Val);
+  return isa_wrap<typename std::remove_pointer<Target>::type, From>::call(Val);
 }
 
 ///
@@ -97,35 +105,35 @@ inline bool isa(const From &Val) {
 ///
 template <class To, class From>
 struct cast_type_deduction {
-  typedef To &ret_type;
+  typedef To &return_type;
 };
 template <class To, class From>
 struct cast_type_deduction<To, const From> {
-  typedef const To &ret_type;
+  typedef const To &return_type;
 };
 
 template <class To, class From>
 struct cast_type_deduction<To, From *> {
-  typedef To *ret_type;
+  typedef To *return_type;
 };
 
 template <class To, class From>
 struct cast_type_deduction<To, const From *> {
-  typedef const To *ret_type;
+  typedef const To *return_type;
 };
 
 template <class To, class From>
 struct cast_type_deduction<To, const From *const> {
-  typedef const To *ret_type;
+  typedef const To *return_type;
 };
 
 template <class To, class From>
 struct cast_value {
-  static typename cast_type_deduction<To, From>::ret_type doit(
+  static typename cast_type_deduction<To, From>::return_type call(
       const From &Val) {
-    typename cast_type_deduction<To, From>::ret_type Res2 =
-        (typename cast_type_deduction<To, From>::ret_type) const_cast<From &>(
-            Val);
+    typename cast_type_deduction<To, From>::return_type Res2 =
+        (typename cast_type_deduction<To, From>::return_type) const_cast<
+            From &>(Val);
     return Res2;
   }
 };
@@ -134,31 +142,32 @@ struct cast_value {
 /// \brief dyn_cast From to To.
 ///
 template <class To, class From>
-inline typename cast_type_deduction<To, From>::ret_type dyn_cast_impl(
+inline typename cast_type_deduction<To, From>::return_type dyn_cast_impl(
     From &Val) {  // NOLINT
   if (!isa<To>(Val)) {
     throw("dyn_cast_impl<To>() argument of incompatible type!");
   }
-  return cast_value<To, From>::doit(Val);
+  return cast_value<To, From>::call(Val);
 }
 
 template <class To, class From>
-inline typename cast_type_deduction<To, From *>::ret_type dyn_cast_impl(
+inline typename cast_type_deduction<To, From *>::return_type dyn_cast_impl(
     From *Val) {
   if (!isa<To>(Val)) {
     throw("dyn_cast_impl<To>() argument of incompatible type!");
   }
-  return cast_value<To, From *>::doit(Val);
+  return cast_value<To, From *>::call(Val);
 }
 
 template <class To, class From>
-inline typename cast_type_deduction<To, From>::ret_type dyn_cast(
+inline typename cast_type_deduction<To, From>::return_type dyn_cast(
     From &Val) {  // NOLINT
   return dyn_cast_impl<To>(Val);
 }
 
 template <class To, class From>
-inline typename cast_type_deduction<To, From *>::ret_type dyn_cast(From *Val) {
+inline typename cast_type_deduction<To, From *>::return_type dyn_cast(
+    From *Val) {
   return dyn_cast_impl<To>(Val);
 }
 

--- a/paddle/ir/cast_utils.h
+++ b/paddle/ir/cast_utils.h
@@ -1,0 +1,165 @@
+// Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+namespace ir {
+template <typename Target, typename From, typename Enabler = void>
+struct isa_impl {
+  static inline bool doit(const From &Val) { return Target::classof(Val); }
+};
+
+template <typename Target, typename From>
+struct isa_impl<
+    Target,
+    From,
+    typename std::enable_if<std::is_base_of<Target, From>::value>::type> {
+  static inline bool doit(const From &) { return true; }
+};
+
+template <typename Target, typename From>
+struct isa_wrap {
+  static inline bool doit(const From &Val) {
+    return isa_impl<Target, From>::doit(Val);
+  }
+};
+
+template <typename Target, typename From>
+struct isa_wrap<Target, const From> {
+  static inline bool doit(const From &Val) {
+    return isa_impl<Target, From>::doit(Val);
+  }
+};
+
+template <typename Target, typename From>
+struct isa_wrap<Target, From *> {
+  static inline bool doit(const From *Val) {
+    if (Val == nullptr) {
+      throw("isa<> used on a null pointer");
+    }
+    return isa_impl<Target, From>::doit(*Val);
+  }
+};
+
+template <typename Target, typename From>
+struct isa_wrap<Target, From *const> {
+  static inline bool doit(const From *Val) {
+    if (Val == nullptr) {
+      throw("isa<> used on a null pointer");
+    }
+    return isa_impl<Target, From>::doit(*Val);
+  }
+};
+
+template <typename Target, typename From>
+struct isa_wrap<Target, const From *> {
+  static inline bool doit(const From *Val) {
+    if (Val == nullptr) {
+      throw("isa<> used on a null pointer");
+    }
+    return isa_impl<Target, From>::doit(*Val);
+  }
+};
+
+template <typename Target, typename From>
+struct isa_wrap<Target, const From *const> {
+  static inline bool doit(const From *Val) {
+    if (Val == nullptr) {
+      throw("isa<> used on a null pointer");
+    }
+    return isa_impl<Target, From>::doit(*Val);
+  }
+};
+
+///
+/// \brief isa func: if (isa<Type>(value)) { ... }.
+///
+template <class Target, class From>
+inline bool isa(const From &Val) {
+  return isa_wrap<typename std::remove_pointer<Target>::type, From>::doit(Val);
+}
+
+///
+/// \brief cast type deduction by From and To.
+///
+template <class To, class From>
+struct cast_type_deduction {
+  typedef To &ret_type;
+};
+template <class To, class From>
+struct cast_type_deduction<To, const From> {
+  typedef const To &ret_type;
+};
+
+template <class To, class From>
+struct cast_type_deduction<To, From *> {
+  typedef To *ret_type;
+};
+
+template <class To, class From>
+struct cast_type_deduction<To, const From *> {
+  typedef const To *ret_type;
+};
+
+template <class To, class From>
+struct cast_type_deduction<To, const From *const> {
+  typedef const To *ret_type;
+};
+
+template <class To, class From>
+struct cast_value {
+  static typename cast_type_deduction<To, From>::ret_type doit(
+      const From &Val) {
+    typename cast_type_deduction<To, From>::ret_type Res2 =
+        (typename cast_type_deduction<To, From>::ret_type) const_cast<From &>(
+            Val);
+    return Res2;
+  }
+};
+
+///
+/// \brief dyn_cast From to To.
+///
+template <class To, class From>
+inline typename cast_type_deduction<To, From>::ret_type dyn_cast_impl(
+    From &Val) {  // NOLINT
+  if (!isa<To>(Val)) {
+    throw("dyn_cast_impl<To>() argument of incompatible type!");
+  }
+  return cast_value<To, From>::doit(Val);
+}
+
+template <class To, class From>
+inline typename cast_type_deduction<To, From *>::ret_type dyn_cast_impl(
+    From *Val) {
+  if (!isa<To>(Val)) {
+    throw("dyn_cast_impl<To>() argument of incompatible type!");
+  }
+  return cast_value<To, From *>::doit(Val);
+}
+
+template <class To, class From>
+inline typename cast_type_deduction<To, From>::ret_type dyn_cast(
+    From &Val) {  // NOLINT
+  return dyn_cast_impl<To>(Val);
+}
+
+template <class To, class From>
+inline typename cast_type_deduction<To, From *>::ret_type dyn_cast(From *Val) {
+  return dyn_cast_impl<To>(Val);
+}
+
+}  // namespace ir

--- a/paddle/ir/ir_context.cc
+++ b/paddle/ir/ir_context.cc
@@ -85,7 +85,6 @@ class IrContextImpl {
 
   // Cached AbstractType instances.
   std::unordered_map<TypeId, AbstractType *> registed_abstract_types_;
-
   ir::SpinLock registed_abstract_types_lock_;
 
   // TypeStorage uniquer and cache instances.
@@ -93,12 +92,15 @@ class IrContextImpl {
 
   // The dialcet registered in the context.
   std::unordered_map<std::string, Dialect *> registed_dialect_;
-
   ir::SpinLock registed_dialect_lock_;
 
-  // Some built-in types.
+  // Cache some built-in type objects.
+  Float16Type fp16_type;
   Float32Type fp32_type;
+  Float64Type fp64_type;
+  Int16Type int16_type;
   Int32Type int32_type;
+  Int64Type int64_type;
 
   ir::SpinLock destructor_lock_;
 };
@@ -113,8 +115,12 @@ IrContext::IrContext() : impl_(new IrContextImpl()) {
   GetOrRegisterDialect<BuiltinDialect>();
   VLOG(4) << "==============================================";
 
+  impl_->fp16_type = TypeManager::get<Float16Type>(this);
   impl_->fp32_type = TypeManager::get<Float32Type>(this);
+  impl_->fp64_type = TypeManager::get<Float64Type>(this);
+  impl_->int16_type = TypeManager::get<Int16Type>(this);
   impl_->int32_type = TypeManager::get<Int32Type>(this);
+  impl_->int64_type = TypeManager::get<Int64Type>(this);
 }
 
 void IrContext::RegisterAbstractType(ir::TypeId type_id,
@@ -173,8 +179,16 @@ const AbstractType &AbstractType::lookup(TypeId type_id, IrContext *ctx) {
   }
 }
 
+Float16Type Float16Type::get(IrContext *ctx) { return ctx->impl().fp16_type; }
+
 Float32Type Float32Type::get(IrContext *ctx) { return ctx->impl().fp32_type; }
 
+Float64Type Float64Type::get(IrContext *ctx) { return ctx->impl().fp64_type; }
+
+Int16Type Int16Type::get(IrContext *ctx) { return ctx->impl().int16_type; }
+
 Int32Type Int32Type::get(IrContext *ctx) { return ctx->impl().int32_type; }
+
+Int64Type Int64Type::get(IrContext *ctx) { return ctx->impl().int64_type; }
 
 }  // namespace ir

--- a/paddle/ir/tests/type_test.cc
+++ b/paddle/ir/tests/type_test.cc
@@ -134,7 +134,8 @@ TEST(type_test, built_in_type) {
 
   // Test 2: Test the parameteric built-in type of IrContext.
   ir::DenseTensorTypeStorage::Dim dims = {1, 2, 3};
-  ir::DataLayout data_layout = ir::DataLayout::NCHW;
+  ir::DenseTensorTypeStorage::DataLayout data_layout =
+      ir::DenseTensorTypeStorage::DataLayout::NCHW;
   ir::DenseTensorTypeStorage::LoD lod = {{1, 2, 3}, {4, 5, 6}};
   size_t offset = 0;
 
@@ -149,6 +150,11 @@ TEST(type_test, built_in_type) {
   EXPECT_EQ(dense_tensor_1 != dense_tensor_3, 1);
   EXPECT_EQ(dense_tensor_1.type_id() == dense_tensor_2.type_id(), 1);
   EXPECT_EQ(ir::DenseTensorType::classof(dense_tensor_1), 1);
+
+  ir::DenseTensorType dense_tensor_4 =
+      ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
+  EXPECT_EQ(dense_tensor_4.offset() == 2, 1);
+  EXPECT_EQ(dense_tensor_4.data_layout() == data_layout, 1);
 }
 
 // Customize a parameterized TypeStorage IntegerTypeStorage.

--- a/paddle/ir/tests/type_test.cc
+++ b/paddle/ir/tests/type_test.cc
@@ -144,24 +144,25 @@ TEST(type_test, built_in_type) {
 
   ir::DenseTensorType dense_tensor_4 =
       ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
-  EXPECT_EQ(dense_tensor_4.offset(), 2);
+  EXPECT_EQ(dense_tensor_4.offset() == 2, 1);
   EXPECT_EQ(dense_tensor_4.dtype().isa<ir::Float32Type>(), true);
   EXPECT_EQ(dense_tensor_4.data_layout(), data_layout);
 
   // Test 3: Test isa and dyn_cast.
   EXPECT_EQ(fp16_1.isa<ir::Float16Type>(), true);
   EXPECT_EQ(fp16_1.isa<ir::Float32Type>(), false);
-  EXPECT_EQ(fp16_1.isa<ir::DenseTensorType>(), true);
+  EXPECT_EQ(fp16_1.isa<ir::DenseTensorType>(), false);
   EXPECT_EQ(fp16_1.isa<ir::Type>(), true);
   EXPECT_EQ(dense_tensor_1.isa<ir::DenseTensorType>(), true);
 
   ir::DenseTensorType dense_tensor_cast_1 =
       dense_tensor_1.dyn_cast<ir::DenseTensorType>();
   EXPECT_EQ(dense_tensor_cast_1.isa<ir::DenseTensorType>(), true);
-  EXPECT_EQ(dense_tensor_cast_1.offset(), 0);
-
-  auto int64_cast_1 = ir::dyn_cast<ir::Int64Type>(int64_1);
-  EXPECT_EQ(int64_cast_1.isa<ir::Int64Type>(), true);
+  EXPECT_EQ(dense_tensor_cast_1.offset() == 0, 1);
+  const ir::DenseTensorType dense_tensor_cast_2 =
+      ir::dyn_cast<ir::DenseTensorType>(dense_tensor_1);
+  EXPECT_EQ(dense_tensor_cast_2.isa<ir::DenseTensorType>(), true);
+  EXPECT_EQ(dense_tensor_cast_2.offset() == 0, 1);
 }
 
 // Customize a parameterized TypeStorage IntegerTypeStorage.
@@ -230,7 +231,7 @@ TEST(type_test, custom_type_dialect) {
   EXPECT_EQ(int8.dialect().id(), ir::TypeId::get<IntegerDialect>());
 
   std::vector<ir::Dialect *> dialect_list = ctx->GetRegisteredDialects();
-  EXPECT_EQ(dialect_list.size(), 3);  // integer, builtin, fake
+  EXPECT_EQ(dialect_list.size() == 3, 1);  // integer, builtin, fake
 
   ir::Dialect *dialect_builtin1 = ctx->GetRegisteredDialect("builtin");
   ir::Dialect *dialect_builtin2 =

--- a/paddle/ir/tests/type_test.cc
+++ b/paddle/ir/tests/type_test.cc
@@ -138,17 +138,17 @@ TEST(type_test, built_in_type) {
   ir::DenseTensorTypeStorage::LoD lod = {{1, 2, 3}, {4, 5, 6}};
   size_t offset = 0;
 
-  ir::Type lod_tensor_1 =
+  ir::Type dense_tensor_1 =
       ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, offset);
-  ir::Type lod_tensor_2 =
+  ir::Type dense_tensor_2 =
       ir::DenseTensorType::get(ctx, fp32_2, dims, data_layout, lod, offset);
-  ir::Type lod_tensor_3 =
+  ir::Type dense_tensor_3 =
       ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
 
-  EXPECT_EQ(lod_tensor_1 == lod_tensor_2, 1);
-  EXPECT_EQ(lod_tensor_1 != lod_tensor_3, 1);
-  EXPECT_EQ(lod_tensor_1.type_id() == lod_tensor_2.type_id(), 1);
-  EXPECT_EQ(ir::DenseTensorType::classof(lod_tensor_1), 1);
+  EXPECT_EQ(dense_tensor_1 == dense_tensor_2, 1);
+  EXPECT_EQ(dense_tensor_1 != dense_tensor_3, 1);
+  EXPECT_EQ(dense_tensor_1.type_id() == dense_tensor_2.type_id(), 1);
+  EXPECT_EQ(ir::DenseTensorType::classof(dense_tensor_1), 1);
 }
 
 // Customize a parameterized TypeStorage IntegerTypeStorage.

--- a/paddle/ir/tests/type_test.cc
+++ b/paddle/ir/tests/type_test.cc
@@ -155,6 +155,21 @@ TEST(type_test, built_in_type) {
       ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
   EXPECT_EQ(dense_tensor_4.offset() == 2, 1);
   EXPECT_EQ(dense_tensor_4.data_layout() == data_layout, 1);
+
+  // Test 3: Test isa and dyn_cast.
+  EXPECT_EQ(fp16_1.isa<ir::Float16Type>() == true, 1);
+  EXPECT_EQ(fp16_1.isa<ir::Float32Type>() == true, 0);
+  EXPECT_EQ(fp16_1.isa<ir::DenseTensorType>() == true, 0);
+  EXPECT_EQ(fp16_1.isa<ir::Type>() == true, 1);
+  EXPECT_EQ(dense_tensor_1.isa<ir::DenseTensorType>() == true, 1);
+
+  ir::DenseTensorType dense_tensor_cast_1 =
+      dense_tensor_1.dyn_cast<ir::DenseTensorType>();
+  EXPECT_EQ(dense_tensor_cast_1.isa<ir::DenseTensorType>() == true, 1);
+  EXPECT_EQ(dense_tensor_cast_1.offset() == 0, 1);
+
+  auto int64_cast_1 = ir::dyn_cast<ir::Int64Type>(int64_1);
+  EXPECT_EQ(int64_cast_1.isa<ir::Int64Type>() == true, 1);
 }
 
 // Customize a parameterized TypeStorage IntegerTypeStorage.

--- a/paddle/ir/tests/type_test.cc
+++ b/paddle/ir/tests/type_test.cc
@@ -70,12 +70,22 @@ TEST(type_test, type_base) {
 }
 
 TEST(type_test, built_in_type) {
-  // Test 1: Test the built-in type of IrContext.
+  // Test the interfaces of class Type: judgment, type_id, abstract_type,
+  // classof.
   ir::IrContext *ctx = ir::IrContext::Instance();
-  ir::Type fp32_1 = ir::Float32Type::get(ctx);
 
-  // Test 2: Test the interfaces of class Type: judgment, type_id,
-  // abstract_type, classof.
+  // Test 1: Test the parameterless built-in type of IrContext.
+  ir::Type fp16_1 = ir::Float16Type::get(ctx);
+  ir::Type fp16_2 = ir::Float16Type::get(ctx);
+  EXPECT_EQ(fp16_1 == fp16_2, 1);
+  EXPECT_EQ(fp16_1 != fp16_2, 0);
+  EXPECT_EQ(fp16_1.type_id() == fp16_2.type_id(), 1);
+  EXPECT_EQ(&fp16_1.abstract_type() ==
+                &ir::AbstractType::lookup(fp16_1.type_id(), ctx),
+            1);
+  EXPECT_EQ(ir::Float16Type::classof(fp16_1), 1);
+
+  ir::Type fp32_1 = ir::Float32Type::get(ctx);
   ir::Type fp32_2 = ir::Float32Type::get(ctx);
   EXPECT_EQ(fp32_1 == fp32_2, 1);
   EXPECT_EQ(fp32_1 != fp32_2, 0);
@@ -85,6 +95,25 @@ TEST(type_test, built_in_type) {
             1);
   EXPECT_EQ(ir::Float32Type::classof(fp32_1), 1);
 
+  ir::Type fp64_1 = ir::Float64Type::get(ctx);
+  ir::Type fp64_2 = ir::Float64Type::get(ctx);
+  EXPECT_EQ(fp64_1 == fp64_2, 1);
+  EXPECT_EQ(fp64_1 != fp64_2, 0);
+  EXPECT_EQ(fp64_1.type_id() == fp64_2.type_id(), 1);
+  EXPECT_EQ(&fp64_1.abstract_type() ==
+                &ir::AbstractType::lookup(fp64_1.type_id(), ctx),
+            1);
+  EXPECT_EQ(ir::Float64Type::classof(fp64_1), 1);
+
+  ir::Type int16_1 = ir::Int16Type::get(ctx);
+  ir::Type int16_2 = ir::Int16Type::get(ctx);
+  EXPECT_EQ(int16_1 == int16_2, 1);
+  EXPECT_EQ(int16_1.type_id() == int16_2.type_id(), 1);
+  EXPECT_EQ(&int16_1.abstract_type() ==
+                &ir::AbstractType::lookup(int16_1.type_id(), ctx),
+            1);
+  EXPECT_EQ(ir::Int16Type::classof(int16_1), 1);
+
   ir::Type int32_1 = ir::Int32Type::get(ctx);
   ir::Type int32_2 = ir::Int32Type::get(ctx);
   EXPECT_EQ(int32_1 == int32_2, 1);
@@ -93,6 +122,33 @@ TEST(type_test, built_in_type) {
                 &ir::AbstractType::lookup(int32_1.type_id(), ctx),
             1);
   EXPECT_EQ(ir::Int32Type::classof(int32_1), 1);
+
+  ir::Type int64_1 = ir::Int64Type::get(ctx);
+  ir::Type int64_2 = ir::Int64Type::get(ctx);
+  EXPECT_EQ(int64_1 == int64_2, 1);
+  EXPECT_EQ(int64_1.type_id() == int64_2.type_id(), 1);
+  EXPECT_EQ(&int64_1.abstract_type() ==
+                &ir::AbstractType::lookup(int64_1.type_id(), ctx),
+            1);
+  EXPECT_EQ(ir::Int64Type::classof(int64_1), 1);
+
+  // Test 2: Test the parameteric built-in type of IrContext.
+  ir::DenseTensorTypeStorage::Dim dims = {1, 2, 3};
+  ir::DataLayout data_layout = ir::DataLayout::NCHW;
+  ir::DenseTensorTypeStorage::LoD lod = {{1, 2, 3}, {4, 5, 6}};
+  size_t offset = 0;
+
+  ir::Type lod_tensor_1 =
+      ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, offset);
+  ir::Type lod_tensor_2 =
+      ir::DenseTensorType::get(ctx, fp32_2, dims, data_layout, lod, offset);
+  ir::Type lod_tensor_3 =
+      ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
+
+  EXPECT_EQ(lod_tensor_1 == lod_tensor_2, 1);
+  EXPECT_EQ(lod_tensor_1 != lod_tensor_3, 1);
+  EXPECT_EQ(lod_tensor_1.type_id() == lod_tensor_2.type_id(), 1);
+  EXPECT_EQ(ir::DenseTensorType::classof(lod_tensor_1), 1);
 }
 
 // Customize a parameterized TypeStorage IntegerTypeStorage.

--- a/paddle/ir/tests/type_test.cc
+++ b/paddle/ir/tests/type_test.cc
@@ -77,59 +77,50 @@ TEST(type_test, built_in_type) {
   // Test 1: Test the parameterless built-in type of IrContext.
   ir::Type fp16_1 = ir::Float16Type::get(ctx);
   ir::Type fp16_2 = ir::Float16Type::get(ctx);
-  EXPECT_EQ(fp16_1 == fp16_2, 1);
-  EXPECT_EQ(fp16_1 != fp16_2, 0);
-  EXPECT_EQ(fp16_1.type_id() == fp16_2.type_id(), 1);
-  EXPECT_EQ(&fp16_1.abstract_type() ==
-                &ir::AbstractType::lookup(fp16_1.type_id(), ctx),
-            1);
+  EXPECT_EQ(fp16_1, fp16_2);
+  EXPECT_EQ(fp16_1.type_id(), fp16_2.type_id());
+  EXPECT_EQ(&fp16_1.abstract_type(),
+            &ir::AbstractType::lookup(fp16_1.type_id(), ctx));
   EXPECT_EQ(ir::Float16Type::classof(fp16_1), 1);
 
   ir::Type fp32_1 = ir::Float32Type::get(ctx);
   ir::Type fp32_2 = ir::Float32Type::get(ctx);
-  EXPECT_EQ(fp32_1 == fp32_2, 1);
-  EXPECT_EQ(fp32_1 != fp32_2, 0);
-  EXPECT_EQ(fp32_1.type_id() == fp32_2.type_id(), 1);
-  EXPECT_EQ(&fp32_1.abstract_type() ==
-                &ir::AbstractType::lookup(fp32_1.type_id(), ctx),
-            1);
+  EXPECT_EQ(fp32_1, fp32_2);
+  EXPECT_EQ(fp32_1.type_id(), fp32_2.type_id());
+  EXPECT_EQ(&fp32_1.abstract_type(),
+            &ir::AbstractType::lookup(fp32_1.type_id(), ctx));
   EXPECT_EQ(ir::Float32Type::classof(fp32_1), 1);
 
   ir::Type fp64_1 = ir::Float64Type::get(ctx);
   ir::Type fp64_2 = ir::Float64Type::get(ctx);
-  EXPECT_EQ(fp64_1 == fp64_2, 1);
-  EXPECT_EQ(fp64_1 != fp64_2, 0);
-  EXPECT_EQ(fp64_1.type_id() == fp64_2.type_id(), 1);
-  EXPECT_EQ(&fp64_1.abstract_type() ==
-                &ir::AbstractType::lookup(fp64_1.type_id(), ctx),
-            1);
+  EXPECT_EQ(fp64_1, fp64_2);
+  EXPECT_EQ(fp64_1.type_id(), fp64_2.type_id());
+  EXPECT_EQ(&fp64_1.abstract_type(),
+            &ir::AbstractType::lookup(fp64_1.type_id(), ctx));
   EXPECT_EQ(ir::Float64Type::classof(fp64_1), 1);
 
   ir::Type int16_1 = ir::Int16Type::get(ctx);
   ir::Type int16_2 = ir::Int16Type::get(ctx);
-  EXPECT_EQ(int16_1 == int16_2, 1);
-  EXPECT_EQ(int16_1.type_id() == int16_2.type_id(), 1);
-  EXPECT_EQ(&int16_1.abstract_type() ==
-                &ir::AbstractType::lookup(int16_1.type_id(), ctx),
-            1);
+  EXPECT_EQ(int16_1, int16_2);
+  EXPECT_EQ(int16_1.type_id(), int16_2.type_id());
+  EXPECT_EQ(&int16_1.abstract_type(),
+            &ir::AbstractType::lookup(int16_1.type_id(), ctx));
   EXPECT_EQ(ir::Int16Type::classof(int16_1), 1);
 
   ir::Type int32_1 = ir::Int32Type::get(ctx);
   ir::Type int32_2 = ir::Int32Type::get(ctx);
-  EXPECT_EQ(int32_1 == int32_2, 1);
-  EXPECT_EQ(int32_1.type_id() == int32_2.type_id(), 1);
-  EXPECT_EQ(&int32_1.abstract_type() ==
-                &ir::AbstractType::lookup(int32_1.type_id(), ctx),
-            1);
+  EXPECT_EQ(int32_1, int32_2);
+  EXPECT_EQ(int32_1.type_id(), int32_2.type_id());
+  EXPECT_EQ(&int32_1.abstract_type(),
+            &ir::AbstractType::lookup(int32_1.type_id(), ctx));
   EXPECT_EQ(ir::Int32Type::classof(int32_1), 1);
 
   ir::Type int64_1 = ir::Int64Type::get(ctx);
   ir::Type int64_2 = ir::Int64Type::get(ctx);
-  EXPECT_EQ(int64_1 == int64_2, 1);
-  EXPECT_EQ(int64_1.type_id() == int64_2.type_id(), 1);
-  EXPECT_EQ(&int64_1.abstract_type() ==
-                &ir::AbstractType::lookup(int64_1.type_id(), ctx),
-            1);
+  EXPECT_EQ(int64_1, int64_2);
+  EXPECT_EQ(int64_1.type_id(), int64_2.type_id());
+  EXPECT_EQ(&int64_1.abstract_type(),
+            &ir::AbstractType::lookup(int64_1.type_id(), ctx));
   EXPECT_EQ(ir::Int64Type::classof(int64_1), 1);
 
   // Test 2: Test the parameteric built-in type of IrContext.
@@ -146,31 +137,31 @@ TEST(type_test, built_in_type) {
   ir::Type dense_tensor_3 =
       ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
 
-  EXPECT_EQ(dense_tensor_1 == dense_tensor_2, 1);
-  EXPECT_EQ(dense_tensor_1 != dense_tensor_3, 1);
-  EXPECT_EQ(dense_tensor_1.type_id() == dense_tensor_2.type_id(), 1);
+  EXPECT_EQ(dense_tensor_1, dense_tensor_2);
+  EXPECT_NE(dense_tensor_1, dense_tensor_3);
+  EXPECT_EQ(dense_tensor_1.type_id(), dense_tensor_2.type_id());
   EXPECT_EQ(ir::DenseTensorType::classof(dense_tensor_1), 1);
 
   ir::DenseTensorType dense_tensor_4 =
       ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
-  EXPECT_EQ(dense_tensor_4.offset() == 2, 1);
-  EXPECT_EQ(dense_tensor_4.dtype().isa<ir::Float32Type>() == true, 1);
-  EXPECT_EQ(dense_tensor_4.data_layout() == data_layout, 1);
+  EXPECT_EQ(dense_tensor_4.offset(), 2);
+  EXPECT_EQ(dense_tensor_4.dtype().isa<ir::Float32Type>(), true);
+  EXPECT_EQ(dense_tensor_4.data_layout(), data_layout);
 
   // Test 3: Test isa and dyn_cast.
-  EXPECT_EQ(fp16_1.isa<ir::Float16Type>() == true, 1);
-  EXPECT_EQ(fp16_1.isa<ir::Float32Type>() == true, 0);
-  EXPECT_EQ(fp16_1.isa<ir::DenseTensorType>() == true, 0);
-  EXPECT_EQ(fp16_1.isa<ir::Type>() == true, 1);
-  EXPECT_EQ(dense_tensor_1.isa<ir::DenseTensorType>() == true, 1);
+  EXPECT_EQ(fp16_1.isa<ir::Float16Type>(), true);
+  EXPECT_EQ(fp16_1.isa<ir::Float32Type>(), false);
+  EXPECT_EQ(fp16_1.isa<ir::DenseTensorType>(), true);
+  EXPECT_EQ(fp16_1.isa<ir::Type>(), true);
+  EXPECT_EQ(dense_tensor_1.isa<ir::DenseTensorType>(), true);
 
   ir::DenseTensorType dense_tensor_cast_1 =
       dense_tensor_1.dyn_cast<ir::DenseTensorType>();
-  EXPECT_EQ(dense_tensor_cast_1.isa<ir::DenseTensorType>() == true, 1);
-  EXPECT_EQ(dense_tensor_cast_1.offset() == 0, 1);
+  EXPECT_EQ(dense_tensor_cast_1.isa<ir::DenseTensorType>(), true);
+  EXPECT_EQ(dense_tensor_cast_1.offset(), 0);
 
   auto int64_cast_1 = ir::dyn_cast<ir::Int64Type>(int64_1);
-  EXPECT_EQ(int64_cast_1.isa<ir::Int64Type>() == true, 1);
+  EXPECT_EQ(int64_cast_1.isa<ir::Int64Type>(), true);
 }
 
 // Customize a parameterized TypeStorage IntegerTypeStorage.
@@ -228,25 +219,25 @@ TEST(type_test, custom_type_dialect) {
 
   ir::Type int1_1 = IntegerType::get(ctx, 1, 0);
   ir::Type int1_2 = IntegerType::get(ctx, 1, 0);
-  EXPECT_EQ(int1_1 == int1_2, 1);
+  EXPECT_EQ(int1_1, int1_2);
 
   ir::Type int8 = IntegerType::get(ctx, 8, 0);
-  EXPECT_EQ(int8 == int1_2, 0);
+  EXPECT_NE(int8, int1_2);
 
   //  Test 2: Test Dialect interfaces
-  EXPECT_EQ(ctx == int8.ir_context(), 1);
+  EXPECT_EQ(ctx, int8.ir_context());
 
-  EXPECT_EQ(int8.dialect().id() == ir::TypeId::get<IntegerDialect>(), 1);
+  EXPECT_EQ(int8.dialect().id(), ir::TypeId::get<IntegerDialect>());
 
   std::vector<ir::Dialect *> dialect_list = ctx->GetRegisteredDialects();
-  EXPECT_EQ(dialect_list.size() == 3, 1);  // integer, builtin, fake
+  EXPECT_EQ(dialect_list.size(), 3);  // integer, builtin, fake
 
   ir::Dialect *dialect_builtin1 = ctx->GetRegisteredDialect("builtin");
   ir::Dialect *dialect_builtin2 =
       ctx->GetRegisteredDialect<ir::BuiltinDialect>();
-  EXPECT_EQ(dialect_builtin1 == dialect_builtin2, 1);
+  EXPECT_EQ(dialect_builtin1, dialect_builtin2);
 
   ir::Dialect *dialect_integer1 = ctx->GetRegisteredDialect("integer");
   ir::Dialect *dialect_integer2 = ctx->GetRegisteredDialect<IntegerDialect>();
-  EXPECT_EQ(dialect_integer1 == dialect_integer2, 1);
+  EXPECT_EQ(dialect_integer1, dialect_integer2);
 }

--- a/paddle/ir/tests/type_test.cc
+++ b/paddle/ir/tests/type_test.cc
@@ -154,6 +154,7 @@ TEST(type_test, built_in_type) {
   ir::DenseTensorType dense_tensor_4 =
       ir::DenseTensorType::get(ctx, fp32_1, dims, data_layout, lod, 2);
   EXPECT_EQ(dense_tensor_4.offset() == 2, 1);
+  EXPECT_EQ(dense_tensor_4.dtype().isa<ir::Float32Type>() == true, 1);
   EXPECT_EQ(dense_tensor_4.data_layout() == data_layout, 1);
 
   // Test 3: Test isa and dyn_cast.

--- a/paddle/ir/type.h
+++ b/paddle/ir/type.h
@@ -61,9 +61,14 @@ class Type {
   IrContext *ir_context() const;
 
   ///
-  /// \brief Methods for type judgment and query.
+  /// \brief Methods for type judgment and cast.
   ///
   static bool classof(Type) { return true; }
+
+  template <typename T>
+  bool isa() {
+    return type_id() == TypeId::get<T>();
+  }
 
   ///
   /// \brief Enable hashing Type.

--- a/paddle/ir/type.h
+++ b/paddle/ir/type.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "paddle/ir/cast_utils.h"
 #include "paddle/ir/type_base.h"
 
 namespace ir {
@@ -66,8 +67,13 @@ class Type {
   static bool classof(Type) { return true; }
 
   template <typename T>
-  bool isa() {
-    return type_id() == TypeId::get<T>();
+  bool isa() const {
+    return ir::isa<T>(*this);
+  }
+
+  template <typename U>
+  U dyn_cast() const {
+    return ir::dyn_cast<U>(*this);
   }
 
   ///

--- a/paddle/ir/type.h
+++ b/paddle/ir/type.h
@@ -37,15 +37,19 @@ class Type {
   Type &operator=(const Type &other) = default;
 
   ///
-  /// \brief Comparison operations.
+  /// \brief Some operators are overloaded.
   ///
   bool operator==(Type other) const { return storage_ == other.storage_; }
+
   bool operator!=(Type other) const { return storage_ != other.storage_; }
 
   explicit operator bool() const { return storage_; }
 
   bool operator!() const { return storage_ == nullptr; }
 
+  ///
+  /// \brief Some type attribute acquisition interfaces.
+  ///
   TypeId type_id() { return storage_->abstract_type().type_id(); }
 
   const AbstractType &abstract_type() { return storage_->abstract_type(); }
@@ -55,6 +59,11 @@ class Type {
   const Dialect &dialect() const { return storage_->abstract_type().dialect(); }
 
   IrContext *ir_context() const;
+
+  ///
+  /// \brief Methods for type judgment and query.
+  ///
+  static bool classof(Type) { return true; }
 
   ///
   /// \brief Enable hashing Type.


### PR DESCRIPTION
### PR types
New features

### PR changes
APIs

### Describe
Pcard-67160

> Paddle 类型系统开发主要分为4个阶段：（1）Type基础数据结构开发（[PR1](https://github.com/PaddlePaddle/Paddle/pull/50242)）、（2）Type类型生成工具开发（[PR2](https://github.com/PaddlePaddle/Paddle/pull/50412)）、（3）IrContext（[PR2](https://github.com/PaddlePaddle/Paddle/pull/50412)）、Dialect数据结构开发（[PR3](https://github.com/PaddlePaddle/Paddle/pull/50959)）、（4）**内置类型开发（本PR）**。

#### 1、PR 主要内容

##### 1.1 内置类型添加

新增 5 种内置类型：`DenseTensorType`、`Float16Type`、`Float64Type`、`Int16Type`、`Int64Type`。至此，内置 Dialect 拥有的内置类型包括 7 种：详见：[builtin_type.h]([paddle/ir/builtin_type.h](https://github.com/PaddlePaddle/Paddle/pull/51112/files#diff-1054199422b8bc418181202d01f64fdf14dd20432a781b1a6afdfa6794dcc831))。

- [builtin_type.h]([paddle/ir/builtin_type.h](https://github.com/PaddlePaddle/Paddle/pull/51112/files#diff-1054199422b8bc418181202d01f64fdf14dd20432a781b1a6afdfa6794dcc831))：内置 Type 定义
- [builtin_type_storage.h]([paddle/ir/builtin_type_storage.h](https://github.com/PaddlePaddle/Paddle/pull/51112/files#diff-d9bfea53d93d00d6329e9b0c1c977732675734bc0645fa75d105bb21b9e006f0))：内置有参 TypeStorage 定义

内置类型的创建及使用方法如下：
```C++
ir::IrContext *ctx = ir::IrContext::Instance();
// 从 context 中获取 Float32Type 对象
ir::Type fp32 = ir::Float32Type::get(ctx);
// 定义 DenseTensorType 的一些参数
ir::DenseTensorTypeStorage::Dim dims = {1, 2, 3};
ir::DenseTensorTypeStorage::DataLayout data_layout = ir::DenseTensorTypeStorage::DataLayout::NCHW;
ir::DenseTensorTypeStorage::LoD lod = {{1, 2, 3}, {4, 5, 6}};
size_t offset = 0;
// 从 context 中获取 DenseTensorType 对象
ir::Type dense_tensor = ir::DenseTensorType::get(ctx, fp32, dims, data_layout, lod, offset);
```

##### 1.2 丰富Type接口

新增```ir::Type::isa``` 及 ```ir::Type::dyn_cast``` 方法：
- ```isa``` : 判断Type对象是否为某个类型
- ```dyn_cast``` : 类型转换，将Type对象cast为另一种类型对象

使用示例如下：
```c++
// 序接1.1示例代码
// 1) 判断 ir::Type 类型的对象 dense_tensor 是否为 ir::DenseTensorType 类型
std::cout << dense_tensor.isa<ir::DenseTensorType>() << std::endl; // 1
// 2) 将 ir::Type 转换为 ir::DenseTensorType
ir::DenseTensorType dense_tensor_cast = dense_tensor.dyn_cast<ir::DenseTensorType>();
std::cout << dense_tensor_cast.offset() << std::endl;  // 0
```