### PR TITLE
[CodeStyle][C401&C402] replace unnecessary generator set and dict

### DIFF
--- a/python/paddle/distributed/auto_parallel/tuner/tunable_space.py
+++ b/python/paddle/distributed/auto_parallel/tuner/tunable_space.py
@@ -117,7 +117,7 @@ class TunableSpace:
                 {"class_name": v.__class__.__name__, "state": v.get_state()}
                 for v in self._variables.values()
             ],
-            "values": dict((k, v) for (k, v) in self.values.items()),
+            "values": {k: v for (k, v) in self.values.items()},
         }
 
     @classmethod
@@ -126,7 +126,7 @@ class TunableSpace:
         for v in state["variables"]:
             v = _deserialize_tunable_variable(v)
             ts._variables[v.name] = v
-        ts._values = dict((k, v) for (k, v) in state["values"].items())
+        ts._values = {k: v for (k, v) in state["values"].items()}
         return ts
 
 

--- a/python/paddle/distributed/auto_parallel/tuner/tunable_variable.py
+++ b/python/paddle/distributed/auto_parallel/tuner/tunable_variable.py
@@ -88,7 +88,7 @@ class Choice(TunableVariable):
     def __init__(self, name, values, default=None):
         super().__init__(name=name, default=default)
 
-        types = set(type(v) for v in values)
+        types = {type(v) for v in values}
         if len(types) > 1:
             raise TypeError(
                 "Choice can contain only one type of value, but found values: {} with types: {}.".format(

--- a/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
+++ b/python/paddle/distributed/fleet/meta_parallel/parallel_layers/pp_layers.py
@@ -433,9 +433,9 @@ class PipelineLayer(nn.Layer):
             return
 
         layers_desc = self._layers_desc
-        shared_layer_names = set(
+        shared_layer_names = {
             s.layer_name for s in layers_desc if isinstance(s, SharedLayerDesc)
-        )
+        }
         for key in shared_layer_names:
             shared_layers = []
             for idx, layer in enumerate(layers_desc):
@@ -445,9 +445,9 @@ class PipelineLayer(nn.Layer):
                 ):
                     shared_layers.append(idx)
 
-            shared_stages = set(
+            shared_stages = {
                 self.get_stage_from_index(idx) for idx in shared_layers
-            )
+            }
             self._dp_degree = self._topo.get_dim('data')
             self._mp_degree = self._topo.get_dim('model')
             self._sharding_degree = self._topo.get_dim('sharding')

--- a/python/paddle/distributed/ps/utils/public.py
+++ b/python/paddle/distributed/ps/utils/public.py
@@ -194,7 +194,7 @@ class TrainerRuntimeConfig:
                     'communicator_send_queue_size'
                 ] = num_threads
 
-        return dict((key, str(self.runtime_configs[key])) for key in need_keys)
+        return {key: str(self.runtime_configs[key]) for key in need_keys}
 
 
 def get_lr_ops(program):

--- a/python/paddle/incubate/distributed/fleet/parameter_server/distribute_transpiler/distributed_strategy.py
+++ b/python/paddle/incubate/distributed/fleet/parameter_server/distribute_transpiler/distributed_strategy.py
@@ -128,7 +128,7 @@ class TrainerRuntimeConfig:
                     'communicator_send_queue_size'
                 ] = num_threads
 
-        return dict((key, str(self.runtime_configs[key])) for key in need_keys)
+        return {key: str(self.runtime_configs[key]) for key in need_keys}
 
     def display(self, configs):
         raw0, raw1, length = 45, 5, 50

--- a/python/paddle/static/quantization/tests/quant2_int8_image_classification_comparison.py
+++ b/python/paddle/static/quantization/tests/quant2_int8_image_classification_comparison.py
@@ -357,7 +357,7 @@ class Quant2Int8ImageClassificationComparisonTest(unittest.TestCase):
         assert quant_acc1 - int8_acc1 <= threshold
 
     def _strings_from_csv(self, string):
-        return set(s.strip() for s in string.split(','))
+        return {s.strip() for s in string.split(',')}
 
     def _ints_from_csv(self, string):
         return set(map(int, string.split(',')))

--- a/python/paddle/static/quantization/tests/quant2_int8_nlp_comparison.py
+++ b/python/paddle/static/quantization/tests/quant2_int8_nlp_comparison.py
@@ -294,7 +294,7 @@ class QuantInt8NLPComparisonTest(unittest.TestCase):
         assert quant_acc - int8_acc <= threshold
 
     def _strings_from_csv(self, string):
-        return set(s.strip() for s in string.split(','))
+        return {s.strip() for s in string.split(',')}
 
     def _ints_from_csv(self, string):
         return set(map(int, string.split(',')))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[C401](https://beta.ruff.rs/docs/rules/unnecessary-generator-set/) 将生成器中的 `set()` 替换成 `{}`，使 python 代码更易理解，同时提升代码运行效率，具体如下：

> It is unnecessary to use set around a generator expression, since there are equivalent comprehensions for these types. Using a comprehension is clearer and more idiomatic.
> Examples
> ```Python
> set(f(x) for x in foo) #这里相当于先创建 generator `(f(x) for x in foo)` 之后在调用 `set` 转换成集合。
> ```
> Use instead:
> ```Python
> {f(x) for x in foo} #这里直接创建了 set comprehension，可以省去一步函数的调用，因此可以优化性能。
> ```
> Notes:可以通过调用 dis 模块查看字节码。
> ```Python
> import dis
> 
> dis.dis(compile("set(f(x) for x in foo)", "<string>", "exec"))
> 
> dis.dis(compile("{f(x) for x in foo}", "<string>", "exec"))
> ```
> <p align="right"> —— <a href="https://beta.ruff.rs/docs/rules/unnecessary-generator-set/">unnecessary-generator-set (C401)</a></p>



[C402](https://beta.ruff.rs/docs/rules/unnecessary-generator-dict/) 将生成器中的 `dict((x, f(x)) for x in foo)
` 替换成 `{x: f(x) for x in foo}`，使 python 代码更易理解，同时提升代码运行效率，具体如下：

> It is unnecessary to use dict around a generator expression, since there are equivalent comprehensions for these types. Using a comprehension is clearer and more idiomatic.
> Examples
> ```Python
> dict((x, f(x)) for x in foo) #这里相当于先创建 generator `((x, f(x)) for x in foo)` 之后在调用 `dict` 转换成字典。
> ```
> Use instead:
> ```Python
> {x: f(x) for x in foo} #这里直接创建了 dict comprehension，可以省去一步函数的调用，因此可以优化性能。
> ```
> Notes:可以通过调用 dis 模块查看字节码。
> ```Python
> import dis
> 
> dis.dis(compile("dict((x, f(x)) for x in foo)", "<string>", "exec"))
> 
> dis.dis(compile("{x: f(x) for x in foo}", "<string>", "exec"))
> ```
> <p align="right"> —— <a href="https://beta.ruff.rs/docs/rules/unnecessary-generator-dict/">unnecessary-generator-dict (C402)</a></p>

参考链接：
- [unnecessary-generator-set (C401)](https://beta.ruff.rs/docs/rules/unnecessary-generator-set/)
- [unnecessary-generator-dict (C402)](https://beta.ruff.rs/docs/rules/unnecessary-generator-dict/)
- [flake8 plugin to help you write better list/set/dict comprehensions](https://pypi.org/project/flake8-comprehensions/)

Tracking issue:
- https://github.com/PaddlePaddle/Paddle/issues/51729