### PR TITLE
remove enforce.h in paddle/phi/backends/xpu/xpu_header.h

### DIFF
--- a/paddle/phi/backends/xpu/xpu_context.h
+++ b/paddle/phi/backends/xpu/xpu_context.h
@@ -19,10 +19,10 @@ limitations under the License. */
 #include <memory>
 
 #include "paddle/phi/backends/xpu/forwards.h"
+#include "paddle/phi/backends/xpu/xpu_header.h"
 #include "paddle/phi/backends/xpu/xpu_info.h"
 #include "paddle/phi/common/place.h"
 #include "paddle/phi/core/device_context.h"
-#include "xpu/runtime.h"
 
 namespace xpu = baidu::xpu::api;
 

--- a/paddle/phi/backends/xpu/xpu_header.h
+++ b/paddle/phi/backends/xpu/xpu_header.h
@@ -21,7 +21,6 @@ limitations under the License. */
 
 #include "paddle/phi/common/bfloat16.h"
 #include "paddle/phi/common/float16.h"
-#include "paddle/phi/core/enforce.h"
 #include "xpu/runtime.h"
 #include "xpu/runtime_ex.h"
 #include "xpu/xdnn.h"


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
移除原因：XPU新增自定义算子的时候需要用到xpu_header.h这个头文件，但是里面包含的enforce.h会引入第三方库的包含，导致编译报错，所以需要删除
