### PR TITLE
NO.49 为 Paddle bce_loss 算子实现 float16 数据类型支持

### DIFF
--- a/paddle/phi/kernels/gpu/bce_loss_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_grad_kernel.cu
@@ -18,8 +18,6 @@
 #include <vector>
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
-#include "paddle/phi/common/amp_type_traits.h"
-#include "paddle/phi/common/data_type.h"
 #include "paddle/phi/core/hostdevice.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"

--- a/paddle/phi/kernels/gpu/bce_loss_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_grad_kernel.cu
@@ -17,9 +17,9 @@
 #include <algorithm>
 #include <vector>
 
+#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/data_type.h"
-#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/hostdevice.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
@@ -38,8 +38,12 @@ struct BCELossGradFunctor {
 
   HOSTDEVICE inline T operator()(const T x, const T label, const T dout) const {
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-    MPType term1 = max((static_cast<MPType>(one) - static_cast<MPType>(x)) * static_cast<MPType>(x), static_cast<MPType>(eps));
-    return static_cast<T>(static_cast<MPType>(dout) * (static_cast<MPType>(x) - static_cast<MPType>(label)) / term1);
+    MPType term1 = max((static_cast<MPType>(one) - static_cast<MPType>(x)) *
+                           static_cast<MPType>(x),
+                       static_cast<MPType>(eps));
+    return static_cast<T>(
+        static_cast<MPType>(dout) *
+        (static_cast<MPType>(x) - static_cast<MPType>(label)) / term1);
   }
 };
 
@@ -59,7 +63,8 @@ void BCELossGradKernel(const Context& dev_ctx,
 }  // namespace phi
 
 PD_REGISTER_KERNEL(bce_loss_grad,
-                   GPU, ALL_LAYOUT,
+                   GPU,
+                   ALL_LAYOUT,
                    phi::BCELossGradKernel,
                    float,
                    double,

--- a/paddle/phi/kernels/gpu/bce_loss_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_kernel.cu
@@ -17,9 +17,9 @@
 #include <algorithm>
 #include <vector>
 
+#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/common/amp_type_traits.h"
 #include "paddle/phi/common/data_type.h"
-#include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/hostdevice.h"
 #include "paddle/phi/core/kernel_registry.h"
 #include "paddle/phi/kernels/funcs/elementwise_base.h"
@@ -44,8 +44,11 @@ struct BCELossFunctor {
         x);
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
     MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)), static_cast<MPType>(neg_100));
-    MPType term2 = max(phi::kps::details::Log(one - static_cast<MPType>(x)), static_cast<MPType>(neg_100));
-    return static_cast<T>(((static_cast<MPType>(label) - static_cast<MPType>(one)) * term2) - (static_cast<MPType>(label) * term1));
+    MPType term2 = 
+        max(phi::kps::details::Log(one - static_cast<MPType>(x)), static_cast<MPType>(neg_100));
+    return static_cast<T>(
+        ((static_cast<MPType>(label) - static_cast<MPType>(one)) * term2) - 
+        (static_cast<MPType>(label) * term1));
   }
 };
 

--- a/paddle/phi/kernels/gpu/bce_loss_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_kernel.cu
@@ -40,7 +40,8 @@ struct BCELossFunctor {
   HOSTDEVICE inline T operator()(const T x, const T label) const {
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
     PADDLE_ENFORCE(
-        (static_cast<MPType>(x) >= static_cast<MPType>(0)) && (static_cast<MPType>(x) <= static_cast<MPType>(one)),
+        (static_cast<MPType>(x) >= static_cast<MPType>(0)) &&
+            (static_cast<MPType>(x) <= static_cast<MPType>(one)),
         "Input is expected to be within the interval [0, 1], but received %f.",
         x);
     MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)),

