### PR TITLE
[AMP] Add bfloat16 Support for `elementwise_pow` Op

### DIFF
--- a/paddle/phi/kernels/cpu/elementwise_grad_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_grad_kernel.cc
@@ -105,4 +105,5 @@ PD_REGISTER_KERNEL(elementwise_pow_grad,
                    float,
                    double,
                    int,
-                   int64_t) {}
+                   int64_t,
+                   phi::dtype::bfloat16) {}

--- a/paddle/phi/kernels/cpu/elementwise_kernel.cc
+++ b/paddle/phi/kernels/cpu/elementwise_kernel.cc
@@ -166,7 +166,8 @@ PD_REGISTER_KERNEL(elementwise_pow_raw,
                    float,
                    double,
                    int,
-                   int64_t) {}
+                   int64_t,
+                   phi::dtype::bfloat16) {}
 
 PD_REGISTER_KERNEL(heaviside,
                    CPU,

--- a/paddle/phi/kernels/elementwise_kernel.cc
+++ b/paddle/phi/kernels/elementwise_kernel.cc
@@ -140,7 +140,8 @@ PD_REGISTER_KERNEL(elementwise_pow,
                    float,
                    double,
                    int,
-                   int64_t) {}
+                   int64_t,
+                   phi::dtype::bfloat16) {}
 
 PD_REGISTER_KERNEL(subtract,
                    CPU,
@@ -232,7 +233,8 @@ PD_REGISTER_KERNEL(elementwise_pow,
                    double,
                    int,
                    int64_t,
-                   phi::dtype::float16) {}
+                   phi::dtype::float16,
+                   phi::dtype::bfloat16) {}
 
 #endif
 

--- a/paddle/phi/kernels/funcs/elementwise_functor.h
+++ b/paddle/phi/kernels/funcs/elementwise_functor.h
@@ -23,6 +23,7 @@ limitations under the License. */
 
 #include "xpu/kernel/math_xpu2.h"  // pow()
 #endif
+#include "paddle/phi/common/amp_type_traits.h"
 
 namespace phi {
 namespace funcs {
@@ -585,68 +586,55 @@ struct InverseFloorDivideFunctor {
   }
 };
 
+#if defined(__CUDA_ARCH__) || defined(__HIPCC__)
+template <typename T, typename MPType>
+inline HOSTDEVICE typename std::enable_if<std::is_integral<T>::value, T>::type
+compute_pow(const T a, const T b) {
+  // TODO(wujionghao): A potential speed improvement is supporting different
+  // types in C++.
+  // On CUDAPlace, std::pow(3, 1) calls pow(float, float), and
+  // it will return a float number like 2.99... , which floor to 2
+  // when cast to int by default and it is wrong.
+  // Use llrint to cast it to the nearest integer, which is 3.
+  return std::llrint(std::pow(static_cast<double>(a), static_cast<double>(b)));
+}
+template <typename T, typename MPType>
+inline HOSTDEVICE typename std::enable_if<!std::is_integral<T>::value, T>::type
+compute_pow(const T a, const T b) {
+  MPType a_val = static_cast<MPType>(a);
+  MPType b_val = static_cast<MPType>(b);
+#ifdef PADDLE_WITH_XPU_KP
+  return static_cast<T>(pow(a_val, b_val));
+#endif
+  return static_cast<T>(std::pow(a_val, b_val));
+}
+#else
+template <typename T, typename MPType>
+inline HOSTDEVICE T compute_pow(const T a, const T b) {
+  MPType a_val = static_cast<MPType>(a);
+  MPType b_val = static_cast<MPType>(b);
+#ifdef PADDLE_WITH_XPU_KP
+  return static_cast<T>(pow(a_val, b_val));
+#endif
+  return static_cast<T>(std::pow(a_val, b_val));
+}
+#endif
+
 template <typename T>
 struct ElementwisePowFunctor {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   inline HOSTDEVICE T operator()(const T a, const T b) const {
-// TODO(wujionghao): A potential speed improvement is supporting different
-// types in C++.
-#if defined(__CUDA_ARCH__) || defined(__HIPCC__)
-    // On CUDAPlace, std::pow(3, 1) calls pow(float, float), and
-    // it will return a float number like 2.99... , which floor to 2
-    // when cast to int by default and it is wrong.
-    // Use llrint to cast it to the nearest integer, which is 3.
-    if (std::is_integral<T>::value) {
-      return std::llrint(
-          std::pow(static_cast<double>(a), static_cast<double>(b)));
-    }
-#endif
-#ifdef PADDLE_WITH_XPU_KP
-    return pow(a, b);
-#endif
-    return std::pow(a, b);
+    return compute_pow<T, MPType>(a, b);
   }
 };
 
 template <typename T>
 struct ElementwiseInversePowFunctor {
+  using MPType = typename phi::dtype::MPTypeTrait<T>::Type;
   inline HOSTDEVICE T operator()(const T a, const T b) const {
-// TODO(wujionghao): A potential speed improvement is supporting different
-// types in C++.
-#if defined(__CUDA_ARCH__) || defined(__HIPCC__)
-    // On CUDAPlace, std::pow(3, 1) calls pow(float, float), and
-    // it will return a float number like 2.99... , which floor to 2
-    // when cast to int by default and it is wrong.
-    // Use llrint to cast it to the nearest integer, which is 3.
-    if (std::is_integral<T>::value) {
-      return std::llrint(
-          std::pow(static_cast<double>(b), static_cast<double>(a)));
-    }
-#endif
-#ifdef PADDLE_WITH_XPU_KP
-    return pow(b, a);
-#endif
-    return std::pow(b, a);
+    return compute_pow<T, MPType>(b, a);
   }
 };
 
-template <>
-struct ElementwisePowFunctor<dtype::float16> {
-  inline HOSTDEVICE dtype::float16 operator()(const dtype::float16 a,
-                                              const dtype::float16 b) const {
-    float f_a = static_cast<float>(a);
-    float f_b = static_cast<float>(b);
-    return static_cast<dtype::float16>(std::pow(f_a, f_b));
-  }
-};
-
-template <>
-struct ElementwiseInversePowFunctor<dtype::float16> {
-  inline HOSTDEVICE dtype::float16 operator()(const dtype::float16 a,
-                                              const dtype::float16 b) const {
-    float f_a = static_cast<float>(a);
-    float f_b = static_cast<float>(b);
-    return static_cast<dtype::float16>(std::pow(f_b, f_a));
-  }
-};
 }  // namespace funcs
 }  // namespace phi

