### PR TITLE
fix UT when np >= 1.23

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -954,16 +954,17 @@ class TestVarBase(unittest.TestCase):
         py_idx = [[0, 2, 0, 1, 3], [0, 0, 1, 2, 0]]
 
         # note(chenjianye):
-        # Non-tuple sequence for multidimensional indexing is supported in numpy < 1.24.
-        # For List case, the outermost `[]` will be treated as tuple `()` in version less than 1.24,
+        # Non-tuple sequence for multidimensional indexing is supported in numpy < 1.23.
+        # For List case, the outermost `[]` will be treated as tuple `()` in version less than 1.23,
         # which is used to wrap index elements for multiple axes.
-        # And from 1.24, this will be treat as a whole and only works on one axis.
+        # And from 1.23, this will be treat as a whole and only works on one axis.
         #
-        # e.g. x[[[0],[1]]] = x[([0],[1])] = x[[0],[1]] (in version < 1.24)
-        #      x[[[0],[1]]] = x[array([[0],[1]])] (in version >= 1.24)
+        # e.g. x[[[0],[1]]] == x[([0],[1])] == x[[0],[1]] (in version < 1.23)
+        #      x[[[0],[1]]] == x[array([[0],[1]])] (in version >= 1.23)
         #
+        # Here, we just modify the code to remove the impact of numpy version changes,
+        # changing x[[[0],[1]]] to x[tuple([[0],[1]])] == x[([0],[1])] == x[[0],[1]].
         # Whether the paddle behavior in this case will change is still up for debate.
-        # Here, we just modify the code to remove the impact of numpy version changes.
         idx = [paddle.to_tensor(py_idx[0]), paddle.to_tensor(py_idx[1])]
         np.testing.assert_array_equal(x[idx].numpy(), array[tuple(py_idx)])
         np.testing.assert_array_equal(x[py_idx].numpy(), array[tuple(py_idx)])

--- a/python/paddle/fluid/tests/unittests/test_variable.py
+++ b/python/paddle/fluid/tests/unittests/test_variable.py
@@ -597,16 +597,17 @@ class TestVariableSlice(unittest.TestCase):
 
 class TestListIndex(unittest.TestCase):
     # note(chenjianye):
-    # Non-tuple sequence for multidimensional indexing is supported in numpy < 1.24.
-    # For List case, the outermost `[]` will be treated as tuple `()` in version less than 1.24,
+    # Non-tuple sequence for multidimensional indexing is supported in numpy < 1.23.
+    # For List case, the outermost `[]` will be treated as tuple `()` in version less than 1.23,
     # which is used to wrap index elements for multiple axes.
-    # And from 1.24, this will be treat as a whole and only works on one axis.
+    # And from 1.23, this will be treat as a whole and only works on one axis.
     #
-    # e.g. x[[[0],[1]]] = x[([0],[1])] = x[[0],[1]] (in version < 1.24)
-    #      x[[[0],[1]]] = x[array([[0],[1]])] (in version >= 1.24)
+    # e.g. x[[[0],[1]]] == x[([0],[1])] == x[[0],[1]] (in version < 1.23)
+    #      x[[[0],[1]]] == x[array([[0],[1]])] (in version >= 1.23)
     #
+    # Here, we just modify the code to remove the impact of numpy version changes,
+    # changing x[[[0],[1]]] to x[tuple([[0],[1]])] == x[([0],[1])] == x[[0],[1]].
     # Whether the paddle behavior in this case will change is still up for debate.
-    # Here, we just modify the code to remove the impact of numpy version changes.
 
     def setUp(self):
         np.random.seed(2022)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-66985
#### Motivation
In Numpy, the behavior of non-tuple sequence for multidimensional indexing has been changed since 1.23.  This incompatible upgrade caused our unittests of indexing to fail, which preventing our CI environment from upgrading to new numpy versions. (see PR https://github.com/PaddlePaddle/Paddle/pull/49556)

In a word, currently, the numpy versions are different between CI and user's environment.
This PR makes indexing unit test works well at numpy version >=1.23 and < 1.23, both.

#### What Numpy changed
  In fact, numpy already gave warnings in version <1.23:
```
__main__:1: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
```
For List case, the outermost `[]` will be treated as tuple `()` in version less than 1.23, which is used to wrap index elements for multiple axes. And from 1.23, this will be treat as a whole and only works on one axis.

#### For future Paddle
Whether the paddle behavior in this case will change is still up for debate. Currently, we still keep the same behavior.

