### PR TITLE
[Perf] remove sync_calc_stream and sync_comm_stream

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/raw_program_optimizer.py
@@ -408,12 +408,12 @@ class RawProgramOptimizer(MetaOptimizerBase):
                 while block.ops[idx].type != 'c_allreduce_sum':
                     idx += 1
                 grad_segment, param_segment = grad_param_segments[i]
-                for param in param_segment:
+                for grad in grad_segment:
                     block._insert_op_without_sync(
                         idx + 1,
                         type='depend',
-                        inputs={'X': param, 'Dep': fused_var},
-                        outputs={'Out': param},
+                        inputs={'X': grad, 'Dep': fused_var},
+                        outputs={'Out': grad},
                     )
                     idx += 1
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
@@ -110,6 +110,7 @@ class TestFleetMetaOptimizerPrecision(TestDistRunnerBase):
             fleet.init(role)
             strategy = paddle.distributed.fleet.DistributedStrategy()
             strategy.without_graph_optimization = True
+            strategy.fuse_all_reduce_ops = False
             optimizer = fleet.distributed_optimizer(
                 optimizer, strategy=strategy
             )

--- a/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_raw_program_optimizer.py
@@ -110,7 +110,6 @@ class TestFleetMetaOptimizerPrecision(TestDistRunnerBase):
             fleet.init(role)
             strategy = paddle.distributed.fleet.DistributedStrategy()
             strategy.without_graph_optimization = True
-            strategy.fuse_all_reduce_ops = False
             optimizer = fleet.distributed_optimizer(
                 optimizer, strategy=strategy
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
PR #50719 导致静态图ResNet多卡性能下降20%。
![image](https://user-images.githubusercontent.com/14904151/226856164-1773188b-968a-41d6-9283-b821ff1e5d4b.png)
原因是`RawProgramOptimizer`会插入两类同步Op:
1. `c_sync_calc_stream`：导致计算流和通信流不能overlap，通信堵塞在所有的计算kernel完成后执行
2. `c_sync_sync_stream`：导致多个step之间不能overlap，必须一个step的所有Op执行完后才会开始执行下一个Step

使用`StandaloneExecutor`执行默认会为`c_allreduce_sum`插入`cudaEvent`确保数据依赖，因此没有必要保留这两类同步Op。有以下两个例外场景：
1. 开启了fuse策略：此时新执行器可以确保`c_allreduce_sum`与反向计算kernel之间的同步关系，但是不能确保`c_allreduce_sum`与优化器Op之间的关系，此时需要插入额外的`depend` Op，更详细的解释可以参考`StreamAnalyzer::AnalyseEventInfoForTwoInstructions`中的注释。
2. 开启了`graident_merge`策略：此时优化器Op会有一个子block，在子block中进行反向计算，由于新执行器的依赖分析目前还不支持跨多个block，因此保留这种场景下的同步Op。

目前针对`PaddleNLP_gpt3_bs16_fp16_DP2-MP1-PP1_N1C2`对比了 `paddle2.4.2`和此PR的loss，如下图所示，收敛趋势略有diff，基本保持一致。
![loss](https://user-images.githubusercontent.com/14904151/228487704-cce18c31-7d29-4cb6-ad2b-a26a805985b8.png)

#### 可能风险
PR合入后，如果使用`core.Executor`执行`RawProgramOptimizer`优化后的`Program`，可能导致数据冲突，但`core.Executor`目前并非静态图执行的默认选项，预计影响有限。
#### Others
Card-68299