### PR TITLE
fix TraceEventCollector namespace

### DIFF
--- a/paddle/phi/backends/device_base.h
+++ b/paddle/phi/backends/device_base.h
@@ -19,15 +19,9 @@
 #include "paddle/phi/backends/event.h"
 #include "paddle/phi/backends/stream.h"
 
-#include "paddle/phi/api/profiler/trace_event_collector.h"
-
-namespace paddle {
-namespace platform {
-class TraceEventCollector;
-}  // namespace platform
-}  // namespace paddle
-
 namespace phi {
+
+class TraceEventCollector;
 
 class DeviceInterface {  // Driver / Runtime
  public:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes 

### PR changes
Others

### Describe
fix TraceEventCollector namespace to avoid PaddleCustomDevice compile error