### PR TITLE
[CodeStyle][C404] Unnecessary list comprehension (rewrite as a dict comprehension)

### DIFF
--- a/python/paddle/distributed/passes/auto_parallel_sharding.py
+++ b/python/paddle/distributed/passes/auto_parallel_sharding.py
@@ -1790,7 +1790,7 @@ def group_param(sharding_info, fuse_size):
 class ShardingInfo:
     def __init__(self, group, rank, params_grads, partition_algor):
         self.group = group
-        self.params_grads = dict([(p.name, (p, g)) for p, g in params_grads])
+        self.params_grads = {p.name: (p, g) for p, g in params_grads}
         assert len(self.params_grads) == len(
             set(self.params_grads)
         ), "found duplicated param in params_grads"

--- a/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
+++ b/python/paddle/fluid/tests/unittests/distributed_fused_lamb_test_base.py
@@ -231,9 +231,7 @@ def run_model(use_distributed_lamb, use_fp16, use_master_param_norm, **kwargs):
 
     def reader():
         for _ in range(6):
-            yield dict(
-                [(grad.name, gen_random_grad_tensor(grad)) for grad in grads]
-            )
+            yield {grad.name: gen_random_grad_tensor(grad) for grad in grads}
 
     scope = paddle.static.Scope()
     fetch_list = params


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Unnecessary list comprehension (rewrite as a dict comprehension)
According to https://beta.ruff.rs/docs/rules/unnecessary-generator-set/ and https://pypi.org/project/flake8-comprehensions/
C404 : Unnecessary list comprehension - rewrite as a dict comprehension.

So we can rewrite dict([(x, f(x)) for x in foo]) as {x: f(x) for x in foo}

Timing use:
``` python
>>>from timeit import timeit
>>>timeit("dict([(x,x*2) for x in range(1,100)])")
9.798447493463755
>>>timeit("{x:x*2 for x in range(1,100)}")
5.622418139129877

>>>time(dict([(x,x*2) for x in range(1,100)]))
CPU times: user 27 µs, sys: 0 ns, total: 27 µs
Wall time: 31.5 µs
>>>time({x:x*2 for x in range(1,100)})
CPU times: user 15 µs, sys: 0 ns, total: 15 µs
Wall time: 19.6 µs
```

Changed 2 files, 2 places, and no semantic or syntax error. The conclusions are as follows：
using rule：✅ 
auto fix：✅

command as follow：
```bash
# install ruff 0.0.254
pip install ruff==0.0.254
# using command to auto fix:
ruff --select C404 . --fix
```