### PR TITLE
[Paddle-Inference]use cutlass teller

### DIFF
--- a/paddle/fluid/framework/ir/conv2d_fusion_layout_transfer_pass.cc
+++ b/paddle/fluid/framework/ir/conv2d_fusion_layout_transfer_pass.cc
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "paddle/fluid/framework/ir/conv2d_fusion_layout_transfer_pass.h"
-
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include "paddle/fluid/framework/ir/cutlass_teller.h"
 
 #include "paddle/fluid/framework/data_layout_transform.h"
 #include "paddle/fluid/framework/ir/graph_helper.h"
@@ -112,17 +112,6 @@ void Conv2dFusionLayoutTransferPass::ApplyImpl(ir::Graph *graph) const {
           phi::DataType::FLOAT16 ||
       Get<bool>("enable_gpu_mixed");
   bool cutlass_enable = Get<bool>("use_cutlass");
-
-#ifdef PADDLE_WITH_CUTLASS
-  const auto &prop = platform::GetDeviceProperties(Get<int>("gpu_device_id"));
-  int sm_version = prop.major * 10 + prop.minor;
-  // Now we only implement cutlass kernel on SM75.
-  if (sm_version == 75) {
-  } else {
-    cutlass_enable = false;
-  }
-#endif
-
   if (!is_fp16_precision) return;
 
   PADDLE_ENFORCE_EQ(graph->IsMainGraph(),
@@ -152,14 +141,17 @@ void Conv2dFusionLayoutTransferPass::ApplyImpl(ir::Graph *graph) const {
   std::string target_op_type = "conv2d_fusion";
   std::unordered_set<ir::Node *> valid_ops;
 
+  // 确定这个conv2d_fuison 能否以cuDNN 的NHWC方式运行
+  // 不会设置或更改任何东西
   auto cuDNNIsValid = [&](ir::Node *op_node) -> bool {
     if (op_node->Op()->Type() != target_op_type) return false;
     auto data_format =
         op_node->Op()->GetAttrIfExists<std::string>("data_format");
     if (data_format != "NCHW") return false;
     auto filter_names = op_node->Op()->Input("Filter");
-    constexpr int NHWC_ALIGNMENT = 8;
-    // If filter's channel is not multiple of 8, conv2d_fusion not run at nhwc.
+    constexpr int CUDNN_ALIGNMENT = 8;
+    // If filter's channel is not multiple of CUDNN_ALIGNMENT, conv2d_fusion not
+    // run at nhwc.
     for (const auto &filter_name : filter_names) {
       if (weights_shape_nhwc.count(filter_name)) {
         continue;
@@ -168,10 +160,11 @@ void Conv2dFusionLayoutTransferPass::ApplyImpl(ir::Graph *graph) const {
       const auto &filter_tensor = filter_var->Get<phi::DenseTensor>();
       CHECK_EQ(filter_tensor.dims().size() == 4UL, true);
       int oc = filter_tensor.dims()[0];
-      int ic = filter_tensor.dims()[1];
-      bool cutlass_can_support =
-          oc % NHWC_ALIGNMENT == 0 && ic % NHWC_ALIGNMENT == 0;
-      if (!cutlass_can_support) {
+      auto groups = op_node->Op()->GetAttrIfExists<int>("groups");
+      int ic = filter_tensor.dims()[1] * groups;
+      bool cudnn_can_support =
+          oc % CUDNN_ALIGNMENT == 0 && ic % CUDNN_ALIGNMENT == 0;
+      if (!cudnn_can_support) {
         return false;
       }
     }
@@ -179,35 +172,32 @@ void Conv2dFusionLayoutTransferPass::ApplyImpl(ir::Graph *graph) const {
   };
 
   auto CutlassIsValid = [&](ir::Node *op_node) -> bool {
-    auto act_type = op_node->Op()->GetAttrIfExists<std::string>("activation");
-    // conv2d_fusion has two forms: conv + bias + act, conv + bias +
-    // elmentwise_add + act.
-    std::unordered_set<std::string> cutlass_cba_act_set = {
-        "relu", "swish", "identity", "leaky_relu"};
-    std::unordered_set<std::string> cutlass_cbaa_act_set = {"relu"};
-    bool is_residual = op_node->Op()->Input("ResidualData").size() >= 1UL;
-
-    if (is_residual) {
-      if (!cutlass_cbaa_act_set.count(act_type)) {
-        return false;
-      }
-    } else {
-      if (!cutlass_cba_act_set.count(act_type)) {
-        return false;
-      }
-    }
-    return true;
+    return CutlassTeller::Instance()->Conv2dFusionCanSupport(
+               op_node, scope, Get<int>("gpu_device_id")) &&
+           cutlass_enable;
   };
 
   for (auto *op_node : op_nodes) {
     CHECK_EQ(op_node->IsOp(), true);
-    if (cuDNNIsValid(op_node)) {
+    if (cuDNNIsValid(op_node) || CutlassIsValid(op_node)) {
       valid_ops.insert(op_node);
       auto *op_desc = op_node->Op();
-      op_desc->SetAttr("data_format", std::string{"NHWC"});
-      if (cutlass_enable && CutlassIsValid(op_node)) {
+      // const auto &filter_tensor =
+      // scope->FindLocalVar(op_desc->Input("Filter")[0])->Get<phi::DenseTensor>();
+      // int kh = filter_tensor.dims()[2];
+
+      // auto groups = op_desc->GetAttrIfExists<int>("groups");
+      // auto strides = op_desc->GetAttrIfExists<std::vector<int>>("strides");
+      // (groups <= 1 || kh == 3)
+
+      if (CutlassIsValid(op_node)) {
         op_desc->SetType("conv2d_fusion_cutlass");
+        // conv2d_fusion_cutlass must have this attribute because of signature.
+        if (!op_desc->HasAttr("fuse_alpha")) {
+          op_desc->SetAttr("fuse_alpha", 0.f);
+        }
       }
+      op_desc->SetAttr("data_format", std::string{"NHWC"});
       op_desc->Flush();
 
       // transfer weights

--- a/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/framework/ir/conv_elementwise_add_act_fuse_pass.h"
-
+#include "paddle/fluid/framework/ir/cutlass_teller.h"
 #include "paddle/fluid/framework/op_version_registry.h"
 
 namespace paddle {
@@ -159,29 +159,17 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
   std::unordered_set<std::string> cudnn_act_set({"identity", "relu"});
 #endif
 
-  std::unordered_set<std::string> cutlass_act_set;
+  std::unordered_set<std::string> cutlass_act_set =
+      CutlassTeller::Instance()->CbaAct(Get<int>("gpu_device_id"));
   std::unordered_set<std::string> all_act_set = cudnn_act_set;
 
   bool is_fp16_precision =
       static_cast<phi::DataType>(Get<int>("model_precision")) ==
           phi::DataType::FLOAT16 ||
       Get<bool>("enable_gpu_mixed");
-  constexpr int CUTLASS_NHWC_ALIGNMENT = 8;
   bool cutlass_enable = Get<bool>("use_cutlass");
   if (is_fp16_precision && cutlass_enable) {
-#ifdef PADDLE_WITH_CUTLASS
-    const auto& prop = platform::GetDeviceProperties(Get<int>("gpu_device_id"));
-    int sm_version = prop.major * 10 + prop.minor;
-    // Now we only implement cutlass kernel on SM75.
-    if (sm_version == 75) {
-      // Cutlass now support these cba activations.
-      cutlass_act_set.insert("swish");
-      cutlass_act_set.insert("relu");
-      cutlass_act_set.insert("identity");
-      cutlass_act_set.insert("leaky_relu");
-    }
     all_act_set.insert(cutlass_act_set.begin(), cutlass_act_set.end());
-#endif
   }
 
   patterns::ConvElementwiseaddAct pattern(gpd.mutable_pattern(), pattern_name);
@@ -203,14 +191,17 @@ void ConvElementwiseAddActFusePass::ApplyImpl(ir::Graph* graph) const {
     auto* filter_var = scope->FindLocalVar(conv_filter->Name());
     auto* filter_tensor = filter_var->GetMutable<phi::DenseTensor>();
     CHECK_EQ(filter_tensor->dims().size() == 4UL, true);
+    auto groups = conv_op->Op()->GetAttrIfExists<int>("groups");
+    int oc = filter_tensor->dims()[0];
+    int kc = filter_tensor->dims()[1];
+    int kh = filter_tensor->dims()[2];
+    int kw = filter_tensor->dims()[3];
+
+    bool cutlass_can_fuse = CutlassTeller::Instance()->Conv2dCanSupport(
+        oc, kc, kh, kw, groups, act_op_type, Get<int>("gpu_device_id"));
+    bool cudnn_can_fuse = cudnn_act_set.count(act_op_type);
     // When this conv2d_fusion problem size is not supported by cutlass and not
     // supported by cuDNN, we should not apply this pass.
-    int oc = filter_tensor->dims()[0];
-    int ic = filter_tensor->dims()[1];
-    bool cutlass_can_fuse = oc % CUTLASS_NHWC_ALIGNMENT == 0 &&
-                            ic % CUTLASS_NHWC_ALIGNMENT == 0 &&
-                            cutlass_act_set.count(act_op_type);
-    bool cudnn_can_fuse = cudnn_act_set.count(act_op_type);
     if (!cutlass_can_fuse && !cudnn_can_fuse) {
       return;
     }

--- a/paddle/fluid/framework/ir/cutlass_teller.h
+++ b/paddle/fluid/framework/ir/cutlass_teller.h
@@ -26,7 +26,7 @@ class CutlassTeller {
     return &global;
   }
 
-  // 判断这个NCHW conv2d_fusion是否可以转成NHWC 让 cutlass 来处理！
+  // Determine this NCHW conv2d_fusion can be fused for cutlass?
   bool Conv2dFusionCanSupport(ir::Node *conv2d_fusion_node,
                               Scope *scope,
                               int device_id) {
@@ -56,7 +56,8 @@ class CutlassTeller {
     return true;
   }
 
-  // 判断这个conv+bias能否和act融合，然后让cutlass来处理！
+  // Determine whether this conv can be fused with the activation by cutlass
+  // backend.
   bool Conv2dCanSupport(int oc,
                         int kc,
                         int kh,
@@ -112,15 +113,12 @@ class CutlassTeller {
   };
   const std::unordered_set<std::string> cba_act_set = {
       "relu", "swish", "identity", "leaky_relu", "sigmoid"};
+
+  // conv2d_depthwise act
   const std::unordered_set<std::string> cdba_act_set = {
       "identity", "relu", "swish", "sigmoid"};
   const std::unordered_set<std::string> cbaa_act_set = {"relu"};
 };
-
-// const std::unordered_set<std::string> CutlassTeller::cutlass_cba_act_set =
-// {"relu", "swish", "identity", "leaky_relu"}; const
-// std::unordered_set<std::string> CutlassTeller::cutlass_cbaa_act_set =
-// {"relu"};
 
 }  // namespace ir
 }  // namespace framework

--- a/paddle/fluid/framework/ir/cutlass_teller.h
+++ b/paddle/fluid/framework/ir/cutlass_teller.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <unordered_set>
+#include "paddle/fluid/platform/device/gpu/gpu_info.h"
+namespace paddle {
+namespace framework {
+namespace ir {
+
+class CutlassTeller {
+ public:
+  static CutlassTeller *Instance() {
+    static CutlassTeller global;
+    return &global;
+  }
+
+  // 判断这个NCHW conv2d_fusion是否可以转成NHWC 让 cutlass 来处理！
+  bool Conv2dFusionCanSupport(ir::Node *conv2d_fusion_node,
+                              Scope *scope,
+                              int device_id) {
+    auto op_desc = conv2d_fusion_node->Op();
+    if (op_desc->Type() != "conv2d_fusion") return false;
+    auto data_format = op_desc->GetAttrIfExists<std::string>("data_format");
+    if (data_format != "NCHW") return false;
+
+    auto filter_names = op_desc->Input("Filter");
+
+    for (const auto &filter_name : filter_names) {
+      auto *filter_var = scope->FindLocalVar(filter_name);
+      const auto &filter_tensor = filter_var->Get<phi::DenseTensor>();
+      CHECK_EQ(filter_tensor.dims().size() == 4UL, true);
+      auto groups = op_desc->GetAttrIfExists<int>("groups");
+      int oc = filter_tensor.dims()[0];
+      int kc = filter_tensor.dims()[1];
+      int kh = filter_tensor.dims()[2];
+      int kw = filter_tensor.dims()[3];
+      auto act_type = op_desc->GetAttrIfExists<std::string>("activation");
+      bool has_residual = op_desc->Input("ResidualData").size() >= 1UL;
+      if (!Conv2dCanSupport(
+              oc, kc, kh, kw, groups, act_type, device_id, has_residual)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // 判断这个conv+bias能否和act融合，然后让cutlass来处理！
+  bool Conv2dCanSupport(int oc,
+                        int kc,
+                        int kh,
+                        int kw,
+                        int groups,
+                        std::string activation,
+                        int device_id,
+                        bool has_residual = false) {
+    int sm_version = platform::GetGPUComputeCapability(device_id);
+    int ic = kc * groups;
+    if (!cutlass_sm.count(sm_version)) {
+      return false;
+    }
+    if (oc % CUTLASS_NHWC_ALIGNMENT != 0) {
+      return false;
+    }
+
+    if (ic % CUTLASS_NHWC_ALIGNMENT != 0) {
+      return false;
+    }
+
+    if (groups == 1) {
+      if (!has_residual && !cba_act_set.count(activation)) {
+        return false;
+      }
+      if (has_residual && !cbaa_act_set.count(activation)) {
+        return false;
+      }
+    } else if (groups == ic && ic == oc) {
+      if (has_residual) {
+        return false;
+      }
+      // conv2d_depthwise
+      if (!cdba_act_set.count(activation)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  std::unordered_set<std::string> CbaAct(int device_id) {
+    int sm_version = platform::GetGPUComputeCapability(device_id);
+    if (cutlass_sm.count(sm_version)) {
+      return cba_act_set;
+    } else {
+      return {};
+    }
+  }
+
+  static const int CUTLASS_NHWC_ALIGNMENT = 8;
+  const std::unordered_set<int> cutlass_sm = {
+      75,
+  };
+  const std::unordered_set<std::string> cba_act_set = {
+      "relu", "swish", "identity", "leaky_relu", "sigmoid"};
+  const std::unordered_set<std::string> cdba_act_set = {
+      "identity", "relu", "swish", "sigmoid"};
+  const std::unordered_set<std::string> cbaa_act_set = {"relu"};
+};
+
+// const std::unordered_set<std::string> CutlassTeller::cutlass_cba_act_set =
+// {"relu", "swish", "identity", "leaky_relu"}; const
+// std::unordered_set<std::string> CutlassTeller::cutlass_cbaa_act_set =
+// {"relu"};
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/ir/cutlass_teller.h
+++ b/paddle/fluid/framework/ir/cutlass_teller.h
@@ -26,7 +26,7 @@ class CutlassTeller {
     return &global;
   }
 
-  // Determine this NCHW conv2d_fusion can be fused for cutlass?
+  // Determine this NCHW conv2d_fusion can be computed by cutlass?
   bool Conv2dFusionCanSupport(ir::Node *conv2d_fusion_node,
                               Scope *scope,
                               int device_id) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 以前判断CUTLASS能否支持某个conv的逻辑是分散在每个Pass里的
  - 例如 conv bias act的融合是在 pass conv_elementwise_add_act_fuse_pass 中加了一堆逻辑判断其是否支持CUTLASS
  - conv2d_fusion_layout_transfer_pass 中也有一部分逻辑判断conv2d_fusion其是否支持CUTLASS
  - 以后还会需要在更多的pass中判断其conv/gemm是否支持CUTLASS
- 现在把这部分逻辑都放到 cutlass_teller.h 中了。