### PR TITLE
[Werror] fix Werror-maybe-uninitialized in roi_align_grad_kernel

### DIFF
--- a/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
@@ -81,7 +81,7 @@ void RoiAlignGradKernel(const Context& dev_ctx,
                         int sampling_ratio,
                         bool aligned,
                         DenseTensor* dx) {
-  auto in_dims = x.dims();
+  auto in_dims = phi::vectorize<int>(x.dims());
   int channels = in_dims[1];
   int height = in_dims[2];
   int width = in_dims[3];

--- a/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc
@@ -81,7 +81,7 @@ void RoiAlignGradKernel(const Context& dev_ctx,
                         int sampling_ratio,
                         bool aligned,
                         DenseTensor* dx) {
-  auto in_dims = phi::vectorize<int>(x.dims());
+  const auto& in_dims = x.dims();
   int channels = in_dims[1];
   int height = in_dims[2];
   int width = in_dims[3];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
类似于 #51608 ，参考 #51605 #47143
修复 GCC 9.4.0 由于-Werror=maybe-uninitialized 引起的编译失败

```shell
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc: In function ‘void phi::RoiAlignGradKernel(const Context&, const phi::DenseTensor&, const phi::DenseTensor&, const paddle::optional<phi::DenseTensor>&, const phi::DenseTensor&, int, int, float, int, bool, phi::DenseTensor*) [with T = float; Context = phi::CPUContext]’:
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:87:7: error: ‘*((void*)& in_dims +24)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   87 |   int width = in_dims[3];
      |       ^~~~~
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:84:8: error: ‘*((void*)& in_dims +16)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   84 |   auto in_dims = x.dims();
      |        ^~~~~~~
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:85:7: error: ‘*((void*)& in_dims +8)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   85 |   int channels = in_dims[1];
      |       ^~~~~~~~
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc: In function ‘void phi::RoiAlignGradKernel(const Context&, const phi::DenseTensor&, const phi::DenseTensor&, const paddle::optional<phi::DenseTensor>&, const phi::DenseTensor&, int, int, float, int, bool, phi::DenseTensor*) [with T = int; Context = phi::CPUContext]’:
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:84:8: error: ‘*((void*)& in_dims +24)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   84 |   auto in_dims = x.dims();
      |        ^~~~~~~
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:84:8: error: ‘*((void*)& in_dims +16)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:85:7: error: ‘*((void*)& in_dims +8)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   85 |   int channels = in_dims[1];
      |       ^~~~~~~~
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc: In function ‘void phi::RoiAlignGradKernel(const Context&, const phi::DenseTensor&, const phi::DenseTensor&, const paddle::optional<phi::DenseTensor>&, const phi::DenseTensor&, int, int, float, int, bool, phi::DenseTensor*) [with T = double; Context = phi::CPUContext]’:
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:87:7: error: ‘*((void*)& in_dims +24)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   87 |   int width = in_dims[3];
      |       ^~~~~
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:84:8: error: ‘*((void*)& in_dims +16)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   84 |   auto in_dims = x.dims();
      |        ^~~~~~~
/mnt/c/Users/jyz/Projects/pd/paddle/phi/kernels/cpu/roi_align_grad_kernel.cc:85:7: error: ‘*((void*)& in_dims +8)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   85 |   int channels = in_dims[1];
      |       ^~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [paddle/phi/kernels/CMakeFiles/phi_cpu.dir/build.make:4346: paddle/phi/kernels/CMakeFiles/phi_cpu.dir/cpu/roi_align_grad_kernel.cc.o] Error 1
```