### PR TITLE
Delete maximum_raw and minimum_raw op

### DIFF
--- a/paddle/phi/api/yaml/legacy_backward.yaml
+++ b/paddle/phi/api/yaml/legacy_backward.yaml
@@ -781,7 +781,7 @@
 
 - backward_op : maximum_grad
   forward : maximum(Tensor x, Tensor y) -> Tensor(out)
-  args : (Tensor x, Tensor y, Tensor out_grad, int axis=-1)
+  args : (Tensor x, Tensor y, Tensor out_grad)
   output : Tensor(x_grad), Tensor(y_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta
@@ -829,7 +829,7 @@
 
 - backward_op : minimum_grad
   forward : minimum(Tensor x, Tensor y) -> Tensor(out)
-  args : (Tensor x, Tensor y, Tensor out_grad, int axis=-1)
+  args : (Tensor x, Tensor y, Tensor out_grad)
   output : Tensor(x_grad), Tensor(y_grad)
   infer_meta :
     func : GeneralBinaryGradInferMeta

--- a/paddle/phi/kernels/cpu/elementwise_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_grad_kernel.cc
@@ -28,10 +28,10 @@ void MaximumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   funcs::ElementwiseGradPreProcess(dout, dx);
+  int axis = -1;
   phi::funcs::ElemwiseGradCompute<Context, T, MaxGradDx<T>, MaxGradDy<T>>(
       dev_ctx, x, y, dout, dout, axis, dx, dy, MaxGradDx<T>(), MaxGradDy<T>());
 }
@@ -41,10 +41,10 @@ void MinimumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   funcs::ElementwiseGradPreProcess(dout, dx);
+  int axis = -1;
   phi::funcs::ElemwiseGradCompute<Context, T, MinGradDx<T>, MinGradDy<T>>(
       dev_ctx, x, y, dout, dout, axis, dx, dy, MinGradDx<T>(), MinGradDy<T>());
 }

