### PR TITLE
Improve stablity of Paddle-TensorRT FP16 UT GitHub (1)

### DIFF
--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -662,6 +662,9 @@ class TrtLayerAutoScanTest(AutoScanTest):
                 )
         return config
 
+    def get_avalible_input_type(self) -> List[np.dtype]:
+        return [np.float32]
+
     def assert_tensors_near(
         self,
         atol: float,
@@ -759,78 +762,81 @@ class TrtLayerAutoScanTest(AutoScanTest):
                 nodes_num,
                 threshold,
             ) in self.sample_predictor_configs(prog_config):
-                if os.path.exists(self.cache_dir):
-                    shutil.rmtree(self.cache_dir)
+                for input_type in self.get_avalible_input_type():
+                    if os.path.exists(self.cache_dir):
+                        shutil.rmtree(self.cache_dir)
 
-                if isinstance(threshold, float):
-                    atol = threshold
-                    rtol = 1e-8
-                elif isinstance(threshold, list) or isinstance(
-                    threshold, tuple
-                ):
-                    atol = threshold[0]
-                    rtol = threshold[1]
-                else:
-                    raise NotImplementedError
+                    if isinstance(threshold, float):
+                        atol = threshold
+                        rtol = 1e-8
+                    elif isinstance(threshold, list) or isinstance(
+                        threshold, tuple
+                    ):
+                        atol = threshold[0]
+                        rtol = threshold[1]
+                    else:
+                        raise NotImplementedError
 