--- a/paddle/phi/kernels/gpu/bce_loss_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_kernel.cu
@@ -43,11 +43,12 @@ struct BCELossFunctor {
         "Input is expected to be within the interval [0, 1], but received %f.",
         x);
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-    MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)), static_cast<MPType>(neg_100));
-    MPType term2 = 
-        max(phi::kps::details::Log(one - static_cast<MPType>(x)), static_cast<MPType>(neg_100));
+    MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)),
+                       static_cast<MPType>(neg_100));
+    MPType term2 = max(phi::kps::details::Log(static_cast<MPType>(one) - static_cast<MPType>(x)),
+                       static_cast<MPType>(neg_100));
     return static_cast<T>(
-        ((static_cast<MPType>(label) - static_cast<MPType>(one)) * term2) - 
+        ((static_cast<MPType>(label) - static_cast<MPType>(one)) * term2) -
         (static_cast<MPType>(label) * term1));
   }
 };

--- a/paddle/phi/kernels/gpu/bce_loss_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_kernel.cu
@@ -38,11 +38,11 @@ struct BCELossFunctor {
   }
 
   HOSTDEVICE inline T operator()(const T x, const T label) const {
+    using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
     PADDLE_ENFORCE(
-        (x >= static_cast<T>(0)) && (x <= one),
+        (static_cast<MPType>(x) >= static_cast<MPType>(0)) && (static_cast<MPType>(x) <= static_cast<MPType>(one)),
         "Input is expected to be within the interval [0, 1], but received %f.",
         x);
-    using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
     MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)),
                        static_cast<MPType>(neg_100));
     MPType term2 = max(phi::kps::details::Log(static_cast<MPType>(one) -

--- a/paddle/phi/kernels/gpu/bce_loss_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_kernel.cu
@@ -43,8 +43,8 @@ struct BCELossFunctor {
         "Input is expected to be within the interval [0, 1], but received %f.",
         x);
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-    MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)), neg_100);
-    MPType term2 = max(phi::kps::details::Log(one - static_cast<MPType>(x)), neg_100);
+    MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)), static_cast<MPType>(neg_100));
+    MPType term2 = max(phi::kps::details::Log(one - static_cast<MPType>(x)), static_cast<MPType>(neg_100));
     return static_cast<T>(((static_cast<MPType>(label) - static_cast<MPType>(one)) * term2) - (static_cast<MPType>(label) * term1));
   }
 };

--- a/paddle/phi/kernels/gpu/bce_loss_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_kernel.cu
@@ -43,8 +43,8 @@ struct BCELossFunctor {
         "Input is expected to be within the interval [0, 1], but received %f.",
         x);
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
-    MPType term1 = max(phi::dtype::details::Log(static_cast<MPType>(x)), neg_100);
-    MPType term2 = max(phi::dtype::details::Log(one - static_cast<MPType>(x)), neg_100);
+    MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)), neg_100);
+    MPType term2 = max(phi::kps::details::Log(one - static_cast<MPType>(x)), neg_100);
     return static_cast<T>(((static_cast<MPType>(label) - static_cast<MPType>(one)) * term2) - (static_cast<MPType>(label) * term1));
   }
 };

