### PR TITLE
[Fix] `paddle.scale` Gives Wrong Results with Input Tensor of Integer Type

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scale_op.py
@@ -312,5 +312,67 @@ class TestScaleOpZeroNumelVariable(unittest.TestCase):
             self.assertEqual(out, data)
 
 
+class TestScaleIntOp(OpTest):
+    def setUp(self):
+        self.op_type = "scale"
+        self.python_api = paddle.scale
+        self._dtypes = [np.uint8, np.int8, np.int16, np.int32, np.int64]
+
+    def test_check_output(self):
+        for dtype in self._dtypes:
+            self.dtype = dtype
+            # `scale` be a floating number
+            self.inputs = {'X': np.random.random((10, 10)).astype(self.dtype)}
+            self.attrs = {'scale': 0.5}
+            self.outputs = {
+                'Out': (self.inputs['X'] * self.attrs['scale']).astype(
+                    self.dtype
+                )
+            }
+            self.check_output(check_eager=True)
+            # `scale` be an integer
+            self.inputs = {'X': np.random.random((10, 10)).astype(self.dtype)}
+            self.attrs = {'scale': 2}
+            self.outputs = {
+                'Out': (self.inputs['X'] * self.attrs['scale']).astype(
+                    self.dtype
+                )
+            }
+            self.check_output(check_eager=True)
+
+
+class TestScaleIntOpScaleVariable(OpTest):
+    def setUp(self):
+        self.op_type = "scale"
+        self.python_api = paddle.scale
+        self._dtypes = [np.uint8, np.int8, np.int16, np.int32, np.int64]
+
+    def test_check_output(self):
+        for dtype in self._dtypes:
+            self.dtype = dtype
+            # `scale` be a floating number
+            self.scale = 0.5
+            self.inputs = {
+                'X': np.random.random((10, 10)).astype(self.dtype),
+                'ScaleTensor': np.asarray([self.scale]).astype(self.dtype),
+            }
+            self.attrs = {}
+            self.outputs = {
+                'Out': (self.inputs['X'] * self.scale).astype(self.dtype)
+            }
+            self.check_output(check_eager=True)
+            # `scale` be an integer
+            self.scale = 2
+            self.inputs = {
+                'X': np.random.random((10, 10)).astype(self.dtype),
+                'ScaleTensor': np.asarray([self.scale]).astype(self.dtype),
+            }
+            self.attrs = {}
+            self.outputs = {
+                'Out': (self.inputs['X'] * self.scale).astype(self.dtype)
+            }
+            self.check_output(check_eager=True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
**Minimum example to reproduce**:
```python
import paddle
print(int(paddle.scale(paddle.to_tensor([64], dtype='int64'), 0.5)))
```
**Expected result**: `32`
**Actual result**: `0`

**Causes**: Given an scaling factor `scale`(a floating-typed scalar) and an offset `bias`(a floating number), `Scale` OP coerces `scale` and `bias` to the dtype of input tensor `x`, before calculating the scaling result.

**Solution**: Prevent pre-calculation type coersions in `Scale` OP implementation.

**Known limitations**: For the CPU kernel we make use of `phi::funcs::EigenScale`, which requires `x`, `scale`, and `bias` to be of the same data type. As a workaround, I added two extra type conversion operations when `x` has integer dtypes and `scale` is of floating type, which introduces overheads.

