### PR TITLE
[phi decopuling] decouple dependency to device_context in phi (Part 2)

### DIFF
--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -193,23 +193,5 @@ const Place& NPUPinnedDeviceContext::GetPlace() const { return place_; }
 
 #endif
 
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-
-CUDAPinnedDeviceContext::CUDAPinnedDeviceContext() {
-  eigen_device_.reset(new Eigen::DefaultDevice());
-}
-
-CUDAPinnedDeviceContext::CUDAPinnedDeviceContext(CUDAPinnedPlace place)
-    : place_(place) {
-  eigen_device_.reset(new Eigen::DefaultDevice());
-}
-
-Eigen::DefaultDevice* CUDAPinnedDeviceContext::eigen_device() const {
-  return eigen_device_.get();
-}
-
-const Place& CUDAPinnedDeviceContext::GetPlace() const { return place_; }
-#endif
-
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -234,24 +234,7 @@ class NPUPinnedDeviceContext
 #endif
 
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-// Currently, CUDAPinnedDeviceContext is only used to data copying.
-class CUDAPinnedDeviceContext
-    : public DeviceContext,
-      public phi::TypeInfoTraits<DeviceContext, CUDAPinnedDeviceContext> {
- public:
-  CUDAPinnedDeviceContext();
-  explicit CUDAPinnedDeviceContext(CUDAPinnedPlace place);
-
-  const Place& GetPlace() const override;
-
-  Eigen::DefaultDevice* eigen_device() const;
-
-  static const char* name() { return "CUDAPinnedDeviceContext"; }
-
- private:
-  CUDAPinnedPlace place_;
-  std::unique_ptr<Eigen::DefaultDevice> eigen_device_;
-};
+using CUDAPinnedDeviceContext = phi::GPUPinnedContext;
 #endif
 
 #ifdef PADDLE_WITH_CUSTOM_DEVICE

--- a/paddle/phi/README.md
+++ b/paddle/phi/README.md
@@ -548,15 +548,15 @@ Meanwhile, we need to simplify the writing method of Kernel registration. The ex
 
     ```c++
     REGISTER_OP_CPU_KERNEL(
-        scale, ops::ScaleKernel<paddle::platform::CPUDeviceContext, float>,
-        ops::ScaleKernel<paddle::platform::CPUDeviceContext, double>,
-        ops::ScaleKernel<paddle::platform::CPUDeviceContext,
-                         paddle::platform::bfloat16>,
-        ops::ScaleKernel<paddle::platform::CPUDeviceContext, uint8_t>,
-        ops::ScaleKernel<paddle::platform::CPUDeviceContext, int8_t>,
-        ops::ScaleKernel<paddle::platform::CPUDeviceContext, int16_t>,
-        ops::ScaleKernel<paddle::platform::CPUDeviceContext, int>,
-        ops::ScaleKernel<paddle::platform::CPUDeviceContext, int64_t>);
+        scale, ops::ScaleKernel<phi::CPUContext, float>,
+        ops::ScaleKernel<phi::CPUContext, double>,
+        ops::ScaleKernel<phi::CPUContext,
+                         phi::dtype::bfloat16>,
+        ops::ScaleKernel<phi::CPUContext, uint8_t>,
+        ops::ScaleKernel<phi::CPUContext, int8_t>,
+        ops::ScaleKernel<phi::CPUContext, int16_t>,
+        ops::ScaleKernel<phi::CPUContext, int>,
+        ops::ScaleKernel<phi::CPUContext, int64_t>);
     ```
 
 2. Paddle-Lite's kernel registration method declares input and output information for each Kernel, but since the kernel of each data type is different, it will also cause redundancy in the writing method. As you can see in the following code, except for the data type, other information is basically redundant.

--- a/paddle/phi/backends/custom/custom_device.cc
+++ b/paddle/phi/backends/custom/custom_device.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "paddle/fluid/platform/profiler/trace_event_collector.h"
+#include "paddle/phi/api/profiler/trace_event_collector.h"
 #include "paddle/phi/backends/callback_manager.h"
 #include "paddle/phi/backends/context_pool.h"
 #include "paddle/phi/backends/custom/enforce_custom.h"
