### PR TITLE
fix phi backend header should not include fluid header file

### DIFF
--- a/paddle/phi/CMakeLists.txt
+++ b/paddle/phi/CMakeLists.txt
@@ -55,7 +55,7 @@ file(
 )
 
 # generate inner headers include dir for users
-generate_unify_header(backends)
+generate_unify_header(backends EXCLUDES context_pool_utils.h)
 generate_unify_header(core EXCLUDES cuda_stream.h)
 generate_unify_header(infermeta)
 generate_unify_header(kernels SKIP_SUFFIX grad_kernel)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

https://github.com/PaddlePaddle/Paddle/pull/50865 introduce "context_pool_utils.h" which auomatically added into 'phi/include/backend.h', while "context_pool_utils.h" introduce the fluid header of "paddle/fluid/memory/allocation/allocator_facade.h", which broken the custom device compile.
