### PR TITLE
[Paddle Inference] support double data type

### DIFF
--- a/paddle/fluid/inference/api/paddle_infer_contrib.cc
+++ b/paddle/fluid/inference/api/paddle_infer_contrib.cc
@@ -71,6 +71,12 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
                           cb,
                           cb_params);
         break;
+      case PaddleDType::FLOAT64:
+        src.CopyToCpuImpl(dst.mutable_data<double>(PlaceType::kCPU),
+                          exec_stream,
+                          cb,
+                          cb_params);
+        break;
       case PaddleDType::FLOAT32:
         src.CopyToCpuImpl(dst.mutable_data<float>(PlaceType::kCPU),
                           exec_stream,
@@ -104,8 +110,8 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
         break;
       default:
         PADDLE_THROW(paddle::platform::errors::Unimplemented(
-            "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16 and "
-            "FLOAT32 is supported in Tensor. Others not implements"));
+            "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16, FLOAT32 and "
+            "FLOAT64 is supported in Tensor. Others not implements"));
     }
     // gpu => gpu or cpu => gpu
   } else {
@@ -129,6 +135,12 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
         src_data =
             static_cast<void*>(src.data<int64_t>(&src_place, &data_size));
         data_len = data_size * sizeof(int64_t);
+        break;
+      case PaddleDType::FLOAT64:
+        dst_data =
+            static_cast<void*>(dst.mutable_data<double>(PlaceType::kGPU));
+        src_data = static_cast<void*>(src.data<double>(&src_place, &data_size));
+        data_len = data_size * sizeof(double);
         break;
       case PaddleDType::FLOAT32:
         dst_data = static_cast<void*>(dst.mutable_data<float>(PlaceType::kGPU));
@@ -162,8 +174,8 @@ void TensorUtils::CopyTensorImpl(Tensor* p_dst,
         break;
       default:
         PADDLE_THROW(paddle::platform::errors::Unimplemented(
-            "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16 and "
-            "FLOAT32 is supported in Tensor. Others not implements"));
+            "Only INT32, INT64, UINT8, INT8, BOOL, FLOAT16, FLOAT32 and "
+            "FLOAT64 is supported in Tensor. Others not implements"));
     }
 
     paddle::platform::DeviceContextPool& pool =

--- a/paddle/fluid/inference/api/paddle_tensor.h
+++ b/paddle/fluid/inference/api/paddle_tensor.h
@@ -56,6 +56,7 @@ enum DataType {
   INT32,
   UINT8,
   INT8,
+  FLOAT64,
   FLOAT32,
   FLOAT16,
   BOOL,

--- a/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
+++ b/paddle/fluid/inference/tests/api/paddle_infer_api_copy_tensor_tester.cc
@@ -205,6 +205,13 @@ static void test_copy_tensor(PlaceType src_place, PlaceType dst_place) {
   }
 }
 
+TEST(CopyTensor, float64) {
+  test_copy_tensor<double>(PlaceType::kCPU, PlaceType::kCPU);
+  test_copy_tensor<double>(PlaceType::kCPU, PlaceType::kGPU);
+  test_copy_tensor<double>(PlaceType::kGPU, PlaceType::kCPU);
+  test_copy_tensor<double>(PlaceType::kGPU, PlaceType::kGPU);
+}
+
 TEST(CopyTensor, float32) {
   test_copy_tensor<float>(PlaceType::kCPU, PlaceType::kCPU);
   test_copy_tensor<float>(PlaceType::kCPU, PlaceType::kGPU);

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -175,6 +175,9 @@ py::dtype PaddleDTypeToNumpyDType(PaddleDType dtype) {
     case PaddleDType::INT64:
       dt = py::dtype::of<int64_t>();
       break;
+    case PaddleDType::FLOAT64:
+      dt = py::dtype::of<double>();
+      break;
     case PaddleDType::FLOAT32:
       dt = py::dtype::of<float>();
       break;
@@ -192,8 +195,8 @@ py::dtype PaddleDTypeToNumpyDType(PaddleDType dtype) {
       break;
     default:
       PADDLE_THROW(platform::errors::Unimplemented(
-          "Unsupported data type. Now only supports INT32, INT64, FLOAT32, "
-          "FLOAT16, INT8, UINT8 and BOOL."));
+          "Unsupported data type. Now only supports INT32, INT64, FLOAT64, "
+          "FLOAT32, FLOAT16, INT8, UINT8 and BOOL."));
   }
 
   return dt;
