### PR TITLE
[Sparse]Add scale_qk_coeff for gpt model

### DIFF
--- a/paddle/phi/api/yaml/sparse_backward.yaml
+++ b/paddle/phi/api/yaml/sparse_backward.yaml
@@ -442,7 +442,7 @@
     func : values_coo_grad{sparse_coo, dense-> sparse_coo}
 
 - backward_op: fused_attention_grad
-  forward : fused_attention(Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask, float scale_qk_coeff) -> Tensor(out), Tensor(softmax)
+  forward : fused_attention(Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask, float scale_qk_coeff, float dropout_rate) -> Tensor(out), Tensor(softmax)
   args: (Tensor query, Tensor key, Tensor value, Tensor softmax, Tensor out_grad)
   output : Tensor(query_grad), Tensor(key_grad), Tensor(value_grad)
   infer_meta :

--- a/paddle/phi/api/yaml/sparse_backward.yaml
+++ b/paddle/phi/api/yaml/sparse_backward.yaml
@@ -442,7 +442,7 @@
     func : values_coo_grad{sparse_coo, dense-> sparse_coo}
 
 - backward_op: fused_attention_grad
-  forward : fused_attention(Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask) -> Tensor(out), Tensor(softmax)
+  forward : fused_attention(Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask, float scale_qk_coeff) -> Tensor(out), Tensor(softmax)
   args: (Tensor query, Tensor key, Tensor value, Tensor softmax, Tensor out_grad)
   output : Tensor(query_grad), Tensor(key_grad), Tensor(value_grad)
   infer_meta :

--- a/paddle/phi/api/yaml/sparse_ops.yaml
+++ b/paddle/phi/api/yaml/sparse_ops.yaml
@@ -445,8 +445,7 @@
     data_type : dtype
 
 - op: fused_attention
-  args : (Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor
-  key_padding_mask, Tensor attn_mask, float scale_qk_coeff=1.0, float dropout_rate=0.0)
+  args : (Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask, float scale_qk_coeff=1.0, float dropout_rate=0.0)
   output : Tensor(out), Tensor(softmax)
   infer_meta :
     func : sparse::FusedAttentionInferMeta

--- a/paddle/phi/api/yaml/sparse_ops.yaml
+++ b/paddle/phi/api/yaml/sparse_ops.yaml
@@ -445,7 +445,8 @@
     data_type : dtype
 
 - op: fused_attention
-  args : (Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask, float scale_qk_coeff=1.0)
+  args : (Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor
+  key_padding_mask, Tensor attn_mask, float scale_qk_coeff=1.0, float dropout_rate=0.0)
   output : Tensor(out), Tensor(softmax)
   infer_meta :
     func : sparse::FusedAttentionInferMeta

--- a/paddle/phi/api/yaml/sparse_ops.yaml
+++ b/paddle/phi/api/yaml/sparse_ops.yaml
@@ -445,7 +445,7 @@
     data_type : dtype
 
 - op: fused_attention
-  args : (Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask)
+  args : (Tensor query, Tensor key, Tensor value, Tensor sparse_mask, Tensor key_padding_mask, Tensor attn_mask, float scale_qk_coeff=1.0)
   output : Tensor(out), Tensor(softmax)
   infer_meta :
     func : sparse::FusedAttentionInferMeta
@@ -454,7 +454,6 @@
     layout : sparse_mask
     data_type: query
   optional : key_padding_mask, attn_mask
-  intermediate : softmax
   backward: fused_attention_grad
 
 - op: masked_matmul

