### PR TITLE
Fix fused_gemm_epilogue compilation not declared problem

### DIFF
--- a/paddle/fluid/operators/fused/fused_gemm_epilogue_op.h
+++ b/paddle/fluid/operators/fused/fused_gemm_epilogue_op.h
@@ -28,6 +28,7 @@ limitations under the License. */
 
 #include "gflags/gflags.h"
 #include "paddle/fluid/framework/scope_guard.h"
+#include "paddle/fluid/memory/memory.h"
 #include "paddle/fluid/platform/dynload/cublasLt.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/float16.h"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

card-67591
修复了在cuda 11.06 上算子编译的问题：
![2393b68294cbd1ea8499a591160e3ea7](https://user-images.githubusercontent.com/9301846/223325808-ac003061-a764-4fbe-9b35-79b578f2b3cd.png)
