### PR TITLE
add symbol InitDevices InitMemoryMethod

### DIFF
--- a/paddle/fluid/inference/paddle_inference.map
+++ b/paddle/fluid/inference/paddle_inference.map
@@ -64,6 +64,9 @@
 			/* *paddle::platform::GetExportedFlagInfoMap*; */
 
 			/* *paddle::framework*; */
+			*paddle::framework::InitDevices*;
+			*paddle::framework::InitMemoryMethod*;
+                        
 			*paddle::framework::InterpreterCore*;
 			*paddle::framework::Executor*;
 			*paddle::framework::proto*;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
BUG:
https://github.com/PaddlePaddle/Paddle/issues/51551

由于PHI算子库的解藕，新的内存模块phi::memory_utils无法实现自动初始化。
内存分配器需要调用paddle::framework::InitMemoryMethod之后。
才能单独使用PHI C++算子接口。

给这两个必要接口添加到符号表。