### PR TITLE
【Paddle-TRT-FIX】fix trt layer output type

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/cast_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/cast_op.cc
@@ -44,16 +44,20 @@ class CastOpConverter : public OpConverter {
     switch (out_dtype) {
       case 0:  // BOOL = 0
         layer->setOutputType(0, nvinfer1::DataType::kBOOL);
+        layer->getOutput(0)->setType(nvinfer1::DataType::kBOOL);
         break;
       case 2:  // INT32 = 2
       case 3:  // INT64 = 3 there is no int64 in tensorrt subgraph
         layer->setOutputType(0, nvinfer1::DataType::kINT32);
+        layer->getOutput(0)->setType(nvinfer1::DataType::kINT32);
         break;
       case 4:  // FP16 = 4
         layer->setOutputType(0, nvinfer1::DataType::kHALF);
+        layer->getOutput(0)->setType(nvinfer1::DataType::kHALF);
         break;
       case 5:  // FP32 = 5
         layer->setOutputType(0, nvinfer1::DataType::kFLOAT);
+        layer->getOutput(0)->setType(nvinfer1::DataType::kFLOAT);
         break;
       default:
         LOG(ERROR) << "Unable to convert a fluid data type(" << out_dtype


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-66775/show?source=undefined
修复该卡片。
主要原因在于cast op后，输出的类型没有按照预期成功转换，导致进入elmentwise后，两个input类型不匹配。
根源在于setOutputType可能会失效，加上getOutput(0)->setType()来确保类型一定会被转换。
TRT官方网站对二者的说明：
<img width="999" alt="image" src="https://user-images.githubusercontent.com/88373061/222621416-1bdfa6fe-9f1e-49d1-b3b3-ce51e47886e4.png">
验证通过
<img width="1080" alt="截屏2023-03-02 17 19 24" src="https://user-images.githubusercontent.com/88373061/222621534-9d842e69-1347-48df-af95-2f1f92e34836.png">


