### PR TITLE
[GCC9][Werror]fix -Werror=maybe-uninitialized

### DIFF
--- a/paddle/fluid/operators/detection/roi_perspective_transform_op.cc
+++ b/paddle/fluid/operators/detection/roi_perspective_transform_op.cc
@@ -256,7 +256,7 @@ class CPUROIPerspectiveTransformOpKernel : public framework::OpKernel<T> {
     auto transformed_width = ctx.Attr<int>("transformed_width");
     auto spatial_scale = ctx.Attr<float>("spatial_scale");
 
-    auto in_dims = in->dims();
+    const auto& in_dims = in->dims();
     int channels = in_dims[1];
     int in_height = in_dims[2];
     int in_width = in_dims[3];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
新出现的-Werror=maybe-uninitialized 错误
务必记得phi::vectorize 套用dims
```
auto in_dims = phi::vectorize(in->dims());
```
不用vectorize 就会报错Werror
```
auto in_dims = in->dims();
```
Log

```
[ 79%] Building CXX object paddle/fluid/operators/detection/CMakeFiles/roi_perspective_transform_op.dir/roi_perspective_transform_op.cc.o
/media/wjl/D2/github/fork/10/Paddle/paddle/fluid/operators/detection/roi_perspective_transform_op.cc: In member function ‘void paddle::operators::CPUROIPerspectiveTransformOpKernel<T>::Compute(const paddle::framework::ExecutionContext&) const [with T = float]’:
/media/wjl/D2/github/fork/10/Paddle/paddle/fluid/operators/detection/roi_perspective_transform_op.cc:262:9: error: ‘*((void*)& in_dims +24)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  262 |     int in_width = in_dims[3];
      |         ^~~~~~~~
/media/wjl/D2/github/fork/10/Paddle/paddle/fluid/operators/detection/roi_perspective_transform_op.cc:261:9: error: ‘*((void*)& in_dims +16)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  261 |     int in_height = in_dims[2];
      |         ^~~~~~~~~
/media/wjl/D2/github/fork/10/Paddle/paddle/fluid/operators/detection/roi_perspective_transform_op.cc:259:10: error: ‘*((void*)& in_dims +8)’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  259 |     auto in_dims = in->dims();
```