--- a/paddle/phi/kernels/gpu/bce_loss_kernel.cu
+++ b/paddle/phi/kernels/gpu/bce_loss_kernel.cu
@@ -45,7 +45,8 @@ struct BCELossFunctor {
     using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
     MPType term1 = max(phi::kps::details::Log(static_cast<MPType>(x)),
                        static_cast<MPType>(neg_100));
-    MPType term2 = max(phi::kps::details::Log(static_cast<MPType>(one) - static_cast<MPType>(x)),
+    MPType term2 = max(phi::kps::details::Log(static_cast<MPType>(one) -
+                                              static_cast<MPType>(x)),
                        static_cast<MPType>(neg_100));
     return static_cast<T>(
         ((static_cast<MPType>(label) - static_cast<MPType>(one)) * term2) -

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -18,8 +18,7 @@ import numpy as np
 from eager_op_test import OpTest
 
 import paddle
-import paddle.fluid as fluid
-import paddle.fluid.core as core
+from paddle import fluid
 
 
 def test_static_layer(
@@ -294,15 +293,15 @@ class TestBceLossOpFloat16(TestBceLossOp):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        if core.is_compiled_with_cuda():
-            place = core.CUDAPlace(0)
-            if core.is_float16_supported(place):
+        if fluid.core.is_compiled_with_cuda():
+            place = fluid.core.CUDAPlace(0)
+            if fluid.core.is_float16_supported(place):
                 self.check_output_with_place(place, ['X'], 'Out')
 
     def test_check_grad(self):
-        if core.is_compiled_with_cuda():
-            place = core.CUDAPlace(0)
-            if core.is_float16_supported(place):
+        if fluid.core.is_compiled_with_cuda():
+            place = fluid.core.CUDAPlace(0)
+            if fluid.core.is_float16_supported(place):
                 self.check_grad_with_place(
                     place,
                     ['X'],
@@ -328,7 +327,7 @@ class TestBceLossOpStaticFP16(unittest.TestCase):
             out = paddle.nn.functional.binary_cross_entropy(
                 x, y, reduction="none"
             )
-            if core.is_compiled_with_cuda():
+            if fluid.core.is_compiled_with_cuda():
                 place = paddle.CUDAPlace(0)
                 exe = paddle.static.Executor(place)
                 exe.run(paddle.static.default_startup_program())

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -283,7 +283,6 @@ class TestBceLossOpCase2(OpTest):
 class TestBceLossOpFloat16(OpTest):
     def setUp(self):
         self.init_test_case()
-        self.op_type = "bce_loss_fp16"
         self.python_api = bce_wrapper
         input_np = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
             "float16"

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -313,6 +313,25 @@ class TestBceLossOpFloat16(TestBceLossOp):
                 )
 
 
+class TestBceLossOpStaticFP16(unittest.TestCase):
+    def test_fp16(self):
+        input_data = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
+            "float16"
+        )
+        label_data = paddle.randint(low=0, high=2, shape=[10, 10]).astype(
+            "float16"
+        )
+        with paddle.static.program_guard(paddle.static.Program()):
+            x = paddle.static.data(shape=[10, 10], name='x', dtype='float16')
+            y = paddle.static.data(shape=[10, 10], name='y', dtype='float16')
+            out = paddle.bce_loss(x, y)
+            if core.is_compiled_with_cuda():
+                place = paddle.CUDAPlace(0)
+                exe = paddle.static.Executor(place)
+                exe.run(paddle.static.default_startup_program())
+                out = exe.run(feed={'x': input_data, 'y': label_data}, fetch_list=[out])
+
+
 if __name__ == "__main__":
     paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -280,11 +280,8 @@ class TestBceLossOpCase2(OpTest):
         self.shape = [2, 3, 20]
 
 
-class TestBceLossOpFloat16(OpTest):
+class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
-        self.init_test_case()
-        self.op_type = "bce_loss"
-        self.python_api = bce_wrapper
         input_np = np.random.uniform(0.1, 0.8, self.shape).astype("float16")
         label_np = np.random.randint(0, 2, self.shape).astype("float16")
         output_np = bce_loss(input_np, label_np)

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -281,10 +281,10 @@ class TestBceLossOpCase2(OpTest):
 
 class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
-        input_np = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
+        input_np = np.random.uniform(0.1, 0.8, self.shape).astype(
             "float16"
         )
-        label_np = paddle.randint(low=0, high=2, shape=[10, 10]).astype(
+        label_np = np.random.randint(0, 2, self.shape).astype(
             "float16"
         )
         output_np = bce_loss(input_np, label_np)

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -280,10 +280,8 @@ class TestBceLossOpCase2(OpTest):
         self.shape = [2, 3, 20]
 
 
-class TestBceLossOpFloat16(OpTest):
+class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
-        self.init_test_case()
-        self.python_api = bce_wrapper
         input_np = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
             "float16"
         )
@@ -299,7 +297,7 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, ['X'], 'Out', atol=1e-3)
+                self.check_output_with_place(place, ['X'], 'Out')
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -327,7 +325,9 @@ class TestBceLossOpStaticFP16(unittest.TestCase):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data(shape=[10, 10], name='x', dtype='float16')
             y = paddle.static.data(shape=[10, 10], name='y', dtype='float16')
-            out = bce_loss(x, y)
+            out = paddle.nn.functional.binary_cross_entropy(
+                x, y, reduction="none"
+            )
             if core.is_compiled_with_cuda():
                 place = paddle.CUDAPlace(0)
                 exe = paddle.static.Executor(place)

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -298,7 +298,7 @@ class TestBceLossOpFloat16(TestBceLossOp):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
                 self.check_output_with_place(
-                    place, ['X'], 'Out', check_eager=True, atol=1e-3
+                    place, ['X'], 'Out', atol=1e-3
                 )
 
     def test_check_grad(self):
@@ -309,7 +309,6 @@ class TestBceLossOpFloat16(TestBceLossOp):
                     place,
                     ['X'],
                     'Out',
-                    check_eager=True,
                     max_relative_error=1e-2,
                 )
 

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -283,7 +283,7 @@ class TestBceLossOpCase2(OpTest):
 class TestBceLossOpFloat16(OpTest):
     def setUp(self):
         self.init_test_case()
-        self.op_type = "bce_loss"
+        self.op_type = "bce_loss_fp16"
         self.python_api = bce_wrapper
         input_np = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
             "float16"
@@ -300,9 +300,7 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(
-                    place, ['X'], 'Out', atol=1e-3
-                )
+                self.check_output_with_place(place, ['X'], 'Out', atol=1e-3)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -314,7 +312,7 @@ class TestBceLossOpFloat16(OpTest):
                     'Out',
                     max_relative_error=1e-2,
                 )
