### PR TITLE
[Werror]修复maybe-uninitialized编译致命警告

### DIFF
--- a/paddle/fluid/operators/detection/multiclass_nms_op.cc
+++ b/paddle/fluid/operators/detection/multiclass_nms_op.cc
@@ -361,7 +361,7 @@ class MultiClassNMSKernel : public framework::OpKernel<T> {
     auto index = ctx.Output<phi::DenseTensor>("Index");
     bool has_roisnum = ctx.HasInput("RoisNum") ? true : false;
     auto rois_num = ctx.Input<phi::DenseTensor>("RoisNum");
-    auto score_dims = scores->dims();
+    auto score_dims = phi::vectorize<int>(scores->dims());
     auto score_size = score_dims.size();
     auto& dev_ctx = ctx.template device_context<phi::CPUContext>();
 

--- a/paddle/fluid/operators/fused/fusion_repeated_fc_relu_op.cc
+++ b/paddle/fluid/operators/fused/fusion_repeated_fc_relu_op.cc
@@ -153,7 +153,7 @@ class FusionRepeatedFCReluKernel : public framework::OpKernel<T> {
     auto place = ctx.GetPlace();
     int weight_sz = static_cast<int>(weights.size());
 
-    auto i_dims = in->dims();
+    auto i_dims = phi::vectorize<int>(in->dims());
     const auto& w_dims = weights[0]->dims();
     phi::jit::matmul_attr_t attr;
     attr.m = i_dims[0];

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -689,7 +689,7 @@ void _sliceCompute(const phi::DenseTensor *in,
                    const std::vector<int> &axes,
                    const std::vector<int> &starts) {
   auto &eigen_place = *ctx.eigen_device();
-  auto out_dims = out->dims();
+  auto out_dims = phi::vectorize<int>(out->dims());
   auto in_dims = in->dims();
 
   auto offsets = Eigen::DSizes<Eigen::DenseIndex, D>();

--- a/paddle/phi/kernels/cpu/matrix_nms_kernel.cc
+++ b/paddle/phi/kernels/cpu/matrix_nms_kernel.cc
@@ -255,7 +255,7 @@ void MatrixNMSKernel(const Context& ctx,
                      DenseTensor* out,
                      DenseTensor* index,
                      DenseTensor* roisnum) {
-  auto score_dims = scores.dims();
+  auto score_dims = phi::vectorize<int>(scores.dims());
   auto batch_size = score_dims[0];
   auto num_boxes = score_dims[2];
   auto box_dim = bboxes.dims()[2];

--- a/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
+++ b/paddle/phi/kernels/cpu/multiclass_nms3_kernel.cc
@@ -496,7 +496,7 @@ void MultiClassNMSKernel(const Context& ctx,
                          DenseTensor* nms_rois_num) {
   bool return_index = index != nullptr;
   bool has_roisnum = rois_num.get_ptr() != nullptr;
-  auto score_dims = scores.dims();
+  auto score_dims = phi::vectorize<int>(scores.dims());
   auto score_size = score_dims.size();
 
   std::vector<std::map<int, std::vector<int>>> all_indices;

--- a/paddle/phi/kernels/sparse/cpu/sparse_utils_kernel.cc
+++ b/paddle/phi/kernels/sparse/cpu/sparse_utils_kernel.cc
@@ -258,7 +258,7 @@ void CooToDenseCPUKernel(const CPUContext& dev_ctx,
   const auto dense_dims = x.dims();
   const auto indices = x.indices();
   const auto values = x.values();
-  const auto indices_dims = indices.dims();
+  const auto indices_dims = phi::vectorize<int>(indices.dims());
   int64_t sparse_dim = indices_dims[0];
   if (indices_dims.size() == 1) {
     sparse_dim = 1;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

BUG问题见 https://github.com/PaddlePaddle/Paddle/issues/51605
这个PR清空了-Werror=maybe-uninitialized

auto score_dims = scores.dims(); 在-Werror=maybe-uninitialized的规则下编译出错
需要改为 auto score_dims = phi::vectorize(scores.dims());