### PR TITLE
Optimization for layerNormGrad [Part1]

### DIFF
--- a/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
+++ b/paddle/phi/kernels/funcs/layer_norm_impl.cu.h
@@ -504,8 +504,8 @@ __inline__ __device__ void cuLoadAddStridedInputs(const int64_t i1_block,
                                                   const int row_stride,
                                                   U *warp_buf1,
                                                   U *warp_buf2,
-                                                  const T *input,
-                                                  const T *dout,
+                                                  const T *__restrict__ input,
+                                                  const T *__restrict__ dout,
                                                   const int64_t i1_end,
                                                   const int64_t n2,
                                                   const U *__restrict__ mean,
@@ -1326,22 +1326,22 @@ __global__ void LayerNormBackwardComputeGradInput(
 
     U sum_loss1 = static_cast<U>(0);
     U sum_loss2 = static_cast<U>(0);
+    U gamma_data = static_cast<U>(0);
     U k_dout_data = static_cast<U>(0);
     U k_input_data = static_cast<U>(0);
-    ScaleT gamma_data = static_cast<ScaleT>(0);
     if (gamma != NULL) {
       for (int l = thrx; l < n2; l += numx) {
-        k_dout_data = static_cast<U>(k_dout[i]);
-        k_input_data = static_cast<U>(k_input[i]);
-        gamma_data = static_cast<U>(gamma[i]);
+        gamma_data = static_cast<U>(gamma[l]);
+        k_dout_data = static_cast<U>(k_dout[l]);
+        k_input_data = static_cast<U>(k_input[l]);
         sum_loss1 += k_dout_data * gamma_data;
         sum_loss2 +=
             k_dout_data * gamma_data * (k_input_data - c_mean) * c_invvar;
       }
     } else {
       for (int l = thrx; l < n2; l += numx) {
-        k_dout_data = static_cast<U>(k_dout[i]);
-        k_input_data = static_cast<U>(k_input[i]);
+        k_dout_data = static_cast<U>(k_dout[l]);
+        k_input_data = static_cast<U>(k_input[l]);
         sum_loss1 += k_dout_data;
         sum_loss2 += k_dout_data * (k_input_data - c_mean) * c_invvar;
       }

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -265,8 +265,8 @@ class TestLayerNormOp(unittest.TestCase):
             test_with_place(place, shape, begin_norm_axis)
 
     def test_check_forward_backward_with_scale_and_bias(self):
-        self.check_forward_backward(shape=[1, 3, 4, 5], begin_norm_axis=1)
         self.check_forward_backward(shape=[2, 3, 4, 5], begin_norm_axis=1)
+        self.check_forward_backward(shape=[1, 3, 4, 5], begin_norm_axis=1)
         self.check_forward_backward(
             shape=[2, 3, 4, 5],
             begin_norm_axis=1,
@@ -290,6 +290,7 @@ class TestLayerNormOp(unittest.TestCase):
             shape=[92, 513, 129], begin_norm_axis=2, y_grad_scale=0.1
         )
         self.check_forward_backward(shape=[3, 34, 1134], begin_norm_axis=2)
+        self.check_forward_backward(shape=[3, 2, 1133], begin_norm_axis=2)
         self.check_forward_backward(
             shape=[92, 513, 1134], begin_norm_axis=2, y_grad_scale=0.1
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

- 优化点：
1. 优化了数据读取操作，减少一次数据读取；
2. 优化掉多余的`__syncthreads()` 操作;
3. 优化了内存申请操作，减少了malloc和free的规模.

- 优化效果：
1. 模型层面：AF2 模型性能由 3.0897s/step 提升至 3.0548s/step, 约 1.1%.
2. 算子层面：在小feature_size 层面，性能超越APEX

**LayerNormBackwardComputeGradInput**  kernel time cost in 100 iter is below:

Shape | Norm Axis | dtype | Dev / ms | Opt / ms | Diff
-- | -- | -- | -- | -- | --
[65530, 64] | 1 | FP32 | 9.9512 | 5.809 | 41.63%
[65536, 128] | 1 | FP32 | 10.891 | 8.196 | 24.75%
[262144, 64] | 1 | FP32 | 38.741 | 21.783 | 43.77%