-    
+
     def init_test_case(self):
         self.shape = [10, 10]
 
@@ -335,7 +333,9 @@ class TestBceLossOpStaticFP16(unittest.TestCase):
                 place = paddle.CUDAPlace(0)
                 exe = paddle.static.Executor(place)
                 exe.run(paddle.static.default_startup_program())
-                out = exe.run(feed={'x': input_data, 'y': label_data}, fetch_list=[out])
+                out = exe.run(
+                    feed={'x': input_data, 'y': label_data}, fetch_list=[out]
+                )
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -282,8 +282,12 @@ class TestBceLossOpCase2(OpTest):
 
 class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
-        input_np = paddle.uniform(min=0.1, max=0.8, shape=[10,10]).astype("float16")
-        label_np = paddle.randint(low=0, high=2, shape=[10,10]).astype("float16")
+        input_np = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
+            "float16"
+        )
+        label_np = paddle.randint(low=0, high=2, shape=[10, 10]).astype(
+            "float16"
+        )
         output_np = bce_loss(input_np, label_np)
 
         self.inputs = {'X': input_np, 'Label': label_np}
@@ -294,7 +298,7 @@ class TestBceLossOpFloat16(TestBceLossOp):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
                 self.check_output_with_place(
-                    place, ['X', 'Label'], 'Out', check_eager=True, atol=1e-3
+                    place, ['X'], 'Out', check_eager=True, atol=1e-3
                 )
 
     def test_check_grad(self):
@@ -303,12 +307,11 @@ class TestBceLossOpFloat16(TestBceLossOp):
             if core.is_float16_supported(place):
                 self.check_grad_with_place(
                     place,
-                    ['X', 'Label'],
+                    ['X'],
                     'Out',
                     check_eager=True,
                     max_relative_error=1e-2,
                 )
-
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -324,7 +324,7 @@ class TestBceLossOpStaticFP16(unittest.TestCase):
         with paddle.static.program_guard(paddle.static.Program()):
             x = paddle.static.data(shape=[10, 10], name='x', dtype='float16')
             y = paddle.static.data(shape=[10, 10], name='y', dtype='float16')
-            out = paddle.bce_loss(x, y)
+            out = bce_loss(x, y)
             if core.is_compiled_with_cuda():
                 place = paddle.CUDAPlace(0)
                 exe = paddle.static.Executor(place)

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -293,47 +293,13 @@ class TestBceLossOpFloat16(TestBceLossOp):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        if fluid.core.is_compiled_with_cuda():
-            place = fluid.core.CUDAPlace(0)
-            if fluid.core.is_float16_supported(place):
-                self.check_output_with_place(place, ['X'], 'Out')
+        self.check_output()
 
     def test_check_grad(self):
