### PR TITLE
[DyStatic] global bugfix

### DIFF
--- a/python/paddle/jit/dy2static/program_translator.py
+++ b/python/paddle/jit/dy2static/program_translator.py
@@ -23,6 +23,7 @@ from paddle.amp.auto_cast import _in_amp_guard
 from paddle.fluid import _non_static_mode, core, framework
 from paddle.fluid.data_feeder import check_type
 from paddle.fluid.dygraph.base import param_guard, switch_to_static_graph
+from paddle.jit.dy2static.utils import recover_globals_attribute
 from paddle.nn.layer import layers
 from paddle.utils import flatten, gast
 
@@ -95,6 +96,10 @@ class FunctionCache:
             static_func = self._convert(func)
             self._converted_static_func_caches[func] = static_func
 
+        # After transform dygraph function into callable_func saved in tmp file,
+        # it lost the global variables from imported statements or defined in source file.
+        # Recovers the necessary variables by `__globals__`.
+        recover_globals_attribute(func, static_func)
         return static_func
 
     def _convert(self, func):

--- a/python/paddle/jit/dy2static/utils.py
+++ b/python/paddle/jit/dy2static/utils.py
@@ -587,10 +587,6 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
             'Function: %s doesn\'t exist in the Module transformed from AST.'
             % func_name
         )
-    # After transform dygraph function into callable_func saved in tmp file,
-    # it lost the global variables from imported statements or defined in source file.
-    # Recovers the necessary variables by `__globals__`.
-    recover_globals_attribute(dyfunc, callable_func)
 
     return callable_func, f.name
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
PCard-66972
修复了global熟悉导致的动转静bug，因为 globals 只会设置一次，所以无法捕捉变化。