--- a/paddle/phi/kernels/gpu/elementwise_grad_kernel.cu
+++ b/paddle/phi/kernels/gpu/elementwise_grad_kernel.cu
@@ -150,4 +150,5 @@ PD_REGISTER_KERNEL(elementwise_pow_grad,
                    double,
                    int,
                    phi::dtype::float16,
+                   phi::dtype::bfloat16,
                    int64_t) {}

--- a/paddle/phi/kernels/kps/elementwise_kernel.cu
+++ b/paddle/phi/kernels/kps/elementwise_kernel.cu
@@ -181,5 +181,6 @@ PD_REGISTER_KERNEL(elementwise_pow_raw,
                    double,
                    int,
                    float16,
+                   bfloat16,
                    int64_t) {}
 #endif

--- a/python/paddle/fluid/tests/unittests/test_elementwise_pow_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_pow_op.py
@@ -311,9 +311,9 @@ class TestElementwisePowOpFP16(OpTest):
 
     def test_check_output(self):
         if hasattr(self, 'attrs'):
-            self.check_output(check_eager=False, atol=1e-3)
+            self.check_output(check_eager=False)
         else:
-            self.check_output(check_eager=True, atol=1e-3)
+            self.check_output(check_eager=True)
 
     def test_check_grad(self):
         self.check_grad(
@@ -324,7 +324,6 @@ class TestElementwisePowOpFP16(OpTest):
             ),
             check_eager=True,
             check_prim=True,
-            max_relative_error=1e-2,
         )
 
 
@@ -345,14 +344,12 @@ class TestElementwisePowBF16Op(OpTest):
 
     def test_check_output(self):
         if hasattr(self, 'attrs'):
-            self.check_output(check_eager=False, atol=0.01)
+            self.check_output(check_eager=False)
         else:
-            self.check_output(check_eager=True, atol=0.01)
+            self.check_output(check_eager=True)
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X', 'Y'], 'Out', check_eager=True, max_relative_error=1e-2
-        )
+        self.check_grad(['X', 'Y'], 'Out', check_eager=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
OPs

### Describe

Add bfloat16 support (on CPU, GPU, and XPU devices) for the `elementwise_pow` operator. The unittest cases get updated, too.