-        if fluid.core.is_compiled_with_cuda():
-            place = fluid.core.CUDAPlace(0)
-            if fluid.core.is_float16_supported(place):
-                self.check_grad_with_place(
-                    place,
-                    ['X'],
-                    'Out',
-                    max_relative_error=1e-2,
-                )
+        self.check_grad(['X'], 'Out')
 
     def init_test_case(self):
         self.shape = [10, 10]
-
-
-class TestBceLossOpStaticFP16(unittest.TestCase):
-    def test_fp16(self):
-        input_data = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
-            "float16"
-        )
-        label_data = paddle.randint(low=0, high=2, shape=[10, 10]).astype(
-            "float16"
-        )
-        with paddle.static.program_guard(paddle.static.Program()):
-            x = paddle.static.data(shape=[10, 10], name='x', dtype='float16')
-            y = paddle.static.data(shape=[10, 10], name='y', dtype='float16')
-            out = paddle.nn.functional.binary_cross_entropy(
-                x, y, reduction="none"
-            )
-            if fluid.core.is_compiled_with_cuda():
-                place = paddle.CUDAPlace(0)
-                exe = paddle.static.Executor(place)
-                exe.run(paddle.static.default_startup_program())
-                out = exe.run(
-                    feed={'x': input_data, 'y': label_data}, fetch_list=[out]
-                )
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -282,8 +282,8 @@ class TestBceLossOpCase2(OpTest):
 
 class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
-        input_np = np.random.uniform(0.1, 0.8, self.shape).astype("float16")
-        label_np = np.random.randint(0, 2, self.shape).astype("float16")
+        input_np = paddle.uniform(min=0.1, max=0.8, shape=[10,10]).astype("float16")
+        label_np = paddle.randint(low=0, high=2, shape=[10,10]).astype("float16")
         output_np = bce_loss(input_np, label_np)
 
         self.inputs = {'X': input_np, 'Label': label_np}
@@ -309,8 +309,6 @@ class TestBceLossOpFloat16(TestBceLossOp):
                     max_relative_error=1e-2,
                 )
 
-    def init_test_case(self):
-        self.shape = [10, 10]
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -280,8 +280,11 @@ class TestBceLossOpCase2(OpTest):
         self.shape = [2, 3, 20]
 
 
-class TestBceLossOpFloat16(TestBceLossOp):
+class TestBceLossOpFloat16(OpTest):
     def setUp(self):
+        self.init_test_case()
+        self.op_type = "bce_loss"
+        self.python_api = bce_wrapper
         input_np = paddle.uniform(min=0.1, max=0.8, shape=[10, 10]).astype(
             "float16"
         )
@@ -311,6 +314,9 @@ class TestBceLossOpFloat16(TestBceLossOp):
                     'Out',
                     max_relative_error=1e-2,
                 )
+    
+    def init_test_case(self):
+        self.shape = [10, 10]
 
 
 class TestBceLossOpStaticFP16(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -291,10 +291,10 @@ class TestBceLossOpFloat16(TestBceLossOp):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(atol=1e-3)
+        self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', max_relative_error=1e-3)
+        self.check_grad(['X'], 'Out')
 
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -290,10 +290,10 @@ class TestBceLossOpFloat16(TestBceLossOp):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output()
+        self.check_output(1e-3)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X'], 'Out', max_relative_error=1e-3)
 
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -281,6 +281,7 @@ class TestBceLossOpCase2(OpTest):
 
 class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
+        self.init_test_case()
         input_np = np.random.uniform(0.1, 0.8, self.shape).astype(
             "float16"
         )

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -291,7 +291,7 @@ class TestBceLossOpFloat16(TestBceLossOp):
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):
-        self.check_output(1e-3)
+        self.check_output(atol=1e-3)
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out', max_relative_error=1e-3)

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -282,12 +282,8 @@ class TestBceLossOpCase2(OpTest):
 class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
         self.init_test_case()
