### PR TITLE
Try to enable the collect of kernel registry infomation when there is no operators to test.

### DIFF
--- a/tools/ci_op_benchmark.sh
+++ b/tools/ci_op_benchmark.sh
@@ -119,7 +119,7 @@ function load_CHANGE_OP_FILES {
     LOG "[INFO] Uninstall PaddlePaddle ..."
     pip uninstall -y paddlepaddle paddlepaddle_gpu
     LOG "[INFO] Install PaddlePaddle ..."
-    pip install build/${branch_name}/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl
+    pip install build/pr_whl/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl
     collect_kernel_registry_info
     LOG "[INFO] No op to test, skip this ci." && exit 0
   fi

--- a/tools/ci_op_benchmark.sh
+++ b/tools/ci_op_benchmark.sh
@@ -115,8 +115,14 @@ function load_CHANGE_OP_FILES {
       load_CHANGE_OP_FILES_by_header_file $change_file
     fi
   done
-  [ ${#CHANGE_OP_FILES[@]} -eq 0 ] && LOG "[INFO] No op to test, skip this ci." && \
-  exit 0
+  if [ ${#CHANGE_OP_FILES[@]} -eq 0 ]; then
+    LOG "[INFO] Uninstall PaddlePaddle ..."
+    pip uninstall -y paddlepaddle paddlepaddle_gpu
+    LOG "[INFO] Install PaddlePaddle ..."
+    pip install build/${branch_name}/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl
+    collect_kernel_registry_info
+    LOG "[INFO] No op to test, skip this ci." && exit 0
+  fi
 }
 
 # Clone benchmark repo
@@ -202,9 +208,9 @@ function run_op_benchmark_test {
   # pip install tensorflow==2.3.0 tensorflow-probability
   for branch_name in "dev_whl" "pr_whl"
   do
-    LOG "[INFO] Uninstall Paddle ..."
+    LOG "[INFO] Uninstall PaddlePaddle ..."
     pip uninstall -y paddlepaddle paddlepaddle_gpu
-    LOG "[INFO] Install Paddle ..."
+    LOG "[INFO] Install PaddlePaddle ..."
     pip install build/${branch_name}/paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl
     logs_dir="$(pwd)/logs-${branch_name}"
     [ -d $logs_dir ] && rm -rf $logs_dir/* || mkdir -p $logs_dir


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
OP Benchmark CI没有算子要测试时也能打印Kernel统计信息，效果如下：
![image](https://user-images.githubusercontent.com/12538138/224229604-e2e84696-ea47-4e6b-ac8c-ed1b24e14fe1.png)