### PR TITLE
【Paddle-Fix-CI-bug】fix conv3d_transpose in windows trt8.4

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv3d_transpose.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_convert_conv3d_transpose.py
@@ -121,32 +121,19 @@ class TrtConvertConv3dTransposeTest(TrtLayerAutoScanTest):
             program_config.ops[i].attrs for i in range(len(program_config.ops))
         ]
 
-        if os.name == "nt":
-            # for static_shape
-            clear_dynamic_shape()
-            self.trt_param.precision = paddle_infer.PrecisionType.Float32
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, False
-            ), 1e-1
-            # for dynamic_shape
-            generate_dynamic_shape(attrs)
-            self.trt_param.precision = paddle_infer.PrecisionType.Float32
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, True
-            ), 1e-1
-        else:
-            # for static_shape
-            clear_dynamic_shape()
-            self.trt_param.precision = paddle_infer.PrecisionType.Float32
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, False
-            ), 1e-3
-            # for dynamic_shape
-            generate_dynamic_shape(attrs)
-            self.trt_param.precision = paddle_infer.PrecisionType.Float32
-            yield self.create_inference_config(), generate_trt_nodes_num(
-                attrs, True
-            ), 1e-3
+        atol = 1e-1 if os.name == "nt" else 1e-3
+        # for static_shape
+        clear_dynamic_shape()
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, False
+        ), atol
+        # for dynamic_shape
+        generate_dynamic_shape(attrs)
+        self.trt_param.precision = paddle_infer.PrecisionType.Float32
+        yield self.create_inference_config(), generate_trt_nodes_num(
+            attrs, True
+        ), atol
 
     def add_skip_trt_case(self):
         pass


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
https://ku.baidu-int.com/knowledge/HFVrC7hq1Q/yKeL8Lljko/4lPDclqtA3/acc5ebdac5b842
单侧在CI上机器验证无bulid egine falied的问题，但存在精度下降问题。
在linux下1e-3可以通过，经测试在windows下1e-1可以通过。
windows机器下TRT版本8.4.3.1 1e-1精度验证通过。
<img width="1306" alt="a9b7079f4f170ab6e2324eaf1fdc34c6" src="https://user-images.githubusercontent.com/88373061/224885105-d7502ff2-0fb5-454d-9f9a-7e003e2cfaa2.png">
