### PR TITLE
limit protobuf version >= 3.20.2

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.20.0
 numpy>=1.13
-protobuf>3.20.0 ; platform_system != "Windows"
+protobuf>=3.20.2 ; platform_system != "Windows"
 protobuf>=3.1.0, <=3.20.2 ; platform_system == "Windows"
 Pillow
 decorator

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.20.0
 numpy>=1.13
-protobuf>=3.20.0 ; platform_system != "Windows"
+protobuf>3.20.0 ; platform_system != "Windows"
 protobuf>=3.1.0, <=3.20.2 ; platform_system == "Windows"
 Pillow
 decorator


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
others
### Describe
<!-- Describe what this PR does -->
Pcard-67006
We propose raising the lower limit of protobuf version to 3.20.2
