### PR TITLE
Fix batch_norm momentum

### DIFF
--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -870,7 +870,7 @@ void BatchNormKernel(const Context &ctx,
       // skip the batch norm calculation, let y = x.
       phi::Copy(ctx, x, ctx.GetPlace(), false, y);
     } else {
-      double this_factor = 1. - momentum;
+      double this_factor = momentum;
 #ifdef PADDLE_WITH_HIP
       const int num = transformed_x.numel();
       const int block = 256;
@@ -945,7 +945,6 @@ void BatchNormKernel(const Context &ctx,
           ((x_dims.size() == 2 && N >= CUDNN_PER_ACTIVATION_THRESHOLD) ||
            (x_dims.size() == 3 && N >= CUDNN_SPATIAL_THRESHOLD_TRAIN));
       if (use_native_kernel) {
-        double this_factor = momentum;
         dim3 block;
         dim3 grid;
         const int block_size = 512;

--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -945,6 +945,7 @@ void BatchNormKernel(const Context &ctx,
           ((x_dims.size() == 2 && N >= CUDNN_PER_ACTIVATION_THRESHOLD) ||
            (x_dims.size() == 3 && N >= CUDNN_SPATIAL_THRESHOLD_TRAIN));
       if (use_native_kernel) {
+        double this_factor = momentum;
         dim3 block;
         dim3 grid;
         const int block_size = 512;

--- a/paddle/phi/kernels/gpu/batch_norm_kernel.cu
+++ b/paddle/phi/kernels/gpu/batch_norm_kernel.cu
@@ -870,8 +870,9 @@ void BatchNormKernel(const Context &ctx,
       // skip the batch norm calculation, let y = x.
       phi::Copy(ctx, x, ctx.GetPlace(), false, y);
     } else {
-      double this_factor = momentum;
+      double this_factor = 1. - momentum;
 #ifdef PADDLE_WITH_HIP
+      this_factor = momentum;
       const int num = transformed_x.numel();
       const int block = 256;
       const int max_threads = ctx.GetMaxPhysicalThreadCount();
@@ -945,6 +946,7 @@ void BatchNormKernel(const Context &ctx,
           ((x_dims.size() == 2 && N >= CUDNN_PER_ACTIVATION_THRESHOLD) ||
            (x_dims.size() == 3 && N >= CUDNN_SPATIAL_THRESHOLD_TRAIN));
       if (use_native_kernel) {
+        double this_factor = momentum;
         dim3 block;
         dim3 grid;
         const int block_size = 512;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
修复batch_norm中`momentum`的使用，`BNForwardTraining`中计算mean的规则是：
https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/gpu/batch_norm_kernel.cu#L156
```
 mean[i] = (1 - exponentialAverageFactor) * mean_val +
                exponentialAverageFactor * mean[i];
```
https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/gpu/batch_norm_kernel.cu#L873
但是在调用它BNForwardTraining之前对momentum进行了变换： `double this_factor = 1. - momentum;`，exponentialAverageFactor即是this_factor。
所以实际的`mean[i] = momentum * mean_val + (1-momentum) * mean[i];`，其中`mean_val`是当前算的均值。
而API文档中定义的是：`moving_mean=moving_mean∗momentum+μβ∗(1.−momentum)`，其中μβ是当前算的均值。

因此自定义kernel的计算规则和定义的不一致，这里将 `double this_factor = 1. - momentum;`改成`double this_factor=momentum`即可。

后面自定义kernel的地方保持了和`BNForwardTraining`一样的计算规则，所以做相应修改。