### PR TITLE
【Hackathon No.89】 Remove circle import Part6

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -23,7 +23,11 @@ from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
 from paddle.fluid import _non_static_mode, core, framework
 from paddle.fluid.data_feeder import check_type
 from paddle.fluid.dygraph import layers
-from paddle.fluid.dygraph.base import param_guard, switch_to_static_graph
+from paddle.fluid.dygraph.base import (
+    _switch_declarative_mode_guard_,
+    param_guard,
+    switch_to_static_graph,
+)
 from paddle.fluid.layers.utils import flatten
 from paddle.utils import gast
 
@@ -993,8 +997,6 @@ class ConcreteProgram:
             framework.default_startup_program().random_seed
         )
 
-        from paddle.fluid.dygraph.base import _switch_declarative_mode_guard_
-
         with framework.program_guard(main_program, startup_program):
             with _switch_declarative_mode_guard_(is_declarative=True):
                 # 1. Adds `fluid.data` layers for input if needed
@@ -1028,10 +1030,6 @@ class ConcreteProgram:
                         if error_data:
                             error_data.raise_new_exception()
                         raise
-
-                from paddle.jit.dy2static.program_translator import (
-                    ProgramTranslator,
-                )
 
                 # 3. Gets all ParamBases and buffered VarBases in the function
                 all_parameters_and_buffers = (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/50663#task89

### Details
- 根据https://github.com/PaddlePaddle/Paddle/discussions/50711 将jit下的import移动到文件头部
- 本PR不对from paddle.incubate.autograd.primapi import to_prim 以及from paddle.static import InputSpec 进行解决

python/paddle/jit/dy2static/program_translator.py在头部引用了paddle.fluid.dygraph.base 中元素，在函数中引用其他元素，可以直接移动到文件头部。