### PR TITLE
remove duplicate mkldnn_data_type

### DIFF
--- a/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
+++ b/paddle/fluid/framework/ir/op_compat_sensible_pass.cc
@@ -33,7 +33,6 @@ std::unordered_set<std::string> global_extra_attrs = {
     "use_mkldnn",
     "mkldnn_data_type",
     "use_quantizer",
-    "mkldnn_data_type",
     "use_cudnn",
     "name",
     "with_quant_attr"};

--- a/paddle/phi/api/yaml/op_compat.yaml
+++ b/paddle/phi/api/yaml/op_compat.yaml
@@ -298,7 +298,7 @@
   backward : conv2d_grad
   extra :
     attrs : [bool is_test = false, bool use_cudnn = true, bool use_mkldnn = false, bool use_addto = false,
-             str mkldnn_data_type = "float32", bool force_fp32_output = false,
+             bool force_fp32_output = false,
              int workspace_size_MB = phi::backends::gpu::GetDefaultConvWorkspaceSizeLimitMB(), bool exhaustive_search = false]
 
 - op : conv2d_fusion


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
Fixes duplicated mkldnn_data_type attribute in fused_conv2d after cpu_quantize_placement_pass changes conv to fused_conv and mkldnn_data_type wasn't overwritten from float32 to int8.
![image](https://user-images.githubusercontent.com/17185347/224739986-5c61e710-9ab1-4b33-aa3a-877766dd6360.png)

I also removed dupliacated entry in global_extra_attrs construction.
