### PR TITLE
fix dtype checking for softmax

### DIFF
--- a/python/paddle/nn/functional/activation.py
+++ b/python/paddle/nn/functional/activation.py
@@ -1110,15 +1110,15 @@ def softmax(x, axis=-1, dtype=None, name=None):
         use_cudnn = True
         if dtype is None:
             check_variable_and_dtype(
-                x, 'x', ['float16', 'float32', 'float64'], 'softmax'
+                x, 'x', ['float16', 'bfloat16', 'float32', 'float64'], 'softmax'
             )
         else:
             check_dtype(
                 dtype,
                 'dtype',
-                ['float32', 'float64'],
+                ['float16', 'bfloat16', 'float32', 'float64'],
                 'softmax',
-                'If dtype is not None, it only support float32 or float64.',
+                'If dtype is not None, it only support float16, bfloat16, float32 or float64.',
             )
 
         helper = LayerHelper("softmax", **locals())

--- a/python/paddle/nn/layer/activation.py
+++ b/python/paddle/nn/layer/activation.py
@@ -1324,7 +1324,7 @@ class Softmax(Layer):
         self._name = name
 
     def forward(self, x):
-        return F.softmax(x, self._axis, self._dtype, self._name)
+        return F.softmax(x, self._axis, name=self._name)
 
     def extra_repr(self):
         name_str = ', name={}'.format(self._name) if self._name else ''


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> APIs

### Describe
<!-- Describe what this PR does --> fix dtype checking for softmax

- 去掉nn.Softmax在调用softmax接口时对dtype参数的传递。原因：amp.decorate会将模型中所有layer的dtype设置为fp16，主要是为了转换参数类型。但是在amp中softmax在o1下默认要用fp32类型计算，如果传递了dtype将会导致在softmax调用时将输入转换为fp16类型，背离预期。
- dtype的检查增加float16和bfloat16的支持，算子底层已实现。
