### PR TITLE
Modify the registration information of the interpolate kernel.

### DIFF
--- a/paddle/phi/kernels/xpu/interpolate_kernel.cc
+++ b/paddle/phi/kernels/xpu/interpolate_kernel.cc
@@ -223,11 +223,13 @@ void NearestInterpKernel(
 
 PD_REGISTER_KERNEL(
     bilinear_interp, XPU, ALL_LAYOUT, phi::BilinearInterpKernel, float) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);
 }
 PD_REGISTER_KERNEL(
     nearest_interp, XPU, ALL_LAYOUT, phi::NearestInterpKernel, float) {
+  kernel->InputAt(1).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(2).SetBackend(phi::Backend::ALL_BACKEND);
   kernel->InputAt(3).SetBackend(phi::Backend::ALL_BACKEND);
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
输入 tensor 在 op 执行的时候，会根据 tensor 信息进行 PrepareData 操作，当 interpolate 算子含有 OutSize tensor 输入时，kernel 注册信息默认该 tensor 是在 xpu place 上面，但是 PrepareData 函数判断是否需要进行 transfer 是通过GetKernelTypeForVar 函数，interpolate 这个算子在 GetKernelTypeForVar 函数中，将 OutSize tensor 注册为 AllBackends，和 kernel 注册的时候不一致，导致 interpolate 算子在 PrepareData 阶段报错。