### PR TITLE
[Polish utils/pybind.h] Delete p_tensor_type in pybind.h

### DIFF
--- a/paddle/utils/pybind.cc
+++ b/paddle/utils/pybind.cc
@@ -21,8 +21,8 @@ DECLARE_string(tensor_operants_mode);
 namespace paddle {
 namespace pybind {
 
-PyTypeObject* p_tensor_type;
-PyTypeObject* p_string_tensor_type;
+PyTypeObject* p_tensor_type = nullptr;
+PyTypeObject* p_string_tensor_type = nullptr;
 
 bool PyCheckTensor(PyObject* obj) {
   if (!p_tensor_type) {

--- a/paddle/utils/pybind.h
+++ b/paddle/utils/pybind.h
@@ -24,8 +24,6 @@ namespace py = pybind11;
 namespace paddle {
 namespace pybind {
 
-extern PyTypeObject* p_tensor_type;
-
 typedef struct {
   PyObject_HEAD paddle::Tensor tensor;
   // Weak references


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Pcard-66988

`utils/pybind.h` 作为对外开放的文件，应尽量保持简洁。Extension 机制依赖于 pybind11，使得文件中需要添加 Python 和 C++ 的转换逻辑，其中 `p_tensor_type` 不用被包含在头文件中，本 PR 删除这个指针。

As the exposed header file, `utils/pybind.h` should keep concise as much as possible. The conversion between Python and C++ has to be added in `pybind.h` because the Extension relies on pybind11. However, `p_tensor_type` is not needed in this header file, this PR deletes this pointer.