### PR TITLE
fix wrong backward grad of amin/amax

### DIFF
--- a/paddle/phi/kernels/gpu/reduce_amin_amax_common.h
+++ b/paddle/phi/kernels/gpu/reduce_amin_amax_common.h
@@ -92,7 +92,14 @@ void ReduceCudaAMaxAMinGrad(const Context& dev_ctx,
           reduce_dims,
           false);
 
-  // 3. dx = Div(dout, equal_out)
+  // 3. dx = dout * 1
+  std::vector<const phi::DenseTensor*> mul_inputs = {&new_dout,
+                                                     &equal_out_tensor};
+  std::vector<phi::DenseTensor*> mul_outputs = {&equal_out_tensor};
+  funcs::BroadcastKernel<phi::ElementwiseType::kBinary, T, T>(
+      dev_ctx, mul_inputs, &mul_outputs, 0, funcs::MultiplyFunctor<T>());
+
+  // 4. dx = Div(dx, equal_out)
   std::vector<const phi::DenseTensor*> grad_inputs = {&equal_out_tensor,
                                                       equal_count};
   std::vector<phi::DenseTensor*> grad_outputs = {new_dx_tensor};


### PR DESCRIPTION
### PR types

Bug fixes 

### PR changes

OPs

### Describe

We fix two bugs of amin/amax backward:

1. when input is a int32 or int64 tensor, its grad is zero, which is wrong:

example code:
```
import paddle                                                                                                                                                                                                                                                                                  
data = paddle.to_tensor([2, 2], dtype='int64')                                                                                                             
data.stop_gradient = False                                                                                                                                 
data.register_hook(lambda grad: print('data grad', grad))                                                                                                  
min_a = paddle.amin(data)                                                                                                                                  
print("===min_a: ", min_a)                                                                                                                                 
min_a.register_hook(lambda grad: print('min_a grad', grad))                                                                                                
loss = min_a * 2.                                                                                                                                          
loss.register_hook(lambda grad: print('loss grad', grad))                                                                                                  
loss.backward()
```

results before bug fix:
![image](https://user-images.githubusercontent.com/22235422/223379342-39c94d28-1d48-4248-a9fc-cd8ef3c356d0.png)

results after bug fix:
![image](https://user-images.githubusercontent.com/22235422/223379778-6a34e0b3-0603-4742-8e57-101a47eace41.png)

2. grad of input did not accumulate the grad of output:

example code:
```
import paddle                                                                                                                                                                                                                                                                                  
data = paddle.to_tensor([2, 2], dtype='float32')                                                                                                             
data.stop_gradient = False                                                                                                                                 
data.register_hook(lambda grad: print('data grad', grad))                                                                                                  
min_a = paddle.amin(data)                                                                                                                                  
print("===min_a: ", min_a)                                                                                                                                 
min_a.register_hook(lambda grad: print('min_a grad', grad))                                                                                                
loss = min_a * 2.                                                                                                                                          
loss.register_hook(lambda grad: print('loss grad', grad))                                                                                                  
loss.backward()
```

results before bug fix:
![image](https://user-images.githubusercontent.com/22235422/223380225-b25782dc-e702-4fc0-9978-54c2cfeea4d9.png)

results after bug fix:
![image](https://user-images.githubusercontent.com/22235422/223380294-5ce4fda7-07ae-4650-950a-30134b4d49b3.png)

