### PR TITLE
[Polish CustomOP] Clean custom OP output when importing modules

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -190,7 +190,6 @@ def custom_write_stub(resource, pyfile):
                     assert isinstance(spec.loader, importlib.abc.Loader)
                     spec.loader.exec_module(mod)
                 except ImportError:
-                    print('using custom operator only')
                     mod = types.ModuleType(__name__)
 
             # load custom op shared library with abs path


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Pcard-66988

Delete debug output when importing modules of custom op.

<img width="646" alt="f26bdcfea440a20e43b515ce98374911" src="https://user-images.githubusercontent.com/17810795/222435756-3f03d35f-d667-4881-985c-de76661ecc66.png">

