### PR TITLE
【Hackathon No.31】 Fix divide zero bug for Case 6:paddle.nn.functional.softmax_with_cross_entropy

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -29,7 +29,7 @@ def cross_entropy(softmax, label, soft_label, axis, ignore_index=-1):
     axis %= len(shape)
     n = int(np.prod(shape[:axis]))
     axis_dim = shape[axis]
-    remain = int(np.prod(shape[axis + 1:]))
+    remain = int(np.prod(shape[axis + 1 :]))
     softmax_reshape = softmax.reshape((n, axis_dim, remain))
     label_reshape = label.reshape((n, 1, remain))
     result = np.zeros_like(label_reshape, dtype=softmax.dtype)
@@ -930,11 +930,14 @@ class TestSoftmaxWithCrossEntropyOpDivideZero(unittest.TestCase):
         def divide_zero_case():
             array = np.array([], dtype=np.float32)
             logits = paddle.to_tensor(
-                np.reshape(array, [1, 0]), dtype='float32')
+                np.reshape(array, [1, 0]), dtype='float32'
+            )
             array = np.array([1], dtype=np.float32)
             label = paddle.to_tensor(np.reshape(array, [1]), dtype='float32')
             paddle.nn.functional.softmax_with_cross_entropy(
-                logits, label, soft_label=True, numeric_stable_mode=True, axis=0)
+                logits, label, soft_label=True, numeric_stable_mode=True, axis=0
+            )
+
         self.assertRaises(ValueError, divide_zero_case)
 
 

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -927,7 +927,7 @@ class TestSoftmaxWithCrossEntropyOpBoundary1(TestSoftmaxWithCrossEntropyOp):
 
 class TestSoftmaxWithCrossEntropyOpDivideZero(unittest.TestCase):
     def test_errors(self):
-        def divide_zero_case():
+        with self.assertRaises(ValueError):
             array = np.array([], dtype=np.float32)
             logits = paddle.to_tensor(
                 np.reshape(array, [1, 0]), dtype='float32'
@@ -937,8 +937,6 @@ class TestSoftmaxWithCrossEntropyOpDivideZero(unittest.TestCase):
             paddle.nn.functional.softmax_with_cross_entropy(
                 logits, label, soft_label=True, numeric_stable_mode=True, axis=0
             )
-
-        self.assertRaises(ValueError, divide_zero_case)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -29,7 +29,7 @@ def cross_entropy(softmax, label, soft_label, axis, ignore_index=-1):
     axis %= len(shape)
     n = int(np.prod(shape[:axis]))
     axis_dim = shape[axis]
-    remain = int(np.prod(shape[axis + 1 :]))
+    remain = int(np.prod(shape[axis + 1:]))
     softmax_reshape = softmax.reshape((n, axis_dim, remain))
     label_reshape = label.reshape((n, 1, remain))
     result = np.zeros_like(label_reshape, dtype=softmax.dtype)
@@ -923,6 +923,19 @@ class TestSoftmaxWithCrossEntropyOpBoundary1(TestSoftmaxWithCrossEntropyOp):
         self.logits = np.full(self.shape, 1000.0).astype(self.dtype)
         self.logits[:, :, 0, :] = -1000.0
         self.use_softmax = True
+
+
+class TestSoftmaxWithCrossEntropyOpDivideZero(unittest.TestCase):
+    def test_errors(self):
+        def divide_zero_case():
+            array = np.array([], dtype=np.float32)
+            logits = paddle.to_tensor(
+                np.reshape(array, [1, 0]), dtype='float32')
+            array = np.array([1], dtype=np.float32)
+            label = paddle.to_tensor(np.reshape(array, [1]), dtype='float32')
+            paddle.nn.functional.softmax_with_cross_entropy(
+                logits, label, soft_label=True, numeric_stable_mode=True, axis=0)
+        self.assertRaises(ValueError, divide_zero_case)
 
 
 if __name__ == "__main__":

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -2338,6 +2338,8 @@ def softmax_with_cross_entropy(
             # Tensor(shape=[1], dtype=float32, place=Place(gpu:0), stop_gradient=True,
             #        [1.15328646])
     """
+    if 0 in logits.shape:
+        raise ValueError("The dims of Input(X) should be greater than 0.")
     return fluid_softmax_with_cross_entropy(
         logits,
         label,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
[#49919(comment)](https://github.com/PaddlePaddle/Paddle/issues/49919#issuecomment-1386643789)