### PR TITLE
pool2d and pool2d_grad support case of kernel_size > kh/kw for xpu

### DIFF
--- a/paddle/phi/kernels/xpu/pool_grad_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_grad_kernel.cc
@@ -157,6 +157,12 @@ void Pool2dGradKernel(const Context& ctx,
 
     PADDLE_ENFORCE_XDNN_SUCCESS(r, "adaptive_pool2d_grad");
   } else {
+    if (kernel_size[0] > in_h) {
+      kernel_size[0] = in_h;
+    }
+    if (kernel_size[1] > in_w) {
+      kernel_size[1] = in_w;
+    }
     if (pooling_type == "max") {
       // TODO(zhanghuan05) to bind max_pool2d_grad_indices xpu api
       r = xpu::max_pool2d_grad<XPUType>(

--- a/paddle/phi/kernels/xpu/pool_kernel.cc
+++ b/paddle/phi/kernels/xpu/pool_kernel.cc
@@ -90,6 +90,12 @@ void Pool2dKernel(const Context& ctx,
   int* index_data = nullptr;
   int r = xpu::Error_t::SUCCESS;
   if (!adaptive) {
+    if (kernel_size[0] > in_h) {
+      kernel_size[0] = in_h;
+    }
+    if (kernel_size[1] > in_w) {
+      kernel_size[1] = in_w;
+    }
     if (pooling_type == "max") {
       r = xpu::max_pool2d<XPUType>(
           ctx.x_context(),


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
pool2d and pool2d_grad 的底层实现中当 kernel_size > kh/kw 时会出现参数检查错误，本pr通过修改kernel_size可以绕过该限制。

