### PR TITLE
No.47 为 Paddle cross 算子实现 float16 数据类型支持

### DIFF
--- a/paddle/phi/kernels/gpu/cross_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_grad_kernel.cu
@@ -46,6 +46,33 @@ __global__ void CrossGrad(const T* x,
 
     out_dx[pos2] = out[pos1] * y[pos0] - out[pos0] * y[pos1];
     out_dy[pos2] = out[pos0] * x[pos1] - out[pos1] * x[pos0];
+    
+    using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
+    MPType x_pos0_mp = static_cast<MPType>(x[pos0]);
+    MPType x_pos1_mp = static_cast<MPType>(x[pos1]);
+    MPType x_pos2_mp = static_cast<MPType>(x[pos2]);
+    MPType y_pos0_mp = static_cast<MPType>(y[pos0]);
+    MPType y_pos1_mp = static_cast<MPType>(y[pos1]);
+    MPType y_pos2_mp = static_cast<MPType>(y[pos2]);
+    MPType out_pos0_mp = static_cast<MPType>(out[pos0]);
+    MPType out_pos1_mp = static_cast<MPType>(out[pos1]);
+    MPType out_pos2_mp = static_cast<MPType>(out[pos2]);
+
+    out_dx[pos0] =
+        static_cast<T>(out_pos2_mp * y_pos1_mp - out_pos1_mp * y_pos2_mp);
+    out_dy[pos0] =
+        static_cast<T>(out_pos1_mp * x_pos2_mp - out_pos2_mp * x_pos1_mp);
+
+    out_dx[pos1] =
+        static_cast<T>(out_pos0_mp * y_pos2_mp - out_pos2_mp * y_pos0_mp);
+    out_dy[pos1] =
+        static_cast<T>(out_pos2_mp * x_pos0_mp - out_pos0_mp * x_pos2_mp);
+
+    out_dx[pos2] =
+        static_cast<T>(out_pos1_mp * y_pos0_mp - out_pos0_mp * y_pos1_mp);
+    out_dy[pos2] =
+        static_cast<T>(out_pos0_mp * x_pos1_mp - out_pos1_mp * x_pos0_mp);
   }
 }
 
@@ -172,6 +199,7 @@ PD_REGISTER_KERNEL(cross_grad,
                    GPU,
                    ALL_LAYOUT,
                    phi::CrossGradKernel,
+                   phi::dtype::float16,
                    float,
                    double,
                    int,

--- a/paddle/phi/kernels/gpu/cross_kernel.cu
+++ b/paddle/phi/kernels/gpu/cross_kernel.cu
@@ -16,6 +16,7 @@
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_launch_config.h"
+#include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/index_calculator.h"
@@ -39,6 +40,18 @@ __global__ void Cross(const T* x,
     out[pos0] = x[pos1] * y[pos2] - x[pos2] * y[pos1];
     out[pos1] = x[pos2] * y[pos0] - x[pos0] * y[pos2];
     out[pos2] = x[pos0] * y[pos1] - x[pos1] * y[pos0];
+    using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
+
+    MPType x_pos0_mp = static_cast<MPType>(x[pos0]);
+    MPType x_pos1_mp = static_cast<MPType>(x[pos1]);
+    MPType x_pos2_mp = static_cast<MPType>(x[pos2]);
+    MPType y_pos0_mp = static_cast<MPType>(y[pos0]);
+    MPType y_pos1_mp = static_cast<MPType>(y[pos1]);
+    MPType y_pos2_mp = static_cast<MPType>(y[pos2]);
+
+    out[pos0] = static_cast<T>(x_pos1_mp * y_pos2_mp - x_pos2_mp * y_pos1_mp);
+    out[pos1] = static_cast<T>(x_pos2_mp * y_pos0_mp - x_pos0_mp * y_pos2_mp);
+    out[pos2] = static_cast<T>(x_pos0_mp * y_pos1_mp - x_pos1_mp * y_pos0_mp);
   }
 }
 
@@ -155,3 +168,12 @@ void CrossKernel(const Context& dev_ctx,
 
 PD_REGISTER_KERNEL(
     cross, GPU, ALL_LAYOUT, phi::CrossKernel, float, double, int, int64_t) {}
+PD_REGISTER_KERNEL(cross,
+                   GPU,
+                   ALL_LAYOUT,
+                   phi::CrossKernel,
+                   phi::dtype::float16,
+                   float,
+                   double,
+                   int,
+                   int64_t) {}

--- a/python/paddle/fluid/tests/unittests/test_cross_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_op.py
@@ -64,7 +64,22 @@ class TestCrossOpCase1(TestCrossOp):
             z_list.append(np.cross(self.inputs['X'][i], self.inputs['Y'][i]))
         self.outputs = {'Out': np.array(z_list).reshape(self.shape)}
 
+        
+class TestCrossOpCase2(TestCrossOp):
+    def initTestCase(self):
+        self.shape = (2048, 3)
+        self.dtype = np.float16
 
+    def init_output(self):
+        z_list = []
+        for i in range(2048):
+            z_list.append(np.cross(self.inputs['X'][i], self.inputs['Y'][i]))
+        self.outputs = {'Out': np.array(z_list).reshape(self.shape)}
+
+    def test_check_output(self):
+        self.check_output(atol=1e-3, check_eager=True)
+        
+        
 class TestCrossAPI(unittest.TestCase):
     def input_data(self):
         self.data_x = np.array(


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
op benchmark
<html>
<body>
<!--StartFragment-->

shape | axis | fp32 | fp16
-- | -- | -- | --
2048, 3 | 1 | 0.119930141 | 0.119697561
16, 3, 20480 | 1 | 0.136250866 | 0.124568842
16, 20, 3, 40, 50 | 2 | 0.164437537 | 0.140431219

<!--EndFragment-->
</body>
</html>