-                is_fp8 = (
-                    pred_config.tensorrt_precision_mode()
-                    == paddle_infer.PrecisionType.Int8
-                )
-                if (not is_fp8 and quant) or (is_fp8 and not quant):
-                    continue
-
-                ignore_flag = False
-                for teller, reason, note in self.ignore_cases:
-                    if teller(prog_config, pred_config):
-                        ignore_flag = True
-                        if reason == IgnoreReasons.TRT_NOT_IMPLEMENTED:
-                            self.ignore_log(
-                                f"[TRT_NOT_IMPLEMENTED] {note} vs {self.inference_config_str(pred_config)}"
-                            )
-                        elif reason == IgnoreReasons.TRT_NOT_SUPPORT:
-                            self.ignore_log(
-                                f"[TRT_NOT_SUPPORT] {note} vs {self.inference_config_str(pred_config)}"
-                            )
-                        else:
-                            raise NotImplementedError
-                        break
-
-                if ignore_flag:
-                    continue
-
-                try:
-                    pred_config_deserialize = paddle_infer.Config(pred_config)
-                    trt_result = self.run_test_config(
-                        model, params, prog_config, pred_config, feed_data
+                    is_fp8 = (
+                        pred_config.tensorrt_precision_mode()
+                        == paddle_infer.PrecisionType.Int8
                     )
-                    self.assert_tensors_near(
-                        atol, rtol, trt_result, baseline_result
-                    )
-                    trt_engine_num, paddle_op_num = nodes_num
-                    self.assert_op_size(trt_engine_num, paddle_op_num)
+                    if (not is_fp8 and quant) or (is_fp8 and not quant):
+                        continue
 
-                    # deserialize test
-                    if trt_engine_num > 0:
-                        self.run_test_config(
-                            model,
-                            params,
-                            prog_config,
-                            pred_config_deserialize,
-                            feed_data,
+                    ignore_flag = False
+                    for teller, reason, note in self.ignore_cases:
+                        if teller(prog_config, pred_config):
+                            ignore_flag = True
+                            if reason == IgnoreReasons.TRT_NOT_IMPLEMENTED:
+                                self.ignore_log(
+                                    f"[TRT_NOT_IMPLEMENTED] {note} vs {self.inference_config_str(pred_config)}"
+                                )
+                            elif reason == IgnoreReasons.TRT_NOT_SUPPORT:
+                                self.ignore_log(
+                                    f"[TRT_NOT_SUPPORT] {note} vs {self.inference_config_str(pred_config)}"
+                                )
+                            else:
+                                raise NotImplementedError
+                            break
+
+                    if ignore_flag:
+                        continue
+
+                    try:
+                        pred_config_deserialize = paddle_infer.Config(
+                            pred_config
                         )
+                        trt_result = self.run_test_config(
+                            model, params, prog_config, pred_config, feed_data
+                        )
+                        self.assert_tensors_near(
+                            atol, rtol, trt_result, baseline_result
+                        )
+                        trt_engine_num, paddle_op_num = nodes_num
+                        self.assert_op_size(trt_engine_num, paddle_op_num)
 
-                    self.success_log(f"program_config: {prog_config}")
-                    self.success_log(
-                        f"predictor_config: {self.inference_config_str(pred_config)}"
-                    )
-                except Exception as e:
-                    self.fail_log(f"program_config: {prog_config}")
-                    self.fail_log(
-                        f"predictor_config: {self.inference_config_str(pred_config)}"
-                    )
-                    self.fail_log(f"\033[1;31m ERROR INFO: {e}\033[0m")
-                    all_passes = False
+                        # deserialize test
+                        if trt_engine_num > 0:
+                            self.run_test_config(
+                                model,
+                                params,
+                                prog_config,
+                                pred_config_deserialize,
+                                feed_data,
+                            )
+
+                        self.success_log(f"program_config: {prog_config}")
+                        self.success_log(
+                            f"predictor_config: {self.inference_config_str(pred_config)}"
+                        )
+                    except Exception as e:
+                        self.fail_log(f"program_config: {prog_config}")
+                        self.fail_log(
+                            f"predictor_config: {self.inference_config_str(pred_config)}"
+                        )
+                        self.fail_log(f"\033[1;31m ERROR INFO: {e}\033[0m")
+                        all_passes = False
 
         self.assertTrue(all_passes)
 

--- a/test/ir/inference/auto_scan_test.py
+++ b/test/ir/inference/auto_scan_test.py
@@ -763,6 +763,7 @@ class TrtLayerAutoScanTest(AutoScanTest):
                 threshold,
             ) in self.sample_predictor_configs(prog_config):
                 for input_type in self.get_avalible_input_type():
+                    prog_config = prog_config.set_input_type(input_type)
                     if os.path.exists(self.cache_dir):
                         shutil.rmtree(self.cache_dir)
 

--- a/test/ir/inference/program_config.py
+++ b/test/ir/inference/program_config.py
@@ -54,8 +54,8 @@ class TensorConfig:
         if data_gen is not None:
             self.data_gen = data_gen
             self.data = data_gen()
-            self.dtype = data_gen().dtype
-            self.shape = data_gen().shape
+            self.dtype = self.data.dtype
+            self.shape = self.data.shape
         else:
             assert (
                 shape is not None
@@ -66,6 +66,11 @@ class TensorConfig:
 
     def __repr__(self):
         return str({'shape': self.shape, 'lod': self.lod, 'dtype': self.dtype})
+
+    def astype(self, type: np.dtype):
+        self.data = self.data.astype(type)
+        self.dtype = self.data.dtype
+        return self
 
 
 class VarType(enum.Enum):
@@ -269,6 +274,16 @@ class ProgramConfig:
             log_str += '[' + t + ': ' + str(v) + ']'
 
         return log_str
+
+    def set_input_type(self, type: np.dtype):
+        for inp in self.inputs.values():
+            inp.astype(type)
+        for weight in self.weights.values():
+            weight.astype(type)
+        return self
+
+    def get_input_type(self) -> np.dtype:
+        return next(iter(self.inputs.values())).dtype
 
 
 def create_fake_model(program_config):

--- a/test/ir/inference/test_multihead_matmul_fuse_pass_v3.py
+++ b/test/ir/inference/test_multihead_matmul_fuse_pass_v3.py
@@ -33,6 +33,9 @@ class TestMultiheadMatmulFusePass(PassAutoScanTest):
         def generate_elewise_input():
             return np.random.random([1, 12, 128, 128]).astype(np.float32)
 
+        def generate_weight(shape):
+            return np.random.random(shape).astype(np.float32)
+
         mul_0 = OpConfig(
             "mul",
             inputs={"X": ["mul_x"], "Y": ["mul_0_w"]},
@@ -195,13 +198,27 @@ class TestMultiheadMatmulFusePass(PassAutoScanTest):
                 ),
             },
             weights={
-                "mul_0_w": TensorConfig(shape=[768, 768]),
-                "mul_1_w": TensorConfig(shape=[768, 768]),
-                "mul_2_w": TensorConfig(shape=[768, 768]),
-                "mul_3_w": TensorConfig(shape=[768, 768]),
-                "ele_0_w": TensorConfig(shape=[768]),
-                "ele_1_w": TensorConfig(shape=[768]),
-                "ele_2_w": TensorConfig(shape=[768]),
+                "mul_0_w": TensorConfig(
+                    data_gen=partial(generate_weight, [768, 768])
+                ),
+                "mul_1_w": TensorConfig(
+                    data_gen=partial(generate_weight, [768, 768])
+                ),
+                "mul_2_w": TensorConfig(
+                    data_gen=partial(generate_weight, [768, 768])
+                ),
+                "mul_3_w": TensorConfig(
+                    data_gen=partial(generate_weight, [768, 768])
+                ),
+                "ele_0_w": TensorConfig(
+                    data_gen=partial(generate_weight, [768])
+                ),
+                "ele_1_w": TensorConfig(
+                    data_gen=partial(generate_weight, [768])
+                ),
+                "ele_2_w": TensorConfig(
+                    data_gen=partial(generate_weight, [768])
+                ),
             },
             outputs=[ops[-1].outputs["Out"][0]],
         )

--- a/test/ir/inference/test_trt_convert_bitwise_not.py
+++ b/test/ir/inference/test_trt_convert_bitwise_not.py
@@ -103,11 +103,11 @@ class TrtConvertActivationTest(TrtLayerAutoScanTest):
             ver = paddle_infer.get_trt_compile_version()
             trt_version = ver[0] * 1000 + ver[1] * 100 + ver[2] * 10
             if trt_version >= 8400:
-                if self.dims == 1 and not dynamic_shape:
+                if self.dims == 1:
                     return 0, 3
                 return 1, 2
             else:
-                if (self.dims == 1 and not dynamic_shape) or (
+                if self.dims <= 2 or (
                     program_config.inputs['input_data'].dtype
                     in ['bool', 'int8', 'uint8']
                 ):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
This Pull Request consists of the following changes:

1. In engine.cc, a temporary blacklist function IsFP16BlacklistLayer has been added for Conv2D layers due to a bug in TensorRT versions 8.6.1.0 and later. This function prevents precision settings on Conv2D layers to mitigate the issue until the TensorRT team provides a permanent fix.
2. Also in engine.cc, we ensure that only valid layers are processed in FP16 mode.
3. In auto_scan_test.py, the logging level has been made configurable via the PADDLE_TEST_LOGLEVEL environment variable.
4. Several log messages have been modified to use f-strings for more readable code.
5. In program_config.py, a new method has been added to change the data type of the tensor's data.
