### PR TITLE
Add output defs for topk kernel

### DIFF
--- a/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
+++ b/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc
@@ -118,7 +118,6 @@ static std::set<std::string> OpsNeedSetOutputDtypeWhenRegisterPhiKernel = {
     "sgd",
     "svd",
     "sync_batch_norm_grad",
-    "top_k",
     "unique",
     "unique_consecutive_flattened_tensor",
     "unique_raw",

--- a/paddle/phi/kernels/cpu/top_k_kernel.cc
+++ b/paddle/phi/kernels/cpu/top_k_kernel.cc
@@ -241,4 +241,6 @@ void TopkKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    topk, CPU, ALL_LAYOUT, phi::TopkKernel, float, double, int32_t, int64_t) {}
+    topk, CPU, ALL_LAYOUT, phi::TopkKernel, float, double, int32_t, int64_t) {
+  kernel->OutputAt(1).SetDataType(paddle::experimental::DataType::INT64);
+}

--- a/paddle/phi/kernels/gpu/top_k_kernel.cu
+++ b/paddle/phi/kernels/gpu/top_k_kernel.cu
@@ -348,4 +348,6 @@ PD_REGISTER_KERNEL(topk,
                    double,
                    int,
                    int64_t,
-                   phi::dtype::float16) {}
+                   phi::dtype::float16) {
+  kernel->OutputAt(1).SetDataType(paddle::experimental::DataType::INT64);
+}

--- a/paddle/phi/kernels/xpu/top_k_kernel.cc
+++ b/paddle/phi/kernels/xpu/top_k_kernel.cc
@@ -187,4 +187,6 @@ void TopkKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(
-    topk, XPU, ALL_LAYOUT, phi::TopkKernel, float, phi::dtype::float16) {}
+    topk, XPU, ALL_LAYOUT, phi::TopkKernel, float, phi::dtype::float16) {
+  kernel->OutputAt(1).SetDataType(paddle::experimental::DataType::INT64);
+}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
Pcard-67003

本PR作为飞桨快乐开源活动issue https://github.com/PaddlePaddle/Paddle/issues/51292 的示范例子，为`top_k`算子的输出参数`indices`注册数据类型DataType。

以下为修复`top_k`算子注册信息的过程，参与任务的开发者可参照实现对其它算子注册信息的修复：

**1. 阅读kernel实现**
在 [paddle/phi/kernels](https://github.com/PaddlePaddle/Paddle/tree/develop/paddle/phi/kernels)目录下找到[top_k算子的kernel代码](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/phi/kernels/gpu/top_k_kernel.cu)，可以发现`TopKKernel`函数有`out`和`indices`两个输出Tensor，分别表示查找到的top-k结果以及对应的索引信息；其中`out`的数据类型与kernel类型一致，但`indices`的数据类型`int64_t`与kernel类型不一致，需要进行注册。
```C++
template <typename T, typename Context>
void TopkKernel(const Context& dev_ctx,
                const DenseTensor& x,
                const Scalar& k_scalar,
                int axis,
                bool largest,
                bool sorted,
                DenseTensor* out,
                DenseTensor* indices) {
    ...
    T* output_data = dev_ctx.template Alloc<T>(out);
    int64_t* indices_data = dev_ctx.template Alloc<int64_t>(indices);
    ...                    
  }
```
我们可以通过kernel中分配内存（`Alloc`或`HostAlloc`）的操作，来判断一个输出Tensor的DataType信息。若在分配内存时传入kernel实例化的模板参数`T`，则表示该输出Tensor数据类型与kernel一致，这种情况不需要专门做注册（未注册的参数数据类型默认与kernel相同）；若分配内存时传入与`T`不同的模板参数，则表示该输出Tensor数据类型与kernel不一致，需要做注册。
除了通过阅读代码进行判断，也可以查阅算子对应的[API文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/index_cn.html)，文档中一般都会说明输出参数的数据类型。

**2. 添加注册信息**
判断出`top_k`的`indices`参数需要注册数据类型后，找到`top_k`的kernel注册代码，在注册宏的花括号`{}`中设置输出参数的数据类型：
```C++
kernel->OutputAt(1).SetDataType(phi::DataType::INT64);
```
`kernel->OutputAt()`中传入注册DataType的输出参数编号，编号从0开始，按kernel函数声明中的位置依次递增。如`top_k` kernel的第0个输出为`out`，第1个输出为`indices`。

注意：本PR代码中DataType使用了`paddle::experimental::`命名空间，这是算子库项目开发初期使用的命名空间。`paddle::experimental::DataType`与`phi::DataType`是等价的，后续按规范要求，需要统一成`phi::DataType`。存量代码的改造工作正在进行中，**增量代码需直接使用`phi::DataType`**。

在添加注册信息时，若该算子分开注册了多种类型的kernel，对于每种kernel都需要添加上输出参数的数据类型。如`top_k`算子在`cpu/top_k_kernel.cc`、`gpu/top_k_kernel.cu`和`xpu/top_k_kernel.cc中`分别注册了cpu、gpu和xpu三种kernel，需要在这三处注册代码中都分别添加数据类型注册。一般来说，一个算子至少会分开注册cpu、gpu和xpu三种不同的后端设备类型，某些算子还会分开注册不同的DataType和Layout类型。

由于静态图中通过[黑名单](https://github.com/PaddlePaddle/Paddle/blob/731b407eebccabdd3b09c7480319fdd480f8d0c7/paddle/fluid/framework/new_executor/interpreter/interpreter_util.cc#L51)机制对一些未规范注册DataType的算子屏蔽了全静态选kernel功能，在完成算子的DataType注册后，请顺手将其从黑名单中移除。

有些算子的输出数据类型是无法静态确定的，需要根据一些输入信息进行推导，此时可对该参数注册`UNDEFINED`类型。注册`UNDEFINED`的参数需要通过InferMeta进行推导，因此，若对某个参数注册了`UNDEFINED`，你需要确保该算子的InferMeta已被正确地实现和注册。具体地，你需要：
（1）在[paddle/phi/infermeta/](https://github.com/PaddlePaddle/Paddle/tree/develop/paddle/phi/infermeta)目录下找到该算子的InferMeta实现，检查该算子的InferMeta中是否正确实现了`UNDEFINED`参数的DataType推导逻辑，若未实现或实现有误，则需要你对相关逻辑进行修复。关于InferMeta的实现，可参考[《开发C++算子》](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/api_contributing_guides/new_cpp_op_cn.html)文档中[实现InferMeta函数](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/dev_guides/api_contributing_guides/new_cpp_op_cn.html#infermeta)一节。
（2）在[paddle/fluid/operators/](https://github.com/PaddlePaddle/Paddle/tree/develop/paddle/fluid/operators)目录下找到该算子的注册信息，确保该算子的InferShape已迁移成phi下的InferMeta。若一个算子的InferShape已迁移，则该算子不会实现InferShape函数，且在算子注册时会注册`xxxInferShapeFunction`的信息；若未迁移，则需要你对该算子的InferShape进行迁移。关于InferShape的迁移，可参考PR https://github.com/PaddlePaddle/Paddle/pull/39517 。

**3. 代码测试**
本次任务不需要专门新写单测进行验证，在完成问题修复后，找到修复算子对应的单测，运行该单测进行验证即可。算子的单测通常被命名为`test_xxx_op`的形式，如`test_top_k_op`。如果你在本地无法找到算子对应的单测，可以在编译通过后提交PR跑CI测试，CI系统会对对应算子的单测进行测试，并反馈给你测试失败的单测列表。