@@ -252,7 +255,12 @@ void PaddleInferShareExternalData(paddle_infer::Tensor &tensor,  // NOLINT
   for (int i = 0; i < input_tensor.dims().size(); ++i) {
     shape.push_back(input_tensor.dims()[i]);
   }
-  if (input_tensor.dtype() == phi::DataType::FLOAT32) {
+  if (input_tensor.dtype() == phi::DataType::FLOAT64) {
+    tensor.ShareExternalData(
+        static_cast<double *>(input_tensor.data()),
+        shape,
+        ToPaddleInferPlace(input_tensor.place().GetType()));
+  } else if (input_tensor.dtype() == phi::DataType::FLOAT32) {
     tensor.ShareExternalData(
         static_cast<float *>(input_tensor.data()),
         shape,
@@ -275,7 +283,7 @@ void PaddleInferShareExternalData(paddle_infer::Tensor &tensor,  // NOLINT
   } else {
     PADDLE_THROW(platform::errors::Unimplemented(
         "Unsupported data type. Now share_external_data only supports INT32, "
-        "INT64, FLOAT32 and FLOAT16."));
+        "INT64, FLOAT64, FLOAT32 and FLOAT16."));
   }
 }
 
@@ -285,7 +293,13 @@ void PaddleTensorShareExternalData(paddle_infer::Tensor &tensor,  // NOLINT
   for (int i = 0; i < paddle_tensor.dims().size(); ++i) {
     shape.push_back(paddle_tensor.dims()[i]);
   }
-  if (paddle_tensor.dtype() == phi::DataType::FLOAT32) {
+
+  if (paddle_tensor.dtype() == phi::DataType::FLOAT64) {
+    tensor.ShareExternalData(
+        static_cast<double *>(paddle_tensor.data<double>()),
+        shape,
+        ToPaddleInferPlace(paddle_tensor.place().GetType()));
+  } else if (paddle_tensor.dtype() == phi::DataType::FLOAT32) {
     tensor.ShareExternalData(
         static_cast<float *>(paddle_tensor.data<float>()),
         shape,
@@ -335,6 +349,9 @@ size_t PaddleGetDTypeSize(PaddleDType dt) {
     case PaddleDType::INT64:
       size = sizeof(int64_t);
       break;
+    case PaddleDType::FLOAT64:
+      size = sizeof(double);
+      break;
     case PaddleDType::FLOAT32:
       size = sizeof(float);
       break;
@@ -352,8 +369,8 @@ size_t PaddleGetDTypeSize(PaddleDType dt) {
       break;
     default:
       PADDLE_THROW(platform::errors::Unimplemented(
-          "Unsupported data t ype. Now only supports INT32, INT64, FLOAT32, "
-          "FLOAT16, INT8, UINT8 and BOOL."));
+          "Unsupported data t ype. Now only supports INT32, INT64, FLOAT64, "
+          "FLOAT32, FLOAT16, INT8, UINT8 and BOOL."));
   }
   return size;
 }
@@ -370,6 +387,9 @@ py::array ZeroCopyTensorToNumpy(ZeroCopyTensor &tensor) {  // NOLINT
       break;
     case PaddleDType::INT64:
       tensor.copy_to_cpu(static_cast<int64_t *>(array.mutable_data()));
+      break;
+    case PaddleDType::FLOAT64:
+      tensor.copy_to_cpu<double>(static_cast<double *>(array.mutable_data()));
       break;
     case PaddleDType::FLOAT32:
       tensor.copy_to_cpu<float>(static_cast<float *>(array.mutable_data()));
@@ -389,8 +409,8 @@ py::array ZeroCopyTensorToNumpy(ZeroCopyTensor &tensor) {  // NOLINT
       break;
     default:
       PADDLE_THROW(platform::errors::Unimplemented(
-          "Unsupported data type. Now only supports INT32, INT64, FLOAT32, "
-          "FLOAT16, INT8, UINT8 and BOOL."));
+          "Unsupported data type. Now only supports INT32, INT64, FLOAT64, "
+          "FLOAT32, FLOAT16, INT8, UINT8 and BOOL."));
   }
   return array;
 }
@@ -407,6 +427,9 @@ py::array PaddleInferTensorToNumpy(paddle_infer::Tensor &tensor) {  // NOLINT
       break;
     case PaddleDType::INT64:
       tensor.CopyToCpu(static_cast<int64_t *>(array.mutable_data()));
+      break;
+    case PaddleDType::FLOAT64:
+      tensor.CopyToCpu<double>(static_cast<double *>(array.mutable_data()));
       break;
     case PaddleDType::FLOAT32:
       tensor.CopyToCpu<float>(static_cast<float *>(array.mutable_data()));
@@ -426,8 +449,8 @@ py::array PaddleInferTensorToNumpy(paddle_infer::Tensor &tensor) {  // NOLINT
       break;
     default:
       PADDLE_THROW(platform::errors::Unimplemented(
-          "Unsupported data t ype. Now only supports INT32, INT64, FLOAT32, "
-          "FLOAT16, INT8, UINT8 and BOOL."));
+          "Unsupported data t ype. Now only supports INT32, INT64, FLOAT64, "
+          "FLOAT32, FLOAT16, INT8, UINT8 and BOOL."));
   }
   return array;
 }