--- a/paddle/phi/infermeta/sparse/multiary.cc
+++ b/paddle/phi/infermeta/sparse/multiary.cc
@@ -23,6 +23,7 @@ void FusedAttentionInferMeta(const MetaTensor& query,
                              const MetaTensor& sparse_mask,
                              const MetaTensor& key_padding_mask,
                              const MetaTensor& attn_mask,
+                             const float scale_qv_coeff,
                              MetaTensor* out,
                              MetaTensor* softmax) {
   // TODO(zhouwei,zhangkaihuo) add correct infer meta

--- a/paddle/phi/infermeta/sparse/multiary.cc
+++ b/paddle/phi/infermeta/sparse/multiary.cc
@@ -24,6 +24,7 @@ void FusedAttentionInferMeta(const MetaTensor& query,
                              const MetaTensor& key_padding_mask,
                              const MetaTensor& attn_mask,
                              const float scale_qv_coeff,
+                             const float dropout_rate,
                              MetaTensor* out,
                              MetaTensor* softmax) {
   // TODO(zhouwei,zhangkaihuo) add correct infer meta

--- a/paddle/phi/infermeta/sparse/multiary.h
+++ b/paddle/phi/infermeta/sparse/multiary.h
@@ -25,6 +25,7 @@ void FusedAttentionInferMeta(const MetaTensor& query,
                              const MetaTensor& sparse_mask,
                              const MetaTensor& key_padding_mask,
                              const MetaTensor& attn_mask,
+                             const float scale_qv_coeff,
                              MetaTensor* out,
                              MetaTensor* softmax);
 

--- a/paddle/phi/infermeta/sparse/multiary.h
+++ b/paddle/phi/infermeta/sparse/multiary.h
@@ -26,6 +26,7 @@ void FusedAttentionInferMeta(const MetaTensor& query,
                              const MetaTensor& key_padding_mask,
                              const MetaTensor& attn_mask,
                              const float scale_qv_coeff,
+                             const float dropout_rate,
                              MetaTensor* out,
                              MetaTensor* softmax);
 

--- a/paddle/phi/kernels/sparse/fused_attention_kernel.h
+++ b/paddle/phi/kernels/sparse/fused_attention_kernel.h
@@ -29,6 +29,7 @@ void FusedAttentionCsrKernel(
     const SparseCsrTensor& sparse_mask,
     const paddle::optional<DenseTensor>& key_padding_mask,
     const paddle::optional<DenseTensor>& attn_mask,
+    const float scale_qk_coeff,
     DenseTensor* out,
     SparseCsrTensor* softmax);
 

--- a/paddle/phi/kernels/sparse/fused_attention_kernel.h
+++ b/paddle/phi/kernels/sparse/fused_attention_kernel.h
@@ -30,6 +30,7 @@ void FusedAttentionCsrKernel(
     const paddle::optional<DenseTensor>& key_padding_mask,
     const paddle::optional<DenseTensor>& attn_mask,
     const float scale_qk_coeff,
+    const float dropout_rate,
     DenseTensor* out,
     SparseCsrTensor* softmax);
 

--- a/paddle/phi/kernels/sparse/gpu/fused_attention_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/fused_attention_kernel.cu
@@ -106,7 +106,7 @@ void FusedAttentionCsrKernel(
     const float scale_qk_coeff,
     DenseTensor* out,
     SparseCsrTensor* softmax) {
-#if CUDA_VERSION >= 11070
+#if CUDA_VERSION >= 11080
   /* Check Shape */
   auto q_dim = query.dims();
   auto q_rank = q_dim.size();
@@ -224,8 +224,6 @@ void FusedAttentionCsrKernel(
       scale_qk_coeff);
 
   softmax->set_dims(phi::make_ddim({q_dim[0], q_dim[1], q_dim[2], q_dim[2]}));
-
-  // dropout
 
   MatmulCsrDenseKernel<T, Context>(dev_ctx, *softmax, value, out);
 

--- a/paddle/phi/kernels/sparse/gpu/fused_attention_kernel.cu
+++ b/paddle/phi/kernels/sparse/gpu/fused_attention_kernel.cu
@@ -104,6 +104,7 @@ void FusedAttentionCsrKernel(
     const paddle::optional<DenseTensor>& key_padding_mask,
     const paddle::optional<DenseTensor>& attn_mask,
     const float scale_qk_coeff,
+    const float dropout_rate,
     DenseTensor* out,
     SparseCsrTensor* softmax) {
 #if CUDA_VERSION >= 11080
@@ -222,6 +223,11 @@ void FusedAttentionCsrKernel(
       q_dim[1],
       batch_nnz,
       scale_qk_coeff);
+
+  // dropout
+  if (dropout != 0.0) {
+    // call sparse DropoutKernel
+  }
 
   softmax->set_dims(phi::make_ddim({q_dim[0], q_dim[1], q_dim[2], q_dim[2]}));
 

--- a/python/paddle/sparse/nn/functional/transformer.py
+++ b/python/paddle/sparse/nn/functional/transformer.py
@@ -26,6 +26,7 @@ def attention(
     sparse_mask,
     key_padding_mask=None,
     attn_mask=None,
+    scale_qk_coeff=1.0,
     name=None,
 ):
     r"""
@@ -56,6 +57,7 @@ def attention(
             2D tensor with shape: [batch_size, seq_len]. dtype can be float32 or float64. Default: None.
         attn_mask(DenseTensor, optional): The attention mask tensor in the Attention module.
             2D tensor with shape: [seq_len, seq_len]. dtype can be float32 or float64. Default: None.
+        scale_qk_coeff(float, optional): scale the result of Q*K. Default:1.0.
         name(str, optional): The default value is None. Normally there is no need for user
                         to set this property. For more information, please refer to
                         :ref:`api_guide_Name`.
@@ -92,5 +94,11 @@ def attention(
             output.backward()
     """
     return _C_ops.sparse_fused_attention(
-        query, key, value, sparse_mask, key_padding_mask, attn_mask
+        query,
+        key,
+        value,
+        sparse_mask,
+        key_padding_mask,
+        attn_mask,
+        scale_qk_coeff,
     )

--- a/python/paddle/sparse/nn/functional/transformer.py
+++ b/python/paddle/sparse/nn/functional/transformer.py
@@ -27,6 +27,7 @@ def attention(
     key_padding_mask=None,
     attn_mask=None,
     scale_qk_coeff=1.0,
+    dropout_rate=0.0,
     name=None,
 ):
     r"""
@@ -58,6 +59,8 @@ def attention(
         attn_mask(DenseTensor, optional): The attention mask tensor in the Attention module.
             2D tensor with shape: [seq_len, seq_len]. dtype can be float32 or float64. Default: None.
         scale_qk_coeff(float, optional): scale the result of Q*K. Default:1.0.
+        dropout_rate(float, optional): The dropout probability used on attention
+            weights to drop some attention targets. 0 for no dropout. Default 0
         name(str, optional): The default value is None. Normally there is no need for user
                         to set this property. For more information, please refer to
                         :ref:`api_guide_Name`.
@@ -101,4 +104,5 @@ def attention(
         key_padding_mask,
         attn_mask,
         scale_qk_coeff,
+        dropout_rate,
     )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. [gpt模型实现中](https://github.com/PaddlePaddle/PaddleFleetX/blob/develop/ppfleetx/models/language_model/gpt/dygraph/single_model.py#L251) 可能考虑到精度问题，将scale操作分两步进行（计算公式和一次scale是等价的），这里为了保持一致，给sparse.nn.functional.attention添加一个scale_qk_coeff参数，kernel的计算也保持分两步进行。
2. 考虑到已有模型中对attn_mask的处理都是采用加上一个数(比如-1e4)，因此kernel中对attn_mask的处理也改成相同处理，并且支持[batch_size, seq_len]和[seq_len, seq_len]两种shape。已有模型实现：[gpt](https://github.com/PaddlePaddle/PaddleFleetX/blob/develop/ppfleetx/models/language_model/gpt/dygraph/single_model.py#L254), [bert](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/nn/layer/transformer.py#L429)
