### PR TITLE
Support op check list and op skip in check_nan_inf_tools

### DIFF
--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -15,15 +15,78 @@
 #include "paddle/fluid/eager/nan_inf_utils.h"
 
 #include "paddle/fluid/framework/details/nan_inf_utils_detail.h"
+#include "paddle/fluid/framework/lod_tensor.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
 #include "paddle/phi/core/selected_rows.h"
 
+#include "paddle/phi/core/compat/convert_utils.h"
+DECLARE_int32(check_nan_inf_level);
 namespace egr {
 
+static std::once_flag dump_list_init_flag;
+
+static std::unordered_set<std::string>& nan_inf_check_op_list() {
+  static std::unordered_set<std::string> _check_op_list = {};
+  return _check_op_list;
+}
+
+static std::unordered_set<std::string>& nan_inf_skip_op_list() {
+  static std::unordered_set<std::string> _skip_op_list = {};
+  return _skip_op_list;
+}
+
+static void InitDumpListFormEnv() {
+  nan_inf_check_op_list();
+  nan_inf_skip_op_list();
+  const char* check_op_list = std::getenv("FLAGS_check_nan_inf_op_list");
+  const char* skip_op_list = std::getenv("FLAGS_skip_nan_inf_op_list");
+
+  if (check_op_list) {
+    std::stringstream ss(check_op_list);
+    std::string op_type;
+    LOG(INFO) << "Please set op list according to the "
+                 "paddle.amp.low_precision_op_list()";
+    while (std::getline(ss, op_type, ',')) {
+      nan_inf_check_op_list().emplace(op_type);
+    }
+  }
+
+  if (skip_op_list) {
+    std::stringstream ss(skip_op_list);
+    std::string op_type;
+    LOG(INFO) << "Please set op list according to the "
+                 "paddle.amp.low_precision_op_list()";
+    while (std::getline(ss, op_type, ',')) {
+      nan_inf_skip_op_list().emplace(op_type);
+    }
+  }
+
+  for (auto const& key : nan_inf_check_op_list()) {
+    if (nan_inf_skip_op_list().count(key) != 0) {
+      LOG(INFO) << "Check nan inf op list: " << key;
+    }
+  }
+}
+bool CheckOp(const std::string& api_name) {
+  if (nan_inf_skip_op_list().count("all") ||
+      nan_inf_skip_op_list().count(api_name)) {
+    return false;
+  }
+
+  if (nan_inf_check_op_list().count("all") ||
+      nan_inf_check_op_list().count(api_name)) {
+    return true;
+  }
+
+  return true;
+}
+
 void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
-  if (tensor.initialized()) {
+  std::call_once(dump_list_init_flag, InitDumpListFormEnv);
+  auto op_name = phi::TransToFluidOpName(api_name);
+  if (tensor.initialized() && CheckOp(op_name)) {
     auto& tensor_name = tensor.name();
     const phi::DenseTensor* dense_tensor{nullptr};
     if (tensor.is_dense_tensor()) {
@@ -34,6 +97,31 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
     } else {
       VLOG(10) << "Only DenseTensor or SelectedRows need to check, "
                << tensor_name << " is no need.";
+      return;
+    }
+
+    // dump data
+    if (FLAGS_check_nan_inf_level == 4) {
+      auto dir_path = paddle::framework::details::GetNanPath();
+      std::string adr_name = paddle::string::Sprintf("%d", tensor.impl());
+      std::string folder_path = dir_path + "tensor_dump/";
+      std::string mkdir_cmd = "mkdir -p " + folder_path;
+      PADDLE_ENFORCE_EQ(system(mkdir_cmd.c_str()),
+                        0,
+                        paddle::platform::errors::NotFound(
+                            "Cannot create folder %s", folder_path));
+
+      std::string str_file_name = folder_path + api_name + "_" + adr_name;
+      std::ofstream fout(str_file_name, std::ios::out | std::ios::binary);
+
+      PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
+                        true,
+                        paddle::platform::errors::Unavailable(
+                            "Cannot open %s to save tensor.", str_file_name));
+
+      VLOG(4) << "The Dump file path is " << str_file_name;
+      paddle::framework::SerializeToStream(fout, *dense_tensor);
+      fout.close();
       return;
     }
 

--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -40,8 +40,8 @@ static std::unordered_set<std::string>& nan_inf_skip_op_list() {
 static void InitDumpListFormEnv() {
   nan_inf_check_op_list();
   nan_inf_skip_op_list();
-  const char* check_op_list = std::getenv("FLAGS_check_nan_inf_op_list");
-  const char* skip_op_list = std::getenv("FLAGS_skip_nan_inf_op_list");
+  const char* check_op_list = std::getenv("Paddle_check_nan_inf_op_list");
+  const char* skip_op_list = std::getenv("Paddle_skip_nan_inf_op_list");
 
   if (check_op_list) {
     std::stringstream ss(check_op_list);

--- a/paddle/fluid/eager/nan_inf_utils.cc
+++ b/paddle/fluid/eager/nan_inf_utils.cc
@@ -15,7 +15,6 @@
 #include "paddle/fluid/eager/nan_inf_utils.h"
 
 #include "paddle/fluid/framework/details/nan_inf_utils_detail.h"
-#include "paddle/fluid/framework/lod_tensor.h"
 #include "paddle/phi/backends/cpu/cpu_context.h"
 #include "paddle/phi/backends/gpu/gpu_context.h"
 #include "paddle/phi/core/dense_tensor.h"
@@ -103,31 +102,6 @@ void CheckTensorHasNanOrInf(const std::string& api_name, const Tensor& tensor) {
     } else {
       VLOG(10) << "Only DenseTensor or SelectedRows need to check, "
                << tensor_name << " is no need.";
-      return;
-    }
-
-    // dump data
-    if (FLAGS_check_nan_inf_level == 4) {
-      auto dir_path = paddle::framework::details::GetNanPath();
-      std::string adr_name = paddle::string::Sprintf("%d", tensor.impl());
-      std::string folder_path = dir_path + "tensor_dump/";
-      std::string mkdir_cmd = "mkdir -p " + folder_path;
-      PADDLE_ENFORCE_EQ(system(mkdir_cmd.c_str()),
-                        0,
-                        paddle::platform::errors::NotFound(
-                            "Cannot create folder %s", folder_path));
-
-      std::string str_file_name = folder_path + api_name + "_" + adr_name;
-      std::ofstream fout(str_file_name, std::ios::out | std::ios::binary);
-
-      PADDLE_ENFORCE_EQ(static_cast<bool>(fout),
-                        true,
-                        paddle::platform::errors::Unavailable(
-                            "Cannot open %s to save tensor.", str_file_name));
-
-      VLOG(4) << "The dump file's path is " << str_file_name;
-      paddle::framework::SerializeToStream(fout, *dense_tensor);
-      fout.close();
       return;
     }
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -197,6 +197,7 @@ limitations under the License. */
 #endif
 
 #include "paddle/fluid/eager/api/utils/global_utils.h"
+#include "paddle/fluid/eager/nan_inf_utils.h"
 #include "paddle/fluid/imperative/layout_autotune.h"
 #include "paddle/fluid/prim/utils/eager/eager_tensor_operants.h"
 #include "paddle/fluid/prim/utils/static/static_tensor_operants.h"
@@ -2852,6 +2853,12 @@ All parameter, weight, gradient are variables in Paddle.
   // Add the api for nan op debug
   m.def("set_nan_inf_debug_path",
         &paddle::framework::details::SetNanInfDebugPath);
+
+  m.def("check_numerics",
+        [](const std::string &op_name, const paddle::Tensor &tensor) {
+          VLOG(4) << "Check tensor whether has nan or inf.";
+          egr::CheckTensorHasNanOrInf(op_name, tensor);
+        });
 
   BindFleetWrapper(&m);
   BindIO(&m);

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -43,8 +43,8 @@ class TestNanInf(unittest.TestCase):
         out, err = proc.communicate()
         returncode = proc.returncode
 
-        # print(out)
-        # print(err)
+        print(out)
+        print(err)
 
         # in python3, type(out+err) is 'bytes', need use encode
         assert (out + err).find('There are NAN or INF'.encode()) != -1
@@ -75,8 +75,8 @@ class TestCheckSkipEnv(TestNanInf):
         super().setUp()
         # windows python have some bug with env, so need use str to pass ci
         # otherwise, "TypeError: environment can only contain strings"
-        self.env[str("Paddle_check_nan_inf_op_list")] = str("mean")
-        self.env[str("Paddle_skip_nan_inf_op_list")] = str("elementwise_add")
+        self.env["Paddle_check_nan_inf_op_list"] = "mean"
+        self.env["Paddle_skip_nan_inf_op_list"] = "elementwise_add"
 
 
 class TestNanInfCheckResult(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -75,6 +75,7 @@ class TestCheckSkipEnv(TestNanInf):
         super().setUp()
         # windows python have some bug with env, so need use str to pass ci
         # otherwise, "TypeError: environment can only contain strings"
+
         self.env[str("Paddle_check_nan_inf_op_list")] = str("mean")
         self.env[str("Paddle_skip_nan_inf_op_list")] = str("elementwise_add")
 

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -43,8 +43,8 @@ class TestNanInf(unittest.TestCase):
         out, err = proc.communicate()
         returncode = proc.returncode
 
-        print(out)
-        print(err)
+        # print(out)
+        # print(err)
 
         # in python3, type(out+err) is 'bytes', need use encode
         assert (out + err).find('There are NAN or INF'.encode()) != -1
@@ -73,12 +73,9 @@ class TestNanInfEnv(TestNanInf):
 class TestCheckSkipEnv(TestNanInf):
     def setUp(self):
         super().setUp()
-        paddle.set_flags(
-            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 3}
-        )
         # windows python have some bug with env, so need use str to pass ci
         # otherwise, "TypeError: environment can only contain strings"
-        self.env[str("Paddle_check_nan_inf_op_list")] = str("elementwise_mul")
+        self.env[str("Paddle_check_nan_inf_op_list")] = str("mean")
         self.env[str("Paddle_skip_nan_inf_op_list")] = str("elementwise_add")
 
 

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -75,7 +75,6 @@ class TestCheckSkipEnv(TestNanInf):
         super().setUp()
         # windows python have some bug with env, so need use str to pass ci
         # otherwise, "TypeError: environment can only contain strings"
-
         self.env[str("Paddle_check_nan_inf_op_list")] = str("mean")
         self.env[str("Paddle_skip_nan_inf_op_list")] = str("elementwise_add")
 

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -170,13 +170,6 @@ class TestNanInfCheckResult(unittest.TestCase):
         if paddle.fluid.core.is_compiled_with_cuda():
             self.check_nan_inf_level(use_cuda=True, dtype="float16")
 
-    def test_check_nan_inf_level_for_dump(self):
-        paddle.set_flags(
-            {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 4}
-        )
-        if paddle.fluid.core.is_compiled_with_cuda():
-            self.check_nan_inf_level(use_cuda=True, dtype="float16")
-
     def test_check_numerics(self):
         paddle.set_flags(
             {"FLAGS_check_nan_inf": 1, "FLAGS_check_nan_inf_level": 3}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

+ 添加 Paddle_check_nan_inf_op_list环境变量和Paddle_skip_nan_inf_op_list 环境变量

环境变量说明：
Paddle_skip_nan_inf_op_list 用于设置在check_nan_inf检查时需要跳过的算子名称，当设置为"all"时，表示跳过所有算子检查。在设置算子名称时需参考paddle.amp.get_low_precision_op_list()API中返回的算子名称，保证算子设置有效
     设置方法：export Paddle_skip_nan_inf_op_list="all"; export Paddle_skip_nan_inf_op_list="elementwise_add",


Paddle_check_nan_inf_op_list 用于设置在check_nan_inf检查时需要检查的算子名称，当设置为"all"时，表示所有检查算子。在设置算子名称时需参考paddle.amp.get_low_precision_op_list()API中返回的算子名称，保证算子设置有效
     设置方法：export Paddle_check_nan_inf_op_list="all"; export Paddle_check_nan_inf_op_list="elementwise_add",

优先级说明：
Paddle_skip_nan_inf_op_list 优先级高于Paddle_check_nan_inf_op_list， 当算子被加入到Paddle_skip_nan_inf_op_list后将直接跳过该算子的nan_inf检查。
当算子不在Paddle_skip_nan_inf_op_list 且存在于Paddle_check_nan_inf_op_list时才对该算子进行nan_inf检查。