@@ -822,45 +822,44 @@ class CustomDevice : public DeviceInterface {
   }
 
   // Profiler
-  void ProfilerInitialize(paddle::platform::TraceEventCollector* collector,
+  void ProfilerInitialize(phi::TraceEventCollector* collector,
                           void** user_data) override {
     CHECK_PTR(pimpl_->profiler_initialize);
     PADDLE_ENFORCE_CUSTOM_DEVICE_SUCCESS(pimpl_->profiler_initialize(
         reinterpret_cast<C_Profiler>(collector), user_data));
   }
 
-  void ProfilerFinalize(paddle::platform::TraceEventCollector* collector,
+  void ProfilerFinalize(phi::TraceEventCollector* collector,
                         void* user_data) override {
     CHECK_PTR(pimpl_->profiler_finalize);
     PADDLE_ENFORCE_CUSTOM_DEVICE_SUCCESS(pimpl_->profiler_finalize(
         reinterpret_cast<C_Profiler>(collector), user_data));
   }
 
-  void ProfilerPrepareTracing(paddle::platform::TraceEventCollector* collector,
+  void ProfilerPrepareTracing(phi::TraceEventCollector* collector,
                               void* user_data) override {
     CHECK_PTR(pimpl_->profiler_prepare_tracing);
     PADDLE_ENFORCE_CUSTOM_DEVICE_SUCCESS(pimpl_->profiler_prepare_tracing(
         reinterpret_cast<C_Profiler>(collector), user_data));
   }
 
-  void ProfilerStartTracing(paddle::platform::TraceEventCollector* collector,
+  void ProfilerStartTracing(phi::TraceEventCollector* collector,
                             void* user_data) override {
     CHECK_PTR(pimpl_->profiler_start_tracing);
     PADDLE_ENFORCE_CUSTOM_DEVICE_SUCCESS(pimpl_->profiler_start_tracing(
         reinterpret_cast<C_Profiler>(collector), user_data));
   }
 
-  void ProfilerStopTracing(paddle::platform::TraceEventCollector* collector,
+  void ProfilerStopTracing(phi::TraceEventCollector* collector,
                            void* user_data) override {
     CHECK_PTR(pimpl_->profiler_stop_tracing);
     PADDLE_ENFORCE_CUSTOM_DEVICE_SUCCESS(pimpl_->profiler_stop_tracing(
         reinterpret_cast<C_Profiler>(collector), user_data));
   }
 
-  void ProfilerCollectTraceData(
-      paddle::platform::TraceEventCollector* collector,
-      uint64_t start_ns,
-      void* user_data) override {
+  void ProfilerCollectTraceData(phi::TraceEventCollector* collector,
+                                uint64_t start_ns,
+                                void* user_data) override {
     CHECK_PTR(pimpl_->profiler_collect_trace_data);
     PADDLE_ENFORCE_CUSTOM_DEVICE_SUCCESS(pimpl_->profiler_collect_trace_data(
         reinterpret_cast<C_Profiler>(collector), start_ns, user_data));

--- a/paddle/phi/backends/device_base.cc
+++ b/paddle/phi/backends/device_base.cc
@@ -369,35 +369,33 @@ void DeviceInterface::BlasAXPBY(size_t dev_id,
 }
 
 // profiler
-void DeviceInterface::ProfilerInitialize(
-    paddle::platform::TraceEventCollector* collector, void** user_data) {
+void DeviceInterface::ProfilerInitialize(phi::TraceEventCollector* collector,
+                                         void** user_data) {
   INTERFACE_UNIMPLEMENT;
 }
 
-void DeviceInterface::ProfilerFinalize(
-    paddle::platform::TraceEventCollector* collector, void* user_data) {
+void DeviceInterface::ProfilerFinalize(phi::TraceEventCollector* collector,
+                                       void* user_data) {
   INTERFACE_UNIMPLEMENT;
 }
 
 void DeviceInterface::ProfilerPrepareTracing(
-    paddle::platform::TraceEventCollector* collector, void* user_data) {
+    phi::TraceEventCollector* collector, void* user_data) {
   INTERFACE_UNIMPLEMENT;
 }
 
-void DeviceInterface::ProfilerStartTracing(
-    paddle::platform::TraceEventCollector* collector, void* user_data) {
+void DeviceInterface::ProfilerStartTracing(phi::TraceEventCollector* collector,
+                                           void* user_data) {
   INTERFACE_UNIMPLEMENT;
 }
 
-void DeviceInterface::ProfilerStopTracing(
-    paddle::platform::TraceEventCollector* collector, void* user_data) {
+void DeviceInterface::ProfilerStopTracing(phi::TraceEventCollector* collector,
+                                          void* user_data) {
   INTERFACE_UNIMPLEMENT;
 }
 
 void DeviceInterface::ProfilerCollectTraceData(
-    paddle::platform::TraceEventCollector* collector,
-    uint64_t start_ns,
-    void* user_data) {
+    phi::TraceEventCollector* collector, uint64_t start_ns, void* user_data) {
   INTERFACE_UNIMPLEMENT;
 }
 

--- a/paddle/phi/backends/device_base.h
+++ b/paddle/phi/backends/device_base.h
@@ -19,6 +19,8 @@
 #include "paddle/phi/backends/event.h"
 #include "paddle/phi/backends/stream.h"
 
+#include "paddle/phi/api/profiler/trace_event_collector.h"
+
 namespace paddle {
 namespace platform {
 class TraceEventCollector;
@@ -243,25 +245,24 @@ class DeviceInterface {  // Driver / Runtime
                          void* y);
 
   // profiler
-  virtual void ProfilerInitialize(
-      paddle::platform::TraceEventCollector* collector, void** user_data);
+  virtual void ProfilerInitialize(phi::TraceEventCollector* collector,
+                                  void** user_data);
 
-  virtual void ProfilerFinalize(
-      paddle::platform::TraceEventCollector* collector, void* user_data);
+  virtual void ProfilerFinalize(phi::TraceEventCollector* collector,
+                                void* user_data);
 
-  virtual void ProfilerPrepareTracing(
-      paddle::platform::TraceEventCollector* collector, void* user_data);
+  virtual void ProfilerPrepareTracing(phi::TraceEventCollector* collector,
+                                      void* user_data);
 
-  virtual void ProfilerStartTracing(
-      paddle::platform::TraceEventCollector* collector, void* user_data);
+  virtual void ProfilerStartTracing(phi::TraceEventCollector* collector,
+                                    void* user_data);
 
-  virtual void ProfilerStopTracing(
-      paddle::platform::TraceEventCollector* collector, void* user_data);
+  virtual void ProfilerStopTracing(phi::TraceEventCollector* collector,
+                                   void* user_data);
 
-  virtual void ProfilerCollectTraceData(
-      paddle::platform::TraceEventCollector* collector,
-      uint64_t start_ns,
-      void* user_data);
+  virtual void ProfilerCollectTraceData(phi::TraceEventCollector* collector,
+                                        uint64_t start_ns,
+                                        void* user_data);
 
  private:
   const std::string type_;

--- a/paddle/phi/backends/device_manager.cc
+++ b/paddle/phi/backends/device_manager.cc
@@ -597,49 +597,44 @@ void DeviceManager::CCLRecv(const std::string& device_type,
 }
 
 // profiler
-void DeviceManager::ProfilerInitialize(
-    const std::string& dev_type,
-    paddle::platform::TraceEventCollector* collector,
-    void** context) {
+void DeviceManager::ProfilerInitialize(const std::string& dev_type,
+                                       phi::TraceEventCollector* collector,
+                                       void** context) {
   auto dev_impl = GetDeviceInterfaceWithType(dev_type);
   dev_impl->ProfilerInitialize(collector, context);
 }
 
-void DeviceManager::ProfilerFinalize(
-    const std::string& dev_type,
-    paddle::platform::TraceEventCollector* collector,
-    void* context) {
+void DeviceManager::ProfilerFinalize(const std::string& dev_type,
+                                     phi::TraceEventCollector* collector,
+                                     void* context) {
   auto dev_impl = GetDeviceInterfaceWithType(dev_type);
   dev_impl->ProfilerFinalize(collector, context);
 }
 
-void DeviceManager::ProfilerPrepareTracing(
-    const std::string& dev_type,
-    paddle::platform::TraceEventCollector* collector,
-    void* context) {
+void DeviceManager::ProfilerPrepareTracing(const std::string& dev_type,
+                                           phi::TraceEventCollector* collector,
+                                           void* context) {
   auto dev_impl = GetDeviceInterfaceWithType(dev_type);
   dev_impl->ProfilerPrepareTracing(collector, context);
 }
 
-void DeviceManager::ProfilerStartTracing(
-    const std::string& dev_type,
-    paddle::platform::TraceEventCollector* collector,
-    void* context) {
+void DeviceManager::ProfilerStartTracing(const std::string& dev_type,
+                                         phi::TraceEventCollector* collector,
+                                         void* context) {
   auto dev_impl = GetDeviceInterfaceWithType(dev_type);
   dev_impl->ProfilerStartTracing(collector, context);
 }
 
-void DeviceManager::ProfilerStopTracing(
-    const std::string& dev_type,
-    paddle::platform::TraceEventCollector* collector,
-    void* context) {
+void DeviceManager::ProfilerStopTracing(const std::string& dev_type,
+                                        phi::TraceEventCollector* collector,
+                                        void* context) {
   auto dev_impl = GetDeviceInterfaceWithType(dev_type);
   dev_impl->ProfilerStopTracing(collector, context);
 }
 
 void DeviceManager::ProfilerCollectTraceData(
     const std::string& dev_type,
-    paddle::platform::TraceEventCollector* collector,
+    phi::TraceEventCollector* collector,
     uint64_t start_ns,
     void* context) {
   auto dev_impl = GetDeviceInterfaceWithType(dev_type);

--- a/paddle/phi/backends/device_manager.h
+++ b/paddle/phi/backends/device_manager.h
@@ -242,30 +242,25 @@ class DeviceManager {
                       const stream::Stream& stream);
 
   // profiler
-  static void ProfilerInitialize(
-      const std::string& dev_type,
-      paddle::platform::TraceEventCollector* collector,
-      void** context);
+  static void ProfilerInitialize(const std::string& dev_type,
+                                 phi::TraceEventCollector* collector,
+                                 void** context);
   static void ProfilerFinalize(const std::string& dev_type,
-                               paddle::platform::TraceEventCollector* collector,
+                               phi::TraceEventCollector* collector,
                                void* context);
-  static void ProfilerPrepareTracing(
-      const std::string& dev_type,
-      paddle::platform::TraceEventCollector* collector,
-      void* context);
-  static void ProfilerStartTracing(
-      const std::string& dev_type,
-      paddle::platform::TraceEventCollector* collector,
-      void* context);
-  static void ProfilerStopTracing(
-      const std::string& dev_type,
-      paddle::platform::TraceEventCollector* collector,
-      void* context);
-  static void ProfilerCollectTraceData(
-      const std::string& dev_type,
-      paddle::platform::TraceEventCollector* collector,
-      uint64_t start_ns,
-      void* context);
+  static void ProfilerPrepareTracing(const std::string& dev_type,
+                                     phi::TraceEventCollector* collector,
+                                     void* context);
+  static void ProfilerStartTracing(const std::string& dev_type,
+                                   phi::TraceEventCollector* collector,
+                                   void* context);
+  static void ProfilerStopTracing(const std::string& dev_type,
+                                  phi::TraceEventCollector* collector,
+                                  void* context);
+  static void ProfilerCollectTraceData(const std::string& dev_type,
+                                       phi::TraceEventCollector* collector,
+                                       uint64_t start_ns,
+                                       void* context);
 
   static void Clear();
 

--- a/paddle/phi/backends/gpu/gpu_context.cc
+++ b/paddle/phi/backends/gpu/gpu_context.cc
@@ -1046,4 +1046,20 @@ void GPUContext::SetDnnAttr(const std::string& attr_name, Attribute attr) {
 
 void GPUContext::ClearDnnAttr() { return impl_->ClearDnnAttr(); }
 
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+GPUPinnedContext::GPUPinnedContext() {
+  eigen_device_.reset(new Eigen::DefaultDevice());
+}
+
+GPUPinnedContext::GPUPinnedContext(GPUPinnedPlace place) : place_(place) {
+  eigen_device_.reset(new Eigen::DefaultDevice());
+}
+
+Eigen::DefaultDevice* GPUPinnedContext::eigen_device() const {
+  return eigen_device_.get();
+}
+
+const Place& GPUPinnedContext::GetPlace() const { return place_; }
+#endif
+
 }  // namespace phi

--- a/paddle/phi/backends/gpu/gpu_context.h
+++ b/paddle/phi/backends/gpu/gpu_context.h
@@ -262,6 +262,27 @@ class PADDLE_API GPUContext : public DeviceContext,
   std::unique_ptr<Impl> impl_;
 };
 
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+// Currently, GPUPinnedContext is only used to data copying.
+class GPUPinnedContext
+    : public DeviceContext,
+      public phi::TypeInfoTraits<DeviceContext, GPUPinnedContext> {
+ public:
+  GPUPinnedContext();
+  explicit GPUPinnedContext(GPUPinnedPlace place);
+
+  const Place& GetPlace() const override;
+
+  Eigen::DefaultDevice* eigen_device() const;
+
+  static const char* name() { return "GPUPinnedContext"; }
+
+ private:
+  GPUPinnedPlace place_;
+  std::unique_ptr<Eigen::DefaultDevice> eigen_device_;
+};
+#endif
+
 // Note: In order to register the kernel of CUDNN, DnnContext is required.
 // Currently, CUDNN kernel directly uses GPUContext. But if the kernel function
 // has the same name, this will lead to duplicate instantiations of GPU kernel

--- a/paddle/phi/kernels/funcs/math_function.cu
+++ b/paddle/phi/kernels/funcs/math_function.cu
@@ -114,20 +114,17 @@ template struct SetConstant<phi::GPUContext, bool>;
 template struct SetConstant<phi::GPUContext, phi::dtype::complex<float>>;
 template struct SetConstant<phi::GPUContext, phi::dtype::complex<double>>;
 
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, float16>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext,
-                            bfloat16>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, float>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, double>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, uint8_t>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, int>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, int16_t>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, int64_t>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext, bool>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext,
-                            phi::dtype::complex<float>>;
-template struct SetConstant<paddle::platform::CUDAPinnedDeviceContext,
-                            phi::dtype::complex<double>>;
+template struct SetConstant<phi::GPUPinnedContext, float16>;
+template struct SetConstant<phi::GPUPinnedContext, bfloat16>;
+template struct SetConstant<phi::GPUPinnedContext, float>;
+template struct SetConstant<phi::GPUPinnedContext, double>;
+template struct SetConstant<phi::GPUPinnedContext, uint8_t>;
+template struct SetConstant<phi::GPUPinnedContext, int>;
+template struct SetConstant<phi::GPUPinnedContext, int16_t>;
+template struct SetConstant<phi::GPUPinnedContext, int64_t>;
+template struct SetConstant<phi::GPUPinnedContext, bool>;
+template struct SetConstant<phi::GPUPinnedContext, phi::dtype::complex<float>>;
+template struct SetConstant<phi::GPUPinnedContext, phi::dtype::complex<double>>;
 
 #define DEFINE_GPU_TRANS(RANK)                                     \
   template struct Transpose<phi::GPUContext, bool, RANK>;          \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
- Subsequent PR of #50865
- `platform::CUDAPinnedDeviceContext` -> `phi::GPUPinnedContext`
- replace`paddle::platform::TraceEventCollector` usage
