### PR TITLE
[OPT]Set order for hybridparallel setting

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -55,7 +55,7 @@ message HybridConfig {
   optional int32 mp_degree = 2 [ default = 1 ];
   optional int32 pp_degree = 3 [ default = 1 ];
   optional int32 sharding_degree = 4 [ default = 1 ];
-  optional string order = 5 [ default = 'dp->pp->sharding->mp' ];
+  optional string order = 5 [ default = 'dp,pp,sharding,mp' ];
 }
 
 message AMPConfig {

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -55,6 +55,7 @@ message HybridConfig {
   optional int32 mp_degree = 2 [ default = 1 ];
   optional int32 pp_degree = 3 [ default = 1 ];
   optional int32 sharding_degree = 4 [ default = 1 ];
+  optional string order = 5 [ default = 'dp->pp->sharding->mp' ];
 }
 
 message AMPConfig {

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -55,7 +55,7 @@ message HybridConfig {
   optional int32 mp_degree = 2 [ default = 1 ];
   optional int32 pp_degree = 3 [ default = 1 ];
   optional int32 sharding_degree = 4 [ default = 1 ];
-  optional string order = 5 [ default = 'dp,pp,sharding,mp' ];
+  repeated string order = 5 ;
 }
 
 message AMPConfig {

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -1684,7 +1684,7 @@ class DistributedStrategy:
                     "dp_degree": 1,
                     "mp_degree": 2,
                     "pp_degree": 1,
-                    "order":"dp->pp->sharding->mp"}
+                    "order":"dp,pp,sharding,mp"}
 
         """
         return get_msg_dict(self.strategy.hybrid_configs)

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -1673,7 +1673,7 @@ class DistributedStrategy:
 
             **pp_degree(int)**: set number of GPUs in a pipeline parallel group. Default 1
 
-            **order(string)**: set hybrid parallel dimensions, the order is from outside to inside. Default dp,pp,sharding,mp
+            **order(list(string))**: set hybrid parallel dimensions, the order is from outside to inside. Default ['dp','pp','sharding','mp']
 
         Examples:
             .. code-block:: python
@@ -1684,7 +1684,7 @@ class DistributedStrategy:
                     "dp_degree": 1,
                     "mp_degree": 2,
                     "pp_degree": 1,
-                    "order":"dp,pp,sharding,mp"}
+                    "order":['dp','pp','sharding','mp']}
 
         """
         return get_msg_dict(self.strategy.hybrid_configs)

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -1673,6 +1673,8 @@ class DistributedStrategy:
 
             **pp_degree(int)**: set number of GPUs in a pipeline parallel group. Default 1
 
+            **order(string)**: set hybrid parallel dimensions, the order is from outside to inside. Default dp->pp->sharding->mp
+
         Examples:
             .. code-block:: python
 
@@ -1681,7 +1683,8 @@ class DistributedStrategy:
                 strategy.hybrid_configs = {
                     "dp_degree": 1,
                     "mp_degree": 2,
-                    "pp_degree": 1}
+                    "pp_degree": 1,
+                    "order":"dp->pp->sharding->mp"}
 
         """
         return get_msg_dict(self.strategy.hybrid_configs)

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -1673,7 +1673,7 @@ class DistributedStrategy:
 
             **pp_degree(int)**: set number of GPUs in a pipeline parallel group. Default 1
 
-            **order(string)**: set hybrid parallel dimensions, the order is from outside to inside. Default dp->pp->sharding->mp
+            **order(string)**: set hybrid parallel dimensions, the order is from outside to inside. Default dp,pp,sharding,mp
 
         Examples:
             .. code-block:: python

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -412,9 +412,9 @@ class Fleet:
             "mp": ['model', self.mp_degree],
         }
 
-        order = self.hybrid_configs["order"].split(',')
+        order = self.hybrid_configs["order"]
         assert (
-            order[:].sort() == d_hybrid_degree.keys()[:].sort()
+            order[:].sort() == list(d_hybrid_degree.keys())[:].sort()
         ), "The order setting is incorrect"
 
         hybrid_group_names = []

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -405,14 +405,27 @@ class Fleet:
 
         self.dp_degree = max(self.dp_degree, 1)
 
+        d_hybrid_degree = {
+            "dp": ["data", self.dp_degree],
+            "pp": ['pipe', self.pp_degree],
+            "sharding": ['sharding', self.sharding_degree],
+            "mp": ['model', self.mp_degree],
+        }
+
+        order = self.hybrid_configs["order"]
+        assert (
+            order[:].sort() == d_hybrid_degree.keys()[:].sort()
+        ), "The order setting is incorrect"
+
+        hybrid_group_names = []
+        dims = []
+        for h_name in order:
+            name, degree = d_hybrid_degree[h_name]
+            hybrid_group_names.append(name)
+            dims.append(degree)
+
         self._topology = tp.CommunicateTopology(
-            hybrid_group_names=["data", "pipe", "sharding", "model"],
-            dims=[
-                self.dp_degree,
-                self.pp_degree,
-                self.sharding_degree,
-                self.mp_degree,
-            ],
+            hybrid_group_names=hybrid_group_names, dims=dims
         )
 
         self._hcg = tp.HybridCommunicateGroup(self._topology)

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -412,7 +412,7 @@ class Fleet:
             "mp": ['model', self.mp_degree],
         }
 
-        order = self.hybrid_configs["order"]
+        order = self.hybrid_configs["order"].split('->')
         assert (
             order[:].sort() == d_hybrid_degree.keys()[:].sort()
         ), "The order setting is incorrect"

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -413,9 +413,10 @@ class Fleet:
         }
 
         order = self.hybrid_configs["order"]
-        assert (
-            order[:].sort() == list(d_hybrid_degree.keys())[:].sort()
-        ), "The order setting is incorrect"
+        if not order:
+            order = ['dp', 'pp', 'sharding', 'mp']
+        if order[:].sort() != list(d_hybrid_degree.keys())[:].sort():
+            assert False, "The order of hybrid_config setting is incorrect."
 
         hybrid_group_names = []
         dims = []

--- a/python/paddle/distributed/fleet/fleet.py
+++ b/python/paddle/distributed/fleet/fleet.py
@@ -412,7 +412,7 @@ class Fleet:
             "mp": ['model', self.mp_degree],
         }
 
-        order = self.hybrid_configs["order"].split('->')
+        order = self.hybrid_configs["order"].split(',')
         assert (
             order[:].sort() == d_hybrid_degree.keys()[:].sort()
         ), "The order setting is incorrect"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[HybridParallel]Set order for hybridparallel setting.


```python
strategy = fleet.DistributedStrategy()
strategy.hybrid_configs = {
                        "dp_degree": 2
                        "mp_degree": 2,
                        "pp_degree": 2
                        "sharding_degree": 1,
                        "order": "pp,dp,sharding,mp"
}

```