### PR TITLE
increase timeout limit of test_resnet_prim_cinn

### DIFF
--- a/python/paddle/fluid/tests/unittests/prim/model/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/prim/model/CMakeLists.txt
@@ -8,7 +8,7 @@ foreach(TEST_OP ${TEST_OPS})
   py_test_modules(${TEST_OP} MODULES ${TEST_OP} ENVS ${GC_ENVS})
 endforeach()
 
-set_tests_properties(test_resnet_prim_cinn PROPERTIES TIMEOUT 400)
+set_tests_properties(test_resnet_prim_cinn PROPERTIES TIMEOUT 800)
 set_tests_properties(test_bert_prim_cinn PROPERTIES TIMEOUT 500)
 
 if(WITH_CINN)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
increase timeout limit of test_resnet_prim_cinn, from 400s -> 800s, to avoid timeout error

Works on reducing the compiling time of cinn is on the way.