### PR TITLE
[Unify CustomOp Headerfile] Inference headerfile includes paddle/extension.h

### DIFF
--- a/cmake/phi_header.cmake
+++ b/cmake/phi_header.cmake
@@ -51,3 +51,6 @@ phi_header_path_compat(
 file(RENAME
      ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/extension.h
      ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/ext_all.h)
+# Included header file of training and inference can be unified as single file: paddle/extension.h
+file(COPY ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/ext_all.h
+     DESTINATION ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/extension.h)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
Pcard-66988

随着 phi 的规范化程度不断提高，一些具有“experimental”的标识可以考虑移除。
用户在使用自定义算子做推理时，需要替换引入的头文件，本 PR 在保证兼容性的前提下，将 `paddle/extension.h` 头文件也拷贝到推理目录下，使得用户在推理场景下使用自定义算子时，不需要做源码改动。

As the standardization of phi continues to increase, some flags with "experimental" may be considered for removal.
Users must substitute the header file to `include/experimental/ext_all.h` when using the custom operators in the inference scenario. Under the premise of ensuring compatibility, this PR copies the `paddle/extension.h` header file into the inference directory so that users do not need to change the source file when they use custom operators under inference scenario.

- Ref document PR: https://github.com/PaddlePaddle/docs/pull/5736
