### PR TITLE
fix Tensor::mutable_data lack custom place & fix gtest not load custom device

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1740,7 +1740,8 @@ std::unique_ptr<ZeroCopyTensor> AnalysisPredictor::GetInputTensor(
         static_cast<size_t>(PaddlePlace::kCUSTOM) +
         phi::CustomRegisteredDeviceMap::Instance()
             .GetOrRegisterGlobalDeviceTypeId(place_.GetDeviceType()));
-    res->SetPlace(paddleplace, custom_place.GetDeviceId());
+    res->SetPlace(
+        paddleplace, custom_place.GetDeviceId(), place_.GetDeviceType());
   } else {
     auto gpu_place = place_;
     res->SetPlace(PaddlePlace::kGPU, gpu_place.GetDeviceId());
@@ -1796,7 +1797,8 @@ std::unique_ptr<ZeroCopyTensor> AnalysisPredictor::GetOutputTensor(
         static_cast<size_t>(PaddlePlace::kCUSTOM) +
         phi::CustomRegisteredDeviceMap::Instance()
             .GetOrRegisterGlobalDeviceTypeId(place_.GetDeviceType()));
-    res->SetPlace(paddleplace, custom_place.GetDeviceId());
+    res->SetPlace(
+        paddleplace, custom_place.GetDeviceId(), place_.GetDeviceType());
   } else {
     auto gpu_place = place_;
     res->SetPlace(PaddlePlace::kGPU, gpu_place.GetDeviceId());

--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -127,6 +127,10 @@ T *Tensor::mutable_data(PlaceType place) {
     case static_cast<int>(PlaceType::kNPU): {
       return tensor->mutable_data<T>(paddle::platform::NPUPlace(device_));
     }
+    case static_cast<int>(PlaceType::kCUSTOM): {
+      return tensor->mutable_data<T>(
+          paddle::platform::CustomPlace(device_type_, device_));
+    }
     default:
       PADDLE_THROW(paddle::platform::errors::Unavailable(
           "Only CPU / CUDA / XPU / NPU places is supported. The place `%d` is "
@@ -150,6 +154,8 @@ T *Tensor::data(PlaceType *place, int *size) const {
     *place = PlaceType::kXPU;
   } else if (paddle::platform::is_npu_place(tensor->place())) {
     *place = PlaceType::kNPU;
+  } else if (paddle::platform::is_custom_place(tensor->place())) {
+    *place = PlaceType::kCUSTOM;
   } else {
     *place = PlaceType::kUNK;
   }
@@ -741,9 +747,12 @@ void Tensor::SetName(const std::string &name) { name_ = name; }
 
 const std::string &Tensor::name() const { return name_; }
 
-void Tensor::SetPlace(PlaceType place, int device) {
+void Tensor::SetPlace(PlaceType place,
+                      int device,
+                      const std::string device_type) {
   place_ = place;
   device_ = device;
+  device_type_ = device_type;
 }
 
 #ifdef PADDLE_WITH_ONNXRUNTIME

--- a/paddle/fluid/inference/api/paddle_tensor.h
+++ b/paddle/fluid/inference/api/paddle_tensor.h
@@ -176,7 +176,10 @@ class PD_INFER_DECL Tensor {
   template <typename T>
   void* FindTensor() const;
 
-  void SetPlace(PlaceType place, int device = -1);
+  void SetPlace(PlaceType place,
+                int device = -1,
+                const std::string device_type = "");
+
   void SetName(const std::string& name);
 
   template <typename T>
@@ -195,6 +198,7 @@ class PD_INFER_DECL Tensor {
   const void* device_contexs_{nullptr};
   PlaceType place_;
   int device_;
+  std::string device_type_;
 
 #ifdef PADDLE_WITH_ONNXRUNTIME
   bool is_ort_tensor_{false};


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[paddle/fluid/inference/api/details/zero_copy_tensor.cc](https://github.com/PaddlePaddle/Paddle/compare/develop...engineer1109:fix-data?expand=1#diff-012247f22ceecf153a7a84e7523f0ef43b48cfb52b5701ddc4860a662d266b03)
```cpp
template <typename T>
T *Tensor::data(PlaceType *place, int *size) const

template <typename T>
T *Tensor::mutable_data(PlaceType place)
```
这两个函数缺乏CustomDevice Place的处理过程，导致CustomDevice无法使用paddle_infer::Tensor::mutable_data 或 data
例如
```
auto input_t = m_predictor->GetInputHandle(input_names[0]);
auto inputPtr = input_t->mutable_data<float>(paddle_infer::PlaceType::kCUSTOM);
```
会直接报出如下错误
```
Only CPU / CUDA / XPU / NPU places is supported.
```
这里加入Custom Place的处理代码。
支持place_ >= PlaceType::kCUSTOM