-        input_np = np.random.uniform(0.1, 0.8, self.shape).astype(
-            "float16"
-        )
-        label_np = np.random.randint(0, 2, self.shape).astype(
-            "float16"
-        )
+        input_np = np.random.uniform(0.1, 0.8, self.shape).astype("float16")
+        label_np = np.random.randint(0, 2, self.shape).astype("float16")
         output_np = bce_loss(input_np, label_np)
 
         self.inputs = {'X': input_np, 'Label': label_np}

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -282,6 +282,7 @@ class TestBceLossOpCase2(OpTest):
 class TestBceLossOpFloat16(TestBceLossOp):
     def setUp(self):
         self.init_test_case()
+        self.python_api = bce_wrapper
         input_np = np.random.uniform(0.1, 0.8, self.shape).astype("float16")
         label_np = np.random.randint(0, 2, self.shape).astype("float16")
         output_np = bce_loss(input_np, label_np)

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -299,7 +299,7 @@ class TestBceLossOpFloat16(OpTest):
                 self.check_output_with_place(place, check_eager=True)
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out')
+        self.check_grad(['X', 'Label'], 'Out')
 
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -302,7 +302,9 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_grad_with_place(place, ['X'], 'Out', max_relative_error=1e-2)
+                self.check_grad_with_place(
+                    place, ['X'], 'Out', max_relative_error=1e-2
+                )
         
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -296,15 +296,13 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=1e-2)
+                self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_grad_with_place(
-                    place, ['X'], 'Out', max_relative_error=1e-2
-                )
+                self.check_grad_with_place(place, ['X'], 'Out')
         
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -302,7 +302,7 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_grad_with_place(place, ['X'], 'Out', atol=1e-3)
+                self.check_grad_with_place(place, ['X'], 'Out', max_relative_error=1e-2)
 
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -19,7 +19,7 @@ from eager_op_test import OpTest
 
 import paddle
 import paddle.fluid as fluid
-
+import paddle.fluid.core as core
 
 def test_static_layer(
     place, input_np, label_np, reduction='mean', weight_np=None
@@ -278,6 +278,30 @@ class TestBceLossOpCase2(OpTest):
     def init_test_cast(self):
         self.shape = [2, 3, 20]
 
+
+class TestBceLossOpFloat16(OpTest):
+    def setUp(self):
+        self.init_test_case()
+        self.op_type = "bce_loss"
+        self.python_api = bce_wrapper
+        input_np = np.random.uniform(0.1, 0.8, self.shape).astype("float16")
+        label_np = np.random.randint(0, 2, self.shape).astype("float16")
+        output_np = bce_loss(input_np, label_np)
+
+        self.inputs = {'X': input_np, 'Label': label_np}
+        self.outputs = {'Out': output_np}
+
+    def test_check_output(self):
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+            if core.is_float16_supported(place):
+                self.check_output_with_place(place, check_eager=True)
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out')
+
+    def init_test_case(self):
+        self.shape = [10, 10]
 
 if __name__ == "__main__":
     paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -296,13 +296,21 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=1e-3)
+                self.check_output_with_place(
+                    place, ['X', 'Label'], 'Out', check_eager=True, atol=1e-3
+                )
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_grad_with_place(place, ['X'], 'Out', max_relative_error=1e-2)
+                self.check_grad_with_place(
+                    place,
+                    ['X', 'Label'],
+                    'Out',
+                    check_eager=True,
+                    max_relative_error=1e-2,
+                )
 
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -296,11 +296,14 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, check_eager=True)
+                self.check_output_with_place(place, atol=1e-2)
 
     def test_check_grad(self):
-        self.check_grad(['X', 'Label'], 'Out')
-
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+            if core.is_float16_supported(place):
+                self.check_grad_with_place(place, ['X'], 'Out', max_relative_error=1e-2)
+        
     def init_test_case(self):
         self.shape = [10, 10]
 

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -303,7 +303,7 @@ class TestBceLossOpFloat16(OpTest):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
                 self.check_grad_with_place(place, ['X'], 'Out')
