### PR TITLE
fix bug on mac: gflags allow command line reparsing

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -67,16 +67,6 @@ PADDLE_DEFINE_EXPORTED_int32(
     "been dropped when you are profiling, try increasing this value.");
 
 namespace paddle {
-namespace platform {
-
-void ParseCommandLineFlags(int argc, char **argv, bool remove) {
-  ::GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, remove);
-}
-
-}  // namespace platform
-}  // namespace paddle
-
-namespace paddle {
 namespace framework {
 
 #ifdef _WIN32
@@ -109,6 +99,7 @@ bool InitGflags(std::vector<std::string> args) {
             << ", Init commandline: " << line;
 
     char **arr = argv.data();
+    ::GFLAGS_NAMESPACE::AllowCommandLineReparsing();
     ::GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &arr, true);
     successed = true;
 

--- a/paddle/fluid/platform/init.h
+++ b/paddle/fluid/platform/init.h
@@ -21,14 +21,6 @@ limitations under the License. */
 #include "glog/logging.h"
 
 namespace paddle {
-namespace platform {
-
-void ParseCommandLineFlags(int argc, char** argv, bool remove);
-
-}  // namespace platform
-}  // namespace paddle
-
-namespace paddle {
 namespace framework {
 
 bool InitGflags(std::vector<std::string> argv);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

![image](https://user-images.githubusercontent.com/23653004/222654660-7b05fc80-2683-4e0e-a4eb-c319cc7efda4.png)
