### PR TITLE
Fix dy2st fp16 train error with control flow

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fp16_with_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fp16_with_control_flow.py
@@ -30,6 +30,8 @@ class Net(paddle.nn.Layer):
         y = 0
         for i in range(paddle.shape(x)[0]):
             y = y + x[i]
+            for j in range(paddle.shape(x)[0]):
+                y = y + x[j]
         return y
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fp16_with_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fp16_with_control_flow.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import paddle
+
+
+class Net(paddle.nn.Layer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.linear = paddle.nn.Linear(10, 10)
+
+    @paddle.jit.to_static
+    def forward(self, x):
+        x = self.linear(x)
+        y = 0
+        for i in range(paddle.shape(x)[0]):
+            y = y + x[i]
+        return y
+
+
+class TestMNIST(unittest.TestCase):
+    def test_run(self):
+        if paddle.fluid.is_compiled_with_cuda():
+            x = paddle.ones((10, 10))
+            net = Net()
+            net.eval()
+            net = paddle.amp.decorate(
+                models=net, optimizers=None, level='O2', save_dtype='float32'
+            )
+            with paddle.amp.auto_cast(
+                enable=True,
+                custom_white_list=None,
+                custom_black_list=None,
+                level='O2',
+            ):
+                out = net(x)
+                np.testing.assert_equal(out.shape, (10,))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/static/amp/fp16_utils.py
+++ b/python/paddle/static/amp/fp16_utils.py
@@ -513,7 +513,7 @@ def cast_model_to_fp16(program, amp_lists=None, use_fp16_guard=True):
                                 e
                             )
                         )
-                        out_var = global_block.var(out_var_name)
+                        out_var = block._var_recursive(out_var_name)
                         if out_var is not None:
                             _logger.debug(
                                 "-- var {} is got in the global block --".format(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix dy2st fp16 train error with control flow
本PR修复动转静+amp时的两个报错的问题
1. 嵌套控制流，在amp转写program时，会有找不到var的错误。比如下面的program中，block2/3是两个嵌套的控制流，在处理block3时，`range_1.tmp_0_slice_0`变量通过`global_block.var(in_var_name)`是不到的，需要通过`block._var_recursive(in_var_name)`进行查找
![image](https://user-images.githubusercontent.com/23097963/223413041-a9d6eeaa-9ae5-432e-ba0c-38a638c6c792.png)
2. 在amp转写program时，rename op的input/output时没有处理sub block，导致执行时找不到var。如单测中的case所示

card-67231