### PR TITLE
Fix var-ref errors for standalone executor trace mode

### DIFF
--- a/paddle/fluid/framework/new_executor/interpretercore.cc
+++ b/paddle/fluid/framework/new_executor/interpretercore.cc
@@ -204,6 +204,8 @@ void InterpreterCore::RunImpl() {
     gc_ = CreateInterpreterCoreGarbageCollector(place_, vec_instruction_);
   }
 
+  interpreter::ResetAtomicGuard guard(&deps_, &refs_);
+
   if ((execution_config_.used_for_jit || execution_config_.used_for_cinn) &&
       (sync_op_num_ == 0)) {
     VLOG(4) << "Tracing Instruction List";
@@ -1022,7 +1024,6 @@ void InterpreterCore::RunInstruction(const Instruction& instr_node) {
 
 void InterpreterCore::ExecuteInstructionList(
     const std::vector<Instruction>& vec_instr) {
-  interpreter::ResetAtomicGuard guard(&deps_, &refs_);
   unfinished_op_number_ = vec_instr.size();
   if (unfinished_op_number_ == 0) {
     VLOG(4) << "No op to run, return";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
Pcard-67003

新执行器trace执行模式下，每轮跑完算子后，变量引用计数`VarRefInfo`未重置。从第三个step开始，引用计数错乱（初始即为0，为第二个step执行结束时的状态），导致显存无法被GC。
本PR修复此问题。