### PR TITLE
fix mp ops

### DIFF
--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
@@ -46,6 +46,8 @@ def _c_identity(tensor, group=None):
         class c_identity_eager(PyLayer):
             @staticmethod
             def forward(ctx, tensor):
+                # use assign to skip inplace operator
+                tensor = paddle.assign(tensor)
                 return tensor
 
             @staticmethod


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
When defining a PyLayer, if forward return the input directly, we should call x paddle.assign(x), and then return x. This can avoid the  in-place operator which may cause an error. 