### PR TITLE
[Paddle Inference] Support dims 1 input of activation and unary op for dynamic shape.

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -113,10 +113,13 @@ struct SimpleOpTypeSetTeller : public Teller {
       auto x_var_name = desc.Input("X")[0];
       auto* x_var_desc = block->FindVar(x_var_name);
       const auto x_shape = x_var_desc->GetShape();
-      if (x_shape.size() == 1) {
-        VLOG(3) << op_type
-                << " op does not support input's dim is 1 in tensorrt.";
-        return false;
+      if (!with_dynamic_shape) {
+        if (x_shape.size() == 1) {
+          VLOG(3) << op_type
+                  << " op does not support input's dim is 1 in tensorrt with "
+                     "static shape.";
+          return false;
+        }
       }
 #if !IS_TRT_VERSION_GE(7000)
       if (op_type == "erf") {

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_activation.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_activation.py
@@ -132,7 +132,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if self.dims == 1:
+            if not dynamic_shape and self.dims == 1:
                 return 0, 3
             return 1, 2
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_celu.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_celu.py
@@ -104,7 +104,7 @@ class TrtConvertCeluTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if self.dims == 1:
+            if not dynamic_shape and self.dims == 1:
                 return 0, 3
             return 1, 2
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logsigmoid.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_logsigmoid.py
@@ -101,7 +101,7 @@ class TrtConvertLogSigmoidTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if self.dims == 1:
+            if not dynamic_shape and self.dims == 1:
                 return 0, 3
             return 1, 2
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_silu.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_silu.py
@@ -101,7 +101,7 @@ class TrtConvertSiluTest(TrtLayerAutoScanTest):
             self.dynamic_shape.opt_input_shape = {}
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
-            if self.dims == 1:
+            if not dynamic_shape and self.dims == 1:
                 return 0, 3
             return 1, 2
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unary.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_unary.py
@@ -171,7 +171,7 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
 
         def generate_trt_nodes_num(attrs, dynamic_shape):
             ver = paddle_infer.get_trt_compile_version()
-            if self.dims == 1 or (
+            if (self.dims == 1 and not dynamic_shape) or (
                 self.op_type == "sign"
                 and (
                     not dynamic_shape


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Support dims 1 input of activation and unary op for dynamic shape.