### PR TITLE
[Fix Bug] Fix CustomOP cmake copy file error in inference

### DIFF
--- a/cmake/phi_header.cmake
+++ b/cmake/phi_header.cmake
@@ -53,4 +53,6 @@ file(RENAME
      ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/ext_all.h)
 # Included header file of training and inference can be unified as single file: paddle/extension.h
 file(COPY ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/include/experimental/ext_all.h
-     DESTINATION ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/extension.h)
+     DESTINATION ${PADDLE_INFERENCE_INSTALL_DIR}/paddle)
+file(RENAME ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/ext_all.h
+     ${PADDLE_INFERENCE_INSTALL_DIR}/paddle/extension.h)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Pcard-66988


<img width="962" alt="76916231a644c40abded061fea0ace92" src="https://user-images.githubusercontent.com/17810795/227856174-0301f978-e273-4ac1-aabb-82d58064ed52.png">

Change `file(COPY ...)` to `file(COPY ...) + file(RENAME ...)`

