### PR TITLE
[Build]Fix maybe-uninitialized

### DIFF
--- a/paddle/fluid/operators/detection/roi_perspective_transform_op.cc
+++ b/paddle/fluid/operators/detection/roi_perspective_transform_op.cc
@@ -256,7 +256,7 @@ class CPUROIPerspectiveTransformOpKernel : public framework::OpKernel<T> {
     auto transformed_width = ctx.Attr<int>("transformed_width");
     auto spatial_scale = ctx.Attr<float>("spatial_scale");
 
-    auto in_dims = in->dims();
+    auto in_dims = phi::vectorize<int>(in->dims());
     int channels = in_dims[1];
     int in_height = in_dims[2];
     int in_width = in_dims[3];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Similar with #52083, can fix -Wno-error=maybe-uninitialized with gcc-9.3.1.

![WechatIMG65](https://user-images.githubusercontent.com/17897736/228433522-6b9db841-7880-4ee0-9a14-e41c5d84db78.jpeg)

