### PR TITLE
[with_data_parallel][part13] remove with_data_parallel in example code

### DIFF
--- a/paddle/fluid/pybind/parallel_executor.cc
+++ b/paddle/fluid/pybind/parallel_executor.cc
@@ -372,17 +372,13 @@ void BindParallelExecutor(pybind11::module &m) {  // NOLINT
     Examples:
         .. code-block:: python
 
-            import os
             import paddle
             import paddle.static as static
 
             paddle.enable_static()
 
-            os.environ['CPU_NUM'] = str(2)
-            places = static.cpu_places()
-
             data = static.data(name="x", shape=[None, 1], dtype="float32")
-            hidden = static.nn.fc(input=data, size=10)
+            hidden = static.nn.fc(data, size=10)
             loss = paddle.mean(hidden)
             paddle.optimizer.SGD(learning_rate=0.01).minimize(loss)
 

--- a/paddle/fluid/pybind/parallel_executor.cc
+++ b/paddle/fluid/pybind/parallel_executor.cc
@@ -390,10 +390,7 @@ void BindParallelExecutor(pybind11::module &m) {  // NOLINT
             build_strategy.enable_inplace = True
             build_strategy.memory_optimize = True
             build_strategy.reduce_strategy = static.BuildStrategy.ReduceStrategy.Reduce
-            program = static.CompiledProgram(static.default_main_program())
-            program = program.with_data_parallel(loss_name=loss.name,
-                                                  build_strategy=build_strategy,
-                                                  places=places)
+            program = static.CompiledProgram(static.default_main_program(), build_strategy=build_strategy)
 )DOC");
 
   py::enum_<BuildStrategy::ReduceStrategy>(build_strategy, "ReduceStrategy")
@@ -461,7 +458,6 @@ void BindParallelExecutor(pybind11::module &m) {  // NOLINT
                     .. code-block:: python
 
                         import numpy
-                        import os
                         import paddle
                         import paddle.static as static
 
@@ -471,20 +467,8 @@ void BindParallelExecutor(pybind11::module &m) {  // NOLINT
                         place = paddle.CUDAPlace(0) if use_cuda else paddle.CPUPlace()
                         exe = static.Executor(place)
 
-                        # NOTE: If you use CPU to run the program, you need
-                        # to specify the CPU_NUM, otherwise, paddle will use
-                        # all the number of the logic core as the CPU_NUM,
-                        # in that case, the batch size of the input should be
-                        # greater than CPU_NUM, if not, the process will be
-                        # failed by an exception.
-                        if not use_cuda:
-                            os.environ['CPU_NUM'] = str(2)
-                            places = static.cpu_places()
-                        else:
-                            places = static.cuda_places()
-
                         data = static.data(name='X', shape=[None, 1], dtype='float32')
-                        hidden = static.nn.fc(input=data, size=10)
+                        hidden = static.nn.fc(data, size=10)
                         loss = paddle.mean(hidden)
                         paddle.optimizer.SGD(learning_rate=0.01).minimize(loss)
 
@@ -492,19 +476,18 @@ void BindParallelExecutor(pybind11::module &m) {  // NOLINT
 
                         build_strategy = static.BuildStrategy()
                         build_strategy.gradient_scale_strategy = \
-                                  static.BuildStrategy.GradientScaleStrategy.Customized
+                                    static.BuildStrategy.GradientScaleStrategy.Customized
                         compiled_prog = static.CompiledProgram(
-                                  static.default_main_program()).with_data_parallel(
-                                          loss_name=loss.name, build_strategy=build_strategy,
-                                          places=places)
+                                    static.default_main_program(),
+                                    build_strategy=build_strategy,
+                        )
 
-                        dev_count =  len(places)
                         x = numpy.random.random(size=(10, 1)).astype('float32')
-                        loss_grad = numpy.ones((dev_count)).astype("float32") * 0.01
+                        loss_grad = numpy.ones((1)).astype("float32") * 0.01
                         loss_grad_name = loss.name+"@GRAD"
                         loss_data = exe.run(compiled_prog,
-                                              feed={"X": x, loss_grad_name : loss_grad},
-                                              fetch_list=[loss.name, loss_grad_name])
+                                                feed={"X": x, loss_grad_name : loss_grad},
+                                                fetch_list=[loss.name, loss_grad_name])
                    )DOC")
       .def_property(
           "debug_graphviz_path",

--- a/python/paddle/fluid/compiler.py
+++ b/python/paddle/fluid/compiler.py
@@ -82,18 +82,6 @@ def _has_optimize_op(block):
     return False
 
 
-def _has_optimizer_in_control_flow(program):
-    if not program:
-        program = framework.default_main_program()
-    for op in program.global_block().ops:
-        if op.type == "conditional_block_grad":
-            sub_block = program.block(op._block_attr_id("sub_block"))
-            if _has_optimize_op(sub_block):
-                return True
-
-    return False
-
-
 def _should_broadcast_or_not_exists(program, var_name):
     block = program.global_block()
     var = block.vars.get(var_name, None)

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -26,7 +26,6 @@ from .framework import (
     _in_eager_without_dygraph_check,
 )
 from .framework import _cpu_num, _cuda_ids
-from ..utils import deprecated
 
 __all__ = ['DataFeeder']
 
@@ -452,11 +451,6 @@ class DataFeeder:
             ret_dict[each_name] = each_converter.done()
         return ret_dict
 
-    @deprecated(
-        since="2.5.0",
-        level=1,
-        reason="since parallel_executor is removed, there's no need to maintain this api",
-    )
     def feed_parallel(self, iterable, num_places=None):
         """
         Similar with feed function, feed_parallel is used with multiple devices (CPU|GPU).
@@ -480,10 +474,7 @@ class DataFeeder:
             ..  code-block:: python
 
                 import numpy as np
-                import paddle
                 import paddle.fluid as fluid
-
-                paddle.enable_static()
 
                 def generate_reader(batch_size, base=0, factor=1):
                     def _reader():
@@ -497,13 +488,20 @@ class DataFeeder:
                 z = paddle.add(x, y)
 
                 feeder = fluid.DataFeeder(['x','y'], fluid.CPUPlace())
+                place_num = 2
+                places = [fluid.CPUPlace() for x in range(place_num)]
                 data = []
                 exe = fluid.Executor(fluid.CPUPlace())
                 exe.run(fluid.default_startup_program())
-                program = fluid.CompiledProgram(fluid.default_main_program())
+                program = fluid.CompiledProgram(fluid.default_main_program()).with_data_parallel(places=places)
 
-                reader_list = [generate_reader(5, 0, 1)]
-                res = exe.run(program=program, feed=list(feeder.feed_parallel(reader_list, 1)), fetch_list=[z])
+                # print sample feed_parallel r result
+                # for item in list(feeder.feed_parallel([generate_reader(5, 0, 1), generate_reader(3, 10, 2)], 2)):
+                #     print(item['x'])
+                #     print(item['y'])
+
+                reader_list = [generate_reader(5, 0, 1), generate_reader(3, 10, 2)]
+                res = exe.run(program=program, feed=list(feeder.feed_parallel(reader_list, 2)), fetch_list=[z])
                 print(res)
 
         """
@@ -540,11 +538,6 @@ class DataFeeder:
         else:
             return _cpu_num()
 
-    @deprecated(
-        since="2.5.0",
-        level=1,
-        reason="since parallel_executor is removed, there's no need to maintain this api",
-    )
     def decorate_reader(
         self, reader, multi_devices, num_places=None, drop_last=True
     ):
@@ -577,8 +570,6 @@ class DataFeeder:
                 import paddle.fluid as fluid
                 import paddle.fluid.compiler as compiler
 
-                paddle.enable_static()
-
                 def reader():
                     def _mini_batch(batch_size):
                         for i in range(batch_size):
@@ -587,18 +578,21 @@ class DataFeeder:
                     for _ in range(10):
                         yield _mini_batch(np.random.randint(1, 10))
 
+                place_num = 3
+                places = [fluid.CPUPlace() for _ in range(place_num)]
+
                 # a simple network sample
                 data = fluid.data(name='data', shape=[None, 4, 4], dtype='float32')
                 label = fluid.data(name='label', shape=[None, 1], dtype='int64')
                 hidden = paddle.static.nn.fc(x=data, size=10)
 
-                feeder = fluid.DataFeeder(place=fluid.CPUPlace(), feed_list=[data, label])
-                reader = feeder.decorate_reader(reader, multi_devices=True, num_places=1, drop_last=True)
+                feeder = fluid.DataFeeder(place=places[0], feed_list=[data, label])
+                reader = feeder.decorate_reader(reader, multi_devices=True, num_places=3, drop_last=True)
 
-                exe = fluid.Executor()
+                exe = fluid.Executor(places[0])
                 exe.run(fluid.default_startup_program())
                 compiled_prog = compiler.CompiledProgram(
-                            fluid.default_main_program())
+                         fluid.default_main_program()).with_data_parallel(places=places)
 
                 for i,data in enumerate(reader()):
                     # print data if you like


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
This PR deletes `with_data_parallel` from example code, while `with_data_parallel` has been deleted in #50425 . There are still two references of `with_data_parallel` in example code of `DataFeeder`, which will be deleted later.
#### Other
Pcard-67004