### PR TITLE
add conv2d and conv2d_grad as default deny cinn ops

### DIFF
--- a/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
+++ b/paddle/fluid/framework/paddle2cinn/build_cinn_pass.h
@@ -79,7 +79,8 @@ class OpTransInfo {
   DeParamCondT deny_param_cond_{{"batch_norm", {"ReserveSpace"}},
                                 {"batch_norm_grad", {"ReserveSpace"}}};
 
-  std::unordered_set<std::string> default_deny_ops_{"feed", "fetch"};
+  std::unordered_set<std::string> default_deny_ops_{
+      "feed", "fetch", "conv2d", "conv2d_grad"};
 };
 
 // A pass named BuildCinnPass, the function of this pass is:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add conv2d and conv2d_grad as default deny cinn ops