### PR TITLE
Make flash attention available above nvcc 11.2

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -531,6 +531,8 @@ if(WITH_GPU
     include(external/cutlass) # download, build, install cusparselt
     list(APPEND third_party_deps extern_cutlass)
     set(WITH_CUTLASS ON)
+  endif()
+  if(${CMAKE_CUDA_COMPILER_VERSION} GREATER_EQUAL 11.2)
     include(external/flashattn)
     list(APPEND third_party_deps extern_flashattn)
     set(WITH_FLASHATTN ON)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Do not compile flash-attn in nvcc 11.0.