-        
+
     def init_test_case(self):
         self.shape = [10, 10]
 

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -21,6 +21,7 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 
+
 def test_static_layer(
     place, input_np, label_np, reduction='mean', weight_np=None
 ):
@@ -302,6 +303,7 @@ class TestBceLossOpFloat16(OpTest):
 
     def init_test_case(self):
         self.shape = [10, 10]
+
 
 if __name__ == "__main__":
     paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -296,13 +296,13 @@ class TestBceLossOpFloat16(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place)
+                self.check_output_with_place(place, atol=1e-3)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_grad_with_place(place, ['X'], 'Out')
+                self.check_grad_with_place(place, ['X'], 'Out', atol=1e-3)
 
     def init_test_case(self):
         self.shape = [10, 10]

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -633,10 +633,10 @@ def binary_cross_entropy(
     Parameters:
         input (Tensor): The input predications tensor. 2-D tensor with shape: [N, *],
             N is batch_size, `*` means number of additional dimensions. The ``input``
-            should always be the output of sigmod.  Available dtype is float32, float64.
+            should always be the output of sigmod.  Available dtype is float16, float32, float64.
         label (Tensor): The target labels tensor. 2-D tensor with the same shape as
             ``input``. The target labels which values should be numbers between 0 and 1.
-            Available dtype is float32, float64.
+            Available dtype is float16, float32, float64.
         weight (Tensor, optional): A manual rescaling weight given to the loss of each
             batch element. If given, has to be a Tensor of size nbatch and the data type
             is float32, float64. Default is ``'None'``.
@@ -686,10 +686,10 @@ def binary_cross_entropy(
             return out
     else:
         check_variable_and_dtype(
-            input, 'input', ['float32', 'float64'], 'binary_cross_entropy'
+            input, 'input', ['float16', 'float32', 'float64'], 'binary_cross_entropy'
         )
         check_variable_and_dtype(
-            label, 'label', ['float32', 'float64'], 'binary_cross_entropy'
+            label, 'label', ['float16', 'float32', 'float64'], 'binary_cross_entropy'
         )
 
         sub_name = name if weight is None and reduction == 'none' else None

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -686,10 +686,16 @@ def binary_cross_entropy(
             return out
     else:
         check_variable_and_dtype(
-            input, 'input', ['float16', 'float32', 'float64'], 'binary_cross_entropy'
+            input,
+            'input',
+            ['float16', 'float32', 'float64'],
+            'binary_cross_entropy',
         )
         check_variable_and_dtype(
-            label, 'label', ['float16', 'float32', 'float64'], 'binary_cross_entropy'
+            label,
+            'label',
+            ['float16', 'float32', 'float64'],
+            'binary_cross_entropy',
         )
 
         sub_name = name if weight is None and reduction == 'none' else None

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -732,8 +732,8 @@ class BCELoss(Layer):
             For more information, please refer to :ref:`api_guide_Name`.
 
     Shape:
-        - input (Tensor): 2-D tensor with shape: ``[N, *]``, N is batch_size, `*` means number of additional dimensions. The input ``input`` should always be the output of sigmod. Available dtype is float32, float64.
-        - label (Tensor): 2-D tensor with the same shape as ``input``. The target labels which values should be numbers between 0 and 1. Available dtype is float32, float64.
+        - input (Tensor): 2-D tensor with shape: ``[N, *]``, N is batch_size, `*` means number of additional dimensions. The input ``input`` should always be the output of sigmod. Available dtype is float16, float32, float64.
+        - label (Tensor): 2-D tensor with the same shape as ``input``. The target labels which values should be numbers between 0 and 1. Available dtype is float16, float32, float64.
         - output (Tensor): If ``reduction`` is ``'none'``, the shape of output is same as ``input`` , else the shape of output is scalar.
 
     Returns:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 OPs 
### Describe
<!-- Describe what this PR does -->
任务链接：https://github.com/PaddlePaddle/Paddle/issues/51281
NO.49 为 Paddle bce_loss 算子实现 float16 数据类型支持