--- a/paddle/phi/kernels/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_kernel.cc
@@ -22,11 +22,11 @@
 namespace phi {
 
 template <typename T, typename Context>
-void MaximumRawKernel(const Context& dev_ctx,
-                      const DenseTensor& x,
-                      const DenseTensor& y,
-                      int axis,
-                      DenseTensor* out) {
+void MaximumKernel(const Context& dev_ctx,
+                   const DenseTensor& x,
+                   const DenseTensor& y,
+                   DenseTensor* out) {
+  int axis = -1;
   // allocate memory for out
   dev_ctx.template Alloc<T>(out);
   funcs::ElementwiseCompute<funcs::MaximumFunctor<T>, T>(
@@ -34,11 +34,11 @@ void MaximumRawKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void MinimumRawKernel(const Context& dev_ctx,
-                      const DenseTensor& x,
-                      const DenseTensor& y,
-                      int axis,
-                      DenseTensor* out) {
+void MinimumKernel(const Context& dev_ctx,
+                   const DenseTensor& x,
+                   const DenseTensor& y,
+                   DenseTensor* out) {
+  int axis = -1;
   // allocate memory for out
   dev_ctx.template Alloc<T>(out);
   funcs::ElementwiseCompute<funcs::MinimumFunctor<T>, T>(
@@ -127,19 +127,19 @@ PD_REGISTER_KERNEL(
 PD_REGISTER_KERNEL(
     fmin, CPU, ALL_LAYOUT, phi::FMinKernel, float, double, int, int64_t) {}
 
-PD_REGISTER_KERNEL(maximum_raw,
+PD_REGISTER_KERNEL(maximum,
                    CPU,
                    ALL_LAYOUT,
-                   phi::MaximumRawKernel,
+                   phi::MaximumKernel,
                    float,
                    double,
                    int,
                    int64_t,
                    phi::dtype::bfloat16) {}
-PD_REGISTER_KERNEL(minimum_raw,
+PD_REGISTER_KERNEL(minimum,
                    CPU,
                    ALL_LAYOUT,
-                   phi::MinimumRawKernel,
+                   phi::MinimumKernel,
                    float,
                    double,
                    int,

--- a/paddle/phi/kernels/elementwise_grad_kernel.h
+++ b/paddle/phi/kernels/elementwise_grad_kernel.h
@@ -40,7 +40,6 @@ void MaximumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy);
 
@@ -49,7 +48,6 @@ void MinimumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy);
 

--- a/paddle/phi/kernels/elementwise_kernel.cc
+++ b/paddle/phi/kernels/elementwise_kernel.cc
@@ -24,24 +24,6 @@
 namespace phi {
 
 template <typename T, typename Context>
-void MaximumKernel(const Context& dev_ctx,
-                   const DenseTensor& x,
-                   const DenseTensor& y,
-                   DenseTensor* out) {
-  int axis = -1;
-  MaximumRawKernel<T>(dev_ctx, x, y, axis, out);
-}
-
-template <typename T, typename Context>
-void MinimumKernel(const Context& dev_ctx,
-                   const DenseTensor& x,
-                   const DenseTensor& y,
-                   DenseTensor* out) {
-  int axis = -1;
-  MinimumRawKernel<T>(dev_ctx, x, y, axis, out);
-}
-
-template <typename T, typename Context>
 void RemainderKernel(const Context& dev_ctx,
                      const DenseTensor& x,
                      const DenseTensor& y,
@@ -105,24 +87,6 @@ void SubtractKernel(const Context& dev_ctx,
 using complex64 = ::phi::dtype::complex<float>;
 using complex128 = ::phi::dtype::complex<double>;
 
-PD_REGISTER_KERNEL(maximum,
-                   CPU,
-                   ALL_LAYOUT,
-                   phi::MaximumKernel,
-                   float,
-                   double,
-                   int,
-                   int64_t,
-                   phi::dtype::bfloat16) {}
-PD_REGISTER_KERNEL(minimum,
-                   CPU,
-                   ALL_LAYOUT,
-                   phi::MinimumKernel,
-                   float,
-                   double,
-                   int,
-                   int64_t,
-                   phi::dtype::bfloat16) {}
 PD_REGISTER_KERNEL(remainder,
                    CPU,
                    ALL_LAYOUT,
@@ -193,26 +157,6 @@ PD_REGISTER_KERNEL(divide,
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
 
-PD_REGISTER_KERNEL(maximum,
-                   KPS,
-                   ALL_LAYOUT,
-                   phi::MaximumKernel,
-                   float,
-                   double,
-                   int,
-                   int64_t,
-                   phi::dtype::float16,
-                   phi::dtype::bfloat16) {}
-PD_REGISTER_KERNEL(minimum,
-                   KPS,
-                   ALL_LAYOUT,
-                   phi::MinimumKernel,
-                   float,
-                   double,
-                   int,
-                   int64_t,
-                   phi::dtype::float16,
-                   phi::dtype::bfloat16) {}
 PD_REGISTER_KERNEL(remainder,
                    GPU,
                    ALL_LAYOUT,
@@ -329,10 +273,6 @@ PD_REGISTER_KERNEL(floor_divide,
                    phi::FloorDivideKernel,
                    float,
                    phi::dtype::float16) {}
-PD_REGISTER_KERNEL(
-    maximum, XPU, ALL_LAYOUT, phi::MaximumKernel, float, phi::dtype::float16) {}
-PD_REGISTER_KERNEL(
-    minimum, XPU, ALL_LAYOUT, phi::MinimumKernel, float, phi::dtype::float16) {}
 PD_REGISTER_KERNEL(remainder,
                    XPU,
                    ALL_LAYOUT,

--- a/paddle/phi/kernels/elementwise_kernel.h
+++ b/paddle/phi/kernels/elementwise_kernel.h
@@ -32,24 +32,10 @@ void FMinKernel(const Context& dev_ctx,
                 DenseTensor* out);
 
 template <typename T, typename Context>
-void MaximumRawKernel(const Context& dev_ctx,
-                      const DenseTensor& x,
-                      const DenseTensor& y,
-                      int axis,
-                      DenseTensor* out);
-
-template <typename T, typename Context>
 void MaximumKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const DenseTensor& y,
                    DenseTensor* out);
-
-template <typename T, typename Context>
-void MinimumRawKernel(const Context& dev_ctx,
-                      const DenseTensor& x,
-                      const DenseTensor& y,
-                      int axis,
-                      DenseTensor* out);
 
 template <typename T, typename Context>
 void MinimumKernel(const Context& dev_ctx,

--- a/paddle/phi/kernels/gpu/elementwise_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/elementwise_grad_kernel.cu
@@ -31,11 +31,10 @@ void MaximumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   const auto place = dev_ctx.GetPlace();
-
+  int axis = -1;
   if (dx != nullptr && dy != nullptr) {
     std::vector<const DenseTensor*> ins = {&x, &y, &dout};
     GetGradXAndYOut<ElementwiseType::kTernary, T>(
@@ -63,10 +62,10 @@ void MinimumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   const auto place = dev_ctx.GetPlace();
+  int axis = -1;
   if (dx != nullptr && dy != nullptr) {
     std::vector<const DenseTensor*> ins = {&x, &y, &dout};
     GetGradXAndYOut<ElementwiseType::kTernary, T>(

--- a/paddle/phi/kernels/kps/elementwise_kernel.cu
+++ b/paddle/phi/kernels/kps/elementwise_kernel.cu
@@ -23,25 +23,39 @@
 namespace phi {
 
 // Create the definition of Maximum
-DEFINE_CUDA_ELEMENTWISE_OP(Maximum)
 template <typename T, typename Context>
 void MaximumKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const DenseTensor& y,
                    DenseTensor* out) {
-  int axis = -1;
-  MaximumRawKernel<T>(dev_ctx, x, y, axis, out);
+  std::vector<const DenseTensor*> inputs;
+  inputs.reserve(2);
+  std::vector<DenseTensor*> outputs;
+  outputs.reserve(1);
+  inputs.emplace_back(&x);
+  inputs.emplace_back(&y);
+  outputs.emplace_back(out);
+  dev_ctx.template Alloc<T>(out);
+  funcs::BroadcastKernel<ElementwiseType::kBinary, T, T>(
+      dev_ctx, inputs, &outputs, -1, funcs::MaximumFunctor<T>());
 }
 
 // Create the definition of Minimum
-DEFINE_CUDA_ELEMENTWISE_OP(Minimum)
 template <typename T, typename Context>
 void MinimumKernel(const Context& dev_ctx,
                    const DenseTensor& x,
                    const DenseTensor& y,
                    DenseTensor* out) {
-  int axis = -1;
-  MinimumRawKernel<T>(dev_ctx, x, y, axis, out);
+  std::vector<const DenseTensor*> inputs;
+  inputs.reserve(2);
+  std::vector<DenseTensor*> outputs;
+  outputs.reserve(1);
+  inputs.emplace_back(&x);
+  inputs.emplace_back(&y);
+  outputs.emplace_back(out);
+  dev_ctx.template Alloc<T>(out);
+  funcs::BroadcastKernel<ElementwiseType::kBinary, T, T>(
+      dev_ctx, inputs, &outputs, -1, funcs::MinimumFunctor<T>());
 }
 // Create the definition of Remainder
 DEFINE_CUDA_ELEMENTWISE_OP(Remainder)
@@ -87,12 +101,6 @@ void ElementwisePowKernel(const Context& dev_ctx,
 }  // namespace phi
 
 #ifdef PADDLE_WITH_XPU_KP
-PD_REGISTER_KERNEL(maximum, KPS, ALL_LAYOUT, phi::MaximumKernel, float) {}
-PD_REGISTER_KERNEL(maximum_raw, KPS, ALL_LAYOUT, phi::MaximumRawKernel, float) {
-}
-PD_REGISTER_KERNEL(minimum, KPS, ALL_LAYOUT, phi::MinimumKernel, float) {}
-PD_REGISTER_KERNEL(minimum_raw, KPS, ALL_LAYOUT, phi::MinimumRawKernel, float) {
-}
 PD_REGISTER_KERNEL(floor_divide, KPS, ALL_LAYOUT, phi::FloorDivideKernel, int) {
 }
 PD_REGISTER_KERNEL(
@@ -129,20 +137,20 @@ PD_REGISTER_KERNEL(fmin,
                    float16,
                    int64_t) {}
 
-PD_REGISTER_KERNEL(maximum_raw,
+PD_REGISTER_KERNEL(maximum,
                    KPS,
                    ALL_LAYOUT,
-                   phi::MaximumRawKernel,
+                   phi::MaximumKernel,
                    float,
                    double,
                    int,
                    int64_t,
                    float16,
                    bfloat16) {}
-PD_REGISTER_KERNEL(minimum_raw,
+PD_REGISTER_KERNEL(minimum,
                    KPS,
                    ALL_LAYOUT,
-                   phi::MinimumRawKernel,
+                   phi::MinimumKernel,
                    float,
                    double,
                    int,

--- a/paddle/phi/kernels/xpu/elementwise_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_grad_kernel.cc
@@ -25,7 +25,6 @@ void MaximumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   using XPUType = typename XPUTypeTrait<T>::Type;
@@ -51,7 +50,6 @@ void MinimumGradKernel(const Context& dev_ctx,
                        const DenseTensor& x,
                        const DenseTensor& y,
                        const DenseTensor& dout,
-                       int axis,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   using XPUType = typename XPUTypeTrait<T>::Type;

--- a/paddle/phi/kernels/xpu/elementwise_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_grad_kernel.cc
@@ -28,7 +28,7 @@ void MaximumGradKernel(const Context& dev_ctx,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-
+  int axis = -1;
   auto f = [](xpu::Context* ctx,
               const XPUType* x,
               const XPUType* y,
@@ -53,7 +53,7 @@ void MinimumGradKernel(const Context& dev_ctx,
                        DenseTensor* dx,
                        DenseTensor* dy) {
   using XPUType = typename XPUTypeTrait<T>::Type;
-
+  int axis = -1;
   auto f = [](xpu::Context* ctx,
               const XPUType* x,
               const XPUType* y,

--- a/paddle/phi/kernels/xpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/xpu/elementwise_kernel.cc
@@ -40,12 +40,12 @@ void FloorDivideRawKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void MaximumRawKernel(const Context& dev_ctx,
-                      const DenseTensor& x,
-                      const DenseTensor& y,
-                      int axis,
-                      DenseTensor* out) {
+void MaximumKernel(const Context& dev_ctx,
+                   const DenseTensor& x,
+                   const DenseTensor& y,
+                   DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  int axis = -1;
   auto f = [](xpu::Context* ctx,
               const XPUType* x,
               const XPUType* y,
@@ -59,12 +59,12 @@ void MaximumRawKernel(const Context& dev_ctx,
 }
 
 template <typename T, typename Context>
-void MinimumRawKernel(const Context& dev_ctx,
-                      const DenseTensor& x,
-                      const DenseTensor& y,
-                      int axis,
-                      DenseTensor* out) {
+void MinimumKernel(const Context& dev_ctx,
+                   const DenseTensor& x,
+                   const DenseTensor& y,
+                   DenseTensor* out) {
   using XPUType = typename XPUTypeTrait<T>::Type;
+  int axis = -1;
   auto f = [](xpu::Context* ctx,
               const XPUType* x,
               const XPUType* y,
@@ -123,18 +123,10 @@ PD_REGISTER_KERNEL(floor_divide_raw,
                    phi::FloorDivideRawKernel,
                    float,
                    phi::dtype::float16) {}
-PD_REGISTER_KERNEL(maximum_raw,
-                   XPU,
-                   ALL_LAYOUT,
-                   phi::MaximumRawKernel,
-                   float,
-                   phi::dtype::float16) {}
-PD_REGISTER_KERNEL(minimum_raw,
-                   XPU,
-                   ALL_LAYOUT,
-                   phi::MinimumRawKernel,
-                   float,
-                   phi::dtype::float16) {}
+PD_REGISTER_KERNEL(
+    maximum, XPU, ALL_LAYOUT, phi::MaximumKernel, float, phi::dtype::float16) {}
+PD_REGISTER_KERNEL(
+    minimum, XPU, ALL_LAYOUT, phi::MinimumKernel, float, phi::dtype::float16) {}
 PD_REGISTER_KERNEL(remainder_raw,
                    XPU,
                    ALL_LAYOUT,

--- a/paddle/phi/ops/compat/elementwise_sig.cc
+++ b/paddle/phi/ops/compat/elementwise_sig.cc
@@ -66,20 +66,12 @@ KernelSignature ElementwiseDivOpArgumentMapping(
 
 KernelSignature ElementwiseMaxOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
-  int axis = paddle::any_cast<int>(ctx.Attr("axis"));
-  if (axis == -1) {
-    return KernelSignature("maximum", {"X", "Y"}, {}, {"Out"});
-  }
-  return KernelSignature("maximum_raw", {"X", "Y"}, {"axis"}, {"Out"});
+  return KernelSignature("maximum", {"X", "Y"}, {}, {"Out"});
 }
 
 KernelSignature ElementwiseMinOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
-  int axis = paddle::any_cast<int>(ctx.Attr("axis"));
-  if (axis == -1) {
-    return KernelSignature("minimum", {"X", "Y"}, {}, {"Out"});
-  }
-  return KernelSignature("minimum_raw", {"X", "Y"}, {"axis"}, {"Out"});
+  return KernelSignature("minimum", {"X", "Y"}, {}, {"Out"});
 }
 
 KernelSignature ElementwiseModOpArgumentMapping(
@@ -210,13 +202,13 @@ KernelSignature ElementwiseMulTripleGradOpArgumentMapping(
 KernelSignature ElementwiseMaxGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature(
-      "maximum_grad", {"X", "Y", "Out@GRAD"}, {"axis"}, {"X@GRAD", "Y@GRAD"});
+      "maximum_grad", {"X", "Y", "Out@GRAD"}, {}, {"X@GRAD", "Y@GRAD"});
 }
 
 KernelSignature ElementwiseMinGradOpArgumentMapping(
     const ArgumentMappingContext& ctx) {
   return KernelSignature(
-      "minimum_grad", {"X", "Y", "Out@GRAD"}, {"axis"}, {"X@GRAD", "Y@GRAD"});
+      "minimum_grad", {"X", "Y", "Out@GRAD"}, {}, {"X@GRAD", "Y@GRAD"});
 }
 
 KernelSignature ElementwiseHeavisideGradOpArgumentMapping(

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_elementwise.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_elementwise.py
@@ -840,6 +840,8 @@ class TrtConvertElementwiseTestOneInputCornerCase(TrtLayerAutoScanTest):
                 ]:
                     self.op_type = op_type
                     for axis in [-1 if len(shape) == 1 else 1]:
+                        if op_type in ["elementwise_min", "elementwise_max"]:
+                            axis = -1
                         self.dims = len(shape)
                         dics = [{"axis": axis}]
                         ops_config = [

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_max_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_max_op_mlu.py
@@ -203,53 +203,6 @@ class TestElementwiseMaxOp_vector(TestElementwiseMaxOp):
         )
         self.out = np.maximum(self.x, self.y)
 
-
-class TestElementwiseMaxOp_broadcast_0(TestElementwiseMaxOp):
-    def init_input_output(self):
-        self.x = np.random.uniform(0.5, 1, (100, 5, 2)).astype(self.dtype)
-        sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-        self.y = self.x[:, 0, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            self.dtype
-        )
-        self.out = np.maximum(self.x, self.y.reshape(100, 1, 1))
-
-    def init_axis(self):
-        self.axis = 0
-
-
-class TestElementwiseMaxOp_broadcast_1(TestElementwiseMaxOp):
-    def init_input_output(self):
-        self.x = np.random.uniform(0.5, 1, (2, 100, 3)).astype(self.dtype)
-        sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-        self.y = self.x[0, :, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            self.dtype
-        )
-        self.out = np.maximum(self.x, self.y.reshape(1, 100, 1))
-
-    def init_axis(self):
-        self.axis = 1
-
-    def test_check_grad_ingore_x(self):
-        _, dy = ComputeGrad(self.x, self.y, self.out, self.axis)
-        self.check_grad_with_place(
-            self.place,
-            ['Y'],
-            'Out',
-            no_grad_set=set("X"),
-            user_defined_grads=[dy],
-        )
-
-    def test_check_grad_ingore_y(self):
-        dx, _ = ComputeGrad(self.x, self.y, self.out, self.axis)
-        self.check_grad_with_place(
-            self.place,
-            ['X'],
-            'Out',
-            no_grad_set=set("Y"),
-            user_defined_grads=[dx],
-        )
-
-
 class TestElementwiseMaxOp_broadcast_2(TestElementwiseMaxOp):
     def init_input_output(self):
         self.x = np.random.uniform(0.5, 1, (2, 3, 100)).astype(self.dtype)
@@ -284,19 +237,6 @@ class TestElementwiseMaxOp_broadcast_2(TestElementwiseMaxOp):
             no_grad_set=set("Y"),
             user_defined_grads=[dx],
         )
-
-
-class TestElementwiseMaxOp_broadcast_3(TestElementwiseMaxOp):
-    def init_input_output(self):
-        self.x = np.random.uniform(0.5, 1, (2, 50, 2, 1)).astype(self.dtype)
-        sgn = np.random.choice([-1, 1], (50, 2)).astype(self.dtype)
-        self.y = self.x[0, :, :, 0] + sgn * np.random.uniform(
-            1, 2, (50, 2)
-        ).astype(self.dtype)
-        self.out = np.maximum(self.x, self.y.reshape(1, 50, 2, 1))
-
-    def init_axis(self):
-        self.axis = 1
 
 
 class TestElementwiseMaxOp_broadcast_4(TestElementwiseMaxOp):

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_max_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_max_op_npu.py
@@ -163,52 +163,6 @@ class TestElementwiseMaxOp_vector(TestElementwiseMaxOp):
         self.out = np.maximum(self.x, self.y)
 
 
-class TestElementwiseMaxOp_broadcast_0(TestElementwiseMaxOp):
-    def init_input_output(self):
-        self.x = np.random.uniform(0.5, 1, (100, 5, 2)).astype(self.dtype)
-        sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-        self.y = self.x[:, 0, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            self.dtype
-        )
-        self.out = np.maximum(self.x, self.y.reshape(100, 1, 1))
-
-    def init_axis(self):
-        self.axis = 0
-
-
-class TestElementwiseMaxOp_broadcast_1(TestElementwiseMaxOp):
-    def init_input_output(self):
-        self.x = np.random.uniform(0.5, 1, (2, 100, 3)).astype(self.dtype)
-        sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-        self.y = self.x[0, :, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            self.dtype
-        )
-        self.out = np.maximum(self.x, self.y.reshape(1, 100, 1))
-
-    def init_axis(self):
-        self.axis = 1
-
-    def test_check_grad_ingore_x(self):
-        _, dy = ComputeGrad(self.x, self.y, self.out, self.axis)
-        self.check_grad_with_place(
-            self.place,
-            ['Y'],
-            'Out',
-            no_grad_set=set("X"),
-            user_defined_grads=[dy],
-        )
-
-    def test_check_grad_ingore_y(self):
-        dx, _ = ComputeGrad(self.x, self.y, self.out, self.axis)
-        self.check_grad_with_place(
-            self.place,
-            ['X'],
-            'Out',
-            no_grad_set=set("Y"),
-            user_defined_grads=[dx],
-        )
-
-
 class TestElementwiseMaxOp_broadcast_2(TestElementwiseMaxOp):
     def init_input_output(self):
         self.x = np.random.uniform(0.5, 1, (2, 3, 100)).astype(self.dtype)
@@ -244,18 +198,6 @@ class TestElementwiseMaxOp_broadcast_2(TestElementwiseMaxOp):
             user_defined_grads=[dx],
         )
 
-
-class TestElementwiseMaxOp_broadcast_3(TestElementwiseMaxOp):
-    def init_input_output(self):
-        self.x = np.random.uniform(0.5, 1, (2, 50, 2, 1)).astype(self.dtype)
-        sgn = np.random.choice([-1, 1], (50, 2)).astype(self.dtype)
-        self.y = self.x[0, :, :, 0] + sgn * np.random.uniform(
-            1, 2, (50, 2)
-        ).astype(self.dtype)
-        self.out = np.maximum(self.x, self.y.reshape(1, 50, 2, 1))
-
-    def init_axis(self):
-        self.axis = 1
 
 
 class TestElementwiseMaxOp_broadcast_4(TestElementwiseMaxOp):

--- a/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
@@ -155,44 +155,6 @@ class TestElementwiseMaxOp_Vector(TestElementwiseOp):
         self.outputs = {'Out': np.maximum(self.inputs['X'], self.inputs['Y'])}
 
 
-class TestElementwiseMaxOp_broadcast_0(TestElementwiseOp):
-    def setUp(self):
-        self.op_type = "elementwise_max"
-        self.python_api = paddle.maximum
-        x = np.random.uniform(0.5, 1, (100, 5, 2)).astype(np.float64)
-        sgn = np.random.choice([-1, 1], (100,)).astype(np.float64)
-        y = x[:, 0, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            np.float64
-        )
-        self.inputs = {'X': x, 'Y': y}
-
-        self.attrs = {'axis': 0}
-        self.outputs = {
-            'Out': np.maximum(
-                self.inputs['X'], self.inputs['Y'].reshape(100, 1, 1)
-            )
-        }
-
-
-class TestElementwiseMaxOp_broadcast_1(TestElementwiseOp):
-    def setUp(self):
-        self.op_type = "elementwise_max"
-        self.python_api = paddle.maximum
-        x = np.random.uniform(0.5, 1, (2, 100, 3)).astype(np.float64)
-        sgn = np.random.choice([-1, 1], (100,)).astype(np.float64)
-        y = x[0, :, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            np.float64
-        )
-        self.inputs = {'X': x, 'Y': y}
-
-        self.attrs = {'axis': 1}
-        self.outputs = {
-            'Out': np.maximum(
-                self.inputs['X'], self.inputs['Y'].reshape(1, 100, 1)
-            )
-        }
-
-
 class TestElementwiseMaxOp_broadcast_2(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_max"
@@ -207,25 +169,6 @@ class TestElementwiseMaxOp_broadcast_2(TestElementwiseOp):
         self.outputs = {
             'Out': np.maximum(
                 self.inputs['X'], self.inputs['Y'].reshape(1, 1, 100)
-            )
-        }
-
-
-class TestElementwiseMaxOp_broadcast_3(TestElementwiseOp):
-    def setUp(self):
-        self.op_type = "elementwise_max"
-        self.python_api = paddle.maximum
-        x = np.random.uniform(0.5, 1, (2, 50, 2, 1)).astype(np.float64)
-        sgn = np.random.choice([-1, 1], (50, 2)).astype(np.float64)
-        y = x[0, :, :, 0] + sgn * np.random.uniform(1, 2, (50, 2)).astype(
-            np.float64
-        )
-        self.inputs = {'X': x, 'Y': y}
-
-        self.attrs = {'axis': 1}
-        self.outputs = {
-            'Out': np.maximum(
-                self.inputs['X'], self.inputs['Y'].reshape(1, 50, 2, 1)
             )
         }
 

--- a/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
@@ -116,44 +116,6 @@ class TestElementwiseMinOp_Vector(TestElementwiseOp):
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
 
-class TestElementwiseMinOp_broadcast_0(TestElementwiseOp):
-    def setUp(self):
-        self.op_type = "elementwise_min"
-        self.python_api = broadcast_wrapper(shape=[100, 1, 1])
-        x = np.random.uniform(0.5, 1, (100, 3, 2)).astype(np.float64)
-        sgn = np.random.choice([-1, 1], (100,)).astype(np.float64)
-        y = x[:, 0, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            np.float64
-        )
-        self.inputs = {'X': x, 'Y': y}
-
-        self.attrs = {'axis': 0}
-        self.outputs = {
-            'Out': np.minimum(
-                self.inputs['X'], self.inputs['Y'].reshape(100, 1, 1)
-            )
-        }
-
-
-class TestElementwiseMinOp_broadcast_1(TestElementwiseOp):
-    def setUp(self):
-        self.op_type = "elementwise_min"
-        self.python_api = broadcast_wrapper(shape=[1, 100, 1])
-        x = np.random.uniform(0.5, 1, (2, 100, 3)).astype(np.float64)
-        sgn = np.random.choice([-1, 1], (100,)).astype(np.float64)
-        y = x[0, :, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-            np.float64
-        )
-        self.inputs = {'X': x, 'Y': y}
-
-        self.attrs = {'axis': 1}
-        self.outputs = {
-            'Out': np.minimum(
-                self.inputs['X'], self.inputs['Y'].reshape(1, 100, 1)
-            )
-        }
-
-
 class TestElementwiseMinOp_broadcast_2(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
@@ -168,25 +130,6 @@ class TestElementwiseMinOp_broadcast_2(TestElementwiseOp):
         self.outputs = {
             'Out': np.minimum(
                 self.inputs['X'], self.inputs['Y'].reshape(1, 1, 100)
-            )
-        }
-
-
-class TestElementwiseMinOp_broadcast_3(TestElementwiseOp):
-    def setUp(self):
-        self.op_type = "elementwise_min"
-        self.python_api = broadcast_wrapper(shape=[1, 25, 4, 1])
-        x = np.random.uniform(0.5, 1, (2, 25, 4, 1)).astype(np.float64)
-        sgn = np.random.choice([-1, 1], (25, 4)).astype(np.float64)
-        y = x[0, :, :, 0] + sgn * np.random.uniform(1, 2, (25, 4)).astype(
-            np.float64
-        )
-        self.inputs = {'X': x, 'Y': y}
-
-        self.attrs = {'axis': 1}
-        self.outputs = {
-            'Out': np.minimum(
-                self.inputs['X'], self.inputs['Y'].reshape(1, 25, 4, 1)
             )
         }
 
@@ -247,10 +190,7 @@ class TestElementwiseMinOpFP16(unittest.TestCase):
         self.check_main((13, 17), (13, 17))
         self.check_main((10, 3, 4), (1,))
         self.check_main((100,), (100,))
-        self.check_main((100, 3, 2), (100,), 0)
-        self.check_main((2, 100, 3), (100,), 1)
         self.check_main((2, 3, 100), (100,))
-        self.check_main((2, 25, 4, 1), (25, 4), 1)
         self.check_main((2, 10, 2, 5), (2, 10, 1, 5))
 
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_max_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_max_op_xpu.py
@@ -108,38 +108,6 @@ class XPUTestElementwiseMaxOp(XPUOpTestWrapper):
                 'Out': np.maximum(self.inputs['X'], self.inputs['Y'])
             }
 
-    class TestElementwiseMaxOp_broadcast_0(TestElementwiseOp):
-        def init_input_output(self):
-            x = np.random.uniform(0.5, 1, (100, 5, 2)).astype(self.dtype)
-            sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-            y = x[:, 0, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-                self.dtype
-            )
-            self.inputs = {'X': x, 'Y': y}
-
-            self.attrs = {'axis': 0}
-            self.outputs = {
-                'Out': np.maximum(
-                    self.inputs['X'], self.inputs['Y'].reshape(100, 1, 1)
-                )
-            }
-
-    class TestElementwiseMaxOp_broadcast_1(TestElementwiseOp):
-        def init_input_output(self):
-            x = np.random.uniform(0.5, 1, (2, 100, 3)).astype(self.dtype)
-            sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-            y = x[0, :, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-                self.dtype
-            )
-            self.inputs = {'X': x, 'Y': y}
-
-            self.attrs = {'axis': 1}
-            self.outputs = {
-                'Out': np.maximum(
-                    self.inputs['X'], self.inputs['Y'].reshape(1, 100, 1)
-                )
-            }
-
     class TestElementwiseMaxOp_broadcast_2(TestElementwiseOp):
         def init_input_output(self):
             x = np.random.uniform(0.5, 1, (1, 3, 100)).astype(self.dtype)
@@ -152,22 +120,6 @@ class XPUTestElementwiseMaxOp(XPUOpTestWrapper):
             self.outputs = {
                 'Out': np.maximum(
                     self.inputs['X'], self.inputs['Y'].reshape(1, 1, 100)
-                )
-            }
-
-    class TestElementwiseMaxOp_broadcast_3(TestElementwiseOp):
-        def init_input_output(self):
-            x = np.random.uniform(0.5, 1, (2, 50, 2, 1)).astype(self.dtype)
-            sgn = np.random.choice([-1, 1], (50, 2)).astype(self.dtype)
-            y = x[0, :, :, 0] + sgn * np.random.uniform(1, 2, (50, 2)).astype(
-                self.dtype
-            )
-            self.inputs = {'X': x, 'Y': y}
-
-            self.attrs = {'axis': 1}
-            self.outputs = {
-                'Out': np.maximum(
-                    self.inputs['X'], self.inputs['Y'].reshape(1, 50, 2, 1)
                 )
             }
 

--- a/python/paddle/fluid/tests/unittests/xpu/test_elementwise_min_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_elementwise_min_op_xpu.py
@@ -107,36 +107,6 @@ class XPUTestElementwiseMinOp(XPUOpTestWrapper):
                 'Out': np.minimum(self.inputs['X'], self.inputs['Y'])
             }
 
-    class TestElementwiseMinOp_broadcast_0(TestElementwiseOp):
-        def init_input_output(self):
-            x = np.random.uniform(0.5, 1, (100, 3, 2)).astype(self.dtype)
-            sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-            y = x[:, 0, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-                self.dtype
-            )
-            self.attrs = {'axis': 0}
-            self.inputs = {'X': x, 'Y': y}
-            self.outputs = {
-                'Out': np.minimum(
-                    self.inputs['X'], self.inputs['Y'].reshape(100, 1, 1)
-                )
-            }
-
-    class TestElementwiseMinOp_broadcast_1(TestElementwiseOp):
-        def init_input_output(self):
-            x = np.random.uniform(0.5, 1, (2, 100, 3)).astype(self.dtype)
-            sgn = np.random.choice([-1, 1], (100,)).astype(self.dtype)
-            y = x[0, :, 0] + sgn * np.random.uniform(1, 2, (100,)).astype(
-                self.dtype
-            )
-            self.attrs = {'axis': 1}
-            self.inputs = {'X': x, 'Y': y}
-            self.outputs = {
-                'Out': np.minimum(
-                    self.inputs['X'], self.inputs['Y'].reshape(1, 100, 1)
-                )
-            }
-
     class TestElementwiseMinOp_broadcast_2(TestElementwiseOp):
         def init_input_output(self):
             x = np.random.uniform(0.5, 1, (2, 3, 100)).astype(self.dtype)
@@ -148,21 +118,6 @@ class XPUTestElementwiseMinOp(XPUOpTestWrapper):
             self.outputs = {
                 'Out': np.minimum(
                     self.inputs['X'], self.inputs['Y'].reshape(1, 1, 100)
-                )
-            }
-
-    class TestElementwiseMinOp_broadcast_3(TestElementwiseOp):
-        def init_input_output(self):
-            x = np.random.uniform(0.5, 1, (2, 25, 4, 1)).astype(self.dtype)
-            sgn = np.random.choice([-1, 1], (25, 4)).astype(self.dtype)
-            y = x[0, :, :, 0] + sgn * np.random.uniform(1, 2, (25, 4)).astype(
-                self.dtype
-            )
-            self.attrs = {'axis': 1}
-            self.inputs = {'X': x, 'Y': y}
-            self.outputs = {
-                'Out': np.minimum(
-                    self.inputs['X'], self.inputs['Y'].reshape(1, 25, 4, 1)
                 )
             }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
maximum_raw 和minimum_raw 理论上不会用到，故可以删除