### PR TITLE
[AMP] add fp16&bf16 support for flatten op

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -329,16 +329,6 @@ class TestFlattenFP16Op_ZeroDim(TestFlattenOp_ZeroDim):
         self.dtype = "float16"
 
 
-@unittest.skipIf(
-    not core.is_compiled_with_cuda()
-    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
-    "core is not complied with CUDA and not support the bfloat16",
-)
-class TestFlattenBF16Op_ZeroDim(TestFlattenOp_ZeroDim):
-    def init_test_dtype(self):
-        self.dtype = "uint16"
-
-
 class TestFlattenOpSixDims(TestFlattenOp):
     def init_test_case(self):
         self.in_shape = (3, 2, 3, 2, 4, 4)

--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -44,10 +44,20 @@ class TestFlattenOp(OpTest):
         self.enable_cinn = True
 
     def test_check_output(self):
-        self.check_output(no_check_set=["XShape"], check_prim=True)
+        if str(self.dtype) in {"float16", "uint16"}:
+            self.check_output_with_place(
+                core.CUDAPlace(0), no_check_set=["XShape"], check_prim=True
+            )
+        else:
+            self.check_output(no_check_set=["XShape"], check_prim=True)
 
     def test_check_grad(self):
-        self.check_grad(["X"], "Out", check_prim=True)
+        if str(self.dtype) in {"float16", "uint16"}:
+            self.check_grad_with_place(
+                core.CUDAPlace(0), ["X"], "Out", check_prim=True
+            )
+        else:
+            self.check_grad(["X"], "Out", check_prim=True)
 
     def init_test_case(self):
         self.in_shape = (3, 2, 5, 4)
@@ -65,7 +75,10 @@ class TestFlattenOp(OpTest):
         self.dtype = "float64"
 
     def init_input_data(self):
-        self.inputs = {"X": np.random.random(self.in_shape).astype(self.dtype)}
+        x = np.random.random(self.in_shape).astype("float32")
+        if str(self.dtype) == "uint16":
+            x = convert_float_to_uint16(x)
+        self.inputs = {"X": x}
 
 
 class TestFlattenFP32Op(TestFlattenOp):
@@ -90,10 +103,6 @@ class TestFlattenFP16Op(TestFlattenOp):
 class TestFlattenBF16Op(TestFlattenOp):
     def init_test_dtype(self):
         self.dtype = "uint16"
-
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlattenOp_1(TestFlattenOp):
@@ -133,10 +142,6 @@ class TestFlattenBF16Op_1(TestFlattenOp_1):
     def init_test_dtype(self):
         self.dtype = "uint16"
 
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
-
 
 class TestFlattenOp_2(TestFlattenOp):
     def init_test_case(self):
@@ -174,10 +179,6 @@ class TestFlattenFP16Op_2(TestFlattenOp_2):
 class TestFlattenBF16Op_2(TestFlattenOp_2):
     def init_test_dtype(self):
         self.dtype = "uint16"
-
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlattenOp_3(TestFlattenOp):
@@ -217,10 +218,6 @@ class TestFlattenBF16Op_3(TestFlattenOp_3):
     def init_test_dtype(self):
         self.dtype = "uint16"
 
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
-
 
 class TestFlattenOp_4(TestFlattenOp):
     def init_test_case(self):
@@ -259,10 +256,6 @@ class TestFlattenBF16Op_4(TestFlattenOp_4):
     def init_test_dtype(self):
         self.dtype = "uint16"
 
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
-
 
 class TestFlattenOp_5(TestFlattenOp):
     def init_test_case(self):
@@ -300,10 +293,6 @@ class TestFlattenFP16Op_5(TestFlattenOp_5):
 class TestFlattenBF16Op_5(TestFlattenOp_5):
     def init_test_dtype(self):
         self.dtype = "uint16"
-
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlattenOp_6(TestFlattenOp):
@@ -346,10 +335,6 @@ class TestFlattenBF16Op_6(TestFlattenOp_6):
     def init_test_dtype(self):
         self.dtype = "uint16"
 
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
-
 
 class TestFlattenOpSixDims(TestFlattenOp):
     def init_test_case(self):
