### PR TITLE
[Zero-Dim] Support 0-D tensor for some oneDNN unary kernels

### DIFF
--- a/paddle/fluid/framework/data_transform.cc
+++ b/paddle/fluid/framework/data_transform.cc
@@ -72,10 +72,12 @@ void TransformData(const phi::KernelKey &expected_kernel_type,
           // NHWC or NCHW
           phi::OneDNNContext::tls().set_cur_paddle_data_layout(lin);
         }
+
+        auto out_dims = out.dims().size() != 0 ? vectorize(out.dims())
+                                               : std::vector<int64_t>{1};
+
         dnnl::memory::desc out_mem_desc(
-            vectorize(out.dims()),
-            phi::funcs::ToOneDNNDataType(in.dtype()),
-            out_format);
+            out_dims, phi::funcs::ToOneDNNDataType(in.dtype()), out_format);
         out.set_mem_desc(out_mem_desc);
       } else {
         // Case2 - transfrom from ONEDNN OPKernel to Non-ONEDNN OPKernel

--- a/paddle/fluid/framework/data_transform.cc
+++ b/paddle/fluid/framework/data_transform.cc
@@ -60,9 +60,6 @@ void TransformData(const phi::KernelKey &expected_kernel_type,
       if (lin != DataLayout::ONEDNN && lout == DataLayout::ONEDNN) {
         // Case1 - transform from Non-ONEDNN OPKernel to ONEDNN OPKernel
         // Just set layout/format. No real transform occur
-
-        auto out_format = phi::funcs::OneDNNFormatForSize(
-            in.dims().size(), phi::funcs::ToOneDNNFormat(lin));
         out.ShareDataWith(input_tensor);
         // For NHWC data we need reshape of tensors as MKL-DNN
         // is expecting NHWC dims description order
@@ -73,11 +70,8 @@ void TransformData(const phi::KernelKey &expected_kernel_type,
           phi::OneDNNContext::tls().set_cur_paddle_data_layout(lin);
         }
 
-        auto out_dims = out.dims().size() != 0 ? vectorize(out.dims())
-                                               : std::vector<int64_t>{1};
-
-        dnnl::memory::desc out_mem_desc(
-            out_dims, phi::funcs::ToOneDNNDataType(in.dtype()), out_format);
+        dnnl::memory::desc out_mem_desc =
+            phi::funcs::make_memory_desc(out, lin);
         out.set_mem_desc(out_mem_desc);
       } else {
         // Case2 - transfrom from ONEDNN OPKernel to Non-ONEDNN OPKernel

--- a/paddle/phi/backends/onednn/onednn_helper.h
+++ b/paddle/phi/backends/onednn/onednn_helper.h
@@ -36,7 +36,9 @@ void* to_void_cast(const Type* t) {
 
 inline OneDNNMemoryFormat OneDNNFormatForSize(size_t dims_size,
                                               OneDNNMemoryFormat data_format) {
-  if (dims_size == 1) {
+  if (dims_size == 0) {
+    return OneDNNMemoryFormat::x;
+  } else if (dims_size == 1) {
     return OneDNNMemoryFormat::x;
   } else if (dims_size == 2) {
     return OneDNNMemoryFormat::nc;

--- a/paddle/phi/backends/onednn/onednn_reuse.h
+++ b/paddle/phi/backends/onednn/onednn_reuse.h
@@ -776,7 +776,8 @@ class SoftmaxOneDNNHandler
         errors::InvalidArgument(
             "The shape of input and output tensor must be identical."));
 
-    const int canonical_axis = funcs::CanonicalAxis(axis, x->dims().size());
+    int rank = x->dims().size() != 0 ? x->dims().size() : 1;
+    const int canonical_axis = funcs::CanonicalAxis(axis, rank);
     this->AcquireForwardPrimitiveDescriptor(
         dnnl::prop_kind::forward_scoring, x->mem_desc(), canonical_axis);
   }
@@ -790,8 +791,8 @@ class SoftmaxOneDNNHandler
                                 dnnl::softmax_forward,
                                 dnnl::softmax_backward>(onednn_engine,
                                                         cpu_place) {
-    const int canonical_axis =
-        funcs::CanonicalAxis(axis, out_grad->dims().size());
+    int rank = out_grad->dims().size() != 0 ? out_grad->dims().size() : 1;
+    const int canonical_axis = funcs::CanonicalAxis(axis, rank);
     this->AcquireForwardPrimitiveDescriptor(
         dnnl::prop_kind::forward_scoring, out->mem_desc(), canonical_axis);
     this->AcquireBackwardPrimitiveDescriptor(

--- a/paddle/phi/kernels/funcs/data_layout_transform.cc
+++ b/paddle/phi/kernels/funcs/data_layout_transform.cc
@@ -65,7 +65,7 @@ void TransDataLayoutFromOneDNN(DataLayout in_layout,
   auto& cpu_engine = dev_ctx->GetEngine();
 
   auto in_tz = vectorize<int64_t>(in.dims());
-  auto out_tz = in_tz;
+  auto out_tz = in_tz.size() != 0 ? in_tz : std::vector<int64_t>{1};
 
   auto in_type = ToOneDNNDataType(in.dtype());
   PADDLE_ENFORCE_NE(

--- a/paddle/phi/kernels/funcs/data_layout_transform.cc
+++ b/paddle/phi/kernels/funcs/data_layout_transform.cc
@@ -51,6 +51,27 @@ void* GetDataFromTensor(const DenseTensor& tensor,
   }
 }
 
+// This helper function is used to construct a dnnl memory descriptor from a
+// reference dense tensor and a target layout. For 0-D tensor case, we will
+// construct a 1-D memory descriptor with shape [1], since oneDNN didn't support
+// 0-D now.
+dnnl::memory::desc make_memory_desc(const phi::DenseTensor& ref_tensor,
+                                    phi::DataLayout target_layout) {
+  auto ref_dims = vectorize<int64_t>(ref_tensor.dims());
+  auto ref_type = ToOneDNNDataType(ref_tensor.dtype());
+  PADDLE_ENFORCE_NE(ref_type,
+                    OneDNNDataType::undef,
+                    errors::InvalidArgument(
+                        "Ref tensor type (%s) is not supported by oneDNN.",
+                        ref_tensor.dtype()));
+
+  auto md_dims = ref_dims.size() != 0 ? ref_dims : std::vector<int64_t>{1};
+  auto md_format =
+      OneDNNFormatForSize(md_dims.size(), ToOneDNNFormat(target_layout));
+  dnnl::memory::desc md(md_dims, ref_type, md_format);
+  return md;
+}
+
 void TransDataLayoutFromOneDNN(DataLayout in_layout,
                                DataLayout out_layout,
                                const DenseTensor& in,
@@ -64,19 +85,7 @@ void TransDataLayoutFromOneDNN(DataLayout in_layout,
   auto* dev_ctx = dynamic_cast<OneDNNContext*>(pool.Get(place));
   auto& cpu_engine = dev_ctx->GetEngine();
 
-  auto in_tz = vectorize<int64_t>(in.dims());
-  auto out_tz = in_tz.size() != 0 ? in_tz : std::vector<int64_t>{1};
-
-  auto in_type = ToOneDNNDataType(in.dtype());
-  PADDLE_ENFORCE_NE(
-      in_type,
-      OneDNNDataType::undef,
-      errors::InvalidArgument("Input tensor type (%s) is not supported.",
-                              in.dtype()));
-
-  auto out_format =
-      OneDNNFormatForSize(in_tz.size(), ToOneDNNFormat(out_layout));
-  dnnl::memory::desc out_mem_desc(out_tz, in_type, out_format);
+  dnnl::memory::desc out_mem_desc = make_memory_desc(in, out_layout);
 
   // output tensor has the same dims as input. Reorder don't change dims
   out->set_mem_desc(out_mem_desc);
@@ -85,6 +94,8 @@ void TransDataLayoutFromOneDNN(DataLayout in_layout,
   // Note(0x45f): Using initialized() to support slice Tensors
   // with shapes like [0, 0, 0].
   if (in.initialized() && ((in.mem_desc() != out->mem_desc()) || always_copy)) {
+    auto in_tz = vectorize<int64_t>(in.dims());
+    auto in_type = ToOneDNNDataType(in.dtype());
     void* in_data = GetDataFromTensor(in, in_type);
 
     ReorderOneDNNHandler handler(in_tz, in.dtype(), in_type, cpu_engine);

--- a/paddle/phi/kernels/funcs/data_layout_transform.h
+++ b/paddle/phi/kernels/funcs/data_layout_transform.h
@@ -85,6 +85,9 @@ void TransDataLayoutFromOneDNN(DataLayout in_layout,
                                bool always_copy = false);
 void* GetDataFromTensor(const DenseTensor& tensor, OneDNNDataType type);
 
+dnnl::memory::desc make_memory_desc(const phi::DenseTensor& ref_tensor,
+                                    phi::DataLayout target_layout);
+
 #endif
 
 }  // namespace funcs

--- a/paddle/phi/kernels/onednn/log_softmax_kernel.cc
+++ b/paddle/phi/kernels/onednn/log_softmax_kernel.cc
@@ -32,7 +32,7 @@ class LogSoftmaxOneDNNHandler
                           const int axis)
       : funcs::OneDNNHandlerNoCachingT<T, dnnl::logsoftmax_forward>(
             onednn_engine, cpu_place) {
-    int rank = x.dims().size() != 0 ? x.dims().size() : 1;
+    const int rank = x.dims().size() != 0 ? x.dims().size() : 1;
     const int canonical_axis = funcs::CanonicalAxis(axis, rank);
     this->AcquireForwardPrimitiveDescriptor(
         dnnl::prop_kind::forward_inference, x.mem_desc(), canonical_axis);

--- a/paddle/phi/kernels/onednn/log_softmax_kernel.cc
+++ b/paddle/phi/kernels/onednn/log_softmax_kernel.cc
@@ -32,8 +32,10 @@ class LogSoftmaxOneDNNHandler
                           const int axis)
       : funcs::OneDNNHandlerNoCachingT<T, dnnl::logsoftmax_forward>(
             onednn_engine, cpu_place) {
+    int rank = x.dims().size() != 0 ? x.dims().size() : 1;
+    const int canonical_axis = funcs::CanonicalAxis(axis, rank);
     this->AcquireForwardPrimitiveDescriptor(
-        dnnl::prop_kind::forward_inference, x.mem_desc(), axis);
+        dnnl::prop_kind::forward_inference, x.mem_desc(), canonical_axis);
   }
 };
 
@@ -43,7 +45,6 @@ void LogSoftmaxKernel(const Context& dev_ctx,
                       int axis,
                       DenseTensor* out) {
   const auto& onednn_engine = dev_ctx.GetEngine();
-  axis = axis >= 0 ? axis : x.dims().size() + axis;
 
   LogSoftmaxOneDNNHandler<T> handler(
       onednn_engine, dev_ctx.GetPlace(), x, axis);

--- a/paddle/phi/kernels/transfer_layout_kernel.cc
+++ b/paddle/phi/kernels/transfer_layout_kernel.cc
@@ -148,9 +148,10 @@ void TransferLayoutMKLDNN(const Context& dev_ctx,
       OneDNNContext::tls().set_cur_paddle_data_layout(src_layout);
     }
 
-    dnnl::memory::desc out_mem_desc(vectorize<int64_t>(out->dims()),
-                                    funcs::ToOneDNNDataType(x.dtype()),
-                                    out_format);
+    auto out_dims = out->dims().size() != 0 ? vectorize<int64_t>(out->dims())
+                                            : std::vector<int64_t>{1};
+    dnnl::memory::desc out_mem_desc(
+        out_dims, funcs::ToOneDNNDataType(x.dtype()), out_format);
     out->set_mem_desc(out_mem_desc);
   } else if (src_layout == DataLayout::ONEDNN &&
              dst_layout != DataLayout::ONEDNN) {

--- a/paddle/phi/kernels/transfer_layout_kernel.cc
+++ b/paddle/phi/kernels/transfer_layout_kernel.cc
@@ -136,9 +136,6 @@ void TransferLayoutMKLDNN(const Context& dev_ctx,
   if (src_layout != DataLayout::ONEDNN && dst_layout == DataLayout::ONEDNN) {
     // Case1 - transform from Non-MKLDNN OPKernel to MKLDNN OPKernel
     // Just set layout/format. No real transform occur
-    auto out_format = funcs::OneDNNFormatForSize(
-        x.dims().size(), funcs::ToOneDNNFormat(src_layout));
-
     out->ShareDataWith(x);
     // For NHWC data we need reshape of tensors as MKL-DNN
     // is expecting NHWC dims description order
@@ -148,10 +145,7 @@ void TransferLayoutMKLDNN(const Context& dev_ctx,
       OneDNNContext::tls().set_cur_paddle_data_layout(src_layout);
     }
 
-    auto out_dims = out->dims().size() != 0 ? vectorize<int64_t>(out->dims())
-                                            : std::vector<int64_t>{1};
-    dnnl::memory::desc out_mem_desc(
-        out_dims, funcs::ToOneDNNDataType(x.dtype()), out_format);
+    dnnl::memory::desc out_mem_desc = funcs::make_memory_desc(*out, src_layout);
     out->set_mem_desc(out_mem_desc);
   } else if (src_layout == DataLayout::ONEDNN &&
              dst_layout != DataLayout::ONEDNN) {

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
@@ -114,14 +114,6 @@ class TestMKLDNNLeakyRelu_ZeroDim(TestLeakyRelu_ZeroDim):
     def init_dtype(self):
         self.dtype = np.float32
 
-    def test_check_output(self):
-        self.check_output(check_dygraph=False)
-
-    def test_check_grad(self):
-        if self.dtype == np.float16:
-            return
-        self.check_grad(['X'], 'Out', check_dygraph=False)
-
 
 class TestMKLDNNGeluDim2(TestActivation):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
@@ -24,27 +24,27 @@ import paddle.nn.functional as F
 from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 from paddle.fluid.tests.unittests.test_activation_op import (
     TestAbs,
+    TestAbs_ZeroDim,
     TestActivation,
+    TestActivation_ZeroDim,
     TestHardSwish,
+    TestHardSwish_ZeroDim,
     TestLeakyRelu,
+    TestLeakyRelu_ZeroDim,
     TestRelu,
     TestRelu6,
-    TestSigmoid,
-    TestSqrt,
-    TestSwish,
-    TestTanh,
-    TestSoftplus,
-    TestAbs_ZeroDim,
-    TestActivation_ZeroDim,
-    TestHardSwish_ZeroDim,
-    TestLeakyRelu_ZeroDim,
-    TestRelu_ZeroDim,
     TestRelu6_ZeroDim,
+    TestRelu_ZeroDim,
+    TestSigmoid,
     TestSigmoid_ZeroDim,
-    TestSqrt_ZeroDim,
-    TestSwish_ZeroDim,
-    TestTanh_ZeroDim,
+    TestSoftplus,
     TestSoftplus_ZeroDim,
+    TestSqrt,
+    TestSqrt_ZeroDim,
+    TestSwish,
+    TestSwish_ZeroDim,
+    TestTanh,
+    TestTanh_ZeroDim,
 )
 from paddle.fluid.tests.unittests.test_gelu_op import gelu
 
@@ -58,6 +58,7 @@ class TestMKLDNNReluDim2(TestRelu):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNRelu_ZeroDim(TestRelu_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -67,6 +68,7 @@ class TestMKLDNNRelu_ZeroDim(TestRelu_ZeroDim):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNRelu6Dim2(TestRelu6):
     def setUp(self):
         super().setUp()
@@ -75,6 +77,7 @@ class TestMKLDNNRelu6Dim2(TestRelu6):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNRelu6_ZeroDim(TestRelu6_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -82,6 +85,7 @@ class TestMKLDNNRelu6_ZeroDim(TestRelu6_ZeroDim):
 
     def init_dtype(self):
         self.dtype = np.float32
+
 
 class TestMKLDNNLeakyReluDim2(TestLeakyRelu):
     def setUp(self):
@@ -100,6 +104,7 @@ class TestMKLDNNLeakyReluDim2(TestLeakyRelu):
             return
         self.check_grad(['X'], 'Out', check_dygraph=False)
 
+
 class TestMKLDNNLeakyRelu_ZeroDim(TestLeakyRelu_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -117,6 +122,7 @@ class TestMKLDNNLeakyRelu_ZeroDim(TestLeakyRelu_ZeroDim):
             return
         self.check_grad(['X'], 'Out', check_dygraph=False)
 
+
 class TestMKLDNNGeluDim2(TestActivation):
     def setUp(self):
         self.op_type = "gelu"
@@ -130,6 +136,7 @@ class TestMKLDNNGeluDim2(TestActivation):
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
 
+
 class TestMKLDNNGelu_ZeroDim(TestActivation_ZeroDim):
     def setUp(self):
         self.op_type = "gelu"
@@ -142,6 +149,7 @@ class TestMKLDNNGelu_ZeroDim(TestActivation_ZeroDim):
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
+
 
 class TestMKLDNNGeluDim2Approx(TestActivation):
     def setUp(self):
@@ -166,6 +174,7 @@ class TestMKLDNNTanhDim2(TestTanh):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNTanh_ZeroDim(TestTanh_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -174,6 +183,7 @@ class TestMKLDNNTanh_ZeroDim(TestTanh_ZeroDim):
 
     def init_dtype(self):
         self.dtype = np.float32
+
 
 class TestMKLDNNSqrtDim2(TestSqrt):
     def setUp(self):
@@ -184,6 +194,7 @@ class TestMKLDNNSqrtDim2(TestSqrt):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNSqrt_ZeroDim(TestSqrt_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -193,6 +204,7 @@ class TestMKLDNNSqrt_ZeroDim(TestSqrt_ZeroDim):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNAbsDim2(TestAbs):
     def setUp(self):
         super().setUp()
@@ -201,6 +213,7 @@ class TestMKLDNNAbsDim2(TestAbs):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNAbs_ZeroDim(TestAbs_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -208,6 +221,7 @@ class TestMKLDNNAbs_ZeroDim(TestAbs_ZeroDim):
 
     def init_dtype(self):
         self.dtype = np.float32
+
 
 class TestMKLDNNSwishDim2(TestSwish):
     def setUp(self):
@@ -219,6 +233,7 @@ class TestMKLDNNSwishDim2(TestSwish):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNSwish_ZeroDim(TestSwish_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -229,25 +244,30 @@ class TestMKLDNNSwish_ZeroDim(TestSwish_ZeroDim):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNHardSwishDim2(TestHardSwish):
     def setUp(self):
         super().setUp()
         self.attrs = {"use_mkldnn": True}
+
 
 class TestMKLDNNHardSwish_ZeroDim(TestHardSwish_ZeroDim):
     def setUp(self):
         super().setUp()
         self.attrs = {"use_mkldnn": True}
 
+
 class TestMKLDNNSigmoidDim2(TestSigmoid):
     def setUp(self):
         super().setUp()
         self.attrs = {"use_mkldnn": True}
 
+
 class TestMKLDNNSigmoid_ZeroDim(TestSigmoid_ZeroDim):
     def setUp(self):
         super().setUp()
         self.attrs = {"use_mkldnn": True}
+
 
 class TestMKLDNNReluDim4(TestRelu):
     def setUp(self):
@@ -470,6 +490,7 @@ class TestMKLDNNMish(TestActivation):
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
 
+
 class TestMKLDNNMish_ZeroDim(TestActivation_ZeroDim):
     def setUp(self):
         self.op_type = "mish"
@@ -483,6 +504,7 @@ class TestMKLDNNMish_ZeroDim(TestActivation_ZeroDim):
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
 
+
 class TestMKLDNNRound(TestActivation):
     def setUp(self):
         self.op_type = "round"
@@ -494,6 +516,7 @@ class TestMKLDNNRound(TestActivation):
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
 
+
 class TestMKLDNNRound_ZeroDim(TestActivation_ZeroDim):
     def setUp(self):
         self.op_type = "round"
@@ -504,6 +527,7 @@ class TestMKLDNNRound_ZeroDim(TestActivation_ZeroDim):
         self.inputs = {'X': x}
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
+
 
 class TestMKLDNNSigmoidDim4(TestSigmoid):
     def setUp(self):
@@ -534,6 +558,7 @@ class TestMKLDNNEluDefaultAlpha(TestActivation):
     def set_alpha(self):
         self.alpha = 1.0
 
+
 class TestMKLDNNEluDefaultAlpha_ZeroDim(TestActivation_ZeroDim):
     def setUp(self):
         self.op_type = "elu"
@@ -552,6 +577,7 @@ class TestMKLDNNEluDefaultAlpha_ZeroDim(TestActivation_ZeroDim):
     def set_alpha(self):
         self.alpha = 1.0
 
+
 class TestMKLDNNEluCustomAlpha(TestMKLDNNEluDefaultAlpha):
     def set_alpha(self):
         self.alpha = 2.5
@@ -567,6 +593,7 @@ class TestMKLDNNExpOp(TestActivation):
         self.attrs = {'use_mkldnn': True}
         self.outputs = {'Out': np.exp(x)}
 
+
 class TestMKLDNNExpOp_ZeroDim(TestActivation_ZeroDim):
     def setUp(self):
         self.op_type = "exp"
@@ -576,6 +603,7 @@ class TestMKLDNNExpOp_ZeroDim(TestActivation_ZeroDim):
         self.inputs = {'X': x}
         self.attrs = {'use_mkldnn': True}
         self.outputs = {'Out': np.exp(x)}
+
 
 # Check if primitives already exist in backward
 class TestMKLDNNAbsPrimitivesAlreadyExist(unittest.TestCase):
@@ -600,6 +628,7 @@ class TestMKLDNNAbsPrimitivesAlreadyExist(unittest.TestCase):
             self, self.op_type, self.x, self.out, self.out_grad, self.x_grad
         )
 
+
 class TestMKLDNNSoftplusDim2(TestSoftplus):
     def setUp(self):
         super().setUp()
@@ -608,6 +637,7 @@ class TestMKLDNNSoftplusDim2(TestSoftplus):
     def init_dtype(self):
         self.dtype = np.float32
 
+
 class TestMKLDNNSoftplus_ZeroDim(TestSoftplus_ZeroDim):
     def setUp(self):
         super().setUp()
@@ -615,6 +645,7 @@ class TestMKLDNNSoftplus_ZeroDim(TestSoftplus_ZeroDim):
 
     def init_dtype(self):
         self.dtype = np.float32
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
@@ -135,7 +135,7 @@ class TestMKLDNNGelu_ZeroDim(TestActivation_ZeroDim):
         self.python_api = F.gelu
         self.dtype = np.float32
 
-        x = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
+        x = np.random.uniform(-1, 1, []).astype(self.dtype)
         out = gelu(x, False)
 
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
@@ -489,7 +489,7 @@ class TestMKLDNNMish_ZeroDim(TestActivation_ZeroDim):
         self.python_api = F.mish
         self.dtype = np.float32
 
-        x = np.random.uniform(0.1, 1, [2, 4, 3, 5]).astype(self.dtype)
+        x = np.random.uniform(0.1, 1, []).astype(self.dtype)
         out = x * np.tanh(np.log(1 + np.exp(x)))
 
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
@@ -513,7 +513,7 @@ class TestMKLDNNRound_ZeroDim(TestActivation_ZeroDim):
     def setUp(self):
         self.op_type = "round"
         self.python_api = paddle.round
-        x = np.random.uniform(0.1, 1, [2, 4, 3, 5]).astype(np.float32)
+        x = np.random.uniform(0.1, 1, []).astype(np.float32)
         out = np.round(x)
 
         self.inputs = {'X': x}
@@ -557,7 +557,7 @@ class TestMKLDNNEluDefaultAlpha_ZeroDim(TestActivation_ZeroDim):
         self.python_api = F.elu
         self.set_alpha()
 
-        x = np.random.random((5, 5, 4)).astype("float32")
+        x = np.random.random(()).astype("float32")
 
         self.inputs = {'X': x}
         self.attrs = {'use_mkldnn': True, 'alpha': self.alpha}
@@ -590,7 +590,7 @@ class TestMKLDNNExpOp_ZeroDim(TestActivation_ZeroDim):
     def setUp(self):
         self.op_type = "exp"
         self.python_api = paddle.exp
-        x = np.random.random((5, 5, 4)).astype("float32")
+        x = np.random.random(()).astype("float32")
 
         self.inputs = {'X': x}
         self.attrs = {'use_mkldnn': True}

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
@@ -33,6 +33,18 @@ from paddle.fluid.tests.unittests.test_activation_op import (
     TestSqrt,
     TestSwish,
     TestTanh,
+    TestSoftplus,
+    TestAbs_ZeroDim,
+    TestActivation_ZeroDim,
+    TestHardSwish_ZeroDim,
+    TestLeakyRelu_ZeroDim,
+    TestRelu_ZeroDim,
+    TestRelu6_ZeroDim,
+    TestSigmoid_ZeroDim,
+    TestSqrt_ZeroDim,
+    TestSwish_ZeroDim,
+    TestTanh_ZeroDim,
+    TestSoftplus_ZeroDim,
 )
 from paddle.fluid.tests.unittests.test_gelu_op import gelu
 
@@ -46,6 +58,14 @@ class TestMKLDNNReluDim2(TestRelu):
     def init_dtype(self):
         self.dtype = np.float32
 
+class TestMKLDNNRelu_ZeroDim(TestRelu_ZeroDim):
+    def setUp(self):
+        super().setUp()
+
+        self.attrs = {"use_mkldnn": True}
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 class TestMKLDNNRelu6Dim2(TestRelu6):
     def setUp(self):
@@ -55,6 +75,13 @@ class TestMKLDNNRelu6Dim2(TestRelu6):
     def init_dtype(self):
         self.dtype = np.float32
 
+class TestMKLDNNRelu6_ZeroDim(TestRelu6_ZeroDim):
+    def setUp(self):
+        super().setUp()
+        self.attrs.update({"use_mkldnn": True})
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 class TestMKLDNNLeakyReluDim2(TestLeakyRelu):
     def setUp(self):
@@ -73,6 +100,22 @@ class TestMKLDNNLeakyReluDim2(TestLeakyRelu):
             return
         self.check_grad(['X'], 'Out', check_dygraph=False)
 
+class TestMKLDNNLeakyRelu_ZeroDim(TestLeakyRelu_ZeroDim):
+    def setUp(self):
+        super().setUp()
+
+        self.attrs = {"use_mkldnn": True}
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output(check_dygraph=False)
+
+    def test_check_grad(self):
+        if self.dtype == np.float16:
+            return
+        self.check_grad(['X'], 'Out', check_dygraph=False)
 
 class TestMKLDNNGeluDim2(TestActivation):
     def setUp(self):
@@ -87,6 +130,18 @@ class TestMKLDNNGeluDim2(TestActivation):
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
 
+class TestMKLDNNGelu_ZeroDim(TestActivation_ZeroDim):
+    def setUp(self):
+        self.op_type = "gelu"
+        self.python_api = F.gelu
+        self.dtype = np.float32
+
+        x = np.random.uniform(-1, 1, [11, 17]).astype(self.dtype)
+        out = gelu(x, False)
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.outputs = {'Out': out}
+        self.attrs = {"use_mkldnn": True}
 
 class TestMKLDNNGeluDim2Approx(TestActivation):
     def setUp(self):
@@ -111,6 +166,14 @@ class TestMKLDNNTanhDim2(TestTanh):
     def init_dtype(self):
         self.dtype = np.float32
 
+class TestMKLDNNTanh_ZeroDim(TestTanh_ZeroDim):
+    def setUp(self):
+        super().setUp()
+
+        self.attrs = {"use_mkldnn": True}
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 class TestMKLDNNSqrtDim2(TestSqrt):
     def setUp(self):
@@ -121,6 +184,14 @@ class TestMKLDNNSqrtDim2(TestSqrt):
     def init_dtype(self):
         self.dtype = np.float32
 
+class TestMKLDNNSqrt_ZeroDim(TestSqrt_ZeroDim):
+    def setUp(self):
+        super().setUp()
+
+        self.attrs = {"use_mkldnn": True}
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 class TestMKLDNNAbsDim2(TestAbs):
     def setUp(self):
@@ -130,6 +201,13 @@ class TestMKLDNNAbsDim2(TestAbs):
     def init_dtype(self):
         self.dtype = np.float32
 
+class TestMKLDNNAbs_ZeroDim(TestAbs_ZeroDim):
+    def setUp(self):
+        super().setUp()
+        self.attrs = {"use_mkldnn": True}
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 class TestMKLDNNSwishDim2(TestSwish):
     def setUp(self):
@@ -141,18 +219,35 @@ class TestMKLDNNSwishDim2(TestSwish):
     def init_dtype(self):
         self.dtype = np.float32
 
+class TestMKLDNNSwish_ZeroDim(TestSwish_ZeroDim):
+    def setUp(self):
+        super().setUp()
+
+        self.attrs["use_mkldnn"] = True
+        self.check_eager = False
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 class TestMKLDNNHardSwishDim2(TestHardSwish):
     def setUp(self):
         super().setUp()
         self.attrs = {"use_mkldnn": True}
 
+class TestMKLDNNHardSwish_ZeroDim(TestHardSwish_ZeroDim):
+    def setUp(self):
+        super().setUp()
+        self.attrs = {"use_mkldnn": True}
 
 class TestMKLDNNSigmoidDim2(TestSigmoid):
     def setUp(self):
         super().setUp()
         self.attrs = {"use_mkldnn": True}
 
+class TestMKLDNNSigmoid_ZeroDim(TestSigmoid_ZeroDim):
+    def setUp(self):
+        super().setUp()
+        self.attrs = {"use_mkldnn": True}
 
 class TestMKLDNNReluDim4(TestRelu):
     def setUp(self):
@@ -375,6 +470,18 @@ class TestMKLDNNMish(TestActivation):
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
 
+class TestMKLDNNMish_ZeroDim(TestActivation_ZeroDim):
+    def setUp(self):
+        self.op_type = "mish"
+        self.python_api = F.mish
+        self.dtype = np.float32
+
+        x = np.random.uniform(0.1, 1, [2, 4, 3, 5]).astype(self.dtype)
+        out = x * np.tanh(np.log(1 + np.exp(x)))
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.outputs = {'Out': out}
+        self.attrs = {"use_mkldnn": True}
 
 class TestMKLDNNRound(TestActivation):
     def setUp(self):
@@ -387,6 +494,16 @@ class TestMKLDNNRound(TestActivation):
         self.outputs = {'Out': out}
         self.attrs = {"use_mkldnn": True}
 
+class TestMKLDNNRound_ZeroDim(TestActivation_ZeroDim):
+    def setUp(self):
+        self.op_type = "round"
+        self.python_api = paddle.round
+        x = np.random.uniform(0.1, 1, [2, 4, 3, 5]).astype(np.float32)
+        out = np.round(x)
+
+        self.inputs = {'X': x}
+        self.outputs = {'Out': out}
+        self.attrs = {"use_mkldnn": True}
 
 class TestMKLDNNSigmoidDim4(TestSigmoid):
     def setUp(self):
@@ -417,6 +534,23 @@ class TestMKLDNNEluDefaultAlpha(TestActivation):
     def set_alpha(self):
         self.alpha = 1.0
 
+class TestMKLDNNEluDefaultAlpha_ZeroDim(TestActivation_ZeroDim):
+    def setUp(self):
+        self.op_type = "elu"
+        self.python_api = F.elu
+        self.set_alpha()
+
+        x = np.random.random((5, 5, 4)).astype("float32")
+
+        self.inputs = {'X': x}
+        self.attrs = {'use_mkldnn': True, 'alpha': self.alpha}
+        self.outputs = {
+            'Out': np.maximum(0, x)
+            + np.minimum(0, self.alpha * (np.exp(x) - 1))
+        }
+
+    def set_alpha(self):
+        self.alpha = 1.0
 
 class TestMKLDNNEluCustomAlpha(TestMKLDNNEluDefaultAlpha):
     def set_alpha(self):
@@ -433,6 +567,15 @@ class TestMKLDNNExpOp(TestActivation):
         self.attrs = {'use_mkldnn': True}
         self.outputs = {'Out': np.exp(x)}
 
+class TestMKLDNNExpOp_ZeroDim(TestActivation_ZeroDim):
+    def setUp(self):
+        self.op_type = "exp"
+        self.python_api = paddle.exp
+        x = np.random.random((5, 5, 4)).astype("float32")
+
+        self.inputs = {'X': x}
+        self.attrs = {'use_mkldnn': True}
+        self.outputs = {'Out': np.exp(x)}
 
 # Check if primitives already exist in backward
 class TestMKLDNNAbsPrimitivesAlreadyExist(unittest.TestCase):
@@ -457,6 +600,21 @@ class TestMKLDNNAbsPrimitivesAlreadyExist(unittest.TestCase):
             self, self.op_type, self.x, self.out, self.out_grad, self.x_grad
         )
 
+class TestMKLDNNSoftplusDim2(TestSoftplus):
+    def setUp(self):
+        super().setUp()
+        self.attrs.update({"use_mkldnn": True})
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+class TestMKLDNNSoftplus_ZeroDim(TestSoftplus_ZeroDim):
+    def setUp(self):
+        super().setUp()
+        self.attrs.update({"use_mkldnn": True})
+
+    def init_dtype(self):
+        self.dtype = np.float32
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
@@ -58,9 +58,10 @@ class TestCastBF16ToFP32MKLDNNOp(OpTest):
             user_defined_grads=[self.inputs['X']],
             user_defined_grad_outputs=[self.outputs['Out']],
         )
-    
+
     def init_shape(self):
         self.shape = [10, 10]
+
 
 class TestCastFP32ToBF16MKLDNNOp(TestCastBF16ToFP32MKLDNNOp):
     def init_data(self):
@@ -79,9 +80,11 @@ class TestCastFP32ToFP32MKLDNNOp(TestCastBF16ToFP32MKLDNNOp):
         self.x = np.random.random(size=[7, 15]).astype("float32")
         self.out = self.x
 
+
 class TestCastBF16ToFP32MKLDNNOp_ZeroDim(TestCastBF16ToFP32MKLDNNOp):
     def init_shape(self):
         self.shape = []
+
 
 if __name__ == '__main__':
     paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_cast_mkldnn_op.py
@@ -26,10 +26,11 @@ from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 )
 class TestCastBF16ToFP32MKLDNNOp(OpTest):
     def init_data(self):
-        self.out = np.random.random(size=[10, 10]).astype("float32")
+        self.out = np.random.random(size=self.shape).astype("float32")
         self.x = convert_float_to_uint16(self.out)
 
     def setUp(self):
+        self.init_shape()
         self.init_data()
         self.inputs = {'X': self.x}
         self.outputs = {'Out': self.out}
@@ -57,7 +58,9 @@ class TestCastBF16ToFP32MKLDNNOp(OpTest):
             user_defined_grads=[self.inputs['X']],
             user_defined_grad_outputs=[self.outputs['Out']],
         )
-
+    
+    def init_shape(self):
+        self.shape = [10, 10]
 
 class TestCastFP32ToBF16MKLDNNOp(TestCastBF16ToFP32MKLDNNOp):
     def init_data(self):
@@ -76,6 +79,9 @@ class TestCastFP32ToFP32MKLDNNOp(TestCastBF16ToFP32MKLDNNOp):
         self.x = np.random.random(size=[7, 15]).astype("float32")
         self.out = self.x
 
+class TestCastBF16ToFP32MKLDNNOp_ZeroDim(TestCastBF16ToFP32MKLDNNOp):
+    def init_shape(self):
+        self.shape = []
 
 if __name__ == '__main__':
     paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_clip_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_clip_mkldnn_op.py
@@ -51,7 +51,9 @@ class TestClipOneDNNOp(OpTest):
         self.shape = [10, 10]
 
     def set_inputs(self):
-        self.inputs = {'X': np.array(np.random.random(self.shape).astype(np.float32) * 25)}
+        self.inputs = {
+            'X': np.array(np.random.random(self.shape).astype(np.float32) * 25)
+        }
         self.x_fp32 = self.inputs['X']
 
     def set_additional_inputs(self):
@@ -69,9 +71,11 @@ class TestClipOneDNNOp(OpTest):
     def test_check_grad(self):
         self.check_grad(['X'], 'Out')
 
+
 class TestClipOneDNNOp_ZeroDim(TestClipOneDNNOp):
     def init_shape(self):
         self.shape = []
+
 
 class TestClipMinAsInputOneDNNOp(TestClipOneDNNOp):
     def set_additional_inputs(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_clip_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_clip_mkldnn_op.py
@@ -25,10 +25,10 @@ from paddle.fluid.tests.unittests.op_test import (
 )
 
 
-@OpTestTool.skip_if_not_cpu_bf16()
 class TestClipOneDNNOp(OpTest):
     def setUp(self):
         self.op_type = "clip"
+        self.init_shape()
         self.set_inputs()
         self.set_attrs()
         self.set_additional_inputs()
@@ -47,8 +47,11 @@ class TestClipOneDNNOp(OpTest):
 
         self.outputs = {'Out': np.clip(self.x_fp32, self.min, self.max)}
 
+    def init_shape(self):
+        self.shape = [10, 10]
+
     def set_inputs(self):
-        self.inputs = {'X': np.random.random((10, 10)).astype(np.float32) * 25}
+        self.inputs = {'X': np.array(np.random.random(self.shape).astype(np.float32) * 25)}
         self.x_fp32 = self.inputs['X']
 
     def set_additional_inputs(self):
@@ -66,6 +69,9 @@ class TestClipOneDNNOp(OpTest):
     def test_check_grad(self):
         self.check_grad(['X'], 'Out')
 
+class TestClipOneDNNOp_ZeroDim(TestClipOneDNNOp):
+    def init_shape(self):
+        self.shape = []
 
 class TestClipMinAsInputOneDNNOp(TestClipOneDNNOp):
     def set_additional_inputs(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_log_softmax_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_log_softmax_mkldnn_op.py
@@ -26,7 +26,6 @@ from paddle.fluid.tests.unittests.op_test import (
 from paddle.fluid.tests.unittests.test_log_softmax import ref_log_softmax
 
 
-@OpTestTool.skip_if_not_cpu_bf16()
 class TestLogSoftmaxOneDNNOp(OpTest):
     def setUp(self):
         self.op_type = 'log_softmax'
@@ -35,7 +34,11 @@ class TestLogSoftmaxOneDNNOp(OpTest):
         self.set_axis()
 
         x = np.random.uniform(0.1, 1.0, self.shape).astype(np.float32)
-        out = np.apply_along_axis(ref_log_softmax, self.axis, x)
+        out = (
+            np.apply_along_axis(ref_log_softmax, self.axis, x)
+            if len(self.shape) > 0
+            else np.array(0.0).astype(self.dtype)
+        )
 
         if self.dtype == np.uint16:
             x = convert_float_to_uint16(x)
@@ -55,6 +58,11 @@ class TestLogSoftmaxOneDNNOp(OpTest):
 
     def test_check_output(self):
         self.check_output_with_place(core.CPUPlace())
+
+
+class TestLogSoftmax0DOneDNNOp(TestLogSoftmaxOneDNNOp):
+    def set_shape(self):
+        self.shape = []
 
 
 class TestLogSoftmax1DOneDNNOp(TestLogSoftmaxOneDNNOp):
@@ -78,11 +86,13 @@ class TestLogSoftmaxPositiveAxisOneDNNOp(TestLogSoftmaxOneDNNOp):
 
 
 # BF16 TESTS
+@OpTestTool.skip_if_not_cpu_bf16()
 class TestLogSoftmax1DBF16OneDNNOp(TestLogSoftmax1DOneDNNOp):
     def set_dtype(self):
         self.dtype = np.uint16
 
 
+@OpTestTool.skip_if_not_cpu_bf16()
 class TestLogSoftmaxPositiveAxisBF16OneDNNOp(
     TestLogSoftmaxPositiveAxisOneDNNOp
 ):
@@ -90,9 +100,10 @@ class TestLogSoftmaxPositiveAxisBF16OneDNNOp(
         self.dtype = np.uint16
 
 
+@OpTestTool.skip_if_not_cpu_bf16()
 class TestLogSoftmax5DBF16OneDNNOp(TestLogSoftmax5DOneDNNOp):
-    def set_shape(self):
-        self.shape = [2, 3, 4, 5, 6]
+    def set_dtype(self):
+        self.dtype = np.uint16
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
@@ -22,13 +22,17 @@ from paddle.fluid.tests.unittests.op_test import OpTest
 
 class TestScaleOp(OpTest):
     def setUp(self):
+        self.init_shape()
         self.op_type = "scale"
-        self.inputs = {'X': np.random.random((10, 10)).astype(np.float32)}
+        self.inputs = {'X': np.random.random(self.shape).astype(np.float32)}
         self.attrs = {'scale': -2.3, 'use_mkldnn': True, 'bias': 0.2}
         self.use_mkldnn = True
         self.outputs = {
             'Out': (self.inputs['X'] * self.attrs['scale']) + self.attrs['bias']
         }
+
+    def init_shape(self):  
+        self.shape = [10, 10]
 
     def test_check_output(self):
         self.check_output(check_dygraph=False)
@@ -36,6 +40,9 @@ class TestScaleOp(OpTest):
     def test_check_grad(self):
         self.check_grad(['X'], 'Out')
 
+class TestScaleOp_ZeroDim(TestScaleOp):
+    def init_shape(self):  
+        self.shape = []
 
 class TestScaleOpBiasNotAfterScale(OpTest):
     def setUp(self):
@@ -59,6 +66,7 @@ class TestScaleOpBiasNotAfterScale(OpTest):
         self.check_grad(['X'], 'Out')
 
 
+# FIXME(xx) no use_mkldnn attr, does this case run into oneDNN?
 class TestScaleOpScaleTensor(OpTest):
     def setUp(self):
         self.op_type = "scale"
@@ -77,6 +85,7 @@ class TestScaleOpScaleTensor(OpTest):
         self.check_grad(['X'], 'Out')
 
 
+# FIXME(xx) no use_mkldnn attr, does this case run into oneDNN?
 class TestScaleOpScaleTensorNotBiasAfterScale(OpTest):
     def setUp(self):
         self.op_type = "scale"

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
@@ -68,7 +68,6 @@ class TestScaleOpBiasNotAfterScale(OpTest):
         self.check_grad(['X'], 'Out')
 
 
-# FIXME(xx) no use_mkldnn attr, does this case run into oneDNN?
 class TestScaleOpScaleTensor(OpTest):
     def setUp(self):
         self.op_type = "scale"
@@ -87,7 +86,6 @@ class TestScaleOpScaleTensor(OpTest):
         self.check_grad(['X'], 'Out')
 
 
-# FIXME(xx) no use_mkldnn attr, does this case run into oneDNN?
 class TestScaleOpScaleTensorNotBiasAfterScale(OpTest):
     def setUp(self):
         self.op_type = "scale"

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_scale_mkldnn_op.py
@@ -31,7 +31,7 @@ class TestScaleOp(OpTest):
             'Out': (self.inputs['X'] * self.attrs['scale']) + self.attrs['bias']
         }
 
-    def init_shape(self):  
+    def init_shape(self):
         self.shape = [10, 10]
 
     def test_check_output(self):
@@ -40,9 +40,11 @@ class TestScaleOp(OpTest):
     def test_check_grad(self):
         self.check_grad(['X'], 'Out')
 
+
 class TestScaleOp_ZeroDim(TestScaleOp):
-    def init_shape(self):  
+    def init_shape(self):
         self.shape = []
+
 
 class TestScaleOpBiasNotAfterScale(OpTest):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_softmax_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_softmax_mkldnn_op.py
@@ -26,6 +26,7 @@ from paddle.fluid.tests.unittests.test_softmax_op import (
     TestSoftmaxOp4,
     TestSoftmaxOp5,
     TestSoftmaxOp6,
+    TestSoftmaxOp_ZeroDim1,
 )
 
 
@@ -95,26 +96,38 @@ class TestSoftmaxMKLDNNOp(TestSoftmaxOp):
 class TestSoftmaxMKLDNNOp2(TestSoftmaxOp2):
     def init_kernel_type(self):
         self.use_mkldnn = True
+        # oneDNN doesn't support float64 dtype
+        self.dtype = np.float32
 
 
 class TestSoftmaxMKLDNNOp3(TestSoftmaxOp3):
     def init_kernel_type(self):
         self.use_mkldnn = True
+        self.dtype = np.float32
 
 
 class TestSoftmaxMKLDNNOp4(TestSoftmaxOp4):
     def init_kernel_type(self):
         self.use_mkldnn = True
+        self.dtype = np.float32
 
 
 class TestSoftmaxMKLDNNOp5(TestSoftmaxOp5):
     def init_kernel_type(self):
         self.use_mkldnn = True
+        self.dtype = np.float32
 
 
 class TestSoftmaxMKLDNNOp6(TestSoftmaxOp6):
     def init_kernel_type(self):
         self.use_mkldnn = True
+        self.dtype = np.float32
+
+
+class TestSoftmaxMKLDNNOp_ZeroDim(TestSoftmaxOp_ZeroDim1):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+        self.dtype = np.float32
 
 
 # Check if primitives already exist in backward

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -122,6 +122,7 @@ class TestSoftmaxOp_ZeroDim1(TestSoftmaxOp):
         self.use_mkldnn = False
         # explicilty use float32 for ROCm, as MIOpen does not yet support float64
         self.dtype = np.float32 if core.is_compiled_with_rocm() else np.float64
+        self.init_kernel_type()
 
         np.random.seed(0)
         x = np.random.uniform(0.1, 1, []).astype(self.dtype)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe
Partially solve https://github.com/PaddlePaddle/Paddle/issues/51364, support 0-d tensor for the following onednn elementwise kernels:

kernel | 0D Usage need to be supported | status
-- | -- | --
abs | element-wise   unary, 0D->0D | DONE
elu | element-wise   unary, 0D->0D | DONE
exp | element-wise   unary, 0D->0D | DONE
gelu | element-wise   unary, 0D->0D | DONE
hardswish | element-wise   unary, 0D->0D | DONE
leaky_relu | element-wise   unary, 0D->0D | DONE
mish | element-wise   unary, 0D->0D | DONE
relu | element-wise   unary, 0D->0D | DONE
relu6 | element-wise   unary, 0D->0D | DONE
sigmoid | element-wise   unary, 0D->0D | DONE
sqrt | element-wise   unary, 0D->0D | DONE
swish | element-wise   unary, 0D->0D | DONE
tanh | element-wise   unary, 0D->0D | DONE
round | element-wise   unary, 0D->0D | DONE
softplus | element-wise   unary, 0D->0D | DONE
cast | element-wise   unary, 0D->0D | DONE
clip | element-wise   unary, 0D->0D | DONE
scale | element-wise   unary, 0D->0D | DONE
softmax | when   input 0D, outputs is 0D and value is 1.0, grad is 0D and value is 0.0 | DONE
log_softmax | when   input 0D, outputs is 0D and value is 0.0, grad is 0D and value is 0.0 | DONE


