### PR TITLE
Fix fused_linear bfloat16 kernel registration error

### DIFF
--- a/paddle/fluid/operators/fused/fused_gemm_epilogue_op.cu
+++ b/paddle/fluid/operators/fused/fused_gemm_epilogue_op.cu
@@ -130,5 +130,6 @@ REGISTER_OP_CUDA_KERNEL(
     ops::FusedGemmEpilogueGradKernel<phi::GPUContext, double>,
     ops::FusedGemmEpilogueGradKernel<phi::GPUContext,
                                      paddle::platform::float16>,
-    ops::FusedGemmEpilogueKernel<phi::GPUContext, paddle::platform::bfloat16>);
+    ops::FusedGemmEpilogueGradKernel<phi::GPUContext,
+                                     paddle::platform::bfloat16>);
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fix `fused_linear` bfloat16 kernel registration error.