### PR TITLE
Fix roll kernel gpu bug.

### DIFF
--- a/paddle/phi/kernels/gpu/roll_kernel_impl.h
+++ b/paddle/phi/kernels/gpu/roll_kernel_impl.h
@@ -39,7 +39,7 @@ __global__ void RollCudaKernel(const T* input,
 
 #pragma unroll
   for (size_t i = 0; i < Rank; i++) {
-    new_dim_idx = (idx / strides[i]) % sizes[i] + shifts[i];
+    new_dim_idx = (output_idx / strides[i]) % sizes[i] + shifts[i];
     if (new_dim_idx >= sizes[i]) {
       output_idx += (shifts[i] - sizes[i]) * strides[i];
     } else {

--- a/python/paddle/fluid/tests/unittests/test_roll_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roll_op.py
@@ -64,7 +64,7 @@ class TestRollOpCase2(TestRollOp):
 class TestRollOpCase3(TestRollOp):
     def init_dtype_type(self):
         self.dtype = np.float32
-        self.x_shape = (10, 10)
+        self.x_shape = (11, 11)
         self.shifts = [1, 1]
         self.axis = [-1, 1]
 
@@ -88,7 +88,7 @@ class TestRollFP16OpCase2(TestRollOp):
 class TestRollFP16OpCase3(TestRollOp):
     def init_dtype_type(self):
         self.dtype = np.float16
-        self.x_shape = (10, 10)
+        self.x_shape = (11, 11)
         self.shifts = [1, 1]
         self.axis = [-1, 1]
 
@@ -141,7 +141,7 @@ class TestRollBF16OpCase2(TestRollOp):
 class TestRollBF16OpCase3(TestRollOp):
     def init_dtype_type(self):
         self.dtype = np.uint16
-        self.x_shape = (10, 10)
+        self.x_shape = (11, 11)
         self.shifts = [1, 1]
         self.axis = [-1, 1]
         self.place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_roll_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roll_op.py
@@ -61,6 +61,14 @@ class TestRollOpCase2(TestRollOp):
         self.axis = [-1, -2]
 
 
+class TestRollOpCase3(TestRollOp):
+    def init_dtype_type(self):
+        self.dtype = np.float32
+        self.x_shape = (3, 2)
+        self.shifts = [1, 1]
+        self.axis = [-1, 1]
+
+
 class TestRollFP16OP(TestRollOp):
     def init_dtype_type(self):
         self.dtype = np.float16
@@ -75,6 +83,14 @@ class TestRollFP16OpCase2(TestRollOp):
         self.x_shape = (100, 10, 5)
         self.shifts = [8, -1]
         self.axis = [-1, -2]
+
+
+class TestRollFP16OpCase3(TestRollOp):
+    def init_dtype_type(self):
+        self.dtype = np.float16
+        self.x_shape = (3, 2)
+        self.shifts = [1, 1]
+        self.axis = [-1, 1]
 
 
 @unittest.skipIf(
@@ -108,6 +124,26 @@ class TestRollBF16OpCase2(TestRollOp):
         self.x_shape = (10, 5, 5)
         self.shifts = [8, -1]
         self.axis = [-1, -2]
+        self.place = core.CUDAPlace(0)
+
+    def test_check_output(self):
+        self.check_output_with_place(self.place, check_eager=True)
+
+    def test_check_grad_normal(self):
+        self.check_grad_with_place(self.place, ['X'], 'Out', check_eager=True)
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestRollBF16OpCase3(TestRollOp):
+    def init_dtype_type(self):
+        self.dtype = np.uint16
+        self.x_shape = (3, 2)
+        self.shifts = [1, 1]
+        self.axis = [-1, 1]
         self.place = core.CUDAPlace(0)
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/test_roll_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roll_op.py
@@ -64,7 +64,7 @@ class TestRollOpCase2(TestRollOp):
 class TestRollOpCase3(TestRollOp):
     def init_dtype_type(self):
         self.dtype = np.float32
-        self.x_shape = (3, 2)
+        self.x_shape = (10, 10)
         self.shifts = [1, 1]
         self.axis = [-1, 1]
 
@@ -88,7 +88,7 @@ class TestRollFP16OpCase2(TestRollOp):
 class TestRollFP16OpCase3(TestRollOp):
     def init_dtype_type(self):
         self.dtype = np.float16
-        self.x_shape = (3, 2)
+        self.x_shape = (10, 10)
         self.shifts = [1, 1]
         self.axis = [-1, 1]
 
@@ -141,7 +141,7 @@ class TestRollBF16OpCase2(TestRollOp):
 class TestRollBF16OpCase3(TestRollOp):
     def init_dtype_type(self):
         self.dtype = np.uint16
-        self.x_shape = (3, 2)
+        self.x_shape = (10, 10)
         self.shifts = [1, 1]
         self.axis = [-1, 1]
         self.place = core.CUDAPlace(0)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
Fix gpu roll kernel.
```python
import paddle
x = paddle.to_tensor([[1, 2, 3], [4, 5, 6]])
y = paddle.roll(x, shifts=[1, 1], axis=[1, 1])
```
Before this pr, the behavior of this sample code is undefined. This pr fix this problem.
