### PR TITLE
Remove unused parameter nums in kernel function index_select_grad 

### DIFF
--- a/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
@@ -31,12 +31,10 @@ template <typename T, typename IndexT>
 __global__ void index_select_grad_cuda_kernel(const T* output_grad,
                                               T* input_grad,
                                               const IndexT* index,
-                                              int64_t nums,
                                               int64_t N,
                                               int64_t stride,
                                               int64_t size,
-                                              int64_t delta,
-                                              void* null_flag) {
+                                              int64_t delta) {
   CUDA_KERNEL_LOOP_TYPE(idx, N, int64_t) {
     int64_t pre_idx = idx / (stride * size);
     int64_t dim_idx = idx % (stride * size) / stride;
@@ -105,24 +103,20 @@ void IndexSelectGradKernel(const Context& ctx,
         <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
                                              in_grad_data,
                                              index_data,
-                                             index_nums,
                                              out_nums,
                                              stride,
                                              size,
-                                             delta,
-                                             nullptr);
+                                             delta);
   } else {
     const int* index_data = index.data<int>();
     index_select_grad_cuda_kernel<T, int>
         <<<grid_dim, block_dim, 0, stream>>>(output_grad_data,
                                              in_grad_data,
                                              index_data,
-                                             index_nums,
                                              out_nums,
                                              stride,
                                              size,
-                                             delta,
-                                             nullptr);
+                                             delta);
   }
 }
 

--- a/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
@@ -98,6 +98,7 @@ void IndexSelectGradKernel(const Context& ctx,
     block_dim = 1;
     grid_dim.x = 1;
   }
+
   if (index_type == phi::DataType::INT64) {
     const int64_t* index_data = index.data<int64_t>();
     index_select_grad_cuda_kernel<T, int64_t>

--- a/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/index_select_grad_kernel.cu
@@ -43,7 +43,7 @@ __global__ void index_select_grad_cuda_kernel(const T* output_grad,
     IndexT src_dim_idx = index[dim_idx];
     int64_t input_idx =
         idx + (delta * pre_idx + src_dim_idx - dim_idx) * stride;
-    phi::CudaAtomicAdd(input_grad + input_idx, output_grad[idx]);
+    phi::CudaAtomicAdd(&input_grad[input_idx], output_grad[idx]);
   }
 }
 

--- a/python/paddle/fluid/tests/unittests/test_index_select_op.py
+++ b/python/paddle/fluid/tests/unittests/test_index_select_op.py
@@ -29,7 +29,6 @@ class TestIndexSelectOp(OpTest):
         self.python_api = paddle.index_select
         self.op_type = "index_select"
         self.init_dtype_type()
-
         index_np = np.random.randint(
             low=0, high=self.x_shape[self.dim], size=self.index_size
         )

--- a/python/paddle/fluid/tests/unittests/test_index_select_op.py
+++ b/python/paddle/fluid/tests/unittests/test_index_select_op.py
@@ -28,7 +28,6 @@ class TestIndexSelectOp(OpTest):
     def setUp(self):
         self.python_api = paddle.index_select
         self.op_type = "index_select"
-        self.prim_op_type = "comp"
         self.init_dtype_type()
 
         index_np = np.random.randint(
@@ -59,10 +58,10 @@ class TestIndexSelectOp(OpTest):
         self.index_size = 100
 
     def test_check_output(self):
-        self.check_output(check_eager=True, check_prim=True)
+        self.check_output(check_eager=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', check_eager=True, check_prim=True)
+        self.check_grad(['X'], 'Out', check_eager=True)
 
 
 class TestIndexSelectOpCase2(TestIndexSelectOp):

--- a/python/paddle/fluid/tests/unittests/test_index_select_op.py
+++ b/python/paddle/fluid/tests/unittests/test_index_select_op.py
@@ -21,12 +21,16 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 
+np.random.seed(1024)
+
 
 class TestIndexSelectOp(OpTest):
     def setUp(self):
         self.python_api = paddle.index_select
         self.op_type = "index_select"
+        self.prim_op_type = "comp"
         self.init_dtype_type()
+
         index_np = np.random.randint(
             low=0, high=self.x_shape[self.dim], size=self.index_size
         )
@@ -55,10 +59,10 @@ class TestIndexSelectOp(OpTest):
         self.index_size = 100
 
     def test_check_output(self):
-        self.check_output(check_eager=True)
+        self.check_output(check_eager=True, check_prim=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', check_eager=True)
+        self.check_grad(['X'], 'Out', check_eager=True, check_prim=True)
 
 
 class TestIndexSelectOpCase2(TestIndexSelectOp):
@@ -68,6 +72,18 @@ class TestIndexSelectOpCase2(TestIndexSelectOp):
         self.dim = -2
         self.x_shape = (10, 10, 4, 10)
         self.index_size = 10
+
+
+class TestIndexSelectOpFp16(TestIndexSelectOp):
+    def init_dtype_type(self):
+        super().init_dtype_type()
+        self.x_type = np.float16
+
+
+class TestIndexSelectOpCase2fp16(TestIndexSelectOpCase2):
+    def init_dtype_type(self):
+        super().init_dtype_type()
+        self.x_type = np.float16
 
 
 class TestIndexSelectOpCaseSingleThread(TestIndexSelectOp):
@@ -89,10 +105,11 @@ class TestIndexSelectAPI(unittest.TestCase):
                 [5.0, 6.0, 7.0, 8.0],
                 [9.0, 10.0, 11.0, 12.0],
             ]
-        )
+        ).astype("float32")
         self.data_index = np.array([0, 1, 1]).astype('int32')
 
     def test_index_select_api(self):
+        paddle.enable_static()
         self.input_data()
 
         # case 1:
@@ -128,6 +145,7 @@ class TestIndexSelectAPI(unittest.TestCase):
         np.testing.assert_allclose(expect_out, np.array(res), rtol=1e-05)
 
     def test_dygraph_api(self):
+        paddle.disable_static()
         self.input_data()
         # case 1:
         with fluid.dygraph.guard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Remove  unused parameters in kernel function.