### PR TITLE
[Dy2St]Fix is_paddle_func not take effect for plain paddle API

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
@@ -270,6 +270,7 @@ class TestNotToConvert2(TestRecursiveCall2):
 
 
 # Situation 3 : test to_static for paddle api
+@paddle.jit.not_to_static
 def forward(self, x):
     if x.shape[0] > 1:
         x = x + 1

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -335,7 +335,7 @@ def is_paddle_func(func, ignore_white_list=True):
         flag = m is not None and m.__name__.startswith(PADDLE_MODULE_PREFIX)
         if ignore_white_list:
             flag = flag and not in_white_list(m, func_name)
-        # breakpoint()
+
         return flag
     except Exception:
         return False

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -320,26 +320,22 @@ def is_paddle_func(func, ignore_white_list=True):
     def in_white_list(module, func_name):
         if func_name is None:
             return False
-        return (module.__name__ + '.' + func_name) in AS_NOT_INNER_FUNC_LIST
+        return (module.__name__ + '.' + func_name) in INNER_FUNC_WHITE_LIST
 
     try:
         if isinstance(func, functools.partial):
             func = func.func
 
         func_name = getattr(func, '__name__', None)
-        # In case of dynamically monkey patch customised function
-        # into paddle class obj, so we consider its class module
-        # path as prefix.
-        if hasattr(func, "__self__"):
-            func = func.__self__
-            func_name = func.__class__.__name__
-        elif inspect.ismethod(func):
+        if inspect.ismethod(func):
+            func_name = func.__self__.__class__.__name__
             func = func.__func__
 
         m = inspect.getmodule(func)
         flag = m is not None and m.__name__.startswith(PADDLE_MODULE_PREFIX)
         if ignore_white_list:
             flag = flag and not in_white_list(m, func_name)
+        # breakpoint()
         return flag
     except Exception:
         return False

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -320,7 +320,7 @@ def is_paddle_func(func, ignore_white_list=True):
     def in_white_list(module, func_name):
         if func_name is None:
             return False
-        return (module.__name__ + '.' + func_name) in INNER_FUNC_WHITE_LIST
+        return (module.__name__ + '.' + func_name) in AS_NOT_INNER_FUNC_LIST
 
     try:
         if isinstance(func, functools.partial):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Pcard-66972
修复了 https://github.com/PaddlePaddle/Paddle/pull/50596 引入的is_paddle_func对于paddle 普通API未生效的问题 