### PR TITLE
[Polish extension.h] extension.h add PADDLE_NO_PYTHON macro

### DIFF
--- a/paddle/extension.h
+++ b/paddle/extension.h
@@ -16,7 +16,7 @@ limitations under the License. */
 
 // All paddle apis in C++ frontend
 #include "paddle/phi/api/all.h"
-// Python bindings for the C++ frontend
-#ifndef PADDLE_ON_INFERENCE
+// Python bindings for the C++ frontend (includes Python.h)
+#if !defined(PADDLE_ON_INFERENCE) && !defined(PADDLE_NO_PYTHON)
 #include "paddle/utils/pybind.h"
 #endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Pcard-66987

`extension.h` add `PADDLE_NO_PYTHON` macro.

`paddle/utils/pybind.h` relies on pybind11, which indirectly relies on `Python.h` header file. Hence add `PADDLE_NO_PYTHON` macro to control whether include `paddle/utils/pybind.h` headerfile.