### PR TITLE
【Hackathon No.32】为 Paddle 优化 expand_as 前向&反向 op 在 GPU 上的计算性能

### DIFF
--- a/paddle/phi/kernels/gpu/expand_as_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_as_grad_kernel.cu
@@ -15,8 +15,52 @@
 #include "paddle/phi/kernels/expand_as_grad_kernel.h"
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/expand_as_grad_kernel_impl.h"
+#include "paddle/phi/kernels/funcs/reduce_function.h"
+
+#define MAX_RANK_SUPPORTED 6
+
+namespace phi {
+
+template <typename T, typename Context>
+void ExpandAsGradKernel(const Context& context,
+                        const DenseTensor& x,
+                        const DenseTensor& out_grad,
+                        const std::vector<int>& target_shape,
+                        DenseTensor* in_grad) {
+  auto in_dims = x.dims();
+  auto out_dims = out_grad.dims();
+  int in_rank = in_dims.size();
+  int out_rank = out_dims.size();
+
+  PADDLE_ENFORCE_GE(
+      out_rank,
+      1,
+      errors::InvalidArgument("The rank of the input 'Out@GRAD' for "
+                              "expand_as_v2_grad op must be greater than or "
+                              "equal to 1, but the value received is %d.",
+                              out_rank));
+  PADDLE_ENFORCE_LE(
+      out_rank,
+      MAX_RANK_SUPPORTED,
+      errors::InvalidArgument("The rank of the input 'Out@GRAD' for "
+                              "expand_as_v2_grad op must be less than or equal "
+                              "to %d, but the value received is %d.",
+                              MAX_RANK_SUPPORTED,
+                              out_rank));
+
+  context.template Alloc<T>(in_grad);
+  if (in_dims == out_dims) {
+    phi::Copy(context, out_grad, context.GetPlace(), false, in_grad);
+  } else {
+    std::vector<int> reduce_dims = funcs::GetReduceDim(in_dims, out_dims, -1);
+    funcs::ReduceKernel<T, T, kps::AddFunctor, kps::IdentityFunctor<T>>(
+        context, out_grad, in_grad, kps::IdentityFunctor<T>(), reduce_dims);
+  }
+}
+
+}  // namespace phi
 
 PD_REGISTER_KERNEL(expand_as_grad,
                    GPU,

--- a/paddle/phi/kernels/gpu/expand_as_kernel.cu
+++ b/paddle/phi/kernels/gpu/expand_as_kernel.cu
@@ -15,8 +15,93 @@
 #include "paddle/phi/kernels/expand_as_kernel.h"
 
 #include "paddle/phi/backends/gpu/gpu_context.h"
+#include "paddle/phi/common/scalar.h"
+#include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/kernel_registry.h"
-#include "paddle/phi/kernels/impl/expand_as_kernel_impl.h"
+#include "paddle/phi/kernels/funcs/broadcast_function.h"
+
+#define MAX_RANK_SUPPORTED 6
+
+namespace phi {
+
+template <typename T, typename Context>
+void ExpandAsKernel(const Context& ctx,
+                    const DenseTensor& x,
+                    const paddle::optional<DenseTensor>& y,
+                    const std::vector<int>& target_shape,
+                    DenseTensor* out) {
+  int rank = x.dims().size();
+  int target_rank = static_cast<int>(target_shape.size());
+  auto vec_in_dims = phi::vectorize<int>(x.dims());
+  PADDLE_ENFORCE_GE(target_rank,
+                    rank,
+                    errors::InvalidArgument(
+                        "The rank (%d) of the input 'target_tensor' for "
+                        "expand_as_v2 op must be greater than or equal to "
+                        "the rank (%d) of the input 'x'.",
+                        target_rank,
+                        rank));
+  PADDLE_ENFORCE_GE(
+      rank,
+      1,
+      errors::InvalidArgument("The rank (%d) of the input 'x' for "
+                              "expand_as_v2 op must be positive.",
+                              rank));
+  PADDLE_ENFORCE_LE(target_rank,
+                    MAX_RANK_SUPPORTED,
+                    errors::InvalidArgument(
+                        "The rank (%d) of the input 'target_tensor' for "
+                        "expand_as_v2 op must be less than or equal to %d.",
+                        target_rank,
+                        MAX_RANK_SUPPORTED));
+
+  unsigned int diff = target_rank - rank;
+  vec_in_dims.insert(vec_in_dims.begin(), diff, 1);
+
+  for (unsigned int i = 0; i < vec_in_dims.size(); ++i) {
+    PADDLE_ENFORCE_NE(
+        target_shape[i],
+        0,
+        errors::InvalidArgument("The value of target shape cannot be zero."));
+    if (i < diff) {
+      PADDLE_ENFORCE_GT(
+          target_shape[i],
+          0,
+          errors::InvalidArgument(
+              "The expanded size (%d) for non-existing dimensions must be "
+              "positive for expand_as_v2 op.",
+              target_shape[i]));
+    } else if (target_shape[i] > 0) {
+      if (vec_in_dims[i] != 1) {
+        PADDLE_ENFORCE_EQ(
+            vec_in_dims[i],
+            target_shape[i],
+            errors::InvalidArgument(
+                "The value (%d) of the non-singleton dimension does not match"
+                " the corresponding value (%d) in shape for expand_as_v2 op.",
+                vec_in_dims[i],
+                target_shape[i]));
+      }
+    } else {
+      PADDLE_ENFORCE_EQ(
+          target_shape[i],
+          -1,
+          errors::InvalidArgument(
+              "When the value in shape is negative for expand_as_v2 op, "
+              "only -1 is supported, but the value received is %d.",
+              target_shape[i]));
+    }
+  }
+
+  out->Resize(phi::make_ddim(target_shape));
+  ctx.template Alloc<T>(out);
+  std::vector<const DenseTensor*> ins = {&x};
+  std::vector<DenseTensor*> outs = {out};
+  phi::funcs::BroadcastKernel<ElementwiseType::kUnary, T, T>(
+      ctx, ins, &outs, -1, kps::IdentityFunctor<T>());
+}
+
+}  // namespace phi
 
 PD_REGISTER_KERNEL(expand_as,
                    GPU,


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
OPs

### Describe

目前 Paddle 内 `expand_as` 前向和反向算子的 GPU 实现采用 Eigen 组合的模式，缺少 GPU Kernel，性能相对不足，希望实现高性能的 GPU 计算 Kernel，为 Paddle 优化 `expand_as` op 在 GPU 上的计算性能。

+ 开发环境
1. 设备：Tesla V100-32G
2. CUDA 11.2，cuDNN v8.1.1 

+ 优化方法

由于expand_as前向的过程与**广播机制**类似，后向的过程与**求和约归**类似，因此直接通过使用飞桨内部的 `BroadcastKernel` 和 `ReduceKernel` 来对expand_as算子进行优化。

+ 优化效果
 
完成优化后，Paddle(Optimized)与优化前的Paddle(Baseline)的性能对比:
    
| Case | Data type | src_shape       | dst_shape           | Paddle Baseline(ms) | Optimized(ms) | Diff               |
| ---- | --------- | ---------       | ---------           | ---------------     | ---------     | ----               |
| 0    | float32   | [1785, 1]       | [1785, 128]         | 0.2244              | 0.1150        | faster than 48.760%|
| 1    | float32   | [5, 1, 1]       | [5, 128, 128]       | 3.6155              | 0.1179        | faster than 96.738%|
| 2    | float32   | [32, 807, 1]    | [32, 807, 807]      | 1.4826              | 0.6428        | faster than 56.646%|
| 3    | float64   | [32, 1, 1]      | [32, 807, 807]      | 288.7776            | 1.2293        | faster than 99.570%|
| 4    | float64   | [1, 1, 64 ,5]   | [64, 128, 64, 5]    | 3.1326              | 0.2746        | faster than 91.645%|
| 5    | float64   | [5, 1, 1, 1, 1] | [5, 1, 713, 1, 889] | 240.8861            | 0.2960        | faster than 99.877%|

针对以上6种不同的case, 优化后的性能有所提升，并且要扩展的Tensor元素数量越多，性能提升越明显，优化后的算子在case 5上的用时更是直接缩短至baseline的1/814。