### PR TITLE
Update amp_lists of static amp: remove no kernel op in amp_lists.unsupported_fp16_list

### DIFF
--- a/paddle/fluid/imperative/amp_auto_cast.h
+++ b/paddle/fluid/imperative/amp_auto_cast.h
@@ -32,7 +32,7 @@ enum class AmpLevel {
   O2,      // almost fp16
   O3,      // fp16
 };
-
+std::unordered_set<std::string> OpNoKernelInfos();
 std::tuple<std::unordered_set<std::string>,
            std::unordered_set<std::string>,
            std::unordered_set<std::string>>

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -2040,6 +2040,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("supports_int8", SupportsInt8);
   m.def("supports_vnni", SupportsVNNI);
   m.def("op_supported_infos", imperative::OpSupportedInfos);
+  m.def("op_no_kernel_infos", imperative::OpNoKernelInfos);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);
   m.def("is_compiled_with_dist", IsCompiledWithDIST);
   m.def("_cuda_synchronize", [](const platform::CUDAPlace &place) {

--- a/python/paddle/static/amp/bf16/amp_lists.py
+++ b/python/paddle/static/amp/bf16/amp_lists.py
@@ -114,6 +114,7 @@ gray_list = {
     'split',
 }
 
+no_kernel_list = core.op_no_kernel_infos()
 _, _, _sys_unsupported_bf16_list = core.op_supported_infos(
     'CPU', core.VarDesc.VarType.BF16
 )
@@ -126,4 +127,5 @@ fp32_list |= gray_list_fp16
 fp32_list -= bf16_list
 fp32_list -= gray_list
 unsupported_list -= bf16_list
+unsupported_list -= no_kernel_list
 unsupported_list -= gray_list

--- a/python/paddle/static/amp/fp16_lists.py
+++ b/python/paddle/static/amp/fp16_lists.py
@@ -195,8 +195,9 @@ else:
         'GPU', core.VarDesc.VarType.FP16
     )
 
+no_kernel_list = core.op_no_kernel_infos()
 unsupported_fp16_list = (
     _extra_unsupported_fp16_list | _sys_unsupported_fp16_list
 )
-
+unsupported_fp16_list -= no_kernel_list
 CustomOpLists = AutoMixedPrecisionLists

--- a/python/paddle/static/amp/fp16_utils.py
+++ b/python/paddle/static/amp/fp16_utils.py
@@ -430,15 +430,6 @@ def cast_model_to_fp16(program, amp_lists=None, use_fp16_guard=True):
 
     if amp_lists is None:
         amp_lists = AutoMixedPrecisionLists()
-    amp_lists.unsupported_list -= {
-        "conditional_block_grad",
-        "conditional_block",
-        "conditional_block_infer",
-        "select_input",
-        "while",
-        "while_grad",
-        "cast",
-    }
     global_block = program.global_block()
     keep_fp32_ops = set()
     to_fp16_var_names = set()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
在amp_lists.unsupported_fp16_list中自动删去无kernel实现的op，这部分op不需要keep fp32。同时做了同样操作在bf16(amp_list.py)