### PR TITLE
[CustomOP Inplace] Automap inplace dtype and shape, prepare for vector<Tensor> output

### DIFF
--- a/paddle/phi/api/ext/op_meta_info.h
+++ b/paddle/phi/api/ext/op_meta_info.h
@@ -672,6 +672,7 @@ class PADDLE_API OpMetaInfo {
   std::vector<std::string> outputs_;
   std::vector<std::string> attrs_;
   std::unordered_map<std::string, std::string> inplace_map_;
+  std::unordered_map<std::string, std::string> inplace_reverse_map_;
   // 2. func info
   KernelFunc kernel_fn_{nullptr};
   InferShapeFunc infer_shape_fn_{nullptr};
@@ -699,6 +700,10 @@ class OpMetaInfoHelper {
   static const std::unordered_map<std::string, std::string>& GetInplaceMap(
       const paddle::OpMetaInfo& info) {
     return info.inplace_map_;
+  }
+  static const std::unordered_map<std::string, std::string>&
+  GetInplaceReverseMap(const paddle::OpMetaInfo& info) {
+    return info.inplace_reverse_map_;
   }
   static const KernelFunc& GetKernelFn(const paddle::OpMetaInfo& info) {
     return info.kernel_fn_;

--- a/paddle/phi/api/lib/op_meta_info.cc
+++ b/paddle/phi/api/lib/op_meta_info.cc
@@ -215,6 +215,9 @@ OpMetaInfo& OpMetaInfo::SetInplaceMap(
     std::unordered_map<std::string, std::string>&& inplace_map) {
   inplace_map_ =
       std::forward<std::unordered_map<std::string, std::string>>(inplace_map);
+  for (const auto& pair : inplace_map_) {
+    inplace_reverse_map_[pair.second] = pair.first;
+  }
   return *this;
 }
 OpMetaInfo& OpMetaInfo::SetKernelFn(KernelFunc&& func) {

--- a/python/paddle/fluid/tests/custom_op/custom_inplace.cc
+++ b/python/paddle/fluid/tests/custom_op/custom_inplace.cc
@@ -106,22 +106,6 @@ void MultiInplaceForward(paddle::Tensor& x,  // NOLINT
       }));
 }
 
-std::vector<paddle::DataType> MultiInplaceInferDtype(
-    const paddle::DataType& x_dtype,
-    const paddle::DataType& y_dtype,
-    const paddle::DataType& a_dtype,
-    const paddle::DataType& b_dtype) {
-  return {x_dtype, a_dtype};
-}
-
-std::vector<std::vector<int64_t>> MultiInplaceInferShape(
-    const std::vector<int64_t>& x_shape,
-    const std::vector<int64_t>& y_shape,
-    const std::vector<int64_t>& a_shape,
-    const std::vector<int64_t>& b_shape) {
-  return {x_shape, a_shape};
-}
-
 std::vector<paddle::Tensor> MultiInplaceBackward(
     const paddle::Tensor& x,
     const paddle::Tensor& y,
@@ -154,9 +138,7 @@ PD_BUILD_OP(custom_multi_inplace)
     .Inputs({"X", "Y", "A", "B"})
     .Outputs({"OutXY", "OutAB"})
     .SetInplaceMap({{"X", "OutXY"}, {"A", "OutAB"}})
-    .SetKernelFn(PD_KERNEL(MultiInplaceForward))
-    .SetInferShapeFn(PD_INFER_SHAPE(MultiInplaceInferShape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(MultiInplaceInferDtype));
+    .SetKernelFn(PD_KERNEL(MultiInplaceForward));
 
 PD_BUILD_GRAD_OP(custom_multi_inplace)
     .Inputs({"X", "Y", paddle::Grad("OutXY"), "A", "B", paddle::Grad("OutAB")})

--- a/python/paddle/fluid/tests/custom_op/custom_inplace.cc
+++ b/python/paddle/fluid/tests/custom_op/custom_inplace.cc
@@ -61,16 +61,6 @@ void AddForward(paddle::Tensor& x, const paddle::Tensor& y) {  // NOLINT
                              }));
 }
 
