### PR TITLE
tensor_meta: construct scalar tensor_meta

### DIFF
--- a/paddle/phi/core/dense_tensor.h
+++ b/paddle/phi/core/dense_tensor.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+/* Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -116,6 +116,10 @@ class DenseTensor : public TensorBase,
   /// \brief Test whether the metadata is valid.
   /// \return Whether the metadata is valid.
   bool valid() const noexcept override { return meta_.valid(); }
+
+  /// \brief Returns whether the tensor is a scalar
+  /// \return Whether the tensor is a scalar
+  bool is_scalar() const { return meta_.is_scalar; }
 
   /// \brief Test whether the allocation is allocated.
   /// return Whether the allocation is allocated.

--- a/paddle/phi/core/tensor_meta.cc
+++ b/paddle/phi/core/tensor_meta.cc
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+/* Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ DenseTensorMeta::DenseTensorMeta() { use_gpudnn = true; }
 DenseTensorMeta::DenseTensorMeta(DataType dtype, const DDim& dims)
     : dims(dims), dtype(dtype) {
   use_gpudnn = true;
+  is_scalar = dims.size() == 0;
 }
 
 DenseTensorMeta::DenseTensorMeta(DataType dtype,
@@ -29,6 +30,7 @@ DenseTensorMeta::DenseTensorMeta(DataType dtype,
                                  size_t offset)
     : dims(dims), dtype(dtype), layout(layout), offset(offset) {
   use_gpudnn = true;
+  is_scalar = dims.size() == 0;
 }
 
 DenseTensorMeta::DenseTensorMeta(DataType dtype,
@@ -38,6 +40,7 @@ DenseTensorMeta::DenseTensorMeta(DataType dtype,
                                  size_t offset)
     : dims(dims), dtype(dtype), layout(layout), lod(lod), offset(offset) {
   use_gpudnn = true;
+  is_scalar = dims.size() == 0;
 }
 
 bool DenseTensorMeta::valid() const noexcept {
@@ -48,7 +51,9 @@ bool DenseTensorMeta::valid() const noexcept {
   return valid;
 }
 
-StringTensorMeta::StringTensorMeta(const DDim& dims) : dims(dims) {}
+StringTensorMeta::StringTensorMeta(const DDim& dims) : dims(dims) {
+  is_scalar = dims.size() == 0;
+}
 
 bool StringTensorMeta::valid() const noexcept {
   bool valid{true};


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
APIs

### Describe
Construct tensor_meta with scalar info. This can be convenient to check if a tensor is a scalar tensor.