### PR TITLE
[CodeStyle][C400] replace unnecessary generator list

### DIFF
--- a/python/paddle/distributed/auto_parallel/operators/dist_pnorm.py
+++ b/python/paddle/distributed/auto_parallel/operators/dist_pnorm.py
@@ -364,7 +364,7 @@ class DistributedPNormImpl0(DistributedOperatorImpl):
             slice_ends.append(item[1])
             slices_axes.append(idx)
 
-        infer_flags = list(1 for i in range(len(slices_axes)))
+        infer_flags = [1 for i in range(len(slices_axes))]
         attrs = {
             "axes": slices_axes,
             "starts": slice_starts,

--- a/python/paddle/distributed/auto_parallel/reshard.py
+++ b/python/paddle/distributed/auto_parallel/reshard.py
@@ -507,7 +507,7 @@ class Inserter:
         # use slice
         else:
             inputs = {'Input': tensor}
-            infer_flags = list(1 for i in range(len(axes)))
+            infer_flags = [1 for i in range(len(axes))]
             attrs = {
                 "axes": axes,
                 "starts": starts,
@@ -2944,7 +2944,7 @@ class Resharder:
                         to_slice_tensor_shape = op_desc.shape
                     slice_desc = {}
                     slice_desc["op"] = "slice"
-                    infer_flags = list(1 for i in range(len(op_desc.axes)))
+                    infer_flags = [1 for i in range(len(op_desc.axes))]
                     slice_desc["attrs"] = {
                         "axes": op_desc.axes,
                         "starts": op_desc.starts,

--- a/python/paddle/distributed/auto_parallel/tuner/recorder.py
+++ b/python/paddle/distributed/auto_parallel/tuner/recorder.py
@@ -101,7 +101,7 @@ class MetricRecords:
             self._records[step] = MetricRecord(value, step=step)
 
     def get_best_value(self):
-        values = list(r.mean() for r in self._records.values())
+        values = [r.mean() for r in self._records.values()]
         if not values:
             return None
         if self._direction == "min":

--- a/python/paddle/distributed/fleet/recompute/recompute.py
+++ b/python/paddle/distributed/fleet/recompute/recompute.py
@@ -209,11 +209,11 @@ class RecomputeFunction(PyLayer):
                     if isinstance(inp, (core.VarBase, core.eager.Tensor))
                 )
             else:
-                grads = list(
+                grads = [
                     inp._grad_ivar()
                     for inp in detached_inputs
                     if isinstance(inp, (core.VarBase, core.eager.Tensor))
-                )
+                ]
             return grads
 
 

--- a/python/paddle/fluid/tests/unittests/autograd/utils.py
+++ b/python/paddle/fluid/tests/unittests/autograd/utils.py
@@ -60,9 +60,9 @@ def _compute_numerical_jacobian(func, xs, delta, np_dtype):
     ys = list(as_tensors(func(*xs)))
     fin_size = len(xs)
     fout_size = len(ys)
-    jacobian = list([] for _ in range(fout_size))
+    jacobian = [[] for _ in range(fout_size)]
     for i in range(fout_size):
-        jac_i = list([] for _ in range(fin_size))
+        jac_i = [[] for _ in range(fin_size)]
         for j in range(fin_size):
             jac_i[j] = np.zeros(
                 (_product(ys[i].shape), _product(xs[j].shape)), dtype=np_dtype
@@ -94,9 +94,9 @@ def _compute_numerical_hessian(func, xs, delta, np_dtype):
     xs = list(as_tensors(xs))
     ys = list(as_tensors(func(*xs)))
     fin_size = len(xs)
-    hessian = list([] for _ in range(fin_size))
+    hessian = [[] for _ in range(fin_size)]
     for i in range(fin_size):
-        hessian_i = list([] for _ in range(fin_size))
+        hessian_i = [[] for _ in range(fin_size)]
         for j in range(fin_size):
             hessian_i[j] = np.zeros(
                 (_product(xs[i].shape), _product(xs[j].shape)), dtype=np_dtype

--- a/python/paddle/fluid/tests/unittests/test_conv2d_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_layer.py
@@ -23,7 +23,7 @@ from paddle import fluid, nn
 
 
 def _reverse_repeat_list(t, n):
-    return list(x for x in reversed(t) for _ in range(n))
+    return [x for x in reversed(t) for _ in range(n)]
 
 
 class Conv2DTestCase(unittest.TestCase):

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -43,7 +43,7 @@ def _reverse_repeat_list(t, n):
     This can be used to translate padding arg used by Conv and Pooling modules
     to the ones used by `F.pad`.
     """
-    return list(x for x in reversed(t) for _ in range(n))
+    return [x for x in reversed(t) for _ in range(n)]
 
 
 class _ConvNd(Layer):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -323,7 +323,7 @@ def slice(input, axes, starts, ends):
                 )
             )
 
-        infer_flags = list(1 for i in range(len(axes)))
+        infer_flags = [1 for i in range(len(axes))]
 
         tmp_tensor_type = core.eager.Tensor
 
@@ -337,7 +337,7 @@ def slice(input, axes, starts, ends):
         elif isinstance(starts, tmp_tensor_type):
             tensor_t = starts.numpy()
             starts = [ele for ele in tensor_t]
-            infer_flags = list(-1 for i in range(len(axes)))
+            infer_flags = [-1 for i in range(len(axes))]
 
         if isinstance(ends, (list, tuple)):
             ends = [
@@ -349,7 +349,7 @@ def slice(input, axes, starts, ends):
         elif isinstance(ends, tmp_tensor_type):
             tensor_t = ends.numpy()
             ends = [ele for ele in tensor_t]
-            infer_flags = list(-1 for i in range(len(axes)))
+            infer_flags = [-1 for i in range(len(axes))]
 
         return _C_ops.slice(input, axes, starts, ends, infer_flags, [])
     else:
@@ -366,13 +366,13 @@ def slice(input, axes, starts, ends):
 
         inputs = {'Input': input}
         attrs = {'axes': axes}
-        infer_flags = list(1 for i in range(len(axes)))
+        infer_flags = [1 for i in range(len(axes))]
 
         # starts
         if isinstance(starts, Variable):
             starts.stop_gradient = True
             inputs['StartsTensor'] = starts
-            infer_flags = list(-1 for i in range(len(axes)))
+            infer_flags = [-1 for i in range(len(axes))]
         elif isinstance(starts, (list, tuple)):
             attrs['starts'] = []
             if paddle.utils._contain_var(starts):
@@ -392,7 +392,7 @@ def slice(input, axes, starts, ends):
         if isinstance(ends, Variable):
             ends.stop_gradient = True
             inputs['EndsTensor'] = ends
-            infer_flags = list(-1 for i in range(len(axes)))
+            infer_flags = [-1 for i in range(len(axes))]
         elif isinstance(ends, (list, tuple)):
             attrs['ends'] = []
             if paddle.utils._contain_var(ends):
@@ -3907,7 +3907,7 @@ def strided_slice(x, axes, starts, ends, strides, name=None):
 
         inputs = {'Input': x}
         attrs = {'axes': axes}
-        infer_flags = list(1 for i in range(len(axes)))
+        infer_flags = [1 for i in range(len(axes))]
         # starts
         if isinstance(starts, Variable):
             starts.stop_gradient = True

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -4662,7 +4662,7 @@ def diff(x, n=1, axis=-1, prepend=None, append=None, name=None):
         axis = 0
     dtype = x.dtype
     axes = [axis]
-    infer_flags = list(1 for i in range(len(axes)))
+    infer_flags = [1 for i in range(len(axes))]
     if in_dygraph_mode():
         has_pend = False
         input_list = []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[C400](https://beta.ruff.rs/docs/rules/unnecessary-generator-list/) 将生成器中的 `list()` 替换成 `[]`，使 python 代码更易理解。

> It is unnecessary to use list around a generator expression, since there are equivalent comprehensions for these types. Using a comprehension is clearer and more idiomatic.
> Examples
> ```Python
> list(f(x) for x in foo)
> ```
> Use instead:
> ```Python
> [f(x) for x in foo]
> ```
> <p align="right"> —— <a href="https://beta.ruff.rs/docs/rules/unnecessary-generator-list/">unnecessary-generator-list (C400)</a></p>

如上所述，可以通过引入 C400 自动将生成器中的 `list()` 替换成 `[]` ，且转写后不会影响代码的语义，修复命令如下：
```Python
# 安装 ruff 0.0.254
pip install ruff==0.0.254
# 确定本 rule 自动修复方案合适，因此直接使用命令自动修复
ruff --select C400 . --fix
```
参考链接：
- [unnecessary-generator-list (C400)](https://beta.ruff.rs/docs/rules/unnecessary-generator-list/)
- [A flake8 plugin to help you write better list/set/dict comprehensions](https://pypi.org/project/flake8-comprehensions/)

Tracking issue:
- https://github.com/PaddlePaddle/Paddle/issues/51729