### PR TITLE
【Hackathon No.89】 Remove circle import Part3

### DIFF
--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -36,13 +36,17 @@ from .convert_operators import (
     convert_range,
     convert_zip,
 )
+from .program_translator import (
+    CONVERSION_OPTIONS,
+    StaticFunction,
+    convert_to_static,
+    unwrap_decorators,
+)
 
 __all__ = []
 
 
 translator_logger = TranslatorLogger()
-
-CONVERSION_OPTIONS = "__jst_not_to_static"
 
 
 class ConversionOptions:
@@ -198,12 +202,6 @@ def convert_call(func):
             #  [1. 1. 1.]]
 
     """
-    # NOTE(Aurelius84): Fix it after all files migrating into jit.
-    from paddle.jit.dy2static.program_translator import (
-        StaticFunction,
-        convert_to_static,
-        unwrap_decorators,
-    )
 
     translator_logger.log(
         1, "Convert callable object: convert {}.".format(func)

--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -29,7 +29,6 @@ from paddle.utils import gast
 
 from . import error, logging_utils
 from .ast_transformer import DygraphToStaticAst
-from .convert_call_func import CONVERSION_OPTIONS
 from .function_spec import (
     FunctionSpec,
     _hash_spec_names,
@@ -59,6 +58,8 @@ __all__ = []
 # For each traced function, we set `max_traced_program_count` = 10 to consider caching performance.
 # Once exceeding the threshold, we will raise warning to users to make sure the conversion is as expected.
 MAX_TRACED_PROGRAM_COUNT = 10
+
+CONVERSION_OPTIONS = "__jst_not_to_static"
 
 
 def synchronized(func):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/50663#task89

### Details
- 根据https://github.com/PaddlePaddle/Paddle/discussions/50711 将jit下的import移动到文件头部
- 本PR不对'from paddle.nn import Sequential' 进行解决，暂时仅对jit内部的循环引用问题进行梳理，待梳理完毕后再调整外部引用。

convert_call_func.py无法在文件头import program_translator的原因：被program_translator在文件头import，但是import内容仅为字符串

解决方案：将字符串声明移动到program_translator，由convert_call_func对convert_call_func进行import即可将函数中import移动到函数头