### PR TITLE
[CodeStyle][PLR0911] too-many-return-statements

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -30,16 +30,16 @@ from paddle.fluid import Program, core, program_guard
 
 def convert_to_dtype_(dtype):
     _dtype_map = {
+        0: core.VarDesc.VarType.BOOL,
+        1: core.VarDesc.VarType.INT16,
+        2: core.VarDesc.VarType.INT32,
+        3: core.VarDesc.VarType.INT64,
+        4: core.VarDesc.VarType.FP16,
         5: core.VarDesc.VarType.FP32,
         6: core.VarDesc.VarType.FP64,
-        4: core.VarDesc.VarType.FP16,
-        2: core.VarDesc.VarType.INT32,
-        1: core.VarDesc.VarType.INT16,
-        3: core.VarDesc.VarType.INT64,
-        0: core.VarDesc.VarType.BOOL,
-        22: core.VarDesc.VarType.BF16,
         20: core.VarDesc.VarType.UINT8,
-        21: core.VarDesc.VarType.INT8
+        21: core.VarDesc.VarType.INT8,
+        22: core.VarDesc.VarType.BF16
     }
     if dtype in _dtype_map.keys():
         return _dtype_map[dtype]

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -38,6 +38,8 @@ def convert_to_dtype_(dtype):
         3: core.VarDesc.VarType.INT64,
         0: core.VarDesc.VarType.BOOL,
         22: core.VarDesc.VarType.BF16,
+        20: core.VarDesc.VarType.UINT8,
+        21: core.VarDesc.VarType.INT8
     }
     if dtype in _dtype_map.keys():
         return _dtype_map[dtype]

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -29,27 +29,19 @@ from paddle.fluid import Program, core, program_guard
 
 
 def convert_to_dtype_(dtype):
-    if dtype == 5:
-        return core.VarDesc.VarType.FP32
-    elif dtype == 6:
-        return core.VarDesc.VarType.FP64
-    elif dtype == 4:
-        return core.VarDesc.VarType.FP16
-    elif dtype == 2:
-        return core.VarDesc.VarType.INT32
-    elif dtype == 1:
-        return core.VarDesc.VarType.INT16
-    elif dtype == 3:
-        return core.VarDesc.VarType.INT64
-    elif dtype == 0:
-        return core.VarDesc.VarType.BOOL
-    elif dtype == 22:
-        return core.VarDesc.VarType.BF16
-    elif dtype == 20:
-        return core.VarDesc.VarType.UINT8
-    elif dtype == 21:
-        return core.VarDesc.VarType.INT8
-    elif dtype == np.complex64:
+    _dtype_map = {
+        5: core.VarDesc.VarType.FP32,
+        6: core.VarDesc.VarType.FP64,
+        4: core.VarDesc.VarType.FP16,
+        2: core.VarDesc.VarType.INT32,
+        1: core.VarDesc.VarType.INT16,
+        3: core.VarDesc.VarType.INT64,
+        0: core.VarDesc.VarType.BOOL,
+        22: core.VarDesc.VarType.BF16,
+    }
+    if dtype in _dtype_map.keys():
+        return _dtype_map[dtype]
+    else:
         raise ValueError("Not supported dtype %s" % dtype)
 
 

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -39,7 +39,7 @@ def convert_to_dtype_(dtype):
         6: core.VarDesc.VarType.FP64,
         20: core.VarDesc.VarType.UINT8,
         21: core.VarDesc.VarType.INT8,
-        22: core.VarDesc.VarType.BF16
+        22: core.VarDesc.VarType.BF16,
     }
     if dtype in _dtype_map.keys():
         return _dtype_map[dtype]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#51729 61
https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-return-statements.html
限制 return 在函数中使用次数 < 6, 重写方法复杂，评估为不适合引入
并部分代码可简化 例https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/tests/unittests/test_cast_op.py#L31
