### PR TITLE
[Zero-Dim] support ONEDNN 0D for full_kernel

### DIFF
--- a/paddle/phi/backends/onednn/onednn_helper.h
+++ b/paddle/phi/backends/onednn/onednn_helper.h
@@ -69,6 +69,9 @@ inline OneDNNMemoryFormat OneDNNFormatForSize(size_t dims_size,
 
 inline dnnl::memory::format_tag GetPlainOneDNNFormat(int tensor_rank) {
   switch (tensor_rank) {
+    case 0:
+      // use 1D to represent 0D
+      return dnnl::memory::format_tag::a;
     case 1:
       return dnnl::memory::format_tag::a;
     case 2:

--- a/paddle/phi/kernels/onednn/transpose_grad_kernel.cc
+++ b/paddle/phi/kernels/onednn/transpose_grad_kernel.cc
@@ -30,7 +30,7 @@ void TransposeGradKernel(const Context& dev_ctx,
 
   const auto& onednn_engine = dev_ctx.GetEngine();
 
-  if (axis.size() == 1) {
+  if (axis.size() == 1 || axis.size() == 0) {
     Copy<Context>(dev_ctx, out_grad, out_grad.place(), false, x_grad);
     x_grad->set_mem_desc(out_grad.mem_desc());
     return;

--- a/paddle/phi/kernels/onednn/transpose_kernel.cc
+++ b/paddle/phi/kernels/onednn/transpose_kernel.cc
@@ -112,7 +112,7 @@ void TransposeKernel(const Context& dev_ctx,
   SetInMemDescWithLogicalLayoutFusesSupport(
       dev_ctx, const_cast<DenseTensor*>(&x), x.mem_desc());
 
-  if (axis.size() == 1) {
+  if (axis.size() == 1 || axis.size() == 0) {
     Copy<Context>(dev_ctx, x, x.place(), false, out);
     out->set_mem_desc(x.mem_desc());
     return;

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_mkldnn_op.py
@@ -87,5 +87,11 @@ class TestCase4(TestTransposeMKLDNN):
         self.axis = (4, 2, 3, 1, 0, 5)
 
 
+class TestCase_ZeroDim(TestTransposeMKLDNN):
+    def initTestCase(self):
+        self.shape = ()
+        self.axis = ()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
solve https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-67472/show?source=drawer-header

support ONEDNN 0D for full_kernel