### PR TITLE
[AMP OP&Test] Support bf16/fp16 for dropout and full_like op

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -257,7 +257,7 @@ class TestFP16DropoutOp(OpTest):
         self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', max_relative_error=0.05)
+        self.check_grad(['X'], 'Out')
 
 
 @unittest.skipIf(

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -256,6 +256,9 @@ class TestFP16DropoutOp(OpTest):
     def test_check_output(self):
         self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
 
+    def test_check_grad_normal(self):
+        self.check_grad(['X'], 'Out', max_relative_error=0.05)
+
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda() or not core.op_support_gpu("dropout"),

--- a/python/paddle/fluid/tests/unittests/test_full_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_full_like_op.py
@@ -140,9 +140,6 @@ class TestFullLikeOp1(OpTest):
     def test_check_output(self):
         self.check_output(check_prim=True)
 
-    def test_check_grad_normal(self):
-        self.check_grad(['X'], ['Out'])
-
     def if_enable_cinn(self):
         pass
 

--- a/python/paddle/fluid/tests/unittests/test_full_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_full_like_op.py
@@ -15,7 +15,8 @@
 import unittest
 
 import numpy as np
-from op_test import OpTest, convert_float_to_uint16
+from eager_op_test import OpTest
+from op_test import convert_float_to_uint16
 
 import paddle
 import paddle.fluid.core as core
@@ -143,7 +144,7 @@ class TestFullLikeOp1(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output(check_eager=True)
+        self.check_output(check_prim=True)
 
     def test_check_grad_normal(self):
         self.check_grad(['X'], ['Out'])
@@ -188,7 +189,7 @@ class TestFullLikeOp4(unittest.TestCase):
         paddle.enable_static()
 
 
-class TestFullLikeOp5(TestFullLikeOp1):
+class TestFullLikeFP16Op(TestFullLikeOp1):
     def init_data(self):
         self.fill_value = 6666
         self.shape = [10, 10]
@@ -203,7 +204,7 @@ class TestFullLikeOp5(TestFullLikeOp1):
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
     "core is not complied with CUDA and not support the bfloat16",
 )
-class TestFullLikeOp6(TestFullLikeOp1):
+class TestFullLikeBF16Op(TestFullLikeOp1):
     def init_data(self):
         self.fill_value = 6666
         self.shape = [10, 10]

--- a/python/paddle/fluid/tests/unittests/test_full_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_full_like_op.py
@@ -15,8 +15,7 @@
 import unittest
 
 import numpy as np
-from eager_op_test import OpTest
-from op_test import convert_float_to_uint16
+from eager_op_test import OpTest, convert_float_to_uint16
 
 import paddle
 import paddle.fluid.core as core
@@ -106,10 +105,6 @@ class TestFullOpError(unittest.TestCase):
             )
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda(),
-    "core is not complied with CUDA and not support the bfloat16",
-)
 class TestFullLikeOp1(OpTest):
     # test basic
     def setUp(self):
@@ -136,7 +131,6 @@ class TestFullLikeOp1(OpTest):
             'value': self.fill_value,
             'dtype': convert_np_dtype_to_dtype_(self.dtype),
         }
-        self.place = core.CUDAPlace(0)
 
     def init_data(self):
         self.fill_value = 5
@@ -195,9 +189,6 @@ class TestFullLikeFP16Op(TestFullLikeOp1):
         self.shape = [10, 10]
         self.dtype = np.float16
 
-    def if_enable_cinn(self):
-        pass
-
 
 @unittest.skipIf(
     not core.is_compiled_with_cuda()
@@ -209,9 +200,6 @@ class TestFullLikeBF16Op(TestFullLikeOp1):
         self.fill_value = 6666
         self.shape = [10, 10]
         self.dtype = np.uint16
-
-    def if_enable_cinn(self):
-        pass
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_full_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_full_like_op.py
@@ -116,7 +116,7 @@ class TestFullLikeOp1(OpTest):
         self.prim_op_type = "comp"
         self.python_api = fill_any_like_wrapper
         self.init_data()
-        # self.if_enable_cinn()
+        self.if_enable_cinn()
 
         bf16_flag = self.dtype == np.uint16
         x = np.zeros(self.shape).astype(np.float32 if bf16_flag else self.dtype)
@@ -146,7 +146,7 @@ class TestFullLikeOp1(OpTest):
         self.check_output(check_eager=True)
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], ['Out'], max_relative_error=100)
+        self.check_grad(['X'], ['Out'])
 
     def if_enable_cinn(self):
         pass


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Support bf16/fp16 for dropout and full_like op.