### PR TITLE
【PRIM】fix cast prim api dtype mapping error between phi and fluid

### DIFF
--- a/paddle/fluid/operators/cast_op.cc
+++ b/paddle/fluid/operators/cast_op.cc
@@ -79,8 +79,7 @@ class CastCompositeGradOpMaker : public prim::CompositeGradOpMakerBase {
         std::make_shared<prim::DescTensor>(this->SingleInputGrad("X")));
     auto dx_ptr = this->GetOutputPtr(&x_grad);
     std::string dx_name = this->GetOutputName(x_grad);
-    auto dtype = static_cast<paddle::experimental::DataType>(
-        this->Attr<int>("in_dtype"));
+    auto dtype = phi::TransToPhiDataType((this->Attr<int>("in_dtype")));
     prim::cast_grad<prim::DescTensor>(out_grad, dtype, dx_ptr);
     this->RecoverOutputName(x_grad, dx_name);
   }

--- a/paddle/fluid/prim/api/manual_prim/static_prim_api.cc
+++ b/paddle/fluid/prim/api/manual_prim/static_prim_api.cc
@@ -161,8 +161,8 @@ Tensor cast<DescTensor>(const Tensor& x, DataType dtype) {
                {std::static_pointer_cast<prim::DescTensor>(x.impl())->Name()});
   op->SetOutput(
       "Out", {std::static_pointer_cast<prim::DescTensor>(out.impl())->Name()});
-  op->SetAttr("in_dtype", static_cast<int>(x.dtype()));
-  op->SetAttr("out_dtype", static_cast<int>(dtype));
+  op->SetAttr("in_dtype", paddle::framework::TransToProtoVarType(x.dtype()));
+  op->SetAttr("out_dtype", paddle::framework::TransToProtoVarType(dtype));
   op->CheckAttrs();
   op->InferVarType(block);
   op->InferShape(*block);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

- fix cast prim api dtype mapping error between phi and fluid