### PR TITLE
remove op.py in fluid

### DIFF
--- a/python/paddle/fluid/tests/unittests/benchmark.py
+++ b/python/paddle/fluid/tests/unittests/benchmark.py
@@ -16,8 +16,7 @@ import time
 
 import numpy as np
 from eager_op_test import OpTest
-
-from paddle.fluid.op import Operator
+from op import OperatorFactory
 
 
 class BenchmarkSuite(OpTest):
@@ -65,7 +64,9 @@ class BenchmarkSuite(OpTest):
             else:
                 outputs.append(var_name)
         if len(outputs) == 0:
-            for out_name, out_dup in Operator.get_op_outputs(self.op_type):
+            for out_name, out_dup in OperatorFactory.get_op_outputs(
+                self.op_type
+            ):
                 outputs.append(str(out_name))
         return outputs
 

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dgc_momentum_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dgc_momentum_op.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 
 
 class TestDGCMomentumOp1(unittest.TestCase):
@@ -116,7 +116,7 @@ class TestDGCMomentumOp1(unittest.TestCase):
     def check_momentum_step(self, place):
         self.setup(place=place)
 
-        dgc_momentum_op = Operator(self.op_type, **self.kwargs)
+        dgc_momentum_op = OperatorFactory(self.op_type, **self.kwargs)
         dgc_momentum_op.run(self.scope, self.place)
 
         self.check(
@@ -136,7 +136,7 @@ class TestDGCMomentumOp1(unittest.TestCase):
     def check_sgd_step(self, place):
         self.setup(place=place, step=15.0)
 
-        dgc_momentum_op = Operator(self.op_type, **self.kwargs)
+        dgc_momentum_op = OperatorFactory(self.op_type, **self.kwargs)
         dgc_momentum_op.run(self.scope, self.place)
 
         self.check(

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_dgc_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_dgc_op.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 
 g_array_size = 102400
 
@@ -134,7 +134,7 @@ class TestDGCOp(unittest.TestCase):
             'regular_type': int(2),
         }
 
-        dgc_op = Operator('dgc', **kwargs)
+        dgc_op = OperatorFactory('dgc', **kwargs)
 
         # atol = 1e-6
         dgc_op.run(self.scope, self.place)

--- a/python/paddle/fluid/tests/unittests/collective/fleet/test_recv_save_op.py
+++ b/python/paddle/fluid/tests/unittests/collective/fleet/test_recv_save_op.py
@@ -25,7 +25,7 @@ from dist_test_utils import remove_ps_flag
 from paddle import fluid
 from paddle.fluid import core
 from paddle.fluid.framework import Program, program_guard
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 from paddle.incubate.distributed.fleet.parameter_server.mode import (
     DistributedMode,
 )
@@ -103,7 +103,7 @@ class TestListenAndServOp(unittest.TestCase):
                 emaps = ['127.0.0.1:' + str(port0), '127.0.0.1:' + str(port1)]
 
                 # create and run recv and save operator
-                remote_recv_op = Operator(
+                remote_recv_op = OperatorFactory(
                     "recv_save",
                     trainer_id=0,
                     shape=[10, 8],

--- a/python/paddle/fluid/tests/unittests/eager_op_test.py
+++ b/python/paddle/fluid/tests/unittests/eager_op_test.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 from copy import copy
 
 import numpy as np
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
@@ -34,7 +35,6 @@ from paddle.fluid.framework import (
     Program,
     _current_expected_place,
 )
-from paddle.fluid.op import Operator
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from prim_op_test import OpTestUtils, PrimForwardChecker, PrimGradChecker
@@ -1089,7 +1089,9 @@ class OpTest(unittest.TestCase):
                         fetch_list.append(var.name)
             # if the fetch_list still empty, fill the fetch_list by the operator output.
             if len(fetch_list) == 0:
-                for out_name, out_dup in Operator.get_op_outputs(self.op_type):
+                for out_name, out_dup in OperatorFactory.get_op_outputs(
+                    self.op_type
+                ):
                     fetch_list.append(str(out_name))
 
             if enable_inplace is not None:
@@ -1684,7 +1686,9 @@ class OpTest(unittest.TestCase):
                     self._compare_list(name, actual, expect)
 
             def compare_outputs_with_expects(self):
-                for out_name, out_dup in Operator.get_op_outputs(self.op_type):
+                for out_name, out_dup in OperatorFactory.get_op_outputs(
+                    self.op_type
+                ):
                     if self._is_skip_name(out_name):
                         continue
                     if out_dup:

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_sum_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_sum_mkldnn_op.py
@@ -16,8 +16,8 @@ import unittest
 
 import numpy as np
 
-import paddle.fluid.op as fluid_op
 from paddle.fluid import core
+from paddle.fluid.tests.unittests.op import OperatorFactory
 from paddle.fluid.tests.unittests.test_sum_op import TestSumOp
 
 
@@ -70,7 +70,7 @@ class TestMKLDNNSumInplaceOp(unittest.TestCase):
                 tensor = var.get_tensor()
                 tensor.set(var_value, place)
 
-        sum_op = fluid_op.Operator(
+        sum_op = OperatorFactory(
             "sum", X=["x0", "x1"], Out=out_var_name, use_mkldnn=True
         )
         expected_out = np.array(self.x0 + self.x1)

--- a/python/paddle/fluid/tests/unittests/mlu/test_batch_norm_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_batch_norm_op_mlu.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 import sys
 
 sys.path.append('..')
@@ -286,7 +286,7 @@ class TestBatchNormOpInference(unittest.TestCase):
         mean_out_tensor = mean_tensor
         variance_out_tensor = variance_tensor
 
-        batch_norm_op = Operator(
+        batch_norm_op = OperatorFactory(
             "batch_norm",
             # inputs
             X="x_val",

--- a/python/paddle/fluid/tests/unittests/mlu/test_batch_norm_op_mlu_v2.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_batch_norm_op_mlu_v2.py
@@ -16,7 +16,6 @@ import os
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import sys
 
 sys.path.append("..")

--- a/python/paddle/fluid/tests/unittests/mlu/test_elementwise_mul_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_elementwise_mul_op_mlu.py
@@ -19,7 +19,6 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid import Program, compiler, program_guard
-from paddle.fluid.op import Operator
 
 import sys
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_fill_constant_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_fill_constant_op_mlu.py
@@ -21,7 +21,7 @@ from eager_op_test import OpTest, convert_float_to_uint16
 
 import paddle
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 import paddle.fluid as fluid
 import numpy as np
 from paddle.fluid import compiler, Program, program_guard
@@ -101,7 +101,7 @@ class TestFillConstantOpWithSelectedRows(unittest.TestCase):
         out = scope.var('Out').get_selected_rows()
 
         # create and run fill_constant_op operator
-        fill_constant_op = Operator(
+        fill_constant_op = OperatorFactory(
             "fill_constant", shape=[123, 92], value=3.8, Out='Out'
         )
         fill_constant_op.run(scope, place)

--- a/python/paddle/fluid/tests/unittests/mlu/test_gaussian_random_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_gaussian_random_op_mlu.py
@@ -17,7 +17,6 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 from paddle.fluid.executor import Executor
 import sys
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_momentum_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_momentum_op_mlu.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import sys
 
 sys.path.append('..')

--- a/python/paddle/fluid/tests/unittests/mlu/test_scale_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_scale_op_mlu.py
@@ -21,7 +21,7 @@ from eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 from paddle.static import Program, program_guard
 
 paddle.enable_static()
@@ -101,7 +101,7 @@ class TestScaleOpSelectedRows(unittest.TestCase):
         out_tensor._set_dims(in_tensor._get_dims())
 
         # create and run sgd operator
-        scale_op = Operator("scale", X=in_name, Out=out_name, scale=scale)
+        scale_op = OperatorFactory("scale", X=in_name, Out=out_name, scale=scale)
         scale_op.run(scope, place)
 
         # get and compare result

--- a/python/paddle/fluid/tests/unittests/mlu/test_shape_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_shape_op_mlu.py
@@ -20,9 +20,6 @@ sys.path.append("..")
 from eager_op_test import OpTest
 import paddle
 
-# from paddle.fluid import core
-# from paddle.fluid.op import Operator
-
 paddle.enable_static()
 SEED = 2022
 

--- a/python/paddle/fluid/tests/unittests/mlu/test_truncated_gaussian_random_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_truncated_gaussian_random_op_mlu.py
@@ -22,7 +22,6 @@ import sys
 
 sys.path.append("..")
 from eager_op_test import OpTest
-from paddle.fluid.op import Operator
 from paddle.fluid.executor import Executor
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_uniform_random_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_uniform_random_op_mlu.py
@@ -22,7 +22,7 @@ from eager_op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 import paddle
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 from test_uniform_random_op import (
@@ -89,7 +89,7 @@ class TestMLUUniformRandomOpSelectedRows(unittest.TestCase):
         scope = core.Scope()
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             Out="X",
             shape=[1000, 784],

--- a/python/paddle/fluid/tests/unittests/mlu/test_where_index_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_where_index_op_mlu.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 from eager_op_test import OpTest
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 import paddle
@@ -60,7 +60,7 @@ class TestAllFalse(unittest.TestCase):
         out = scope.var("Out").get_tensor()
         out.set(np.full(self.shape, 0).astype('int64'), place)
 
-        op = Operator("where_index", Condition="Condition", Out="Out")
+        op = OperatorFactory("where_index", Condition="Condition", Out="Out")
         op.run(scope, place)
 
         out_array = np.array(out)

--- a/python/paddle/fluid/tests/unittests/mlu/test_where_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_where_op_mlu.py
@@ -23,7 +23,6 @@ import paddle.fluid.layers as layers
 import paddle.fluid.core as core
 from eager_op_test import OpTest
 from paddle.fluid import compiler, Program, program_guard
-from paddle.fluid.op import Operator
 from paddle.fluid.backward import append_backward
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/mlu/test_yolo_box_op_mlu.py
+++ b/python/paddle/fluid/tests/unittests/mlu/test_yolo_box_op_mlu.py
@@ -21,7 +21,6 @@ from eager_op_test import OpTest
 import paddle
 from paddle.fluid import core
 import paddle.fluid as fluid
-from paddle.fluid.op import Operator
 from paddle.fluid.executor import Executor
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_batch_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_batch_norm_op_npu.py
@@ -20,7 +20,6 @@ sys.path.append("..")
 import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from paddle.fluid.op import Operator
 from eager_op_test import OpTest, _set_use_system_allocator
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/npu/test_beam_search_decode_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_beam_search_decode_op_npu.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import paddle
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 import paddle.fluid as fluid
 from paddle.fluid.framework import Program, program_guard
 
@@ -83,7 +83,7 @@ class TestBeamSearchDecodeNPUOp(unittest.TestCase):
         sentence_ids = self.scope.var("sentence_ids").get_tensor()
         sentence_scores = self.scope.var("sentence_scores").get_tensor()
 
-        beam_search_decode_op = Operator(
+        beam_search_decode_op = OperatorFactory(
             "beam_search_decode",
             # inputs
             Ids="ids",

--- a/python/paddle/fluid/tests/unittests/npu/test_instance_norm_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_instance_norm_op_npu.py
@@ -23,7 +23,6 @@ import paddle
 from paddle import fluid
 from paddle.static import Program, program_guard
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 from paddle.fluid.dygraph import to_variable
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_momentum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_momentum_op_npu.py
@@ -21,7 +21,6 @@ from eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 from test_momentum_op import calculate_momentum_by_numpy
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_rmsprop_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_rmsprop_op_npu.py
@@ -19,7 +19,6 @@ sys.path.append("..")
 from eager_op_test import OpTest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 import paddle
 

--- a/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_truncated_gaussian_random_op_npu.py
@@ -21,7 +21,6 @@ from eager_op_test import OpTest
 import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.op import Operator
 from paddle.fluid.executor import Executor
 
 paddle.enable_static()

--- a/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_uniform_random_op_npu.py
@@ -22,7 +22,7 @@ from eager_op_test import OpTest
 import paddle
 import paddle.fluid.core as core
 import paddle
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 from test_uniform_random_op import (
@@ -89,7 +89,7 @@ class TestNPUUniformRandomOpSelectedRows(unittest.TestCase):
         scope = core.Scope()
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             Out="X",
             shape=[1000, 784],

--- a/python/paddle/fluid/tests/unittests/npu/test_where_index_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_where_index_npu.py
@@ -19,7 +19,6 @@ import sys
 
 sys.path.append("..")
 from eager_op_test import OpTest
-from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 

--- a/python/paddle/fluid/tests/unittests/op.py
+++ b/python/paddle/fluid/tests/unittests/op.py
@@ -14,8 +14,8 @@
 
 import numpy as np
 
-import paddle.fluid.core as core
-import paddle.fluid.proto.framework_pb2 as framework_pb2
+from paddle.fluid import core
+from paddle.fluid.proto import framework_pb2
 
 
 def get_all_op_protos():
@@ -215,7 +215,7 @@ def create_op_creation_method(op_proto):
 
 class OperatorFactory:
     def __init__(self):
-        self.op_methods = dict()
+        self.op_methods = {}
 
         for op_proto in get_all_op_protos():
             method = create_op_creation_method(op_proto)
@@ -264,72 +264,3 @@ class OperatorFactory:
 
     def get_op_extra_attr_names(self, type):
         return self.get_op_info(type).extra_attrs
-
-
-class __RecurrentOp__:
-    __proto__ = None
-    type = "recurrent"
-
-    def __init__(self):
-        # cache recurrent_op's proto
-        if self.__proto__ is None:
-            for op_proto in get_all_op_protos():
-                if op_proto.type == self.type:
-                    self.__proto__ = op_proto
-
-    def __call__(self, *args, **kwargs):
-        if self.type not in args and "type" not in kwargs:
-            kwargs["type"] = self.type
-        # create proto
-        create_method = OpDescCreationMethod(self.__proto__)
-        proto = create_method(*args, **kwargs)
-        # create rnnop
-        return core.RecurrentOp.create(proto.SerializeToString())
-
-
-class __DynamicRecurrentOp__:
-    __proto__ = None
-    type = "dynamic_recurrent"
-
-    def __init__(self):
-        # cache recurrent_op's proto
-        if self.__proto__ is None:
-            for op_proto in get_all_op_protos():
-                if op_proto.type == self.type:
-                    self.__proto__ = op_proto
-
-    def __call__(self, *args, **kwargs):
-        if self.type not in args and "type" not in kwargs:
-            kwargs["type"] = self.type
-        # create proto
-        create_method = OpDescCreationMethod(self.__proto__)
-        proto = create_method(*args, **kwargs)
-        # create rnnop
-        return core.DynamicRecurrentOp.create(proto.SerializeToString())
-
-
-class __CondOp__:
-    __proto__ = None
-    type = "cond"
-
-    def __init__(self):
-        # cache recurrent_op's proto
-        if self.__proto__ is None:
-            for op_proto in get_all_op_protos():
-                if op_proto.type == self.type:
-                    self.__proto__ = op_proto
-
-    def __call__(self, *args, **kwargs):
-        if self.type not in args and "type" not in kwargs:
-            kwargs["type"] = self.type
-        # create proto
-        create_method = OpDescCreationMethod(self.__proto__)
-        proto = create_method(*args, **kwargs)
-        # create condop
-        return core.CondOp.create(proto.SerializeToString())
-
-
-Operator = OperatorFactory()  # The default global factory
-RecurrentOp = __RecurrentOp__()
-DynamicRecurrentOp = __DynamicRecurrentOp__()
-CondOp = __CondOp__()

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 from copy import copy
 
 import numpy as np
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
@@ -39,7 +40,6 @@ from paddle.fluid.framework import (
     _test_eager_guard,
     in_dygraph_mode,
 )
-from paddle.fluid.op import Operator
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from prim_op_test import OpTestUtils, PrimForwardChecker, PrimGradChecker
@@ -1063,7 +1063,9 @@ class OpTest(unittest.TestCase):
                         fetch_list.append(var.name)
             # if the fetch_list still empty, fill the fetch_list by the operator output.
             if len(fetch_list) == 0:
-                for out_name, out_dup in Operator.get_op_outputs(self.op_type):
+                for out_name, out_dup in OperatorFactory.get_op_outputs(
+                    self.op_type
+                ):
                     fetch_list.append(str(out_name))
 
             if enable_inplace is not None:
@@ -1657,7 +1659,9 @@ class OpTest(unittest.TestCase):
                     self._compare_list(name, actual, expect)
 
             def compare_outputs_with_expects(self):
-                for out_name, out_dup in Operator.get_op_outputs(self.op_type):
+                for out_name, out_dup in OperatorFactory.get_op_outputs(
+                    self.op_type
+                ):
                     if self._is_skip_name(out_name):
                         continue
                     if out_dup:

--- a/python/paddle/fluid/tests/unittests/test_activation_sparse_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_sparse_op.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 class TestSparseSquareOp(unittest.TestCase):
@@ -42,7 +42,7 @@ class TestSparseSquareOp(unittest.TestCase):
 
         out_selected_rows = scope.var('Out').get_selected_rows()
         # create and run sqrt operator
-        square_op = Operator("square", X='X', Out='Out')
+        square_op = OperatorFactory("square", X='X', Out='Out')
         square_op.run(scope, place)
 
         # get and compare result
@@ -79,7 +79,7 @@ class TestSparseSqrtOp(unittest.TestCase):
 
         out_selected_rows = scope.var('Out1').get_selected_rows()
         # create and run sqrt operator
-        sqrt_op = Operator("sqrt", X='X1', Out='Out1')
+        sqrt_op = OperatorFactory("sqrt", X='X1', Out='Out1')
         sqrt_op.run(scope, place)
 
         # get and compare result

--- a/python/paddle/fluid/tests/unittests/test_adagrad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adagrad_op.py
@@ -17,10 +17,10 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 def adamgrad_wrapper(
@@ -140,7 +140,7 @@ class TestSparseAdagradOp(unittest.TestCase):
         moment_np_array = np.full((height, row_numel), 2.0).astype("float32")
         moment.set(moment_np_array, place)
 
-        adagrad_op = Operator(
+        adagrad_op = OperatorFactory(
             "adagrad",
             Param='Param',
             Grad='Grad',

--- a/python/paddle/fluid/tests/unittests/test_adam_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adam_op.py
@@ -16,11 +16,11 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 def adam_wrapper(
@@ -430,7 +430,7 @@ class TestSparseAdamOp(unittest.TestCase):
             op_args[k] = self.attrs[k]
 
         # create and run sgd operator
-        adam_op = Operator("adam", **op_args)
+        adam_op = OperatorFactory("adam", **op_args)
         adam_op.run(scope, place)
 
         for key, np_array in self.outputs.items():

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
@@ -17,12 +17,12 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest, _set_use_system_allocator
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import Program, core, program_guard
 from paddle.fluid.framework import grad_var_name
-from paddle.fluid.op import Operator
 
 _set_use_system_allocator(True)
 
@@ -284,7 +284,7 @@ class TestBatchNormOpInference(unittest.TestCase):
         mean_out_tensor = mean_tensor
         variance_out_tensor = variance_tensor
 
-        batch_norm_op = Operator(
+        batch_norm_op = OperatorFactory(
             "batch_norm",
             # inputs
             X="x_val",

--- a/python/paddle/fluid/tests/unittests/test_beam_search_decode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_beam_search_decode_op.py
@@ -15,9 +15,9 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 class TestBeamSearchDecodeOp(unittest.TestCase):
@@ -81,7 +81,7 @@ class TestBeamSearchDecodeOp(unittest.TestCase):
         sentence_ids = self.scope.var("sentence_ids").get_tensor()
         sentence_scores = self.scope.var("sentence_scores").get_tensor()
 
-        beam_search_decode_op = Operator(
+        beam_search_decode_op = OperatorFactory(
             "beam_search_decode",
             # inputs
             Ids="ids",

--- a/python/paddle/fluid/tests/unittests/test_beam_search_op.py
+++ b/python/paddle/fluid/tests/unittests/test_beam_search_op.py
@@ -15,9 +15,9 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 def create_tensor(scope, name, np_data):
@@ -41,7 +41,7 @@ class BeamSearchOpTester(unittest.TestCase):
         self.scope.var('parent_idx').get_tensor()
 
     def test_run(self):
-        op = Operator(
+        op = OperatorFactory(
             'beam_search',
             pre_ids='pre_ids',
             pre_scores='pre_scores',

--- a/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
@@ -16,9 +16,9 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 import paddle
-from paddle import fluid
 from paddle.fluid import core
 from paddle.nn import clip
 
@@ -119,7 +119,7 @@ class TestClipByNormOpWithSelectedRows(unittest.TestCase):
         out_selected_rows = scope.var('Out').get_selected_rows()
 
         # run clip_by_norm_op
-        clip_by_norm_op = fluid.op.Operator(
+        clip_by_norm_op = OperatorFactory(
             "clip_by_norm", max_norm=self.max_norm, X='X', Out='Out'
         )
         clip_by_norm_op.run(scope, place)

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -17,11 +17,11 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import Program, core, program_guard
-from paddle.fluid.op import Operator
 
 
 def _reference_testing(x, batch_size, batch_sum, batch_square_sum, slot_dim=-1):
@@ -144,7 +144,7 @@ class TestDataNormOpInference(unittest.TestCase):
         scales_tensor = create_or_get_tensor(scope, "scales", None, place)
 
         if not enable_scale_and_shift:
-            data_norm_op = Operator(
+            data_norm_op = OperatorFactory(
                 "data_norm",
                 # inputs
                 X="x_val",
@@ -170,7 +170,7 @@ class TestDataNormOpInference(unittest.TestCase):
             bias_tensor = create_or_get_tensor(
                 scope, "bias", OpTest.np_dtype_to_fluid_dtype(bias), place
             )
-            data_norm_op = Operator(
+            data_norm_op = OperatorFactory(
                 "data_norm",
                 # inputs
                 X="x_val",

--- a/python/paddle/fluid/tests/unittests/test_fake_init_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fake_init_op.py
@@ -14,8 +14,9 @@
 
 import unittest
 
+from op import OperatorFactory
+
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 class TestFakeInitOpSelectedRows(unittest.TestCase):
@@ -33,7 +34,9 @@ class TestFakeInitOpSelectedRows(unittest.TestCase):
         var_shape = [4, 784]
 
         # create and run fake_init_op
-        fake_init_op = Operator("fake_init", Out=out_var_name, shape=var_shape)
+        fake_init_op = OperatorFactory(
+            "fake_init", Out=out_var_name, shape=var_shape
+        )
         fake_init_op.run(scope, place)
 
         self.assertEqual(var_shape, out_tensor._get_dims())

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -16,11 +16,11 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest, convert_float_to_uint16
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import Program, core, program_guard
-from paddle.fluid.op import Operator
 
 
 def fill_wrapper(shape, value=0.0):
@@ -125,7 +125,7 @@ class TestFillConstantOpWithSelectedRows(unittest.TestCase):
         out = scope.var('Out').get_selected_rows()
 
         # create and run fill_constant_op operator
-        fill_constant_op = Operator(
+        fill_constant_op = OperatorFactory(
             "fill_constant", shape=[123, 92], value=3.8, Out='Out'
         )
         fill_constant_op.run(scope, place)

--- a/python/paddle/fluid/tests/unittests/test_fill_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_op.py
@@ -16,9 +16,9 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 class TestFillOp1(OpTest):
@@ -63,7 +63,7 @@ class TestFillOp3(unittest.TestCase):
 
         # create and run fill_op operator
         val = np.random.random(size=[300, 200])
-        fill_op = Operator(
+        fill_op = OperatorFactory(
             "fill",
             value=val.flatten(),
             shape=[300, 200],

--- a/python/paddle/fluid/tests/unittests/test_ftrl_op.py
+++ b/python/paddle/fluid/tests/unittests/test_ftrl_op.py
@@ -16,9 +16,9 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 def ftrl_step(param, grad, rows, sq_accum, lin_accum, lr, l1, l2, lr_power):
@@ -177,7 +177,7 @@ class TestSparseFTRLOp(unittest.TestCase):
         )
 
         # create and run operator
-        op = Operator(
+        op = OperatorFactory(
             "ftrl",
             Param='Param',
             Grad='Grad',

--- a/python/paddle/fluid/tests/unittests/test_get_tensor_from_selected_rows_op.py
+++ b/python/paddle/fluid/tests/unittests/test_get_tensor_from_selected_rows_op.py
@@ -15,10 +15,10 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 import paddle
 from paddle.fluid import Program, core, program_guard
-from paddle.fluid.op import Operator
 from paddle.nn import clip
 
 
@@ -69,7 +69,7 @@ class TestGetTensorFromSelectedRows(unittest.TestCase):
         # initialize input variable Out
         out = scope.var("Out").get_tensor()
 
-        op = Operator("get_tensor_from_selected_rows", X="X", Out="Out")
+        op = OperatorFactory("get_tensor_from_selected_rows", X="X", Out="Out")
 
         op.run(scope, place)
 

--- a/python/paddle/fluid/tests/unittests/test_lamb_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lamb_op.py
@@ -16,10 +16,10 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 paddle.enable_static()
 
@@ -351,7 +351,7 @@ class TestSparseLambOp(unittest.TestCase):
             op_args[k] = self.attrs[k]
 
         # create and run sgd operator
-        lamb_op = Operator("lamb", **op_args)
+        lamb_op = OperatorFactory("lamb", **op_args)
         lamb_op.run(scope, place)
 
         for key, np_array in self.outputs.items():

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
@@ -15,11 +15,11 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 import paddle
 from paddle import enable_static, fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 from paddle.fluid.tests.unittests.op_test import (
     OpTest,
     convert_float_to_uint16,
@@ -151,7 +151,9 @@ class TestLookupTableBF16OpWIsSelectedRows(unittest.TestCase):
         out_tensor = self.scope.var('Out').get_tensor()
 
         # create and run lookup_table operator
-        lookup_table = Operator(self.op_type, W='W', Ids='Ids', Out='Out')
+        lookup_table = OperatorFactory(
+            self.op_type, W='W', Ids='Ids', Out='Out'
+        )
         lookup_table.run(self.scope, self.place)
 
         # get result from Out

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -15,13 +15,13 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 from op_test import OpTest, check_out_dtype, skip_check_grad_ci
 
 import paddle
 import paddle.nn.functional as F
 from paddle import fluid
 from paddle.fluid import Program, core, program_guard
-from paddle.fluid.op import Operator
 
 
 class TestLookupTableOp(OpTest):
@@ -124,7 +124,9 @@ class TestLookupTableWIsSelectedRows(unittest.TestCase):
         out_tensor = self.create_out_tensor(scope, place)
 
         # create and run lookup_table operator
-        lookup_table = Operator("lookup_table", W='W', Ids='Ids', Out='Out')
+        lookup_table = OperatorFactory(
+            "lookup_table", W='W', Ids='Ids', Out='Out'
+        )
         lookup_table.run(scope, place)
 
         # get result from Out
@@ -300,7 +302,9 @@ class TestLookupTableWIsSelectedRowsInt8(unittest.TestCase):
         out_tensor = self.create_out_tensor(scope, place)
 
         # create and run lookup_table operator
-        lookup_table = Operator("lookup_table", W='W', Ids='Ids', Out='Out')
+        lookup_table = OperatorFactory(
+            "lookup_table", W='W', Ids='Ids', Out='Out'
+        )
         lookup_table.run(scope, place)
 
         # get result from Out
@@ -424,7 +428,9 @@ class TestLookupTableWIsSelectedRowsInt16(unittest.TestCase):
         out_tensor = self.create_out_tensor(scope, place)
 
         # create and run lookup_table operator
-        lookup_table = Operator("lookup_table", W='W', Ids='Ids', Out='Out')
+        lookup_table = OperatorFactory(
+            "lookup_table", W='W', Ids='Ids', Out='Out'
+        )
         lookup_table.run(scope, place)
 
         # get result from Out

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
@@ -16,11 +16,11 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest, skip_check_grad_ci
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import Program, core, program_guard
-from paddle.fluid.op import Operator
 
 
 class TestStaticGraphSupportMultipleInt(unittest.TestCase):
@@ -160,7 +160,9 @@ class TestLookupTableWIsSelectedRows(unittest.TestCase):
         out_tensor = self.create_out_tensor(scope, place)
 
         # create and run lookup_table operator
-        lookup_table = Operator("lookup_table_v2", W='W', Ids='Ids', Out='Out')
+        lookup_table = OperatorFactory(
+            "lookup_table_v2", W='W', Ids='Ids', Out='Out'
+        )
         lookup_table.run(scope, place)
 
         # get result from Out

--- a/python/paddle/fluid/tests/unittests/test_merge_selectedrows_op.py
+++ b/python/paddle/fluid/tests/unittests/test_merge_selectedrows_op.py
@@ -15,9 +15,9 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 class TestMergeSelectedRows(unittest.TestCase):
@@ -49,7 +49,7 @@ class TestMergeSelectedRows(unittest.TestCase):
         # initialize input variable Out
         out = scope.var("Out").get_selected_rows()
 
-        op = Operator("merge_selected_rows", X="X", Out="Out")
+        op = OperatorFactory("merge_selected_rows", X="X", Out="Out")
 
         op.run(scope, place)
 

--- a/python/paddle/fluid/tests/unittests/test_momentum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_momentum_op.py
@@ -16,12 +16,12 @@ import unittest
 
 import numpy
 import numpy as np
+from op import OperatorFactory
 from op_test import OpTest
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 def calculate_momentum_by_numpy(
@@ -338,7 +338,7 @@ class TestSparseMomentumOp(unittest.TestCase):
         lr.set(lr_array, place)
 
         # create and run operator
-        op = Operator(
+        op = OperatorFactory(
             "momentum",
             Param='Param',
             Grad='Grad',
@@ -450,7 +450,7 @@ class TestSparseMomentumOpWithMultiPrecision(unittest.TestCase):
         lr.set(lr_array, place)
 
         # create and run operator
-        op = Operator(
+        op = OperatorFactory(
             "momentum",
             Param='Param',
             Grad='Grad',

--- a/python/paddle/fluid/tests/unittests/test_operator.py
+++ b/python/paddle/fluid/tests/unittests/test_operator.py
@@ -15,8 +15,8 @@
 import unittest
 
 import numpy as np
+import op
 
-from paddle.fluid import op
 from paddle.fluid.proto import framework_pb2
 
 
@@ -218,7 +218,7 @@ class TestOpDescCreationMethod(unittest.TestCase):
 
 class TestOpCreations(unittest.TestCase):
     def test_all(self):
-        add_op = op.Operator("sum", X=["a", "b"], Out="z")
+        add_op = op.OperatorFactory("sum", X=["a", "b"], Out="z")
         self.assertIsNotNone(add_op)
         # Invoke C++ DebugString()
         self.assertEqual(

--- a/python/paddle/fluid/tests/unittests/test_rmsprop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_rmsprop_op.py
@@ -15,11 +15,11 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 def create_selected_rows_and_tensor(
@@ -188,7 +188,7 @@ class TestRmspropOp(TestBase):
             kwargs['MeanGrad'] = self.mean_grad_name
             kwargs['MeanGradOut'] = self.mean_grad_name
 
-        rmsprop_op = Operator('rmsprop', **kwargs)
+        rmsprop_op = OperatorFactory('rmsprop', **kwargs)
         atol = 1e-6
 
         rmsprop_op.run(self.scope, self.place)

--- a/python/paddle/fluid/tests/unittests/test_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scale_op.py
@@ -17,12 +17,12 @@ import unittest
 import gradient_checker
 import numpy as np
 from decorator_helper import prog_scope
+from op import OperatorFactory
 from op_test import OpTest, convert_float_to_uint16
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 from paddle.static import Program, program_guard
 
 
@@ -104,7 +104,9 @@ class TestScaleOpSelectedRows(unittest.TestCase):
         out_tensor._set_dims(in_tensor._get_dims())
 
         # create and run sgd operator
-        scale_op = Operator("scale", X=in_name, Out=out_name, scale=scale)
+        scale_op = OperatorFactory(
+            "scale", X=in_name, Out=out_name, scale=scale
+        )
         scale_op.run(scope, place)
 
         # get and compare result

--- a/python/paddle/fluid/tests/unittests/test_sgd_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sgd_op.py
@@ -15,12 +15,12 @@
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 from op_test import OpTest
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 paddle.enable_static()
 
@@ -80,7 +80,7 @@ class TestSparseSGDOp(unittest.TestCase):
         lr.set(lr_array, place)
 
         # create and run sgd operator
-        sgd_op = Operator(
+        sgd_op = OperatorFactory(
             "sgd",
             Param='Param',
             Grad='Grad',
@@ -173,7 +173,7 @@ class TestSGDOpOptimizeSelectedRows(unittest.TestCase):
             )
 
         # create and run sgd operator
-        sgd_op = Operator(
+        sgd_op = OperatorFactory(
             "sgd",
             Param='Param',
             Grad='Grad',

--- a/python/paddle/fluid/tests/unittests/test_sgd_op_bf16.py
+++ b/python/paddle/fluid/tests/unittests/test_sgd_op_bf16.py
@@ -16,11 +16,11 @@ import struct
 import unittest
 
 import numpy as np
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 from paddle.fluid.tests.unittests.op_test import (
     OpTest,
     OpTestTool,
@@ -148,7 +148,7 @@ class TestSparseGradSGDOpBF16(TestSparseSGDOpBF16):
         )
         _, lr_value = self.create_dense_lr_var(scope, place)
 
-        sgd_op = Operator(
+        sgd_op = OperatorFactory(
             'sgd',
             Param='Param',
             Grad='Grad',
@@ -206,7 +206,7 @@ class TestSparseGradParamSGDOpBF16(TestSparseSGDOpBF16):
         )
         _, lr_value = self.create_dense_lr_var(scope, place)
 
-        sgd_op = Operator(
+        sgd_op = OperatorFactory(
             'sgd',
             Param='Param',
             Grad='Grad',

--- a/python/paddle/fluid/tests/unittests/test_shape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_shape_op.py
@@ -16,10 +16,10 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest, convert_float_to_uint16
+from op import OperatorFactory
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 class TestShapeOp(OpTest):
@@ -73,7 +73,7 @@ class TestShapeWithSelectedRows(unittest.TestCase):
 
         # initialize input variable Out
         out_shape = scope.var("Out").get_tensor()
-        op = Operator("shape", Input="X", Out="Out")
+        op = OperatorFactory("shape", Input="X", Out="Out")
 
         op.run(scope, place)
 

--- a/python/paddle/fluid/tests/unittests/test_share_data_op.py
+++ b/python/paddle/fluid/tests/unittests/test_share_data_op.py
@@ -16,9 +16,9 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest
+from op import OperatorFactory
 
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 class TestShareDataOp(OpTest):
@@ -48,7 +48,7 @@ class TestShareDataOpOnDifferentPlaces(unittest.TestCase):
         x.set(np_array, place)
         out = scope.var("Out").get_tensor()
 
-        op = Operator("share_data", X="X", Out="Out")
+        op = OperatorFactory("share_data", X="X", Out="Out")
         op.run(scope, place)
         np.testing.assert_allclose(np_array, out, rtol=1e-05)
 
@@ -70,7 +70,7 @@ class TestShareDataOpOnDifferentPlaces(unittest.TestCase):
         out = scope.var("Out").get_selected_rows()
         out_tensor = out.get_tensor()
 
-        op = Operator("share_data", X="X", Out="Out")
+        op = OperatorFactory("share_data", X="X", Out="Out")
         op.run(scope, place)
 
         out_height = out.height()

--- a/python/paddle/fluid/tests/unittests/test_sum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sum_op.py
@@ -25,13 +25,13 @@ from eager_op_test import (
     convert_float_to_uint16,
     convert_uint16_to_float,
 )
+from op import OperatorFactory
 
 import paddle
 import paddle.inference as paddle_infer
 from paddle import enable_static, fluid
 from paddle.fluid import core
 from paddle.fluid.layer_helper import LayerHelper
-from paddle.fluid.op import Operator
 
 
 def sum_wrapper(X, use_mkldnn=False):
@@ -119,7 +119,7 @@ class TestSelectedRowsSumOp(unittest.TestCase):
         out = scope.var(out_var_name).get_selected_rows()
 
         # create and run sum operator
-        sum_op = Operator("sum", X=["W1", "W2", "W3"], Out=out_var_name)
+        sum_op = OperatorFactory("sum", X=["W1", "W2", "W3"], Out=out_var_name)
         sum_op.run(scope, place)
 
         has_data_w_num = 0
@@ -210,7 +210,7 @@ class TestSelectedRowsSumBF16Op(TestSelectedRowsSumOp):
         out = scope.var(out_var_name).get_selected_rows()
 
         # create and run sum operator
-        sum_op = Operator("sum", X=["W1", "W2", "W3"], Out=out_var_name)
+        sum_op = OperatorFactory("sum", X=["W1", "W2", "W3"], Out=out_var_name)
         sum_op.run(scope, place)
 
         has_data_w_num = 0
@@ -263,7 +263,7 @@ class TestLoDTensorAndSelectedRowsOp(TestSelectedRowsSumOp):
             out_name = "out"
 
         # create and run sum operator
-        sum_op = Operator("sum", X=["x1", "x2"], Out=out_name)
+        sum_op = OperatorFactory("sum", X=["x1", "x2"], Out=out_name)
         sum_op.run(scope, place)
 
         result = np.ones((1, self.height)).astype(np.int32).tolist()[0]

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_bf16_op.py
@@ -16,11 +16,11 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest, convert_uint16_to_float
+from op import OperatorFactory
 
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 from paddle.fluid.tests.unittests.test_uniform_random_op import (
     output_hist,
     output_hist_diag,
@@ -120,7 +120,7 @@ class TestUniformRandomOpBF16SelectedRows(unittest.TestCase):
         scope = core.Scope()
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             Out="X",
             shape=[1000, 784],
@@ -143,7 +143,7 @@ class TestUniformRandomOpBF16SelectedRowsWithDiagInit(
         scope = core.Scope()
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             Out="X",
             shape=[500, 784],
@@ -194,7 +194,7 @@ class TestUniformRandomOpBF16SelectedRowsShapeTensor(unittest.TestCase):
         shape_tensor = scope.var("Shape").get_tensor()
         shape_tensor.set(np.array([1000, 784]).astype("int64"), place)
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             ShapeTensor="Shape",
             Out="X",
@@ -222,7 +222,7 @@ class TestUniformRandomOpBF16SelectedRowsShapeTensorList(
         shape_2 = scope.var("shape2").get_tensor()
         shape_2.set(np.array([784]).astype("int64"), place)
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             ShapeTensorList=["shape1", "shape2"],
             Out="X",

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
@@ -17,13 +17,13 @@ import unittest
 
 import numpy as np
 from eager_op_test import OpTest, convert_uint16_to_float
+from op import OperatorFactory
 from test_attribute_var import UnittestBase
 
 import paddle
 from paddle import fluid
 from paddle.fluid import Program, core, program_guard
 from paddle.fluid.framework import convert_np_dtype_to_dtype_
-from paddle.fluid.op import Operator
 from paddle.tensor import random
 
 
@@ -257,7 +257,7 @@ class TestUniformRandomOpSelectedRows(unittest.TestCase):
         scope = core.Scope()
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             Out="X",
             shape=[1000, 784],
@@ -278,7 +278,7 @@ class TestUniformRandomOpSelectedRowsWithDiagInit(
         scope = core.Scope()
         out = scope.var("X").get_selected_rows()
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             Out="X",
             shape=[500, 784],
@@ -418,7 +418,7 @@ class TestUniformRandomOpSelectedRowsShapeTensor(unittest.TestCase):
         shape_tensor = scope.var("Shape").get_tensor()
         shape_tensor.set(np.array([1000, 784]).astype("int64"), place)
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             ShapeTensor="Shape",
             Out="X",
@@ -451,7 +451,7 @@ class TestUniformRandomOpSelectedRowsShapeTensorList(unittest.TestCase):
         shape_2 = scope.var("shape2").get_tensor()
         shape_2.set(np.array([784]).astype("int64"), place)
         paddle.seed(10)
-        op = Operator(
+        op = OperatorFactory(
             "uniform_random",
             ShapeTensorList=["shape1", "shape2"],
             Out="X",

--- a/python/paddle/fluid/tests/unittests/testsuite.py
+++ b/python/paddle/fluid/tests/unittests/testsuite.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import numpy as np
+from op import OperatorFactory
 
 from paddle.fluid import core
-from paddle.fluid.op import Operator
 
 
 def create_op(scope, op_type, inputs, outputs, attrs, cache_list=None):
@@ -31,7 +31,7 @@ def create_op(scope, op_type, inputs, outputs, attrs, cache_list=None):
         scope.var(var_name).get_tensor()
         kwargs[name].append(var_name)
 
-    for in_name, in_dup in Operator.get_op_inputs(op_type):
+    for in_name, in_dup in OperatorFactory.get_op_inputs(op_type):
         if in_name in inputs:
             kwargs[in_name] = []
             if in_dup:
@@ -47,7 +47,7 @@ def create_op(scope, op_type, inputs, outputs, attrs, cache_list=None):
             scope.var(name)
             kwargs[name].append(name)
 
-    for out_name, out_dup in Operator.get_op_outputs(op_type):
+    for out_name, out_dup in OperatorFactory.get_op_outputs(op_type):
         if out_name in outputs:
             kwargs[out_name] = []
             if out_dup:
@@ -58,15 +58,15 @@ def create_op(scope, op_type, inputs, outputs, attrs, cache_list=None):
             else:
                 __create_var__(out_name, out_name)
 
-    for attr_name in Operator.get_op_attr_names(op_type):
+    for attr_name in OperatorFactory.get_op_attr_names(op_type):
         if attr_name in attrs:
             kwargs[attr_name] = attrs[attr_name]
 
-    for extra_attr_name in Operator.get_op_extra_attr_names(op_type):
+    for extra_attr_name in OperatorFactory.get_op_extra_attr_names(op_type):
         if extra_attr_name in attrs:
             kwargs[extra_attr_name] = attrs[extra_attr_name]
 
-    return Operator(op_type, **kwargs)
+    return OperatorFactory(op_type, **kwargs)
 
 
 def set_input(scope, op, inputs, place):
@@ -83,7 +83,7 @@ def set_input(scope, op, inputs, place):
         elif isinstance(var, int):
             scope.find_var(var_name).set_int(var)
 
-    for in_name, in_dup in Operator.get_op_inputs(op.type()):
+    for in_name, in_dup in OperatorFactory.get_op_inputs(op.type()):
         if in_name in inputs:
             if in_dup:
                 sub_in = inputs[in_name]

--- a/python/paddle/fluid/tests/unittests/xpu/test_adam_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_adam_op_xpu.py
@@ -27,7 +27,7 @@ from xpu.get_test_cover_info import (
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 
 
 class XPUTestAdamOp(XPUOpTestWrapper):
@@ -407,7 +407,7 @@ class TestSparseAdamOp(unittest.TestCase):
             op_args[k] = self.attrs[k]
 
         # create and run adam operator
-        adam_op = Operator("adam", **op_args)
+        adam_op = OperatorFactory("adam", **op_args)
         adam_op.run(scope, place)
 
         for key, np_array in self.outputs.items():

--- a/python/paddle/fluid/tests/unittests/xpu/test_fill_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_fill_op_xpu.py
@@ -27,7 +27,7 @@ from xpu.get_test_cover_info import (
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 
 paddle.enable_static()
 
@@ -77,7 +77,7 @@ class XPUTestFillOp(XPUOpTestWrapper):
 
             # create and run fill_op operator
             val = np.random.random(size=[300, 200])
-            fill_op = Operator(
+            fill_op = OperatorFactory(
                 "fill",
                 value=val.flatten(),
                 shape=[300, 200],

--- a/python/paddle/fluid/tests/unittests/xpu/test_rmsprop_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_rmsprop_op_xpu.py
@@ -29,7 +29,7 @@ from xpu.get_test_cover_info import (
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 
 paddle.enable_static()
 
@@ -295,7 +295,7 @@ class TestRmspropOp(TestBase):
             kwargs['MeanGrad'] = self.mean_grad_name
             kwargs['MeanGradOut'] = self.mean_grad_name
 
-        rmsprop_op = Operator('rmsprop', **kwargs)
+        rmsprop_op = OperatorFactory('rmsprop', **kwargs)
         atol = 1e-6
 
         rmsprop_op.run(self.scope, self.place)

--- a/python/paddle/fluid/tests/unittests/xpu/test_sgd_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_sgd_op_xpu.py
@@ -28,7 +28,7 @@ from xpu.get_test_cover_info import (
 import paddle
 from paddle import fluid
 from paddle.fluid import core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 
 
 class XPUTestSgdOp(XPUOpTestWrapper):
@@ -118,7 +118,7 @@ class TestSparseSGDOp(unittest.TestCase):
         lr.set(lr_array, place)
 
         # create and run sgd operator
-        sgd_op = Operator(
+        sgd_op = OperatorFactory(
             "sgd",
             Param='Param',
             Grad='Grad',

--- a/python/paddle/fluid/tests/unittests/xpu/test_shape_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_shape_op_xpu.py
@@ -27,7 +27,7 @@ from xpu.get_test_cover_info import (
 
 import paddle
 from paddle.fluid import core
-from paddle.fluid.op import Operator
+from paddle.fluid.tests.unittests.op import OperatorFactory
 
 paddle.enable_static()
 
@@ -96,7 +96,7 @@ class XPUTestShapeOp(XPUOpTestWrapper):
             x_tensor = x.get_tensor()
             x_tensor.set(np_array, place)
             out_shape = scope.var("Out").get_tensor()
-            op = Operator("shape", Input="X", Out="Out")
+            op = OperatorFactory("shape", Input="X", Out="Out")
 
             op.run(scope, place)
 


### PR DESCRIPTION
### PR types
Others

### PR changes
APIs

### Describe
To clean the code in paddle.fluid, the useless codes should be removed and code still be used should move to a new position.

fluid 目录下的 op.py 仅单测中使用，是optest的依赖，因此将其迁移到单测里
旧的PR链接：https://github.com/PaddlePaddle/Paddle/pull/51759