### PR TITLE
Update weight_norm_hook.py

### DIFF
--- a/python/paddle/nn/utils/weight_norm_hook.py
+++ b/python/paddle/nn/utils/weight_norm_hook.py
@@ -232,6 +232,7 @@ def remove_weight_norm(layer, name='weight'):
             # Conv2D(3, 5, kernel_size=[3, 3], data_format=NCHW)
 
             remove_weight_norm(conv)
+            # The following is a display to remove weight the effect after the norm:
             # print(conv.weight_g)
             # AttributeError: 'Conv2D' object has no attribute 'weight_g'
     """


### PR DESCRIPTION
Add comments

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
APIs

### Describe
添加注释：
```python
remove_weight_norm(conv)
# print(conv.weight_g)
# AttributeError: 'Conv2D' object has no attribute 'weight_g'
```
改为：
```python
remove_weight_norm(conv)
# The following is a display to remove weight the effect after the norm:
# print(conv.weight_g)
# AttributeError: 'Conv2D' object has no attribute 'weight_g'
```