### PR TITLE
[with_data_parallel][part9] remove with_data_parallel in misc

### DIFF
--- a/python/paddle/fluid/tests/unittests/auto_checkpoint_utils.py
+++ b/python/paddle/fluid/tests/unittests/auto_checkpoint_utils.py
@@ -82,9 +82,7 @@ class AutoCheckpointBase(unittest.TestCase):
             sgd, loss, image, label = simple_net()
 
             if minimize:
-                compiled = fluid.CompiledProgram(main_prog).with_data_parallel(
-                    loss_name=loss.name
-                )
+                compiled = fluid.CompiledProgram(main_prog)
             else:
                 compiled = None
             loader = fluid.io.DataLoader.from_generator(

--- a/python/paddle/fluid/tests/unittests/ir_memory_optimize_net_base.py
+++ b/python/paddle/fluid/tests/unittests/ir_memory_optimize_net_base.py
@@ -80,9 +80,8 @@ class BuildIrMemOptBase(unittest.TestCase):
         exe = fluid.Executor(place)
         exe.run(fluid.default_startup_program())
 
-        train_cp = compiler.CompiledProgram(fluid.default_main_program())
-        train_cp = train_cp.with_data_parallel(
-            loss_name=cost.name, build_strategy=build_strategy
+        train_cp = compiler.CompiledProgram(
+            fluid.default_main_program(), build_strategy=build_strategy
         )
         fetch_list = [cost.name]
 

--- a/python/paddle/fluid/tests/unittests/test_cuda_graph_static_mode_error.py
+++ b/python/paddle/fluid/tests/unittests/test_cuda_graph_static_mode_error.py
@@ -52,9 +52,7 @@ class TestCUDAGraphInFirstBatch(unittest.TestCase):
             build_strategy = paddle.static.BuildStrategy()
             build_strategy.allow_cuda_graph_capture = True
             compiled_program = paddle.static.CompiledProgram(
-                main
-            ).with_data_parallel(
-                loss_name=loss.name, build_strategy=build_strategy, places=place
+                main, build_strategy=build_strategy
             )
 
             cuda_graph = None

--- a/python/paddle/jit/api.py
+++ b/python/paddle/jit/api.py
@@ -1678,11 +1678,8 @@ class TracedLayer:
     @switch_to_static_graph
     def _compile(self):
         self._compiled_program = CompiledProgram(
-            self._program
-        ).with_data_parallel(
+            self._program,
             build_strategy=self._build_strategy,
-            exec_strategy=self._exec_strategy,
-            places=self._place,
         )
 
     def _build_feed(self, inputs):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

The api with_data_parallel will be removed after paddle2.5. So its references should be removed at same time.
The `with_data_parallel` here has no effect since the `place` was or should be 1.

#### Others
Pcard-67004