### PR TITLE
[AMP OP&Test] Add float16 OpTest for squeeze, unsqueeze 

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_squeeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squeeze_op.py
@@ -53,6 +53,31 @@ class TestSqueezeOp(OpTest):
         self.attrs = {"axes": self.axes}
 
 
+class TestSqueezeFP16Op(OpTest):
+    def setUp(self):
+        self.op_type = "squeeze"
+        self.init_test_case()
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float16")}
+        self.init_attrs()
+        self.outputs = {
+            "Out": self.inputs["X"].reshape(self.new_shape),
+        }
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        self.check_grad(["X"], "Out")
+
+    def init_test_case(self):
+        self.ori_shape = (1, 3, 1, 40)
+        self.axes = (0, 2)
+        self.new_shape = (3, 40)
+
+    def init_attrs(self):
+        self.attrs = {"axes": self.axes}
+
+
 class TestSqueezeBF16Op(OpTest):
     def setUp(self):
         self.op_type = "squeeze"

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -59,38 +59,6 @@ class TestTransposeOp(OpTest):
         self.axis = (1, 0)
 
 
-class TestTransposeFP16Op(OpTest):
-    def setUp(self):
-        self.init_op_type()
-        self.initTestCase()
-        self.python_api = paddle.transpose
-        self.public_python_api = paddle.transpose
-        self.prim_op_type = "prim"
-        self.inputs = {'X': np.random.random(self.shape).astype("float16")}
-        self.attrs = {
-            'axis': list(self.axis),
-            'use_mkldnn': self.use_mkldnn,
-        }
-        self.outputs = {
-            'XShape': np.random.random(self.shape).astype("float16"),
-            'Out': self.inputs['X'].transpose(self.axis),
-        }
-
-    def init_op_type(self):
-        self.op_type = "transpose2"
-        self.use_mkldnn = False
-
-    def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
-
-    def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_prim=True)
-
-    def initTestCase(self):
-        self.shape = (3, 40)
-        self.axis = (1, 0)
-
-
 class TestCase0(TestTransposeOp):
     def initTestCase(self):
         self.shape = (100,)
@@ -211,42 +179,6 @@ class TestAutoTuneTransposeOp(OpTest):
         }
         self.outputs = {
             'XShape': np.random.random(self.shape).astype("float64"),
-            'Out': self.inputs['X'].transpose(self.axis),
-        }
-
-    def initTestCase(self):
-        fluid.core.set_autotune_range(0, 3)
-        fluid.core.update_autotune_status()
-        fluid.core.enable_autotune()
-        self.shape = (1, 12, 256, 1)
-        self.axis = (0, 3, 2, 1)
-
-    def init_op_type(self):
-        self.op_type = "transpose2"
-        self.use_mkldnn = False
-
-    def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
-        fluid.core.disable_autotune()
-
-    def test_check_grad(self):
-        self.check_grad(['X'], 'Out', check_prim=True)
-
-
-class TestAutoTuneTransposeFP16Op(OpTest):
-    def setUp(self):
-        self.init_op_type()
-        self.initTestCase()
-        self.python_api = paddle.transpose
-        self.public_python_api = paddle.transpose
-        self.prim_op_type = "prim"
-        self.inputs = {'X': np.random.random(self.shape).astype("float16")}
-        self.attrs = {
-            'axis': list(self.axis),
-            'use_mkldnn': self.use_mkldnn,
-        }
-        self.outputs = {
-            'XShape': np.random.random(self.shape).astype("float16"),
             'Out': self.inputs['X'].transpose(self.axis),
         }
 

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -59,6 +59,38 @@ class TestTransposeOp(OpTest):
         self.axis = (1, 0)
 
 
+class TestTransposeFP16Op(OpTest):
+    def setUp(self):
+        self.init_op_type()
+        self.initTestCase()
+        self.python_api = paddle.transpose
+        self.public_python_api = paddle.transpose
+        self.prim_op_type = "prim"
+        self.inputs = {'X': np.random.random(self.shape).astype("float16")}
+        self.attrs = {
+            'axis': list(self.axis),
+            'use_mkldnn': self.use_mkldnn,
+        }
+        self.outputs = {
+            'XShape': np.random.random(self.shape).astype("float16"),
+            'Out': self.inputs['X'].transpose(self.axis),
+        }
+
+    def init_op_type(self):
+        self.op_type = "transpose2"
+        self.use_mkldnn = False
+
+    def test_check_output(self):
+        self.check_output(no_check_set=['XShape'])
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out', check_prim=True)
+
+    def initTestCase(self):
+        self.shape = (3, 40)
+        self.axis = (1, 0)
+
+
 class TestCase0(TestTransposeOp):
     def initTestCase(self):
         self.shape = (100,)
@@ -179,6 +211,42 @@ class TestAutoTuneTransposeOp(OpTest):
         }
         self.outputs = {
             'XShape': np.random.random(self.shape).astype("float64"),
+            'Out': self.inputs['X'].transpose(self.axis),
+        }
+
+    def initTestCase(self):
+        fluid.core.set_autotune_range(0, 3)
+        fluid.core.update_autotune_status()
+        fluid.core.enable_autotune()
+        self.shape = (1, 12, 256, 1)
+        self.axis = (0, 3, 2, 1)
+
+    def init_op_type(self):
+        self.op_type = "transpose2"
+        self.use_mkldnn = False
+
+    def test_check_output(self):
+        self.check_output(no_check_set=['XShape'])
+        fluid.core.disable_autotune()
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out', check_prim=True)
+
+
+class TestAutoTuneTransposeFP16Op(OpTest):
+    def setUp(self):
+        self.init_op_type()
+        self.initTestCase()
+        self.python_api = paddle.transpose
+        self.public_python_api = paddle.transpose
+        self.prim_op_type = "prim"
+        self.inputs = {'X': np.random.random(self.shape).astype("float16")}
+        self.attrs = {
+            'axis': list(self.axis),
+            'use_mkldnn': self.use_mkldnn,
+        }
+        self.outputs = {
+            'XShape': np.random.random(self.shape).astype("float16"),
             'Out': self.inputs['X'].transpose(self.axis),
         }
 

--- a/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
@@ -50,6 +50,29 @@ class TestUnsqueezeOp(OpTest):
         self.attrs = {"axes": self.axes}
 
 
+class TestUnsqueezeFP16Op(OpTest):
+    def setUp(self):
+        self.init_test_case()
+        self.op_type = "unsqueeze"
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float16")}
+        self.init_attrs()
+        self.outputs = {"Out": self.inputs["X"].reshape(self.new_shape)}
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        self.check_grad(["X"], "Out")
+
+    def init_test_case(self):
+        self.ori_shape = (3, 40)
+        self.axes = (1, 2)
+        self.new_shape = (3, 1, 1, 40)
+
+    def init_attrs(self):
+        self.attrs = {"axes": self.axes}
+
+
 class TestUnsqueezeBF16Op(OpTest):
     def setUp(self):
         self.init_test_case()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

Others

### Describe
<!-- Describe what this PR does -->

为squeeze, unsqueeze op增加float16的OpTest