### PR TITLE
[Paddle-TRT] fix GN when params.c% params.cPerBlock != 0

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
@@ -160,7 +160,6 @@ void groupNormNHWCSum(const GroupNormNHWCParams &params, cudaStream_t stream) {
 
   // The number of blocks to compute all the channels.
   grid.x = divUp(params.c, params.cPerBlock);
-  lock;
   // The number of blocks to compute all the activations in a given instance.
   grid.y = divUp(params.hw, params.hwPerBlock);
   // The number of instances.
@@ -288,7 +287,6 @@ void groupNormNCHW32SumQDQ(const GroupNormNHWCParams &params,
 
   // The number of blocks to compute all the channels.
   grid.x = divUp(params.c, params.cPerBlock);
-  lock;
   // The number of blocks to compute all the activations in a given instance.
   grid.y = divUp(params.hw, params.hwPerBlock);
   // The number of instances.

--- a/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/group_norm_op_plugin.cu
@@ -159,7 +159,8 @@ void groupNormNHWCSum(const GroupNormNHWCParams &params, cudaStream_t stream) {
   dim3 grid;
 
   // The number of blocks to compute all the channels.
-  grid.x = params.c / params.cPerBlock;
+  grid.x = divUp(params.c, params.cPerBlock);
+  lock;
   // The number of blocks to compute all the activations in a given instance.
   grid.y = divUp(params.hw, params.hwPerBlock);
   // The number of instances.
@@ -286,7 +287,8 @@ void groupNormNCHW32SumQDQ(const GroupNormNHWCParams &params,
   dim3 grid;
 
   // The number of blocks to compute all the channels.
-  grid.x = params.c / params.cPerBlock;
+  grid.x = divUp(params.c, params.cPerBlock);
+  lock;
   // The number of blocks to compute all the activations in a given instance.
   grid.y = divUp(params.hw, params.hwPerBlock);
   // The number of instances.
@@ -410,7 +412,7 @@ void groupNormNCHW32ScaleQDQ(const GroupNormNHWCParams &params,
   dim3 grid;
 
   // The number of blocks to compute all the channels.
-  grid.x = params.c / params.cPerBlock;
+  grid.x = divUp(params.c, params.cPerBlock);
   // The number of blocks to compute all the activations in a given instance.
   grid.y = divUp(params.hw, params.hwPerBlock);
   // The number of instances.
@@ -516,7 +518,7 @@ void groupNormNHWCScale(const GroupNormNHWCParams &params,
   dim3 grid;
 
   // The number of blocks to compute all the channels.
-  grid.x = params.c / params.cPerBlock;
+  grid.x = divUp(params.c, params.cPerBlock);
   // The number of blocks to compute all the activations in a given instance.
   grid.y = divUp(params.hw, params.hwPerBlock);
   // The number of instances.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
- 当GN跑1024通道时，params.cPerBlock = 320，这个时候结果有误，此PR修复下。