### PR TITLE
Revert "fix softmaxce null point in shape test"

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cc
@@ -162,13 +162,6 @@ class SoftmaxWithCrossEntropyOp : public framework::OperatorWithKernel {
                           "R is the rank of Input(Logits)."));
 
     axis = phi::funcs::CanonicalAxis(axis, logits_rank);
-
-    PADDLE_ENFORCE_EQ(logits_dims.size(),
-                      labels_dims.size(),
-                      platform::errors::InvalidArgument(
-                          "Input(Logits) and Input(Label) should in "
-                          "same dimensions size."));
-
     for (int i = 0; i < logits_rank; i++) {
       if (i != axis) {
         if (ctx->IsRuntime() || (logits_dims[i] > 0 && labels_dims[i] > 0)) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Reverts PaddlePaddle/Paddle#51850
这个PR影响了PaddleSlim的正常运行，暂时Revert掉。

PaddleSlim问题的复现步骤如下：
1、安装[https://github.com/PaddlePaddle/Paddle/pull/51850](https://github.com/PaddlePaddle/Paddle/pull/51850%E5%AF%B9%E5%BA%94%E7%9A%84paddle)  对应的paddle whl包

2.安装slim

git clone https://github.com/PaddlePaddle/PaddleSlim.git 

cd PaddleSlim

python setup.py bdist_wheel 

python -m pip install paddleslim-0.0.0.dev0-py3-none-any.whl



3.启动命令

cd PaddleSlim/example/auto_compression/nlp

wget https://bj.bcebos.com/v1/paddle-slim-models/act/afqmc.tar

tar -xf afqmc.tar

python run.py --config_path='./configs/pp-minilm/auto/afqmc.yaml' --save_dir='./save_ppminilm_afqmc_new_calib_debug'

![image](https://user-images.githubusercontent.com/26922892/227442785-37a37af3-ac47-45a3-a6bd-c85d7e461ce2.png)