@@ -387,10 +372,6 @@ class TestFlattenFP16OpSixDims(TestFlattenOpSixDims):
 class TestFlattenBF16OpSixDims(TestFlattenOpSixDims):
     def init_test_dtype(self):
         self.dtype = "uint16"
-
-    def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlatten2OpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -15,9 +15,10 @@
 import unittest
 
 import numpy as np
-from eager_op_test import OpTest
+from eager_op_test import OpTest, convert_float_to_uint16
 
 import paddle
+from paddle.fluid import core
 
 
 class TestFlattenOp(OpTest):
@@ -31,7 +32,8 @@ class TestFlattenOp(OpTest):
         self.stop_axis = -1
         self.skip_cinn()
         self.init_test_case()
-        self.inputs = {"X": np.random.random(self.in_shape).astype("float64")}
+        self.init_test_dtype()
+        self.init_input_data()
         self.init_attrs()
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.new_shape),
@@ -59,6 +61,40 @@ class TestFlattenOp(OpTest):
             "stop_axis": self.stop_axis,
         }
 
+    def init_test_dtype(self):
+        self.dtype = "float64"
+
+    def init_input_data(self):
+        self.inputs = {"X": np.random.random(self.in_shape).astype(self.dtype)}
+
+
+class TestFlattenFP32Op(TestFlattenOp):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16Op(TestFlattenOp):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16Op(TestFlattenOp):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
+
 
 class TestFlattenOp_1(TestFlattenOp):
     def init_test_case(self):
@@ -72,6 +108,34 @@ class TestFlattenOp_1(TestFlattenOp):
             "start_axis": self.start_axis,
             "stop_axis": self.stop_axis,
         }
+
+
+class TestFlattenFP32Op_1(TestFlattenOp_1):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16Op_1(TestFlattenOp_1):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16Op_1(TestFlattenOp_1):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlattenOp_2(TestFlattenOp):
@@ -88,6 +152,34 @@ class TestFlattenOp_2(TestFlattenOp):
         }
 
 
+class TestFlattenFP32Op_2(TestFlattenOp_2):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16Op_2(TestFlattenOp_2):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16Op_2(TestFlattenOp_2):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
+
+
 class TestFlattenOp_3(TestFlattenOp):
     def init_test_case(self):
         self.in_shape = (3, 2, 5, 4)
@@ -100,6 +192,34 @@ class TestFlattenOp_3(TestFlattenOp):
             "start_axis": self.start_axis,
             "stop_axis": self.stop_axis,
         }
+
+
+class TestFlattenFP32Op_3(TestFlattenOp_3):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16Op_3(TestFlattenOp_3):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16Op_3(TestFlattenOp_3):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlattenOp_4(TestFlattenOp):
@@ -116,6 +236,34 @@ class TestFlattenOp_4(TestFlattenOp):
         }
 
 
+class TestFlattenFP32Op_4(TestFlattenOp_4):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16Op_4(TestFlattenOp_4):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16Op_4(TestFlattenOp_4):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
+
+
 class TestFlattenOp_5(TestFlattenOp):
     def init_test_case(self):
         self.in_shape = (3, 2, 5, 4)
@@ -128,6 +276,34 @@ class TestFlattenOp_5(TestFlattenOp):
             "start_axis": self.start_axis,
             "stop_axis": self.stop_axis,
         }
+
+
+class TestFlattenFP32Op_5(TestFlattenOp_5):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16Op_5(TestFlattenOp_5):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16Op_5(TestFlattenOp_5):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlattenOp_6(TestFlattenOp):
@@ -147,6 +323,34 @@ class TestFlattenOp_6(TestFlattenOp):
         }
 
 
+class TestFlattenFP32Op_6(TestFlattenOp_6):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16Op_6(TestFlattenOp_6):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16Op_6(TestFlattenOp_6):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
+
+
 class TestFlattenOpSixDims(TestFlattenOp):
     def init_test_case(self):
         self.in_shape = (3, 2, 3, 2, 4, 4)
@@ -159,6 +363,34 @@ class TestFlattenOpSixDims(TestFlattenOp):
             "start_axis": self.start_axis,
             "stop_axis": self.stop_axis,
         }