@@ -506,6 +529,7 @@ void BindInferenceApi(py::module *m) {
 namespace {
 void BindPaddleDType(py::module *m) {
   py::enum_<PaddleDType>(*m, "PaddleDType")
+      .value("FLOAT64", PaddleDType::FLOAT64)
       .value("FLOAT32", PaddleDType::FLOAT32)
       .value("FLOAT16", PaddleDType::FLOAT16)
       .value("INT64", PaddleDType::INT64)
@@ -1075,6 +1099,7 @@ void BindZeroCopyTensor(py::module *m) {
       .def("copy_from_cpu", &ZeroCopyTensorCreate<uint8_t>)
       .def("copy_from_cpu", &ZeroCopyTensorCreate<int32_t>)
       .def("copy_from_cpu", &ZeroCopyTensorCreate<int64_t>)
+      .def("copy_from_cpu", &ZeroCopyTensorCreate<double>)
       .def("copy_from_cpu", &ZeroCopyTensorCreate<float>)
       .def("copy_from_cpu", &ZeroCopyTensorCreate<paddle_infer::float16>)
       .def("copy_from_cpu", &ZeroCopyTensorCreate<bool>)
@@ -1098,6 +1123,7 @@ void BindPaddleInferTensor(py::module *m) {
       .def("_copy_from_cpu_bind", &PaddleInferTensorCreate<uint8_t>)
       .def("_copy_from_cpu_bind", &PaddleInferTensorCreate<int32_t>)
       .def("_copy_from_cpu_bind", &PaddleInferTensorCreate<int64_t>)
+      .def("_copy_from_cpu_bind", &PaddleInferTensorCreate<double>)
       .def("_copy_from_cpu_bind", &PaddleInferTensorCreate<float>)
       .def("_copy_from_cpu_bind",
            &PaddleInferTensorCreate<paddle_infer::float16>)

--- a/python/paddle/fluid/tests/unittests/ir/test_inference_datatype.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_inference_datatype.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+import paddle
+from paddle.inference import Config, DataType, create_predictor
+
+paddle.set_default_dtype('float64')
+
+
+class TestNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = paddle.nn.Linear(4, 4)
+        self.fc2 = paddle.nn.Linear(4, 4)
+
+    def forward(self, x):
+        out = self.fc1(x)
+        out = self.fc2(out)
+        out = paddle.nn.functional.relu(out)
+        return out
+
+
+@unittest.skipIf(
+    not paddle.is_compiled_with_cuda(), 'should compile with cuda.'
+)
+class TestDoubleOnGPU(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        net = TestNet()
+        model = paddle.jit.to_static(
+            net,
+            input_spec=[
+                paddle.static.InputSpec(shape=[None, 4], dtype='float64')
+            ],
+        )
+        paddle.jit.save(
+            model,
+            os.path.join(
+                self.temp_dir.name, 'test_inference_datatype_model/inference'
+            ),
+        )
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def init_predictor(self):
+        config = Config(
+            os.path.join(
+                self.temp_dir.name,
+                'test_inference_datatype_model/inference.pdmodel',
+            ),
+            os.path.join(
+                self.temp_dir.name,
+                'test_inference_datatype_model/inference.pdiparams',
+            ),
+        )
+        config.enable_use_gpu(256, 0)
+        config.enable_memory_optim()
+        # NOTE(liuyuanle): Because double computing is not supported in our pass implementation,
+        # we need to turn off IR optimization.
+        config.switch_ir_optim(False)
+        predictor = create_predictor(config)
+        return predictor
+
+    def test_output(self):
+        predictor = self.init_predictor()
+
+        input = np.ones((3, 4)).astype(np.float64)
+
+        input_names = predictor.get_input_names()
+        input_tensor = predictor.get_input_handle(input_names[0])
+        input_tensor.reshape(input.shape)
+        input_tensor.copy_from_cpu(input.copy())
+        assert input_tensor.type() == DataType.FLOAT64
+
+        predictor.run()
+
+        output_names = predictor.get_output_names()
+        output_tensor = predictor.get_output_handle(output_names[0])
+        assert output_tensor.type() == DataType.FLOAT64
+
+        output_data = output_tensor.copy_to_cpu()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

support double data type.

NOTE: 使用示例请参考PR实现中的单测示例，需要注意的是由于pass实现暂不支持double权重计算，因此使用时需要将IR优化关闭。