### PR TITLE
address question inputs is Tensor array not Dense Tensor in static amp mode.

### DIFF
--- a/python/paddle/static/amp/fp16_utils.py
+++ b/python/paddle/static/amp/fp16_utils.py
@@ -438,6 +438,9 @@ def cast_model_to_fp16(program, amp_lists=None, use_fp16_guard=True):
         "while",
         "while_grad",
         "cast",
+        "tensor_array_to_tensor",
+        "lod_array_length",
+        "write_to_array",
     }
     global_block = program.global_block()
     keep_fp32_ops = set()


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
解决 amp 中存在输入为array tensor相关操作导致插入cast，但是cast op输入类型不支持array tensor的问题。