### PR TITLE
fix QAT export bug when prune input_spec

### DIFF
--- a/python/paddle/quantization/imperative/qat.py
+++ b/python/paddle/quantization/imperative/qat.py
@@ -530,6 +530,7 @@ class ImperativeQuantizeOutputs:
             model, paddle.nn.Layer
         ), "The model must be the instance of paddle.nn.Layer."
 
+        paddle.jit.to_static(model, input_spec=input_spec)
         paddle.jit.save(layer=model, path=path, input_spec=input_spec, **config)
 
         is_dynamic_mode = False


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix QAT export bug when prune input_spec. 