### PR TITLE
In single-stream scenario of new executor,  DO NOT create a new stream to capture cuda graph

### DIFF
--- a/paddle/phi/backends/gpu/cuda/cuda_graph.h
+++ b/paddle/phi/backends/gpu/cuda/cuda_graph.h
@@ -196,14 +196,6 @@ class CUDAGraph {
   // supported during capturing CUDA Graph.
   static bool IsValidCapturing();
 
-  static void SetIsCUDAGraphStreamCreated(bool create_cuda_graph_stream) {
-    capturing_graph_->is_cuda_graph_stream_created_ = create_cuda_graph_stream;
-  }
-
-  static bool IsCUDAGraphStreamCreated() {
-    return capturing_graph_->is_cuda_graph_stream_created_;
-  }
-
   static bool IsThreadLocalCapturing() {
 #if CUDA_VERSION >= 10010
     return IsCapturing() &&
@@ -253,8 +245,6 @@ class CUDAGraph {
   std::mutex func_mtx_;
 
   bool is_first_run_{true};
-
-  bool is_cuda_graph_stream_created_{false};
 
   static paddle::optional<std::thread::id> capturing_thread_id_;
   static std::unique_ptr<CUDAGraph> capturing_graph_;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

PR #51389 已经为新执行器的cuda graph支持了多流功能，本PR修复其中的一些问题。

原PR中，在新执行器只有单流、但这个流不是默认计算流的场景下，仍然会创建一个新的stream来capture cuda graph。这个新创建stream的过程是不必要的，且增加了默认stream与capture stream之间eventWait的开销。本PR对其进行了修复，并优化了capture stream选择的逻辑。
- interpretercore第一轮Convert阶段会记录所有op执行的stream。
    - 如果stream数量大于1：表示新执行器使用多流。会创建新的stream来capture。
    - 如果stream数量等于1：表示新执行器使用单流。不会创建新的stream，直接获取记录的这个stream即可，不管这个stream是默认计算流还是其他流。
    - 如果stream数量等于0：表示没有使用新执行器，或者新执行器中没有op执行。会使用默认计算流来capture cuda graph。
- 后续判断是否创建新流、是否需要eventWait，直接判断stream数量是否大于1即可。所以将没用的`is_cuda_graph_stream_created_`属性删除了。

另外，优化了interpretercore中的一些报错信息。

Pcard-66979
