### PR TITLE
Delete axis of fmax kernel

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -498,7 +498,7 @@
 
 - backward_op : fmax_grad
   forward : fmax(Tensor x, Tensor y) -> Tensor(out)
-  args : (Tensor x, Tensor y, Tensor out_grad, int axis = -1)
+  args : (Tensor x, Tensor y, Tensor out_grad)
   output : Tensor(x_grad), Tensor(y_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta

--- a/paddle/phi/kernels/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_kernel.cc
@@ -121,14 +121,8 @@ using complex128 = ::phi::dtype::complex<double>;
 // NOTE(chenweihang): using bfloat16 will cause redefine with xpu bfloat16
 // using bfloat16 = ::phi::dtype::bfloat16;
 
-PD_REGISTER_KERNEL(fmax_raw,
-                   CPU,
-                   ALL_LAYOUT,
-                   phi::FMaxRawKernel,
-                   float,
-                   double,
-                   int,
-                   int64_t) {}
+PD_REGISTER_KERNEL(
+    fmax, CPU, ALL_LAYOUT, phi::FMaxKernel, float, double, int, int64_t) {}
 
 PD_REGISTER_KERNEL(
     fmin, CPU, ALL_LAYOUT, phi::FMinKernel, float, double, int, int64_t) {}

--- a/paddle/phi/kernels/elementwise_grad_kernel.h
+++ b/paddle/phi/kernels/elementwise_grad_kernel.h
@@ -24,7 +24,6 @@ void ElementwiseFMaxGradKernel(const Context& dev_ctx,
                                const DenseTensor& x,
                                const DenseTensor& y,
                                const DenseTensor& out_grad,
-                               int axis,
                                DenseTensor* x_grad,
                                DenseTensor* y_grad);
 

--- a/paddle/phi/kernels/elementwise_kernel.cc
+++ b/paddle/phi/kernels/elementwise_kernel.cc
@@ -101,20 +101,9 @@ void SubtractKernel(const Context& dev_ctx,
   SubtractRawKernel<T>(dev_ctx, x, y, axis, out);
 }
 
-template <typename T, typename Context>
-void FMaxKernel(const Context& dev_ctx,
-                const DenseTensor& x,
-                const DenseTensor& y,
-                DenseTensor* out) {
-  FMaxRawKernel<T, Context>(dev_ctx, x, y, -1, out);
-}
-
 }  // namespace phi
 using complex64 = ::phi::dtype::complex<float>;
 using complex128 = ::phi::dtype::complex<double>;
-
-PD_REGISTER_KERNEL(
-    fmax, CPU, ALL_LAYOUT, phi::FMaxKernel, float, double, int, int64_t) {}
 
 PD_REGISTER_KERNEL(maximum,
                    CPU,
@@ -203,16 +192,6 @@ PD_REGISTER_KERNEL(divide,
                    complex128) {}
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-
-PD_REGISTER_KERNEL(fmax,
-                   KPS,
-                   ALL_LAYOUT,
-                   phi::FMaxKernel,
-                   float,
-                   double,
-                   int,
-                   phi::dtype::float16,
-                   int64_t) {}
 
 PD_REGISTER_KERNEL(maximum,
                    KPS,

--- a/paddle/phi/kernels/elementwise_kernel.h
+++ b/paddle/phi/kernels/elementwise_kernel.h
@@ -20,13 +20,6 @@
 namespace phi {
 
 template <typename T, typename Context>
-void FMaxRawKernel(const Context& dev_ctx,
-                   const DenseTensor& x,
-                   const DenseTensor& y,
-                   int axis,
-                   DenseTensor* out);
-
-template <typename T, typename Context>
 void FMaxKernel(const Context& dev_ctx,
                 const DenseTensor& x,
                 const DenseTensor& y,

--- a/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_grad_kernel_impl.h
@@ -265,7 +265,6 @@ void ElementwiseFMaxGradKernel(const Context& dev_ctx,
                                const DenseTensor& x,
                                const DenseTensor& y,
                                const DenseTensor& out_grad,
-                               int axis,
                                DenseTensor* x_grad,
                                DenseTensor* y_grad) {
   funcs::ElementwiseGradPreProcess(out_grad, x_grad);
@@ -273,6 +272,7 @@ void ElementwiseFMaxGradKernel(const Context& dev_ctx,
   auto out = out_grad;  // Fake out, not used
   auto x_dim = x.dims();
   auto y_dim = y.dims();
+  int axis = -1;
   if (x.dims() == y.dims()) {
     funcs::ElemwiseGradComputeNoBroadcast<Context,
                                           T,

--- a/paddle/phi/kernels/impl/elementwise_kernel_impl.h
+++ b/paddle/phi/kernels/impl/elementwise_kernel_impl.h
@@ -67,14 +67,13 @@ namespace phi {
   }
 
 template <typename T, typename Context>
-void FMaxRawKernel(const Context& dev_ctx,
-                   const DenseTensor& x,
-                   const DenseTensor& y,
-                   int axis,
-                   DenseTensor* out) {
+void FMaxKernel(const Context& dev_ctx,
+                const DenseTensor& x,
+                const DenseTensor& y,
+                DenseTensor* out) {
   dev_ctx.template Alloc<T>(out);
   funcs::ElementwiseCompute<funcs::FMaxFunctor<T>, T, T>(
-      dev_ctx, x, y, axis, funcs::FMaxFunctor<T>(), out);
+      dev_ctx, x, y, -1, funcs::FMaxFunctor<T>(), out);
 }
 
 template <typename T, typename Context>

--- a/paddle/phi/kernels/kps/elementwise_kernel.cu
+++ b/paddle/phi/kernels/kps/elementwise_kernel.cu
@@ -109,10 +109,10 @@ using bfloat16 = phi::dtype::bfloat16;
 using complex64 = ::phi::dtype::complex<float>;
 using complex128 = ::phi::dtype::complex<double>;
 
-PD_REGISTER_KERNEL(fmax_raw,
+PD_REGISTER_KERNEL(fmax,
                    KPS,
                    ALL_LAYOUT,
-                   phi::FMaxRawKernel,
+                   phi::FMaxKernel,
                    float,
                    double,
                    int,

--- a/paddle/phi/ops/compat/elementwise_sig.cc
+++ b/paddle/phi/ops/compat/elementwise_sig.cc
@@ -176,7 +176,7 @@ KernelSignature ElementwiseMulGradOpArgumentMapping(
 
 KernelSignature ElementwiseFMaxOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
-  return KernelSignature("fmax_raw", {"X", "Y"}, {"axis"}, {"Out"});
+  return KernelSignature("fmax", {"X", "Y"}, {}, {"Out"});
 }
 
 KernelSignature ElementwiseFMinOpArgumentMapping(
@@ -187,7 +187,7 @@ KernelSignature ElementwiseFMinOpArgumentMapping(
 KernelSignature ElementwiseFMaxGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature(
-      "fmax_grad", {"X", "Y", "Out@GRAD"}, {"axis"}, {"X@GRAD", "Y@GRAD"});
+      "fmax_grad", {"X", "Y", "Out@GRAD"}, {}, {"X@GRAD", "Y@GRAD"});
 }
 
 KernelSignature ElementwiseMulDoubleGradOpArgumentMapping(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fmax作为elementwise系列算子，由于模板复用在定义时引入了axis参数，但在API使用时从未传入axis参数，因此fmax的kernel在计算时axis值永远为-1，所以理论上可以将axis从fmax的输入参数中去除。