-std::vector<paddle::DataType> AddInferDtype(const paddle::DataType& x_dtype,
-                                            const paddle::DataType& y_dtype) {
-  return {x_dtype};
-}
-
-std::vector<std::vector<int64_t>> AddInferShape(
-    const std::vector<int64_t>& x_shape, const std::vector<int64_t>& y_shape) {
-  return {x_shape};
-}
-
 std::vector<paddle::Tensor> AddBackward(const paddle::Tensor& x,
                                         const paddle::Tensor& y,
                                         paddle::Tensor& out_grad) {  // NOLINT
@@ -92,9 +82,7 @@ PD_BUILD_OP(custom_add)
     .Inputs({"X", "Y"})
     .Outputs({"Out"})
     .SetInplaceMap({{"X", "Out"}})
-    .SetKernelFn(PD_KERNEL(AddForward))
-    .SetInferShapeFn(PD_INFER_SHAPE(AddInferShape))
-    .SetInferDtypeFn(PD_INFER_DTYPE(AddInferDtype));
+    .SetKernelFn(PD_KERNEL(AddForward));
 
 PD_BUILD_GRAD_OP(custom_add)
     .Inputs({"X", "Y", paddle::Grad("Out")})

--- a/python/paddle/fluid/tests/custom_op/test_custom_inplace.py
+++ b/python/paddle/fluid/tests/custom_op/test_custom_inplace.py
@@ -88,7 +88,7 @@ def inplace_static_add(func, device, dtype, np_x, np_y):
     return x_v, out_v, x_grad_v, y_grad_v, out_grad_v
 
 
-def inplace_dynamic_relu(phi_func, device, dtype, np_x, np_y, np_z):
+def inplace_dynamic_relu_net(phi_func, device, dtype, np_x, np_y, np_z):
     paddle.set_device(device)
     x = paddle.to_tensor(np_x, dtype=dtype, stop_gradient=False)
     y = paddle.to_tensor(np_y, dtype=dtype, stop_gradient=False)
@@ -107,7 +107,7 @@ def inplace_dynamic_relu(phi_func, device, dtype, np_x, np_y, np_z):
     return x.numpy(), y.numpy(), out.numpy(), x.grad.numpy(), y.grad.numpy()
 
 
-def inplace_static_relu(func, device, dtype, np_x, np_y, np_z):
+def inplace_static_relu_net(func, device, dtype, np_x, np_y, np_z):
     paddle.enable_static()
     paddle.set_device(device)
     with static.scope_guard(static.Scope()):
@@ -354,7 +354,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                 self.check_output(phi_x_grad, pd_x_grad, "x_grad")
                 self.check_output(phi_y_grad, pd_y_grad, "y_grad")
 
-    def test_static_multiple_inplace_relu(self):
+    def test_static_relu_net(self):
         for device in self.devices:
             for dtype in self.dtypes:
                 (
@@ -363,7 +363,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                     pd_out,
                     pd_x_grad,
                     pd_y_grad,
-                ) = inplace_static_relu(
+                ) = inplace_static_relu_net(
                     paddle.nn.functional.relu,
                     device,
                     dtype,
@@ -377,7 +377,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                     phi_out,
                     phi_x_grad,
                     phi_y_grad,
-                ) = inplace_static_relu(
+                ) = inplace_static_relu_net(
                     custom_inplace.custom_relu_inplace,
                     device,
                     dtype,
@@ -391,7 +391,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                 self.check_output_allclose(phi_x_grad, pd_x_grad, "x_grad")
                 self.check_output_allclose(phi_y_grad, pd_y_grad, "y_grad")
 
-    def test_dynamic_multiple_inplace_relu(self):
+    def test_dynamic_relu_net(self):
         for device in self.devices:
             for dtype in self.dtypes:
                 (
@@ -400,7 +400,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                     pd_out,
                     pd_x_grad,
                     pd_y_grad,
-                ) = inplace_dynamic_relu(
+                ) = inplace_dynamic_relu_net(
                     False,
                     device,
                     dtype,
@@ -414,7 +414,7 @@ class TestCustomInplaceJit(unittest.TestCase):
                     phi_out,
                     phi_x_grad,
                     phi_y_grad,
-                ) = inplace_dynamic_relu(
+                ) = inplace_dynamic_relu_net(
                     True,
                     device,
                     dtype,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
New features

### PR changes
OPs

### Describe
Pcard-66988

用户设置 `SetInplaceMap` 后，如果 `Outputs` 中的名称都在 InplaceMap 中，则不再需要显式的指定 `SetInferShapeFn` 和 `SetInferDtypeFn`，自动对 InplaceMap 中输入输出间的 shape dtype 做映射，提升用户易用性。

本 PR 是支持 vector<Tensor> 输出的前置准备，因为 `SetInferShapeFn` 和 `SetInferDtypeFn` 中不支持输出 vector<Tensor> 对应的 shape 和 dtype，只能通过自动映射的方式隐式处理。

After setting `SetInplaceMap`, if all the names of `Outputs` are inside InplaceMap, users don't have to set `SetInferShapeFn` and `SetInferDtypeFn` explicitly, the framework will map the shape and data type between inputs and outputs automatically.

This PR prepares for the next PR of supporting vector\<Tensor\> outputs, we have to implicitly map inputs and outputs' shape and data type because `SetInferShapeFn` and `SetInferDtypeFn` cannot support output shape and data type of vector\<Tensor\>

- Next PR: https://github.com/PaddlePaddle/Paddle/pull/52114