### PR TITLE
【Hackathon No.89】 Remove circle import Part4

### DIFF
--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -455,7 +455,8 @@ class PartialProgramLayer:
         """
         Return current train or eval program hash id.
         """
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
+        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
+        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
 
         if self.training:
             if _in_amp_guard():
@@ -474,7 +475,8 @@ class PartialProgramLayer:
 
     @property
     def train_program(self):
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
+        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
+        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
 
         if _in_amp_guard():
             return self._train_amp_program
@@ -485,7 +487,8 @@ class PartialProgramLayer:
 
     @property
     def infer_program(self):
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
+        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
+        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
 
         if _in_amp_guard():
             return self._infer_amp_program
@@ -496,7 +499,8 @@ class PartialProgramLayer:
 
     @property
     def forward_program(self):
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
+        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
+        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
 
         if self.training:
             if _in_amp_guard():
@@ -511,7 +515,8 @@ class PartialProgramLayer:
 
     @property
     def backward_program(self):
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
+        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
+        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
 
         if self.training:
             if _in_amp_guard():
@@ -708,7 +713,7 @@ class PartialProgramLayer:
         return self._valid_vars(double_grads)
 
     def _cast_fp16_if_pure_fp16(self, in_vars):
-        from paddle.amp.auto_cast import _in_pure_fp16_guard
+        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
 
         if _in_pure_fp16_guard():
             for i, var in enumerate(in_vars):

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -18,6 +18,7 @@ import numpy as np
 
 import paddle
 from paddle import _legacy_C_ops
+from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
 from paddle.fluid import backward, core, framework, program_guard
 from paddle.fluid.compiler import BuildStrategy
 from paddle.fluid.dygraph import layers
@@ -455,8 +456,7 @@ class PartialProgramLayer:
         """
         Return current train or eval program hash id.
         """
-        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
-        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
+        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
 
         if self.training:
             if _in_amp_guard():
@@ -475,9 +475,6 @@ class PartialProgramLayer:
 
     @property
     def train_program(self):
-        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
-        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
-
         if _in_amp_guard():
             return self._train_amp_program
         elif _in_pure_fp16_guard():
@@ -487,8 +484,7 @@ class PartialProgramLayer:
 
     @property
     def infer_program(self):
-        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
-        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
+        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
 
         if _in_amp_guard():
             return self._infer_amp_program
@@ -499,8 +495,7 @@ class PartialProgramLayer:
 
     @property
     def forward_program(self):
-        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
-        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
+        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
 
         if self.training:
             if _in_amp_guard():
@@ -515,8 +510,7 @@ class PartialProgramLayer:
 
     @property
     def backward_program(self):
-        _in_amp_guard = paddle.amp.auto_cast._in_amp_guard
-        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
+        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
 
         if self.training:
             if _in_amp_guard():
@@ -713,7 +707,7 @@ class PartialProgramLayer:
         return self._valid_vars(double_grads)
 
     def _cast_fp16_if_pure_fp16(self, in_vars):
-        _in_pure_fp16_guard = paddle.amp.auto_cast._in_pure_fp16_guard
+        from paddle.amp.auto_cast import _in_pure_fp16_guard
 
         if _in_pure_fp16_guard():
             for i, var in enumerate(in_vars):

--- a/python/paddle/jit/dy2static/partial_program.py
+++ b/python/paddle/jit/dy2static/partial_program.py
@@ -456,8 +456,6 @@ class PartialProgramLayer:
         """
         Return current train or eval program hash id.
         """
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
-
         if self.training:
             if _in_amp_guard():
                 return self._train_amp_program_id
@@ -484,8 +482,6 @@ class PartialProgramLayer:
 
     @property
     def infer_program(self):
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
-
         if _in_amp_guard():
             return self._infer_amp_program
         elif _in_pure_fp16_guard():
@@ -495,8 +491,6 @@ class PartialProgramLayer:
 
     @property
     def forward_program(self):
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
-
         if self.training:
             if _in_amp_guard():
                 progs = self._train_amp_forward_backward_program
@@ -510,8 +504,6 @@ class PartialProgramLayer:
 
     @property
     def backward_program(self):
-        from paddle.amp.auto_cast import _in_amp_guard, _in_pure_fp16_guard
-
         if self.training:
             if _in_amp_guard():
                 progs = self._train_amp_forward_backward_program
@@ -707,8 +699,6 @@ class PartialProgramLayer:
         return self._valid_vars(double_grads)
 
     def _cast_fp16_if_pure_fp16(self, in_vars):
-        from paddle.amp.auto_cast import _in_pure_fp16_guard
-
         if _in_pure_fp16_guard():
             for i, var in enumerate(in_vars):
                 name = var.name


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
- https://github.com/PaddlePaddle/Paddle/issues/50663#task89

### Details
- https://github.com/PaddlePaddle/Paddle/discussions/50711
- https://github.com/PaddlePaddle/community/pull/409
- https://github.com/PaddlePaddle/Paddle/pull/51433

在以往的PR中，jit内部的circle import已经被解决，从这个pr开始，将尝试通过各种方式解决jit和其他文件夹间的循环引用。

本pr解决partial_program.py的循环引用问题。