### PR TITLE
[Dy2static] Auto Remove Step Scope while GradRunProgramNode GCed.

### DIFF
--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -573,7 +573,8 @@ inline void RunProgramGradAPI(
                                                    *backward_global_block,
                                                    global_inner_scope);
     VLOG(4) << "after backward gc all vars";
-    global_inner_scope->SetCanReuesd(false); // can't reuse util call `~GradNodeRunProgram`
+    global_inner_scope->SetCanReuesd(
+        false);  // can't reuse util call `~GradNodeRunProgram`
     details::GcScope(global_inner_scope);
   }
 }

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -573,7 +573,7 @@ inline void RunProgramGradAPI(
                                                    *backward_global_block,
                                                    global_inner_scope);
     VLOG(4) << "after backward gc all vars";
-    global_inner_scope->SetCanReuesd(true);
+    global_inner_scope->SetCanReuesd(false); // can't reuse util call `~GradNodeRunProgram`
     details::GcScope(global_inner_scope);
   }
 }

--- a/paddle/fluid/eager/to_static/run_program_op_node.h
+++ b/paddle/fluid/eager/to_static/run_program_op_node.h
@@ -283,6 +283,7 @@ inline void RunProgramAPI(
     std::vector<paddle::Tensor *> &out,                   // NOLINT
     std::vector<paddle::framework::Scope *> &step_scope,  // NOLINT
     std::vector<paddle::Tensor *> &dout,                  // NOLINT
+    bool require_any_grad,
     const paddle::framework::AttributeMap &attrs) {
   VLOG(2) << "RunProgramOpKernel Compute";
   // In the original run_program OP, the default value of the is_test
@@ -430,8 +431,10 @@ inline void RunProgramAPI(
 
     VLOG(3) << paddle::framework::GenScopeTreeDebugInfo(out_scope_vec->front());
 
-    if (is_test || !egr::Controller::Instance().HasGrad()) {
-      VLOG(4) << "is test, set this scope can reused";
+    if (is_test || !require_any_grad) {
+      VLOG(4) << "don't require any grad, set this scope can reused";
+      VLOG(4) << "is_test: " << is_test
+              << ", require_any_grad: " << require_any_grad;
       global_inner_scope->SetCanReuesd(true);
       details::GcScope(global_inner_scope);
     } else {
@@ -580,7 +583,15 @@ class GradNodeRunProgram : public egr::GradNodeBase {
   GradNodeRunProgram(size_t bwd_in_slot_num, size_t bwd_out_slot_num)
       : egr::GradNodeBase(bwd_in_slot_num, bwd_out_slot_num) {}
 
-  ~GradNodeRunProgram() override = default;
+  ~GradNodeRunProgram() {
+    auto *out_scope_vec = &step_scope_;
+    // Normally out_scope_vec.size() == 1. for safty, we add for-loop here.
+    for (size_t i = 0; i < out_scope_vec->size(); ++i) {
+      paddle::framework::Scope *global_inner_scope = out_scope_vec->at(i);
+      global_inner_scope->SetCanReuesd(true);  // set this to reuse scope.
+      details::GcScope(global_inner_scope);
+    }
+  }
   // Functor: perform backward computations
   virtual paddle::small_vector<std::vector<paddle::Tensor>,
                                egr::kSlotSmallVectorSize>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
PCard-66972
用户可以支持如下的操作，而不用显示的切换到eval模式下了：
```
import paddle
import time
def func(x):
    return  x * x

x = paddle.rand((1, 1000, 1000, 1000))
x.stop_gradient = True
func = paddle.jit.to_static(func)
for i in range(20):
    time.sleep(3)
    print("Step ", i)
    loss = func(x) # <--  mult-forward, but don't call backward.
    del loss
```