### PR TITLE
fix softmaxce null point in shape test

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
@@ -162,6 +162,13 @@ class SoftmaxWithCrossEntropyOp : public framework::OperatorWithKernel {
                           "R is the rank of Input(Logits)."));
 
     axis = phi::funcs::CanonicalAxis(axis, logits_rank);
+
+    PADDLE_ENFORCE_EQ(logits_dims.size(),
+                      labels_dims.size(),
+                      platform::errors::InvalidArgument(
+                          "Input(Logits) and Input(Label) should in "
+                          "same dimensions size."));
+
     for (int i = 0; i < logits_rank; i++) {
       if (i != axis) {
         if (ctx->IsRuntime() || (logits_dims[i] > 0 && labels_dims[i] > 0)) {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
虽然主要case关了，但发现一个小错误，在labels_dims.size小于logits_dims.size时，遍历检查会触发空指针
#49919  