### PR TITLE
[XPU] fix xpu reduce_sum

### DIFF
--- a/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
@@ -19,27 +19,20 @@
 
 namespace phi {
 
-template <typename TX, typename TO, typename Context>
-void CastSumRawGradKernelImpl(const Context& dev_ctx,
-                              const DenseTensor& x,
-                              const DenseTensor& out_grad,
-                              const IntArray& dims_arr,
-                              bool keep_dim,
-                              bool reduce_all,
-                              DenseTensor* x_grad) {
-  dev_ctx.template Alloc<TX>(x_grad);
-  auto* x_grad_data = x_grad->data<TX>();
-
-  DenseTensor x_grad_tmp;
-  DenseTensorMeta x_grad_meta(
-      out_grad.dtype(), x_grad->dims(), x_grad->layout());
-  x_grad_tmp.set_meta(x_grad_meta);
-  TO* x_grad_tmp_data = dev_ctx.template Alloc<TO>(&x_grad_tmp);
-
+template <typename T, typename Context>
+void ReduceSumGradKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const DenseTensor& out_grad,
+                         const IntArray& dims_arr,
+                         bool keep_dim,
+                         bool reduce_all,
+                         DenseTensor* x_grad) {
+  using XPUType = typename XPUTypeTrait<T>::Type;
   reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
   auto dims = dims_arr.GetData();
-  const auto* out_data = out_grad.data<TO>();
-
+  dev_ctx.template Alloc<XPUType>(x_grad);
+  const auto* out_data = out_grad.data<XPUType>();
+  auto* x_grad_data = x_grad->data<XPUType>();
   const auto& input_dim_size = x.dims().size();
   std::vector<int> true_dims;
   for (size_t i = 0; i < dims.size(); ++i) {
@@ -70,75 +63,9 @@ void CastSumRawGradKernelImpl(const Context& dev_ctx,
     ydims = std::vector<int>({1});
   }
 
-  int r1 = xpu::broadcast<TO>(
-      dev_ctx.x_context(), out_data, x_grad_tmp_data, ydims, xdims);
-  PADDLE_ENFORCE_XDNN_SUCCESS(r1, "broadcast");
-
-  int r2 = xpu::cast<TO, TX>(
-      dev_ctx.x_context(), x_grad_tmp_data, x_grad_data, x_grad->numel());
-  PADDLE_ENFORCE_XDNN_SUCCESS(r2, "cast");
-}
-
-template <typename T, typename Context>
-void ReduceSumGradKernel(const Context& dev_ctx,
-                         const DenseTensor& x,
-                         const DenseTensor& out_grad,
-                         const IntArray& dims_arr,
-                         bool keep_dim,
-                         bool reduce_all,
-                         DenseTensor* x_grad) {
-  if (out_grad.dtype() != x.dtype() &&
-      out_grad.dtype() == phi::DataType::INT64) {
-    if (x.dtype() == phi::DataType::INT32 &&
-        out_grad.dtype() == phi::DataType::INT64) {
-      CastSumRawGradKernelImpl<int32_t, int64_t, Context>(
-          dev_ctx, x, out_grad, dims_arr, keep_dim, reduce_all, x_grad);
-    } else if (x.dtype() == phi::DataType::BOOL &&
-               out_grad.dtype() == phi::DataType::INT64) {
-      CastSumRawGradKernelImpl<bool, int64_t, Context>(
-          dev_ctx, x, out_grad, dims_arr, keep_dim, reduce_all, x_grad);
-    }
-  } else {
-    using XPUType = typename XPUTypeTrait<T>::Type;
-    reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
-    auto dims = dims_arr.GetData();
-    dev_ctx.template Alloc<XPUType>(x_grad);
-    const auto* out_data = out_grad.data<XPUType>();
-    auto* x_grad_data = x_grad->data<XPUType>();
-    const auto& input_dim_size = x.dims().size();
-    std::vector<int> true_dims;
-    for (size_t i = 0; i < dims.size(); ++i) {
-      if (dims[i] < 0) {
-        true_dims.push_back(dims[i] + input_dim_size);
-      } else {
-        true_dims.push_back(dims[i]);
-      }
-    }
-
-    std::vector<int> ydims(input_dim_size);
-    std::vector<int> xdims((input_dim_size));
-    std::set<int> dims_set(true_dims.begin(), true_dims.end());
-    for (auto i = 0; i < input_dim_size; i++) {
-      xdims[i] = x.dims()[i];
-      if (dims_set.find(i) != dims_set.end() || reduce_all) {
-        ydims[i] = 1;
-      } else {
-        ydims[i] = x.dims()[i];
-      }
-    }
-
-    // use [1] to replace [], because xpu not support []
-    if (xdims.size() == 0) {
-      xdims = std::vector<int>({1});
-    }
-    if (ydims.size() == 0) {
-      ydims = std::vector<int>({1});
-    }
-
-    int r = xpu::broadcast<XPUType>(
-        dev_ctx.x_context(), out_data, x_grad_data, ydims, xdims);
-    PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast");
-  }
+  int r = xpu::broadcast<XPUType>(
+      dev_ctx.x_context(), out_data, x_grad_data, ydims, xdims);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast");
 }
 
 }  // namespace phi

--- a/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/reduce_sum_grad_kernel.cc
@@ -19,20 +19,27 @@
 
 namespace phi {
 
-template <typename T, typename Context>
-void ReduceSumGradKernel(const Context& dev_ctx,
-                         const DenseTensor& x,
-                         const DenseTensor& out_grad,
-                         const IntArray& dims_arr,
-                         bool keep_dim,
-                         bool reduce_all,
-                         DenseTensor* x_grad) {
-  using XPUType = typename XPUTypeTrait<T>::Type;
+template <typename TX, typename TO, typename Context>
+void CastSumRawGradKernelImpl(const Context& dev_ctx,
+                              const DenseTensor& x,
+                              const DenseTensor& out_grad,
+                              const IntArray& dims_arr,
+                              bool keep_dim,
+                              bool reduce_all,
+                              DenseTensor* x_grad) {
+  dev_ctx.template Alloc<TX>(x_grad);
+  auto* x_grad_data = x_grad->data<TX>();
+
+  DenseTensor x_grad_tmp;
+  DenseTensorMeta x_grad_meta(
+      out_grad.dtype(), x_grad->dims(), x_grad->layout());
+  x_grad_tmp.set_meta(x_grad_meta);
+  TO* x_grad_tmp_data = dev_ctx.template Alloc<TO>(&x_grad_tmp);
+
   reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
   auto dims = dims_arr.GetData();
-  dev_ctx.template Alloc<XPUType>(x_grad);
-  const auto* out_data = out_grad.data<XPUType>();
-  auto* x_grad_data = x_grad->data<XPUType>();
+  const auto* out_data = out_grad.data<TO>();
+
   const auto& input_dim_size = x.dims().size();
   std::vector<int> true_dims;
   for (size_t i = 0; i < dims.size(); ++i) {
@@ -63,9 +70,75 @@ void ReduceSumGradKernel(const Context& dev_ctx,
     ydims = std::vector<int>({1});
   }
 
-  int r = xpu::broadcast<XPUType>(
-      dev_ctx.x_context(), out_data, x_grad_data, ydims, xdims);
-  PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast");
+  int r1 = xpu::broadcast<TO>(
+      dev_ctx.x_context(), out_data, x_grad_tmp_data, ydims, xdims);
+  PADDLE_ENFORCE_XDNN_SUCCESS(r1, "broadcast");
+
+  int r2 = xpu::cast<TO, TX>(
+      dev_ctx.x_context(), x_grad_tmp_data, x_grad_data, x_grad->numel());
+  PADDLE_ENFORCE_XDNN_SUCCESS(r2, "cast");
+}
+
+template <typename T, typename Context>
+void ReduceSumGradKernel(const Context& dev_ctx,
+                         const DenseTensor& x,
+                         const DenseTensor& out_grad,
+                         const IntArray& dims_arr,
+                         bool keep_dim,
+                         bool reduce_all,
+                         DenseTensor* x_grad) {
+  if (out_grad.dtype() != x.dtype() &&
+      out_grad.dtype() == phi::DataType::INT64) {
+    if (x.dtype() == phi::DataType::INT32 &&
+        out_grad.dtype() == phi::DataType::INT64) {
+      CastSumRawGradKernelImpl<int32_t, int64_t, Context>(
+          dev_ctx, x, out_grad, dims_arr, keep_dim, reduce_all, x_grad);
+    } else if (x.dtype() == phi::DataType::BOOL &&
+               out_grad.dtype() == phi::DataType::INT64) {
+      CastSumRawGradKernelImpl<bool, int64_t, Context>(
+          dev_ctx, x, out_grad, dims_arr, keep_dim, reduce_all, x_grad);
+    }
+  } else {
+    using XPUType = typename XPUTypeTrait<T>::Type;
+    reduce_all = recompute_reduce_all(x, dims_arr, reduce_all);
+    auto dims = dims_arr.GetData();
+    dev_ctx.template Alloc<XPUType>(x_grad);
+    const auto* out_data = out_grad.data<XPUType>();
+    auto* x_grad_data = x_grad->data<XPUType>();
+    const auto& input_dim_size = x.dims().size();
+    std::vector<int> true_dims;
+    for (size_t i = 0; i < dims.size(); ++i) {
+      if (dims[i] < 0) {
+        true_dims.push_back(dims[i] + input_dim_size);
+      } else {
+        true_dims.push_back(dims[i]);
+      }
+    }
+
+    std::vector<int> ydims(input_dim_size);
+    std::vector<int> xdims((input_dim_size));
+    std::set<int> dims_set(true_dims.begin(), true_dims.end());
+    for (auto i = 0; i < input_dim_size; i++) {
+      xdims[i] = x.dims()[i];
+      if (dims_set.find(i) != dims_set.end() || reduce_all) {
+        ydims[i] = 1;
+      } else {
+        ydims[i] = x.dims()[i];
+      }
+    }
+
+    // use [1] to replace [], because xpu not support []
+    if (xdims.size() == 0) {
+      xdims = std::vector<int>({1});
+    }
+    if (ydims.size() == 0) {
+      ydims = std::vector<int>({1});
+    }
+
+    int r = xpu::broadcast<XPUType>(
+        dev_ctx.x_context(), out_data, x_grad_data, ydims, xdims);
+    PADDLE_ENFORCE_XDNN_SUCCESS(r, "broadcast");
+  }
 }
 
 }  // namespace phi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
OPs

### Describe
修复reduce_sum算子：reduce_sum cpu当输入类型为int32/bool类型时，会将输入转换为int64类型；xpu reduce算子中缺失此转换。经确认，只有reduce_sum算子中output dtype被set为UNDEFINED。为解决VITDET模型的精度溢出问题，先暂时在reduce_sum kernel中插入类型转换修复此问题。


Linked to https://github.com/PaddlePaddle/Paddle/pull/50443, 更通用的解决方案，本PR先关闭