### PR TITLE
[BugFix] fix raw_program_optimizer not apply when using amp

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -68,8 +68,6 @@ class RawProgramOptimizer(MetaOptimizerBase):
             return False
         if self.user_defined_strategy.sharding:
             return False
-        if self.user_defined_strategy.amp:
-            return False
 
         if self.without_graph_optimization:
             return True

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_amp_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_fleet_amp_meta_optimizer.py
@@ -184,7 +184,7 @@ class TestFleetAMPOptimizer(TestFleetMetaOptimizer):
         applied_meta_list = fleet._get_applied_meta_list()
         applied_graph_list = fleet._get_applied_graph_list()
         print(applied_meta_list, applied_graph_list)
-        self.assertEqual(len(applied_meta_list), 3)
+        self.assertEqual(len(applied_meta_list), 4)
 
         ops = [op.type for op in avg_cost.block.ops]
         outs = [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
这个PR用于修复#50719 导致的一个Bug。该PR在`RawProgramOptimizer._can_apply`中添加了检查，使得`AMPOptimizer`与`RawProgramOptimizer`不能同时开启。本PR修复了这一错误，并相应修改了单测。

This PR fixes a bug caused by #50719 , which adds checks for whether apply `RawProgramOptimizer` and makes it conflicts with `AMPOptimizer`.  This PR fixes this problem and modify the corresponding unit test.
#### Other
Card-68266