+
+
+class TestFlattenFP32OpSixDims(TestFlattenOpSixDims):
+    def init_test_dtype(self):
+        self.dtype = "float32"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda(),
+    "core is not complied with CUDA",
+)
+class TestFlattenFP16OpSixDims(TestFlattenOpSixDims):
+    def init_test_dtype(self):
+        self.dtype = "float16"
+
+
+@unittest.skipIf(
+    not core.is_compiled_with_cuda()
+    or not core.is_bfloat16_supported(core.CUDAPlace(0)),
+    "core is not complied with CUDA and not support the bfloat16",
+)
+class TestFlattenBF16OpSixDims(TestFlattenOpSixDims):
+    def init_test_dtype(self):
+        self.dtype = "uint16"
+
+    def init_input_data(self):
+        x = np.random.random(self.in_shape).astype("float32")
+        self.inputs = {"X": convert_float_to_uint16(x)}
 
 
 class TestFlatten2OpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_contiguous_range_op.py
@@ -75,9 +75,12 @@ class TestFlattenOp(OpTest):
         self.dtype = "float64"
 
     def init_input_data(self):
-        x = np.random.random(self.in_shape).astype("float32")
-        if str(self.dtype) == "uint16":
+        if str(self.dtype) != "uint16":
+            x = np.random.random(self.in_shape).astype(self.dtype)
+        else:
+            x = np.random.random(self.in_shape).astype("float32")
             x = convert_float_to_uint16(x)
+
         self.inputs = {"X": x}
 
 
@@ -295,7 +298,7 @@ class TestFlattenBF16Op_5(TestFlattenOp_5):
         self.dtype = "uint16"
 
 
-class TestFlattenOp_6(TestFlattenOp):
+class TestFlattenOp_ZeroDim(TestFlattenOp):
     def init_test_case(self):
         self.in_shape = tuple()
         self.start_axis = 0
@@ -312,7 +315,7 @@ class TestFlattenOp_6(TestFlattenOp):
         }
 
 
-class TestFlattenFP32Op_6(TestFlattenOp_6):
+class TestFlattenFP32Op_ZeroDim(TestFlattenOp_ZeroDim):
     def init_test_dtype(self):
         self.dtype = "float32"
 
@@ -321,7 +324,7 @@ class TestFlattenFP32Op_6(TestFlattenOp_6):
     not core.is_compiled_with_cuda(),
     "core is not complied with CUDA",
 )
-class TestFlattenFP16Op_6(TestFlattenOp_6):
+class TestFlattenFP16Op_ZeroDim(TestFlattenOp_ZeroDim):
     def init_test_dtype(self):
         self.dtype = "float16"
 
@@ -331,7 +334,7 @@ class TestFlattenFP16Op_6(TestFlattenOp_6):
     or not core.is_bfloat16_supported(core.CUDAPlace(0)),
     "core is not complied with CUDA and not support the bfloat16",
 )
-class TestFlattenBF16Op_6(TestFlattenOp_6):
+class TestFlattenBF16Op_ZeroDim(TestFlattenOp_ZeroDim):
     def init_test_dtype(self):
         self.dtype = "uint16"
 

--- a/python/paddle/fluid/tests/unittests/white_list/op_accuracy_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_accuracy_white_list.py
@@ -31,6 +31,7 @@ NO_FP64_CHECK_GRAD_OP_LIST = [
     'depthwise_conv2d',
     'depthwise_conv2d_transpose',
     'dropout',
+    'flatten_contiguous_range',
     'fused_elemwise_activation',
     'hinge_loss',
     'huber_loss',

--- a/python/paddle/fluid/tests/unittests/white_list/op_accuracy_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_accuracy_white_list.py
@@ -31,7 +31,6 @@ NO_FP64_CHECK_GRAD_OP_LIST = [
     'depthwise_conv2d',
     'depthwise_conv2d_transpose',
     'dropout',
-    'flatten_contiguous_range',
     'fused_elemwise_activation',
     'hinge_loss',
     'huber_loss',

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1591,6 +1591,7 @@ def flatten(x, start_axis=0, stop_axis=-1, name=None):
                 'int32',
                 'int64',
                 'uint8',
+                'uint16',
             ],
             'flatten',
         )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
为flatten算子单测添加`float16 & bfloat16`类型的测试.